### PR TITLE
fix flow for qs auto-update

### DIFF
--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -55,6 +55,7 @@ BUILDNUM_FILE = os.path.join(MEIPASS_DIR, "BUILDNUM")
 LOG_DIR = os.path.join("config", "logs")
 LOG_FILE = os.path.join(LOG_DIR, "quickstart.log")
 MAX_LOG_BACKUPS = 10
+RESTART_NOTICE_FILE = os.path.join(CONFIG_DIR, ".restart_notice.json")
 
 
 def normalize_id(name, existing_ids):
@@ -647,6 +648,39 @@ def update_env_variable(key, value):
                 file.write(line)
         if not key_found:
             file.write(f"{key}={value}\n")
+
+
+def set_restart_notice(reason, message=None):
+    if not isinstance(reason, str) or not reason.strip():
+        return False
+    payload = {
+        "reason": reason.strip(),
+        "message": message.strip() if isinstance(message, str) and message.strip() else None,
+        "created_at": datetime.datetime.utcnow().isoformat() + "Z",
+    }
+    try:
+        with open(RESTART_NOTICE_FILE, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle)
+        return True
+    except Exception as exc:
+        ts_log(f"Failed to write restart notice: {exc}", level="WARNING")
+        return False
+
+
+def consume_restart_notice():
+    if not os.path.exists(RESTART_NOTICE_FILE):
+        return None
+    try:
+        with open(RESTART_NOTICE_FILE, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except Exception as exc:
+        ts_log(f"Failed to read restart notice: {exc}", level="WARNING")
+        payload = None
+    try:
+        os.remove(RESTART_NOTICE_FILE)
+    except Exception as exc:
+        ts_log(f"Failed to remove restart notice: {exc}", level="WARNING")
+    return payload
 
 
 def load_quickstart_config(filename: str):

--- a/quickstart.py
+++ b/quickstart.py
@@ -419,6 +419,9 @@ default_test_libs_tmp = os.path.join(helpers.CONFIG_DIR, "tmp")
 app.config["QS_TEST_LIBS_PATH"] = os.getenv("QS_TEST_LIBS_PATH", default_test_libs_path).strip() or default_test_libs_path
 app.config["QS_TEST_LIBS_TMP"] = os.getenv("QS_TEST_LIBS_TMP", default_test_libs_tmp).strip() or default_test_libs_tmp
 app.config["QUICKSTART_DOCKER"] = helpers.booler(os.getenv("QUICKSTART_DOCKER", "0"))
+restart_notice = helpers.consume_restart_notice()
+app.config["QS_RESTART_NOTICE"] = restart_notice
+app.config["QS_SKIP_AUTO_OPEN"] = bool(restart_notice and restart_notice.get("reason") == "update")
 
 cleanup_flag = os.getenv("QS_CONFIG_CLEANUP_DONE", "").strip().lower()
 if cleanup_flag not in {"1", "true", "yes"}:
@@ -5424,6 +5427,14 @@ def purge_test_libraries():
 
 @app.route("/restart", methods=["POST"])
 def restart_quickstart():
+    data = request.get_json(silent=True) or {}
+    reason = data.get("reason")
+    if reason == "update":
+        helpers.set_restart_notice(
+            "update",
+            "Update complete. Quickstart restarted without auto-opening a browser.",
+        )
+
     def restart():
         # Give time for the response to complete before restarting
         time.sleep(1)
@@ -5582,8 +5593,12 @@ if __name__ == "__main__":
                 helpers.ts_log(
                     f"Port and Debug Settings can be amended via the Settings cog in the UI, " f"right-clicking the system tray icon, or by editing your {DOTENV} file",
                     level="INFO",
-                )  # Open the browser automatically
-                webbrowser.open(f"http://localhost:{running_port}")
+                )
+                if app.config.get("QS_SKIP_AUTO_OPEN"):
+                    helpers.ts_log("Skipping auto-open after update restart.", level="INFO")
+                else:
+                    # Open the browser automatically
+                    webbrowser.open(f"http://localhost:{running_port}")
 
                 # Keep the invisible parent alive
                 self.dialog_parent.showMinimized()

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -191,6 +191,22 @@ function showToast (type, message) {
   toast.show()
 }
 
+document.addEventListener('DOMContentLoaded', () => {
+  const notice = window.QS_RESTART_NOTICE
+  if (!notice || notice.reason !== 'update') return
+
+  const noticeKey = `qs_restart_notice_${notice.reason}_${notice.created_at || ''}`
+  try {
+    if (window.localStorage && window.localStorage.getItem(noticeKey)) return
+    if (window.localStorage) window.localStorage.setItem(noticeKey, '1')
+  } catch (err) {
+    // Ignore localStorage failures (private mode, etc.)
+  }
+
+  const message = notice.message || 'Update complete. Quickstart restarted without auto-opening a browser.'
+  showToast('info', message)
+})
+
 // Mark all <select> elements when changed, so we can tell if a user modified them
 function trackModifiedSelects () {
   document.querySelectorAll('select').forEach(select => {
@@ -201,8 +217,14 @@ function trackModifiedSelects () {
   })
 }
 
-function restartQuickstart () {
-  fetch('/restart', { method: 'POST' })
+function restartQuickstart (reason) {
+  const payload = (typeof reason === 'string' && reason.trim()) ? { reason: reason.trim() } : null
+  const options = { method: 'POST' }
+  if (payload) {
+    options.headers = { 'Content-Type': 'application/json' }
+    options.body = JSON.stringify(payload)
+  }
+  fetch('/restart', options)
     .then(res => res.json())
     .then(data => {
       if (data.success) {
@@ -254,7 +276,7 @@ document.addEventListener('DOMContentLoaded', () => {
             <strong>✅ Update Successful!</strong><br>
             <span class="text-info">Branch: <code>${data.branch || branch}</code></span>
             <pre class="form-control bg-dark text-light" style="height: 300px; overflow-y: auto; overflow-x: auto; white-space: pre;">${lines.join('\n')}</pre>
-            <button class="btn btn-sm btn-success mt-2" onclick="restartQuickstart()">Restart Quickstart</button>
+            <button class="btn btn-sm btn-success mt-2" onclick="restartQuickstart('update')">Restart Quickstart</button>
           `
         } else {
           resultBox.innerHTML = `

--- a/templates/000-base.html
+++ b/templates/000-base.html
@@ -52,6 +52,7 @@
     window.QS_TEST_LIBS_TMP = {{ config.get('QS_TEST_LIBS_TMP', '') | tojson }};
     window.QS_SESSION_LIFETIME_DAYS = "{{ config.get('QS_SESSION_LIFETIME_DAYS', 30) }}";
     window.QS_FLASK_SESSION_DIR = {{ config.get('QS_FLASK_SESSION_DIR', '') | tojson }};
+    window.QS_RESTART_NOTICE = {{ config.get('QS_RESTART_NOTICE') | tojson }};
   </script>
   <script type="text/javascript" src="{{ url_for('static', filename='local-js/000-base.js') }}"></script>
   <script type="text/javascript" src="{{ url_for('static', filename='local-js/pathValidation.js') }}"></script>


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Added an update-restart marker so Quickstart skips auto‑opening the browser after an update restart and shows a one‑time toast instead. The restart endpoint now accepts a reason, the update UI passes update, and the tray auto‑open is gated on that flag. The notice is injected into the base template and shown once per browser via localStorage.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #1037 

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
