### PR TITLE
validate_webhook route plus more

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,7 +13,7 @@ from plexapi.server import PlexServer
 import pyfiglet
 import secrets
 
-from modules.validations import validate_iso3166_1, validate_iso639_1, validate_plex_server, validate_tautulli_server, validate_trakt_server, validate_mal_server, validate_anidb_server, validate_gotify_server
+from modules.validations import validate_iso3166_1, validate_iso639_1, validate_plex_server, validate_tautulli_server, validate_trakt_server, validate_mal_server, validate_anidb_server, validate_gotify_server, validate_webhook_server
 from modules.output import build_config
 from modules.helpers import get_template_list, get_bits, get_menu_list
 from modules.persistence import save_settings, retrieve_settings, check_minimum_settings, flush_session_storage, notification_systems_available
@@ -185,6 +185,10 @@ def validate_anidb():
     data = request.json
     return validate_anidb_server(data)
 
+@app.route('/validate_webhook', methods=['POST'])
+def validate_webhook():
+    data = request.json
+    return validate_webhook_server(data)
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', debug=True)

--- a/modules/persistence.py
+++ b/modules/persistence.py
@@ -143,17 +143,25 @@ def notification_systems_available():
 
     for file in file_list:
         stem, this_num, b = get_bits(file)
+        
         if "notifiarr" in stem:
             notifiarr_data = retrieve_settings(stem)
+            # print(f"Checking Notifiarr settings: {notifiarr_data}")  # Debug print
             try:
-                notifiarr_available = eval(notifiarr_data['valid'])
-            except:
+                notifiarr_available = bool(notifiarr_data['valid'])
+                # print(f"Notifiarr available: {notifiarr_available}")  # Debug print
+            except Exception as e:
+                # print(f"Error checking Notifiarr availability: {e}")  # Debug print
                 notifiarr_available = False
+        
         if "gotify" in stem:
             gotify_data = retrieve_settings(stem)
+            # print(f"Checking Gotify settings: {gotify_data}")  # Debug print
             try:
-                gotify_available = eval(gotify_data['valid'])
-            except:
+                gotify_available = bool(gotify_data['valid'])
+                # print(f"Gotify available: {gotify_available}")  # Debug print
+            except Exception as e:
+                # print(f"Error checking Gotify availability: {e}")  # Debug print
                 gotify_available = False
 
     return notifiarr_available, gotify_available

--- a/modules/validations.py
+++ b/modules/validations.py
@@ -290,3 +290,20 @@ def validate_anidb_server(data):
         return jsonify({'valid': False, 'error': str(e)})
 
     return jsonify({'valid': False, 'error': 'Unknown error'})
+
+
+def validate_webhook_server(data):
+    webhook_url = data.get('webhook_url')
+    message = data.get('message')
+
+    if not webhook_url:
+        return jsonify({"error": "Webhook URL is required"}), 400
+
+    message_data = {"content": message}
+
+    response = requests.post(webhook_url, json=message_data)
+
+    if response.status_code == 204:
+        return jsonify({"success": "Test message sent successfully! Go and ensure that you see the message on the server side."}), 200
+    else:
+        return jsonify({"error": f"Failed to send message: {response.status_code}, {response.text}"}), 400

--- a/templates/090-webhooks.html
+++ b/templates/090-webhooks.html
@@ -46,8 +46,7 @@
         <div class="col"></div>
         <div class="col-8">
           <div class="col align-self-end">
-            <div class="progress" role="progressbar" aria-label="Example with label" aria-valuenow="25"
-              aria-valuemin="0" aria-valuemax="100">
+            <div class="progress" role="progressbar" aria-label="Example with label" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100">
               <div class="progress-bar bg-success" style="width: {{ page_info['progress'] }}%">
                 {{ page_info['progress'] }}%
               </div>
@@ -82,8 +81,8 @@
     <div class="form-floating">
       <select class="form-select" id="webhooks_{{ webhook }}" name="webhooks_{{ webhook }}" onchange="showCustomInput(this)">
         <option value="">None</option>
-        <option value="notifiarr" {% if data.webhooks[webhook] == 'notifiarr' %}selected{% endif %}>Notifiarr</option>
-        <option value="gotify" {% if data.webhooks[webhook] == 'gotify' %}selected{% endif %}>Gotify</option>
+        <option value="notifiarr" {% if page_info['notifiarr_available'] %}enabled{% else %}disabled{% endif %} {% if data.webhooks[webhook] == 'notifiarr' %}selected{% endif %}>Notifiarr</option>
+        <option value="gotify" {% if page_info['gotify_available'] %}enabled{% else %}disabled{% endif %} {% if data.webhooks[webhook] == 'gotify' %}selected{% endif %}>Gotify</option>
         <option value="custom" {% if (data and data.webhooks[webhook] and data.webhooks[webhook].startswith('http')) %}selected{% endif %}>Custom</option>
       </select>
       <label for="webhooks_{{ webhook }}">{{ webhook|replace("_", " ")|title }} Webhook Details</label>
@@ -91,55 +90,80 @@
         <div class="input-group input-group-lg">
           <input type="text" class="form-control custom-webhook-url" placeholder="Enter webhook URL ({{ webhook|replace("_", " ")|title }})"
                  value="{% if (data and data.webhooks[webhook] and data.webhooks[webhook].startswith('http')) %}{{ data.webhooks[webhook] }}{% endif %}">
-          <button class="btn btn-success" type="button">Validate</button>
+          <button class="btn btn-success" type="button" onclick="validateWebhook('{{ webhook }}')">Validate</button>
+        </div>
+        <div class="validation-message" id="validation_message_{{ webhook }}" style="display: none; margin-top: 10px;">
+          <div class="alert alert-info" role="alert">
+            Validating...
+          </div>
         </div>
       </div>
     </div>
     {% endfor %}
 
     <script>
-    function showCustomInput(select) {
-      var customInputId = select.id + "_custom";
-      var customInput = $("#" + customInputId);
-      if ($(select).val() === "custom" || $(select).val().startsWith('http')) {
-        customInput.show();
-        customInput.find("input, button").prop("disabled", false);
-      } else {
-        customInput.hide();
-        customInput.find("input").val("");
-        customInput.find("input, button").prop("disabled", true);
-      }
+    function showCustomInput(selectElement) {
+        var customInputId = selectElement.id + '_custom';
+        if (selectElement.value === 'custom') {
+            document.getElementById(customInputId).style.display = 'block';
+        } else {
+            document.getElementById(customInputId).style.display = 'none';
+        }
     }
 
     $(document).ready(function() {
-      var notifiarrAvailable = $('#notifiarr_available').data('notifiarr-available') === "True";
-      var gotifyAvailable = $('#gotify_available').data('gotify-available') === "True";
-
-      $('select.form-select').each(function() {
-        var notifiarrOption = $(this).find('option[value="notifiarr"]');
-        if (!notifiarrAvailable) {
-          notifiarrOption.prop('disabled', true);
-        }
-
-        var gotifyOption = $(this).find('option[value="gotify"]');
-        if (!gotifyAvailable) {
-          gotifyOption.prop('disabled', true);
-        }
-
-        showCustomInput(this);
-      });
-
-      $('#configForm').on('submit', function(e) {
+        // Initial call to showCustomInput to show or hide custom inputs based on initial selection
         $('select.form-select').each(function() {
-          if ($(this).val() === 'custom') {
-            var customInputId = $(this).attr('id') + '_custom';
-            var customUrl = $('#' + customInputId).find('input.custom-webhook-url').val();
-            $(this).append('<option value="' + customUrl + '" selected="selected">' + customUrl + '</option>');
-            $(this).val(customUrl);
-          }
+            showCustomInput(this);
         });
-      });
+
+        document.getElementById("configForm").addEventListener("submit", function (event) {
+            $('select.form-select').each(function() {
+                if ($(this).val() === 'custom') {
+                    var customInputId = $(this).attr('id') + '_custom';
+                    var customUrl = $('#' + customInputId).find('input.custom-webhook-url').val();
+                    if (customUrl) {
+                        $(this).append('<option value="' + customUrl + '" selected="selected">' + customUrl + '</option>');
+                        $(this).val(customUrl);
+                    }
+                }
+            });
+        });
     });
+
+
+    function validateWebhook(webhookType) {
+        var inputGroup = $('#webhooks_' + webhookType + '_custom').find('.input-group');
+        var webhookUrl = inputGroup.find('input.custom-webhook-url').val();
+        var validationMessage = inputGroup.siblings('.validation-message');
+        var webhookTypeFormatted = webhookType.replace(/_/g, " ").replace(/\b\w/g, function (l) { return l.toUpperCase() });
+
+        validationMessage.html('<div class="alert alert-info" role="alert">Validating...</div>');
+        validationMessage.show();
+
+        fetch('/validate_webhook', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                webhook_url: webhookUrl,
+                message: "Test message for " + webhookTypeFormatted + " webhook"
+            })
+        })
+        .then(response => response.json())
+        .then(data => {
+            if (data.success) {
+                validationMessage.html('<div class="alert alert-success" role="alert">' + data.success + '</div>');
+            } else {
+                validationMessage.html('<div class="alert alert-danger" role="alert">' + data.error + '</div>');
+            }
+        })
+        .catch((error) => {
+            console.error('Error:', error);
+            validationMessage.html('<div class="alert alert-danger" role="alert">An error occurred. Please try again.</div>');
+        });
+    }
     </script>
   </div>
 </form>


### PR DESCRIPTION
This solution suffers from the same "jumpto" problem that the final validation page has. But validate button works and sends webhook to discord. saving and retrieving information on page persists. notifiarr_available and gotify_available are both working and when True, will enable the user to use those as a webhook choice.