### PR TITLE
fixing the strange toggles logic for content_rating

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -806,7 +806,7 @@ def build_config(header_style="standard", config_name=None):
             Groups data (collections, overlays, attributes, etc.) by base library name.
 
             If `normalize_overlays` is True, it strips builder-level suffixes
-            (e.g. `tvshows-show` → `tvshows`) to match show library names.
+            (e.g. `tv_shows-show` → `tv_shows`) to match show library names.
             """
             grouped = {}
 

--- a/static/local-js/overlayHandler.js
+++ b/static/local-js/overlayHandler.js
@@ -256,9 +256,7 @@ function setupParentChildToggleSync () {
     const wrapper = document.querySelector(`[data-toggle-parent="${groupId}"]`)
     const isRadioStyle = parent.type === 'radio' || parent.dataset.radioGroup === 'true'
 
-    // Simulate radio behavior using data-radio-group (add this attribute in Jinja if needed)
     const groupName = parent.name
-
     const childToggles = wrapper?.querySelectorAll('.template-child-toggle') || []
 
     parent.addEventListener('click', () => {
@@ -285,8 +283,8 @@ function setupParentChildToggleSync () {
           }
         })
 
-        // Ensure only one is selected
         if (isChecked && parent.dataset.wasChecked === 'true') {
+          // Toggle OFF previously checked pseudo-radio
           parent.checked = false
           parent.dataset.wasChecked = 'false'
           if (wrapper) wrapper.style.display = 'none'
@@ -294,9 +292,6 @@ function setupParentChildToggleSync () {
             child.checked = false
             child.dispatchEvent(new Event('change', { bubbles: true }))
           })
-          // Clear hidden input
-          const hidden = document.querySelector(`input[type="hidden"][name="${groupName}"]`)
-          if (hidden) hidden.value = ''
         } else {
           parent.dataset.wasChecked = 'true'
           if (wrapper) wrapper.style.display = ''
@@ -304,11 +299,19 @@ function setupParentChildToggleSync () {
             child.checked = true
             child.dispatchEvent(new Event('change', { bubbles: true }))
           })
-
-          // Set hidden input to selected value
-          const hidden = document.querySelector(`input[type="hidden"][name="${groupName}"]`)
-          if (hidden) hidden.value = parent.value
         }
+
+        // Always sync hidden input after processing toggle group
+        setTimeout(() => {
+          const groupToggles = document.querySelectorAll(`input[name="${groupName}"][data-radio-group="true"]`)
+          const anyChecked = Array.from(groupToggles).some(t => t.checked)
+          const selectedToggle = Array.from(groupToggles).find(t => t.checked)
+          const hidden = document.querySelector(`input[type="hidden"][name="${groupName}"]`)
+          if (hidden) {
+            hidden.value = anyChecked ? (selectedToggle?.value || '') : ''
+            console.debug(`[SYNC] Hidden input for ${groupName} = "${hidden.value}"`)
+          }
+        }, 0)
       }
 
       syncing = false
@@ -324,9 +327,19 @@ function setupParentChildToggleSync () {
         parent.checked = anyChecked
         if (wrapper) wrapper.style.display = anyChecked ? '' : 'none'
 
-        // If none checked and radio style, simulate uncheck
         if (!anyChecked && isRadioStyle) {
           parent.dataset.wasChecked = 'false'
+
+          // Clear hidden if no toggle remains selected
+          setTimeout(() => {
+            const groupToggles = document.querySelectorAll(`input[name="${groupName}"][data-radio-group="true"]`)
+            const anyLeftChecked = Array.from(groupToggles).some(t => t.checked)
+            const hidden = document.querySelector(`input[type="hidden"][name="${groupName}"]`)
+            if (hidden) {
+              hidden.value = anyLeftChecked ? (Array.from(groupToggles).find(t => t.checked)?.value || '') : ''
+              console.debug(`[SYNC] Hidden input for ${groupName} = "${hidden.value}"`)
+            }
+          }, 0)
         }
 
         syncing = false


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [] Breaking Change (fix or feature that would break any existing functionality for users)
- [] Documentation Update
- [] Other

## Description

fixing the strange toggles logic for content_rating

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #671 

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [] Windows Executable
- [] Linux Executable
- [] macOS Executable
- [] Docker
- [] Other
