### PR TITLE
Remove duplicate logo

### DIFF
--- a/templates/001-start.html
+++ b/templates/001-start.html
@@ -46,10 +46,7 @@
     <hr class="hr">
     {% include "modals/" + page_info['template_name'] + ".html" ignore missing %}
     <center>
-      <img src="{{ url_for('static', filename='images/logo.webp') }}"
-      alt="Quickstart"
-      style="width: 300px; height: auto;" />
-      <br><br><p><b class="text-danger">Read this warning (hover over the icon): </b>
+      <p><b class="text-danger">Read this warning (hover over the icon): </b>
     <i class="bi bi-exclamation-circle text-danger"
        data-bs-toggle="tooltip"
        data-bs-placement="top"


### PR DESCRIPTION
The start page had a second logo above the warning, I've removed that:

![image](https://github.com/user-attachments/assets/a7f66378-7bc5-4408-a069-64026873efaa)
