### PR TITLE
Delay tooltip for Defaults

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -313,5 +313,5 @@ div#loading {
 }
 
 .tooltip {
-    transition-delay: 0.25s;
+    transition-delay: 0.5s;
 }

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -242,9 +242,9 @@ label {
 /* -------------------- */
 
 .tooltip-inner {
-    background-color: #00bc8c;
+    background-color: #fff;
     color: #000;
-    padding: 1rem;
+    padding: 3px;
     max-width: 600px;
 }
 
@@ -302,4 +302,16 @@ div#loading {
 
 .discord-btn:hover {
     background-color: #5865F2;
+}
+
+
+
+.tooltip.show .tooltip-inner {
+    opacity: 1;
+    visibility: visible;
+    transition: opacity 0s, visibility 0s;
+}
+
+.tooltip {
+    transition-delay: 0.25s;
 }


### PR DESCRIPTION
Closes #293

Adds a 0.5 second hover delay for Defaults tooltips, and makes the border white.

Demo:

![chrome_KVABPveEQ8](https://github.com/user-attachments/assets/3ff1dc79-4836-400c-ba75-80edc4874b9a)

