### PR TITLE
moved /tmp to config/tmp for test libs and kometa extraction

### DIFF
--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -1405,7 +1405,13 @@ def _extract_zip_bytes(zip_bytes: bytes, dest_dir: Path, logs: list[str]) -> boo
         _ensure_dir(dest_dir)
         with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
             root_name = zf.namelist()[0].split("/")[0]  # e.g., Kometa-nightly
-            with tempfile.TemporaryDirectory() as td:
+            # Use a stable tmp under CONFIG_DIR to avoid /tmp RAM constraints
+            tmp_base = Path(CONFIG_DIR) / "tmp"
+            if tmp_base.is_dir():
+                for entry in tmp_base.iterdir():
+                    shutil.rmtree(entry, ignore_errors=True)
+            tmp_base.mkdir(parents=True, exist_ok=True)
+            with tempfile.TemporaryDirectory(dir=tmp_base) as td:
                 tmp_root = Path(td) / root_name
                 zf.extractall(Path(td))
                 # Wipe current contents (keep dest_dir itself)

--- a/quickstart.py
+++ b/quickstart.py
@@ -1742,7 +1742,18 @@ def clone_test_libraries_start():
                 "total": total_size,
             }
 
-            with tempfile.TemporaryDirectory() as tmpdir:
+            # Use a stable tmp folder under the config dir to avoid /tmp RAM mounts
+            tmp_root = os.path.join(base_config_dir, "config", "tmp")
+            # Proactively clean stale tmp folders from previous runs
+            if os.path.isdir(tmp_root):
+                for entry in os.listdir(tmp_root):
+                    try:
+                        shutil.rmtree(os.path.join(tmp_root, entry), ignore_errors=True)
+                    except Exception:
+                        pass
+            os.makedirs(tmp_root, exist_ok=True)
+
+            with tempfile.TemporaryDirectory(dir=tmp_root) as tmpdir:
                 zip_path = os.path.join(tmpdir, "main.zip")
 
                 # Stream download with throttled progress updates
@@ -1890,7 +1901,17 @@ def clone_test_libraries():
         except Exception:
             commit_sha = None
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_root = os.path.join(base_config_dir if use_config_dir else parent_dir, "config", "tmp") if use_config_dir else os.path.join(parent_dir, "tmp")
+        # Clean stale tmp folders if they exist
+        if os.path.isdir(tmp_root):
+            for entry in os.listdir(tmp_root):
+                try:
+                    shutil.rmtree(os.path.join(tmp_root, entry), ignore_errors=True)
+                except Exception:
+                    pass
+        os.makedirs(tmp_root, exist_ok=True)
+
+        with tempfile.TemporaryDirectory(dir=tmp_root) as tmpdir:
             zip_path = os.path.join(tmpdir, "main.zip")
 
             r = requests.get(zip_url)


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Temp download/extract now uses <quickstart_root>/config/tmp (or <dir_of_executable>/config/tmp when frozen), instead of the system /tmp. This avoids RAM-backed /tmp issues on Linux/macOS/Docker. On non-config installs it falls back to <parent_of_quickstart_root>/tmp.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #939 

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
