### PR TITLE
ordered output on final page

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -2349,7 +2349,15 @@ def build_config(header_style="standard", config_name=None):
     plex_summary = helpers.get_plex_summary()
     qs_settings_lines = helpers.get_quickstart_settings_summary()
     qs_settings_block = "\n".join(qs_settings_lines) if qs_settings_lines else ""
-    library_names = list(movie_libraries.values()) + list(show_libraries.values())
+    movie_summary_names = sorted(
+        (str(name).strip() for name in movie_libraries.values() if str(name).strip()),
+        key=lambda value: value.casefold(),
+    )
+    show_summary_names = sorted(
+        (str(name).strip() for name in show_libraries.values() if str(name).strip()),
+        key=lambda value: value.casefold(),
+    )
+    library_names = movie_summary_names + show_summary_names
     library_details = helpers.get_library_summaries(library_names)
 
     yaml_content = (

--- a/modules/output.py
+++ b/modules/output.py
@@ -881,6 +881,15 @@ def build_libraries_section(
 ):
     libraries_section = {}
 
+    def sorted_library_items(libraries):
+        """Return deterministic library ordering by display name, then key."""
+        if not isinstance(libraries, dict):
+            return []
+        return sorted(
+            libraries.items(),
+            key=lambda item: (str(item[1]).casefold(), str(item[0]).casefold()),
+        )
+
     def add_entry(
         library_key,
         library_name,
@@ -1936,8 +1945,8 @@ def build_libraries_section(
 
     #############################################################################################
 
-    # Process movie libraries
-    for lk, ln in movie_libraries.items():
+    # Process movie libraries (A->Z by display name, deterministic on key ties)
+    for lk, ln in sorted_library_items(movie_libraries):
         add_entry(
             lk,
             ln,
@@ -1949,8 +1958,8 @@ def build_libraries_section(
             movie_top_level,
         )
 
-    # Process show libraries
-    for lk, ln in show_libraries.items():
+    # Process show libraries (A->Z by display name, deterministic on key ties)
+    for lk, ln in sorted_library_items(show_libraries):
         add_entry(
             lk,
             ln,

--- a/quickstart.py
+++ b/quickstart.py
@@ -6466,6 +6466,8 @@ def support_info():
         elif key.startswith("sho-library_"):
             show_libraries.append(str(value))
 
+    movie_libraries = sorted((name.strip() for name in movie_libraries if str(name).strip()), key=lambda value: value.casefold())
+    show_libraries = sorted((name.strip() for name in show_libraries if str(name).strip()), key=lambda value: value.casefold())
     library_names = movie_libraries + show_libraries
     if library_names:
         library_details = helpers.get_library_summaries(library_names)


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

PR Summary
Adds deterministic ordering for library output in generated YAML.

What changed
Updated library emission logic in modules/output.py to sort libraries consistently before writing the libraries: section.
Ordering rule is now:
Movie libraries A→Z (case-insensitive, by display name)
Show libraries A→Z (case-insensitive, by display name)
Internal key used as deterministic tie-breaker
Why
Previously, library order depended on insertion/state order and could feel unpredictable between runs/imports. This makes diffs cleaner and output behavior obvious.


## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
