### PR TITLE
fix for sep_style in final output

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -148,20 +148,33 @@ def build_libraries_section(
 
         # ✅ Process Template Variables
         template_vars = {}
-        template_data = templates.get(library_name, {})
+        template_key = extract_library_name(library_key)
+        template_data = templates.get(template_key, {})
 
-        if isinstance(template_data, dict):
-            use_separators = template_data.get(
-                f"{library_type}-library_{library_name}-template_variables[use_separators]",
-                False,
-            )
-            if use_separators not in [None, "None", ""]:
-                template_vars["use_separators"] = bool(use_separators)
+        # ✅ Step 1: Find the exact key that matches the pattern
+        sep_color_key = None
+        for key in template_data.keys():
+            if key.endswith("-template_variables[use_separators]") and key.startswith(
+                f"{library_type}-library_{template_key}"
+            ):
+                sep_color_key = key
+                break  # Stop once we find the matching key
 
-        if template_vars:
-            entry["template_variables"] = template_vars
+        # ✅ Step 2: Extract the value
+        sep_color = template_data.get(sep_color_key)
+
+        # ✅ Step 3: Apply logic if the key was found
+        if sep_color:
+            template_vars["use_separators"] = True
+            template_vars["sep_style"] = sep_color
         else:
+            template_vars["use_separators"] = False  # Default if key is missing
+
+        # ✅ Assign default values if nothing was found
+        if not template_vars:
             entry["template_variables"] = {"use_separators": False}
+        else:
+            entry["template_variables"] = template_vars
 
         # ✅ Process Attributes
         if library_name in attributes:


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Replace the space in the brackets with an X of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [x ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other 

## Description

fix for sep_style in final output

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below. 
    We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->
- Related Issue #425 
- Closes #425 

## Have you updated the Documentation to reflect changes (if necessary)?

<!--
    If your PR warrants Documentation changes, you are expected to make the relevant changes.
    Failure to do so will result in your PR not being approved.
    Replace the space in the brackets with an X of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [x ] No