### PR TITLE
some updates

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -418,11 +418,77 @@ def _prune_template_variables(template_vars, defaults):
 
 
 def optimize_template_variables(config_data, library_types=None):
+    def _to_offset_number(value, fallback):
+        if isinstance(value, bool):
+            return fallback
+        if isinstance(value, (int, float)):
+            return value
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return fallback
+            try:
+                return int(stripped)
+            except ValueError:
+                try:
+                    return float(stripped)
+                except ValueError:
+                    return fallback
+        return fallback
+
+    def _is_ratings_entry(default_name):
+        return isinstance(default_name, str) and (
+            default_name == "ratings" or default_name.startswith("overlay_ratings")
+        )
+
+    def _ensure_explicit_ratings_offsets(tv, defaults):
+        if not isinstance(tv, dict):
+            return
+        slot_ids = []
+        for idx in ("1", "2", "3"):
+            rating_key = f"rating{idx}"
+            image_key = f"{rating_key}_image"
+            if rating_key in tv and image_key in tv:
+                slot_ids.append(idx)
+        if not slot_ids:
+            return
+
+        defaults = defaults or {}
+        back_height = _to_offset_number(tv.get("back_height", defaults.get("back_height")), 160)
+        back_padding = max(0, _to_offset_number(tv.get("back_padding", defaults.get("back_padding")), 15))
+        vertical_step = back_height + back_padding
+        center_index = (len(slot_ids) - 1) / 2
+
+        shared_horizontal = tv.get("horizontal_offset", defaults.get("horizontal_offset", 15))
+        shared_vertical = tv.get("vertical_offset", defaults.get("vertical_offset", 0))
+        shared_horizontal_num = _to_offset_number(shared_horizontal, 15)
+        shared_vertical_num = _to_offset_number(shared_vertical, 0)
+
+        explicit_verticals = []
+        all_explicit_verticals_present = True
+        for idx in slot_ids:
+            key = f"rating{idx}_vertical_offset"
+            if key not in tv:
+                all_explicit_verticals_present = False
+                break
+            explicit_verticals.append(_to_offset_number(tv.get(key), None))
+        if any(value is None for value in explicit_verticals):
+            all_explicit_verticals_present = False
+
+        for slot_position, idx in enumerate(slot_ids):
+            h_key = f"rating{idx}_horizontal_offset"
+            v_key = f"rating{idx}_vertical_offset"
+            if h_key not in tv:
+                tv[h_key] = int(round(shared_horizontal_num))
+            if v_key not in tv or not all_explicit_verticals_present:
+                relative_index = slot_position - center_index
+                tv[v_key] = int(round(shared_vertical_num + (vertical_step * relative_index)))
+
     def _reorder_ratings_template_vars(entry):
         if not isinstance(entry, dict):
             return
         default_name = entry.get("default", "")
-        if not (isinstance(default_name, str) and (default_name == "ratings" or default_name.startswith("overlay_ratings"))):
+        if not _is_ratings_entry(default_name):
             return
         tv = entry.get("template_variables")
         if not isinstance(tv, dict) or not tv:
@@ -554,18 +620,27 @@ def optimize_template_variables(config_data, library_types=None):
                     if offsets:
                         defaults.update(offsets)
 
+                if _is_ratings_entry(entry.get("default")):
+                    _ensure_explicit_ratings_offsets(tv, defaults)
+
                 pruned = _prune_template_variables(tv, defaults)
                 always_keep = set()
-                if entry.get("default") in {"ratings", "overlay_ratings"}:
+                if _is_ratings_entry(entry.get("default")):
                     always_keep.update(
                         {
                             "builder_level",
                             "rating1",
                             "rating1_image",
+                            "rating1_horizontal_offset",
+                            "rating1_vertical_offset",
                             "rating2",
                             "rating2_image",
+                            "rating2_horizontal_offset",
+                            "rating2_vertical_offset",
                             "rating3",
                             "rating3_image",
+                            "rating3_horizontal_offset",
+                            "rating3_vertical_offset",
                             "horizontal_position",
                         }
                     )

--- a/modules/output.py
+++ b/modules/output.py
@@ -437,9 +437,7 @@ def optimize_template_variables(config_data, library_types=None):
         return fallback
 
     def _is_ratings_entry(default_name):
-        return isinstance(default_name, str) and (
-            default_name == "ratings" or default_name.startswith("overlay_ratings")
-        )
+        return isinstance(default_name, str) and (default_name == "ratings" or default_name.startswith("overlay_ratings"))
 
     def _ensure_explicit_ratings_offsets(tv, defaults):
         if not isinstance(tv, dict):

--- a/modules/output.py
+++ b/modules/output.py
@@ -456,12 +456,12 @@ def optimize_template_variables(config_data, library_types=None):
         defaults = defaults or {}
         back_height = _to_offset_number(tv.get("back_height", defaults.get("back_height")), 160)
         back_padding = max(0, _to_offset_number(tv.get("back_padding", defaults.get("back_padding")), 15))
-        vertical_step = back_height + back_padding
+        vertical_step = back_height + (back_padding * 3)
         center_index = (len(slot_ids) - 1) / 2
 
         shared_horizontal = tv.get("horizontal_offset", defaults.get("horizontal_offset", 15))
         shared_vertical = tv.get("vertical_offset", defaults.get("vertical_offset", 0))
-        shared_horizontal_num = _to_offset_number(shared_horizontal, 15)
+        shared_horizontal_num = _to_offset_number(shared_horizontal, 15) + back_padding
         shared_vertical_num = _to_offset_number(shared_vertical, 0)
 
         explicit_verticals = []
@@ -475,6 +475,19 @@ def optimize_template_variables(config_data, library_types=None):
         if any(value is None for value in explicit_verticals):
             all_explicit_verticals_present = False
 
+        explicit_horizontals = []
+        all_explicit_horizontals_present = True
+        for idx in slot_ids:
+            key = f"rating{idx}_horizontal_offset"
+            if key not in tv:
+                all_explicit_horizontals_present = False
+                break
+            explicit_horizontals.append(_to_offset_number(tv.get(key), None))
+        if any(value is None for value in explicit_horizontals):
+            all_explicit_horizontals_present = False
+
+        old_vertical_step = back_height + back_padding
+
         for slot_position, idx in enumerate(slot_ids):
             h_key = f"rating{idx}_horizontal_offset"
             v_key = f"rating{idx}_vertical_offset"
@@ -483,6 +496,26 @@ def optimize_template_variables(config_data, library_types=None):
             if v_key not in tv or not all_explicit_verticals_present:
                 relative_index = slot_position - center_index
                 tv[v_key] = int(round(shared_vertical_num + (vertical_step * relative_index)))
+
+        if all_explicit_horizontals_present and explicit_horizontals and len(set(explicit_horizontals)) == 1:
+            explicit_horizontal = explicit_horizontals[0]
+            legacy_horizontal = _to_offset_number(shared_horizontal, 15)
+            if explicit_horizontal == legacy_horizontal:
+                for idx in slot_ids:
+                    tv[f"rating{idx}_horizontal_offset"] = int(round(shared_horizontal_num))
+
+        if all_explicit_verticals_present and explicit_verticals:
+            legacy_matches = True
+            for slot_position, explicit_vertical in enumerate(explicit_verticals):
+                relative_index = slot_position - center_index
+                expected_legacy = int(round(shared_vertical_num + (old_vertical_step * relative_index)))
+                if explicit_vertical != expected_legacy:
+                    legacy_matches = False
+                    break
+            if legacy_matches:
+                for slot_position, idx in enumerate(slot_ids):
+                    relative_index = slot_position - center_index
+                    tv[f"rating{idx}_vertical_offset"] = int(round(shared_vertical_num + (vertical_step * relative_index)))
 
     def _reorder_ratings_template_vars(entry):
         if not isinstance(entry, dict):
@@ -1152,22 +1185,22 @@ def build_libraries_section(
                         slot_payloads.append(slot_payload)
 
                 back_height = _offset_number(cleaned.get("back_height"), 160)
-                back_padding = _offset_number(cleaned.get("back_padding"), 15)
-                gap = max(0, back_padding)
-                vertical_step = back_height + gap
+                back_padding = max(0, _offset_number(cleaned.get("back_padding"), 15))
+                vertical_step = back_height + (back_padding * 3)
                 center_index = (len(slot_payloads) - 1) / 2 if slot_payloads else 0
+                shared_horizontal_base = _offset_number(cleaned.get("horizontal_offset"), 15)
+                shared_vertical_base = _offset_number(cleaned.get("vertical_offset"), 0)
                 for axis in ["horizontal", "vertical"]:
                     shared_key = f"{axis}_offset"
-                    if shared_key not in cleaned:
-                        continue
-                    shared_val = cleaned.get(shared_key)
-                    shared_number = _offset_number(shared_val, 0)
+                    axis_default = 15 if axis == "horizontal" else 0
+                    shared_val = cleaned.get(shared_key, axis_default)
+                    shared_number = _offset_number(shared_val, axis_default)
                     for slot_position, slot_payload in enumerate(slot_payloads):
                         slot_key = f"_{axis}_offset"
                         if slot_key in slot_payload:
                             continue
                         if axis == "horizontal":
-                            slot_payload[slot_key] = shared_val
+                            slot_payload[slot_key] = int(round(shared_number + back_padding))
                         else:
                             relative_index = slot_position - center_index
                             slot_payload[slot_key] = int(round(shared_number + (vertical_step * relative_index)))
@@ -1177,12 +1210,34 @@ def build_libraries_section(
                 # still represent a single shared anchor from Quickstart's composite preview.
                 # Re-expand them to match the preview stack used on the canvas.
                 vertical_values = [_offset_number(slot_payload.get("_vertical_offset"), None) for slot_payload in slot_payloads]
+                horizontal_values = [_offset_number(slot_payload.get("_horizontal_offset"), None) for slot_payload in slot_payloads]
                 if len(slot_payloads) > 1 and all(value is not None for value in vertical_values):
                     if len(set(vertical_values)) == 1:
                         base_vertical = vertical_values[0]
                         for slot_position, slot_payload in enumerate(slot_payloads):
                             relative_index = slot_position - center_index
                             slot_payload["_vertical_offset"] = int(round(base_vertical + (vertical_step * relative_index)))
+
+                if slot_payloads and all(value is not None for value in horizontal_values):
+                    if len(set(horizontal_values)) == 1:
+                        base_horizontal = horizontal_values[0]
+                        if base_horizontal == shared_horizontal_base:
+                            for slot_payload in slot_payloads:
+                                slot_payload["_horizontal_offset"] = int(round(base_horizontal + back_padding))
+
+                if len(slot_payloads) > 1 and all(value is not None for value in vertical_values):
+                    old_vertical_step = back_height + back_padding
+                    legacy_matches = True
+                    for slot_position, explicit_vertical in enumerate(vertical_values):
+                        relative_index = slot_position - center_index
+                        expected_legacy = int(round(shared_vertical_base + (old_vertical_step * relative_index)))
+                        if explicit_vertical != expected_legacy:
+                            legacy_matches = False
+                            break
+                    if legacy_matches:
+                        for slot_position, slot_payload in enumerate(slot_payloads):
+                            relative_index = slot_position - center_index
+                            slot_payload["_vertical_offset"] = int(round(shared_vertical_base + (vertical_step * relative_index)))
 
                 for slot_position, slot_payload in enumerate(slot_payloads, start=1):
                     rating_key = f"rating{slot_position}"

--- a/quickstart.py
+++ b/quickstart.py
@@ -4771,6 +4771,7 @@ def tail_log():
                 return cached.get("stats")
 
             counts = {
+                "total_lines": 0,
                 "cache": 0,
                 "debug": 0,
                 "info": 0,
@@ -4782,6 +4783,7 @@ def tail_log():
             try:
                 with path.open("r", encoding="utf-8", errors="replace") as handle:
                     for line in handle:
+                        counts["total_lines"] += 1
                         upper = line.upper()
                         if "FROM CACHE" in upper:
                             counts["cache"] += 1

--- a/static/json/quickstart_overlays.json
+++ b/static/json/quickstart_overlays.json
@@ -1859,6 +1859,18 @@
             "default": 30
           },
           {
+            "input_type": "number",
+            "key": "horizontal_offset",
+            "label": "Horizontal Offset",
+            "default": 0
+          },
+          {
+            "input_type": "number",
+            "key": "vertical_offset",
+            "label": "Vertical Offset",
+            "default": 150
+          },
+          {
             "type": "toggle",
             "key": "builder_level",
             "label": "Apply to Show",
@@ -2008,6 +2020,18 @@
             "key": "back_radius",
             "label": "Backdrop Radius",
             "default": 30
+          },
+          {
+            "input_type": "number",
+            "key": "horizontal_offset",
+            "label": "Horizontal Offset",
+            "default": 0
+          },
+          {
+            "input_type": "number",
+            "key": "vertical_offset",
+            "label": "Vertical Offset",
+            "default": 150
           },
           {
             "type": "toggle",

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -1923,6 +1923,19 @@ function wireOffsetReset (scope) {
       if (group) {
         delete group.dataset.resetting
         if (changes.length) {
+          if (isRatingsOverlay) {
+            if (hInput) {
+              hInput.dispatchEvent(new Event('input', { bubbles: true }))
+              hInput.dispatchEvent(new Event('change', { bubbles: true }))
+            }
+            if (vInput) {
+              vInput.dispatchEvent(new Event('input', { bubbles: true }))
+              vInput.dispatchEvent(new Event('change', { bubbles: true }))
+            }
+            if (pInput) {
+              pInput.dispatchEvent(new Event('change', { bubbles: true }))
+            }
+          }
           const trigger = group.querySelector('input:not([disabled]), select:not([disabled]), textarea:not([disabled])')
           if (trigger) {
             trigger.dispatchEvent(new Event('change', { bubbles: true }))
@@ -2097,6 +2110,7 @@ function wireRatingsOffsetSync (scope) {
       backHeight: group.querySelector(`[name="${templateName}[back_height]"]`),
       backPadding: group.querySelector(`[name="${templateName}[back_padding]"]`)
     }
+    const positionInput = group.querySelector(`[name="${templateName}[horizontal_position]"]`)
     const slotDefs = ['rating1', 'rating2', 'rating3'].map(slot => ({
       slot,
       ratingInput: group.querySelector(`[name="${templateName}[${slot}]"]`),
@@ -2121,10 +2135,14 @@ function wireRatingsOffsetSync (scope) {
     }
     const isConfiguredSlot = (slot) => hasMeaningfulValue(slot.ratingInput) && hasMeaningfulValue(slot.imageInput)
     const getActiveSlots = () => slotDefs.filter(isConfiguredSlot)
+    const getBackPadding = () => Math.max(0, toNumber(metricInputs.backPadding?.value, 15))
     const getVerticalStep = () => {
       const backHeight = toNumber(metricInputs.backHeight?.value, 160)
-      const backPadding = Math.max(0, toNumber(metricInputs.backPadding?.value, 15))
-      return backHeight + backPadding
+      const backPadding = getBackPadding()
+      return backHeight + (backPadding * 3)
+    }
+    const getHorizontalSlotOffset = (sharedValue) => {
+      return toNumber(sharedValue, 15) + getBackPadding()
     }
     const updateInputValue = (input, nextValue) => {
       if (!input) return
@@ -2168,8 +2186,11 @@ function wireRatingsOffsetSync (scope) {
         inputs.reduce((sum, input) => sum + toNumber(input.value, toNumber(input.dataset.default, 0)), 0) / inputs.length
       )
       withSyncGuard(() => {
-        sharedInput.value = String(average)
-        sharedInput.dataset.prevValue = String(average)
+        const sharedValue = axis === 'horizontal'
+          ? average - getBackPadding()
+          : average
+        sharedInput.value = String(sharedValue)
+        sharedInput.dataset.prevValue = String(sharedValue)
         sharedInput.dispatchEvent(new Event('input', { bubbles: true }))
         sharedInput.dispatchEvent(new Event('change', { bubbles: true }))
       })
@@ -2187,7 +2208,8 @@ function wireRatingsOffsetSync (scope) {
       sharedInput.dataset.prevValue = String(current)
       withSyncGuard(() => {
         if (axis === 'horizontal') {
-          activeSlots.forEach(slot => updateInputValue(slot.horizontalInput, current))
+          const slotOffset = getHorizontalSlotOffset(current)
+          activeSlots.forEach(slot => updateInputValue(slot.horizontalInput, slotOffset))
           return
         }
         const verticalStep = getVerticalStep()
@@ -2201,8 +2223,8 @@ function wireRatingsOffsetSync (scope) {
     const seedSharedFromSlots = () => {
       const sharedAtDefaults = Object.values(sharedInputs).every(input => !valuesDiffer(input))
       if (!hasExplicitSlotOffsets() || !sharedAtDefaults) return
-      syncSharedFromSlots('horizontal')
-      syncSharedFromSlots('vertical')
+      if (hasExplicitSlotOffsets('horizontal')) syncSharedFromSlots('horizontal')
+      if (hasExplicitSlotOffsets('vertical')) syncSharedFromSlots('vertical')
     }
 
     seedSharedFromSlots()
@@ -2213,6 +2235,16 @@ function wireRatingsOffsetSync (scope) {
       input.addEventListener('input', syncFromShared)
       input.addEventListener('change', syncFromShared)
     })
+
+    if (positionInput && positionInput.dataset.ratingsPositionBound !== 'true') {
+      const refreshFromPosition = () => {
+        if (group.dataset.resetting === 'true') return
+        sharedInputs.horizontal?.dispatchEvent(new Event('change', { bubbles: true }))
+        sharedInputs.vertical?.dispatchEvent(new Event('change', { bubbles: true }))
+      }
+      positionInput.addEventListener('change', refreshFromPosition)
+      positionInput.dataset.ratingsPositionBound = 'true'
+    }
 
     Object.entries(slotInputs).forEach(([axis, inputs]) => {
       inputs.forEach(input => {

--- a/static/local-js/900-final.js
+++ b/static/local-js/900-final.js
@@ -1269,6 +1269,10 @@ $(document).ready(function () {
     }
     const ageText = formatRunSeconds(data.log_age_seconds) || 'n/a'
     let logText = `meta.log updated ${ageText} ago`
+    const totalLines = data?.stats?.total_lines ?? lastLogStatsTotal?.total_lines
+    if (typeof totalLines === 'number' && Number.isFinite(totalLines)) {
+      logText += ` • ${totalLines.toLocaleString()} lines`
+    }
     if (data.log_is_stale && KOMETA_STATUS === 'running') {
       logText += ' • waiting for new meta.log entries from this run'
       $runStatusLog.addClass('text-warning').removeClass('text-muted')

--- a/static/local-js/overlayHandler.js
+++ b/static/local-js/overlayHandler.js
@@ -1733,8 +1733,13 @@ const OverlayHandler = {
       const strokeColor = getTemplateValue(cfg, styleSlot.strokeColorKey, '#00000000')
       const text = sample.text || 'NR'
       const vars = getBackdropVars(cfg)
-      const boxWidth = Math.max(1, Number(vars.back_width) || 160)
-      const boxHeight = Math.max(1, Number(vars.back_height) || 160)
+      const contentWidth = Math.max(1, Number(vars.back_width) || 160)
+      const contentHeight = Math.max(1, Number(vars.back_height) || 160)
+      const innerPad = Number.isFinite(Number(vars.back_padding))
+        ? Math.max(0, Number(vars.back_padding))
+        : Math.round(contentHeight * 0.08)
+      const boxWidth = contentWidth + (innerPad * 2)
+      const boxHeight = contentHeight + (innerPad * 2)
       const canvas = document.createElement('canvas')
       canvas.width = Math.ceil(boxWidth)
       canvas.height = Math.ceil(boxHeight)
@@ -1744,9 +1749,6 @@ const OverlayHandler = {
       const stroke = parseHexColor(vars.back_line_color, { r: 0, g: 0, b: 0, a: 0 })
       const lineWidth = Math.max(0, Number(vars.back_line_width) || 0)
       const radius = Math.max(0, Number(vars.back_radius) || 0)
-      const innerPad = Number.isFinite(Number(vars.back_padding))
-        ? Math.max(0, Number(vars.back_padding))
-        : Math.round(boxHeight * 0.08)
 
       drawRoundedRect(ctx, 0, 0, boxWidth, boxHeight, radius)
       if (fill.a > 0) {
@@ -2167,11 +2169,14 @@ const OverlayHandler = {
       }
 
       const vars = getBackdropVars(cfg)
-      const boxWidth = Math.max(1, Number(vars.back_width) || 160)
-      const boxHeight = Math.max(1, Number(vars.back_height) || 160)
-      const gap = Number.isFinite(Number(vars.back_padding))
+      const contentWidth = Math.max(1, Number(vars.back_width) || 160)
+      const contentHeight = Math.max(1, Number(vars.back_height) || 160)
+      const innerPad = Number.isFinite(Number(vars.back_padding))
         ? Math.max(0, Number(vars.back_padding))
-        : 15
+        : Math.round(contentHeight * 0.08)
+      const boxWidth = contentWidth + (innerPad * 2)
+      const boxHeight = contentHeight + (innerPad * 2)
+      const gap = innerPad
       const canvas = document.createElement('canvas')
       canvas.width = Math.ceil(boxWidth)
       canvas.height = Math.ceil((boxHeight * items.length) + (gap * Math.max(0, items.length - 1)))
@@ -2182,9 +2187,6 @@ const OverlayHandler = {
       const stroke = parseHexColor(vars.back_line_color, { r: 0, g: 0, b: 0, a: 0 })
       const lineWidth = Math.max(0, Number(vars.back_line_width) || 0)
       const radius = Math.max(0, Number(vars.back_radius) || 0)
-      const innerPad = Number.isFinite(Number(vars.back_padding))
-        ? Math.max(0, Number(vars.back_padding))
-        : Math.round(boxHeight * 0.08)
 
       ctx.textAlign = 'center'
       ctx.textBaseline = 'alphabetic'
@@ -2795,7 +2797,12 @@ const OverlayHandler = {
       }
 
       const getActiveLayer = () => boardState.activeLayer || boardState.selectedLayers.values().next().value || null
-      const getJumpTargetId = (overlayId) => (overlayId ? `${libId}-${overlayType}-${overlayId}-overlay-config` : '')
+      const getJumpTargetId = (overlayId) => {
+        if (!overlayId) return ''
+        const cfg = configsById.get(overlayId)
+        if (cfg?.container?.id) return cfg.container.id
+        return `${libId}-${overlayType}-${overlayId}-overlay-config`
+      }
 
       const updateJumpButton = () => {
         if (!jumpToSettingsBtn) return
@@ -3288,6 +3295,8 @@ const OverlayHandler = {
         return { hInput, vInput }
       }
 
+      const getInstanceId = (cfg) => cfg?.instanceId || cfg?.id
+
       const applyVisibility = (cfg, layer) => {
         const toggle = cfg.toggle
         const visible = !toggle || toggle.checked
@@ -3559,7 +3568,7 @@ const OverlayHandler = {
       }
 
       const applyPosition = (cfg) => {
-        const layer = layers.get(cfg.id)
+        const layer = layers.get(getInstanceId(cfg))
         if (!layer) return
         const { hInput, vInput } = getInputs(cfg)
         if (!hInput || !vInput) return
@@ -3603,7 +3612,7 @@ const OverlayHandler = {
 
       const applyEditionPosition = (cfg) => {
         if (!cfg.edition || !cfg.edition.layer) return
-        const baseLayer = layers.get(cfg.id)
+        const baseLayer = layers.get(getInstanceId(cfg))
         if (!baseLayer) return
 
         const { hInput, vInput } = getInputs(cfg)
@@ -3845,12 +3854,14 @@ const OverlayHandler = {
       }
 
       const addOverlayLayer = (cfg) => {
-        if (layers.has(cfg.id)) return layers.get(cfg.id)
+        const instanceId = getInstanceId(cfg)
+        if (layers.has(instanceId)) return layers.get(instanceId)
         const layer = document.createElement('img')
         layer.className = 'overlay-board-layer'
-        layer.alt = cfg.id
-        layer.dataset.overlayId = cfg.id
-        layers.set(cfg.id, layer)
+        layer.alt = instanceId
+        layer.dataset.overlayId = instanceId
+        layer.dataset.overlayType = cfg.id
+        layers.set(instanceId, layer)
         canvas.appendChild(layer)
 
         const handleLoad = () => {
@@ -4049,6 +4060,7 @@ const OverlayHandler = {
       overlayContainers.forEach(container => {
         const cfg = {
           id: container.dataset.overlayId,
+          instanceId: container.dataset.overlayTemplate || container.dataset.overlayId,
           image: container.dataset.overlayImage,
           hId: container.dataset.horizontalId,
           vId: container.dataset.verticalId,
@@ -4074,7 +4086,7 @@ const OverlayHandler = {
             ? container.querySelector(`input[name="${templateName}[use_edition]"]`)
             : null
           cfg.edition = {
-            id: `${cfg.id}__edition`,
+            id: `${cfg.instanceId}__edition`,
             image: editionImage,
             toggle: editionToggle,
             naturalWidth: null,
@@ -4087,7 +4099,7 @@ const OverlayHandler = {
         syncResolutionBackdropHeight(cfg, false)
         syncResolutionEditionVisibility(cfg, false)
         configs.push(cfg)
-        configsById.set(cfg.id, cfg)
+        configsById.set(cfg.instanceId, cfg)
         const layer = addOverlayLayer(cfg)
 
         if (cfg.id === 'overlay_runtimes' && layer) {
@@ -4570,8 +4582,9 @@ const OverlayHandler = {
         openAccordionAncestors(target)
         window.setTimeout(() => {
           target.scrollIntoView({ behavior: 'smooth', block: 'center' })
-          const overlayId = button.dataset.overlayId
-          const overlayToggle = button.closest('.template-toggle-group')?.querySelector('.overlay-toggle')
+          const overlayGroup = button.closest('.template-toggle-group')
+          const overlayId = overlayGroup?.dataset?.overlayTemplate || button.dataset.overlayId
+          const overlayToggle = overlayGroup?.querySelector('.overlay-toggle')
           if (overlayId && overlayToggle) {
             if (!overlayToggle.checked) {
               overlayToggle.checked = true


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

This branch fixes overlay-board instance collisions on the libraries page, with the main impact being correct behavior for show libraries that have separate show-, season-, and episode-level overlays of the same type.

Previously, the libraries canvas keyed overlays by shared base ids such as overlay_ratings, overlay_aspect, and similar defaults. On show libraries, that meant multiple overlay instances could overwrite each other in the board state, because the show, season, and episode variants all reused the same base overlay id. This branch changes the canvas to track overlays by a unique per-instance key derived from the overlay template name, while preserving the base overlay id for type-specific behavior. That fixes incorrect selection/highlighting, reset behavior, and board updates for duplicated overlay types on the same page.

The branch also fixes the canvas/settings jump behavior after that instance-id change. The canvas “jump to settings” action now resolves the actual settings container id from the selected overlay config rather than reconstructing it from the shared overlay id, which restores correct scrolling to the intended settings block.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
