### PR TITLE
fix users for settings page

### DIFF
--- a/modules/persistence.py
+++ b/modules/persistence.py
@@ -293,8 +293,8 @@ def get_stored_plex_credentials(name):
     return None, None
 
 
-def update_stored_plex_libraries(name, movie_libraries, show_libraries, music_libraries):
-    """Update the stored Plex libraries in the database and preserve `validated`."""
+def update_stored_plex_libraries(name, movie_libraries, show_libraries, music_libraries, user_list=None):
+    """Update stored Plex cache fields in the database and preserve `validated`."""
     try:
         # Fetch existing settings from DB before updating
         settings_before = retrieve_settings(name)
@@ -312,6 +312,9 @@ def update_stored_plex_libraries(name, movie_libraries, show_libraries, music_li
         settings_before["plex"]["tmp_movie_libraries"] = ",".join(movie_libraries) if movie_libraries else ""
         settings_before["plex"]["tmp_show_libraries"] = ",".join(show_libraries) if show_libraries else ""
         settings_before["plex"]["tmp_music_libraries"] = ",".join(music_libraries) if music_libraries else ""
+        if user_list is not None:
+            cleaned_users = [str(user).strip() for user in user_list if str(user).strip()]
+            settings_before["plex"]["tmp_user_list"] = ",".join(cleaned_users)
 
         # Convert to a format that `save_settings()` expects
         settings_formatted = settings_before["plex"]  # Pass only the `plex` section

--- a/quickstart.py
+++ b/quickstart.py
@@ -3251,10 +3251,7 @@ def step(name):
     plex_url, plex_token = persistence.get_stored_plex_credentials("010-plex")
     dummy_plex = persistence.get_dummy_data("plex") or {}
     has_plex_credentials = bool(
-        plex_url
-        and plex_token
-        and str(plex_url).strip() != str(dummy_plex.get("url", "")).strip()
-        and str(plex_token).strip() != str(dummy_plex.get("token", "")).strip()
+        plex_url and plex_token and str(plex_url).strip() != str(dummy_plex.get("url", "")).strip() and str(plex_token).strip() != str(dummy_plex.get("token", "")).strip()
     )
     settings_needs_user_refresh = name == "150-settings" and not has_cached_user_list and has_plex_credentials
 

--- a/quickstart.py
+++ b/quickstart.py
@@ -3240,10 +3240,33 @@ def step(name):
     # Ensure 'plex' key exists before accessing sub-keys
     plex_data = all_libraries.get("plex", {})
 
+    cached_user_list = plex_data.get("tmp_user_list", "")
+    if isinstance(cached_user_list, str):
+        has_cached_user_list = any(user.strip() for user in cached_user_list.split(","))
+    elif isinstance(cached_user_list, list):
+        has_cached_user_list = any(str(user).strip() for user in cached_user_list)
+    else:
+        has_cached_user_list = False
+
+    plex_url, plex_token = persistence.get_stored_plex_credentials("010-plex")
+    dummy_plex = persistence.get_dummy_data("plex") or {}
+    has_plex_credentials = bool(
+        plex_url
+        and plex_token
+        and str(plex_url).strip() != str(dummy_plex.get("url", "")).strip()
+        and str(plex_token).strip() != str(dummy_plex.get("token", "")).strip()
+    )
+    settings_needs_user_refresh = name == "150-settings" and not has_cached_user_list and has_plex_credentials
+
     # --- Refresh Plex data if needed ---
-    if name in ["010-plex", "025-libraries", "900-final"] or config_changed:
-        if all_libraries.get("validated"):
+    should_refresh_plex = name in ["010-plex", "025-libraries", "900-final"] or config_changed or settings_needs_user_refresh
+    if should_refresh_plex:
+        if all_libraries.get("validated") or settings_needs_user_refresh:
+            if settings_needs_user_refresh and app.config["QS_DEBUG"]:
+                helpers.ts_log("Auto-refreshing Plex cache for settings page because tmp_user_list is empty.", level="DEBUG")
             refresh_plex_libraries()
+            all_libraries = persistence.retrieve_settings("010-plex")
+            plex_data = all_libraries.get("plex", {})
         telemetry = persistence.retrieve_settings("plex_telemetry")
     else:
         telemetry = persistence.retrieve_settings("plex_telemetry")
@@ -4127,6 +4150,7 @@ def refresh_plex_libraries():
             plex_data.get("movie_libraries", []),
             plex_data.get("show_libraries", []),
             plex_data.get("music_libraries", []),
+            plex_data.get("user_list", []),
         )
 
         # Get fresh telemetry using helpers and store it


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

PR Description
Fixes playlist user population on 150-settings after import, especially in flows where users were not shown unless 010-plex was manually revalidated.

Problem
After importing a config, 150-settings could show “No Plex users detected” even when Plex credentials were present, because tmp_user_list was not reliably refreshed/persisted outside the Plex page validation flow.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
