### PR TITLE
Reporting progress of kometa

### DIFF
--- a/modules/logscan.py
+++ b/modules/logscan.py
@@ -129,9 +129,10 @@ class LogscanAnalyzer:
                 mylogger.info(f"Divider found and set to: {divider}")
                 return  # Exit the function once a divider is found
 
-        # If no match is found for any pattern, use default divider
-        self.global_divider = "="
-        mylogger.info(f"Divider not found, using default divider: {self.global_divider}")
+        # If no match is found for any pattern, keep existing divider or fallback
+        if not getattr(self, "global_divider", None):
+            self.global_divider = "="
+            mylogger.info(f"Divider not found, using default divider: {self.global_divider}")
 
     def extract_memory_value(self, content):
         """
@@ -2308,6 +2309,680 @@ class LogscanAnalyzer:
             if "TRACEBACK" in upper:
                 counts["trace"] += 1
         return counts
+
+    def _normalize_library_name(self, value):
+        if not value:
+            return ""
+        text = str(value).lower()
+        text = text.replace("_", " ").replace("-", " ")
+        cleaned = []
+        for ch in text:
+            if ch.isalnum() or ch.isspace():
+                cleaned.append(ch)
+        normalized = " ".join("".join(cleaned).split())
+        return normalized
+
+    def _match_library_name(self, raw_name, library_entries):
+        if not raw_name:
+            return None
+        needle = self._normalize_library_name(raw_name)
+        if not needle:
+            return None
+        exact = None
+        candidates = []
+        for entry in library_entries:
+            name = entry.get("name")
+            if not name:
+                continue
+            normalized = self._normalize_library_name(name)
+            if not normalized:
+                continue
+            if needle == normalized:
+                exact = name
+                break
+            if needle in normalized or normalized in needle:
+                candidates.append((len(normalized), name))
+        if exact:
+            return exact
+        if candidates:
+            candidates.sort(reverse=True)
+            return candidates[0][1]
+        return None
+
+    def _strip_divider_wrappers(self, message):
+        if not message:
+            return message
+        cleaned = self.remove_repeated_dividers(message)
+        divider = self.global_divider or ""
+        cleaned = cleaned.strip()
+        if divider:
+            cleaned = cleaned.strip(divider).strip()
+        return cleaned.strip("|").strip()
+
+    def _extract_mapping_library(self, message):
+        if not message:
+            return None
+        match = re.search(r"\bMapping\s+(.+?)\s+Library\b", message, re.IGNORECASE)
+        if match:
+            return match.group(1).strip()
+        return None
+
+    def _map_section_to_phase(self, section_name):
+        if not section_name:
+            return None
+        lowered = str(section_name).lower()
+        if "operation" in lowered:
+            return "operations"
+        if "overlay" in lowered:
+            return "overlays"
+        if "collection" in lowered:
+            return "collections"
+        if "metadata" in lowered:
+            return "metadata"
+        return None
+
+    def extract_progress(self, content, library_list=None, selected_libraries=None, previous=None, run_started_at=None):
+        library_entries = []
+        if library_list:
+            for entry in library_list:
+                name = entry.get("name")
+                if not name:
+                    continue
+                library_entries.append(
+                    {
+                        "name": name,
+                        "type": entry.get("type"),
+                    }
+                )
+        selected_norm = None
+        if selected_libraries:
+            selected_norm = {self._normalize_library_name(name) for name in selected_libraries if name}
+
+        def is_selected(name):
+            if not selected_norm:
+                return True
+            return self._normalize_library_name(name) in selected_norm
+
+        statuses = {}
+        for entry in library_entries:
+            name = entry["name"]
+            if selected_norm and not is_selected(name):
+                statuses[name] = "Skipped"
+            else:
+                statuses[name] = "Pending"
+        current_library = None
+        library_hint = None
+        library_durations = {}
+        phase_start = {}
+        phase_last_seen = {}
+        phase_open = {}
+        phase_start_from_previous = set()
+        processing_started_at = None
+        finished_run_seen = False
+        preparation_seconds = None
+        preparation_locked = False
+        preparation_elapsed_seconds = None
+        first_log_ts = None
+        playlists_detected = False
+        playlist_running = False
+        playlist_started_at = None
+        playlist_total_seconds = 0
+        if isinstance(previous, dict):
+            prev_current = previous.get("current_library")
+            if prev_current and prev_current in statuses and statuses[prev_current] == "Pending":
+                statuses[prev_current] = "In progress"
+                current_library = prev_current
+            prev_libs = previous.get("libraries")
+            if isinstance(prev_libs, list):
+                for entry in prev_libs:
+                    name = entry.get("name")
+                    status = entry.get("status")
+                    if name in statuses and status in ("Done", "In progress") and statuses[name] != "Skipped":
+                        statuses[name] = status
+                    durations = entry.get("durations")
+                    if name and isinstance(durations, dict) and durations:
+                        library_durations[name] = dict(durations)
+            prev_phase_starts = previous.get("phase_starts")
+            if isinstance(prev_phase_starts, dict):
+                for key, value in prev_phase_starts.items():
+                    if not key or not value:
+                        continue
+                    parts = str(key).split("||", 1)
+                    if len(parts) != 2:
+                        continue
+                    lib_name, phase_key = parts
+                    if not lib_name or not phase_key:
+                        continue
+                    if lib_name not in statuses or statuses.get(lib_name) == "Skipped":
+                        continue
+                    try:
+                        ts = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+                        if ts.tzinfo is not None:
+                            ts = ts.astimezone().replace(tzinfo=None)
+                    except Exception:
+                        continue
+                    phase_start[(lib_name, phase_key)] = ts
+                    phase_last_seen[(lib_name, phase_key)] = ts
+                    phase_open[lib_name] = phase_key
+                    phase_start_from_previous.add((lib_name, phase_key))
+            if isinstance(previous.get("playlist_total_seconds"), (int, float)):
+                playlist_total_seconds = int(previous.get("playlist_total_seconds") or 0)
+            playlist_running = bool(previous.get("playlist_running"))
+            prev_playlist_started_at = previous.get("playlist_started_at")
+            if prev_playlist_started_at:
+                try:
+                    ts = datetime.fromisoformat(str(prev_playlist_started_at).replace("Z", "+00:00"))
+                    if ts.tzinfo is not None:
+                        ts = ts.astimezone().replace(tzinfo=None)
+                    playlist_started_at = ts
+                except Exception:
+                    playlist_started_at = None
+            prev_last_log_at = previous.get("last_log_at")
+            if isinstance(previous.get("preparation_seconds"), (int, float)):
+                preparation_seconds = int(previous.get("preparation_seconds") or 0)
+                preparation_locked = True
+        else:
+            prev_last_log_at = None
+
+        last_log_cutoff = None
+        if prev_last_log_at:
+            try:
+                last_log_cutoff = datetime.fromisoformat(str(prev_last_log_at).replace("Z", "+00:00"))
+                if last_log_cutoff.tzinfo is not None:
+                    last_log_cutoff = last_log_cutoff.astimezone().replace(tzinfo=None)
+            except Exception:
+                last_log_cutoff = None
+
+        if not content:
+            return {
+                "phase_current": None,
+                "phases_completed": [],
+                "libraries": [
+                    {
+                        "name": entry["name"],
+                        "type": entry.get("type"),
+                        "status": statuses.get(entry["name"], "Pending"),
+                    }
+                    for entry in library_entries
+                ],
+                "current_library": None,
+                "completed_count": 0,
+                "total_count": len(library_entries),
+            }
+
+        self.set_global_divider(content)
+        lines = content.splitlines()
+
+        effective_started_at = run_started_at
+        if effective_started_at is None:
+            marker_re = re.compile(r"\[Quickstart\]\s+Run marker:\s+started=([^\s]+)")
+            for line in lines:
+                match = marker_re.search(line)
+                if not match:
+                    continue
+                raw_ts = match.group(1)
+                try:
+                    ts = datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
+                    if ts.tzinfo is not None:
+                        ts = ts.astimezone().replace(tzinfo=None)
+                    effective_started_at = ts
+                    break
+                except Exception:
+                    continue
+
+        def parse_log_timestamp(line):
+            if not line or not line.startswith("["):
+                return None
+            match = re.match(r"\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d{3}\]", line)
+            if not match:
+                return None
+            try:
+                return datetime.strptime(match.group(1), "%Y-%m-%d %H:%M:%S")
+            except Exception:
+                return None
+
+        start_patterns = [
+            re.compile(r"Processing Library:\s*(.+)", re.IGNORECASE),
+            re.compile(r"Library:\s*(.+)", re.IGNORECASE),
+            re.compile(r"Information on library:\s*(.+)", re.IGNORECASE),
+        ]
+        activity_patterns = [
+            re.compile(r"Caching\s+(.+?)\s+Library Items", re.IGNORECASE),
+            re.compile(r"Loading .* from Library:\s*(.+)", re.IGNORECASE),
+        ]
+        overlays_start_re = re.compile(r"^\s*(.+?)\s+Library\s+Overlays\b", re.IGNORECASE)
+        overlays_end_re = re.compile(r"^Finished\s+(.+?)\s+Library\s+Overlays\b", re.IGNORECASE)
+        operations_start_re = re.compile(r"^\s*(.+?)\s+Library\s+Operations\b", re.IGNORECASE)
+        operations_end_re = re.compile(r"^Finished\s+(.+?)\s+Library\s+Operations\b", re.IGNORECASE)
+        collections_start_re = re.compile(r"^Running\s+(.+?)\s+Collection\s+File\b", re.IGNORECASE)
+        collections_end_re = re.compile(r"^Finished\s+(.+?)\s+Collection\b", re.IGNORECASE)
+        metadata_start_re = re.compile(r"^Running\s+(.+?)\s+Metadata\s+File\b", re.IGNORECASE)
+        playlists_header_re = re.compile(r"^Playlists$", re.IGNORECASE)
+        playlist_runtime_re = re.compile(r"Playlist\s+Run\s+Time:\s*(\d+:\d{2}:\d{2})", re.IGNORECASE)
+        playlist_finished_re = re.compile(r"^Finished\s+.+?\s+Playlist\b", re.IGNORECASE)
+        library_done_re = re.compile(r"^Finished\s+(.+?)\s+Library\b(?!\s+Overlays|\s+Operations)", re.IGNORECASE)
+        allow_unknown = not library_entries
+        last_ts = None
+
+        def _ensure_duration_entry(name):
+            if name not in library_durations:
+                library_durations[name] = {}
+
+        def _apply_cutoff_delta(start_ts, end_ts):
+            if not start_ts or not end_ts:
+                return None
+            if last_log_cutoff and end_ts <= last_log_cutoff:
+                return None
+            if last_log_cutoff and start_ts < last_log_cutoff < end_ts:
+                return max(0, int((end_ts - last_log_cutoff).total_seconds()))
+            return max(0, int((end_ts - start_ts).total_seconds()))
+
+        def _finish_phase(name, phase_key, end_ts):
+            key = (name, phase_key)
+            start_ts = phase_start.get(key)
+            if not start_ts:
+                return
+            if end_ts is None:
+                end_ts = phase_last_seen.get(key) or last_ts
+            if end_ts:
+                if key in phase_start_from_previous:
+                    duration = max(0, int((end_ts - start_ts).total_seconds()))
+                else:
+                    duration = _apply_cutoff_delta(start_ts, end_ts)
+                if duration is not None:
+                    _ensure_duration_entry(name)
+                    existing = library_durations[name].get(phase_key, 0)
+                    library_durations[name][phase_key] = existing + duration
+            phase_start.pop(key, None)
+            phase_last_seen.pop(key, None)
+            if key in phase_start_from_previous:
+                phase_start_from_previous.discard(key)
+            if phase_open.get(name) == phase_key:
+                phase_open.pop(name, None)
+
+        def _start_phase(name, phase_key, start_ts):
+            if not name or start_ts is None:
+                return
+            _ensure_duration_entry(name)
+            prior_phase = phase_open.get(name)
+            if prior_phase and prior_phase != phase_key:
+                _finish_phase(name, prior_phase, start_ts)
+            elif prior_phase == phase_key and phase_key in ("collections", "metadata"):
+                _finish_phase(name, phase_key, start_ts)
+            key = (name, phase_key)
+            if key not in phase_start:
+                phase_start[key] = start_ts
+            phase_last_seen[key] = start_ts
+            phase_open[name] = phase_key
+
+        def _set_current_library(name, ts):
+            nonlocal current_library, library_hint, processing_started_at
+            if not name:
+                return
+            library_hint = name
+            if current_library and current_library != name:
+                prior_phase = phase_open.get(current_library)
+                if prior_phase:
+                    _finish_phase(current_library, prior_phase, ts)
+            current_library = name
+            if ts and processing_started_at is None:
+                processing_started_at = ts
+
+        for raw_line in lines:
+            if not raw_line:
+                continue
+            line_ts = parse_log_timestamp(raw_line)
+            if line_ts and first_log_ts is None:
+                first_log_ts = line_ts
+            if line_ts and (last_ts is None or line_ts > last_ts):
+                last_ts = line_ts
+            if effective_started_at and line_ts and line_ts < effective_started_at:
+                continue
+            if last_log_cutoff and line_ts and line_ts <= last_log_cutoff:
+                continue
+            msg = raw_line.split("|", 1)[1].strip() if "|" in raw_line else raw_line.strip()
+            msg = self._strip_divider_wrappers(msg)
+
+            if "kometa.py" in raw_line and playlists_header_re.match(msg):
+                playlists_detected = True
+                playlist_running = True
+                if playlist_started_at is None and line_ts:
+                    playlist_started_at = line_ts
+                if processing_started_at is None and line_ts:
+                    processing_started_at = line_ts
+                continue
+
+            if "kometa.py" in raw_line and playlist_runtime_re.search(msg):
+                playlists_detected = True
+                match = playlist_runtime_re.search(msg)
+                if match:
+                    seconds = self._parse_hms_to_seconds(match.group(1))
+                    if seconds is not None:
+                        playlist_total_seconds += int(seconds)
+                continue
+
+            if "kometa.py" in raw_line and playlist_finished_re.search(msg):
+                playlists_detected = True
+                if playlist_started_at is None and line_ts:
+                    playlist_started_at = line_ts
+                continue
+
+            if "overlays.py" in raw_line and re.search(r"\bLibrary\s+Overlays\b", msg, re.IGNORECASE):
+                match = overlays_start_re.search(msg)
+                if match:
+                    name = match.group(1).strip()
+                    matched = self._match_library_name(name, library_entries)
+                    if not matched:
+                        if selected_norm or not allow_unknown:
+                            continue
+                        library_entries.append({"name": name, "type": None})
+                        statuses.setdefault(name, "Pending")
+                        matched = name
+                    if statuses.get(matched) not in ("Done", "Skipped"):
+                        if current_library and current_library in statuses and current_library != matched and statuses[current_library] != "Skipped":
+                            statuses[current_library] = "Done"
+                        statuses[matched] = "In progress"
+                        _set_current_library(matched, line_ts)
+                        _start_phase(matched, "overlays", line_ts)
+                continue
+
+            if "overlays.py" in raw_line and overlays_end_re.search(msg):
+                match = overlays_end_re.search(msg)
+                if match:
+                    name = match.group(1).strip()
+                    matched = self._match_library_name(name, library_entries)
+                    if matched:
+                        _finish_phase(matched, "overlays", line_ts)
+                continue
+
+            if "operations.py" in raw_line and operations_start_re.search(msg):
+                match = operations_start_re.search(msg)
+                if match:
+                    name = match.group(1).strip()
+                    matched = self._match_library_name(name, library_entries)
+                    if not matched:
+                        if selected_norm or not allow_unknown:
+                            continue
+                        library_entries.append({"name": name, "type": None})
+                        statuses.setdefault(name, "Pending")
+                        matched = name
+                    if statuses.get(matched) not in ("Done", "Skipped"):
+                        if current_library and current_library in statuses and current_library != matched and statuses[current_library] != "Skipped":
+                            statuses[current_library] = "Done"
+                        statuses[matched] = "In progress"
+                        _set_current_library(matched, line_ts)
+                        _start_phase(matched, "operations", line_ts)
+                continue
+
+            if "operations.py" in raw_line and operations_end_re.search(msg):
+                match = operations_end_re.search(msg)
+                if match:
+                    name = match.group(1).strip()
+                    matched = self._match_library_name(name, library_entries)
+                    if matched and statuses.get(matched) != "Skipped":
+                        statuses[matched] = "Done"
+                        if current_library == matched:
+                            current_library = None
+                        _finish_phase(matched, "operations", line_ts)
+                continue
+
+            if "kometa.py" in raw_line and collections_start_re.search(msg):
+                if current_library:
+                    if statuses.get(current_library) not in ("Done", "Skipped"):
+                        statuses[current_library] = "In progress"
+                    _start_phase(current_library, "collections", line_ts)
+                continue
+
+            if "kometa.py" in raw_line and collections_end_re.search(msg):
+                continue
+
+            if "kometa.py" in raw_line and metadata_start_re.search(msg):
+                if current_library:
+                    if statuses.get(current_library) not in ("Done", "Skipped"):
+                        statuses[current_library] = "In progress"
+                    _start_phase(current_library, "metadata", line_ts)
+                continue
+
+            if "kometa.py" in raw_line and re.search(r"\bMapping\b", msg, re.IGNORECASE):
+                name = self._extract_mapping_library(msg)
+                if name:
+                    matched = self._match_library_name(name, library_entries)
+                    if not matched:
+                        if selected_norm or not allow_unknown:
+                            continue
+                        library_entries.append({"name": name, "type": None})
+                        statuses.setdefault(name, "Pending")
+                        matched = name
+                    if current_library and current_library in statuses and statuses[current_library] != "Skipped":
+                        statuses[current_library] = "Done"
+                    statuses[matched] = "In progress"
+                    _set_current_library(matched, line_ts)
+                    if processing_started_at is None and line_ts:
+                        processing_started_at = line_ts
+                continue
+
+            finished_match = library_done_re.search(msg)
+            if finished_match:
+                name = finished_match.group(1).strip()
+                matched = self._match_library_name(name, library_entries)
+                if matched and statuses.get(matched) != "Skipped":
+                    statuses[matched] = "Done"
+                    if current_library == matched:
+                        current_library = None
+                continue
+
+            if "Finished Libraries Run" in msg:
+                finished_run_seen = True
+                if current_library and current_library in statuses and statuses[current_library] != "Skipped":
+                    statuses[current_library] = "Done"
+                current_library = None
+                playlist_running = False
+                continue
+
+            if "Finished Run" in msg:
+                if current_library and current_library in statuses and statuses[current_library] != "Skipped":
+                    statuses[current_library] = "Done"
+                current_library = None
+                finished_run_seen = True
+                playlist_running = False
+                continue
+
+            for pattern in start_patterns:
+                match = pattern.search(msg)
+                if not match:
+                    continue
+                name = match.group(1).strip()
+                matched = self._match_library_name(name, library_entries)
+                if not matched:
+                    if selected_norm or not allow_unknown:
+                        continue
+                    library_entries.append({"name": name, "type": None})
+                    statuses.setdefault(name, "Pending")
+                    matched = name
+                library_hint = matched
+                break
+
+            for pattern in activity_patterns:
+                match = pattern.search(msg)
+                if not match:
+                    continue
+                name = match.group(1).strip()
+                matched = self._match_library_name(name, library_entries)
+                if not matched:
+                    if selected_norm or not allow_unknown:
+                        continue
+                    library_entries.append({"name": name, "type": None})
+                    statuses.setdefault(name, "Pending")
+                    matched = name
+                library_hint = matched
+                break
+
+        section_runtimes = self.extract_section_runtimes(content)
+        phases_completed = []
+        for section_name in section_runtimes.keys():
+            phase = self._map_section_to_phase(section_name)
+            if phase and phase not in phases_completed:
+                phases_completed.append(phase)
+
+        phase_patterns = [
+            ("operations", re.compile(r"\bLibrary\s+Operations\b|\boperations\.py\b", re.IGNORECASE)),
+            ("metadata", re.compile(r"\bMetadata\s+File\b|\bmeta\.py\b", re.IGNORECASE)),
+            ("collections", re.compile(r"\bCollection\s+File\b|\bBuilding\s+.+\s+Collections\b", re.IGNORECASE)),
+            ("overlays", re.compile(r"\bLibrary\s+Overlays\b|\boverlays\.py\b", re.IGNORECASE)),
+            ("playlists", re.compile(r"^Playlists$|\bPlaylist\b", re.IGNORECASE)),
+        ]
+        phase_current = None
+        phase_sequence = []
+        for raw_line in lines:
+            msg = raw_line.split("|", 1)[1].strip() if "|" in raw_line else raw_line.strip()
+            msg = self._strip_divider_wrappers(msg)
+            line_ts = parse_log_timestamp(raw_line)
+            if last_log_cutoff and line_ts and line_ts <= last_log_cutoff:
+                continue
+            if processing_started_at is not None and line_ts and line_ts < processing_started_at:
+                continue
+            for phase_key, pattern in phase_patterns:
+                if pattern.search(msg):
+                    phase_current = phase_key
+                    phase_sequence.append(phase_key)
+                    break
+        if processing_started_at is None:
+            phase_current = None
+            phase_sequence = []
+
+        summary_header_re = re.compile(r"=+\s*(.+?)\s+Summary\s*=+", re.IGNORECASE)
+        summary_runtime_re = re.compile(r"^(Library\s+.+?)\s*\|\s*(\d+:\d{2}:\d{2})", re.IGNORECASE)
+        summary_library = None
+        for raw_line in lines:
+            msg = raw_line.split("|", 1)[1].strip() if "|" in raw_line else raw_line.strip()
+            msg = self._strip_divider_wrappers(msg)
+            header_match = summary_header_re.search(msg)
+            if header_match:
+                name = header_match.group(1).strip()
+                matched = self._match_library_name(name, library_entries)
+                summary_library = matched
+                continue
+            if not summary_library:
+                continue
+            runtime_match = summary_runtime_re.search(msg)
+            if not runtime_match:
+                continue
+            label = runtime_match.group(1).strip().lower()
+            seconds = self._parse_hms_to_seconds(runtime_match.group(2))
+            if seconds is None:
+                continue
+            phase_key = None
+            if "operations" in label:
+                phase_key = "operations"
+            elif "collections" in label:
+                phase_key = "collections"
+            elif "metadata" in label:
+                phase_key = "metadata"
+            elif "overlays" in label:
+                phase_key = "overlays"
+            if phase_key:
+                _ensure_duration_entry(summary_library)
+                existing = library_durations[summary_library].get(phase_key, 0)
+                library_durations[summary_library][phase_key] = max(existing, int(seconds))
+        if phase_sequence:
+            completed_from_sequence = set()
+            last_phase = phase_sequence[-1]
+            for phase in phase_sequence:
+                if phase != last_phase:
+                    completed_from_sequence.add(phase)
+            for phase in completed_from_sequence:
+                if phase not in phases_completed:
+                    phases_completed.append(phase)
+        if "Finished Run" in content and phase_current and phase_current not in phases_completed:
+            phases_completed.append(phase_current)
+
+        if finished_run_seen and phase_start:
+            for name, phase_key in list(phase_start.keys()):
+                _finish_phase(name, phase_key, last_ts)
+
+        current_phase_elapsed = None
+        if current_library and last_ts:
+            open_phase = phase_open.get(current_library)
+            if open_phase:
+                start_ts = phase_start.get((current_library, open_phase))
+                if start_ts:
+                    effective_start = start_ts
+                    if last_log_cutoff and start_ts < last_log_cutoff:
+                        effective_start = last_log_cutoff
+                    delta = max(0, int((last_ts - effective_start).total_seconds()))
+                    base = 0
+                    if current_library in library_durations:
+                        base = int(library_durations[current_library].get(open_phase, 0) or 0)
+                    current_phase_elapsed = base + delta
+
+        if not preparation_locked and processing_started_at:
+            prep_start = effective_started_at or first_log_ts
+            if prep_start and processing_started_at > prep_start:
+                preparation_seconds = max(0, int((processing_started_at - prep_start).total_seconds()))
+                preparation_locked = True
+        elif not preparation_locked and preparation_seconds is None:
+            prep_start = effective_started_at or first_log_ts
+            if prep_start and last_ts and last_ts > prep_start:
+                preparation_elapsed_seconds = max(0, int((last_ts - prep_start).total_seconds()))
+
+        playlist_elapsed_seconds = None
+        if playlist_running and last_ts and playlist_started_at:
+            effective_start = playlist_started_at
+            if last_log_cutoff and playlist_started_at < last_log_cutoff:
+                effective_start = last_log_cutoff
+            delta = max(0, int((last_ts - effective_start).total_seconds()))
+            playlist_elapsed_seconds = playlist_total_seconds + delta
+
+        if finished_run_seen:
+            for name, status in list(statuses.items()):
+                if status in ("Pending", "In progress"):
+                    if selected_norm and not is_selected(name):
+                        continue
+                    statuses[name] = "Done"
+
+        libraries_payload = []
+        completed_count = 0
+        total_count = 0
+        for entry in library_entries:
+            name = entry["name"]
+            status = statuses.get(name, "Pending")
+            if is_selected(name):
+                total_count += 1
+                if status == "Done":
+                    completed_count += 1
+            libraries_payload.append(
+                {
+                    "name": name,
+                    "type": entry.get("type"),
+                    "status": status,
+                    "durations": library_durations.get(name, {}),
+                }
+            )
+
+        phase_starts_payload = {}
+        for (lib_name, phase_key), start_ts in phase_start.items():
+            if not lib_name or not phase_key or not start_ts:
+                continue
+            phase_starts_payload[f"{lib_name}||{phase_key}"] = start_ts.isoformat()
+
+        return {
+            "phase_current": phase_current,
+            "phases_completed": phases_completed,
+            "libraries": libraries_payload,
+            "current_library": current_library,
+            "completed_count": completed_count,
+            "total_count": total_count if selected_norm else len(library_entries),
+            "current_phase_elapsed_seconds": current_phase_elapsed,
+            "phase_starts": phase_starts_payload,
+            "playlist_total_seconds": playlist_total_seconds,
+            "playlist_running": playlist_running,
+            "playlist_started_at": playlist_started_at.isoformat() if playlist_started_at else None,
+            "playlist_elapsed_seconds": playlist_elapsed_seconds,
+            "playlists_detected": playlists_detected,
+            "run_finished": finished_run_seen,
+            "preparation_seconds": preparation_seconds,
+            "preparation_elapsed_seconds": preparation_elapsed_seconds,
+        }
 
     def extract_analyze_issue_counts(self, content):
         patterns = {

--- a/quickstart.py
+++ b/quickstart.py
@@ -5521,6 +5521,7 @@ def logscan_progress():
             log_stats = None
 
         cached = LOGSCAN_PROGRESS_CACHE
+
         def normalize_progress_for_stopped(data, running, stopped_requested):
             if not isinstance(data, dict) or running:
                 return data

--- a/quickstart.py
+++ b/quickstart.py
@@ -62,6 +62,7 @@ CLONE_PROGRESS: Dict[str, Dict[str, Any]] = {}
 ACTIVE_TEST_LIB_JOB: Dict[str, Any] = {}
 LOG_STATS_CACHE = {"mtime": None, "size": None, "stats": None}
 LOGSCAN_ANALYSIS_CACHE = {"mtime": None, "size": None, "data": None}
+LOGSCAN_PROGRESS_CACHE = {"mtime": None, "size": None, "data": None}
 KOMETA_CPU_CACHE = {}
 SYSTEM_CPU_CACHE = {"total": None, "idle": None}
 MAINTENANCE_STATE = {
@@ -436,6 +437,69 @@ def _launch_kometa_command(command, config_name=None):
     return True, proc.pid
 
 
+def _extract_selected_libraries(command):
+    if not command:
+        return None, None
+    is_win = sys.platform.startswith("win")
+    try:
+        parts = shlex.split(command, posix=not is_win)
+    except Exception:
+        parts = command.split()
+
+    run_option = None
+    selected = None
+    for idx, part in enumerate(parts):
+        if part in ("--run", "--run-libraries", "--times"):
+            run_option = part
+        if part.startswith("--run-libraries="):
+            value = part.split("=", 1)[1].strip().strip('"').strip("'")
+            selected = [v for v in value.split("|") if v.strip()]
+            break
+        if part == "--run-libraries" and idx + 1 < len(parts):
+            value = parts[idx + 1].strip().strip('"').strip("'")
+            selected = [v for v in value.split("|") if v.strip()]
+            run_option = "--run-libraries"
+            break
+    return run_option, selected
+
+
+def _update_run_context(command):
+    run_option, selected = _extract_selected_libraries(command)
+    config_path = None
+    run_mode = "all"
+    if command:
+        is_win = sys.platform.startswith("win")
+        try:
+            parts = shlex.split(command, posix=not is_win)
+        except Exception:
+            parts = command.split()
+        if "--metadata-only" in parts:
+            run_mode = "metadata"
+        elif "--operations-only" in parts:
+            run_mode = "operations"
+        elif "--playlists-only" in parts:
+            run_mode = "playlists"
+        elif "--overlays-only" in parts:
+            run_mode = "overlays"
+        elif "--collections-only" in parts:
+            run_mode = "collections"
+        kometa_root = helpers.get_kometa_root_path()
+        config_path = _extract_kometa_config_path(parts, kometa_root)
+    with RUN_CONTEXT_LOCK:
+        RUN_CONTEXT["run_option"] = run_option
+        RUN_CONTEXT["selected_libraries"] = selected
+        RUN_CONTEXT["run_mode"] = run_mode
+        RUN_CONTEXT["config_path"] = str(config_path) if config_path else None
+        RUN_CONTEXT["started_at"] = datetime.now()
+        RUN_CONTEXT["updated_at"] = datetime.now(timezone.utc).isoformat()
+        RUN_CONTEXT["stop_requested_at"] = None
+
+
+def _get_run_context():
+    with RUN_CONTEXT_LOCK:
+        return dict(RUN_CONTEXT)
+
+
 def _suspend_process_tree(proc):
     try:
         for child in proc.children(recursive=True):
@@ -511,6 +575,7 @@ def _maintenance_guard_loop(app_in):
                 if pending and not active and start_min is not None and end_min is not None:
                     pending = _pop_pending_kometa_start()
                     if pending:
+                        _update_run_context(pending.get("command"))
                         ok, result = _launch_kometa_command(pending.get("command"), pending.get("config_name"))
                         if ok:
                             helpers.ts_log("Kometa started after Plex maintenance window ended.", level="INFO")
@@ -1064,6 +1129,18 @@ def update_quickstart():
 server_session = Session(app)
 server_thread = None
 shutdown_event = threading.Event()
+
+# Track current run context for progress UI.
+RUN_CONTEXT_LOCK = threading.Lock()
+RUN_CONTEXT = {
+    "selected_libraries": None,
+    "run_option": None,
+    "run_mode": "all",
+    "config_path": None,
+    "started_at": None,
+    "updated_at": None,
+    "stop_requested_at": None,
+}
 
 # Ensure json-schema files are up to date at startup
 helpers.ensure_json_schema()
@@ -3418,6 +3495,7 @@ def step(name):
         library_settings = persistence.retrieve_settings("025-libraries").get("libraries", {})
         movie_libraries = []
         show_libraries = []
+        library_dropdown = []
         existing_ids = set()
 
         for key, value in library_settings.items():
@@ -3425,6 +3503,16 @@ def step(name):
                 movie_libraries.append({"id": key.split("-library")[0], "name": value, "type": "movie"})
             elif key.startswith("sho-library_") and key.endswith("-library"):
                 show_libraries.append({"id": key.split("-library")[0], "name": value, "type": "show"})
+
+        if saved_filename:
+            try:
+                config_path = Path(helpers.CONFIG_DIR) / saved_filename
+                config_for_dropdown = _load_progress_config(config_path)
+                library_dropdown = _get_progress_library_list(config_data=config_for_dropdown)
+            except Exception:
+                library_dropdown = []
+        if not library_dropdown:
+            library_dropdown = movie_libraries + show_libraries
 
         html = render_template(
             "900-final.html",
@@ -3439,6 +3527,7 @@ def step(name):
             available_configs=available_configs,
             movie_libraries=movie_libraries,
             show_libraries=show_libraries,
+            library_dropdown=library_dropdown,
             config_dir=str(Path(helpers.CONFIG_DIR).resolve()),
             overlay_fonts=list_overlay_fonts(),
             service_validations=service_validations,
@@ -4914,6 +5003,8 @@ def start_kometa():
                 payload["started_at"] = started_at
             return jsonify(payload), 400
 
+    _update_run_context(command)
+
     start_min, end_min, window_str = _get_maintenance_window_live()
     if start_min is None or end_min is None:
         start_min, end_min, window_str = _get_maintenance_window_from_db()
@@ -4947,6 +5038,9 @@ def stop_kometa():
     try:
         if not procs:
             return jsonify({"warning": "No active Kometa process found."}), 200
+
+        with RUN_CONTEXT_LOCK:
+            RUN_CONTEXT["stop_requested_at"] = datetime.now(timezone.utc).isoformat()
 
         not_kometa = []
         alive_after = []
@@ -5325,6 +5419,184 @@ def logscan_analyze():
     LOGSCAN_ANALYSIS_CACHE.update({"mtime": stats.st_mtime, "size": stats.st_size, "data": result})
     result["cached"] = False
     return jsonify(result)
+
+
+def _load_progress_config(config_path=None):
+    if not config_path:
+        return None
+    try:
+        yaml_parser = YAML(typ="safe", pure=True)
+        with Path(config_path).open("r", encoding="utf-8", errors="ignore") as handle:
+            return yaml_parser.load(handle) or {}
+    except Exception:
+        return None
+
+
+def _normalize_run_order_value(value):
+    lowered = str(value or "").strip().lower()
+    if not lowered:
+        return None
+    if lowered.startswith("operation"):
+        return "operations"
+    if lowered.startswith("overlay"):
+        return "overlays"
+    if lowered.startswith("collection"):
+        return "collections"
+    if lowered.startswith("metadata"):
+        return "metadata"
+    return None
+
+
+def _get_progress_run_order(config_data=None):
+    if not isinstance(config_data, dict):
+        return []
+    settings = config_data.get("settings") if isinstance(config_data.get("settings"), dict) else {}
+    run_order = settings.get("run_order") if isinstance(settings, dict) else None
+    if not isinstance(run_order, list):
+        return []
+    normalized = []
+    for item in run_order:
+        key = _normalize_run_order_value(item)
+        if key and key not in normalized:
+            normalized.append(key)
+    return normalized
+
+
+def _get_progress_library_list(selected_libraries=None, config_path=None, config_data=None):
+    settings = persistence.retrieve_settings("025-libraries")
+    library_settings = settings.get("libraries", {}) if isinstance(settings, dict) else {}
+    libraries = []
+    type_by_name = {}
+    if isinstance(library_settings, dict):
+        for key, value in library_settings.items():
+            if not value:
+                continue
+            if key.startswith("mov-library_") and key.endswith("-library"):
+                type_by_name[value] = "movie"
+            elif key.startswith("sho-library_") and key.endswith("-library"):
+                type_by_name[value] = "show"
+    parsed = config_data if isinstance(config_data, dict) else _load_progress_config(config_path)
+    if isinstance(parsed, dict):
+        lib_section = parsed.get("libraries")
+        if isinstance(lib_section, dict):
+            for lib_name in lib_section.keys():
+                if lib_name:
+                    libraries.append({"name": lib_name, "type": type_by_name.get(lib_name)})
+    if not libraries:
+        for name, lib_type in type_by_name.items():
+            libraries.append({"name": name, "type": lib_type})
+    if selected_libraries:
+        existing = {lib["name"] for lib in libraries}
+        for name in selected_libraries:
+            if name and name not in existing:
+                libraries.append({"name": name, "type": None})
+                existing.add(name)
+    return libraries
+
+
+@app.route("/logscan/progress", methods=["GET"])
+def logscan_progress():
+    kometa_root = helpers.get_kometa_root_path()
+    log_path = kometa_root / "config" / "logs" / "meta.log"
+
+    if not log_path.exists():
+        return jsonify({"error": f"Log file not found at: {log_path}"}), 404
+
+    try:
+        from collections import deque
+        from copy import deepcopy
+
+        size_param = request.args.get("size", "4000")
+        max_lines = None
+        if size_param.lower() not in ("all", "full"):
+            try:
+                max_lines = max(1, min(int(size_param), 20000))
+            except Exception:
+                max_lines = 4000
+
+        log_stats = None
+        try:
+            log_stats = log_path.stat()
+        except Exception:
+            log_stats = None
+
+        cached = LOGSCAN_PROGRESS_CACHE
+        def normalize_progress_for_stopped(data, running, stopped_requested):
+            if not isinstance(data, dict) or running:
+                return data
+            data = deepcopy(data)
+            stopped_library = data.get("current_library")
+            data["current_library"] = None
+            data["phase_current"] = None
+            libraries = data.get("libraries")
+            if isinstance(libraries, list):
+                for entry in libraries:
+                    status = entry.get("status")
+                    name = entry.get("name")
+                    if status == "In progress":
+                        if stopped_requested:
+                            entry["status"] = "Stopped"
+                    elif stopped_library and name == stopped_library and status not in ("Done", "Skipped"):
+                        if stopped_requested:
+                            entry["status"] = "Stopped"
+            return data
+
+        if max_lines:
+            with log_path.open("r", encoding="utf-8", errors="replace") as f:
+                lines = deque(f, maxlen=max_lines)
+            log_content = "".join(lines)
+        else:
+            log_content = log_path.read_text(encoding="utf-8", errors="replace")
+
+        ctx = _get_run_context()
+        selected = ctx.get("selected_libraries")
+        started_at = ctx.get("started_at")
+        config_path = ctx.get("config_path")
+        run_mode = ctx.get("run_mode") or "all"
+        running = helpers.is_kometa_running()
+        stopped_requested = bool(ctx.get("stop_requested_at"))
+
+        if log_stats and cached.get("mtime") == log_stats.st_mtime and cached.get("size") == log_stats.st_size:
+            data = cached.get("data") or {}
+            data = normalize_progress_for_stopped(data, running, stopped_requested)
+            return jsonify(data)
+
+        cached_data = LOGSCAN_PROGRESS_CACHE.get("data")
+        if cached_data and cached_data.get("run_started_at") != started_at:
+            LOGSCAN_PROGRESS_CACHE.update({"mtime": None, "size": None, "data": None})
+        analyzer = logscan.LogscanAnalyzer()
+        config_data = _load_progress_config(config_path)
+        progress = analyzer.extract_progress(
+            log_content,
+            library_list=_get_progress_library_list(
+                selected_libraries=selected,
+                config_path=config_path,
+                config_data=config_data,
+            ),
+            selected_libraries=selected,
+            previous=LOGSCAN_PROGRESS_CACHE.get("data"),
+            run_started_at=started_at,
+        )
+        phase_order = _get_progress_run_order(config_data=config_data)
+        allowed_phases = phase_order or ["operations", "metadata", "collections", "overlays"]
+        playlists_configured = bool(config_data.get("playlists")) if isinstance(config_data, dict) else False
+        if run_mode in ("collections", "overlays", "operations", "metadata", "playlists"):
+            allowed_phases = [run_mode]
+            progress["phase_current"] = run_mode
+            progress["phases_completed"] = []
+        elif "playlists" not in allowed_phases:
+            allowed_phases = allowed_phases + ["playlists"]
+        progress["allowed_phases"] = allowed_phases
+        progress["phase_order"] = allowed_phases
+        progress["playlists_configured"] = playlists_configured
+        progress = normalize_progress_for_stopped(progress, running, stopped_requested)
+        if log_stats:
+            progress["last_log_at"] = datetime.fromtimestamp(log_stats.st_mtime, tz=timezone.utc).isoformat()
+            progress["run_started_at"] = started_at
+            LOGSCAN_PROGRESS_CACHE.update({"mtime": log_stats.st_mtime, "size": log_stats.st_size, "data": progress})
+        return jsonify(progress)
+    except Exception as e:
+        return jsonify({"error": f"Failed to analyze log progress: {str(e)}"}), 500
 
 
 @app.route("/logscan/trends", methods=["GET"])

--- a/static/local-js/900-final.js
+++ b/static/local-js/900-final.js
@@ -9,6 +9,7 @@ let KOMETA_INSTALLED = false
 // Polling handles (hoist to top so all handlers see them safely)
 let kometaInterval = null
 let kometaStatusInterval = null
+let kometaProgressInterval = null
 let kometaPollingStarted = false
 let autoScrollEnabled = true
 let tailSize = '2000'
@@ -20,6 +21,7 @@ let lastLogStatsTotal = null
 let logStatsPollCounter = 0
 let lastLogscanPayload = null
 let logscanPollCounter = 0
+let lastRunProgressPayload = null
 
 const _qsEnvEl = document.getElementById('qs-env')
 const runningOn = (_qsEnvEl && _qsEnvEl.dataset.runningOn) ? _qsEnvEl.dataset.runningOn : ''
@@ -329,6 +331,10 @@ $(document).ready(function () {
       label: 'Operations Only',
       description: 'Only perform operations (e.g., rating/poster updates).'
     },
+    '--metadata-only': {
+      label: 'Metadata Only',
+      description: 'Only run metadata files.'
+    },
     '--collections-only': {
       label: 'Collections Only',
       description: 'Only build collections.'
@@ -413,7 +419,7 @@ $(document).ready(function () {
 
   function updateFlagLabels (showCli) {
     const runOptions = ['--run', '--run-libraries', '--times']
-    const modeFlags = ['--operations-only', '--collections-only', '--playlists-only', '--overlays-only']
+    const modeFlags = ['--operations-only', '--metadata-only', '--collections-only', '--overlays-only', '--playlists-only']
     const logFlags = ['--debug', '--trace', '--log-requests']
     const otherFlags = [
       '--delete-collections', '--delete-labels', '--read-only-config', '--low-priority',
@@ -792,14 +798,18 @@ $(document).ready(function () {
   })
 
   function hideRunCommandSectionUntilValidated () {
+    const accordion = $('#run-command-output-accordion')
     const box = $('#run-command-box')
+    accordion.addClass('d-none')
     box.removeClass('fade-in').addClass('d-none') // Hide instantly
     $('#run-now').prop('disabled', true).html('<i class="bi bi-hourglass-split me-1"></i> Waiting...')
   }
 
   function showRunCommandSectionAfterValidated () {
+    const accordion = $('#run-command-output-accordion')
     const box = $('#run-command-box')
 
+    accordion.removeClass('d-none')
     box.removeClass('d-none') // Reveal element (opacity still 0)
     setTimeout(() => {
       box.addClass('fade-in') // Let browser register change, then fade in
@@ -814,9 +824,222 @@ $(document).ready(function () {
     kometaPollingStarted = true
     if (kometaInterval) clearInterval(kometaInterval)
     if (kometaStatusInterval) clearInterval(kometaStatusInterval)
+    if (kometaProgressInterval) clearInterval(kometaProgressInterval)
     fetchKometaLog()
+    fetchRunProgress()
     kometaInterval = setInterval(fetchKometaLog, 3000)
     kometaStatusInterval = setInterval(checkKometaStatus, 5000)
+    kometaProgressInterval = setInterval(fetchRunProgress, 5000)
+  }
+
+  function stopProgressPolling () {
+    if (kometaProgressInterval) {
+      clearInterval(kometaProgressInterval)
+      kometaProgressInterval = null
+    }
+  }
+
+  const runPhaseOrder = [
+    { key: 'operations', label: 'Operations' },
+    { key: 'metadata', label: 'Metadata' },
+    { key: 'collections', label: 'Collections' },
+    { key: 'overlays', label: 'Overlays' },
+    { key: 'playlists', label: 'Playlists' }
+  ]
+
+  function renderRunProgress (payload) {
+    const container = document.getElementById('run-progress')
+    if (!container) return
+
+    if (!payload || !Array.isArray(payload.libraries)) {
+      container.classList.add('d-none')
+      return
+    }
+
+    lastRunProgressPayload = payload
+    const libraries = payload.libraries
+    const total = payload.total_count || libraries.length
+    const completed = payload.completed_count != null
+      ? payload.completed_count
+      : libraries.filter(entry => entry.status === 'Done').length
+
+    const phaseOrderKeys = Array.isArray(payload.phase_order) && payload.phase_order.length
+      ? payload.phase_order
+      : runPhaseOrder.map(phase => phase.key)
+    const phaseCount = phaseOrderKeys.length || 1
+    const currentPhaseIndex = payload.phase_current
+      ? Math.max(0, phaseOrderKeys.indexOf(payload.phase_current))
+      : 0
+    const totalSteps = total * phaseCount
+    let completedSteps = completed * phaseCount
+    if (payload.current_library && total > 0) {
+      completedSteps = Math.min(totalSteps, completedSteps + currentPhaseIndex)
+    }
+    const percent = totalSteps > 0 ? Math.round((completedSteps / totalSteps) * 100) : 0
+    const bar = document.getElementById('run-progress-bar')
+    if (bar) {
+      bar.style.width = `${percent}%`
+      bar.setAttribute('aria-valuenow', String(percent))
+    }
+
+    const summary = document.getElementById('run-progress-summary')
+    if (summary) {
+      const current = payload.current_library ? ` | Current: ${payload.current_library}` : ''
+      const stepLabel = totalSteps > 0 ? ` | Step ${completedSteps}/${totalSteps}` : ''
+      let lastUpdated = ''
+      if (payload.last_log_at) {
+        const formatter = typeof window.QS_formatTimestamp === 'function' ? window.QS_formatTimestamp : null
+        const label = formatter ? formatter(payload.last_log_at) : new Date(payload.last_log_at).toLocaleString()
+        lastUpdated = ` | Last updated: ${label}`
+      }
+      summary.textContent = `${completed}/${total} libraries complete${current}${stepLabel}${lastUpdated}`
+    }
+
+    const prepRow = document.getElementById('run-prep-row')
+    if (prepRow) {
+      const hasLockedPrep = typeof payload.preparation_seconds === 'number'
+      const prepSeconds = hasLockedPrep
+        ? payload.preparation_seconds
+        : (typeof payload.preparation_elapsed_seconds === 'number' ? payload.preparation_elapsed_seconds : null)
+      if (prepSeconds != null) {
+        const prepLabel = formatRunSeconds(prepSeconds) || '0s'
+        const prepClass = hasLockedPrep ? 'text-bg-success' : 'text-bg-primary'
+        prepRow.innerHTML = `
+          <span class="me-2 fw-semibold">Preparation</span>
+          <span class="badge ${prepClass}">${prepLabel}</span>
+        `
+        prepRow.classList.remove('d-none')
+      } else {
+        prepRow.classList.add('d-none')
+      }
+    }
+
+    const allowed = Array.isArray(payload.allowed_phases) && payload.allowed_phases.length
+      ? new Set(payload.allowed_phases)
+      : null
+    const phaseLookup = new Map(runPhaseOrder.map(phase => [phase.key, phase.label]))
+    const phasesToShow = (Array.isArray(phaseOrderKeys) ? phaseOrderKeys : runPhaseOrder.map(phase => phase.key))
+      .filter(key => !allowed || allowed.has(key))
+      .map(key => ({ key, label: phaseLookup.get(key) || key }))
+    const phaseIndexLookup = new Map(phasesToShow.map((phase, idx) => [phase.key, idx]))
+
+    const headerRow = document.getElementById('run-library-header')
+    if (headerRow) {
+      const phaseHeaders = phasesToShow.map(phase => `<th class="text-end">${phase.label}</th>`).join('')
+      headerRow.innerHTML = `<th>Library</th><th>Type</th><th>Status</th>${phaseHeaders}`
+    }
+
+    const rows = document.getElementById('run-library-rows')
+    if (rows) {
+      const visibleLibraries = libraries.filter(entry => entry.status !== 'Skipped')
+      rows.innerHTML = visibleLibraries.map(entry => {
+        let klass = 'text-bg-secondary'
+        if (entry.status === 'Done') klass = 'text-bg-success'
+        else if (entry.status === 'In progress') klass = 'text-bg-primary'
+        else if (entry.status === 'Stopped') klass = 'text-bg-danger'
+        else if (entry.status === 'Skipped') klass = 'text-bg-dark'
+        const typeLabel = entry.type ? entry.type : '—'
+        const durations = entry.durations || {}
+        const currentPhaseForRow = payload.current_library === entry.name ? payload.phase_current : null
+        const explicitPhases = new Set(Object.keys(durations))
+        let lastSeenIndex = -1
+        explicitPhases.forEach(key => {
+          const idx = phaseIndexLookup.get(key)
+          if (idx != null && idx > lastSeenIndex) lastSeenIndex = idx
+        })
+        if (currentPhaseForRow) {
+          const idx = phaseIndexLookup.get(currentPhaseForRow)
+          if (idx != null && idx > lastSeenIndex) lastSeenIndex = idx
+        }
+        const inferredPhases = new Set()
+        if (entry.status !== 'Skipped' && lastSeenIndex >= 0) {
+          phasesToShow.forEach(phase => {
+            const idx = phaseIndexLookup.get(phase.key)
+            if (idx != null && idx < lastSeenIndex && !explicitPhases.has(phase.key)) {
+              inferredPhases.add(phase.key)
+            }
+          })
+        }
+
+        const durationCells = phasesToShow.map(phase => {
+          if (phase.key === 'playlists') {
+            const total = typeof payload.playlist_total_seconds === 'number' ? payload.playlist_total_seconds : null
+            const running = Boolean(payload.playlist_running)
+            const elapsed = typeof payload.playlist_elapsed_seconds === 'number' ? payload.playlist_elapsed_seconds : null
+            if (running) {
+              const label = elapsed != null ? formatRunSeconds(elapsed) : 'Running'
+              return `<td class="text-end"><span class="badge text-bg-primary">${label || 'Running'}</span></td>`
+            }
+            if (total != null && total > 0) {
+              return `<td class="text-end"><span class="badge text-bg-success">${formatRunSeconds(total)}</span></td>`
+            }
+            if (payload.run_finished) {
+              return '<td class="text-end"><span class="badge text-bg-secondary">Not Configured</span></td>'
+            }
+            return '<td class="text-end text-muted small">—</td>'
+          }
+          const seconds = durations[phase.key]
+          const hasSeconds = typeof seconds === 'number' && Number.isFinite(seconds)
+          const isRunning = currentPhaseForRow === phase.key
+          const isExplicit = explicitPhases.has(phase.key)
+          const isInferred = inferredPhases.has(phase.key)
+          if (entry.status === 'Skipped') {
+            return '<td class="text-end text-muted small">—</td>'
+          }
+          if (isRunning) {
+            const elapsed = typeof payload.current_phase_elapsed_seconds === 'number'
+              ? formatRunSeconds(payload.current_phase_elapsed_seconds)
+              : (hasSeconds ? formatRunSeconds(seconds) : 'Running')
+            return `<td class="text-end"><span class="badge text-bg-primary">${elapsed || 'Running'}</span></td>`
+          }
+          if (isExplicit && hasSeconds) {
+            return `<td class="text-end"><span class="badge text-bg-success">${formatRunSeconds(seconds)}</span></td>`
+          }
+          if (isInferred) {
+            return '<td class="text-end"><span class="badge text-bg-secondary">Not Configured</span></td>'
+          }
+          return '<td class="text-end text-muted small">—</td>'
+        }).join('')
+        return `
+          <tr>
+            <td>${entry.name}</td>
+            <td>${typeLabel}</td>
+            <td><span class="badge ${klass}">${entry.status}</span></td>
+            ${durationCells}
+          </tr>
+        `
+      }).join('')
+    }
+
+    container.classList.remove('d-none')
+  }
+
+  function fetchRunProgress () {
+    return fetch('/logscan/progress')
+      .then(res => {
+        if (!res.ok) return null
+        return res.json()
+      })
+      .then(data => {
+        if (!data) {
+          if (lastRunProgressPayload) {
+            renderRunProgress(lastRunProgressPayload)
+          } else {
+            const container = document.getElementById('run-progress')
+            if (container) container.classList.add('d-none')
+          }
+          return
+        }
+        renderRunProgress(data)
+      })
+      .catch(() => {
+        if (lastRunProgressPayload) {
+          renderRunProgress(lastRunProgressPayload)
+        } else {
+          const container = document.getElementById('run-progress')
+          if (container) container.classList.add('d-none')
+        }
+      })
   }
 
   function getUpdateButtonLabel () {
@@ -1836,9 +2059,31 @@ $(document).ready(function () {
         }
         clearInterval(kometaInterval)
         clearInterval(kometaStatusInterval)
+        stopProgressPolling()
+        if (lastRunProgressPayload) {
+          const stoppedPayload = JSON.parse(JSON.stringify(lastRunProgressPayload))
+          const stoppedLibrary = stoppedPayload.current_library
+          stoppedPayload.current_library = null
+          stoppedPayload.phase_current = null
+          if (Array.isArray(stoppedPayload.libraries)) {
+            stoppedPayload.libraries = stoppedPayload.libraries.map(entry => {
+              if (entry.status === 'In progress') {
+                return { ...entry, status: 'Stopped' }
+              }
+              if (stoppedLibrary && entry.name === stoppedLibrary && !['Done', 'Skipped'].includes(entry.status)) {
+                return { ...entry, status: 'Stopped' }
+              }
+              return entry
+            })
+          }
+          lastRunProgressPayload = stoppedPayload
+          renderRunProgress(stoppedPayload)
+        }
+        KOMETA_STATUS = 'not started'
         $('#run-now').prop('disabled', false)
         $('#run-now-label').text('Run Now')
         $('#stop-now').addClass('d-none') // hide stop again
+        updateRunNowState()
       })
       .catch(err => {
         console.error('Error stopping Kometa process:', err) // Optional for debugging
@@ -1955,6 +2200,10 @@ $(document).ready(function () {
         // If we reach here, it's either "done" or "not started"
         if (typeof kometaInterval !== 'undefined' && kometaInterval) clearInterval(kometaInterval)
         if (typeof kometaStatusInterval !== 'undefined' && kometaStatusInterval) clearInterval(kometaStatusInterval)
+        stopProgressPolling()
+        if (lastRunProgressPayload) {
+          renderRunProgress(lastRunProgressPayload)
+        }
 
         $runNow.html('<i class="bi bi-play-fill me-1"></i> Run Now')
         $stopNow.addClass('d-none').prop('disabled', false)

--- a/static/local-js/900-final.js
+++ b/static/local-js/900-final.js
@@ -897,10 +897,10 @@ $(document).ready(function () {
 
     const prepRow = document.getElementById('run-prep-row')
     if (prepRow) {
-      const hasLockedPrep = typeof payload.preparation_seconds === 'number'
-      const prepSeconds = hasLockedPrep
-        ? payload.preparation_seconds
-        : (typeof payload.preparation_elapsed_seconds === 'number' ? payload.preparation_elapsed_seconds : null)
+      const prepLockedValue = coerceRunSeconds(payload.preparation_seconds)
+      const prepLiveValue = coerceRunSeconds(payload.preparation_elapsed_seconds)
+      const hasLockedPrep = typeof prepLockedValue === 'number'
+      const prepSeconds = hasLockedPrep ? prepLockedValue : prepLiveValue
       if (prepSeconds != null) {
         const prepLabel = formatRunSeconds(prepSeconds) || '0s'
         const prepClass = hasLockedPrep ? 'text-bg-success' : 'text-bg-primary'
@@ -929,9 +929,9 @@ $(document).ready(function () {
       headerRow.innerHTML = `<th>Library</th><th>Type</th><th>Status</th>${phaseHeaders}`
     }
 
+    const visibleLibraries = libraries.filter(entry => entry.status !== 'Skipped')
     const rows = document.getElementById('run-library-rows')
     if (rows) {
-      const visibleLibraries = libraries.filter(entry => entry.status !== 'Skipped')
       rows.innerHTML = visibleLibraries.map(entry => {
         let klass = 'text-bg-secondary'
         if (entry.status === 'Done') klass = 'text-bg-success'
@@ -1009,6 +1009,57 @@ $(document).ready(function () {
           </tr>
         `
       }).join('')
+    }
+
+    const footer = document.getElementById('run-library-footer')
+    const totalRow = document.getElementById('run-library-total-row')
+    if (footer && totalRow) {
+      if (!libraries.length || !phasesToShow.length) {
+        footer.classList.add('d-none')
+      } else {
+        const totals = new Map(phasesToShow.map(phase => [phase.key, 0]))
+        visibleLibraries.forEach(entry => {
+          if (entry.status === 'Skipped') return
+          const durations = entry.durations || {}
+          phasesToShow.forEach(phase => {
+            if (phase.key === 'playlists') {
+              return
+            }
+            const seconds = durations[phase.key]
+            if (typeof seconds === 'number' && Number.isFinite(seconds)) {
+              totals.set(phase.key, (totals.get(phase.key) || 0) + seconds)
+            }
+          })
+        })
+        if (phasesToShow.some(phase => phase.key === 'playlists')) {
+          const playlistTotal = typeof payload.playlist_total_seconds === 'number' ? payload.playlist_total_seconds : null
+          if (playlistTotal != null) {
+            totals.set('playlists', playlistTotal)
+          }
+        }
+        const prepSeconds = (() => {
+          const locked = coerceRunSeconds(payload.preparation_seconds)
+          if (typeof locked === 'number' && Number.isFinite(locked)) return locked
+          const live = coerceRunSeconds(payload.preparation_elapsed_seconds)
+          return typeof live === 'number' && Number.isFinite(live) ? live : 0
+        })()
+        let grandTotal = prepSeconds
+        totals.forEach((value) => {
+          if (typeof value === 'number' && Number.isFinite(value)) {
+            grandTotal += value
+          }
+        })
+        const totalCells = phasesToShow.map(phase => {
+          const totalSeconds = totals.get(phase.key)
+          if (typeof totalSeconds === 'number' && totalSeconds > 0) {
+            return `<td class="text-end"><span class="badge text-bg-success">${formatRunSeconds(totalSeconds)}</span></td>`
+          }
+          return '<td class="text-end text-muted small">—</td>'
+        }).join('')
+        const totalLabel = grandTotal > 0 ? `<span class="badge text-bg-success">${formatRunSeconds(grandTotal)}</span>` : '—'
+        totalRow.innerHTML = `<td class="fw-semibold">Total</td><td>—</td><td>${totalLabel}</td>${totalCells}`
+        footer.classList.remove('d-none')
+      }
     }
 
     container.classList.remove('d-none')
@@ -1318,6 +1369,42 @@ $(document).ready(function () {
     if (mins || hrs) parts.push(`${mins}m`)
     parts.push(`${secs}s`)
     return parts.join(' ')
+  }
+
+  function coerceRunSeconds (value) {
+    if (typeof value === 'number' && Number.isFinite(value)) return value
+    if (typeof value !== 'string') return null
+    const trimmed = value.trim()
+    if (!trimmed) return null
+    if (/^\d+(\.\d+)?$/.test(trimmed)) return Number(trimmed)
+    const clockMatch = trimmed.match(/^(\d+):(\d{2}):(\d{2})$/)
+    if (clockMatch) {
+      const hrs = Number(clockMatch[1])
+      const mins = Number(clockMatch[2])
+      const secs = Number(clockMatch[3])
+      if ([hrs, mins, secs].every(num => Number.isFinite(num))) {
+        return (hrs * 3600) + (mins * 60) + secs
+      }
+    }
+    let total = 0
+    let matched = false
+    const hoursMatch = trimmed.match(/(\d+)\s*h\b/i)
+    if (hoursMatch) {
+      total += Number(hoursMatch[1]) * 3600
+      matched = true
+    }
+    const minsMatch = trimmed.match(/(\d+)\s*m\b/i)
+    if (minsMatch) {
+      total += Number(minsMatch[1]) * 60
+      matched = true
+    }
+    const secsMatch = trimmed.match(/(\d+)\s*s\b/i)
+    if (secsMatch) {
+      total += Number(secsMatch[1])
+      matched = true
+    }
+    if (matched && Number.isFinite(total)) return total
+    return null
   }
 
   function escapeHtml (value) {

--- a/static/local-js/imageHandler.js
+++ b/static/local-js/imageHandler.js
@@ -21,7 +21,7 @@ const ImageHandler = {
 
         const defaultOption = document.createElement('option')
         defaultOption.value = 'default'
-        defaultOption.textContent = `Select ${type} image`
+        defaultOption.textContent = 'Select Uploaded Image'
         dropdown.appendChild(defaultOption)
 
         data.images.forEach(image => {

--- a/templates/900-final.html
+++ b/templates/900-final.html
@@ -579,6 +579,9 @@
                       </tr>
                     </thead>
                     <tbody id="run-library-rows"></tbody>
+                    <tfoot id="run-library-footer" class="table-group-divider d-none">
+                      <tr id="run-library-total-row"></tr>
+                    </tfoot>
                   </table>
                 </div>
               </div>

--- a/templates/900-final.html
+++ b/templates/900-final.html
@@ -210,35 +210,53 @@
   {% endfor %}
 </div>
 {% endif %}
-<div class="form-floating mb-2">
-  <div class="form-text" id="yaml-warnings">
-    <h5>These error(s) occurred while validating your config:</h5><br>
-  </div>
-  <textarea class="form-control" placeholder="Leave a comment here" id="validation-error"
-    style="height: 300px">{{ validation_error }}</textarea>
-</div>
+<div class="accordion mt-3" id="config-output-accordion">
+  <div class="accordion-item">
+    <h2 class="accordion-header" id="config-output-heading">
+      <button class="accordion-button" type="button" data-bs-toggle="collapse"
+        data-bs-target="#config-output-collapse" aria-expanded="true" aria-controls="config-output-collapse">
+        Config Output
+      </button>
+    </h2>
+    <div id="config-output-collapse" class="accordion-collapse collapse show" aria-labelledby="config-output-heading"
+      data-bs-parent="#config-output-accordion">
+      <div class="accordion-body">
+        <div class="form-floating mb-2">
+          <div class="form-text" id="yaml-warnings">
+            <h5>These error(s) occurred while validating your config:</h5><br>
+          </div>
+          <textarea class="form-control" placeholder="Leave a comment here" id="validation-error"
+            style="height: 300px">{{ validation_error }}</textarea>
+        </div>
 
-<!-- YAML Output -->
-<div class="form-floating mb-2">
-  <div class="form-text" id="yaml-content">
-    <br>
-    <h5>Here is the YAML that was generated as a result of your inputs.</h5>
-    <div class="mt-1 mb-2 text-info fw-semibold" id="yaml-line-count"></div>
-    <br>
-    <div class="alert alert-warning" role="alert" id="no-validation-warning">
-      As a reminder, this will most likely <b>NOT</b> work with Kometa as it has not passed validation.
+        <!-- YAML Output -->
+        <div class="form-floating mb-2">
+          <div class="form-text" id="yaml-content">
+            <br>
+            <h5>Here is the YAML that was generated as a result of your inputs.</h5>
+            <div class="mt-1 mb-2 text-info fw-semibold" id="yaml-line-count"></div>
+            <br>
+            <div class="alert alert-warning" role="alert" id="no-validation-warning">
+              As a reminder, this will most likely <b>NOT</b> work with Kometa as it has not passed validation.
+            </div>
+          </div>
+          <textarea readonly id="final-yaml" class="form-control" rows="20">{{ yaml_content }}</textarea>
+        </div>
+
+        <!-- Download Buttons -->
+        {% if yaml_content %}
+        <br>
+        <a href="{{ url_for('download') }}" id="download-btn" class="btn btn-success d-none">Download Config</a>
+        <a href="{{ url_for('download_redacted') }}" id="download-redacted-btn" class="btn btn-warning d-none">Download
+          Redacted
+          Config</a>
+        {% endif %}
+      </div>
     </div>
   </div>
-  <textarea readonly id="final-yaml" class="form-control" rows="20">{{ yaml_content }}</textarea>
 </div>
 
-<!-- Download Buttons -->
 {% if yaml_content %}
-<br>
-<a href="{{ url_for('download') }}" id="download-btn" class="btn btn-success d-none">Download Config</a>
-<a href="{{ url_for('download_redacted') }}" id="download-redacted-btn" class="btn btn-warning d-none">Download Redacted
-  Config</a>
-
 <!-- Run Command Builder -->
 <div id="run-controls-container" class="d-none">
   <hr>
@@ -329,7 +347,8 @@
             <div class="mb-2 mt-3 d-none" id="library-selection-block">
               <label for="library-multiselect" class="form-label">Target Libraries (required)</label>
               <select multiple class="form-select" id="library-multiselect">
-                {% for lib in movie_libraries + show_libraries %}
+                {% set dropdown_libraries = library_dropdown if library_dropdown else (movie_libraries + show_libraries) %}
+                {% for lib in dropdown_libraries %}
                 <option value="{{ lib.name }}">{{ lib.name }}</option>
                 {% endfor %}
               </select>
@@ -355,7 +374,7 @@
                 <input class="form-check-input" type="radio" name="mode-flag" id="opt-mode-none" value="" checked>
                 <label class="form-check-label" for="opt-mode-none">Default</label>
               </div>
-              {% for opt in ["operations-only", "collections-only", "playlists-only", "overlays-only"] %}
+            {% for opt in ["operations-only", "metadata-only", "collections-only", "overlays-only", "playlists-only"] %}
               <div class="form-check form-check-inline">
                 <input class="form-check-input" type="radio" name="mode-flag" id="opt-{{ opt }}" value="--{{ opt }}">
                 <label class="form-check-label" for="opt-{{ opt }}">--{{ opt }}</label>
@@ -460,39 +479,65 @@
     </div>
 
     <!-- Kometa actions (always visible) -->
-    <div id="kometa-actions" class="mt-3" style="max-width: 1200px; width: 100%; margin: 0 auto;">
-      <div class="alert alert-secondary">
-        <div class="mb-2">
-          Kometa will be installed/updated in:
-          <code id="kometa-install-path">{{ kometa_default_display }}</code>
-        </div>
-        <div class="d-flex flex-wrap align-items-center gap-3">
-          <button id="update-kometa-btn" type="button" class="btn btn-primary btn-sm"
-            data-branch="{{ version_info.branch }}">
-            <i class="bi bi-arrow-clockwise me-1"></i> Check for Kometa Updates
+    <div class="accordion mt-3" id="kometa-actions-accordion" style="max-width: 1200px; width: 100%; margin: 0 auto;">
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="kometa-actions-heading">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+            data-bs-target="#kometa-actions-collapse" aria-expanded="false" aria-controls="kometa-actions-collapse">
+            Kometa Install / Update
           </button>
-          <div class="form-check form-switch small">
-            <input class="form-check-input" type="checkbox" id="force-kometa-update">
-            <label class="form-check-label" for="force-kometa-update">Force update</label>
+        </h2>
+        <div id="kometa-actions-collapse" class="accordion-collapse collapse" aria-labelledby="kometa-actions-heading"
+          data-bs-parent="#kometa-actions-accordion">
+          <div class="accordion-body">
+            <div id="kometa-actions">
+              <div class="alert alert-secondary mb-0">
+                <div class="mb-2">
+                  Kometa will be installed/updated in:
+                  <code id="kometa-install-path">{{ kometa_default_display }}</code>
+                </div>
+                <div class="d-flex flex-wrap align-items-center gap-3">
+                  <button id="update-kometa-btn" type="button" class="btn btn-primary btn-sm"
+                    data-branch="{{ version_info.branch }}">
+                    <i class="bi bi-arrow-clockwise me-1"></i> Check for Kometa Updates
+                  </button>
+                  <div class="form-check form-switch small">
+                    <input class="form-check-input" type="checkbox" id="force-kometa-update">
+                    <label class="form-check-label" for="force-kometa-update">Force update</label>
+                  </div>
+                </div>
+                <div class="form-text text-muted mt-1">
+                  Force update re-downloads Kometa even if it is already up to date.
+                </div>
+                <div id="kometa-update-box" class="alert alert-warning mt-2 mb-0 d-none" role="alert">
+                  Update available: <span id="kometa-local-version"></span> -> <span id="kometa-remote-version"></span>.
+                  Click "Update Available" to apply it.
+                </div>
+
+                <pre id="kometa-validation-log" class="form-control bg-dark text-light mt-3"
+                  style="height: 300px; overflow-y: auto; overflow-x: auto; white-space: pre;"></pre>
+              </div>
+            </div>
           </div>
         </div>
-        <div class="form-text text-muted mt-1">
-          Force update re-downloads Kometa even if it is already up to date.
-        </div>
-        <div id="kometa-update-box" class="alert alert-warning mt-2 mb-0 d-none" role="alert">
-          Update available: <span id="kometa-local-version"></span> -> <span id="kometa-remote-version"></span>.
-          Click "Update Available" to apply it.
-        </div>
-
-        <pre id="kometa-validation-log" class="form-control bg-dark text-light mt-3"
-          style="height: 300px; overflow-y: auto; overflow-x: auto; white-space: pre;"></pre>
       </div>
     </div>
 
     <!-- Command Output -->
-    <div id="run-command-box" class="position-relative border rounded bg-body-tertiary p-3 mt-3 d-none">
-      <p class="form-label">Command</p>
-      <pre class="mb-0 text-wrap" style="white-space: pre-wrap; word-break: break-word;">
+    <div id="run-command-output-accordion" class="accordion mt-3 d-none">
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="run-command-output-heading">
+          <button class="accordion-button" type="button" data-bs-toggle="collapse"
+            data-bs-target="#run-command-output-collapse" aria-expanded="true" aria-controls="run-command-output-collapse">
+            Run Command
+          </button>
+        </h2>
+        <div id="run-command-output-collapse" class="accordion-collapse collapse show"
+          aria-labelledby="run-command-output-heading" data-bs-parent="#run-command-output-accordion">
+          <div class="accordion-body">
+            <div id="run-command-box" class="position-relative border rounded bg-body-tertiary p-3 d-none">
+              <p class="form-label">Command</p>
+              <pre class="mb-0 text-wrap" style="white-space: pre-wrap; word-break: break-word;">
 {% set running_on = version_info.running_on | default('') %}
 {% set is_win = 'Windows' in running_on %}
 {% set kometa_default_path = (config_dir ~ '/kometa') %}
@@ -504,45 +549,67 @@
       data-kometa-root-default-display="{{ kometa_default_display }}">
 </code>
 </pre>
-      <button type="button" id="copy-command"
-        class="btn btn-outline-secondary btn-sm position-absolute top-0 end-0 m-2 d-flex align-items-center gap-2">
-        <i class="bi bi-files" id="copy-icon"></i>
-        <span id="copy-text">Copy</span>
-      </button>
-      <button id="run-now" class="btn btn-primary mt-3" disabled>
-        <i class="bi bi-play-fill me-1"></i> <span id="run-now-label">Run Now</span>
-      </button>
-      <button type="button" id="stop-now" class="btn btn-danger mt-3 ms-2 d-none">
-        <i class="bi bi-stop-fill me-1"></i> Stop
-      </button>
-      <div id="run-output" class="mt-3 d-none">
-        <div class="d-flex align-items-center gap-3 flex-wrap mb-2">
-          <small class="text-muted d-block" id="run-output-notice">
-            <i class="bi bi-info-circle"></i> Showing last 2000 lines from meta.log
-          </small>
-          <div class="form-check form-switch">
-            <input class="form-check-input" type="checkbox" id="run-log-autoscroll" checked>
-            <label class="form-check-label" for="run-log-autoscroll">Auto-scroll</label>
-          </div>
-          <div class="d-flex align-items-center gap-2">
-            <label for="run-log-tail" class="form-label mb-0">Tail size</label>
-            <select id="run-log-tail" class="form-select form-select-sm" style="width: 110px;">
-              <option value="200">200</option>
-              <option value="2000" selected>2000</option>
-              <option value="20000">20000</option>
-              <option value="all">All</option>
-            </select>
-          </div>
-          <button type="button" class="btn btn-outline-secondary btn-sm" id="download-log-btn">
-            <i class="bi bi-download me-1"></i> Download log
-          </button>
-          <button type="button" class="btn btn-outline-secondary btn-sm" id="pause-log-btn">
-            <i class="bi bi-pause-circle me-1"></i> Pause
-          </button>
-          <div class="d-flex align-items-center gap-2 flex-wrap log-filter-row">
-            <label for="run-log-filter" class="form-label mb-0">Filter</label>
-            <div class="input-group input-group-sm" style="width: 210px;">
-              <input id="run-log-filter" class="form-control" placeholder="Regex or text">
+              <button type="button" id="copy-command"
+                class="btn btn-outline-secondary btn-sm position-absolute top-0 end-0 m-2 d-flex align-items-center gap-2">
+                <i class="bi bi-files" id="copy-icon"></i>
+                <span id="copy-text">Copy</span>
+              </button>
+              <button id="run-now" class="btn btn-primary mt-3" disabled>
+                <i class="bi bi-play-fill me-1"></i> <span id="run-now-label">Run Now</span>
+              </button>
+              <button type="button" id="stop-now" class="btn btn-danger mt-3 ms-2 d-none">
+                <i class="bi bi-stop-fill me-1"></i> Stop
+              </button>
+              <div id="run-progress" class="mt-3 d-none">
+                <div class="d-flex flex-wrap align-items-center gap-3 mb-2">
+                  <div class="fw-semibold">Run progress</div>
+                  <div id="run-progress-summary" class="text-muted small"></div>
+                </div>
+        <div class="progress mb-2" style="height: 10px;">
+          <div id="run-progress-bar" class="progress-bar" role="progressbar" style="width: 0%"></div>
+        </div>
+        <div id="run-prep-row" class="mb-2 d-none"></div>
+        <div class="table-responsive">
+                  <table class="table table-sm table-striped mb-0">
+                    <thead>
+                      <tr id="run-library-header">
+                        <th>Library</th>
+                        <th>Type</th>
+                        <th>Status</th>
+                      </tr>
+                    </thead>
+                    <tbody id="run-library-rows"></tbody>
+                  </table>
+                </div>
+              </div>
+              <div id="run-output" class="mt-3 d-none">
+                <div class="d-flex align-items-center gap-3 flex-wrap mb-2">
+                  <small class="text-muted d-block" id="run-output-notice">
+                    <i class="bi bi-info-circle"></i> Showing last 2000 lines from meta.log
+                  </small>
+                  <div class="form-check form-switch">
+                    <input class="form-check-input" type="checkbox" id="run-log-autoscroll" checked>
+                    <label class="form-check-label" for="run-log-autoscroll">Auto-scroll</label>
+                  </div>
+                  <div class="d-flex align-items-center gap-2">
+                    <label for="run-log-tail" class="form-label mb-0">Tail size</label>
+                    <select id="run-log-tail" class="form-select form-select-sm" style="width: 110px;">
+                      <option value="200">200</option>
+                      <option value="2000" selected>2000</option>
+                      <option value="20000">20000</option>
+                      <option value="all">All</option>
+                    </select>
+                  </div>
+                  <button type="button" class="btn btn-outline-secondary btn-sm" id="download-log-btn">
+                    <i class="bi bi-download me-1"></i> Download log
+                  </button>
+                  <button type="button" class="btn btn-outline-secondary btn-sm" id="pause-log-btn">
+                    <i class="bi bi-pause-circle me-1"></i> Pause
+                  </button>
+                  <div class="d-flex align-items-center gap-2 flex-wrap log-filter-row">
+                    <label for="run-log-filter" class="form-label mb-0">Filter</label>
+                    <div class="input-group input-group-sm" style="width: 210px;">
+                      <input id="run-log-filter" class="form-control" placeholder="Regex or text">
               <button class="btn btn-outline-secondary d-none" type="button" id="clear-log-filter"
                 aria-label="Clear filter" title="Clear filter">
                 <i class="bi bi-x-lg"></i>

--- a/templates/partials/_movie_overlays.html
+++ b/templates/partials/_movie_overlays.html
@@ -34,7 +34,7 @@
 
                   <input type="hidden" id="{{ library.id }}-movie_selected_image" name="{{ library.id }}-movie_selected_image"
                     value="{{ data.libraries.get(library.id ~ '-movie_selected_image', '') }}">
-                  <label for="{{ library.id }}-movie-image-dropdown">Select Movie Image</label>
+                  <label for="{{ library.id }}-movie-image-dropdown">Select Uploaded Image</label>
                 </div>
 
                 <input type="file" id="{{ library.id }}-movie-upload-image"

--- a/templates/partials/_show_overlays.html
+++ b/templates/partials/_show_overlays.html
@@ -36,7 +36,7 @@
                   <input type="hidden" id="{{ library.id }}-{{ level }}_selected_image"
                     name="{{ library.id }}-{{ level }}_selected_image"
                     value="{{ data.libraries.get(library.id ~ '-' ~ level ~ '_selected_image', '') }}">
-                  <label for="{{ library.id }}-{{ level }}-image-dropdown">Select {{ level.title() }} Image</label>
+                  <label for="{{ library.id }}-{{ level }}-image-dropdown">Select Uploaded Image</label>
                 </div>
 
                 <input type="file" id="{{ library.id }}-{{ level }}-upload-image"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ import sys
 
 import pytest
 
-
 _LOADED = {}
 
 
@@ -43,6 +42,7 @@ def qs_module(app):
     import sys
 
     return sys.modules.get("quickstart") or _LOADED.get("module")
+
 
 @pytest.fixture()
 def client(app):

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -46,8 +46,7 @@ def _configure_page(page):
     page.set_default_timeout(45000)
     page.set_default_navigation_timeout(45000)
 
-    page.add_init_script(
-        """
+    page.add_init_script("""
 (() => {
   if (!window.bootstrap) {
     window.bootstrap = {
@@ -67,8 +66,7 @@ def _configure_page(page):
   attachTooltip();
   window.addEventListener('DOMContentLoaded', attachTooltip);
 })();
-"""
-    )
+""")
 
     def _block_external(route):
         parsed = urlparse(route.request.url)

--- a/tests/e2e/test_final_page_e2e.py
+++ b/tests/e2e/test_final_page_e2e.py
@@ -3,6 +3,7 @@ import re
 import pytest
 from playwright.sync_api import expect
 
+
 def _stub_validate_root(route):
     route.fulfill(
         status=200,
@@ -164,8 +165,7 @@ def test_reconnect_after_refresh_shows_running(page, live_server, monkeypatch, q
 def test_maintenance_pause_resume_toasts(page, live_server):
     page.goto(f"{live_server}/step/001-start", wait_until="domcontentloaded")
 
-    page.evaluate(
-        """() => {
+    page.evaluate("""() => {
           window.QS_handleMaintenanceStatus({
             status: 'running',
             maintenance_paused: true,
@@ -175,13 +175,11 @@ def test_maintenance_pause_resume_toasts(page, live_server):
             queued_started_at: null,
             window_unavailable: false
           })
-        }"""
-    )
+        }""")
     toast1 = page.locator(".toast .toast-body").filter(has_text="Kometa paused for Plex maintenance")
     expect(toast1).to_be_visible()
 
-    page.evaluate(
-        """() => {
+    page.evaluate("""() => {
           window.QS_handleMaintenanceStatus({
             status: 'running',
             maintenance_paused: false,
@@ -191,8 +189,7 @@ def test_maintenance_pause_resume_toasts(page, live_server):
             queued_started_at: null,
             window_unavailable: false
           })
-        }"""
-    )
+        }""")
     toast2 = page.locator(".toast .toast-body").filter(has_text="Plex maintenance ended")
     expect(toast2).to_be_visible()
 
@@ -270,8 +267,7 @@ def test_queued_run_auto_start_toast(page, live_server, monkeypatch, qs_module):
     run_now.click()
 
     page.wait_for_function("() => typeof window.QS_handleMaintenanceStatus === 'function'")
-    page.evaluate(
-        """() => {
+    page.evaluate("""() => {
           window.QS_handleMaintenanceStatus({
             status: 'running',
             maintenance_active: false,
@@ -284,8 +280,7 @@ def test_queued_run_auto_start_toast(page, live_server, monkeypatch, qs_module):
             pending_start: false,
             pending_requested_at: null
           })
-        }"""
-    )
+        }""")
 
     toast = page.locator(".toast .toast-body").filter(has_text="Kometa started from queued request")
     expect(toast).to_be_visible()

--- a/tests/test_logscan_endpoints.py
+++ b/tests/test_logscan_endpoints.py
@@ -2,6 +2,7 @@ import os
 import time
 from pathlib import Path
 
+
 class _FakeAnalyzer:
     def analyze_log_file(self, *args, **kwargs):
         return {

--- a/tests/test_logscan_endpoints.py
+++ b/tests/test_logscan_endpoints.py
@@ -82,3 +82,41 @@ def test_logscan_trends_empty(client, isolated_config_dir):
     payload = resp.get_json()
     assert payload["total_runs"] == 0
     assert payload["runs"] == []
+
+
+def test_logscan_progress_tracks_libraries(client, isolated_config_dir, monkeypatch, qs_module):
+    kometa_root = Path(qs_module.app.config["KOMETA_ROOT"])
+    log_dir = kometa_root / "config" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "meta.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "[2026-04-01 01:13:24,670] [kometa.py:730] [INFO]     |================================== Mapping Movies Library ===================================|",
+                "[2026-04-01 01:13:25,670] [kometa.py:730] [INFO]     |================================== Mapping TV Shows Library ===================================|",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_root_path", lambda: kometa_root)
+
+    def fake_retrieve_settings(section):
+        if section == "025-libraries":
+            return {
+                "libraries": {
+                    "mov-library_movies-library": "Movies",
+                    "sho-library_tv_shows-library": "TV Shows",
+                }
+            }
+        return {}
+
+    monkeypatch.setattr(qs_module.persistence, "retrieve_settings", fake_retrieve_settings)
+
+    resp = client.get("/logscan/progress")
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["total_count"] == 2
+    statuses = {entry["name"]: entry["status"] for entry in payload["libraries"]}
+    assert statuses["Movies"] == "Done"
+    assert statuses["TV Shows"] == "In progress"

--- a/tests/test_more_paths.py
+++ b/tests/test_more_paths.py
@@ -1,5 +1,6 @@
 import time
 
+
 class _FakeProc:
     def __init__(self, pid, cmdline):
         self.pid = pid

--- a/tests/test_next_set.py
+++ b/tests/test_next_set.py
@@ -1,5 +1,6 @@
 import time
 
+
 class _FakeMem:
     def __init__(self, rss):
         self.rss = rss


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

PR Description

Summary

Add logscan-based per‑library run progress with phase ordering, durations, and playlist support.
Improve run status UX on the final page with ordered tables, prep timing, totals, and collapsible sections.
Fix run‑state edge cases (stop handling, queue/run now, divider caching) and align run‑order logic with config.
Key Changes

Backend logscan enhancements for phases, playlists, preparation timing, divider detection, summary parsing, and “run finished” handling.
/logscan/progress payload expanded (phase order, allowed phases, prep timing, playlist stats, stop state handling).
Final page UI rework: phase table columns, totals row, prep row, hidden skipped rows, playlists column, ordered library dropdown, collapsible command/output.


## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
