### PR TITLE
fix last lig hint

### DIFF
--- a/quickstart.py
+++ b/quickstart.py
@@ -6192,8 +6192,6 @@ def _get_incomplete_resume_runs(limit=25, config_name=None):
     for path_key, entry in cache_logs.items():
         if not isinstance(entry, dict):
             continue
-        if entry.get("run_complete"):
-            continue
         try:
             path = Path(path_key).resolve()
         except Exception:
@@ -6224,15 +6222,16 @@ def _get_incomplete_resume_runs(limit=25, config_name=None):
             candidates.append((float(live_mtime), live_meta, {"mtime": live_mtime, "run_complete": False}))
 
     candidates.sort(key=lambda item: item[0], reverse=True)
-    results = []
-    for _, path, entry in candidates:
-        parsed = _analyze_incomplete_log_for_resume(path, cache_entry=entry, config_name=config_name)
-        if not parsed:
-            continue
-        results.append(parsed)
-        if len(results) >= safe_limit:
-            break
-    return results
+    if not candidates:
+        return []
+
+    # Only evaluate the latest run candidate. Older incomplete logs may no longer
+    # be actionable once a newer run has completed.
+    _, path, entry = candidates[0]
+    parsed = _analyze_incomplete_log_for_resume(path, cache_entry=entry, config_name=config_name)
+    if not parsed:
+        return []
+    return [parsed]
 
 
 def _build_latest_incomplete_resume_hint():

--- a/tests/test_resume_hint.py
+++ b/tests/test_resume_hint.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from flask import session
 
 
-def test_get_incomplete_resume_runs_scans_past_unparsable_latest(tmp_path, monkeypatch, qs_module):
+def test_get_incomplete_resume_runs_only_evaluates_latest_candidate(tmp_path, monkeypatch, qs_module):
     latest_candidate = tmp_path / "meta-latest.log"
     older_candidate = tmp_path / "meta-older.log"
     latest_candidate.write_text("latest", encoding="utf-8")
@@ -21,8 +21,11 @@ def test_get_incomplete_resume_runs_scans_past_unparsable_latest(tmp_path, monke
     # Keep live meta candidate out of this test.
     monkeypatch.setattr(qs_module.helpers, "get_kometa_root_path", lambda: tmp_path / "no-meta-root")
 
+    calls = []
+
     def fake_analyze(path, cache_entry=None, config_name=None):
         resolved = Path(path).resolve()
+        calls.append(resolved)
         if resolved == latest_candidate.resolve():
             return None
         if resolved == older_candidate.resolve():
@@ -37,8 +40,8 @@ def test_get_incomplete_resume_runs_scans_past_unparsable_latest(tmp_path, monke
     monkeypatch.setattr(qs_module, "_analyze_incomplete_log_for_resume", fake_analyze)
 
     runs = qs_module._get_incomplete_resume_runs(limit=1, config_name="testcfg")
-    assert len(runs) == 1
-    assert runs[0]["incomplete_log_name"] == older_candidate.name
+    assert runs == []
+    assert calls == [latest_candidate.resolve()]
 
 
 def test_build_latest_incomplete_resume_hint_exposes_explanation(monkeypatch, qs_module):


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

This small update tightens resume guidance to avoid stale recommendations.

What changed
Resume suggestion logic now evaluates only the latest run log candidate.
Older incomplete logs are no longer scanned/fallback candidates.
If the latest run is complete (or not resumable), no resume hint is shown.
Why
Prevents offering resume commands that are no longer relevant after a newer successful run.
Validation
tests/test_resume_hint.py updated for latest-only behavior.
.\scripts\run-tests.ps1 passes (47 passed).


## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
