### PR TITLE
add simkl support

### DIFF
--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -99,8 +99,16 @@ def is_valid_aspect_ratio(image, target_ratio="2:3", tolerance=0.01):
 
 def extract_library_name(key):
     """Extracts the actual library name from the key format."""
-    match = re.match(r"(mov|sho)-library_([^-]+(?:-[^-]+)*)-", key)
-    return match.group(2) if match else None
+    if not isinstance(key, str):
+        return None
+    # Capture only the library-id segment between `-library_` and the next
+    # known section marker. This avoids greedy matches when template variable
+    # keys themselves contain hyphens (e.g. `use_South-Eastern Asia`).
+    match = re.match(
+        r"^(?:mov|sho)-library_(.+?)-(?:library$|collection_|template_|attribute_|overlay_|top_level_)",
+        key,
+    )
+    return match.group(1) if match else None
 
 
 def get_pyfiglet_fonts():

--- a/modules/output.py
+++ b/modules/output.py
@@ -1205,6 +1205,20 @@ def build_libraries_section(
                         k: (True if isinstance(v, (bool, str)) and str(v).lower() == "true" else False if isinstance(v, (bool, str)) and str(v).lower() == "false" else v)
                         for k, v in all_children.items()
                     }
+                    # Normalize legacy Region key spelling so final YAML always uses
+                    # the current Kometa key with a hyphen.
+                    legacy_region_keys = {
+                        "use_South Eastern Asia": "use_South-Eastern Asia",
+                        "radarr_add_missing_South Eastern Asia": "radarr_add_missing_South-Eastern Asia",
+                        "sonarr_add_missing_South Eastern Asia": "sonarr_add_missing_South-Eastern Asia",
+                    }
+                    for old_key, new_key in legacy_region_keys.items():
+                        if old_key not in template_vars:
+                            continue
+                        # If both exist, prefer the new key's explicit value.
+                        if new_key not in template_vars:
+                            template_vars[new_key] = template_vars[old_key]
+                        template_vars.pop(old_key, None)
                     if "exclude" in template_vars:
                         exclude_values = _parse_string_list(template_vars.get("exclude"))
                         if exclude_values:

--- a/quickstart.py
+++ b/quickstart.py
@@ -6200,6 +6200,8 @@ def _get_incomplete_resume_runs(limit=25, config_name=None):
             continue
         if is_running and path.name.lower() == "meta.log":
             continue
+        # Prefer ingest-cache mtime to preserve analyzed-run ordering; live
+        # meta.log is refreshed separately below when Kometa is not running.
         mtime = entry.get("mtime")
         if not isinstance(mtime, (int, float)):
             try:
@@ -6213,13 +6215,20 @@ def _get_incomplete_resume_runs(limit=25, config_name=None):
     except Exception:
         live_meta = None
     if live_meta and live_meta.exists() and live_meta.is_file():
-        already_known = any(item[1] == live_meta for item in candidates)
-        if not already_known and not is_running:
+        if not is_running:
             try:
                 live_mtime = live_meta.stat().st_mtime
             except Exception:
                 live_mtime = 0
-            candidates.append((float(live_mtime), live_meta, {"mtime": live_mtime, "run_complete": False}))
+            # Replace any cached candidate for live meta with a fresh mtime candidate.
+            candidates = [item for item in candidates if item[1] != live_meta]
+            live_entry = cache_logs.get(str(live_meta), {}) if isinstance(cache_logs, dict) else {}
+            if not isinstance(live_entry, dict):
+                live_entry = {}
+            if not isinstance(live_entry.get("mtime"), (int, float)):
+                live_entry["mtime"] = live_mtime
+            live_entry.setdefault("run_complete", False)
+            candidates.append((float(live_mtime), live_meta, live_entry))
 
     candidates.sort(key=lambda item: item[0], reverse=True)
     if not candidates:
@@ -6252,6 +6261,7 @@ def _build_latest_incomplete_resume_hint():
         "original_command": latest.get("run_command") or "",
         "suggested_command": latest.get("resume_primary") or "",
         "log_name": latest.get("incomplete_log_name") or "",
+        "log_path": latest.get("incomplete_log_path") or "",
         "config_name": summary_config,
         "context_mismatch": context_mismatch,
         "explanation": latest.get("resume_explanation") if isinstance(latest.get("resume_explanation"), list) else [],

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1850,6 +1850,17 @@ label {
     /* Space text from border */
 }
 
+/* Final page: draw attention to collapsed Kometa section when an update is available */
+.accordion-header.kometa-update-attention {
+    border-left: 4px solid #ffc107 !important;
+    padding-left: 10px !important;
+}
+
+.accordion-button.kometa-update-attention {
+    color: #ffc107 !important;
+    font-weight: 600;
+}
+
 /* Ensure the accordion header has a transparent background */
 .accordion-button:not(.collapsed) {
     background-color: transparent !important;

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -11227,6 +11227,224 @@
         ]
       },
       {
+        "id": "collection_simkl",
+        "label": "Simkl Charts",
+        "url": "https://kometa.wiki/en/nightly/defaults/chart/simkl",
+        "media_types": [
+          "movie",
+          "show"
+        ],
+        "template_variables": [
+          {
+            "key": "collection_section",
+            "label": "Collection Section",
+            "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
+            "type": "text_input",
+            "default": "020",
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "limit",
+            "label": "Limit",
+            "type": "text_input",
+            "default": "100",
+            "tooltip": "Maximum number of items to return per Simkl list. Valid range is 1 to 500."
+          },
+          {
+            "key": "use_trending_today",
+            "label": "Simkl Trending Today",
+            "tooltip": "Collection of Simkl's Trending Today list.",
+            "type": "toggle",
+            "default": true
+          },
+          {
+            "key": "radarr_add_missing_trending_today",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_add_missing_trending_today",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "use_trending_week",
+            "label": "Simkl Trending This Week",
+            "tooltip": "Collection of Simkl's Trending This Week list.",
+            "type": "toggle",
+            "default": true
+          },
+          {
+            "key": "radarr_add_missing_trending_week",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_add_missing_trending_week",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "use_trending_month",
+            "label": "Simkl Trending This Month",
+            "tooltip": "Collection of Simkl's Trending This Month list.",
+            "type": "toggle",
+            "default": true
+          },
+          {
+            "key": "radarr_add_missing_trending_month",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_add_missing_trending_month",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "use_dvd",
+            "label": "Simkl DVD",
+            "tooltip": "Collection of Simkl's Recently Released on DVD list.",
+            "type": "toggle",
+            "default": true
+          },
+          {
+            "key": "radarr_add_missing_dvd",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_add_missing_dvd",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "style",
+            "label": "Style",
+            "type": "select",
+            "tooltip": "Controls the visual theme of the collections created.",
+            "default": "color",
+            "options": [
+              "color",
+              "white"
+            ]
+          },
+          {
+            "key": "collection_mode",
+            "label": "Collection Mode",
+            "type": "select",
+            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
+            "default": "default",
+            "options": [
+              {
+                "value": "default",
+                "label": "Library Default"
+              },
+              {
+                "value": "hide",
+                "label": "Hide Collection"
+              },
+              {
+                "value": "hide_items",
+                "label": "Hide Items in this Collection"
+              },
+              {
+                "value": "show_items",
+                "label": "Show this Collection and its Items"
+              }
+            ]
+          },
+          {
+            "key": "visible_home",
+            "label": "Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library",
+            "label": "Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared",
+            "label": "Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "collection_order",
+            "label": "Collection Order",
+            "type": "select",
+            "tooltip": "Changes the Collection Order for all collections in a Defaults File.<br><br> Default is <b>Custom (sorted in a custom order)</b> ",
+            "default": "custom",
+            "options": [
+              {
+                "value": "custom",
+                "label": "Custom Order",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "alpha",
+                "label": "Alphabetical Order",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
         "id": "collection_anilist",
         "label": "AniList Charts",
         "url": "https://kometa.wiki/en/nightly/defaults/chart/anilist",
@@ -20840,7 +21058,7 @@
             "default": true
           },
           {
-            "key": "use_South Eastern Asia",
+            "key": "use_South-Eastern Asia",
             "label": "South-Eastern Asia",
             "tooltip": "Collection of Movies that have been filmed in South-Eastern Asia.",
             "type": "toggle",

--- a/static/local-js/900-final.js
+++ b/static/local-js/900-final.js
@@ -84,6 +84,9 @@ $(document).ready(function () {
   const headerGridProgress = document.getElementById('header-style-grid-progress')
   const headerGridProgressBar = headerGridProgress ? headerGridProgress.querySelector('.progress-bar') : null
   const headerStyleLabel = document.getElementById('header-style-label')
+  const kometaActionsHeading = document.getElementById('kometa-actions-heading')
+  const kometaActionsCollapse = document.getElementById('kometa-actions-collapse')
+  const kometaActionsToggle = document.getElementById('kometa-actions-toggle')
 
   function readMetaFlag (id, datasetKey, attrKey) {
     const el = document.getElementById(id)
@@ -775,6 +778,19 @@ $(document).ready(function () {
     })
   }
 
+  function syncKometaUpdateAttention () {
+    if (!kometaActionsHeading || !kometaActionsToggle) return
+    const isCollapsed = kometaActionsToggle.classList.contains('collapsed')
+    const needsAttention = KOMETA_UPDATE_AVAILABLE && isCollapsed
+    kometaActionsHeading.classList.toggle('kometa-update-attention', needsAttention)
+    kometaActionsToggle.classList.toggle('kometa-update-attention', needsAttention)
+  }
+
+  if (kometaActionsCollapse) {
+    kometaActionsCollapse.addEventListener('shown.bs.collapse', syncKometaUpdateAttention)
+    kometaActionsCollapse.addEventListener('hidden.bs.collapse', syncKometaUpdateAttention)
+  }
+
   function showCopyButtonSuccess (iconSelector, textSelector) {
     const $icon = $(iconSelector)
     const $text = $(textSelector)
@@ -1113,6 +1129,7 @@ $(document).ready(function () {
     if ($updateKometaBtn.length) {
       $updateKometaBtn.html(getUpdateButtonLabel())
     }
+    syncKometaUpdateAttention()
   }
 
   function callUpdateKometa () {

--- a/static/local-js/eventHandler.js
+++ b/static/local-js/eventHandler.js
@@ -386,6 +386,18 @@ const EventHandler = {
   },
 
   /**
+   * Returns true if an accordion body has at least one enabled collection toggle selected.
+   * Returns false when collection toggles exist but none are selected.
+   * Returns null when no collection toggles are present.
+   */
+  hasCheckedTemplateGroupToggle: function (accordionBody) {
+    if (!accordionBody) return null
+    const toggles = Array.from(accordionBody.querySelectorAll("input[type='checkbox'][data-template-group]"))
+    if (!toggles.length) return null
+    return toggles.some(toggle => toggle.checked)
+  },
+
+  /**
    * Update accordion highlights when selections change
    */
   updateAccordionHighlights: function () {
@@ -447,6 +459,14 @@ const EventHandler = {
             return toggle?.checked
           })
         }
+      }
+
+      // Collection accordions should not stay highlighted from child values/history
+      // when every parent collection toggle is off.
+      const anyTemplateGroupChecked = EventHandler.hasCheckedTemplateGroupToggle(accordionBody)
+      if (anyTemplateGroupChecked === false) {
+        isCheckedOrSelected = false
+        hasValue = false
       }
 
       if (isCheckedOrSelected || hasValue) {
@@ -562,7 +582,11 @@ const EventHandler = {
       '.list-group li'
     ) !== null
 
-    if (!hasSelections) {
+    // If this accordion has collection toggles and none are enabled, force no highlight.
+    const anyTemplateGroupChecked = EventHandler.hasCheckedTemplateGroupToggle(accordionBody)
+    const effectiveSelections = (anyTemplateGroupChecked === false) ? false : hasSelections
+
+    if (!effectiveSelections) {
       element.classList.remove('selected')
     }
 

--- a/templates/900-final.html
+++ b/templates/900-final.html
@@ -482,7 +482,7 @@
     <div class="accordion mt-3" id="kometa-actions-accordion" style="max-width: 1200px; width: 100%; margin: 0 auto;">
       <div class="accordion-item">
         <h2 class="accordion-header" id="kometa-actions-heading">
-          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+          <button id="kometa-actions-toggle" class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
             data-bs-target="#kometa-actions-collapse" aria-expanded="false" aria-controls="kometa-actions-collapse">
             Kometa Install / Update
           </button>
@@ -566,6 +566,11 @@
                       | Config in log: <code>{{ incomplete_resume_hint.config_name }}</code>
                       {% endif %}
                     </div>
+                    {% if incomplete_resume_hint.log_path %}
+                    <div class="small text-muted mb-1 text-break">
+                      Source path: <code>{{ incomplete_resume_hint.log_path }}</code>
+                    </div>
+                    {% endif %}
                     {% if incomplete_resume_hint.context_mismatch %}
                     <div class="small text-danger mb-1">
                       Warning: this incomplete run was recorded under a different config name than the one currently loaded.


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Title
Add Simkl chart support and fix region key/output alignment

Summary
This PR adds Simkl chart collections support and fixes a key-mapping/output issue that caused use_South-Eastern Asia to be missing from generated final YAML.

What changed

Added Simkl chart collection support in Quickstart collections config (applies to both movies and shows).
Updated output normalization for legacy region key variants so older saved keys map to current dashed form.
Fixed library key parsing to correctly handle template variable keys containing hyphens (e.g. use_South-Eastern Asia), preventing dropped values in final YAML.
Why

Simkl defaults are now available in Kometa and should be selectable/generatable from 025-libraries.
UI state and generated YAML were misaligned for certain hyphenated region keys; this resolves that mismatch.


## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #1172 

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
