### PR TITLE
read KOMETA_ROOT, SESSION_CACHELIB from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 QS_DEBUG=0
 QS_PORT=7171
+QS_FLASK_SESSION_DIR=/config/flask_session
+QS_KOMETA_PATH=/config/kometa

--- a/quickstart.py
+++ b/quickstart.py
@@ -95,8 +95,7 @@ app.config["VERSION_CHECK"] = helpers.check_for_update()
 base_dir = os.path.dirname(os.path.abspath(__file__))
 kometa_path = os.path.abspath(os.path.join(base_dir, "..", "kometa"))
 
-app.config["KOMETA_ROOT"] = kometa_path
-
+app.config["KOMETA_ROOT"] = os.environ.get("QS_KOMETA_PATH", kometa_path)
 
 def start_update_thread():
     """Ensure update_checker_loop runs inside the Flask app context."""
@@ -125,7 +124,8 @@ app.config["QS_DEBUG"] = helpers.booler(os.getenv("QS_DEBUG", "0"))
 app.config["QUICKSTART_DOCKER"] = helpers.booler(os.getenv("QUICKSTART_DOCKER", "0"))
 
 app.config["SESSION_TYPE"] = "cachelib"
-app.config["SESSION_CACHELIB"] = FileSystemCache(cache_dir="flask_session", threshold=500)
+flask_cache_dir = os.environ.get("QS_FLASK_SESSION_DIR", "/config/flask_session")
+app.config["SESSION_CACHELIB"] = FileSystemCache(cache_dir=flask_cache_dir, threshold=500)
 app.config["SESSION_PERMANENT"] = True
 app.config["SESSION_USE_SIGNER"] = False
 

--- a/quickstart.py
+++ b/quickstart.py
@@ -97,6 +97,7 @@ kometa_path = os.path.abspath(os.path.join(base_dir, "..", "kometa"))
 
 app.config["KOMETA_ROOT"] = os.environ.get("QS_KOMETA_PATH", kometa_path)
 
+
 def start_update_thread():
     """Ensure update_checker_loop runs inside the Flask app context."""
     with app.app_context():


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Running Quickstart on Kubernetes the root filesystem is read-only, so attemps to create or write to these directories fail.

Default settings:
flask_session: `/flask_session`
kometa_root: `/kometa`

This change enables users to specify a path. A typical case is to mount `/config` from a persistent volume and create these subdirectories there.

## Which Environment Did You Test On?


- [ ] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [x] Docker
- [x] Other: Kubernetes 1.32.3

