### PR TITLE
Rework Reset / Delete Config Buttons

### DIFF
--- a/templates/001-start.html
+++ b/templates/001-start.html
@@ -83,7 +83,7 @@
       <label for="configSelector">Select or Add Config</label>
     </div>
 
-    <div id="newConfigInput" class="form-floating" style="display: {% if page_info['config_name'] not in available_configs %}block{% else %}none{% endif %};">
+    <div id="newConfigInput" class="form-floating mb-2" style="display: {% if page_info['config_name'] not in available_configs %}block{% else %}none{% endif %};">
       <input
         type="text"
         id="newConfigName"
@@ -96,15 +96,15 @@
     </div>
   </div>
   <form>
-    <div class="d-grid gap-2">
+    <div class="form-floating mb-2">
         <!-- Reset (Start Over) Button -->
-        <button type="button" class="btn btn-warning ms-2" id="resetConfigButton" disabled data-bs-toggle="modal" data-bs-target="#configActionModal" data-action="reset">
+        <button type="button" class="btn btn-warning" id="resetConfigButton" disabled data-bs-toggle="modal" data-bs-target="#configActionModal" data-action="reset">
           <i class="bi bi-arrow-clockwise"></i> Reset
         </button>
 
         <!-- Delete Config Button -->
         <button type="button" class="btn btn-danger ms-2" id="deleteConfigButton" disabled data-bs-toggle="modal" data-bs-target="#configActionModal" data-action="delete">
-          <i class="bi bi-trash"></i>
+          <i class="bi bi-trash"></i> Delete
         </button>
     </div>
   </form>


### PR DESCRIPTION
## Description

Some visual changes for the Reset/Delete Buttons on the Start page.

Added bottom-margin to the Config Name (using form-floating mb-2)

Removed left-side margin from the Reset button so it's in line with everything else (removed ms-2)

Added "Delete" text to Delete button

Made both buttons not full-width

Before:
![image](https://github.com/user-attachments/assets/24d5e975-3ce5-4df7-9fc8-a6442713f032)

After:
![image](https://github.com/user-attachments/assets/fca7cbaf-5828-45e0-9768-3ae1cf29da7d)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change (non-code changes affecting only the wiki)
- [ ] Infrastructure change (changes related to the github repo, build process, or the like)

## Checklist

- [X ] My code was submitted to the develop branch of the repository.
