### PR TITLE
fix for switching configs

### DIFF
--- a/quickstart.py
+++ b/quickstart.py
@@ -1118,7 +1118,7 @@ def bulk_delete_configs():
 
     cleaned = [n.strip() for n in names if isinstance(n, str) and n.strip()]
     if not cleaned:
-        return jsonify(success=False, message="No profiles selected."), 400
+        return jsonify(success=False, message="No configs selected."), 400
 
     available = set(database.get_unique_config_names() or [])
     deleted = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ namesgenerator==0.3
 pillow==12.1.0
 PlexAPI==4.17.2
 pre-commit==4.5.1
-psutil==7.2.1
+psutil==7.2.2
 pyfiglet==1.0.4
 PyQt5==5.15.11; platform_system != "Linux" or platform_machine != "aarch64"
 python-dotenv==1.2.1

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -304,6 +304,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
       confirmBtn.disabled = true
       confirmBtn.textContent = 'Switching...'
+      window.QS_SWITCHING_CONFIG = true
 
       try {
         const res = await fetch('/switch-config', {
@@ -313,14 +314,16 @@ document.addEventListener('DOMContentLoaded', () => {
         })
         const data = await res.json()
         if (!res.ok || !data.success) {
-          throw new Error(data.message || 'Failed to switch profiles.')
+          throw new Error(data.message || 'Failed to switch configs.')
         }
-        showToast('success', `Switched to profile "${data.name}".`)
-        setTimeout(() => location.reload(), 500)
+        showToast('success', `Switched to config "${data.name}".`)
+        const nextUrl = window.location.pathname + window.location.search
+        setTimeout(() => window.location.assign(nextUrl), 150)
       } catch (err) {
+        window.QS_SWITCHING_CONFIG = false
         confirmBtn.disabled = false
         confirmBtn.textContent = 'Switch'
-        showToast('error', err.message || 'Failed to switch profiles.')
+        showToast('error', err.message || 'Failed to switch configs.')
       }
     })
   }

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -6,7 +6,6 @@ document.addEventListener('DOMContentLoaded', function () {
   const scriptsToLoad = [
     '/static/local-js/imageHandler.js',
     '/static/local-js/overlayHandler.js',
-    '/static/local-js/pathValidation.js',
     '/static/local-js/validationHandler.js',
     '/static/local-js/eventHandler.js'
   ]
@@ -355,6 +354,7 @@ document.addEventListener('DOMContentLoaded', function () {
     function autosaveActiveLibrary () {
       const card = libraryContainer.firstElementChild
       if (!activeLibraryId || !card) return Promise.resolve()
+      if (window.QS_SWITCHING_CONFIG) return Promise.resolve()
 
       if (typeof PathValidation !== 'undefined' && PathValidation.validateAll) {
         const pathValid = PathValidation.validateAll(card)

--- a/templates/001-navigation.html
+++ b/templates/001-navigation.html
@@ -27,7 +27,7 @@
           </button>
           <button type="button" class="badge bg-secondary config-badge config-badge-button"
             data-bs-toggle="modal" data-bs-target="#configSwitchModal" data-current="{{ page_info.config_name }}">
-            <span title="Switch profile">
+            <span title="Switch config">
               Config: {{ page_info.config_name }} <i class="bi bi-chevron-down ms-1"></i>
             </span>
           </button>
@@ -166,24 +166,24 @@
     </div>
     {% endif %}
 
-    <!-- Switch Profile Modal -->
+    <!-- Switch Config Modal -->
     <div class="modal fade" id="configSwitchModal" tabindex="-1" aria-labelledby="configSwitchModalLabel" aria-hidden="true">
       <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content border-secondary">
           <div class="modal-header">
-            <h5 class="modal-title" id="configSwitchModalLabel">Switch Profile</h5>
+            <h5 class="modal-title" id="configSwitchModalLabel">Switch Config</h5>
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div class="modal-body">
             {% if available_configs|length > 0 %}
-            <label for="configSwitchSelect" class="form-label">Choose a profile</label>
+            <label for="configSwitchSelect" class="form-label">Choose a config</label>
             <select id="configSwitchSelect" class="form-select">
               {% for name in available_configs %}
               <option value="{{ name }}">{{ name }}</option>
               {% endfor %}
             </select>
             {% else %}
-            <p class="text-muted mb-0">No saved profiles yet. Create and save a config first.</p>
+            <p class="text-muted mb-0">No saved configs yet. Create and save a config first.</p>
             {% endif %}
           </div>
           <div class="modal-footer">


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Fix config switch wiping current page data

Prevents accidental POST resubmits when switching profiles by replacing location.reload() with a clean GET navigation (window.location.assign(path + query)).
Adds a lightweight “switch in progress” flag to suppress Libraries autosave during a profile switch.
Ensures config switching does not save empty/default form data into the newly selected profile.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #1031 

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
