### PR TITLE
Update quickstart_collections.json

### DIFF
--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -24001,13 +24001,13 @@
             ]
           },
           {
-            "key": "use_max",
-            "label": "Max Movies/Shows",
+            "key": "use_hbomax",
+            "label": "HBO Max Movies/Shows",
             "tooltip": "Collection of Movies/Shows Streaming on Max.",
             "type": "toggle"
           },
           {
-            "key": "radarr_add_missing_max",
+            "key": "radarr_add_missing_hbomax",
             "label": "Add missing items to Radarr",
             "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
             "tooltip_variant": "danger",


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [X ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Update key to match documentation from Kometa to avoid accidental mass addition of files with Kometa assuming true for both use_hbomax and radarr_add_missing_hbomax since the values were missing/incorrect.

This update aligns with the key listed at https://kometa.wiki/en/nightly/defaults/both/streaming/#collections-section-030 and I assume resolves my open bug report (unless there is another place in the code where the incorrect key is used and I can't find it.) This using 'hbomax' instead of 'max' in my config did resolve my issue, but I manually updated the key. I'm not technically inclined enough to recompile this and test otherwise. Hope you understand!

## Related Issues [optional]

- Closes #914 

## Which Environment Did You Test On?

- [ ] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ X] Other

I know just enough to be dangerous, but barely enough to be useful when it comes to code. I didn't recompile and test this, but changing the key in my config did resolve the bug.
