### PR TITLE
Ratings offset fix

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -989,7 +989,7 @@ def build_libraries_section(
                         continue
                     slot_payload = {}
                     for key in [k for k in list(cleaned.keys()) if k == rating_key or k.startswith(f"{rating_key}_")]:
-                        suffix = "" if key == rating_key else key[len(rating_key):]
+                        suffix = "" if key == rating_key else key[len(rating_key) :]
                         slot_payload[suffix] = cleaned.pop(key)
                     if slot_payload:
                         slot_payloads.append(slot_payload)
@@ -1019,10 +1019,7 @@ def build_libraries_section(
                 # If all explicit per-slot vertical offsets are identical, they
                 # still represent a single shared anchor from Quickstart's composite preview.
                 # Re-expand them to match the preview stack used on the canvas.
-                vertical_values = [
-                    _offset_number(slot_payload.get("_vertical_offset"), None)
-                    for slot_payload in slot_payloads
-                ]
+                vertical_values = [_offset_number(slot_payload.get("_vertical_offset"), None) for slot_payload in slot_payloads]
                 if len(slot_payloads) > 1 and all(value is not None for value in vertical_values):
                     if len(set(vertical_values)) == 1:
                         base_vertical = vertical_values[0]

--- a/modules/output.py
+++ b/modules/output.py
@@ -940,28 +940,25 @@ def build_libraries_section(
                             continue
                     cleaned[k] = v
 
-                # Enforce ratingN <-> ratingN_image dependency; if either side is empty, drop both
+                def _is_empty(val):
+                    if val is None or val is False:
+                        return True
+                    if isinstance(val, str):
+                        return val.strip() == "" or val.strip().lower() == "none"
+                    return False
+
+                # Enforce ratingN <-> ratingN_image dependency; if either side is empty, drop the slot entirely,
+                # including any stale slot-specific style or offset fields left behind from a previous count.
                 for idx in ["1", "2", "3"]:
                     r_key = f"rating{idx}"
                     i_key = f"{r_key}_image"
                     r_val = cleaned.get(r_key)
                     i_val = cleaned.get(i_key)
                     if r_key in cleaned or i_key in cleaned:
-
-                        def _is_empty(val):
-                            if val is None or val is False:
-                                return True
-                            if isinstance(val, str):
-                                return val.strip() == "" or val.strip().lower() == "none"
-                            return False
-
-                        if _is_empty(r_val):
-                            cleaned.pop(r_key, None)
-                            cleaned.pop(i_key, None)
+                        if _is_empty(r_val) or _is_empty(i_val):
+                            for key in [k for k in list(cleaned.keys()) if k == r_key or k.startswith(f"{r_key}_")]:
+                                cleaned.pop(key, None)
                             continue
-                        if _is_empty(i_val):
-                            cleaned.pop(r_key, None)
-                            cleaned.pop(i_key, None)
 
                 def _offset_number(value, fallback):
                     if isinstance(value, bool):
@@ -981,48 +978,63 @@ def build_libraries_section(
                                 return fallback
                     return fallback
 
-                # Kometa expects per-rating offset keys on the ratings overlay.
-                # Preserve existing group-offset UI by fanning shared offsets out
-                # to each configured rating slot during YAML generation.
-                active_slots = [
-                    idx
-                    for idx in ["1", "2", "3"]
-                    if f"rating{idx}" in cleaned or f"rating{idx}_image" in cleaned
-                ]
+                # Compact the configured rating slots so the emitted YAML always matches the
+                # contiguous stack shown on the Quickstart canvas, even after reducing the
+                # rating count or clearing a middle slot.
+                slot_payloads = []
+                for idx in ["1", "2", "3"]:
+                    rating_key = f"rating{idx}"
+                    image_key = f"{rating_key}_image"
+                    if rating_key not in cleaned or image_key not in cleaned:
+                        continue
+                    slot_payload = {}
+                    for key in [k for k in list(cleaned.keys()) if k == rating_key or k.startswith(f"{rating_key}_")]:
+                        suffix = "" if key == rating_key else key[len(rating_key):]
+                        slot_payload[suffix] = cleaned.pop(key)
+                    if slot_payload:
+                        slot_payloads.append(slot_payload)
+
                 back_height = _offset_number(cleaned.get("back_height"), 160)
                 back_padding = _offset_number(cleaned.get("back_padding"), 15)
                 gap = max(0, back_padding)
                 vertical_step = back_height + gap
-                center_index = (len(active_slots) - 1) / 2 if active_slots else 0
+                center_index = (len(slot_payloads) - 1) / 2 if slot_payloads else 0
                 for axis in ["horizontal", "vertical"]:
                     shared_key = f"{axis}_offset"
                     if shared_key not in cleaned:
                         continue
                     shared_val = cleaned.get(shared_key)
                     shared_number = _offset_number(shared_val, 0)
-                    for slot_position, idx in enumerate(active_slots):
-                        r_key = f"rating{idx}"
-                        slot_key = f"{r_key}_{axis}_offset"
-                        if slot_key in cleaned:
+                    for slot_position, slot_payload in enumerate(slot_payloads):
+                        slot_key = f"_{axis}_offset"
+                        if slot_key in slot_payload:
                             continue
                         if axis == "horizontal":
-                            cleaned[slot_key] = shared_val
+                            slot_payload[slot_key] = shared_val
                         else:
                             relative_index = slot_position - center_index
-                            cleaned[slot_key] = int(round(shared_number + (vertical_step * relative_index)))
+                            slot_payload[slot_key] = int(round(shared_number + (vertical_step * relative_index)))
                     cleaned.pop(shared_key, None)
 
                 # If all explicit per-slot vertical offsets are identical, they
-                # still represent the top of Quickstart's composite preview block.
+                # still represent a single shared anchor from Quickstart's composite preview.
                 # Re-expand them to match the preview stack used on the canvas.
-                vertical_slot_keys = [f"rating{idx}_vertical_offset" for idx in active_slots]
-                if len(vertical_slot_keys) > 1 and all(key in cleaned for key in vertical_slot_keys):
-                    vertical_values = [_offset_number(cleaned.get(key), 0) for key in vertical_slot_keys]
+                vertical_values = [
+                    _offset_number(slot_payload.get("_vertical_offset"), None)
+                    for slot_payload in slot_payloads
+                ]
+                if len(slot_payloads) > 1 and all(value is not None for value in vertical_values):
                     if len(set(vertical_values)) == 1:
                         base_vertical = vertical_values[0]
-                        for slot_position, key in enumerate(vertical_slot_keys):
+                        for slot_position, slot_payload in enumerate(slot_payloads):
                             relative_index = slot_position - center_index
-                            cleaned[key] = int(round(base_vertical + (vertical_step * relative_index)))
+                            slot_payload["_vertical_offset"] = int(round(base_vertical + (vertical_step * relative_index)))
+
+                for slot_position, slot_payload in enumerate(slot_payloads, start=1):
+                    rating_key = f"rating{slot_position}"
+                    for suffix, value in slot_payload.items():
+                        target_key = rating_key if suffix == "" else f"{rating_key}{suffix}"
+                        cleaned[target_key] = value
 
                 if cleaned:
                     overlay_entry["template_variables"] = cleaned

--- a/modules/output.py
+++ b/modules/output.py
@@ -387,6 +387,8 @@ def optimize_template_variables(config_data, library_types=None):
             "rating1_font_color",
             "rating1_stroke_width",
             "rating1_stroke_color",
+            "rating1_horizontal_offset",
+            "rating1_vertical_offset",
             "rating2",
             "rating2_image",
             "rating2_font",
@@ -394,6 +396,8 @@ def optimize_template_variables(config_data, library_types=None):
             "rating2_font_color",
             "rating2_stroke_width",
             "rating2_stroke_color",
+            "rating2_horizontal_offset",
+            "rating2_vertical_offset",
             "rating3",
             "rating3_image",
             "rating3_font",
@@ -401,6 +405,8 @@ def optimize_template_variables(config_data, library_types=None):
             "rating3_font_color",
             "rating3_stroke_width",
             "rating3_stroke_color",
+            "rating3_horizontal_offset",
+            "rating3_vertical_offset",
             "horizontal_position",
             "horizontal_offset",
             "vertical_offset",
@@ -957,6 +963,67 @@ def build_libraries_section(
                             cleaned.pop(r_key, None)
                             cleaned.pop(i_key, None)
 
+                def _offset_number(value, fallback):
+                    if isinstance(value, bool):
+                        return fallback
+                    if isinstance(value, (int, float)):
+                        return value
+                    if isinstance(value, str):
+                        stripped = value.strip()
+                        if not stripped:
+                            return fallback
+                        try:
+                            return int(stripped)
+                        except ValueError:
+                            try:
+                                return float(stripped)
+                            except ValueError:
+                                return fallback
+                    return fallback
+
+                # Kometa expects per-rating offset keys on the ratings overlay.
+                # Preserve existing group-offset UI by fanning shared offsets out
+                # to each configured rating slot during YAML generation.
+                active_slots = [
+                    idx
+                    for idx in ["1", "2", "3"]
+                    if f"rating{idx}" in cleaned or f"rating{idx}_image" in cleaned
+                ]
+                back_height = _offset_number(cleaned.get("back_height"), 160)
+                back_padding = _offset_number(cleaned.get("back_padding"), 15)
+                gap = max(0, back_padding)
+                vertical_step = back_height + gap
+                center_index = (len(active_slots) - 1) / 2 if active_slots else 0
+                for axis in ["horizontal", "vertical"]:
+                    shared_key = f"{axis}_offset"
+                    if shared_key not in cleaned:
+                        continue
+                    shared_val = cleaned.get(shared_key)
+                    shared_number = _offset_number(shared_val, 0)
+                    for slot_position, idx in enumerate(active_slots):
+                        r_key = f"rating{idx}"
+                        slot_key = f"{r_key}_{axis}_offset"
+                        if slot_key in cleaned:
+                            continue
+                        if axis == "horizontal":
+                            cleaned[slot_key] = shared_val
+                        else:
+                            relative_index = slot_position - center_index
+                            cleaned[slot_key] = int(round(shared_number + (vertical_step * relative_index)))
+                    cleaned.pop(shared_key, None)
+
+                # If all explicit per-slot vertical offsets are identical, they
+                # still represent the top of Quickstart's composite preview block.
+                # Re-expand them to match the preview stack used on the canvas.
+                vertical_slot_keys = [f"rating{idx}_vertical_offset" for idx in active_slots]
+                if len(vertical_slot_keys) > 1 and all(key in cleaned for key in vertical_slot_keys):
+                    vertical_values = [_offset_number(cleaned.get(key), 0) for key in vertical_slot_keys]
+                    if len(set(vertical_values)) == 1:
+                        base_vertical = vertical_values[0]
+                        for slot_position, key in enumerate(vertical_slot_keys):
+                            relative_index = slot_position - center_index
+                            cleaned[key] = int(round(base_vertical + (vertical_step * relative_index)))
+
                 if cleaned:
                     overlay_entry["template_variables"] = cleaned
                 else:
@@ -987,6 +1054,8 @@ def build_libraries_section(
                     "rating1_font_color",
                     "rating1_stroke_width",
                     "rating1_stroke_color",
+                    "rating1_horizontal_offset",
+                    "rating1_vertical_offset",
                     "rating2",
                     "rating2_image",
                     "rating2_font",
@@ -994,6 +1063,8 @@ def build_libraries_section(
                     "rating2_font_color",
                     "rating2_stroke_width",
                     "rating2_stroke_color",
+                    "rating2_horizontal_offset",
+                    "rating2_vertical_offset",
                     "rating3",
                     "rating3_image",
                     "rating3_font",
@@ -1001,6 +1072,8 @@ def build_libraries_section(
                     "rating3_font_color",
                     "rating3_stroke_width",
                     "rating3_stroke_color",
+                    "rating3_horizontal_offset",
+                    "rating3_vertical_offset",
                     "horizontal_position",
                     "horizontal_offset",
                     "vertical_offset",

--- a/static/json/quickstart_overlays.json
+++ b/static/json/quickstart_overlays.json
@@ -551,6 +551,16 @@
             "default": "#00000000",
             "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA."
           },
+          "rating1_horizontal_offset": {
+            "input_type": "number",
+            "label": "Rating 1 Horizontal Offset",
+            "default": 15
+          },
+          "rating1_vertical_offset": {
+            "input_type": "number",
+            "label": "Rating 1 Vertical Offset",
+            "default": 0
+          },
           "rating2": {
             "input_type": "select",
             "default": "critic",
@@ -654,6 +664,16 @@
             "default": "#00000000",
             "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA."
           },
+          "rating2_horizontal_offset": {
+            "input_type": "number",
+            "label": "Rating 2 Horizontal Offset",
+            "default": 15
+          },
+          "rating2_vertical_offset": {
+            "input_type": "number",
+            "label": "Rating 2 Vertical Offset",
+            "default": 0
+          },
           "rating3": {
             "input_type": "select",
             "default": "audience",
@@ -756,6 +776,16 @@
             "label": "Rating 3 Stroke Color",
             "default": "#00000000",
             "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA."
+          },
+          "rating3_horizontal_offset": {
+            "input_type": "number",
+            "label": "Rating 3 Horizontal Offset",
+            "default": 15
+          },
+          "rating3_vertical_offset": {
+            "input_type": "number",
+            "label": "Rating 3 Vertical Offset",
+            "default": 0
           },
           "back_align": {
             "input_type": "select",
@@ -911,6 +941,16 @@
             "default": "#00000000",
             "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA."
           },
+          "rating1_horizontal_offset": {
+            "input_type": "number",
+            "label": "Rating 1 Horizontal Offset",
+            "default": 15
+          },
+          "rating1_vertical_offset": {
+            "input_type": "number",
+            "label": "Rating 1 Vertical Offset",
+            "default": 0
+          },
           "rating2": {
             "input_type": "select",
             "default": "audience",
@@ -981,6 +1021,16 @@
             "label": "Rating 2 Stroke Color",
             "default": "#00000000",
             "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA."
+          },
+          "rating2_horizontal_offset": {
+            "input_type": "number",
+            "label": "Rating 2 Horizontal Offset",
+            "default": 15
+          },
+          "rating2_vertical_offset": {
+            "input_type": "number",
+            "label": "Rating 2 Vertical Offset",
+            "default": 0
           },
           "back_align": {
             "input_type": "select",

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -1032,6 +1032,7 @@ document.addEventListener('DOMContentLoaded', function () {
       initRelativeYearInputs(card)
       initScheduleBuilders(card)
       wireOffsetReset(card)
+      wireRatingsOffsetSync(card)
       initSortablesInScope(card)
       setupCustomStringListHandlers('mass_genre_update', card)
       setupCustomStringListHandlers('radarr_remove_by_tag', card)
@@ -1391,6 +1392,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     wireOverlayDetailToggles()
     wireOverlayTemplateSections()
+    wireRatingsOffsetSync()
 
     document.addEventListener('click', (e) => {
       const btn = e.target.closest('.copy-library-btn')
@@ -2009,6 +2011,168 @@ function setupParentChildToggleVisibility (scope) {
 
     updateVisibilityAndBorder(false) // Initial check
     parentToggle.dataset.childVisibilityBound = 'true'
+  })
+}
+
+function wireRatingsOffsetSync (scope) {
+  const root = scope || document
+  root.querySelectorAll('.template-toggle-group[data-overlay-id="overlay_ratings"]').forEach(group => {
+    if (group.dataset.ratingsOffsetSyncBound === 'true') return
+
+    const templateName = group.dataset.overlayTemplate
+    if (!templateName) return
+
+    const sharedInputs = {
+      horizontal: group.querySelector(`[name="${templateName}[horizontal_offset]"]`),
+      vertical: group.querySelector(`[name="${templateName}[vertical_offset]"]`)
+    }
+    if (!sharedInputs.horizontal || !sharedInputs.vertical) return
+
+    const metricInputs = {
+      backHeight: group.querySelector(`[name="${templateName}[back_height]"]`),
+      backPadding: group.querySelector(`[name="${templateName}[back_padding]"]`)
+    }
+    const slotDefs = ['rating1', 'rating2', 'rating3'].map(slot => ({
+      slot,
+      ratingInput: group.querySelector(`[name="${templateName}[${slot}]"]`),
+      imageInput: group.querySelector(`[name="${templateName}[${slot}_image]"]`),
+      horizontalInput: group.querySelector(`[name="${templateName}[${slot}_horizontal_offset]"]`),
+      verticalInput: group.querySelector(`[name="${templateName}[${slot}_vertical_offset]"]`)
+    })).filter(slot => slot.horizontalInput || slot.verticalInput || slot.ratingInput || slot.imageInput)
+    const slotInputs = {
+      horizontal: slotDefs.map(slot => slot.horizontalInput).filter(Boolean),
+      vertical: slotDefs.map(slot => slot.verticalInput).filter(Boolean)
+    }
+
+    const toNumber = (value, fallback = 0) => {
+      const n = Number(value)
+      return Number.isFinite(n) ? n : fallback
+    }
+    const normalizeValue = (value) => String(value ?? '').trim().toLowerCase()
+    const hasMeaningfulValue = (input) => {
+      if (!input) return false
+      const value = normalizeValue(input.value)
+      return value !== '' && value !== 'none'
+    }
+    const getActiveSlots = () => {
+      const active = slotDefs.filter(slot => hasMeaningfulValue(slot.ratingInput) || hasMeaningfulValue(slot.imageInput))
+      return active.length ? active : slotDefs
+    }
+    const getVerticalStep = () => {
+      const backHeight = toNumber(metricInputs.backHeight?.value, 160)
+      const backPadding = Math.max(0, toNumber(metricInputs.backPadding?.value, 15))
+      return backHeight + backPadding
+    }
+    const updateInputValue = (input, nextValue) => {
+      if (!input) return
+      const normalized = String(Math.round(nextValue))
+      if (String(input.value ?? '') === normalized) return
+      input.value = normalized
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+      input.dispatchEvent(new Event('change', { bubbles: true }))
+    }
+
+    const valuesDiffer = (input) => {
+      if (!input) return false
+      return String(input.value ?? '') !== String(input.dataset.default ?? '')
+    }
+    const hasExplicitSlotOffsets = (axis = null) => {
+      const activeSlots = getActiveSlots()
+      const inputs = axis
+        ? activeSlots.map(slot => slot[`${axis}Input`]).filter(Boolean)
+        : activeSlots.flatMap(slot => [slot.horizontalInput, slot.verticalInput]).filter(Boolean)
+      return inputs.some(valuesDiffer)
+    }
+
+    const withSyncGuard = (callback) => {
+      group.dataset.syncingRatingOffsets = 'true'
+      try {
+        callback()
+      } finally {
+        delete group.dataset.syncingRatingOffsets
+      }
+    }
+
+    const syncSharedFromSlots = (axis) => {
+      const sharedInput = sharedInputs[axis]
+      const inputs = getActiveSlots().map(slot => slot[`${axis}Input`]).filter(Boolean)
+      if (!sharedInput || !inputs.length) return
+      if (group.dataset.syncingRatingOffsets === 'true' || group.dataset.resetting === 'true') {
+        sharedInput.dataset.prevValue = String(sharedInput.value ?? '')
+        return
+      }
+      const average = Math.round(
+        inputs.reduce((sum, input) => sum + toNumber(input.value, toNumber(input.dataset.default, 0)), 0) / inputs.length
+      )
+      withSyncGuard(() => {
+        sharedInput.value = String(average)
+        sharedInput.dataset.prevValue = String(average)
+        sharedInput.dispatchEvent(new Event('input', { bubbles: true }))
+        sharedInput.dispatchEvent(new Event('change', { bubbles: true }))
+      })
+    }
+
+    const syncSlotsFromShared = (axis) => {
+      const sharedInput = sharedInputs[axis]
+      const activeSlots = getActiveSlots()
+      if (!sharedInput || !activeSlots.length) return
+      if (group.dataset.syncingRatingOffsets === 'true' || group.dataset.resetting === 'true') {
+        sharedInput.dataset.prevValue = String(sharedInput.value ?? '')
+        return
+      }
+      const current = toNumber(sharedInput.value, toNumber(sharedInput.dataset.default, 0))
+      sharedInput.dataset.prevValue = String(current)
+      withSyncGuard(() => {
+        if (axis === 'horizontal') {
+          activeSlots.forEach(slot => updateInputValue(slot.horizontalInput, current))
+          return
+        }
+        const verticalStep = getVerticalStep()
+        const centerIndex = (activeSlots.length - 1) / 2
+        activeSlots.forEach((slot, index) => {
+          updateInputValue(slot.verticalInput, current + ((index - centerIndex) * verticalStep))
+        })
+      })
+    }
+
+    const seedSharedFromSlots = () => {
+      const sharedAtDefaults = Object.values(sharedInputs).every(input => !valuesDiffer(input))
+      if (!hasExplicitSlotOffsets() || !sharedAtDefaults) return
+      syncSharedFromSlots('horizontal')
+      syncSharedFromSlots('vertical')
+    }
+
+    seedSharedFromSlots()
+
+    Object.entries(sharedInputs).forEach(([axis, input]) => {
+      input.dataset.prevValue = String(input.value ?? '')
+      const syncFromShared = () => syncSlotsFromShared(axis)
+      input.addEventListener('input', syncFromShared)
+      input.addEventListener('change', syncFromShared)
+    })
+
+    Object.entries(slotInputs).forEach(([axis, inputs]) => {
+      inputs.forEach(input => {
+        input.addEventListener('change', () => syncSharedFromSlots(axis))
+      })
+    })
+
+    const refreshDerivedOffsets = () => {
+      if (!valuesDiffer(sharedInputs.horizontal) && !valuesDiffer(sharedInputs.vertical) && !hasExplicitSlotOffsets()) {
+        return
+      }
+      syncSlotsFromShared('horizontal')
+      syncSlotsFromShared('vertical')
+    }
+
+    slotDefs.forEach(slot => {
+      if (slot.ratingInput) slot.ratingInput.addEventListener('change', refreshDerivedOffsets)
+      if (slot.imageInput) slot.imageInput.addEventListener('change', refreshDerivedOffsets)
+    })
+    if (metricInputs.backHeight) metricInputs.backHeight.addEventListener('change', refreshDerivedOffsets)
+    if (metricInputs.backPadding) metricInputs.backPadding.addEventListener('change', refreshDerivedOffsets)
+
+    group.dataset.ratingsOffsetSyncBound = 'true'
   })
 }
 

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -2054,10 +2054,8 @@ function wireRatingsOffsetSync (scope) {
       const value = normalizeValue(input.value)
       return value !== '' && value !== 'none'
     }
-    const getActiveSlots = () => {
-      const active = slotDefs.filter(slot => hasMeaningfulValue(slot.ratingInput) || hasMeaningfulValue(slot.imageInput))
-      return active.length ? active : slotDefs
-    }
+    const isConfiguredSlot = (slot) => hasMeaningfulValue(slot.ratingInput) && hasMeaningfulValue(slot.imageInput)
+    const getActiveSlots = () => slotDefs.filter(isConfiguredSlot)
     const getVerticalStep = () => {
       const backHeight = toNumber(metricInputs.backHeight?.value, 160)
       const backPadding = Math.max(0, toNumber(metricInputs.backPadding?.value, 15))

--- a/static/local-js/overlayHandler.js
+++ b/static/local-js/overlayHandler.js
@@ -2167,7 +2167,9 @@ const OverlayHandler = {
       const vars = getBackdropVars(cfg)
       const boxWidth = Math.max(1, Number(vars.back_width) || 160)
       const boxHeight = Math.max(1, Number(vars.back_height) || 160)
-      const gap = Math.max(6, Math.round(boxHeight * 0.08))
+      const gap = Number.isFinite(Number(vars.back_padding))
+        ? Math.max(0, Number(vars.back_padding))
+        : 15
       const canvas = document.createElement('canvas')
       canvas.width = Math.ceil(boxWidth)
       canvas.height = Math.ceil((boxHeight * items.length) + (gap * Math.max(0, items.length - 1)))

--- a/templates/001-navigation.html
+++ b/templates/001-navigation.html
@@ -174,7 +174,9 @@
         <span class="input-group-text">
           <i class="bi bi-search"></i>
         </span>
-        <input type="search" class="form-control" placeholder="Search this page" aria-label="Search this page"
+        <input type="search" class="form-control"
+          id="{{ page_info['template_name'] }}-page-search"
+          placeholder="Search this page" aria-label="Search this page"
           data-qs-search-input>
         <button type="button" class="btn btn-outline-secondary d-none" data-qs-search-clear>Clear</button>
       </div>

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -1088,7 +1088,10 @@ prefix) %}
                                 </span>
                                 {% endif %}
                             </span>
-                            <select class="form-select" data-relative-year-mode aria-describedby="{{ input_name }}_text"
+                            <select class="form-select"
+                                id="{{ input_name }}_relative_year_mode"
+                                data-relative-year-mode
+                                aria-describedby="{{ input_name }}_text"
                                 {% if disable_toggle %}disabled{% endif %}>
                                 {% for opt in rel_options %}
                                 <option value="{{ opt.value }}" data-kind="{{ opt.kind }}"
@@ -1098,7 +1101,9 @@ prefix) %}
                                 </option>
                                 {% endfor %}
                             </select>
-                            <input type="number" class="form-control" data-relative-year-value inputmode="numeric"
+                            <input type="number" class="form-control"
+                                id="{{ input_name }}_relative_year_value"
+                                data-relative-year-value inputmode="numeric"
                                 min="1" step="1" data-numeric-only="true" placeholder="Year or Offset"
                                 aria-label="Year or offset" {% if disable_toggle %}disabled{% endif %}>
                             <input type="hidden" id="{{ input_name }}" name="{{ input_name }}" value="{{ stored_val }}">
@@ -1120,7 +1125,9 @@ prefix) %}
                                         <i class="bi bi-info-circle-fill"></i>
                                     </span>
                                 </span>
-                                <select class="form-select" data-schedule-mode-select {% if disable_toggle %}disabled{% endif %}>
+                                <select class="form-select"
+                                    id="{{ input_name }}_schedule_mode"
+                                    data-schedule-mode-select {% if disable_toggle %}disabled{% endif %}>
                                     <option value="range">Range</option>
                                     <option value="weekly">Weekly</option>
                                     <option value="monthly">Monthly</option>
@@ -1136,10 +1143,14 @@ prefix) %}
                             <div class="schedule-builder-body">
                                 <div class="schedule-mode" data-schedule-mode="range">
                                     <div class="schedule-grid">
-                                        <input type="date" class="form-control" data-schedule-range-start
+                                        <input type="date" class="form-control"
+                                            id="{{ input_name }}_schedule_range_start"
+                                            data-schedule-range-start
                                             aria-label="Range start" {% if disable_toggle %}disabled{% endif %}>
                                         <span class="schedule-range-sep">to</span>
-                                        <input type="date" class="form-control" data-schedule-range-end
+                                        <input type="date" class="form-control"
+                                            id="{{ input_name }}_schedule_range_end"
+                                            data-schedule-range-end
                                             aria-label="Range end" {% if disable_toggle %}disabled{% endif %}>
                                     </div>
                                     <div class="form-text">Month/day are used; year is ignored.</div>
@@ -1148,31 +1159,43 @@ prefix) %}
                                     <div class="schedule-weekly">
                                         {% for day in ['sun','mon','tue','wed','thu','fri','sat'] %}
                                         <label class="schedule-day">
-                                            <input type="checkbox" value="{{ day }}" data-schedule-week-day {% if disable_toggle %}disabled{% endif %}>
+                                            <input type="checkbox"
+                                                id="{{ input_name }}_schedule_week_{{ day }}"
+                                                value="{{ day }}" data-schedule-week-day {% if disable_toggle %}disabled{% endif %}>
                                             <span>{{ day|capitalize }}</span>
                                         </label>
                                         {% endfor %}
                                     </div>
                                 </div>
                                 <div class="schedule-mode" data-schedule-mode="monthly">
-                                    <input type="number" class="form-control" min="1" max="31" step="1"
+                                    <input type="number" class="form-control"
+                                        id="{{ input_name }}_schedule_month_day"
+                                        min="1" max="31" step="1"
                                         data-schedule-month-day placeholder="Day of month" {% if disable_toggle %}disabled{% endif %}>
                                 </div>
                                 <div class="schedule-mode" data-schedule-mode="yearly">
-                                    <input type="date" class="form-control" data-schedule-yearly
+                                    <input type="date" class="form-control"
+                                        id="{{ input_name }}_schedule_yearly"
+                                        data-schedule-yearly
                                         aria-label="Yearly date" {% if disable_toggle %}disabled{% endif %}>
                                     <div class="form-text">Month/day are used; year is ignored.</div>
                                 </div>
                                 <div class="schedule-mode" data-schedule-mode="date">
-                                    <input type="date" class="form-control" data-schedule-date
+                                    <input type="date" class="form-control"
+                                        id="{{ input_name }}_schedule_date"
+                                        data-schedule-date
                                         aria-label="Exact date" {% if disable_toggle %}disabled{% endif %}>
                                 </div>
                                 <div class="schedule-mode" data-schedule-mode="hourly">
                                     <div class="schedule-grid">
-                                        <input type="number" class="form-control" min="0" max="23" step="1"
+                                        <input type="number" class="form-control"
+                                            id="{{ input_name }}_schedule_hour_start"
+                                            min="0" max="23" step="1"
                                             data-schedule-hour-start placeholder="Start hour" {% if disable_toggle %}disabled{% endif %}>
                                         <span class="schedule-range-sep">to</span>
-                                        <input type="number" class="form-control" min="0" max="23" step="1"
+                                        <input type="number" class="form-control"
+                                            id="{{ input_name }}_schedule_hour_end"
+                                            min="0" max="23" step="1"
                                             data-schedule-hour-end placeholder="End hour (optional)" {% if disable_toggle %}disabled{% endif %}>
                                     </div>
                                 </div>
@@ -1195,7 +1218,9 @@ prefix) %}
                             <details class="schedule-advanced mt-2">
                                 <summary>Advanced (use with caution)</summary>
                                 <div class="form-text mb-2">Only use this if you know Kometa schedule syntax.</div>
-                                <input type="text" class="form-control" data-schedule-raw
+                                <input type="text" class="form-control"
+                                    id="{{ input_name }}_schedule_raw"
+                                    data-schedule-raw
                                     value="{{ stored_val }}" {% if disable_toggle %}disabled{% endif %}>
                             </details>
                             <input type="hidden" id="{{ input_name }}" name="{{ input_name }}" value="{{ stored_val }}">

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -1553,6 +1553,7 @@ prefix) %}
                                                     {% if var_name == 'horizontal_position' %}{% set ns.position_id = template_name ~ '-' ~ var_name %}{% endif %}
                                                     {% set display_label = var_details.label or var_name.replace('_', ' ') %}
                                                     {% set display_value = selected_value %}
+                                                    {% set is_hidden_rating_anchor = overlay.id == 'overlay_ratings' and var_name in ['horizontal_offset', 'vertical_offset'] %}
                                                     {% if var_name in ['back_line_width', 'back_padding', 'back_radius', 'back_width', 'back_height'] %}
                                                         {% set min_value = 1 %}
                                                         {% set selected_num = (selected_value if selected_value is not none else var_details.default) | int %}
@@ -1562,7 +1563,7 @@ prefix) %}
                                                             {% set display_value = selected_num %}
                                                         {% endif %}
                                                     {% endif %}
-                                                    <div class="input-group mb-2">
+                                                    <div class="input-group mb-2{% if is_hidden_rating_anchor %} d-none{% endif %}">
                                                         <span class="input-group-text"
                                                             id="{{ template_name }}-{{ var_name }}_text"
                                                             style="width: 170px;">


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

This PR fixes ratings overlay offset handling so Quickstart’s libraries canvas and exported Kometa YAML stay aligned across movies, shows, and episodes, especially when the number of active ratings changes.

The main change is that ratings now use slot-aware offset generation end to end. On the libraries page, shared ratings movement is converted into ratingN_horizontal_offset and ratingN_vertical_offset using only fully configured rating slots, so moving from 3 to 2 ratings for movies/shows or 2 to 1 for episodes no longer leaves the exported YAML misaligned with the preview. On export, stale slot-specific fields are removed, active ratings are compacted into a contiguous stack, and per-slot offsets are regenerated to match the canvas layout. Schema support was also updated so the prefixed ratings offset keys validate correctly on the final page.

This PR also cleans up a few form issues on the libraries page. The generic ratings horizontal_offset and vertical_offset controls remain internal but are hidden from the visible ratings UI, while the canvas still uses them as anchors. In addition, missing id attributes were added to the relative-year builder, schedule builder controls, and the shared page search input to eliminate browser inspector warnings without changing the existing JS hooks.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #1143 

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
