### PR TITLE
library level settings added and improved import and output

### DIFF
--- a/modules/importer.py
+++ b/modules/importer.py
@@ -1119,7 +1119,10 @@ def prepare_import_payload(
                         for key, value in expanded_template_values.items():
                             if key in allowed:
                                 child_name = f"{lib_id}-template_collection_{clean_id}_{key}"
-                                libraries_data[child_name] = value
+                                if isinstance(value, list):
+                                    libraries_data[child_name] = json.dumps(value, ensure_ascii=True)
+                                else:
+                                    libraries_data[child_name] = value
                                 report.add(
                                     "imported",
                                     f"libraries.{lib_name}.collection_files[{idx}].template_variables.{key}",
@@ -1221,6 +1224,65 @@ def prepare_import_payload(
             elif overlay_files is not None:
                 report.add("unmapped", f"libraries.{lib_name}.overlay_files", "Unsupported overlay_files format.")
 
+            # Library settings
+            settings_section = lib_cfg.get("settings")
+            if isinstance(settings_section, dict):
+                imported_settings = False
+                for key, value in settings_section.items():
+                    if key == "asset_directory":
+                        if isinstance(value, list):
+                            normalized = [str(item).strip() for item in value if str(item).strip()]
+                        elif isinstance(value, str):
+                            normalized = [line.strip() for line in value.splitlines() if line.strip()]
+                        else:
+                            normalized = []
+
+                        if normalized:
+                            libraries_data[f"{lib_id}-attribute_{key}"] = normalized
+                            report.add("imported", f"libraries.{lib_name}.settings.{key}")
+                            imported_settings = True
+                        else:
+                            report.add(
+                                "unmapped",
+                                f"libraries.{lib_name}.settings.{key}",
+                                "No importable asset directory entries found.",
+                            )
+                        continue
+
+                    if key == "prioritize_assets" and not isinstance(value, (dict, list)):
+                        bool_value = None
+                        if isinstance(value, bool):
+                            bool_value = value
+                        elif isinstance(value, str):
+                            lowered = value.strip().lower()
+                            if lowered in {"true", "yes", "1"}:
+                                bool_value = True
+                            elif lowered in {"false", "no", "0"}:
+                                bool_value = False
+
+                        if bool_value is None:
+                            report.add(
+                                "unmapped",
+                                f"libraries.{lib_name}.settings.{key}",
+                                "Invalid boolean value.",
+                            )
+                        else:
+                            libraries_data[f"{lib_id}-attribute_{key}"] = bool_value
+                            report.add("imported", f"libraries.{lib_name}.settings.{key}")
+                            imported_settings = True
+                        continue
+
+                    report.add(
+                        "unmapped",
+                        f"libraries.{lib_name}.settings.{key}",
+                        "Library setting not supported for import.",
+                    )
+
+                if imported_settings:
+                    report.add("imported", f"libraries.{lib_name}.settings")
+            elif settings_section is not None:
+                report.add("unmapped", f"libraries.{lib_name}.settings", "Unsupported settings format.")
+
             # Operations
             operations = lib_cfg.get("operations")
             if isinstance(operations, dict):
@@ -1256,7 +1318,7 @@ def prepare_import_payload(
             elif operations is not None:
                 report.add("unmapped", f"libraries.{lib_name}.operations", "Unsupported operations format.")
 
-            handled_keys = {"collection_files", "overlay_files", "template_variables", "operations"}
+            handled_keys = {"collection_files", "overlay_files", "template_variables", "settings", "operations"}
             handled_keys.update(top_level_map.keys())
             for key in lib_cfg.keys():
                 if key in handled_keys:

--- a/modules/output.py
+++ b/modules/output.py
@@ -1,5 +1,6 @@
 import io
 import os
+import ast
 import json
 import re
 import shutil
@@ -135,6 +136,8 @@ def _coerce_string_list(values):
         if item is None:
             continue
         text = str(item).strip()
+        if text in {"[", "]"}:
+            continue
         if not text or text in seen:
             continue
         cleaned.append(text)
@@ -158,8 +161,54 @@ def _parse_string_list(value):
                 parsed = None
             if isinstance(parsed, list):
                 return _coerce_string_list(parsed)
+            try:
+                parsed = ast.literal_eval(stripped)
+            except Exception:
+                parsed = None
+            if isinstance(parsed, list):
+                return _coerce_string_list(parsed)
         return _coerce_string_list([stripped])
     return _coerce_string_list([value])
+
+
+def _normalize_asset_directory_entry(value):
+    if value is None:
+        return None
+
+    text = str(value).strip()
+    if not text:
+        return None
+
+    # Convert YAML-style escaped Windows paths back to plain paths while preserving UNC prefixes.
+    if re.match(r"^[A-Za-z]:\\\\", text):
+        while "\\\\" in text:
+            text = text.replace("\\\\", "\\")
+        return text
+
+    if text.startswith("\\\\"):
+        prefix = "\\\\"
+        remainder = text[2:]
+        while "\\\\" in remainder:
+            remainder = remainder.replace("\\\\", "\\")
+        return prefix + remainder
+
+    return text
+
+
+def _normalize_asset_directory_values(value):
+    normalized = []
+    if isinstance(value, str):
+        items = value.splitlines()
+    elif isinstance(value, list):
+        items = value
+    else:
+        items = []
+
+    for item in items:
+        cleaned = _normalize_asset_directory_entry(item)
+        if cleaned:
+            normalized.append(cleaned)
+    return normalized
 
 
 def _values_match(default, actual):
@@ -616,7 +665,11 @@ def build_libraries_section(
         if app.config["QS_DEBUG"]:
             helpers.ts_log(f"Processing Library: {library_key} -> {library_name}", level="DEBUG")
 
-        # Process Operations Attributes
+        # Process Library Settings and Operations Attributes
+        library_settings_fields = [
+            "asset_directory",
+            "prioritize_assets",
+        ]
         operations_fields = [
             "assets_for_all",
             "assets_for_all_collections",
@@ -628,6 +681,7 @@ def build_libraries_section(
             "radarr_add_all",
             "sonarr_add_all",
         ]
+        library_settings = {}
         operations = {}
         attr_group = attributes.get(lib_id, {})
         # Begin: Mass Genre Update Section
@@ -785,6 +839,31 @@ def build_libraries_section(
             motu_list.fa.set_block_style()
             operations["mass_original_title_update"] = motu_list
 
+        for field in library_settings_fields:
+            attr_key = f"{library_type}-library_{lib_id}-attribute_{field}"
+            value = attr_group.get(attr_key, None)
+            if value in [None, ""] and field == "asset_directory":
+                legacy_attr_key = f"{library_type}-library_{lib_id}-{field}"
+                value = attr_group.get(legacy_attr_key, None)
+
+            if field == "asset_directory":
+                normalized = _normalize_asset_directory_values(value)
+
+                if normalized:
+                    asset_dirs = CommentedSeq(normalized)
+                    asset_dirs.fa.set_block_style()
+                    library_settings[field] = asset_dirs
+                continue
+
+            if field == "prioritize_assets":
+                bool_value = _coerce_bool(value)
+                if bool_value is not None:
+                    library_settings[field] = bool_value
+                continue
+
+            if value not in [None, "", False]:
+                library_settings[field] = value
+
         for field in operations_fields:
             attr_key = f"{library_type}-library_{lib_id}-attribute_{field}"
             value = attr_group.get(attr_key, None)
@@ -828,6 +907,9 @@ def build_libraries_section(
 
         if delete_collections:
             operations["delete_collections"] = delete_collections
+
+        if library_settings:
+            entry["settings"] = library_settings
 
         if operations:
             entry["operations"] = operations
@@ -1238,6 +1320,9 @@ def build_libraries_section(
                     tv = ov.get("template_variables")
                     if not isinstance(tv, dict):
                         continue
+                    for key, value in list(tv.items()):
+                        if value is None:
+                            tv.pop(key, None)
                     if tv.get("builder_level") == "show":
                         tv.pop("builder_level", None)
                         if not tv:
@@ -1605,6 +1690,7 @@ def reorder_library_section(library_data):
     - `report_path` appears first.
     - `remove_overlays` and `reset_overlays` come next.
     - `template_variables` next.
+    - `settings` appears before `operations`.
     - Keys inside `operations` are ordered as per Kometa Wiki.
     - Other keys retain their natural order.
     """
@@ -1624,7 +1710,11 @@ def reorder_library_section(library_data):
     if "template_variables" in library_data:
         reordered_data["template_variables"] = library_data["template_variables"]
 
-    # 4. Reorder operations
+    # 4. Then library settings
+    if "settings" in library_data:
+        reordered_data["settings"] = library_data["settings"]
+
+    # 5. Reorder operations
     operations_order = [
         "assets_for_all",
         "assets_for_all_collections",
@@ -1669,7 +1759,7 @@ def reorder_library_section(library_data):
                 ordered_ops[k] = v
         reordered_data["operations"] = ordered_ops
 
-    # 5. Finally add any other keys that weren't handled
+    # 6. Finally add any other keys that weren't handled
     for key, value in library_data.items():
         if key not in reordered_data:
             reordered_data[key] = value
@@ -2146,10 +2236,10 @@ def build_config(header_style="standard", config_name=None):
         if dump_name == "settings" and "asset_directory" in cleaned_data.get("settings", {}):
             if isinstance(cleaned_data["settings"]["asset_directory"], str):
                 # Convert multi-line string into a list
-                cleaned_data["settings"]["asset_directory"] = [line.strip() for line in cleaned_data["settings"]["asset_directory"].splitlines() if line.strip()]
+                cleaned_data["settings"]["asset_directory"] = _normalize_asset_directory_values(cleaned_data["settings"]["asset_directory"])
             elif isinstance(cleaned_data["settings"]["asset_directory"], list):
                 # Ensure all list items are strings
-                cleaned_data["settings"]["asset_directory"] = [str(i).strip() for i in cleaned_data["settings"]["asset_directory"]]
+                cleaned_data["settings"]["asset_directory"] = _normalize_asset_directory_values(cleaned_data["settings"]["asset_directory"])
 
         # Dump the cleaned data to YAML
         with io.StringIO() as stream:

--- a/modules/persistence.py
+++ b/modules/persistence.py
@@ -56,8 +56,11 @@ def clean_form_data(form_data):
 
     for key, value in form_data.items():
         # Handle asset_directory as a list
-        if key == "asset_directory":
-            value_list = form_data.getlist(key)
+        if key == "asset_directory" or key.endswith("-attribute_asset_directory"):
+            if isinstance(value, list):
+                value_list = value
+            else:
+                value_list = form_data.getlist(key)
             clean_data[key] = [v.strip() for v in value_list if v.strip()]
 
         elif key.endswith("use_separator"):
@@ -73,6 +76,9 @@ def clean_form_data(form_data):
             clean_data[key] = None
 
         elif isinstance(value, str):
+            if key.endswith("template_overlay_runtimes[text]") and value == "":
+                clean_data[key] = ""
+                continue
             if url_validation.is_url_key(key):
                 raw = value.strip()
                 if raw:

--- a/static/json/quickstart_attributes.json
+++ b/static/json/quickstart_attributes.json
@@ -262,6 +262,37 @@
       "yml_location": "attribute"
     },
     {
+      "prefix": "asset_directory",
+      "type": "text_input",
+      "accordion": "library",
+      "media_types": [
+        "movie",
+        "show"
+      ],
+      "title": "Asset Directory",
+      "wiki": "https://kometa.wiki/en/nightly/kometa/guides/assets/",
+      "description": "Specify the library-level asset directory Kometa should search for posters and backgrounds in this library. Enter one path per line if you want to provide multiple asset directories.",
+      "tooltip_variant": "info",
+      "placeholder": "e.g. C:\\\\Users\\\\bullmoose20\\\\ppm\\\\assets5\\\\test_tv_lib",
+      "multiline": true,
+      "rows": 2,
+      "yml_location": "library_settings"
+    },
+    {
+      "prefix": "prioritize_assets",
+      "type": "boolean_toggle",
+      "accordion": "library",
+      "media_types": [
+        "movie",
+        "show"
+      ],
+      "title": "Prioritize Assets",
+      "wiki": "https://kometa.wiki/en/nightly/config/settings/#prioritize-assets",
+      "description": "When determining which image to use on an item in this library, prioritize the asset_directory over all other image sources.",
+      "tooltip_variant": "info",
+      "yml_location": "library_settings"
+    },
+    {
       "prefix": "assets_for_all_collections",
       "type": "boolean_toggle",
       "accordion": "library",

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -90,7 +90,7 @@ document.addEventListener('DOMContentLoaded', function () {
       if (!Array.isArray(fonts)) return
       const root = scope || document
       root.querySelectorAll('select[data-font-select]').forEach(select => {
-        const currentValue = select.value || ''
+        const currentValue = select.value || select.dataset.default || ''
         const seen = new Set()
         const merged = []
         fonts.forEach(font => {
@@ -1031,6 +1031,7 @@ document.addEventListener('DOMContentLoaded', function () {
       initStylePreviewGrids(card)
       initRelativeYearInputs(card)
       initScheduleBuilders(card)
+      initLibraryAssetDirectoryInputs(card)
       wireOffsetReset(card)
       wireRatingsOffsetSync(card)
       initSortablesInScope(card)
@@ -1099,9 +1100,73 @@ document.addEventListener('DOMContentLoaded', function () {
           return
         }
 
+        if (el.name.endsWith('-attribute_asset_directory')) {
+          if (!Array.isArray(payload[el.name])) payload[el.name] = []
+          payload[el.name].push(el.value ?? '')
+          return
+        }
+
         payload[el.name] = el.value ?? ''
       })
       return payload
+    }
+
+    function initLibraryAssetDirectoryInputs (card) {
+      card.querySelectorAll('[data-library-asset-directory-container]').forEach(container => {
+        if (container.dataset.assetDirectoryBound === 'true') return
+        container.dataset.assetDirectoryBound = 'true'
+
+        const inputName = container.dataset.inputName
+        const addBtnSelector = `[data-add-asset-directory="${container.id}"]`
+        const addBtn = card.querySelector(addBtnSelector)
+        let counter = container.querySelectorAll(`input[name="${inputName}"]`).length
+
+        const buildRow = (value = '') => {
+          counter += 1
+          const row = document.createElement('div')
+          row.className = 'input-group mb-2'
+
+          const input = document.createElement('input')
+          input.type = 'text'
+          input.className = 'form-control'
+          input.name = inputName
+          input.id = `${container.id}_${counter}`
+          input.placeholder = 'Add Asset Directory'
+          input.dataset.pathRule = 'asset_directory'
+          input.value = value
+
+          const removeBtn = document.createElement('button')
+          removeBtn.className = 'btn btn-danger library-remove-asset-directory'
+          removeBtn.type = 'button'
+          removeBtn.textContent = 'Remove'
+
+          row.append(input, removeBtn)
+          return row
+        }
+
+        if (addBtn) {
+          addBtn.addEventListener('click', () => {
+            const row = buildRow('')
+            container.appendChild(row)
+            if (typeof PathValidation !== 'undefined' && PathValidation.attach) {
+              PathValidation.attach(row)
+            }
+          })
+        }
+
+        container.addEventListener('click', event => {
+          if (!event.target.classList.contains('library-remove-asset-directory')) return
+          const fieldGroup = event.target.closest('.input-group')
+          if (!fieldGroup) return
+          let next = fieldGroup.nextElementSibling
+          while (next && next.dataset && next.dataset.pathHint) {
+            const toRemove = next
+            next = next.nextElementSibling
+            toRemove.remove()
+          }
+          container.removeChild(fieldGroup)
+        })
+      })
     }
 
     function autosaveActiveLibrary () {

--- a/static/local-js/overlayHandler.js
+++ b/static/local-js/overlayHandler.js
@@ -502,7 +502,9 @@ const OverlayHandler = {
         const el = container.querySelector(`[name="${templateName}[${key}]"]`)
         if (!el) return defaultVal
         if (el.tagName === 'SELECT') return el.value || defaultVal
-        return el.type === 'number' ? Number(el.value) || defaultVal : el.value || defaultVal
+        if (el.type === 'number') return Number(el.value) || defaultVal
+        if (key === 'text') return el.value ?? ''
+        return el.value || defaultVal
       }
       return {
         text: getVal('text', 'Runtime: '),

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -826,12 +826,14 @@ select_input.key if yml_location == "top_level" else
 {% endmacro %}
 
 {% macro text_input_section(library, data, prefix, title, description, wiki, placeholder="", tooltip_variant="info",
-container_class="border rounded p-3 mb-2", yml_location="attribute") %}
+container_class="border rounded p-3 mb-2", yml_location="attribute", multiline=false, rows=3) %}
 {% set field_prefix = "template_variables" if yml_location == "template_variables" else "" if yml_location ==
 "top_level" else "attribute" %}
 {% set full_id = library.id ~ "-" ~ (field_prefix ~ "_" if field_prefix) ~ prefix %}
 {% set full_name = library.id ~ "-" ~ (field_prefix ~ "[" ~ prefix ~ "]" if field_prefix=="template_variables" else
-prefix) %}
+field_prefix ~ "_" ~ prefix if field_prefix else prefix) %}
+{% set legacy_name = library.id ~ "-" ~ prefix %}
+{% set field_value = data.libraries.get(full_name, data.libraries.get(legacy_name, '')) %}
 <div class="{{ container_class }}">
     <div class="input-group mb-2">
         <span class="input-group-text" id="{{ full_id }}_text">
@@ -842,9 +844,56 @@ prefix) %}
                     class="bi {% if tooltip_variant == 'danger' %}bi-exclamation-circle-fill{% else %}bi-info-circle-fill{% endif %}"></i>
             </span>
         </span>
+        {% if multiline %}
+        <textarea class="form-control" id="{{ full_id }}" name="{{ full_name }}"
+            placeholder="{{ placeholder }}" rows="{{ rows }}">{{ field_value }}</textarea>
+        {% else %}
         <input type="text" class="form-control" id="{{ full_id }}" name="{{ full_name }}"
-            placeholder="{{ placeholder }}" value="{{ data.libraries.get(full_name, '') }}">
+            placeholder="{{ placeholder }}" value="{{ field_value }}">
+        {% endif %}
     </div>
+</div>
+{% endmacro %}
+
+{% macro asset_directory_list_section(library, data, prefix, title, description, wiki, placeholder="Add Asset Directory",
+tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
+{% set full_id = library.id ~ "-attribute_" ~ prefix %}
+{% set full_name = library.id ~ "-attribute_" ~ prefix %}
+{% set legacy_name = library.id ~ "-" ~ prefix %}
+{% set raw_value = data.libraries.get(full_name, data.libraries.get(legacy_name, [])) %}
+{% if raw_value is string %}
+{% set field_values = [raw_value] if raw_value.strip() else [] %}
+{% elif raw_value is sequence and raw_value is not string %}
+{% set field_values = raw_value %}
+{% else %}
+{% set field_values = [] %}
+{% endif %}
+<div class="{{ container_class }}">
+    <label class="form-label d-flex align-items-center gap-2 flex-wrap" for="{{ full_id }}_1">
+        <a href="{{ wiki }}" target="_blank" rel="noopener noreferrer">{{ title }}</a>
+        <span class="text-{{ tooltip_variant }}" data-bs-toggle="tooltip" data-bs-html="true" title="{{ description }}">
+            <i class="bi {% if tooltip_variant == 'danger' %}bi-exclamation-circle-fill{% else %}bi-info-circle-fill{% endif %}"></i>
+        </span>
+        <a href="{{ wiki }}" target="_blank" rel="noopener noreferrer" class="text-decoration-none" data-bs-toggle="tooltip"
+            title="Open Kometa Asset Guide">
+            <i class="bi bi-box-arrow-up-right"></i>
+        </a>
+    </label>
+    <div id="{{ full_id }}_container" data-library-asset-directory-container data-input-name="{{ full_name }}">
+        {% for directory in field_values %}
+        <div class="input-group mb-2">
+            <input type="text" class="form-control" name="{{ full_name }}" id="{{ full_id }}_{{ loop.index }}"
+                data-path-rule="asset_directory" placeholder="{{ placeholder }}" value="{{ directory }}">
+            <button class="btn btn-danger library-remove-asset-directory" type="button">Remove</button>
+        </div>
+        {% endfor %}
+        <div class="input-group mb-2">
+            <input type="text" class="form-control" name="{{ full_name }}" id="{{ full_id }}_blank"
+                data-path-rule="asset_directory" placeholder="{{ placeholder }}">
+            <button class="btn btn-danger library-remove-asset-directory" type="button">Remove</button>
+        </div>
+    </div>
+    <button class="btn btn-primary" data-add-asset-directory="{{ full_id }}_container" type="button">Add Directory</button>
 </div>
 {% endmacro %}
 
@@ -1668,6 +1717,7 @@ prefix) %}
                                                         </div>
                                                     </div>
                                                     {% elif var_name == 'font' or var_name.endswith('_font') %}
+                                                    {% set safe_font_value = var_details.default if selected_value in [none, 'None', ''] else selected_value %}
                                                     <div class="font-row mb-2">
                                                         <div class="input-group font-input-group">
                                                             <span class="input-group-text"
@@ -1678,7 +1728,7 @@ prefix) %}
                                                             {% set fonts_list = overlay_fonts if overlay_fonts else ['Inter-Regular.ttf', 'Inter-Medium.ttf', 'Roboto-Regular.ttf'] %}
                                                             <button type="button" class="btn btn-outline-secondary font-picker-trigger"
                                                                 data-font-picker-target="{{ input_id }}">
-                                                                {{ selected_value if selected_value else 'Select font' }}
+                                                                {{ safe_font_value if safe_font_value else 'Select font' }}
                                                             </button>
                                                             <select class="form-select template-variable-text d-none"
                                                                 id="{{ input_id }}"
@@ -1686,9 +1736,9 @@ prefix) %}
                                                                 aria-describedby="{{ input_id }}_text"
                                                                 data-default="{{ var_details.default }}"
                                                                 data-font-select>
-                                                              <option value="" {% if selected_value=='' %}selected{% endif %}>Select font</option>
+                                                              <option value="" {% if safe_font_value=='' %}selected{% endif %}>Select font</option>
                                                               {% for fnt in fonts_list %}
-                                                              <option value="{{ fnt }}" {% if selected_value==fnt %}selected{% endif %}>{{ fnt }}</option>
+                                                              <option value="{{ fnt }}" {% if safe_font_value==fnt %}selected{% endif %}>{{ fnt }}</option>
                                                               {% endfor %}
                                                             </select>
                                                         </div>
@@ -1696,6 +1746,7 @@ prefix) %}
                                                             data-font-preview data-preview-for="{{ input_id }}">AaBb123</span>
                                                     </div>
                                                           {% else %}
+                                                    {% set safe_text_value = '' if selected_value in [none, 'None'] else selected_value %}
                                                     <div class="input-group mb-2">
                                                         <span class="input-group-text"
                                                             id="{{ input_id }}_text"
@@ -1706,7 +1757,7 @@ prefix) %}
                                                             id="{{ input_id }}"
                                                             name="{{ template_name }}[{{ var_name }}]"
                                                             aria-describedby="{{ input_id }}_text"
-                                                            value="{{ selected_value }}"
+                                                            value="{{ safe_text_value }}"
                                                             data-default="{{ var_details.default }}"
                                                             {% if var_name == 'text' and overlay.id in ['overlay_aspect', 'overlay_video_format'] %}data-skip-yaml="true"{% endif %}>
                                                     </div>

--- a/templates/partials/_movie_attributes.html
+++ b/templates/partials/_movie_attributes.html
@@ -197,6 +197,34 @@
         yml_location=section.yml_location
         ) }}
 
+        {% elif section.type == 'text_input' and section.prefix == 'asset_directory' %}
+        {{ macros.asset_directory_list_section(
+        library,
+        data,
+        section.prefix,
+        section.title,
+        section.description,
+        section.wiki,
+        section.placeholder | default('Add Asset Directory'),
+        section.tooltip_variant | default('info')
+        ) }}
+
+        {% elif section.type == 'text_input' %}
+        {{ macros.text_input_section(
+        library,
+        data,
+        section.prefix,
+        section.title,
+        section.description,
+        section.wiki,
+        tooltip_variant=section.tooltip_variant,
+        container_class=section.container_class,
+        yml_location=section.yml_location,
+        placeholder=section.placeholder,
+        multiline=section.multiline | default(false),
+        rows=section.rows | default(3)
+        ) }}
+
         {% elif section.type == "mapping_list" %}
         {{ macros.mapping_list_section(library, data, section) }}
 
@@ -234,6 +262,17 @@
               container_class=section.container_class,
               yml_location=section.yml_location
             ) }}
+          {% elif section.type == 'text_input' and section.prefix == 'asset_directory' %}
+            {{ macros.asset_directory_list_section(
+              library,
+              data,
+              section.prefix,
+              section.title,
+              section.description,
+              section.wiki,
+              section.placeholder | default('Add Asset Directory'),
+              section.tooltip_variant | default('info')
+            ) }}
           {% elif section.type == 'text_input' %}
             {{ macros.text_input_section(
               library,
@@ -245,7 +284,9 @@
               tooltip_variant=section.tooltip_variant,
               container_class=section.container_class,
               yml_location=section.yml_location,
-              placeholder=section.placeholder
+              placeholder=section.placeholder,
+              multiline=section.multiline | default(false),
+              rows=section.rows | default(3)
             ) }}
           {% endif %}
         {% endfor %}

--- a/templates/partials/_show_attributes.html
+++ b/templates/partials/_show_attributes.html
@@ -197,6 +197,34 @@
         yml_location=section.yml_location
         ) }}
 
+        {% elif section.type == 'text_input' and section.prefix == 'asset_directory' %}
+        {{ macros.asset_directory_list_section(
+        library,
+        data,
+        section.prefix,
+        section.title,
+        section.description,
+        section.wiki,
+        section.placeholder | default('Add Asset Directory'),
+        section.tooltip_variant | default('info')
+        ) }}
+
+        {% elif section.type == 'text_input' %}
+        {{ macros.text_input_section(
+        library,
+        data,
+        section.prefix,
+        section.title,
+        section.description,
+        section.wiki,
+        tooltip_variant=section.tooltip_variant,
+        container_class=section.container_class,
+        yml_location=section.yml_location,
+        placeholder=section.placeholder,
+        multiline=section.multiline | default(false),
+        rows=section.rows | default(3)
+        ) }}
+
         {% elif section.type == "mapping_list" %}
         {{ macros.mapping_list_section(library, data, section) }}
 
@@ -234,6 +262,17 @@
               container_class=section.container_class,
               yml_location=section.yml_location
             ) }}
+          {% elif section.type == 'text_input' and section.prefix == 'asset_directory' %}
+            {{ macros.asset_directory_list_section(
+              library,
+              data,
+              section.prefix,
+              section.title,
+              section.description,
+              section.wiki,
+              section.placeholder | default('Add Asset Directory'),
+              section.tooltip_variant | default('info')
+            ) }}
           {% elif section.type == 'text_input' %}
             {{ macros.text_input_section(
               library,
@@ -245,7 +284,9 @@
               tooltip_variant=section.tooltip_variant,
               container_class=section.container_class,
               yml_location=section.yml_location,
-              placeholder=section.placeholder
+              placeholder=section.placeholder,
+              multiline=section.multiline | default(false),
+              rows=section.rows | default(3)
             ) }}
           {% endif %}
         {% endfor %}


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

This branch fixes import fidelity issues on the libraries page so a clean imported config stays clean after you open 025-libraries and return to final validation.

The first fix addresses overlay font defaults. Some imported overlays, such as status, can omit font and rely on Kometa defaults. After visiting the libraries page, Quickstart was rehydrating that missing value as None, which then got saved back out as font: None and failed schema validation. The libraries font picker now falls back to the overlay default when the imported value is missing, and final YAML generation also drops any lingering None template-variable values before export.

The second fix addresses collection string_list imports, specifically cases like producer/writer exclude. Those list values were being flattened incorrectly during import, which could degrade valid YAML like an exclude list of names into junk such as - '[' on export. Collection template-variable lists are now imported in a stable serialized form, and the exporter’s string-list parser was hardened to recover older malformed values more safely.



## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
