### PR TITLE
Amend CSS of disabled buttons

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -446,6 +446,15 @@ div#loading {
     color: white !important;
 }
 
+.btn.nav-button:disabled,
+.btn.nav-button.disabled {
+    background-color: #212529 !important;
+    border: 2px solid #212529 !important;
+    color: #adb5bd !important;
+    text-decoration: line-through;
+    cursor: not-allowed;
+}
+
 /* Dropdown Styling */
 .dropdown-menu {
     background-color: #343a40;


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Replace the space in the brackets with an X of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [ ] Bug Fix (non-breaking change which fixes an issue)
- [X] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other 

## Description

Amends CSS of disabled buttons to be darker in color and strikethrough the text to make it more obvious it's unusable.

https://github.com/user-attachments/assets/ca195f4c-487d-4be1-896c-99ad2fdfaa53

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below. 
    We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->
- Related Issue #410