### PR TITLE
Restore Placeholder Text to Prototype Config but hide from Input Fields

### DIFF
--- a/json-schema/prototype_config.yml
+++ b/json-schema/prototype_config.yml
@@ -460,8 +460,8 @@ webhooks:                        # Can be individually specified per library as 
   run_end:
   changes:
 plex:                            # Can be individually specified per library as well; REQUIRED for the script to run
-  url:
-  token:
+  url: http://192.168.1.12:32400
+  token: Enter Plex Token
   timeout: 60
   db_cache: 40
   clean_bundles: false
@@ -469,39 +469,39 @@ plex:                            # Can be individually specified per library as 
   optimize: false
   verify_ssl: true
 tmdb:                            # REQUIRED for the script to run
-  apikey:
+  apikey: Enter TMDb API Key
   language: en
   cache_expiration: 60
 tautulli:                        # Can be individually specified per library as well
-  url:
-  apikey:
+  url: http://192.168.1.12:8181
+  apikey: Enter Tautulli API Key
 github:
-  token:
+  token: Enter GitHub Personal Access Token
 omdb:
-  apikey:
+  apikey: Enter OMDb API Key
   cache_expiration: 60
 mdblist:
-  apikey:
+  apikey: Enter MDBList API Key
   cache_expiration: 60
 notifiarr:
-  apikey:
+  apikey: Enter Notifiarr API Key
 gotify:
-  url:
-  token:
+  url: http://192.168.1.12:80
+  token: Enter Gotify Token
 ntfy:
-  url:
-  token:
-  topic:
+  url: http://192.168.1.12:80
+  token: Enter ntfy Access Token
+  topic: Enter ntfy Topic
 anidb:                           # Not required for AniDB builders unless you want mature content
-  username:
-  password:
-  client:
+  username: Enter AniDB Username
+  password: Enter AniDB Password
+  client: Enter AniDB Client
   version: 1
   language: en
   cache_expiration: 60
 radarr:                          # Can be individually specified per library as well
-  url:
-  token:
+  url: http://192.168.1.12:7878
+  token: Enter Radarr API Key
   add_missing: false
   add_existing: false
   root_folder_path: S:/Movies
@@ -513,8 +513,8 @@ radarr:                          # Can be individually specified per library as 
   radarr_path:
   plex_path:
 sonarr:                          # Can be individually specified per library as well
-  url:
-  token:
+  url: http://192.168.1.12:8989
+  token: Enter Sonarr API Key
   add_missing: false
   add_existing: false
   root_folder_path: "S:/TV Shows"
@@ -529,8 +529,8 @@ sonarr:                          # Can be individually specified per library as 
   sonarr_path:
   plex_path:
 trakt:
-  client_id:
-  client_secret:
+  client_id: Enter Trakt Client ID
+  client_secret: Enter Trakt Client Secret
   pin:
   authorization:
     # everything below is autofilled by the script
@@ -541,8 +541,8 @@ trakt:
     scope: public
     created_at:
 mal:
-  client_id:
-  client_secret:
+  client_id: Enter MyAnimeList Client ID
+  client_secret: Enter MyAnimeList Client Secret
   authorization:
     # everything below is autofilled by the script
     access_token:

--- a/templates/010-plex.html
+++ b/templates/010-plex.html
@@ -2,13 +2,13 @@
 {% include "001-navigation.html" %}
 {% include "modals/" + page_info['template_name'] + ".html" ignore missing %}
     <div class="form-floating mb-2">
-      <input type="text" class="form-control" id="plex_url" name="plex_url" value="{{ data['plex']['url']  or '' }}" title="Plex URL" required="">
+      <input type="text" class="form-control" id="plex_url" name="plex_url" value="{{ data['plex']['url'] if data['plex']['url'] and 'http://192.168.1.12:32400' not in data['plex']['url'] else '' }}" required>
       <label for="plex_url">Plex URL<span class="text-info ms-2">(e.g. http://127.0.0.1:32400)</span></label>
     </div>
     <div class="input-group mb-2">
       <div class="form-floating flex-grow-1">
         <input type="password" class="form-control" id="plex_token" name="plex_token"
-               value="{{ data['plex']['url']  or '' }}" title="Token"
+               value="{{ data['plex']['token'] if data['plex']['token'] and 'Enter Plex Token' not in data['plex']['token'] else '' }}" title="Token"
                aria-label="Plex Token" required="">
         <label for="plex_token">Plex Token</label>
       </div>
@@ -27,10 +27,12 @@
     <input type="hidden" class="form-control" id="tmp_music_libraries" name="tmp_music_libraries" value="{{ data['plex']['tmp_music_libraries'] }}" title="">
     <input type="hidden" class="form-control" id="tmp_movie_libraries" name="tmp_movie_libraries" value="{{ data['plex']['tmp_movie_libraries'] }}" title="">
     <input type="hidden" class="form-control" id="tmp_show_libraries" name="tmp_show_libraries" value="{{ data['plex']['tmp_show_libraries'] }}" title="">
+
     <div class="form-floating" style="display:none;">
       <input type="text" class="form-control" id="plex_validated" name="plex_validated" value="{{ data['validated'] }}" title="">
       <label for="plex_validated">Plex Validated</label>
     </div>
+
     <div id="statusMessage" class="status-message"></div>
     <div class="hidden" id="hidden" style="display:none">
       <div class="form-floating mb-2">

--- a/templates/020-tmdb.html
+++ b/templates/020-tmdb.html
@@ -4,7 +4,7 @@
     <div class="input-group mb-2">
       <div class="form-floating flex-grow-1">
         <input type="password" class="form-control" id="tmdb_apikey" name="tmdb_apikey"
-               value="{{ data['tmdb']['apikey']  or '' }}" title="API Key"
+               value="{{ data['tmdb']['apikey'] if data['tmdb']['apikey'] and 'Enter TMDb API Key' not in data['tmdb']['apikey'] else '' }}" title="API Key"
                aria-label="TMDb API Key" required="">
         <label for="tmdb_apikey">TMDb API Key</label>
       </div>

--- a/templates/030-tautulli.html
+++ b/templates/030-tautulli.html
@@ -2,12 +2,12 @@
 {% include "001-navigation.html" %}
 {% include "modals/" + page_info['template_name'] + ".html" ignore missing %}
     <div class="form-floating mb-2">
-      <input type="text" class="form-control" id="tautulli_url" name="tautulli_url" value="{{ data['tautulli']['url']  or '' }}" title="Tautulli URL"> <label for="tautulli_url">Tautulli URL<span class="text-info ms-2">(e.g. http://192.168.1.12:8181)</span></label>
+      <input type="text" class="form-control" id="tautulli_url" name="tautulli_url" value="{{ data['tautulli']['url'] if data['tautulli']['url'] and 'http://192.168.1.12:8181' not in data['tautulli']['url'] else '' }}" title="Tautulli URL"> <label for="tautulli_url">Tautulli URL<span class="text-info ms-2">(e.g. http://192.168.1.12:8181)</span></label>
     </div>
     <div class="input-group mb-2">
       <div class="form-floating flex-grow-1">
         <input type="password" class="form-control" id="tautulli_apikey" name="tautulli_apikey"
-               value="{{ data['tautulli']['apikey']  or '' }}" title="API Key"
+               value="{{ data['tautulli']['apikey'] if data['tautulli']['apikey'] and 'Enter Tautulli API Key' not in data['tautulli']['apikey'] else '' }}" title="API Key"
                aria-label="Tautulli API Key">
         <label for="tautulli_apikey">Tautulli API Key</label>
       </div>

--- a/templates/040-github.html
+++ b/templates/040-github.html
@@ -4,7 +4,7 @@
     <div class="input-group mb-2">
       <div class="form-floating flex-grow-1">
         <input type="password" class="form-control" id="github_token" name="github_token"
-               value="{{ data['github']['token']  or '' }}" title="GitHub Token"
+               value="{{ data['github']['token'] if data['github']['token'] and 'Enter GitHub Personal Access Token' not in data['github']['token'] else '' }}" title="GitHub Token"
                aria-label="GitHub Token">
         <label for="github_token">GitHub Personal Access Token</label>
       </div>

--- a/templates/050-omdb.html
+++ b/templates/050-omdb.html
@@ -4,7 +4,7 @@
     <div class="input-group mb-2">
       <div class="form-floating flex-grow-1">
         <input type="password" class="form-control" id="omdb_apikey" name="omdb_apikey"
-               value="{{ data['omdb']['apikey']  or '' }}" title="OMDb API Key"
+               value="{{ data['omdb']['apikey'] if data['omdb']['apikey'] and 'Enter OMDb API Key' not in data['omdb']['apikey'] else '' }}" title="OMDb API Key"
                aria-label="OMDb API Key">
         <label for="omdb_apikey">OMDb API Key</label>
       </div>

--- a/templates/060-mdblist.html
+++ b/templates/060-mdblist.html
@@ -4,7 +4,7 @@
     <div class="input-group mb-2">
       <div class="form-floating flex-grow-1">
         <input type="password" class="form-control" id="mdblist_apikey" name="mdblist_apikey"
-               value="{{ data['mdblist']['apikey']  or '' }}" title="MDBList API Key"
+               value="{{ data['mdblist']['apikey'] if data['mdblist']['apikey'] and 'Enter MDBList API Key' not in data['mdblist']['apikey'] else '' }}" title="MDBList API Key"
                aria-label="MDBList API Key">
         <label for="mdblist_apikey">MDBList API Key</label>
       </div>

--- a/templates/070-notifiarr.html
+++ b/templates/070-notifiarr.html
@@ -4,7 +4,7 @@
     <div class="input-group mb-2">
       <div class="form-floating flex-grow-1">
         <input type="password" class="form-control" id="notifiarr_apikey" name="notifiarr_apikey"
-               value="{{ data['notifiarr']['apikey']  or '' }}" title="Notifiarr API Key"
+               value="{{ data['notifiarr']['apikey'] if data['notifiarr']['apikey'] and 'Enter Notifiarr API Key' not in data['notifiarr']['apikey'] else '' }}" title="Notifiarr API Key"
                aria-label="Notifiarr API Key">
         <label for="notifiarr_apikey">Notifiarr API Key</label>
       </div>

--- a/templates/080-gotify.html
+++ b/templates/080-gotify.html
@@ -2,12 +2,12 @@
 {% include "001-navigation.html" %}
 {% include "modals/" + page_info['template_name'] + ".html" ignore missing %}
     <div class="form-floating mb-2">
-      <input type="text" class="form-control" id="gotify_url" name="gotify_url" value="{{ data['gotify']['url']  or '' }}" title="Gotify URL"><label for="gotify_url">Gotify URL<span class="text-info ms-2">(e.g. http://192.168.1.12:1234)</span></label>
+      <input type="text" class="form-control" id="gotify_url" name="gotify_url" value="{{ data['gotify']['url'] if data['gotify']['url'] and 'http://192.168.1.12:80' not in data['gotify']['url'] else '' }}" title="Gotify URL"><label for="gotify_url">Gotify URL<span class="text-info ms-2">(e.g. http://192.168.1.12:1234)</span></label>
     </div>
     <div class="input-group mb-2">
       <div class="form-floating flex-grow-1">
         <input type="password" class="form-control" id="gotify_token" name="gotify_token"
-               value="{{ data['gotify']['token']  or '' }}" title="API Key"
+               value="{{ data['gotify']['token'] if data['gotify']['token'] and 'Enter Gotify Token' not in data['gotify']['token'] else '' }}" title="API Key"
                aria-label="API Key">
         <label for="gotify_token">Gotify API Key</label>
       </div>

--- a/templates/085-ntfy.html
+++ b/templates/085-ntfy.html
@@ -2,12 +2,12 @@
 {% include "001-navigation.html" %}
 {% include "modals/" + page_info['template_name'] + ".html" ignore missing %}
     <div class="form-floating mb-2">
-      <input type="text" class="form-control" id="ntfy_url" name="ntfy_url" value="{{ data['ntfy']['url']  or '' }}" title="Enter your ntfy server URL"><label for="ntfy_url">ntfy URL<span class="text-info ms-2">(e.g. https://ntfy.sh)</span></label>
+      <input type="text" class="form-control" id="ntfy_url" name="ntfy_url" value="{{ data['ntfy']['url'] if data['ntfy']['url'] and 'http://192.168.1.12:80' not in data['ntfy']['url'] else '' }}" title="Enter your ntfy server URL"><label for="ntfy_url">ntfy URL<span class="text-info ms-2">(e.g. https://ntfy.sh)</span></label>
     </div>
     <div class="input-group mb-2">
       <div class="form-floating flex-grow-1">
         <input type="password" class="form-control" id="ntfy_token" name="ntfy_token"
-               value="{{ data['ntfy']['token']  or '' }}" title="API Key"
+               value="{{ data['ntfy']['token'] if data['ntfy']['token'] and 'Enter ntfy Access Token' not in data['ntfy']['token'] else '' }}" title="API Key"
                aria-label="API Key">
         <label for="ntfy_token">ntfy API Key</label>
       </div>
@@ -20,7 +20,7 @@
     </div>
 
     <div class="form-floating mb-2">
-      <input type="text" class="form-control" id="ntfy_topic" name="ntfy_topic" value="{{ data['ntfy']['topic']  or '' }}" title="Enter your ntfy topic"><label for="ntfy_url">ntfy Topic<span class="text-info ms-2">(e.g. mykometanotifications)</span></label>
+      <input type="text" class="form-control" id="ntfy_topic" name="ntfy_topic" value="{{ data['ntfy']['topic'] if data['ntfy']['topic'] and 'Enter ntfy Topic' not in data['ntfy']['topic'] else '' }}" title="Enter your ntfy topic"><label for="ntfy_url">ntfy Topic<span class="text-info ms-2">(e.g. mykometanotifications)</span></label>
     </div>
 
     <div class="form-floating" style="display:none;">

--- a/templates/100-anidb.html
+++ b/templates/100-anidb.html
@@ -2,18 +2,18 @@
 {% include "001-navigation.html" %}
 {% include "modals/" + page_info['template_name'] + ".html" ignore missing %}
     <div class="form-floating mb-2">
-      <input type="text" class="form-control" id="anidb_client" name="anidb_client" value="{{ data['anidb']['client']  or '' }}" title=""><label for="anidb_client">AniDb Client</label>
+      <input type="text" class="form-control" id="anidb_client" name="anidb_client" value="{{ data['anidb']['client'] if data['anidb']['client'] and 'Enter AniDB Client' not in data['anidb']['client'] else '' }}" title=""><label for="anidb_client">AniDb Client</label>
     </div>
     <div class="form-floating mb-2">
       <input type="number" class="form-control" id="anidb_version" name="anidb_version" value="{{ data['anidb']['version'] }}" min="1" max="1"><label for="anidb_version">Client Version</label>
     </div>
     <div class="form-floating mb-2">
-      <input type="text" class="form-control" id="anidb_username" name="anidb_username" value="{{ data['anidb']['username']  or '' }}" title=""><label for="anidb_username">Username</label>
+      <input type="text" class="form-control" id="anidb_username" name="anidb_username" value="{{ data['anidb']['username'] if data['anidb']['username'] and 'Enter AniDB Username' not in data['anidb']['username'] else '' }}" title=""><label for="anidb_username">Username</label>
     </div>
     <div class="input-group mb-2">
       <div class="form-floating flex-grow-1">
         <input type="password" class="form-control" id="anidb_password" name="anidb_password"
-               value="{{ data['anidb']['password']  or '' }}" title="Password"
+               value="{{ data['anidb']['password'] if data['anidb']['password'] and 'Enter AniDB Password' not in data['anidb']['password'] else '' }}" title="Password"
                aria-label="Password">
         <label for="anidb_password">AniDB Password</label>
       </div>

--- a/templates/110-radarr.html
+++ b/templates/110-radarr.html
@@ -3,12 +3,12 @@
 {% include "modals/" + page_info['template_name'] + ".html" ignore missing %}
     <div class="form-floating mb-2">
       <input type="text" class="form-control" id="radarr_url" name="radarr_url" title="Radarr URL"
-        value="{{ data['radarr']['url']  or '' }}"><label for="radarr_url">Radarr URL (including URL Base if set)<span class="text-info ms-2">(e.g. http://192.168.1.100:7878)</span></label>
+        value="{{ data['radarr']['url'] if data['radarr']['url'] and 'http://192.168.1.12:7878' not in data['radarr']['url'] else '' }}"><label for="radarr_url">Radarr URL (including URL Base if set)<span class="text-info ms-2">(e.g. http://192.168.1.100:7878)</span></label>
     </div>
     <div class="input-group mb-2">
       <div class="form-floating flex-grow-1">
         <input type="password" class="form-control" id="radarr_token" name="radarr_token"
-               value="{{ data['radarr']['token']  or '' }}" title="Token"
+               value="{{ data['radarr']['token'] if data['radarr']['token'] and 'Enter Radarr API Key' not in data['radarr']['token'] else '' }}" title="Token"
                aria-label="Token">
         <label for="radarr_token">Radarr API Key</label>
       </div>

--- a/templates/120-sonarr.html
+++ b/templates/120-sonarr.html
@@ -2,12 +2,12 @@
 {% include "001-navigation.html" %}
 {% include "modals/" + page_info['template_name'] + ".html" ignore missing %}
     <div class="form-floating mb-2">
-      <input type="text" class="form-control" id="sonarr_url" name="sonarr_url" title="Sonarr URL" value="{{ data['sonarr']['url']  or '' }}"><label for="sonarr_url">Sonarr URL (including URL Base if set)<span class="text-info ms-2">(e.g. http://192.168.1.100:8989)</span></label>
+      <input type="text" class="form-control" id="sonarr_url" name="sonarr_url" title="Sonarr URL" value="{{ data['sonarr']['url'] if data['sonarr']['url'] and 'http://192.168.1.12:8989' not in data['sonarr']['url'] else '' }}"><label for="sonarr_url">Sonarr URL (including URL Base if set)<span class="text-info ms-2">(e.g. http://192.168.1.100:8989)</span></label>
     </div>
     <div class="input-group mb-2">
       <div class="form-floating flex-grow-1">
         <input type="password" class="form-control" id="sonarr_token" name="sonarr_token"
-               value="{{ data['sonarr']['token']  or '' }}" title="Token"
+               value="{{ data['sonarr']['token'] if data['sonarr']['token'] and 'Enter Sonarr API Key' not in data['sonarr']['token'] else '' }}" title="Token"
                aria-label="Token">
         <label for="sonarr_token">Sonarr API Key</label>
       </div>

--- a/templates/130-trakt.html
+++ b/templates/130-trakt.html
@@ -2,13 +2,13 @@
 {% include "001-navigation.html" %}
 {% include "modals/" + page_info['template_name'] + ".html" ignore missing %}
     <div class="form-floating mb-2">
-      <input type="text" class="form-control" id="trakt_client_id" name="trakt_client_id" value="{{ data['trakt']['client_id']  or '' }}" oninput="updateTraktURL(this)">
+      <input type="text" class="form-control" id="trakt_client_id" name="trakt_client_id" value="{{ data['trakt']['client_id'] if data['trakt']['client_id'] and 'Enter Trakt Client ID' not in data['trakt']['client_id'] else '' }}" oninput="updateTraktURL(this)">
       <label for="trakt_client_id">Client ID</label>
     </div>
     <div class="input-group mb-2">
       <div class="form-floating flex-grow-1">
         <input type="password" class="form-control" id="trakt_client_secret" name="trakt_client_secret"
-               value="{{ data['trakt']['client_secret']  or '' }}" title="Client Secret"
+               value="{{ data['trakt']['client_secret'] if data['trakt']['client_secret'] and 'Enter Trakt Client Secret' not in data['trakt']['client_secret'] else '' }}" title="Client Secret"
                aria-label="Client Secret" oninput="updateTraktURL(this)">
         <label for="trakt_client_secret">Client Secret</label>
       </div>

--- a/templates/140-mal.html
+++ b/templates/140-mal.html
@@ -2,7 +2,7 @@
 {% include "001-navigation.html" %}
 {% include "modals/" + page_info['template_name'] + ".html" ignore missing %}
     <div class="form-floating mb-2">
-      <input type="text" class="form-control" id="mal_client_id" name="mal_client_id" value="{{ data['mal']['client_id']  or '' }}" oninput="updateMALTargetURL(this)">
+      <input type="text" class="form-control" id="mal_client_id" name="mal_client_id" value="{{ data['mal']['client_id'] if data['mal']['client_id'] and 'Enter MyAnimeList Client ID' not in data['mal']['client_id'] else '' }}" oninput="updateMALTargetURL(this)">
       <label for="mal_client_id">Client ID</label>
     </div>
     <div class="form-floating mb-2">
@@ -11,7 +11,7 @@
     <div class="input-group mb-2">
       <div class="form-floating flex-grow-1">
         <input type="password" class="form-control" id="mal_client_secret" name="mal_client_secret"
-               value="{{ data['mal']['client_secret']  or '' }}" title="Client Secret"
+               value="{{ data['mal']['client_secret'] if data['mal']['client_secret'] and 'Enter MyAnimeList Client Secret' not in data['mal']['client_secret'] else '' }}" title="Client Secret"
                aria-label="Client Secret" oninput="updateMALTargetURL(this)">
         <label for="mal_client_secret">Client Secret</label>
       </div>


### PR DESCRIPTION
## Description

Restored the placeholder values in the prototype_config file to keep it consistent with Kometa.

placeholder text will not appear in the input fields of Quickstart if they match the default string from prototype config (i.e. if plex token string is "Enter Plex Token" then Quickstart won't show that).

Also fixed an issue where the plex token was showing the plex url string - my bad.

## Type of Change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change (non-code changes affecting only the wiki)
- [ ] Infrastructure change (changes related to the github repo, build process, or the like)

## Checklist

- [X] My code was submitted to the develop branch of the repository.
