### PR TITLE
fix logscan and playlist bugs plus tests

### DIFF
--- a/modules/logscan.py
+++ b/modules/logscan.py
@@ -46,7 +46,7 @@ PEOPLE_README_URLS = [
 PEOPLE_MISSING_WARNING_REGEX = (
     r"Collection Warning: No Poster Found at "
     r"(https://raw\.githubusercontent\.com/"
-    r"(?:Kometa-Team/People-Images|meisnate12/Plex-Meta-Manager-People(?:-[^/]+)?)"
+    r"(?:Kometa-Team/People-Images(?:-[^/]+)?|meisnate12/Plex-Meta-Manager-People(?:-[^/]+)?)"
     r"/[^\s\]]+)"
 )
 PEOPLE_MISSING_WARNING_RE = re.compile(PEOPLE_MISSING_WARNING_REGEX, re.IGNORECASE)
@@ -2648,7 +2648,7 @@ class LogscanAnalyzer:
             msg = raw_line.split("|", 1)[1].strip() if "|" in raw_line else raw_line.strip()
             msg = self._strip_divider_wrappers(msg)
 
-            if "kometa.py" in raw_line and playlists_header_re.match(msg):
+            if playlists_header_re.match(msg):
                 playlists_detected = True
                 playlist_running = True
                 if playlist_started_at is None and line_ts:
@@ -2657,7 +2657,7 @@ class LogscanAnalyzer:
                     processing_started_at = line_ts
                 continue
 
-            if "kometa.py" in raw_line and playlist_runtime_re.search(msg):
+            if playlist_runtime_re.search(msg):
                 playlists_detected = True
                 match = playlist_runtime_re.search(msg)
                 if match:
@@ -2666,7 +2666,7 @@ class LogscanAnalyzer:
                         playlist_total_seconds += int(seconds)
                 continue
 
-            if "kometa.py" in raw_line and playlist_finished_re.search(msg):
+            if playlist_finished_re.search(msg):
                 playlists_detected = True
                 if playlist_started_at is None and line_ts:
                     playlist_started_at = line_ts
@@ -2823,6 +2823,20 @@ class LogscanAnalyzer:
                 break
 
         section_runtimes = self.extract_section_runtimes(content)
+        # Fallback for playlist timing when runtime lines do not match the
+        # stricter live parser patterns (for example continuation lines).
+        if playlist_total_seconds <= 0 and isinstance(section_runtimes, dict):
+            playlist_runtime_total = 0
+            for section_name, seconds in section_runtimes.items():
+                if not isinstance(section_name, str):
+                    continue
+                if "playlist" not in section_name.lower():
+                    continue
+                if isinstance(seconds, (int, float)):
+                    playlist_runtime_total += int(seconds)
+            if playlist_runtime_total > 0:
+                playlist_total_seconds = playlist_runtime_total
+                playlists_detected = True
         phases_completed = []
         for section_name in section_runtimes.keys():
             phase = self._map_section_to_phase(section_name)

--- a/static/local-js/900-final.js
+++ b/static/local-js/900-final.js
@@ -988,12 +988,13 @@ $(document).ready(function () {
             const total = typeof payload.playlist_total_seconds === 'number' ? payload.playlist_total_seconds : null
             const running = Boolean(payload.playlist_running)
             const elapsed = typeof payload.playlist_elapsed_seconds === 'number' ? payload.playlist_elapsed_seconds : null
+            const detected = Boolean(payload.playlists_detected)
             if (running) {
               const label = elapsed != null ? formatRunSeconds(elapsed) : 'Running'
               return `<td class="text-end"><span class="badge text-bg-primary">${label || 'Running'}</span></td>`
             }
-            if (total != null && total > 0) {
-              return `<td class="text-end"><span class="badge text-bg-success">${formatRunSeconds(total)}</span></td>`
+            if (total != null && (total > 0 || detected)) {
+              return `<td class="text-end"><span class="badge text-bg-success">${formatRunSeconds(total) || '0s'}</span></td>`
             }
             if (payload.run_finished) {
               return '<td class="text-end"><span class="badge text-bg-secondary">Not Configured</span></td>'
@@ -1055,7 +1056,8 @@ $(document).ready(function () {
         })
         if (phasesToShow.some(phase => phase.key === 'playlists')) {
           const playlistTotal = typeof payload.playlist_total_seconds === 'number' ? payload.playlist_total_seconds : null
-          if (playlistTotal != null) {
+          const playlistDetected = Boolean(payload.playlists_detected)
+          if (playlistTotal != null && (playlistTotal > 0 || playlistDetected)) {
             totals.set('playlists', playlistTotal)
           }
         }
@@ -1073,6 +1075,12 @@ $(document).ready(function () {
         })
         const totalCells = phasesToShow.map(phase => {
           const totalSeconds = totals.get(phase.key)
+          if (phase.key === 'playlists' && typeof totalSeconds === 'number' && Number.isFinite(totalSeconds)) {
+            const detected = Boolean(payload.playlists_detected)
+            if (totalSeconds > 0 || detected) {
+              return `<td class="text-end"><span class="badge text-bg-success">${formatRunSeconds(totalSeconds) || '0s'}</span></td>`
+            }
+          }
           if (typeof totalSeconds === 'number' && totalSeconds > 0) {
             return `<td class="text-end"><span class="badge text-bg-success">${formatRunSeconds(totalSeconds)}</span></td>`
           }

--- a/tests/test_logscan_people_posters.py
+++ b/tests/test_logscan_people_posters.py
@@ -2,10 +2,7 @@ from modules.logscan import LogscanAnalyzer, PEOPLE_MISSING_WARNING_RE
 
 
 def test_people_warning_regex_matches_signature_repo():
-    line = (
-        "Collection Warning: No Poster Found at "
-        "https://raw.githubusercontent.com/Kometa-Team/People-Images-signature/master/P/Images/Pamela%20Anderson.jpg"
-    )
+    line = "Collection Warning: No Poster Found at " "https://raw.githubusercontent.com/Kometa-Team/People-Images-signature/master/P/Images/Pamela%20Anderson.jpg"
     assert PEOPLE_MISSING_WARNING_RE.search(line)
 
 

--- a/tests/test_logscan_people_posters.py
+++ b/tests/test_logscan_people_posters.py
@@ -1,0 +1,34 @@
+from modules.logscan import LogscanAnalyzer, PEOPLE_MISSING_WARNING_RE
+
+
+def test_people_warning_regex_matches_signature_repo():
+    line = (
+        "Collection Warning: No Poster Found at "
+        "https://raw.githubusercontent.com/Kometa-Team/People-Images-signature/master/P/Images/Pamela%20Anderson.jpg"
+    )
+    assert PEOPLE_MISSING_WARNING_RE.search(line)
+
+
+def test_extract_missing_people_names_from_signature_repo_warning():
+    analyzer = LogscanAnalyzer()
+    line = (
+        "[2026-04-13 13:19:15,251] [builder.py:1725] [WARNING]  | Collection Warning: No Poster Found at "
+        "https://raw.githubusercontent.com/Kometa-Team/People-Images-signature/master/P/Images/Pamela%20Anderson.jpg |"
+    )
+    names = analyzer._extract_missing_people_names([line], available=set(), name_hint=None)
+    assert names == {"pamela anderson"}
+
+
+def test_collect_missing_people_lines_with_signature_repo_warning():
+    analyzer = LogscanAnalyzer()
+    content = "\n".join(
+        [
+            "[2026-04-13 13:19:14,900] [builder.py:1495] [DEBUG] | Validating Method: key_name |",
+            "[2026-04-13 13:19:14,901] [builder.py:1496] [DEBUG] | Value: Pamela Anderson |",
+            "[2026-04-13 13:19:15,251] [builder.py:1725] [WARNING] | Collection Warning: No Poster Found at https://raw.githubusercontent.com/Kometa-Team/People-Images-signature/master/P/Images/Pamela%20Anderson.jpg |",
+            "[2026-04-13 13:19:15,252] [builder.py:1496] [DEBUG] | Value: hide |",
+        ]
+    )
+    items = analyzer.collect_missing_people_lines(content, available_index=set(), max_block_lines=30)
+    assert items
+    assert "pamela anderson" in items[0].get("names", set())

--- a/tests/test_logscan_runtime_parse.py
+++ b/tests/test_logscan_runtime_parse.py
@@ -23,3 +23,35 @@ def test_analyze_content_marks_complete_for_day_runtime():
     assert isinstance(summary, dict)
     assert summary.get("run_complete") is True
     assert summary.get("run_time_seconds") == (1 * 24 * 3600) + (2 * 3600) + (20 * 60) + 31
+
+
+def test_extract_progress_playlist_runtime_from_continuation_line():
+    analyzer = LogscanAnalyzer()
+    content = "\n".join(
+        [
+            "[2026-04-18 10:00:00,000] [kometa.py:803] [INFO] |                                            Playlists                                             |",
+            "[2026-04-18 10:00:01,000] [kometa.py:1226] [INFO] |                               Finished Demo Playlist                                |",
+            "Playlist Run Time: 0:00:05",
+            "[2026-04-18 10:00:02,000] [kometa.py:522] [INFO] |                                            Finished Run                                            |",
+        ]
+    )
+
+    progress = analyzer.extract_progress(content, library_list=[{"name": "Movies", "type": "movie"}])
+    assert progress.get("playlist_total_seconds") == 5
+    assert progress.get("playlists_detected") is True
+
+
+def test_extract_progress_playlist_runtime_when_logged_from_playlists_module():
+    analyzer = LogscanAnalyzer()
+    content = "\n".join(
+        [
+            "[2026-04-18 10:00:00,000] [playlists.py:100] [INFO] |                                            Playlists                                             |",
+            "[2026-04-18 10:00:01,000] [playlists.py:222] [INFO] |                               Finished Demo Playlist                                |",
+            "[2026-04-18 10:00:01,000] [playlists.py:222] [INFO] |                                    Playlist Run Time: 0:00:07                                    |",
+            "[2026-04-18 10:00:02,000] [kometa.py:522] [INFO] |                                            Finished Run                                            |",
+        ]
+    )
+
+    progress = analyzer.extract_progress(content, library_list=[{"name": "Movies", "type": "movie"}])
+    assert progress.get("playlist_total_seconds") == 7
+    assert progress.get("playlists_detected") is True


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Fixes two gaps in Quickstart logscan/final progress reporting:

Playlist timing parsing is now more robust in modules/logscan.py by removing strict kometa.py gating, handling playlist runtime lines from playlists.py, and adding a fallback from section runtimes when continuation-style lines are present.
Final-step UI in static/local-js/900-final.js now shows playlist timing when playlists were detected, including a 0s badge instead of leaving the column blank.
Missing-people poster detection now recognizes Kometa-Team/People-Images-* repos (including People-Images-signature) and correctly extracts names from Collection Warning: No Poster Found ... lines.
Added regression coverage in tests/test_logscan_runtime_parse.py and new tests/test_logscan_people_posters.py.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
