### PR TITLE
Show resouktion bug

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -1467,7 +1467,7 @@ def build_libraries_section(
                             tv["use_edition"] = False
                             use_edition_val = False
                         if use_edition_val is True:
-                            keep_keys = {"use_edition", "horizontal_offset", "vertical_offset"}
+                            keep_keys = {"builder_level", "use_edition", "horizontal_offset", "vertical_offset"}
                             for key in list(tv.keys()):
                                 if key not in keep_keys:
                                     tv.pop(key, None)

--- a/modules/persistence.py
+++ b/modules/persistence.py
@@ -179,13 +179,29 @@ def save_settings(raw_source, form_data):
             merged_libraries = existing_libraries.copy() if isinstance(existing_libraries, dict) else {}
             incoming_libraries = incoming_libraries if isinstance(incoming_libraries, dict) else {}
 
+            def _library_prefix(key):
+                if not isinstance(key, str) or not key.startswith(("mov-library_", "sho-library_")):
+                    return None
+                if "-template_" in key:
+                    return key.split("-template_", 1)[0]
+                if "-attribute_" in key:
+                    return key.split("-attribute_", 1)[0]
+                if "-collection_" in key:
+                    return key.split("-collection_", 1)[0]
+                if "-overlay_" in key:
+                    return key.split("-overlay_", 1)[0]
+                if "-top_level_" in key:
+                    return key.split("-top_level_", 1)[0]
+                if key.endswith("-library"):
+                    return key[: -len("-library")]
+                return None
+
             # Identify library prefixes present in this payload (e.g., mov-library_xxx, sho-library_yyy)
             prefixes = set()
             for key in incoming_libraries:
-                if key.startswith(("mov-library_", "sho-library_")):
-                    parts = key.split("-", 2)
-                    if len(parts) >= 2:
-                        prefixes.add("-".join(parts[:2]))
+                prefix = _library_prefix(key)
+                if prefix:
+                    prefixes.add(prefix)
 
             # Remove existing entries for the affected prefixes so we can replace them cleanly
             for prefix in prefixes:

--- a/quickstart.py
+++ b/quickstart.py
@@ -3346,6 +3346,7 @@ def copy_library_settings():
                 incoming_dict = helpers.build_config_dict("libraries", clean_payload).get("libraries", {})
 
                 merged = libraries_data.copy()
+
                 def _library_prefix(key):
                     if not isinstance(key, str) or not key.startswith(("mov-library_", "sho-library_")):
                         return None

--- a/quickstart.py
+++ b/quickstart.py
@@ -3346,12 +3346,28 @@ def copy_library_settings():
                 incoming_dict = helpers.build_config_dict("libraries", clean_payload).get("libraries", {})
 
                 merged = libraries_data.copy()
+                def _library_prefix(key):
+                    if not isinstance(key, str) or not key.startswith(("mov-library_", "sho-library_")):
+                        return None
+                    if "-template_" in key:
+                        return key.split("-template_", 1)[0]
+                    if "-attribute_" in key:
+                        return key.split("-attribute_", 1)[0]
+                    if "-collection_" in key:
+                        return key.split("-collection_", 1)[0]
+                    if "-overlay_" in key:
+                        return key.split("-overlay_", 1)[0]
+                    if "-top_level_" in key:
+                        return key.split("-top_level_", 1)[0]
+                    if key.endswith("-library"):
+                        return key[: -len("-library")]
+                    return None
+
                 prefixes = set()
                 for key in incoming_dict:
-                    if key.startswith(("mov-library_", "sho-library_")):
-                        parts = key.split("-", 2)
-                        if len(parts) >= 2:
-                            prefixes.add("-".join(parts[:2]))
+                    prefix = _library_prefix(key)
+                    if prefix:
+                        prefixes.add(prefix)
 
                 for prefix in prefixes:
                     for existing_key in list(merged.keys()):

--- a/templates/030-tautulli.html
+++ b/templates/030-tautulli.html
@@ -11,7 +11,11 @@
     </span>
     <input type="text" class="form-control" id="tautulli_url" name="tautulli_url"
         value="{{ data['tautulli']['url'] | string if data['tautulli']['url'] and 'http://192.168.1.12:8181' not in data['tautulli']['url'] | string else '' }}"
-        aria-describedby="tautulli_url_text">
+        aria-describedby="tautulli_url_text"
+        autocomplete="url"
+        autocapitalize="off"
+        autocorrect="off"
+        spellcheck="false">
 </div>
 
 <div class="input-group mb-2">
@@ -24,7 +28,11 @@
     </span>
     <input type="password" class="form-control" id="tautulli_apikey" name="tautulli_apikey"
         value="{{ data['tautulli']['apikey'] | string if data['tautulli']['apikey'] and 'Enter Tautulli API Key' not in data['tautulli']['apikey'] | string else '' }}"
-        aria-describedby="tautulli_apikey_text">
+        aria-describedby="tautulli_apikey_text"
+        autocomplete="current-password"
+        autocapitalize="off"
+        autocorrect="off"
+        spellcheck="false">
     <button class="btn btn-outline-secondary" id="toggleApikeyVisibility" type="button">
         <i class="fas fa-eye"></i>
     </button>


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

This branch fixes library autosave collisions on the libraries page. Libraries with similar ids, such as Movies and Movies-4k, were being merged under the same truncated prefix during autosave and copy operations, which could silently unselect or overwrite the wrong library when moving between 025-libraries and the final page.

The fix updates the library-prefix detection used by persistence and copy/mirror flows so each library keeps its full id across -library, -attribute_, -template_, -overlay_, -collection_, and -top_level_ keys. That prevents one library’s autosave from deleting another library’s saved selection or settings.

removes console error from tautuloi page

ensures resolution has builder_level for season and episode in final yml

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
