### PR TITLE
Config file cleanup

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -9,6 +9,7 @@ CLI
 config
 configs
 Deduped
+deduplicated
 else's
 Emby
 exe

--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -46,6 +46,7 @@ Tautulli
 tmdb
 TODO
 Trakt
+truthy
 txt
 ui
 venv

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Special thanks to [meisnate12](https://github.com/meisnate12), [bullmoose20](htt
   - [Linux/Mac:](#linuxmac)
   - [Debugging \& Changing Ports](#debugging--changing-ports)
 - [Testing](#testing)
+- [Appendix: Dependency Map](#appendix-dependency-map)
 
 ## Prerequisites
 
@@ -432,5 +433,45 @@ Notes for Playwright on Windows:
 
 - Playwright requires named pipes. If you see `Access is denied`, re-run PowerShell as Administrator or adjust security policy to allow Playwright browser processes.
 - E2E tests load Bootstrap and jQuery from CDNs (`cdn.jsdelivr.net`, `code.jquery.com`). If you’re behind a strict firewall, allowlist those hosts or the tests may fail to render the UI correctly.
+
+## Appendix: Dependency Map
+
+This appendix documents the current rules that promote optional setup pages into the menu TODO table. A dependency card appears only when the related page exists in the active template list and at least one active library triggers one of the rules below.
+
+An "active library" means the library include toggle is enabled (`*-library` is truthy). Disabled libraries do not create dependency TODO cards.
+
+| TODO card / page | Step key | Trigger source in Libraries | Exact trigger rule | Example menu reason |
+| --- | --- | --- | --- | --- |
+| Tautulli | `030-tautulli` | Collections | `collection_tautulli` enabled on an active library | `Movies: Tautulli Charts collection enabled` |
+| OMDb | `050-omdb` | Mass update attributes | Any `mass_*` attribute that uses an `omdb` source, including `_order` lists containing `omdb*` | `Movies: mass_content_rating_update uses omdb` |
+| MDBList | `060-mdblist` | Mass update attributes; ratings overlays | Any `mass_*` attribute that uses an `mdb` source, any `_order` list containing `mdb*`, or ratings overlay image set to `letterboxd`, `metacritic`, `rt_tomato`, `rt_popcorn`, or `mdb` | `Movies: movie ratings overlay uses mdb` |
+| AniDB | `100-anidb` | Mass update attributes; collections; template collections; ratings overlays | Any `mass_*` attribute that uses an `anidb` source, any `_order` list containing `anidb*`, `collection_use_anidb`, template collection child ids ending in `use_anidb`, or ratings overlay image set to `anidb` | `Anime Shows: AniDB Popular collection enabled` |
+| Radarr | `110-radarr` | Library attributes; collections; template collections | Any enabled/configured `radarr_add_all*` or `radarr_remove_by_tag*` attribute, any collection id starting with `collection_radarr_`, or any template collection child id starting with `radarr_add_missing_` | `Movies: radarr_add_all enabled` |
+| Sonarr | `120-sonarr` | Library attributes; collections; template collections | Any enabled/configured `sonarr_add_all*` or `sonarr_remove_by_tag*` attribute, any collection id starting with `collection_sonarr_`, or any template collection child id starting with `sonarr_add_missing_` | `TV Shows: sonarr_add_all enabled` |
+| Trakt | `130-trakt` | Collections; ratings overlays | `collection_trakt` enabled on an active library, or ratings overlay image set to `trakt` | `TV Shows: Trakt Charts collection enabled` |
+| MyAnimeList | `140-mal` | Collections; supported mass update attributes; ratings overlays | `collection_myanimelist`, supported `mass_*` operations using `mal`, `mal_english`, or `mal_japanese`, matching `_order` lists containing those values, or ratings overlay image set to `mal` | `Anime: MyAnimeList Charts collection enabled` |
+
+### MyAnimeList-specific mass update operations
+
+The following attribute operations will trigger the MyAnimeList TODO card when they use `mal`, `mal_english`, or `mal_japanese` directly or through the corresponding `_order` list:
+
+| Operation |
+| --- |
+| `mass_genre_update` |
+| `mass_content_rating_update` |
+| `mass_original_title_update` |
+| `mass_studio_update` |
+| `mass_originally_available_update` |
+| `mass_added_at_update` |
+| `mass_audience_rating_update` |
+| `mass_critic_rating_update` |
+| `mass_user_rating_update` |
+
+### Notes
+
+- Duplicate dependency reasons are deduplicated before being shown in the menu.
+- The TODO table is driven from stored Libraries data, not just the current page URL.
+- Only MyAnimeList uses an explicit operation allowlist. OMDb, MDBList, and AniDB mass-update dependency checks are source-prefix driven and already cover matching `mass_*` attributes plus `_order` lists.
+- Validation status still affects whether the card is marked warning vs ready; the table above only covers what makes a provider page become required in the first place.
 
 <!--body3-end-->

--- a/modules/database.py
+++ b/modules/database.py
@@ -130,6 +130,7 @@ def get_unique_config_names():
     with sqlite3.connect(get_database_path(), detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES) as connection:
         connection.row_factory = sqlite3.Row
         with closing(connection.cursor()) as cursor:
+            cursor.execute(persisted_section_table_create())
             cursor.execute("SELECT DISTINCT name FROM section_data ORDER BY name ASC")
             return [row["name"] for row in cursor.fetchall()]
 
@@ -307,6 +308,42 @@ def clear_log_runs():
     return True
 
 
+def _decode_log_run_row(row):
+    if not row:
+        return None
+    decoded = dict(row)
+    section_runtimes = decoded.get("section_runtimes")
+    if isinstance(section_runtimes, str):
+        try:
+            decoded["section_runtimes"] = json.loads(section_runtimes)
+        except json.JSONDecodeError:
+            decoded["section_runtimes"] = None
+    recommendations = decoded.get("recommendations")
+    if isinstance(recommendations, str):
+        try:
+            recommendations = json.loads(recommendations)
+        except json.JSONDecodeError:
+            recommendations = None
+    if isinstance(recommendations, list):
+        decoded["recommendations_count"] = len(recommendations)
+    else:
+        decoded["recommendations_count"] = 0
+    analysis_counts = decoded.get("analysis_counts")
+    if isinstance(analysis_counts, str):
+        try:
+            decoded["analysis_counts"] = json.loads(analysis_counts)
+        except json.JSONDecodeError:
+            decoded["analysis_counts"] = None
+    library_counts = decoded.get("library_counts")
+    if isinstance(library_counts, str):
+        try:
+            decoded["library_counts"] = json.loads(library_counts)
+        except json.JSONDecodeError:
+            decoded["library_counts"] = None
+    decoded["quickstart_run_marker"] = bool(decoded.get("quickstart_run_marker"))
+    return decoded
+
+
 def get_log_runs(limit=100):
     with sqlite3.connect(get_database_path(), detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES) as connection:
         connection.row_factory = sqlite3.Row
@@ -323,39 +360,36 @@ def get_log_runs(limit=100):
                    LIMIT ?""",
                 (limit,),
             )
-            rows = [dict(row) for row in cursor.fetchall()]
+            rows = [_decode_log_run_row(row) for row in cursor.fetchall()]
             for row in rows:
-                section_runtimes = row.get("section_runtimes")
-                if isinstance(section_runtimes, str):
-                    try:
-                        row["section_runtimes"] = json.loads(section_runtimes)
-                    except json.JSONDecodeError:
-                        row["section_runtimes"] = None
-                recommendations = row.get("recommendations")
-                if isinstance(recommendations, str):
-                    try:
-                        recommendations = json.loads(recommendations)
-                    except json.JSONDecodeError:
-                        recommendations = None
-                if isinstance(recommendations, list):
-                    row["recommendations_count"] = len(recommendations)
-                else:
-                    row["recommendations_count"] = 0
                 row.pop("recommendations", None)
-                analysis_counts = row.get("analysis_counts")
-                if isinstance(analysis_counts, str):
-                    try:
-                        row["analysis_counts"] = json.loads(analysis_counts)
-                    except json.JSONDecodeError:
-                        row["analysis_counts"] = None
-                library_counts = row.get("library_counts")
-                if isinstance(library_counts, str):
-                    try:
-                        row["library_counts"] = json.loads(library_counts)
-                    except json.JSONDecodeError:
-                        row["library_counts"] = None
-                row["quickstart_run_marker"] = bool(row.get("quickstart_run_marker"))
-    return rows
+    return [row for row in rows if row]
+
+
+def get_log_run(run_key):
+    with sqlite3.connect(get_database_path(), detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES) as connection:
+        connection.row_factory = sqlite3.Row
+        with closing(connection.cursor()) as cursor:
+            _ensure_log_runs_columns(cursor)
+            cursor.execute(
+                """SELECT run_key, finished_at, run_time_seconds, kometa_version, kometa_newest_version,
+                          config_name, config_hash, run_command, command_signature, section_runtimes,
+                          recommendations, log_mtime, log_size, debug_count, info_count, warning_count,
+                          error_count, critical_count, trace_count, analysis_counts, library_counts,
+                          quickstart_run_marker, config_line_count, cache_line_count, created_at
+                   FROM log_runs
+                   WHERE run_key == ?
+                   LIMIT 1""",
+                (run_key,),
+            )
+            row = cursor.fetchone()
+            if not row:
+                return None
+            decoded = _decode_log_run_row(row)
+            if decoded:
+                decoded.pop("recommendations", None)
+            return decoded
+    return None
 
 
 def get_log_runs_count():
@@ -387,6 +421,15 @@ def get_log_run_recommendations(run_key):
                 except json.JSONDecodeError:
                     recs = None
             return recs if isinstance(recs, list) else []
+
+
+def delete_log_run(run_key):
+    with sqlite3.connect(get_database_path(), detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES) as connection:
+        connection.row_factory = sqlite3.Row
+        with closing(connection.cursor()) as cursor:
+            _ensure_log_runs_columns(cursor)
+            cursor.execute("DELETE FROM log_runs WHERE run_key == ?", (run_key,))
+            return cursor.rowcount > 0
 
 
 ANALYTICS_DEFAULT_PREFS = {

--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -2167,6 +2167,183 @@ def migrate_config_archives(history_limit: int | None = None) -> dict:
     return {"moved": moved, "errors": errors, "history_limit": history_limit}
 
 
+def normalize_config_name_for_storage(config_name: str | None) -> str:
+    name = str(config_name or "").strip().lower().replace(" ", "_")
+    return name or "default"
+
+
+def delete_config_artifacts(config_name: str | None, kometa_root: str | Path | None = None) -> dict:
+    normalized = normalize_config_name_for_storage(config_name)
+    config_dir = Path(CONFIG_DIR)
+    archive_root = config_dir / "archives"
+    removed: list[str] = []
+    errors: list[str] = []
+
+    targets = [
+        config_dir / f"{normalized}_config.yml",
+        archive_root / normalized,
+    ]
+
+    if kometa_root:
+        targets.append(Path(kometa_root) / "config" / f"{normalized}_config.yml")
+
+    for target in targets:
+        try:
+            if not target.exists():
+                continue
+            if target.is_dir():
+                shutil.rmtree(target)
+            else:
+                target.unlink()
+            removed.append(str(target))
+        except Exception as exc:
+            errors.append(f"Failed to remove {target}: {exc}")
+
+    return {"removed": removed, "errors": errors, "config_name": normalized}
+
+
+def list_orphaned_config_artifacts(active_config_names: list[str] | None = None, kometa_root: str | Path | None = None) -> dict:
+    config_dir = Path(CONFIG_DIR)
+    archive_root = config_dir / "archives"
+    current_pattern = re.compile(r"^(?P<name>.+)_config\.yml$", re.IGNORECASE)
+
+    if active_config_names is None:
+        try:
+            from modules import database
+
+            active_config_names = database.get_unique_config_names() or []
+        except Exception as exc:
+            return {"orphans": [], "errors": [f"Failed to load active config names: {exc}"]}
+
+    active_names = {normalize_config_name_for_storage(name) for name in active_config_names if str(name or "").strip()}
+    bundles: dict[str, dict] = {}
+
+    def ensure_bundle(name: str) -> dict:
+        normalized = normalize_config_name_for_storage(name)
+        bundle = bundles.get(normalized)
+        if bundle is None:
+            bundle = {
+                "name": normalized,
+                "has_current_file": False,
+                "has_kometa_copy": False,
+                "has_archive_dir": False,
+                "archive_count": 0,
+                "paths": [],
+            }
+            bundles[normalized] = bundle
+        return bundle
+
+    for path in config_dir.glob("*_config.yml"):
+        if not path.is_file():
+            continue
+        match = current_pattern.match(path.name)
+        if not match:
+            continue
+        bundle = ensure_bundle(match.group("name"))
+        bundle["has_current_file"] = True
+        bundle["paths"].append(str(path))
+
+    if archive_root.exists():
+        for path in archive_root.iterdir():
+            if not path.is_dir():
+                continue
+            bundle = ensure_bundle(path.name)
+            bundle["has_archive_dir"] = True
+            bundle["archive_count"] = sum(1 for child in path.glob("*.yml") if child.is_file())
+            bundle["paths"].append(str(path))
+
+    if kometa_root:
+        kometa_config_dir = Path(kometa_root) / "config"
+        if kometa_config_dir.exists():
+            for path in kometa_config_dir.glob("*_config.yml"):
+                if not path.is_file():
+                    continue
+                match = current_pattern.match(path.name)
+                if not match:
+                    continue
+                bundle = ensure_bundle(match.group("name"))
+                bundle["has_kometa_copy"] = True
+                bundle["paths"].append(str(path))
+
+    orphans = [bundle for name, bundle in sorted(bundles.items()) if name not in active_names]
+    return {"orphans": orphans, "errors": [], "active_names": sorted(active_names)}
+
+
+def list_orphaned_config_versions(config_name: str | None) -> dict:
+    normalized = normalize_config_name_for_storage(config_name)
+    config_dir = Path(CONFIG_DIR)
+    archive_dir = config_dir / "archives" / normalized
+    versions: list[dict] = []
+
+    def add_version(path: Path, kind: str) -> None:
+        try:
+            stats = path.stat()
+        except Exception:
+            return
+        versions.append(
+            {
+                "name": normalized,
+                "path": str(path.resolve()),
+                "kind": kind,
+                "filename": path.name,
+                "mtime": stats.st_mtime,
+                "modified_at": datetime.datetime.fromtimestamp(stats.st_mtime, datetime.UTC).isoformat().replace("+00:00", "Z"),
+                "size": stats.st_size,
+            }
+        )
+
+    current_file = config_dir / f"{normalized}_config.yml"
+    if current_file.exists() and current_file.is_file():
+        add_version(current_file, "current")
+
+    if archive_dir.exists() and archive_dir.is_dir():
+        for path in archive_dir.glob("*.yml"):
+            if path.is_file():
+                add_version(path, "archive")
+
+    versions.sort(key=lambda item: (item.get("mtime") or 0, 1 if item.get("kind") == "current" else 0), reverse=True)
+    return {"name": normalized, "versions": versions}
+
+
+def prune_orphaned_config_archives(active_config_names: list[str] | None = None) -> dict:
+    archive_root = Path(CONFIG_DIR) / "archives"
+    removed: list[str] = []
+    errors: list[str] = []
+
+    if active_config_names is None:
+        try:
+            from modules import database
+
+            active_config_names = database.get_unique_config_names() or []
+        except Exception as exc:
+            return {"removed": [], "errors": [f"Failed to load active config names: {exc}"]}
+
+    active_names = {normalize_config_name_for_storage(name) for name in active_config_names if str(name or "").strip()}
+    if not archive_root.exists():
+        return {"removed": [], "errors": []}
+
+    for path in archive_root.iterdir():
+        if not path.is_dir():
+            continue
+        normalized = normalize_config_name_for_storage(path.name)
+        should_remove = normalized not in active_names
+        if not should_remove:
+            try:
+                should_remove = not any(path.iterdir())
+            except Exception as exc:
+                errors.append(f"Failed to inspect archive directory {path}: {exc}")
+                continue
+        if not should_remove:
+            continue
+        try:
+            shutil.rmtree(path)
+            removed.append(str(path))
+        except Exception as exc:
+            errors.append(f"Failed to remove archive directory {path}: {exc}")
+
+    return {"removed": removed, "errors": errors}
+
+
 def _unwrap_doublewrap(s: str) -> str:
     """Turn ""Foo Bar"" -> "Foo Bar" (leave normal "Foo Bar" alone)."""
     if len(s) >= 2 and s[0] == s[-1] == '"':

--- a/quickstart.py
+++ b/quickstart.py
@@ -2190,7 +2190,6 @@ if cleanup_flag not in {"1", "true", "yes"}:
         helpers.update_env_variable("QS_CONFIG_CLEANUP_DONE", "1")
         os.environ["QS_CONFIG_CLEANUP_DONE"] = "1"
 
-
 def _load_or_create_secret_key():
     env_key = os.getenv("QS_SECRET_KEY", "").strip()
     if env_key:
@@ -2941,6 +2940,9 @@ def clear_data_section(name, section):
 @app.route("/clear_data/<name>")
 def clear_data(name):
     database.reset_data(name)
+    cleanup = helpers.delete_config_artifacts(name, kometa_root=app.config.get("KOMETA_ROOT", "."))
+    for msg in cleanup.get("errors", []):
+        helpers.ts_log(msg, level="WARNING")
     flash("SQLite storage cleared successfully.", "success")
     return redirect(url_for("start"))
 
@@ -3010,6 +3012,9 @@ def bulk_delete_configs():
     for name in cleaned:
         if name in available:
             database.reset_data(name)
+            cleanup = helpers.delete_config_artifacts(name, kometa_root=app.config.get("KOMETA_ROOT", "."))
+            for msg in cleanup.get("errors", []):
+                helpers.ts_log(msg, level="WARNING")
             deleted.append(name)
 
     remaining = database.get_unique_config_names() or []
@@ -3019,6 +3024,438 @@ def bulk_delete_configs():
         current = session["config_name"]
 
     return jsonify(success=True, deleted=deleted, remaining=remaining, current=current)
+
+
+@app.route("/orphaned-config-artifacts", methods=["GET"])
+def orphaned_config_artifacts():
+    result = helpers.list_orphaned_config_artifacts(kometa_root=app.config.get("KOMETA_ROOT", "."))
+    status_code = 200 if not result.get("errors") else 500
+    return jsonify(success=not bool(result.get("errors")), orphans=result.get("orphans", []), errors=result.get("errors", [])), status_code
+
+
+@app.route("/orphaned-config-artifacts/versions", methods=["GET"])
+def orphaned_config_artifact_versions():
+    name = request.args.get("name")
+    normalized = helpers.normalize_config_name_for_storage(name)
+    inventory = helpers.list_orphaned_config_artifacts(kometa_root=app.config.get("KOMETA_ROOT", "."))
+    if inventory.get("errors"):
+        return jsonify(success=False, message="Unable to inspect config storage.", errors=inventory["errors"]), 500
+
+    orphan_names = {item.get("name") for item in inventory.get("orphans", []) if item.get("name")}
+    if normalized not in orphan_names:
+        return jsonify(success=False, message="Config bundle is not currently orphaned."), 404
+
+    result = helpers.list_orphaned_config_versions(normalized)
+    return jsonify(success=True, name=normalized, versions=result.get("versions", []))
+
+
+@app.route("/orphaned-config-artifacts/restore", methods=["POST"])
+def restore_orphaned_config_artifact():
+    data = request.get_json(silent=True) or {}
+    name = helpers.normalize_config_name_for_storage(data.get("name"))
+    selected_path = data.get("path")
+    if not name or not isinstance(selected_path, str) or not selected_path.strip():
+        return jsonify(success=False, message="Config bundle name and version path are required."), 400
+
+    available = database.get_unique_config_names() or []
+    if any(existing.lower() == name.lower() for existing in available):
+        return jsonify(success=False, message="Config already exists in the database."), 400
+
+    inventory = helpers.list_orphaned_config_artifacts(kometa_root=app.config.get("KOMETA_ROOT", "."))
+    if inventory.get("errors"):
+        return jsonify(success=False, message="Unable to inspect config storage.", errors=inventory["errors"]), 500
+
+    orphan_names = {item.get("name") for item in inventory.get("orphans", []) if item.get("name")}
+    if name not in orphan_names:
+        return jsonify(success=False, message="Config bundle is not currently orphaned."), 404
+
+    versions = helpers.list_orphaned_config_versions(name).get("versions", [])
+    version_lookup = {entry.get("path"): entry for entry in versions if entry.get("path")}
+    if selected_path not in version_lookup:
+        return jsonify(success=False, message="Selected version is not available for restore."), 400
+
+    try:
+        source_path = Path(selected_path).resolve()
+        yaml_text = source_path.read_text(encoding="utf-8", errors="replace")
+    except Exception as exc:
+        return jsonify(success=False, message=f"Unable to read the selected config version: {exc}"), 400
+
+    config_data = importer.load_yaml_config(yaml_text)
+    if not config_data:
+        return jsonify(success=False, message="Selected config version could not be parsed as YAML."), 400
+
+    payload, report = importer.prepare_import_payload(config_data, set(), set())
+    if not payload:
+        return jsonify(success=False, message="Selected config version has no importable Quickstart sections."), 400
+
+    for section, data_blob in payload.items():
+        database.save_section_data(
+            name=name,
+            section=section,
+            validated=False,
+            user_entered=True,
+            data=data_blob,
+        )
+
+    config_dir = Path(helpers.CONFIG_DIR)
+    current_file = (config_dir / f"{name}_config.yml").resolve()
+    if source_path != current_file:
+        helpers.save_to_named_config(yaml_text, name)
+    else:
+        kometa_config_dir = Path(app.config.get("KOMETA_ROOT", ".")) / "config"
+        try:
+            kometa_config_dir.mkdir(parents=True, exist_ok=True)
+            (kometa_config_dir / current_file.name).write_text(yaml_text, encoding="utf-8")
+        except OSError as exc:
+            helpers.ts_log(f"Failed to sync restored config to Kometa: {exc}", level="WARNING")
+
+    session["config_name"] = name
+    try:
+        menu_templates = helpers.get_menu_list()
+        workspace_status = _build_workspace_status_context(name, menu_templates, available_configs=database.get_unique_config_names() or [])
+    except Exception:
+        workspace_status = {}
+
+    return jsonify(
+        success=True,
+        config_name=name,
+        restored_path=str(source_path),
+        imported_sections=sorted(payload.keys()),
+        report_summary=report.summary(),
+        workspace_status=workspace_status,
+    )
+
+
+@app.route("/orphaned-config-artifacts/delete", methods=["POST"])
+def delete_orphaned_config_artifacts():
+    data = request.get_json(silent=True) or {}
+    names = data.get("names") or []
+    if not isinstance(names, list):
+        return jsonify(success=False, message="Invalid request payload."), 400
+
+    selected = [helpers.normalize_config_name_for_storage(name) for name in names if str(name or "").strip()]
+    if not selected:
+        return jsonify(success=False, message="No orphaned configs selected."), 400
+
+    inventory = helpers.list_orphaned_config_artifacts(kometa_root=app.config.get("KOMETA_ROOT", "."))
+    if inventory.get("errors"):
+        return jsonify(success=False, message="Unable to inspect config storage.", errors=inventory["errors"]), 500
+
+    orphan_names = {item.get("name") for item in inventory.get("orphans", []) if item.get("name")}
+    invalid = [name for name in selected if name not in orphan_names]
+    if invalid:
+        return jsonify(success=False, message="Only orphaned config bundles can be deleted here.", invalid=invalid), 400
+
+    deleted = []
+    errors = []
+    for name in selected:
+        result = helpers.delete_config_artifacts(name, kometa_root=app.config.get("KOMETA_ROOT", "."))
+        if result.get("errors"):
+            errors.extend(result["errors"])
+        else:
+            deleted.append(name)
+
+    if errors:
+        return jsonify(success=False, deleted=deleted, errors=errors, message="Some orphaned config bundles could not be deleted."), 500
+
+    return jsonify(success=True, deleted=deleted)
+
+
+def _build_logscan_resolution_context(log_dir=None, include_candidate_files=True):
+    cache_entries = []
+    ingest_cache = _load_logscan_ingest_cache()
+    cache_logs = ingest_cache.get("logs", {}) if isinstance(ingest_cache, dict) else {}
+    if isinstance(cache_logs, dict):
+        for raw_path, entry in cache_logs.items():
+            if not isinstance(entry, dict):
+                continue
+            try:
+                path = Path(raw_path).resolve()
+            except Exception:
+                continue
+            if not path.exists() or not path.is_file():
+                continue
+            try:
+                stats = path.stat()
+            except Exception:
+                continue
+            cache_entries.append(
+                {
+                    "path": path,
+                    "mtime": float(stats.st_mtime),
+                    "size": int(stats.st_size),
+                    "run_key": entry.get("run_key"),
+                }
+            )
+
+    candidate_files = []
+    if include_candidate_files:
+        for path in _iter_logscan_candidate_files(log_dir=log_dir, include_archive=True, include_compressed=True):
+            try:
+                stats = path.stat()
+            except Exception:
+                continue
+            candidate_files.append(
+                {
+                    "path": path,
+                    "mtime": float(stats.st_mtime),
+                    "size": int(stats.st_size),
+                    "location": _classify_logscan_file_location(path, log_dir=log_dir),
+                }
+            )
+    return {"cache_entries": cache_entries, "candidate_files": candidate_files}
+
+
+def _find_logscan_cache_entry_for_run(run_key):
+    if not run_key:
+        return None
+    ingest_cache = _load_logscan_ingest_cache()
+    cache_logs = ingest_cache.get("logs", {}) if isinstance(ingest_cache, dict) else {}
+    if not isinstance(cache_logs, dict):
+        return None
+    for raw_path, entry in cache_logs.items():
+        if not isinstance(entry, dict) or entry.get("run_key") != run_key:
+            continue
+        try:
+            path = Path(raw_path).resolve()
+        except Exception:
+            continue
+        if not path.exists() or not path.is_file():
+            continue
+        try:
+            stats = path.stat()
+            mtime = float(stats.st_mtime)
+            size = int(stats.st_size)
+        except Exception:
+            mtime = float(entry.get("mtime", 0) or 0)
+            size = int(entry.get("size", 0) or 0)
+        return {
+            "path": path,
+            "mtime": mtime,
+            "size": size,
+            "run_key": entry.get("run_key"),
+        }
+    return None
+
+
+def _match_logscan_run_to_file(run_record, context=None, log_dir=None, allow_live_fallback=True):
+    if not isinstance(run_record, dict):
+        return None
+    context = context or _build_logscan_resolution_context(log_dir=log_dir)
+    run_key = run_record.get("run_key")
+    if run_key:
+        cache_matches = [entry for entry in context.get("cache_entries", []) if entry.get("run_key") == run_key]
+        if cache_matches:
+            cache_matches.sort(key=lambda entry: entry.get("mtime", 0), reverse=True)
+            match = cache_matches[0]
+            return {
+                "path": match["path"],
+                "location": _classify_logscan_file_location(match["path"], log_dir=log_dir),
+                "size": match.get("size"),
+                "mtime": match.get("mtime"),
+                "source": "cache",
+            }
+
+    target_mtime = run_record.get("log_mtime")
+    target_size = run_record.get("log_size")
+    candidates = []
+    for entry in context.get("candidate_files", []):
+        if not allow_live_fallback and entry.get("location") == "live":
+            continue
+        size_matches = target_size is not None and entry.get("size") == target_size
+        mtime_delta = None
+        mtime_matches = False
+        if target_mtime is not None:
+            try:
+                mtime_delta = abs(float(entry.get("mtime", 0)) - float(target_mtime))
+                mtime_matches = mtime_delta <= 1.0
+            except Exception:
+                mtime_delta = None
+        if not size_matches and not mtime_matches:
+            continue
+        rank = 0
+        if size_matches:
+            rank += 2
+        if mtime_matches:
+            rank += 2
+        candidates.append((rank, mtime_delta if mtime_delta is not None else 999999, -entry.get("mtime", 0), entry))
+    if not candidates:
+        return None
+    candidates.sort()
+    match = candidates[0][3]
+    return {
+        "path": match["path"],
+        "location": match.get("location") or _classify_logscan_file_location(match["path"], log_dir=log_dir),
+        "size": match.get("size"),
+        "mtime": match.get("mtime"),
+        "source": "fallback",
+    }
+
+
+def _resolve_logscan_run_log_info(run_key, run_record=None, context=None):
+    if not run_key:
+        return None
+    cache_matches = []
+    if isinstance(context, dict):
+        cache_matches = [entry for entry in context.get("cache_entries", []) if entry.get("run_key") == run_key]
+    else:
+        direct_match = _find_logscan_cache_entry_for_run(run_key)
+        if direct_match:
+            cache_matches = [direct_match]
+    if cache_matches:
+        cache_matches.sort(key=lambda entry: entry.get("mtime", 0), reverse=True)
+        match = cache_matches[0]
+        location = _classify_logscan_file_location(match["path"])
+        if not (isinstance(run_record, dict) and location == "live"):
+            return {
+                "path": match["path"],
+                "location": location,
+                "size": match.get("size"),
+                "mtime": match.get("mtime"),
+                "source": "cache",
+            }
+    run_record = run_record if isinstance(run_record, dict) else database.get_log_run(run_key)
+    if not run_record:
+        if cache_matches:
+            match = cache_matches[0]
+            return {
+                "path": match["path"],
+                "location": _classify_logscan_file_location(match["path"]),
+                "size": match.get("size"),
+                "mtime": match.get("mtime"),
+                "source": "cache",
+            }
+        return None
+    full_context = context
+    if not isinstance(full_context, dict) or not isinstance(full_context.get("candidate_files"), list) or not full_context.get("candidate_files"):
+        full_context = _build_logscan_resolution_context(include_candidate_files=True)
+    info = _match_logscan_run_to_file(run_record, context=full_context, allow_live_fallback=False)
+    if info:
+        return info
+    if cache_matches:
+        match = cache_matches[0]
+        return {
+            "path": match["path"],
+            "location": _classify_logscan_file_location(match["path"]),
+            "size": match.get("size"),
+            "mtime": match.get("mtime"),
+            "source": "cache",
+        }
+    return None
+
+
+def _resolve_logscan_run_log_path(run_key):
+    info = _resolve_logscan_run_log_info(run_key)
+    return info.get("path") if isinstance(info, dict) else None
+
+
+def _delete_logscan_run_artifact(run_key):
+    run_key = str(run_key or "").strip()
+    if not run_key:
+        return False, {"error": "run_key required"}, 400
+    run_record = database.get_log_run(run_key)
+    incomplete_run = None if run_record else _get_logscan_incomplete_run(run_key)
+    if not run_record and not incomplete_run:
+        return False, {"error": "Run not found.", "run_key": run_key}, 404
+    target_run = run_record if run_record else incomplete_run
+    info = _resolve_logscan_run_log_info(run_key, run_record=target_run)
+    if not info or not info.get("path"):
+        return False, {"error": "Archived log file for this run could not be found.", "run_key": run_key}, 404
+    if info.get("location") != "archive":
+        return False, {"error": "Only archived logs can be deleted from Analytics.", "run_key": run_key}, 409
+    deleted_file = False
+    try:
+        Path(info["path"]).unlink()
+        deleted_file = True
+    except FileNotFoundError:
+        deleted_file = False
+    except Exception as exc:
+        return False, {"error": f"Failed to delete archived log: {exc}", "run_key": run_key}, 500
+
+    if run_record:
+        database.delete_log_run(run_key)
+    _remove_logscan_ingest_cache_entries(run_key=run_key, raw_path=str(Path(info["path"]).resolve()))
+    return True, {
+        "success": True,
+        "run_key": run_key,
+        "deleted_file": deleted_file,
+        "deleted_run": bool(run_record),
+    }, 200
+
+
+def _annotate_logscan_runs(runs, context=None):
+    if not isinstance(runs, list) or not runs:
+        return [] if isinstance(runs, list) else []
+    context = context or _build_logscan_resolution_context()
+    annotated = []
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        row = dict(run)
+        info = _resolve_logscan_run_log_info(row.get("run_key"), run_record=row, context=context)
+        row["log_available"] = bool(info and info.get("path"))
+        row["log_location"] = info.get("location") if info else "missing"
+        row["log_resolved_size"] = info.get("size") if info and isinstance(info.get("size"), int) else row.get("log_size")
+        row["log_can_delete"] = row["log_location"] == "archive" and row["log_available"]
+        annotated.append(row)
+    return annotated
+
+
+@app.route("/logscan/trends/log", methods=["GET"])
+def logscan_trends_log_download():
+    run_key = request.args.get("run_key")
+    if not run_key:
+        return jsonify({"error": "run_key required"}), 400
+    log_path = _resolve_logscan_run_log_path(run_key)
+    if not log_path:
+        return jsonify({"error": "Log file for this run could not be found."}), 404
+    return send_file(
+        str(log_path),
+        as_attachment=True,
+        download_name=log_path.name,
+        mimetype="text/plain",
+    )
+
+
+@app.route("/logscan/trends/log/delete", methods=["POST"])
+def logscan_trends_log_delete():
+    payload = request.get_json(silent=True) or {}
+    raw_run_keys = payload.get("run_keys")
+    if isinstance(raw_run_keys, list):
+        run_keys = [str(value or "").strip() for value in raw_run_keys if str(value or "").strip()]
+    else:
+        run_key = str(payload.get("run_key", "")).strip()
+        run_keys = [run_key] if run_key else []
+    unique_run_keys = list(dict.fromkeys(run_keys))
+    if not unique_run_keys:
+        return jsonify({"error": "run_key required"}), 400
+
+    deleted = []
+    failures = []
+    for run_key in unique_run_keys:
+        success, result, status = _delete_logscan_run_artifact(run_key)
+        if success:
+            deleted.append(result)
+        else:
+            result["status"] = status
+            failures.append(result)
+
+    if not deleted and failures:
+        first = failures[0]
+        return jsonify({"success": False, "error": first.get("error"), "failures": failures}), int(first.get("status", 400))
+
+    response = {
+        "success": not failures,
+        "deleted": len(deleted),
+        "results": deleted,
+        "deleted_file_count": sum(1 for item in deleted if item.get("deleted_file")),
+        "deleted_run_count": sum(1 for item in deleted if item.get("deleted_run")),
+        "failures": failures,
+    }
+    if len(unique_run_keys) == 1 and deleted:
+        response["deleted_file"] = bool(deleted[0].get("deleted_file"))
+        response["deleted_run"] = bool(deleted[0].get("deleted_run"))
+    return jsonify(response)
 
 
 @app.route("/rename-config", methods=["POST"])
@@ -7016,6 +7453,10 @@ def logscan_analyze():
             }
             _save_logscan_ingest_cache(ingest_cache)
             try:
+                _archive_finished_live_meta_log_if_idle(log_path.parent)
+            except Exception:
+                pass
+            try:
                 _archive_rotated_logs(log_path.parent)
             except Exception:
                 pass
@@ -7209,13 +7650,35 @@ def logscan_progress():
 @app.route("/logscan/trends", methods=["GET"])
 def logscan_trends():
     try:
+        _archive_finished_live_meta_log_if_idle()
+    except Exception:
+        pass
+    try:
         limit = int(request.args.get("limit", "50"))
     except Exception:
         limit = 50
     limit = max(1, min(limit, 500))
     total_runs = database.get_log_runs_count()
     ingest_health = _logscan_ingest_health()
-    return jsonify({"runs": database.get_log_runs(limit=limit), "total_runs": total_runs, "ingest_health": ingest_health})
+    resolution_context = _build_logscan_resolution_context()
+    runs = _annotate_logscan_runs(database.get_log_runs(limit=limit), context=resolution_context)
+    incomplete_runs = _annotate_logscan_runs(_get_logscan_incomplete_runs(limit=limit), context=resolution_context)
+    all_runs = database.get_log_runs(limit=max(total_runs, 1)) if total_runs else []
+    all_incomplete_runs = _get_logscan_incomplete_runs(limit=500)
+    return jsonify(
+        {
+            "runs": runs,
+            "incomplete_runs": incomplete_runs,
+            "total_runs": total_runs,
+            "total_incomplete_runs": len(all_incomplete_runs),
+            "ingest_health": ingest_health,
+            "archive_storage": _get_logscan_archive_storage_summary(
+                all_runs=all_runs,
+                incomplete_runs=all_incomplete_runs,
+                context=resolution_context,
+            ),
+        }
+    )
 
 
 @app.route("/logscan/trends/recommendations", methods=["GET"])
@@ -7224,6 +7687,10 @@ def logscan_trends_recommendations():
     if not run_key:
         return jsonify({"error": "run_key required"}), 400
     recommendations = database.get_log_run_recommendations(run_key)
+    if not recommendations:
+        incomplete_run = _get_logscan_incomplete_run(run_key)
+        if incomplete_run:
+            recommendations = incomplete_run.get("recommendations") if isinstance(incomplete_run.get("recommendations"), list) else []
     return jsonify({"run_key": run_key, "recommendations": recommendations})
 
 
@@ -7273,7 +7740,43 @@ def _get_logscan_archive_dir():
     return archive_dir
 
 
-def _get_logscan_log_files(log_dir=None, include_archive=True):
+def _build_logscan_archive_filename(path, stats=None, counter=None):
+    path = Path(path)
+    if stats is None:
+        stats = path.stat()
+    timestamp = datetime.fromtimestamp(float(stats.st_mtime), tz=timezone.utc).strftime("%Y%m%d-%H%M%SZ")
+    size = int(stats.st_size)
+    suffix = "".join(path.suffixes)
+    if not suffix:
+        suffix = ".log"
+    base_name = f"meta-{timestamp}-{size}"
+    if counter and counter > 1:
+        base_name = f"{base_name}-{counter}"
+    return f"{base_name}{suffix}"
+
+
+def _build_logscan_archive_destination(path, archive_dir, stats=None):
+    path = Path(path)
+    archive_dir = Path(archive_dir)
+    if stats is None:
+        stats = path.stat()
+    counter = 1
+    while True:
+        candidate = archive_dir / _build_logscan_archive_filename(path, stats=stats, counter=counter)
+        if candidate.resolve() == path.resolve():
+            return candidate
+        if not candidate.exists():
+            return candidate
+        try:
+            candidate_stats = candidate.stat()
+            if int(candidate_stats.st_size) == int(stats.st_size) and float(candidate_stats.st_mtime) == float(stats.st_mtime):
+                return candidate
+        except Exception:
+            pass
+        counter += 1
+
+
+def _iter_logscan_candidate_files(log_dir=None, include_archive=True, include_compressed=False):
     log_dir = Path(log_dir) if log_dir else helpers.get_kometa_root_path() / "config" / "logs"
     archive_dir = _get_logscan_archive_dir() if include_archive else None
     log_files = []
@@ -7287,7 +7790,7 @@ def _get_logscan_log_files(log_dir=None, include_archive=True):
             if not path.is_file():
                 continue
             suffixes = [suffix.lower() for suffix in path.suffixes]
-            if suffixes and suffixes[-1] in (".gz", ".zip", ".7z"):
+            if not include_compressed and suffixes and suffixes[-1] in (".gz", ".zip", ".7z"):
                 continue
             if ".log" not in path.name.lower():
                 continue
@@ -7300,6 +7803,90 @@ def _get_logscan_log_files(log_dir=None, include_archive=True):
             return 0
 
     return sorted({path.resolve() for path in log_files}, key=_mtime)
+
+
+def _get_logscan_log_files(log_dir=None, include_archive=True):
+    return _iter_logscan_candidate_files(log_dir=log_dir, include_archive=include_archive, include_compressed=False)
+
+
+def _classify_logscan_file_location(path, log_dir=None):
+    if not path:
+        return "missing"
+    try:
+        resolved = Path(path).resolve()
+    except Exception:
+        return "missing"
+    live_dir = (Path(log_dir) if log_dir else helpers.get_kometa_root_path() / "config" / "logs").resolve()
+    archive_dir = _get_logscan_archive_dir().resolve()
+    try:
+        resolved.relative_to(archive_dir)
+        return "archive"
+    except ValueError:
+        pass
+    try:
+        resolved.relative_to(live_dir)
+        return "live"
+    except ValueError:
+        pass
+    return "other"
+
+
+def _format_archived_log_retention_label(keep_limit):
+    if keep_limit <= 0:
+        return "Keep all archived logs"
+    if keep_limit == 1:
+        return "Keep last 1 archived log"
+    return f"Keep last {keep_limit} archived logs"
+
+
+def _get_logscan_archive_storage_summary(all_runs=None, incomplete_runs=None, context=None):
+    context = context or _build_logscan_resolution_context()
+    archive_paths = {}
+    for entry in context.get("candidate_files", []):
+        path = entry.get("path")
+        if not path or _classify_logscan_file_location(path) != "archive":
+            continue
+        archive_paths[str(path.resolve())] = entry
+
+    tracked_paths = set()
+    tracked_bytes = 0
+    for run in list(all_runs or []) + list(incomplete_runs or []):
+        if not isinstance(run, dict):
+            continue
+        info = _resolve_logscan_run_log_info(run.get("run_key"), run_record=run, context=context)
+        if not info or info.get("location") != "archive" or not info.get("path"):
+            continue
+        path_key = str(Path(info["path"]).resolve())
+        if path_key in tracked_paths:
+            continue
+        tracked_paths.add(path_key)
+        if isinstance(info.get("size"), int):
+            tracked_bytes += info["size"]
+        else:
+            entry = archive_paths.get(path_key)
+            tracked_bytes += int(entry.get("size", 0)) if isinstance(entry, dict) else 0
+
+    total_archived_bytes = 0
+    for entry in archive_paths.values():
+        if isinstance(entry.get("size"), int):
+            total_archived_bytes += entry["size"]
+
+    total_archived_files = len(archive_paths)
+    tracked_archived_files = len(tracked_paths)
+    extra_archived_files = max(0, total_archived_files - tracked_archived_files)
+    extra_archived_bytes = max(0, total_archived_bytes - tracked_bytes)
+    keep_limit = int(app.config.get("QS_KOMETA_LOG_KEEP", 0) or 0)
+    return {
+        "archived_bytes": tracked_bytes,
+        "archived_files": tracked_archived_files,
+        "disk_archived_bytes": total_archived_bytes,
+        "disk_archived_files": total_archived_files,
+        "extra_archived_files": extra_archived_files,
+        "extra_archived_bytes": extra_archived_bytes,
+        "keep_limit": keep_limit,
+        "retention_label": _format_archived_log_retention_label(keep_limit),
+        "compression_ready": True,
+    }
 
 
 def _get_logscan_ingest_cache_path():
@@ -7345,6 +7932,77 @@ def _clear_logscan_ingest_cache():
             cache_path.unlink()
     except Exception:
         pass
+
+
+def _remove_logscan_ingest_cache_entries(run_key=None, raw_path=None):
+    cache = _load_logscan_ingest_cache()
+    logs = cache.get("logs", {}) if isinstance(cache, dict) else {}
+    if not isinstance(logs, dict):
+        return False
+    changed = False
+    for cache_key, entry in list(logs.items()):
+        matches_run = bool(run_key and isinstance(entry, dict) and entry.get("run_key") == run_key)
+        matches_path = bool(raw_path and cache_key == raw_path)
+        if not matches_run and not matches_path:
+            continue
+        logs.pop(cache_key, None)
+        changed = True
+    if changed:
+        cache["logs"] = logs
+        _save_logscan_ingest_cache(cache)
+    return changed
+
+
+def _normalize_logscan_archive_filenames(archive_dir=None):
+    archive_dir = Path(archive_dir) if archive_dir else _get_logscan_archive_dir()
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    ingest_cache = _load_logscan_ingest_cache()
+    cache_logs = ingest_cache.get("logs", {}) if isinstance(ingest_cache, dict) else {}
+    if not isinstance(cache_logs, dict):
+        cache_logs = {}
+    renamed = 0
+    skipped = 0
+    errors = []
+    cache_dirty = False
+
+    for path in sorted(_iter_logscan_candidate_files(include_archive=True, include_compressed=False), key=lambda item: item.name.lower()):
+        if _classify_logscan_file_location(path) != "archive":
+            continue
+        try:
+            stats = path.stat()
+            target = _build_logscan_archive_destination(path, archive_dir, stats=stats)
+            if target.resolve() == path.resolve():
+                skipped += 1
+                continue
+            source_key = str(path.resolve())
+            target_key = str(target.resolve())
+            shutil.move(str(path), str(target))
+            if source_key in cache_logs:
+                cache_logs[target_key] = cache_logs.pop(source_key)
+                cache_dirty = True
+            renamed += 1
+        except Exception as exc:
+            errors.append(f"Failed to normalize archived log {path}: {exc}")
+    if cache_dirty:
+        ingest_cache["logs"] = cache_logs
+        _save_logscan_ingest_cache(ingest_cache)
+    return {"renamed": renamed, "skipped": skipped, "errors": errors}
+
+
+logscan_archive_flag = os.getenv("QS_LOGSCAN_ARCHIVE_NAMING_DONE", "").strip().lower()
+if logscan_archive_flag not in {"1", "true", "yes"}:
+    logscan_archive_result = _normalize_logscan_archive_filenames()
+    if logscan_archive_result.get("renamed"):
+        helpers.ts_log(
+            f"Normalized {logscan_archive_result['renamed']} archived Kometa log file(s) to the canonical naming scheme.",
+            level="INFO",
+        )
+    if logscan_archive_result.get("errors"):
+        for msg in logscan_archive_result["errors"]:
+            helpers.ts_log(msg, level="WARNING")
+    else:
+        helpers.update_env_variable("QS_LOGSCAN_ARCHIVE_NAMING_DONE", "1")
+        os.environ["QS_LOGSCAN_ARCHIVE_NAMING_DONE"] = "1"
 
 
 def _normalize_cli_whitespace(command):
@@ -7629,6 +8287,9 @@ def _analyze_incomplete_log_for_resume(log_path, cache_entry=None, config_name=N
         return None
 
     summary = analysis.get("summary") if isinstance(analysis, dict) else None
+    recommendations = analysis.get("recommendations") if isinstance(analysis, dict) else None
+    if not isinstance(recommendations, list):
+        recommendations = []
     if not isinstance(summary, dict):
         return None
     if summary.get("run_complete"):
@@ -7715,7 +8376,8 @@ def _analyze_incomplete_log_for_resume(log_path, cache_entry=None, config_name=N
         "run_command": original_command,
         "command_signature": summary.get("command_signature"),
         "section_runtimes": summary.get("section_runtimes") or {},
-        "recommendations_count": 0,
+        "recommendations_count": len(recommendations),
+        "recommendations": recommendations,
         "log_mtime": mtime,
         "log_size": summary.get("log_size"),
         "debug_count": counts.get("debug", 0),
@@ -7742,6 +8404,192 @@ def _analyze_incomplete_log_for_resume(log_path, cache_entry=None, config_name=N
         "resume_recommendations": suggestions,
         "resume_explanation": explanation,
     }
+
+
+def _build_incomplete_run_from_cache_entry(log_path, cache_entry=None, config_name=None):
+    path = Path(log_path)
+    cache_entry = cache_entry if isinstance(cache_entry, dict) else {}
+    summary = cache_entry.get("summary") if isinstance(cache_entry.get("summary"), dict) else {}
+    recommendations = cache_entry.get("recommendations")
+    if not isinstance(recommendations, list):
+        recommendations = []
+    try:
+        stats = path.stat()
+        mtime = stats.st_mtime
+        size = stats.st_size
+    except Exception:
+        mtime = cache_entry.get("mtime") if isinstance(cache_entry.get("mtime"), (int, float)) else None
+        size = cache_entry.get("size") if isinstance(cache_entry.get("size"), int) else None
+    counts = summary.get("log_counts") if isinstance(summary.get("log_counts"), dict) else {}
+    run_key = summary.get("run_key") or cache_entry.get("run_key")
+    if not run_key:
+        run_key_seed = f"incomplete|cached|{path}|{mtime or 0}|{size or 0}"
+        run_key = hashlib.sha256(run_key_seed.encode("utf-8")).hexdigest()
+    created_at = summary.get("created_at")
+    if not created_at:
+        created_at = cache_entry.get("updated_at") or _iso_from_mtime(mtime)
+    original_command = _inject_config_path_for_command(
+        summary.get("run_command") or "",
+        config_name=summary.get("config_name") or config_name,
+    )
+    return {
+        "run_key": run_key,
+        "finished_at": summary.get("finished_at"),
+        "run_time_seconds": summary.get("run_time_seconds"),
+        "kometa_version": summary.get("kometa_version"),
+        "kometa_newest_version": summary.get("kometa_newest_version"),
+        "config_name": summary.get("config_name") or config_name or "",
+        "config_hash": summary.get("config_hash"),
+        "run_command": original_command,
+        "command_signature": summary.get("command_signature"),
+        "section_runtimes": summary.get("section_runtimes") or {},
+        "recommendations_count": len(recommendations),
+        "recommendations": recommendations,
+        "log_mtime": mtime,
+        "log_size": summary.get("log_size") if isinstance(summary.get("log_size"), int) else size,
+        "debug_count": counts.get("debug", 0),
+        "info_count": counts.get("info", 0),
+        "warning_count": counts.get("warning", 0),
+        "error_count": counts.get("error", 0),
+        "critical_count": counts.get("critical", 0),
+        "trace_count": counts.get("trace", 0),
+        "analysis_counts": summary.get("analysis_counts") if isinstance(summary.get("analysis_counts"), dict) else {},
+        "library_counts": summary.get("library_counts") if isinstance(summary.get("library_counts"), dict) else {},
+        "quickstart_run_marker": bool(summary.get("quickstart_run_marker")),
+        "config_line_count": summary.get("config_line_count"),
+        "cache_line_count": summary.get("cache_line_count"),
+        "created_at": created_at,
+        "run_complete": False,
+        "is_incomplete": True,
+        "incomplete_log_name": path.name,
+        "incomplete_log_path": str(path),
+        "phase_current": cache_entry.get("phase_current"),
+        "current_library": cache_entry.get("current_library"),
+        "current_collection": cache_entry.get("current_collection"),
+        "resume_reason": cache_entry.get("resume_reason") or "Run appears incomplete. Open the report for more detail or download the log for investigation.",
+        "resume_primary": cache_entry.get("resume_primary") or "",
+        "resume_recommendations": cache_entry.get("resume_recommendations") if isinstance(cache_entry.get("resume_recommendations"), list) else [],
+        "resume_explanation": cache_entry.get("resume_explanation") if isinstance(cache_entry.get("resume_explanation"), list) else [],
+    }
+
+
+def _build_incomplete_log_fallback(log_path, cache_entry=None, config_name=None):
+    path = Path(log_path)
+    cache_entry = cache_entry if isinstance(cache_entry, dict) else {}
+    try:
+        stats = path.stat()
+        mtime = stats.st_mtime
+        size = stats.st_size
+    except Exception:
+        mtime = cache_entry.get("mtime") if isinstance(cache_entry.get("mtime"), (int, float)) else None
+        size = cache_entry.get("size") if isinstance(cache_entry.get("size"), int) else None
+    run_key = cache_entry.get("run_key")
+    if not run_key:
+        run_key_seed = f"incomplete|fallback|{path}|{mtime or 0}|{size or 0}"
+        run_key = hashlib.sha256(run_key_seed.encode("utf-8")).hexdigest()
+    created_at = cache_entry.get("updated_at") or _iso_from_mtime(mtime)
+    return {
+        "run_key": run_key,
+        "finished_at": None,
+        "run_time_seconds": None,
+        "kometa_version": "",
+        "kometa_newest_version": "",
+        "config_name": config_name or "",
+        "config_hash": None,
+        "run_command": "",
+        "command_signature": "",
+        "section_runtimes": {},
+        "recommendations_count": 0,
+        "recommendations": [],
+        "log_mtime": mtime,
+        "log_size": size,
+        "debug_count": 0,
+        "info_count": 0,
+        "warning_count": 0,
+        "error_count": 0,
+        "critical_count": 0,
+        "trace_count": 0,
+        "analysis_counts": {},
+        "library_counts": {},
+        "quickstart_run_marker": False,
+        "config_line_count": None,
+        "cache_line_count": None,
+        "created_at": created_at,
+        "run_complete": False,
+        "is_incomplete": True,
+        "incomplete_log_name": path.name,
+        "incomplete_log_path": str(path),
+        "phase_current": None,
+        "current_library": None,
+        "current_collection": None,
+        "resume_reason": "Run appears incomplete. Detailed parse data is not available, but the log is preserved for investigation.",
+        "resume_primary": "",
+        "resume_recommendations": [],
+        "resume_explanation": ["Quickstart preserved this incomplete log file even though detailed parsing was unavailable."],
+    }
+
+
+def _get_logscan_incomplete_runs(limit=100, config_name=None):
+    safe_limit = max(0, min(int(limit or 0), 500))
+    if safe_limit == 0:
+        return []
+    ingest_cache = _load_logscan_ingest_cache()
+    cache_logs = ingest_cache.get("logs", {}) if isinstance(ingest_cache, dict) else {}
+    if not isinstance(cache_logs, dict):
+        return []
+
+    candidates = []
+    for path_key, entry in cache_logs.items():
+        if not isinstance(entry, dict) or entry.get("run_complete") is True:
+            continue
+        try:
+            path = Path(path_key).resolve()
+        except Exception:
+            continue
+        if not path.exists() or not path.is_file():
+            continue
+        try:
+            mtime = path.stat().st_mtime
+        except Exception:
+            mtime = entry.get("mtime") if isinstance(entry.get("mtime"), (int, float)) else 0
+        candidates.append((float(mtime or 0), path, entry))
+
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    parsed_runs = []
+    for _, path, entry in candidates[:safe_limit]:
+        if isinstance(entry.get("summary"), dict):
+            parsed = _build_incomplete_run_from_cache_entry(path, cache_entry=entry, config_name=config_name)
+        else:
+            parsed = _build_incomplete_log_fallback(path, cache_entry=entry, config_name=config_name)
+        if parsed:
+            parsed_runs.append(parsed)
+    return parsed_runs
+
+
+def _get_logscan_incomplete_run(run_key, config_name=None):
+    if not run_key:
+        return None
+    ingest_cache = _load_logscan_ingest_cache()
+    cache_logs = ingest_cache.get("logs", {}) if isinstance(ingest_cache, dict) else {}
+    if not isinstance(cache_logs, dict):
+        return None
+    for path_key, entry in cache_logs.items():
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("run_complete") is True:
+            continue
+        if entry.get("run_key") != run_key:
+            continue
+        path = Path(path_key)
+        if not path.exists() or not path.is_file():
+            return None
+        if isinstance(entry.get("summary"), dict):
+            return _build_incomplete_run_from_cache_entry(path, cache_entry=entry, config_name=config_name)
+        parsed = _analyze_incomplete_log_for_resume(path, cache_entry=entry, config_name=config_name)
+        if parsed:
+            return parsed
+        return _build_incomplete_log_fallback(path, cache_entry=entry, config_name=config_name)
+    return None
 
 
 def _get_incomplete_resume_runs(limit=25, config_name=None):
@@ -7907,19 +8755,19 @@ def _start_logscan_auto_reingest(log_dir):
     return True
 
 
-def _archive_log_file(path, archive_dir, log_dir=None):
+def _archive_log_file(path, archive_dir, log_dir=None, allow_live_meta=False):
     try:
         path = Path(path)
         if not path.exists() or not path.is_file():
             return None
-        if path.name.lower() == "meta.log":
+        if path.name.lower() == "meta.log" and not allow_live_meta:
             return None
         if log_dir and path.resolve().parent != Path(log_dir).resolve():
             return None
         archive_dir = Path(archive_dir)
         archive_dir.mkdir(parents=True, exist_ok=True)
         src_stats = path.stat()
-        dest = archive_dir / path.name
+        dest = _build_logscan_archive_destination(path, archive_dir, stats=src_stats)
         if dest.exists():
             try:
                 dst_stats = dest.stat()
@@ -7928,18 +8776,55 @@ def _archive_log_file(path, archive_dir, log_dir=None):
                     return dest
             except Exception:
                 pass
-            suffix = "".join(path.suffixes)
-            base = path.name[: -len(suffix)] if suffix else path.stem
-            candidate = archive_dir / f"{base}-{int(src_stats.st_mtime)}-{src_stats.st_size}{suffix}"
-            counter = 1
-            while candidate.exists():
-                candidate = archive_dir / f"{base}-{int(src_stats.st_mtime)}-{src_stats.st_size}-{counter}{suffix}"
-                counter += 1
-            dest = candidate
         shutil.move(str(path), str(dest))
         return dest
     except Exception:
         return None
+
+
+def _archive_finished_live_meta_log_if_idle(log_dir=None):
+    log_dir = Path(log_dir) if log_dir else helpers.get_kometa_root_path() / "config" / "logs"
+    live_path = (log_dir / "meta.log").resolve()
+    if helpers.is_kometa_running():
+        return None
+    if not live_path.exists() or not live_path.is_file():
+        return None
+
+    ingest_cache = _load_logscan_ingest_cache()
+    cache_logs = ingest_cache.get("logs", {}) if isinstance(ingest_cache, dict) else {}
+    if not isinstance(cache_logs, dict):
+        return None
+
+    live_key = str(live_path)
+    live_entry = cache_logs.get(live_key)
+    if not isinstance(live_entry, dict):
+        return None
+    if live_entry.get("run_complete") is not True:
+        return None
+    if not live_entry.get("run_key"):
+        return None
+
+    archive_dir = _get_logscan_archive_dir()
+    archived_path = _archive_log_file(live_path, archive_dir, log_dir=log_dir, allow_live_meta=True)
+    if not archived_path:
+        return None
+
+    try:
+        archived_stats = archived_path.stat()
+        archived_key = str(archived_path.resolve())
+    except Exception:
+        return None
+
+    updated_entry = dict(live_entry)
+    updated_entry["mtime"] = archived_stats.st_mtime
+    updated_entry["size"] = archived_stats.st_size
+    updated_entry["updated_at"] = datetime.now(timezone.utc).isoformat()
+    cache_logs.pop(live_key, None)
+    cache_logs[archived_key] = updated_entry
+    ingest_cache["logs"] = cache_logs
+    _save_logscan_ingest_cache(ingest_cache)
+    _prune_logscan_archive(archive_dir)
+    return archived_path
 
 
 def _archive_rotated_logs(log_dir):
@@ -8108,12 +8993,36 @@ def _perform_logscan_reingest(reset, job_id=None, update_state=True):
                     skipped_incomplete += 1
                     if len(sample_incomplete) < 5:
                         sample_incomplete.append(path.name)
+                    incomplete_recommendations = result.get("recommendations") if isinstance(result, dict) else None
+                    if not isinstance(incomplete_recommendations, list):
+                        incomplete_recommendations = []
                     cache_logs[cache_key] = {
                         "mtime": stats.st_mtime,
                         "size": stats.st_size,
                         "run_key": summary.get("run_key"),
                         "run_complete": False,
                         "updated_at": datetime.now(timezone.utc).isoformat(),
+                        "summary": {
+                            "run_key": summary.get("run_key"),
+                            "finished_at": summary.get("finished_at"),
+                            "run_time_seconds": summary.get("run_time_seconds"),
+                            "kometa_version": summary.get("kometa_version"),
+                            "kometa_newest_version": summary.get("kometa_newest_version"),
+                            "config_name": summary.get("config_name"),
+                            "config_hash": summary.get("config_hash"),
+                            "run_command": summary.get("run_command"),
+                            "command_signature": summary.get("command_signature"),
+                            "section_runtimes": summary.get("section_runtimes") if isinstance(summary.get("section_runtimes"), dict) else {},
+                            "log_size": summary.get("log_size"),
+                            "log_counts": summary.get("log_counts") if isinstance(summary.get("log_counts"), dict) else {},
+                            "analysis_counts": summary.get("analysis_counts") if isinstance(summary.get("analysis_counts"), dict) else {},
+                            "library_counts": summary.get("library_counts") if isinstance(summary.get("library_counts"), dict) else {},
+                            "quickstart_run_marker": bool(summary.get("quickstart_run_marker")),
+                            "config_line_count": summary.get("config_line_count"),
+                            "cache_line_count": summary.get("cache_line_count"),
+                            "created_at": summary.get("created_at"),
+                        },
+                        "recommendations": incomplete_recommendations,
                     }
                     cache_dirty = True
                     continue

--- a/quickstart.py
+++ b/quickstart.py
@@ -1,4 +1,5 @@
 import argparse
+import gzip
 import io
 import json
 import os
@@ -3349,6 +3350,54 @@ def _resolve_logscan_run_log_path(run_key):
     return info.get("path") if isinstance(info, dict) else None
 
 
+def _resolve_logscan_run_archive_action_info(run_key, prefer_uncompressed=False):
+    run_key = str(run_key or "").strip()
+    if not run_key:
+        return None
+    ingest_cache = _load_logscan_ingest_cache()
+    cache_logs = ingest_cache.get("logs", {}) if isinstance(ingest_cache, dict) else {}
+    if isinstance(cache_logs, dict):
+        archive_matches = []
+        for raw_path, entry in cache_logs.items():
+            if not isinstance(entry, dict) or entry.get("run_key") != run_key:
+                continue
+            try:
+                path = Path(raw_path).resolve()
+            except Exception:
+                continue
+            if not path.exists() or not path.is_file():
+                continue
+            location = _classify_logscan_file_location(path)
+            if location != "archive":
+                continue
+            try:
+                stats = path.stat()
+                size = int(stats.st_size)
+                mtime = float(stats.st_mtime)
+            except Exception:
+                size = int(entry.get("size", 0) or 0)
+                mtime = float(entry.get("mtime", 0) or 0)
+            archive_matches.append(
+                {
+                    "path": path,
+                    "location": location,
+                    "size": size,
+                    "mtime": mtime,
+                    "source": "cache",
+                    "is_compressed": _is_logscan_gzip_path(path),
+                }
+            )
+        if archive_matches:
+            if prefer_uncompressed:
+                plain_matches = [item for item in archive_matches if not item.get("is_compressed")]
+                if plain_matches:
+                    plain_matches.sort(key=lambda item: item.get("mtime", 0), reverse=True)
+                    return plain_matches[0]
+            archive_matches.sort(key=lambda item: item.get("mtime", 0), reverse=True)
+            return archive_matches[0]
+    return None
+
+
 def _delete_logscan_run_artifact(run_key):
     run_key = str(run_key or "").strip()
     if not run_key:
@@ -3383,6 +3432,60 @@ def _delete_logscan_run_artifact(run_key):
     }, 200
 
 
+def _compress_logscan_run_artifact(run_key):
+    run_key = str(run_key or "").strip()
+    if not run_key:
+        return False, {"error": "run_key required"}, 400
+    run_record = database.get_log_run(run_key)
+    incomplete_run = None if run_record else _get_logscan_incomplete_run(run_key)
+    if not run_record and not incomplete_run:
+        return False, {"error": "Run not found.", "run_key": run_key}, 404
+    target_run = run_record if run_record else incomplete_run
+    info = _resolve_logscan_run_archive_action_info(run_key, prefer_uncompressed=True) or _resolve_logscan_run_log_info(run_key, run_record=target_run)
+    if not info or not info.get("path"):
+        return False, {"error": "Archived log file for this run could not be found.", "run_key": run_key}, 404
+    source_path = Path(info["path"])
+    if info.get("location") != "archive":
+        return False, {"error": "Only archived logs can be compressed from Analytics.", "run_key": run_key}, 409
+    if _is_logscan_gzip_path(source_path):
+        return False, {"error": "Archived log is already compressed.", "run_key": run_key}, 409
+
+    archive_dir = _get_logscan_archive_dir()
+    compressed_path = _archive_log_file(source_path, archive_dir)
+    if not compressed_path or not compressed_path.exists():
+        return False, {"error": "Failed to compress archived log.", "run_key": run_key}, 500
+
+    cache = _load_logscan_ingest_cache()
+    cache_logs = cache.get("logs", {}) if isinstance(cache, dict) else {}
+    if not isinstance(cache_logs, dict):
+        cache_logs = {}
+    source_key = str(source_path.resolve())
+    compressed_key = str(compressed_path.resolve())
+    cache_entry = cache_logs.pop(source_key, None)
+    if not isinstance(cache_entry, dict):
+        cache_entry = {
+            "run_key": run_key,
+            "run_complete": not bool(incomplete_run),
+        }
+    try:
+        compressed_stats = compressed_path.stat()
+        cache_entry["mtime"] = compressed_stats.st_mtime
+        cache_entry["size"] = compressed_stats.st_size
+    except Exception:
+        pass
+    cache_entry["updated_at"] = datetime.now(timezone.utc).isoformat()
+    cache_logs[compressed_key] = cache_entry
+    cache["logs"] = cache_logs
+    _save_logscan_ingest_cache(cache)
+
+    return True, {
+        "success": True,
+        "run_key": run_key,
+        "compressed_file": True,
+        "compressed_path": compressed_key,
+    }, 200
+
+
 def _annotate_logscan_runs(runs, context=None):
     if not isinstance(runs, list) or not runs:
         return [] if isinstance(runs, list) else []
@@ -3396,7 +3499,9 @@ def _annotate_logscan_runs(runs, context=None):
         row["log_available"] = bool(info and info.get("path"))
         row["log_location"] = info.get("location") if info else "missing"
         row["log_resolved_size"] = info.get("size") if info and isinstance(info.get("size"), int) else row.get("log_size")
+        row["log_is_compressed"] = bool(info and info.get("path") and _is_logscan_gzip_path(info["path"]))
         row["log_can_delete"] = row["log_location"] == "archive" and row["log_available"]
+        row["log_can_compress"] = row["log_location"] == "archive" and row["log_available"] and not row["log_is_compressed"]
         annotated.append(row)
     return annotated
 
@@ -3409,11 +3514,12 @@ def logscan_trends_log_download():
     log_path = _resolve_logscan_run_log_path(run_key)
     if not log_path:
         return jsonify({"error": "Log file for this run could not be found."}), 404
+    mimetype = "application/gzip" if _is_logscan_gzip_path(log_path) else "text/plain"
     return send_file(
         str(log_path),
         as_attachment=True,
         download_name=log_path.name,
-        mimetype="text/plain",
+        mimetype=mimetype,
     )
 
 
@@ -3455,6 +3561,45 @@ def logscan_trends_log_delete():
     if len(unique_run_keys) == 1 and deleted:
         response["deleted_file"] = bool(deleted[0].get("deleted_file"))
         response["deleted_run"] = bool(deleted[0].get("deleted_run"))
+    return jsonify(response)
+
+
+@app.route("/logscan/trends/log/compress", methods=["POST"])
+def logscan_trends_log_compress():
+    payload = request.get_json(silent=True) or {}
+    raw_run_keys = payload.get("run_keys")
+    if isinstance(raw_run_keys, list):
+        run_keys = [str(value or "").strip() for value in raw_run_keys if str(value or "").strip()]
+    else:
+        run_key = str(payload.get("run_key", "")).strip()
+        run_keys = [run_key] if run_key else []
+    unique_run_keys = list(dict.fromkeys(run_keys))
+    if not unique_run_keys:
+        return jsonify({"error": "run_key required"}), 400
+
+    compressed = []
+    failures = []
+    for run_key in unique_run_keys:
+        success, result, status = _compress_logscan_run_artifact(run_key)
+        if success:
+            compressed.append(result)
+        else:
+            result["status"] = status
+            failures.append(result)
+
+    if not compressed and failures:
+        first = failures[0]
+        return jsonify({"success": False, "error": first.get("error"), "failures": failures}), int(first.get("status", 400))
+
+    response = {
+        "success": not failures,
+        "compressed": len(compressed),
+        "results": compressed,
+        "failures": failures,
+    }
+    if len(unique_run_keys) == 1 and compressed:
+        response["compressed_file"] = bool(compressed[0].get("compressed_file"))
+        response["compressed_path"] = compressed[0].get("compressed_path")
     return jsonify(response)
 
 
@@ -7740,13 +7885,41 @@ def _get_logscan_archive_dir():
     return archive_dir
 
 
-def _build_logscan_archive_filename(path, stats=None, counter=None):
+def _is_logscan_gzip_path(path):
+    try:
+        suffixes = [suffix.lower() for suffix in Path(path).suffixes]
+    except Exception:
+        return False
+    return bool(suffixes and suffixes[-1] == ".gz")
+
+
+def _read_logscan_text(path, encoding="utf-8", errors="replace"):
+    path = Path(path)
+    if _is_logscan_gzip_path(path):
+        with gzip.open(path, "rt", encoding=encoding, errors=errors) as handle:
+            return handle.read()
+    return path.read_text(encoding=encoding, errors=errors)
+
+
+def _iter_logscan_text_lines(path, encoding="utf-8", errors="replace"):
+    path = Path(path)
+    if _is_logscan_gzip_path(path):
+        with gzip.open(path, "rt", encoding=encoding, errors=errors) as handle:
+            for line in handle:
+                yield line
+        return
+    with path.open("r", encoding=encoding, errors=errors) as handle:
+        for line in handle:
+            yield line
+
+
+def _build_logscan_archive_filename(path, stats=None, counter=None, preferred_suffix=None):
     path = Path(path)
     if stats is None:
         stats = path.stat()
     timestamp = datetime.fromtimestamp(float(stats.st_mtime), tz=timezone.utc).strftime("%Y%m%d-%H%M%SZ")
     size = int(stats.st_size)
-    suffix = "".join(path.suffixes)
+    suffix = preferred_suffix or "".join(path.suffixes)
     if not suffix:
         suffix = ".log"
     base_name = f"meta-{timestamp}-{size}"
@@ -7755,24 +7928,18 @@ def _build_logscan_archive_filename(path, stats=None, counter=None):
     return f"{base_name}{suffix}"
 
 
-def _build_logscan_archive_destination(path, archive_dir, stats=None):
+def _build_logscan_archive_destination(path, archive_dir, stats=None, preferred_suffix=None):
     path = Path(path)
     archive_dir = Path(archive_dir)
     if stats is None:
         stats = path.stat()
     counter = 1
     while True:
-        candidate = archive_dir / _build_logscan_archive_filename(path, stats=stats, counter=counter)
+        candidate = archive_dir / _build_logscan_archive_filename(path, stats=stats, counter=counter, preferred_suffix=preferred_suffix)
         if candidate.resolve() == path.resolve():
             return candidate
         if not candidate.exists():
             return candidate
-        try:
-            candidate_stats = candidate.stat()
-            if int(candidate_stats.st_size) == int(stats.st_size) and float(candidate_stats.st_mtime) == float(stats.st_mtime):
-                return candidate
-        except Exception:
-            pass
         counter += 1
 
 
@@ -7790,7 +7957,9 @@ def _iter_logscan_candidate_files(log_dir=None, include_archive=True, include_co
             if not path.is_file():
                 continue
             suffixes = [suffix.lower() for suffix in path.suffixes]
-            if not include_compressed and suffixes and suffixes[-1] in (".gz", ".zip", ".7z"):
+            if suffixes and suffixes[-1] in (".zip", ".7z"):
+                continue
+            if not include_compressed and suffixes and suffixes[-1] == ".gz":
                 continue
             if ".log" not in path.name.lower():
                 continue
@@ -7806,7 +7975,7 @@ def _iter_logscan_candidate_files(log_dir=None, include_archive=True, include_co
 
 
 def _get_logscan_log_files(log_dir=None, include_archive=True):
-    return _iter_logscan_candidate_files(log_dir=log_dir, include_archive=include_archive, include_compressed=False)
+    return _iter_logscan_candidate_files(log_dir=log_dir, include_archive=include_archive, include_compressed=True)
 
 
 def _classify_logscan_file_location(path, log_dir=None):
@@ -7965,7 +8134,7 @@ def _normalize_logscan_archive_filenames(archive_dir=None):
     errors = []
     cache_dirty = False
 
-    for path in sorted(_iter_logscan_candidate_files(include_archive=True, include_compressed=False), key=lambda item: item.name.lower()):
+    for path in sorted(_iter_logscan_candidate_files(include_archive=True, include_compressed=True), key=lambda item: item.name.lower()):
         if _classify_logscan_file_location(path) != "archive":
             continue
         try:
@@ -8271,7 +8440,7 @@ def _build_resume_explanation(
 
 def _analyze_incomplete_log_for_resume(log_path, cache_entry=None, config_name=None):
     try:
-        content = Path(log_path).read_text(encoding="utf-8", errors="replace")
+        content = _read_logscan_text(log_path, encoding="utf-8", errors="replace")
     except Exception:
         return None
 
@@ -8767,16 +8936,27 @@ def _archive_log_file(path, archive_dir, log_dir=None, allow_live_meta=False):
         archive_dir = Path(archive_dir)
         archive_dir.mkdir(parents=True, exist_ok=True)
         src_stats = path.stat()
-        dest = _build_logscan_archive_destination(path, archive_dir, stats=src_stats)
+        should_compress = not _is_logscan_gzip_path(path)
+        preferred_suffix = ".log.gz" if should_compress else None
+        dest = _build_logscan_archive_destination(path, archive_dir, stats=src_stats, preferred_suffix=preferred_suffix)
         if dest.exists():
+            path.unlink()
+            return dest
+        if should_compress:
             try:
-                dst_stats = dest.stat()
-                if dst_stats.st_size == src_stats.st_size and dst_stats.st_mtime == src_stats.st_mtime:
-                    path.unlink()
-                    return dest
+                with path.open("rb") as source, gzip.open(dest, "wb") as target:
+                    shutil.copyfileobj(source, target)
+                os.utime(dest, (src_stats.st_atime, src_stats.st_mtime))
+                path.unlink()
             except Exception:
-                pass
-        shutil.move(str(path), str(dest))
+                try:
+                    if dest.exists():
+                        dest.unlink()
+                except Exception:
+                    pass
+                raise
+        else:
+            shutil.move(str(path), str(dest))
         return dest
     except Exception:
         return None
@@ -8858,7 +9038,7 @@ def _prune_logscan_archive(archive_dir):
         if not path.is_file():
             continue
         suffixes = [suffix.lower() for suffix in path.suffixes]
-        if suffixes and suffixes[-1] in (".gz", ".zip", ".7z"):
+        if suffixes and suffixes[-1] in (".zip", ".7z"):
             continue
         if ".log" not in path.name.lower():
             continue
@@ -8979,7 +9159,7 @@ def _perform_logscan_reingest(reset, job_id=None, update_state=True):
                 cached_run_key = cached_entry.get("run_key")
                 skip_save_if_cached = cached_entry.get("run_complete") is True and cached_run_key
 
-                content = path.read_text(encoding="utf-8", errors="replace")
+                content = _read_logscan_text(path, encoding="utf-8", errors="replace")
                 result = analyzer.analyze_content(
                     content,
                     log_path=path,

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -2246,6 +2246,52 @@ div#loading {
     justify-content: center;
 }
 
+.logscan-action-stack {
+    display: grid;
+    gap: 0.45rem;
+    justify-items: start;
+    width: 100%;
+}
+
+.logscan-action-stack .logscan-action-btn {
+    min-width: 5.75rem;
+}
+
+.logscan-table-bulk-actions {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-right: auto;
+}
+
+.logscan-table-selection-summary {
+    min-width: 0;
+}
+
+.logscan-select-cell {
+    align-items: center;
+}
+
+.logscan-select-wrap {
+    align-items: center;
+    display: inline-flex;
+    justify-content: center;
+    min-height: 2rem;
+}
+
+.logscan-select-checkbox {
+    cursor: pointer;
+    height: 1rem;
+    margin: 0;
+    width: 1rem;
+}
+
+.qs-workspace-main-panel .table-responsive.logscan-runs-card-table table tr.logscan-row-selected {
+    border-color: rgba(0, 188, 140, 0.8);
+    box-shadow: 0 0 0 1px rgba(0, 188, 140, 0.32);
+}
+
 .logscan-command {
     display: inline-block;
     max-width: 320px;
@@ -2553,6 +2599,12 @@ div#loading {
 .qs-workspace-main-panel .table-responsive.logscan-runs-card-table table td[data-label="Report"] .logscan-action-btn,
 .qs-workspace-main-panel .table-responsive.logscan-runs-card-table table td[data-label="Section runtimes"] .logscan-action-btn {
     min-width: 72px;
+}
+
+.qs-workspace-main-panel .table-responsive.logscan-runs-card-table table td[data-label="Log"] .logscan-action-btn,
+.qs-workspace-main-panel .table-responsive.logscan-runs-card-table table td[data-label="Report"] .logscan-action-btn,
+.qs-workspace-main-panel .table-responsive.logscan-runs-card-table table td[data-label="Section runtimes"] .logscan-action-btn {
+    min-width: 5.75rem;
 }
 
 .logscan-sort-button {
@@ -3301,6 +3353,14 @@ div#loading {
 
 .bulk-delete-item + .bulk-delete-item {
     margin-top: 0.4rem;
+}
+
+.orphaned-artifact-item .form-check-label {
+    display: block;
+}
+
+.orphaned-artifact-meta {
+    word-break: break-word;
 }
 
 .config-badge-button {
@@ -5231,11 +5291,19 @@ body {
     }
 
     .logscan-table-actions > .btn,
+    .logscan-table-bulk-actions > .btn,
     .logscan-table-toolbar > .form-select,
     .logscan-table-pager > .btn {
         width: 100% !important;
         min-width: 0;
         justify-content: center;
+    }
+
+    .logscan-table-bulk-actions {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr);
+        width: 100%;
+        margin-right: 0;
     }
 
     .logscan-table-toolbar > label,

--- a/static/local-js/001-start.js
+++ b/static/local-js/001-start.js
@@ -89,6 +89,16 @@ document.addEventListener('DOMContentLoaded', function () {
   const bulkDeleteSelectAll = document.getElementById('bulkDeleteSelectAll')
   const bulkDeleteCount = document.getElementById('bulkDeleteCount')
   const confirmBulkDeleteButton = document.getElementById('confirmBulkDeleteButton')
+  const orphanedArtifactsModalEl = document.getElementById('orphanedArtifactsModal')
+  const orphanedArtifactsList = document.getElementById('orphanedArtifactsList')
+  const orphanedArtifactsSelectAll = document.getElementById('orphanedArtifactsSelectAll')
+  const orphanedArtifactsCount = document.getElementById('orphanedArtifactsCount')
+  const orphanedArtifactsError = document.getElementById('orphanedArtifactsError')
+  const confirmOrphanedArtifactsDelete = document.getElementById('confirmOrphanedArtifactsDelete')
+  const orphanedArtifactsRestoreModalEl = document.getElementById('orphanedArtifactsRestoreModal')
+  const orphanedArtifactsRestoreList = document.getElementById('orphanedArtifactsRestoreList')
+  const orphanedArtifactsRestoreError = document.getElementById('orphanedArtifactsRestoreError')
+  const confirmOrphanedArtifactsRestore = document.getElementById('confirmOrphanedArtifactsRestore')
   const configActionModalElement = document.getElementById('configActionModal')
   const renameConfigModalEl = document.getElementById('renameConfigModal')
   const renameConfigCurrentName = document.getElementById('renameConfigCurrentName')
@@ -128,6 +138,7 @@ document.addEventListener('DOMContentLoaded', function () {
   if (configActionModalElement) configActionModal = new bootstrap.Modal(configActionModalElement)
 
   let currentAction = ''
+  let orphanedRestoreTarget = ''
   let importToken = null
   let importReportHeader = ''
   let importReportBody = ''
@@ -340,6 +351,232 @@ document.addEventListener('DOMContentLoaded', function () {
     return row
   }
 
+  function setOrphanedArtifactsError (message) {
+    if (!orphanedArtifactsError) return
+    if (!message) {
+      orphanedArtifactsError.classList.add('d-none')
+      orphanedArtifactsError.textContent = ''
+      return
+    }
+    orphanedArtifactsError.classList.remove('d-none')
+    orphanedArtifactsError.textContent = message
+  }
+
+  function setOrphanedArtifactsRestoreError (message) {
+    if (!orphanedArtifactsRestoreError) return
+    if (!message) {
+      orphanedArtifactsRestoreError.classList.add('d-none')
+      orphanedArtifactsRestoreError.textContent = ''
+      return
+    }
+    orphanedArtifactsRestoreError.classList.remove('d-none')
+    orphanedArtifactsRestoreError.textContent = message
+  }
+
+  function updateOrphanedArtifactsState () {
+    if (!orphanedArtifactsList || !confirmOrphanedArtifactsDelete) return
+    const allBoxes = orphanedArtifactsList.querySelectorAll('.orphaned-artifact-checkbox')
+    const checked = orphanedArtifactsList.querySelectorAll('.orphaned-artifact-checkbox:checked')
+
+    if (orphanedArtifactsCount) orphanedArtifactsCount.textContent = String(checked.length)
+    confirmOrphanedArtifactsDelete.disabled = checked.length === 0
+
+    if (orphanedArtifactsSelectAll) {
+      orphanedArtifactsSelectAll.checked = allBoxes.length > 0 && checked.length === allBoxes.length
+      orphanedArtifactsSelectAll.indeterminate = checked.length > 0 && checked.length < allBoxes.length
+      orphanedArtifactsSelectAll.disabled = allBoxes.length === 0
+    }
+  }
+
+  function buildArtifactBadge (text, className) {
+    const badge = document.createElement('span')
+    badge.className = `badge ${className}`
+    badge.textContent = text
+    return badge
+  }
+
+  function buildOrphanedArtifactRow (item, index) {
+    const row = document.createElement('div')
+    row.className = 'form-check bulk-delete-item orphaned-artifact-item'
+
+    const input = document.createElement('input')
+    input.type = 'checkbox'
+    input.className = 'form-check-input orphaned-artifact-checkbox'
+    input.value = item.name
+    input.id = `orphaned-artifact-${index}-${String(item.name || '').replace(/[^a-zA-Z0-9_-]/g, '_')}`
+    input.addEventListener('change', updateOrphanedArtifactsState)
+
+    const label = document.createElement('label')
+    label.className = 'form-check-label orphaned-artifact-label'
+    label.setAttribute('for', input.id)
+
+    const titleRow = document.createElement('div')
+    titleRow.className = 'd-flex flex-wrap align-items-center gap-2'
+
+    const title = document.createElement('span')
+    title.className = 'fw-semibold'
+    title.textContent = item.name
+    titleRow.appendChild(title)
+
+    if (item.has_current_file) titleRow.appendChild(buildArtifactBadge('current yaml', 'bg-primary-subtle text-primary-emphasis'))
+    if (item.has_kometa_copy) titleRow.appendChild(buildArtifactBadge('kometa copy', 'bg-info-subtle text-info-emphasis'))
+    if (item.has_archive_dir) {
+      const archiveText = item.archive_count === 1 ? '1 archive' : `${item.archive_count} archives`
+      titleRow.appendChild(buildArtifactBadge(archiveText, 'bg-warning-subtle text-warning-emphasis'))
+    }
+
+    const meta = document.createElement('div')
+    meta.className = 'small text-muted mt-1 orphaned-artifact-meta'
+    meta.textContent = Array.isArray(item.paths) && item.paths.length
+      ? item.paths.join(' • ')
+      : 'No filesystem paths reported.'
+
+    const actions = document.createElement('div')
+    actions.className = 'mt-2'
+    const restoreButton = document.createElement('button')
+    restoreButton.type = 'button'
+    restoreButton.className = 'btn btn-sm btn-outline-primary orphaned-artifact-restore'
+    restoreButton.dataset.name = item.name
+    restoreButton.textContent = 'Restore...'
+    actions.appendChild(restoreButton)
+
+    label.appendChild(titleRow)
+    label.appendChild(meta)
+    label.appendChild(actions)
+    row.appendChild(input)
+    row.appendChild(label)
+    return row
+  }
+
+  function updateOrphanedArtifactsRestoreState () {
+    if (!confirmOrphanedArtifactsRestore || !orphanedArtifactsRestoreList) return
+    const selected = orphanedArtifactsRestoreList.querySelector('.orphaned-artifact-version-radio:checked')
+    confirmOrphanedArtifactsRestore.disabled = !selected
+  }
+
+  function buildOrphanedArtifactVersionRow (item, index) {
+    const row = document.createElement('div')
+    row.className = 'form-check bulk-delete-item orphaned-artifact-version-item'
+
+    const input = document.createElement('input')
+    input.type = 'radio'
+    input.name = 'orphanedArtifactVersion'
+    input.className = 'form-check-input orphaned-artifact-version-radio'
+    input.value = item.path
+    input.id = `orphaned-artifact-version-${index}`
+    if (index === 0) input.checked = true
+    input.addEventListener('change', updateOrphanedArtifactsRestoreState)
+
+    const label = document.createElement('label')
+    label.className = 'form-check-label orphaned-artifact-label'
+    label.setAttribute('for', input.id)
+
+    const titleRow = document.createElement('div')
+    titleRow.className = 'd-flex flex-wrap align-items-center gap-2'
+
+    const title = document.createElement('span')
+    title.className = 'fw-semibold'
+    title.textContent = item.kind === 'current' ? 'Current saved config' : item.filename
+    titleRow.appendChild(title)
+    titleRow.appendChild(buildArtifactBadge(item.kind === 'current' ? 'current' : 'archive', item.kind === 'current' ? 'bg-primary-subtle text-primary-emphasis' : 'bg-warning-subtle text-warning-emphasis'))
+
+    const meta = document.createElement('div')
+    meta.className = 'small text-muted mt-1 orphaned-artifact-meta'
+    const sizeLabel = Number.isFinite(item.size) ? `${item.size} bytes` : 'size unavailable'
+    meta.textContent = `${item.modified_at || 'unknown time'} • ${sizeLabel} • ${item.path}`
+
+    label.appendChild(titleRow)
+    label.appendChild(meta)
+    row.appendChild(input)
+    row.appendChild(label)
+    return row
+  }
+
+  async function openOrphanedArtifactsRestore (name) {
+    if (!orphanedArtifactsRestoreModalEl || !orphanedArtifactsRestoreList) return
+    orphanedRestoreTarget = String(name || '').trim()
+    if (!orphanedRestoreTarget) return
+    setOrphanedArtifactsRestoreError('')
+    orphanedArtifactsRestoreList.replaceChildren()
+    if (confirmOrphanedArtifactsRestore) confirmOrphanedArtifactsRestore.disabled = true
+
+    const title = document.getElementById('orphanedArtifactsRestoreModalLabel')
+    if (title) title.innerHTML = `<i class="bi bi-arrow-counterclockwise me-2"></i>Restore ${orphanedRestoreTarget}`
+
+    const loading = document.createElement('div')
+    loading.className = 'small text-muted'
+    loading.textContent = 'Loading saved versions...'
+    orphanedArtifactsRestoreList.appendChild(loading)
+
+    const modal = bootstrap.Modal.getOrCreateInstance(orphanedArtifactsRestoreModalEl)
+    modal.show()
+
+    try {
+      const res = await fetch(`/orphaned-config-artifacts/versions?name=${encodeURIComponent(orphanedRestoreTarget)}`)
+      const data = await res.json()
+      if (!res.ok || !data.success) {
+        throw new Error(data.message || 'Failed to load saved versions.')
+      }
+      orphanedArtifactsRestoreList.replaceChildren()
+      const versions = Array.isArray(data.versions) ? data.versions : []
+      if (!versions.length) {
+        const empty = document.createElement('div')
+        empty.className = 'small text-muted'
+        empty.textContent = 'No saved versions were found for this config bundle.'
+        orphanedArtifactsRestoreList.appendChild(empty)
+        updateOrphanedArtifactsRestoreState()
+        return
+      }
+      versions.forEach((item, index) => {
+        orphanedArtifactsRestoreList.appendChild(buildOrphanedArtifactVersionRow(item, index))
+      })
+      updateOrphanedArtifactsRestoreState()
+    } catch (err) {
+      orphanedArtifactsRestoreList.replaceChildren()
+      setOrphanedArtifactsRestoreError(err.message || 'Failed to load saved versions.')
+      updateOrphanedArtifactsRestoreState()
+    }
+  }
+
+  async function renderOrphanedArtifactsList () {
+    if (!orphanedArtifactsList) return
+    orphanedArtifactsList.replaceChildren()
+    setOrphanedArtifactsError('')
+
+    const loading = document.createElement('div')
+    loading.className = 'small text-muted'
+    loading.textContent = 'Scanning config storage...'
+    orphanedArtifactsList.appendChild(loading)
+
+    try {
+      const res = await fetch('/orphaned-config-artifacts')
+      const data = await res.json()
+      if (!res.ok || !data.success) {
+        throw new Error((data.errors && data.errors[0]) || data.message || 'Failed to inspect config storage.')
+      }
+
+      orphanedArtifactsList.replaceChildren()
+      const items = Array.isArray(data.orphans) ? data.orphans : []
+      if (!items.length) {
+        const empty = document.createElement('div')
+        empty.className = 'text-muted small'
+        empty.textContent = 'No orphaned config bundles found.'
+        orphanedArtifactsList.appendChild(empty)
+        updateOrphanedArtifactsState()
+        return
+      }
+
+      items.forEach((item, index) => {
+        orphanedArtifactsList.appendChild(buildOrphanedArtifactRow(item, index))
+      })
+      updateOrphanedArtifactsState()
+    } catch (err) {
+      orphanedArtifactsList.replaceChildren()
+      setOrphanedArtifactsError(err.message || 'Failed to inspect config storage.')
+      updateOrphanedArtifactsState()
+    }
+  }
+
   function renderBulkDeleteList () {
     if (!bulkDeleteList) return
     bulkDeleteList.replaceChildren()
@@ -474,6 +711,102 @@ document.addEventListener('DOMContentLoaded', function () {
       event.preventDefault()
       if (saveConfigButton && !saveConfigButton.disabled) {
         saveConfigButton.click()
+      }
+    })
+  }
+
+  if (orphanedArtifactsModalEl) {
+    orphanedArtifactsModalEl.addEventListener('show.bs.modal', renderOrphanedArtifactsList)
+  }
+
+  if (orphanedArtifactsSelectAll) {
+    orphanedArtifactsSelectAll.addEventListener('change', () => {
+      if (!orphanedArtifactsList) return
+      const checkboxes = orphanedArtifactsList.querySelectorAll('.orphaned-artifact-checkbox')
+      checkboxes.forEach(box => { box.checked = orphanedArtifactsSelectAll.checked })
+      updateOrphanedArtifactsState()
+    })
+  }
+
+  if (confirmOrphanedArtifactsDelete) {
+    confirmOrphanedArtifactsDelete.addEventListener('click', async () => {
+      if (!orphanedArtifactsList) return
+      const selected = Array.from(orphanedArtifactsList.querySelectorAll('.orphaned-artifact-checkbox:checked'))
+        .map(box => box.value)
+      if (!selected.length) {
+        showToast('error', 'Select at least one orphaned config bundle to delete.')
+        return
+      }
+
+      confirmOrphanedArtifactsDelete.disabled = true
+      const originalText = confirmOrphanedArtifactsDelete.textContent
+      confirmOrphanedArtifactsDelete.textContent = 'Deleting...'
+
+      try {
+        const res = await fetch('/orphaned-config-artifacts/delete', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ names: selected })
+        })
+        const data = await res.json()
+        if (!res.ok || !data.success) {
+          throw new Error((data.errors && data.errors[0]) || data.message || 'Failed to delete orphaned config bundles.')
+        }
+        showToast('success', `Deleted ${data.deleted.length} orphaned config bundle(s).`)
+        const modal = bootstrap.Modal.getInstance(orphanedArtifactsModalEl)
+        if (modal) modal.hide()
+        setTimeout(() => window.location.reload(), 900)
+      } catch (err) {
+        confirmOrphanedArtifactsDelete.disabled = false
+        confirmOrphanedArtifactsDelete.textContent = originalText
+        setOrphanedArtifactsError(err.message || 'Failed to delete orphaned config bundles.')
+        showToast('error', err.message || 'Failed to delete orphaned config bundles.')
+      }
+    })
+  }
+
+  if (orphanedArtifactsList) {
+    orphanedArtifactsList.addEventListener('click', (event) => {
+      const button = event.target.closest('.orphaned-artifact-restore')
+      if (!button) return
+      event.preventDefault()
+      event.stopPropagation()
+      openOrphanedArtifactsRestore(button.dataset.name)
+    })
+  }
+
+  if (confirmOrphanedArtifactsRestore) {
+    confirmOrphanedArtifactsRestore.addEventListener('click', async () => {
+      if (!orphanedArtifactsRestoreList || !orphanedRestoreTarget) return
+      const selected = orphanedArtifactsRestoreList.querySelector('.orphaned-artifact-version-radio:checked')
+      if (!selected) {
+        setOrphanedArtifactsRestoreError('Select a saved version to restore.')
+        return
+      }
+
+      confirmOrphanedArtifactsRestore.disabled = true
+      const originalText = confirmOrphanedArtifactsRestore.textContent
+      confirmOrphanedArtifactsRestore.textContent = 'Restoring...'
+
+      try {
+        const res = await fetch('/orphaned-config-artifacts/restore', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: orphanedRestoreTarget, path: selected.value })
+        })
+        const data = await res.json()
+        if (!res.ok || !data.success) {
+          throw new Error(data.message || 'Failed to restore config bundle.')
+        }
+        showToast('success', `Restored '${data.config_name}' from disk.`)
+        const modal = bootstrap.Modal.getInstance(orphanedArtifactsRestoreModalEl)
+        if (modal) modal.hide()
+        setTimeout(() => window.location.reload(), 900)
+      } catch (err) {
+        confirmOrphanedArtifactsRestore.disabled = false
+        confirmOrphanedArtifactsRestore.textContent = originalText
+        setOrphanedArtifactsRestoreError(err.message || 'Failed to restore config bundle.')
+        showToast('error', err.message || 'Failed to restore config bundle.')
       }
     })
   }

--- a/static/local-js/905-analytics.js
+++ b/static/local-js/905-analytics.js
@@ -15,6 +15,7 @@ $(document).ready(function () {
   const $tableSelectComplete = $('#logscan-table-select-complete')
   const $tableSelectIncomplete = $('#logscan-table-select-incomplete')
   const $tableClearSelection = $('#logscan-table-clear-selection')
+  const $tableCompressSelected = $('#logscan-table-compress-selected')
   const $tableDeleteSelected = $('#logscan-table-delete-selected')
   const $tableSelectionSummary = $('#logscan-table-selection-summary')
   const tableCollapseEl = document.getElementById('logscan-recent-runs-collapse')
@@ -47,6 +48,8 @@ $(document).ready(function () {
   const $confirmMissingDownload = $('#logscan-confirm-missing-download')
   const $deleteLogBody = $('#logscan-delete-log-body')
   const $confirmDeleteLog = $('#logscan-confirm-delete-log')
+  const $compressLogBody = $('#logscan-compress-log-body')
+  const $confirmCompressLog = $('#logscan-confirm-compress-log')
   const $runDetailsBody = $('#logscan-run-details-body')
   const $runDetailsTitle = $('#logscan-run-details-title')
   const $preferencesSave = $('#logscan-preferences-save')
@@ -57,10 +60,12 @@ $(document).ready(function () {
   const reingestModalEl = document.getElementById('logscan-reingest-modal')
   const missingDownloadModalEl = document.getElementById('logscan-missing-download-modal')
   const deleteLogModalEl = document.getElementById('logscan-delete-log-modal')
+  const compressLogModalEl = document.getElementById('logscan-compress-log-modal')
   const runDetailsModalEl = document.getElementById('logscan-run-details-modal')
   const preferencesModalEl = document.getElementById('logscan-preferences-modal')
   let missingDownloadUrl = ''
   let pendingDeleteRun = null
+  let pendingCompressRun = null
   let reingestPollTimer = null
   let reingestJobId = null
   let allRuns = []
@@ -1179,6 +1184,19 @@ $(document).ready(function () {
     return getSelectableRuns(runs).filter(run => Boolean(run && run.is_incomplete) === Boolean(isIncomplete))
   }
 
+  function isRunCompressible (run) {
+    return Boolean(run && run.run_key && run.log_can_compress)
+  }
+
+  function getCompressibleRuns (runs) {
+    return Array.isArray(runs) ? runs.filter(isRunCompressible) : []
+  }
+
+  function getSelectedCompressibleRuns () {
+    if (!selectedRunKeys.size) return []
+    return getCompressibleRuns(allTableRuns).filter(run => selectedRunKeys.has(run.run_key))
+  }
+
   function pruneSelectedRunKeys () {
     const validKeys = new Set(getSelectableRuns(allTableRuns).map(run => run.run_key))
     Array.from(selectedRunKeys).forEach(runKey => {
@@ -1194,10 +1212,14 @@ $(document).ready(function () {
     const visibleSelectable = getSelectableRuns(currentTableRuns).length
     const visibleCompleteSelectable = getSelectableRunsByCompletion(currentTableRuns, false).length
     const visibleIncompleteSelectable = getSelectableRunsByCompletion(currentTableRuns, true).length
+    const selectedCompressibleCount = getSelectedCompressibleRuns().length
     if (!selectedCount) {
       $tableSelectionSummary.text('No logs selected.')
     } else {
-      $tableSelectionSummary.text(`${selectedCount} selected. ${visibleSelectable} deletable in current view.`)
+      $tableSelectionSummary.text(`${selectedCount} selected. ${selectedCompressibleCount} compressible. ${visibleSelectable} deletable in current view.`)
+    }
+    if ($tableCompressSelected.length) {
+      $tableCompressSelected.prop('disabled', selectedCompressibleCount === 0)
     }
     if ($tableDeleteSelected.length) {
       $tableDeleteSelected.prop('disabled', selectedCount === 0)
@@ -1326,6 +1348,17 @@ $(document).ready(function () {
       } else {
         logActions.push('<span class="small text-muted">Unavailable</span>')
       }
+      if (run.log_can_compress) {
+        logActions.push(`
+          <button type="button" class="btn nav-button btn-sm logscan-action-btn logscan-compress-log"
+            data-run-key="${escapeHtml(runKey)}"
+            data-run-label="${escapeHtml(runLabel)}">
+            Compress
+          </button>
+        `)
+      } else if (run.log_is_compressed) {
+        logActions.push('<span class="small text-muted">Compressed</span>')
+      }
       if (run.log_can_delete) {
         logActions.push(`
           <button type="button" class="btn nav-button nav-button-danger btn-sm logscan-action-btn logscan-delete-log"
@@ -1342,7 +1375,7 @@ $(document).ready(function () {
       }
       return `
         <tr class="${isSelected ? 'logscan-row-selected' : ''}">
-          ${renderRunCardCell('Select', 'Select this archived log for bulk delete.', `
+          ${renderRunCardCell('Select', 'Select this archived log for bulk actions.', `
             <span class="logscan-select-wrap">
               <input type="checkbox" class="form-check-input logscan-select-checkbox"
                 data-run-key="${escapeHtml(runKey)}"
@@ -1362,7 +1395,7 @@ $(document).ready(function () {
           ${renderRunCardCell('Kometa', 'Version detected for the run, plus newest version when different.', escapeHtml(kometaDisplay))}
           ${renderRunCardCell('Section runtimes', 'Runtime totals parsed per Kometa section.', sectionCell)}
           ${renderRunCardCell('Log size', 'Current on-disk size of the resolved log file when available, otherwise the ingested size.', escapeHtml(formatBytes(sizeBytes)))}
-          ${renderRunCardCell('Log', 'Download the source log for this run. Archived logs can also be deleted here.', `<div class="logscan-action-stack">${logActions.join('')}</div>`)}
+          ${renderRunCardCell('Log', 'Download the source log for this run. Archived plain logs can also be compressed, and archived logs can be deleted here.', `<div class="logscan-action-stack">${logActions.join('')}</div>`)}
           ${renderRunCardCell('Report', run.is_incomplete ? 'Open recommendations and diagnostics captured for this incomplete log.' : 'Open the recommendations recorded for the run.', `
             <div class="logscan-action-stack">
               <button type="button" class="btn nav-button btn-sm logscan-action-btn logscan-run-details"
@@ -2071,6 +2104,7 @@ $(document).ready(function () {
     $tableSelectComplete.prop('disabled', disabled || getSelectableRunsByCompletion(currentTableRuns, false).length === 0)
     $tableSelectIncomplete.prop('disabled', disabled || getSelectableRunsByCompletion(currentTableRuns, true).length === 0)
     $tableClearSelection.prop('disabled', disabled || selectedRunKeys.size === 0)
+    $tableCompressSelected.prop('disabled', disabled || getSelectedCompressibleRuns().length === 0)
     $tableDeleteSelected.prop('disabled', disabled || selectedRunKeys.size === 0)
   }
 
@@ -2387,6 +2421,35 @@ $(document).ready(function () {
     return getSelectableRuns(allTableRuns).filter(run => selectedRunKeys.has(run.run_key))
   }
 
+  function openCompressLogModal (runKeys, runLabel) {
+    const normalizedRunKeys = Array.isArray(runKeys)
+      ? runKeys.map(value => String(value || '').trim()).filter(Boolean)
+      : [String(runKeys || '').trim()].filter(Boolean)
+    if (!normalizedRunKeys.length) return
+    pendingCompressRun = {
+      runKeys: normalizedRunKeys,
+      runLabel,
+      bulk: normalizedRunKeys.length > 1
+    }
+    if ($compressLogBody.length) {
+      if (normalizedRunKeys.length === 1) {
+        $compressLogBody.html(`Compress archived log for <strong>${escapeHtml(runLabel || normalizedRunKeys[0])}</strong> as <code>.log.gz</code>?`)
+      } else {
+        $compressLogBody.html(`Compress <strong>${normalizedRunKeys.length} selected logs</strong> as <code>.log.gz</code>?`)
+      }
+    }
+    if (compressLogModalEl) {
+      bootstrap.Modal.getOrCreateInstance(compressLogModalEl).show()
+      return
+    }
+    const confirmText = normalizedRunKeys.length === 1
+      ? `Compress archived log for ${runLabel || normalizedRunKeys[0]}?`
+      : `Compress ${normalizedRunKeys.length} selected logs?`
+    if (window.confirm(confirmText)) {
+      handleCompressLog()
+    }
+  }
+
   function openDeleteLogModal (runKeys, runLabel) {
     const normalizedRunKeys = Array.isArray(runKeys)
       ? runKeys.map(value => String(value || '').trim()).filter(Boolean)
@@ -2454,6 +2517,45 @@ $(document).ready(function () {
       })
       .finally(() => {
         $confirmDeleteLog.prop('disabled', false)
+      })
+  }
+
+  function handleCompressLog () {
+    if (!pendingCompressRun || !Array.isArray(pendingCompressRun.runKeys) || !pendingCompressRun.runKeys.length) {
+      hideModal(compressLogModalEl)
+      return
+    }
+    $confirmCompressLog.prop('disabled', true)
+    fetch('/logscan/trends/log/compress', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(
+        pendingCompressRun.runKeys.length === 1
+          ? { run_key: pendingCompressRun.runKeys[0] }
+          : { run_keys: pendingCompressRun.runKeys }
+      )
+    })
+      .then(async res => {
+        const data = await res.json().catch(() => ({}))
+        if (!res.ok) {
+          throw new Error((data && data.error) || 'Compress failed')
+        }
+        hideModal(compressLogModalEl)
+        const compressedCount = Number.isFinite(data && data.compressed) ? data.compressed : pendingCompressRun.runKeys.length
+        pendingCompressRun = null
+        if (Array.isArray(data && data.failures) && data.failures.length) {
+          updateStatus(`${compressedCount} logs compressed. ${data.failures.length} failed.`)
+        } else {
+          updateStatus(compressedCount > 1 ? `${compressedCount} logs compressed.` : 'Log compressed.')
+        }
+        fetchRuns({ suppressStatus: true })
+      })
+      .catch(err => {
+        console.error(err)
+        updateStatus(err && err.message ? err.message : 'Failed to compress log.', true)
+      })
+      .finally(() => {
+        $confirmCompressLog.prop('disabled', false)
       })
   }
 
@@ -2578,6 +2680,7 @@ $(document).ready(function () {
   $confirmReset.on('click', handleReset)
   $confirmReingest.on('click', handleReingest)
   $confirmDeleteLog.on('click', handleDeleteLog)
+  $confirmCompressLog.on('click', handleCompressLog)
   $missingDownload.on('click', function (event) {
     event.preventDefault()
     if (!$missingDownload.length || $missingDownload.hasClass('d-none')) return
@@ -2617,6 +2720,12 @@ $(document).ready(function () {
     if (!runKey) return
     openDeleteLogModal(runKey, runLabel)
   })
+  $tableBody.on('click', '.logscan-compress-log', function () {
+    const runKey = $(this).data('runKey') || $(this).attr('data-run-key')
+    const runLabel = $(this).data('runLabel') || $(this).attr('data-run-label') || runKey
+    if (!runKey) return
+    openCompressLogModal(runKey, runLabel)
+  })
   $tableSelectAll.on('click', function () {
     getSelectableRuns(currentTableRuns).forEach(run => selectedRunKeys.add(run.run_key))
     renderTable(currentTableRuns)
@@ -2637,6 +2746,11 @@ $(document).ready(function () {
     const selectedRuns = getSelectedRuns()
     if (!selectedRuns.length) return
     openDeleteLogModal(selectedRuns.map(run => run.run_key), `${selectedRuns.length} selected logs`)
+  })
+  $tableCompressSelected.on('click', function () {
+    const selectedRuns = getSelectedCompressibleRuns()
+    if (!selectedRuns.length) return
+    openCompressLogModal(selectedRuns.map(run => run.run_key), `${selectedRuns.length} selected logs`)
   })
   $tableBody.on('click', '[data-section-details="1"]', function () {
     const runKey = $(this).data('runKey') || $(this).attr('data-run-key')

--- a/static/local-js/905-analytics.js
+++ b/static/local-js/905-analytics.js
@@ -3,6 +3,7 @@
 $(document).ready(function () {
   const $tableBody = $('#logscan-trends-table tbody')
   const $tableSummary = $('#logscan-table-summary')
+  const $tablePolicy = $('#logscan-table-policy')
   const $tableSortKey = $('#logscan-table-sort-key')
   const $tableSortDir = $('#logscan-table-sort-dir')
   const $tablePageSize = $('#logscan-table-page-size')
@@ -10,6 +11,12 @@ $(document).ready(function () {
   const $tablePrev = $('#logscan-table-prev')
   const $tableNext = $('#logscan-table-next')
   const $tableToggle = $('#logscan-table-toggle')
+  const $tableSelectAll = $('#logscan-table-select-all')
+  const $tableSelectComplete = $('#logscan-table-select-complete')
+  const $tableSelectIncomplete = $('#logscan-table-select-incomplete')
+  const $tableClearSelection = $('#logscan-table-clear-selection')
+  const $tableDeleteSelected = $('#logscan-table-delete-selected')
+  const $tableSelectionSummary = $('#logscan-table-selection-summary')
   const tableCollapseEl = document.getElementById('logscan-recent-runs-collapse')
   const $summary = $('#logscan-trends-summary')
   const $daily = $('#logscan-trends-daily')
@@ -38,6 +45,8 @@ $(document).ready(function () {
   const $confirmReingest = $('#logscan-confirm-reingest')
   const $missingDownload = $('#logscan-trends-missing-download')
   const $confirmMissingDownload = $('#logscan-confirm-missing-download')
+  const $deleteLogBody = $('#logscan-delete-log-body')
+  const $confirmDeleteLog = $('#logscan-confirm-delete-log')
   const $runDetailsBody = $('#logscan-run-details-body')
   const $runDetailsTitle = $('#logscan-run-details-title')
   const $preferencesSave = $('#logscan-preferences-save')
@@ -47,17 +56,24 @@ $(document).ready(function () {
   const resetModalEl = document.getElementById('logscan-reset-modal')
   const reingestModalEl = document.getElementById('logscan-reingest-modal')
   const missingDownloadModalEl = document.getElementById('logscan-missing-download-modal')
+  const deleteLogModalEl = document.getElementById('logscan-delete-log-modal')
   const runDetailsModalEl = document.getElementById('logscan-run-details-modal')
   const preferencesModalEl = document.getElementById('logscan-preferences-modal')
   let missingDownloadUrl = ''
+  let pendingDeleteRun = null
   let reingestPollTimer = null
   let reingestJobId = null
   let allRuns = []
+  let allIncompleteRuns = []
+  let allTableRuns = []
   const sectionDetailsByRunKey = new Map()
   let currentFilteredRuns = []
   let currentTableRuns = []
   let allRunsTotal = 0
+  let allIncompleteRunsTotal = 0
+  let latestArchiveStorage = null
   let tablePage = 1
+  const selectedRunKeys = new Set()
   const sortState = { key: 'finished_at', dir: 'desc' }
   let lastIngestState = null
   let analyticsPrefs = null
@@ -88,6 +104,22 @@ $(document).ready(function () {
     if (typeof value !== 'number' || !Number.isFinite(value)) return '0'
     if (Number.isInteger(value)) return String(value)
     return value.toFixed(1).replace(/\.0$/, '')
+  }
+
+  function formatBytes (value) {
+    if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return 'n/a'
+    if (value === 0) return '0 B'
+    const units = ['B', 'KB', 'MB', 'GB', 'TB']
+    let size = value
+    let unitIndex = 0
+    while (size >= 1024 && unitIndex < units.length - 1) {
+      size /= 1024
+      unitIndex += 1
+    }
+    const precision = size >= 10 || unitIndex === 0 ? 1 : 2
+    const rounded = Number(size.toFixed(precision))
+    const display = Number.isInteger(rounded) ? String(rounded) : String(rounded)
+    return `${display} ${units[unitIndex]}`
   }
 
   function formatTimestamp (value) {
@@ -974,6 +1006,30 @@ $(document).ready(function () {
     }).join(''))
   }
 
+  function renderArchiveStorageSummary (storage) {
+    if (!$tablePolicy.length) return
+    const keepLimit = storage && Number.isFinite(storage.keep_limit)
+      ? storage.keep_limit
+      : (parseInt(window.QS_KOMETA_LOG_KEEP || '0', 10) || 0)
+    const retentionLabel = storage && storage.retention_label
+      ? storage.retention_label
+      : (keepLimit > 0 ? `Keep last ${keepLimit} archived logs` : 'Keep all archived logs')
+    const archivedFiles = storage && Number.isFinite(storage.archived_files) ? storage.archived_files : 0
+    const archivedBytes = storage && Number.isFinite(storage.archived_bytes) ? storage.archived_bytes : 0
+    const extraArchivedFiles = storage && Number.isFinite(storage.extra_archived_files) ? storage.extra_archived_files : 0
+    const extraArchivedBytes = storage && Number.isFinite(storage.extra_archived_bytes) ? storage.extra_archived_bytes : 0
+    const fileLabel = archivedFiles === 1 ? 'file' : 'files'
+    const lines = [
+      `Archived log retention: ${retentionLabel}`,
+      `Tracked archived log storage: ${formatBytes(archivedBytes)} across ${archivedFiles} ${fileLabel}`
+    ]
+    if (extraArchivedFiles > 0) {
+      const extraLabel = extraArchivedFiles === 1 ? 'file' : 'files'
+      lines.push(`Additional archived logs on disk not linked to Analytics: ${formatBytes(extraArchivedBytes)} across ${extraArchivedFiles} ${extraLabel}`)
+    }
+    $tablePolicy.html(lines.map(line => `<div>${escapeHtml(line)}</div>`).join(''))
+  }
+
   function renderDaily (runs) {
     const buckets = buildDailyBuckets(runs)
     const days = Object.keys(buckets).sort().slice(-14)
@@ -1111,30 +1167,80 @@ $(document).ready(function () {
     return 10
   }
 
+  function isRunSelectable (run) {
+    return Boolean(run && run.run_key && run.log_can_delete)
+  }
+
+  function getSelectableRuns (runs) {
+    return Array.isArray(runs) ? runs.filter(isRunSelectable) : []
+  }
+
+  function getSelectableRunsByCompletion (runs, isIncomplete) {
+    return getSelectableRuns(runs).filter(run => Boolean(run && run.is_incomplete) === Boolean(isIncomplete))
+  }
+
+  function pruneSelectedRunKeys () {
+    const validKeys = new Set(getSelectableRuns(allTableRuns).map(run => run.run_key))
+    Array.from(selectedRunKeys).forEach(runKey => {
+      if (!validKeys.has(runKey)) {
+        selectedRunKeys.delete(runKey)
+      }
+    })
+  }
+
+  function updateSelectionSummary () {
+    if (!$tableSelectionSummary.length) return
+    const selectedCount = selectedRunKeys.size
+    const visibleSelectable = getSelectableRuns(currentTableRuns).length
+    const visibleCompleteSelectable = getSelectableRunsByCompletion(currentTableRuns, false).length
+    const visibleIncompleteSelectable = getSelectableRunsByCompletion(currentTableRuns, true).length
+    if (!selectedCount) {
+      $tableSelectionSummary.text('No logs selected.')
+    } else {
+      $tableSelectionSummary.text(`${selectedCount} selected. ${visibleSelectable} deletable in current view.`)
+    }
+    if ($tableDeleteSelected.length) {
+      $tableDeleteSelected.prop('disabled', selectedCount === 0)
+    }
+    if ($tableClearSelection.length) {
+      $tableClearSelection.prop('disabled', selectedCount === 0)
+    }
+    if ($tableSelectAll.length) {
+      $tableSelectAll.prop('disabled', visibleSelectable === 0)
+    }
+    if ($tableSelectComplete.length) {
+      $tableSelectComplete.prop('disabled', visibleCompleteSelectable === 0)
+    }
+    if ($tableSelectIncomplete.length) {
+      $tableSelectIncomplete.prop('disabled', visibleIncompleteSelectable === 0)
+    }
+  }
+
   function updateTableSummary (total, pageSize, pageCount) {
+    const totalComplete = Number.isFinite(allRunsTotal) ? allRunsTotal : allRuns.length
+    const totalIncomplete = Number.isFinite(allIncompleteRunsTotal) ? allIncompleteRunsTotal : allIncompleteRuns.length
     if ($tableSummary.length) {
       if (!total) {
         $tableSummary.text('No runs match the current filters.')
       } else {
-        const matchingText = `${total} matching loaded run${total === 1 ? '' : 's'}`
-        const loadedText = allRunsTotal > allRuns.length
-          ? `${allRuns.length} loaded / ${allRunsTotal} total stored`
-          : `${allRuns.length} loaded`
-        $tableSummary.text(`${matchingText}. ${loadedText}. Page size: ${pageSize}.`)
+        $tableSummary.text(`Ingested: ${totalComplete}. Incomplete: ${totalIncomplete}. Showing: ${total}. Page size: ${pageSize}.`)
       }
     }
     if (!$tablePageInfo.length) return
     if (!total) {
       $tablePageInfo.text('No rows')
+      updateSelectionSummary()
       return
     }
     const start = ((tablePage - 1) * pageSize) + 1
     const end = Math.min(total, tablePage * pageSize)
-    $tablePageInfo.text(`Showing ${start}-${end} of ${total} loaded run${total === 1 ? '' : 's'} (page ${tablePage}/${pageCount})`)
+    $tablePageInfo.text(`Showing ${start}-${end} of ${total} loaded entr${total === 1 ? 'y' : 'ies'} (page ${tablePage}/${pageCount})`)
+    updateSelectionSummary()
   }
 
   function renderTable (runs) {
     currentTableRuns = runs
+    pruneSelectedRunKeys()
     const pageSize = getTablePageSize()
     const total = runs.length
     const pageCount = Math.max(1, Math.ceil(total / pageSize))
@@ -1143,7 +1249,7 @@ $(document).ready(function () {
     $tablePrev.prop('disabled', tablePage <= 1 || total === 0)
     $tableNext.prop('disabled', tablePage >= pageCount || total === 0)
     if (!total) {
-      $tableBody.html('<tr><td colspan="10" class="text-muted">No runs match the current filters.</td></tr>')
+      $tableBody.html('<tr><td colspan="14" class="text-muted">No runs match the current filters.</td></tr>')
       return
     }
     sectionDetailsByRunKey.clear()
@@ -1202,9 +1308,51 @@ $(document).ready(function () {
         kometaDisplay = `${run.kometa_version} -> ${run.kometa_newest_version}`
       }
       const runKey = run.run_key || rowKey
+      const isSelectable = isRunSelectable(run)
+      const isSelected = isSelectable && selectedRunKeys.has(runKey)
+      const statusDisplay = run.is_incomplete ? 'Incomplete' : 'Complete'
+      const finishedDisplay = escapeHtml(getDisplayFinished(run))
+      const sizeBytes = typeof run.log_resolved_size === 'number'
+        ? run.log_resolved_size
+        : (typeof run.log_size === 'number' ? run.log_size : null)
+      const runLabel = `${run.config_name || 'default'} @ ${getDisplayFinished(run)}`
+      const logActions = []
+      if (run.log_available) {
+        logActions.push(`
+          <a class="btn nav-button btn-sm logscan-action-btn" href="/logscan/trends/log?run_key=${encodeURIComponent(runKey)}">
+            Download
+          </a>
+        `)
+      } else {
+        logActions.push('<span class="small text-muted">Unavailable</span>')
+      }
+      if (run.log_can_delete) {
+        logActions.push(`
+          <button type="button" class="btn nav-button nav-button-danger btn-sm logscan-action-btn logscan-delete-log"
+            data-run-key="${escapeHtml(runKey)}"
+            data-run-label="${escapeHtml(runLabel)}">
+            Delete
+          </button>
+        `)
+      } else if (run.log_location === 'live') {
+        logActions.push('<span class="small text-muted">Live log</span>')
+      }
+      if (run.is_incomplete && run.resume_reason) {
+        logActions.push(`<span class="small text-warning">${escapeHtml(run.resume_reason)}</span>`)
+      }
       return `
-        <tr>
-          ${renderRunCardCell('Finished', 'Timestamp of the run finishing.', escapeHtml(getDisplayFinished(run)), 'class="text-nowrap"')}
+        <tr class="${isSelected ? 'logscan-row-selected' : ''}">
+          ${renderRunCardCell('Select', 'Select this archived log for bulk delete.', `
+            <span class="logscan-select-wrap">
+              <input type="checkbox" class="form-check-input logscan-select-checkbox"
+                data-run-key="${escapeHtml(runKey)}"
+                ${isSelected ? 'checked' : ''}
+                ${isSelectable ? '' : 'disabled'}
+                aria-label="Select ${escapeHtml(runLabel)}">
+            </span>
+          `, 'class="logscan-select-cell"')}
+          ${renderRunCardCell('Status', 'Complete runs are included in charts. Incomplete logs are shown here for investigation and file management.', escapeHtml(statusDisplay), run.is_incomplete ? 'class="text-nowrap text-warning fw-semibold"' : 'class="text-nowrap text-success fw-semibold"')}
+          ${renderRunCardCell('Finished', 'Timestamp of the run finishing. Incomplete logs are shown here for investigation only and are excluded from charts.', finishedDisplay, 'class="text-nowrap"')}
           ${renderRunCardCell('Runtime', getRuntimeHelpText(run), escapeHtml(formatSeconds(runtimeParts.effective)))}
           ${renderRunCardCell('Config', 'Config name detected for the run.', escapeHtml(run.config_name || 'default'))}
           ${renderRunCardCell('Config lines', 'Non-comment lines captured from the redacted config output.', escapeHtml(String(configLineCount)))}
@@ -1213,9 +1361,13 @@ $(document).ready(function () {
           ${renderRunCardCell('Counts', 'W warnings, E errors, T tracebacks, M movies, S shows, Ep episodes, Tot total library items.', `<span class="logscan-count-chip-row">${countChips}</span>`)}
           ${renderRunCardCell('Kometa', 'Version detected for the run, plus newest version when different.', escapeHtml(kometaDisplay))}
           ${renderRunCardCell('Section runtimes', 'Runtime totals parsed per Kometa section.', sectionCell)}
-          ${renderRunCardCell('Report', 'Open the recommendations recorded for the run.', `
-            <button type="button" class="btn nav-button btn-sm logscan-action-btn logscan-run-details"
-              data-run-key="${escapeHtml(runKey)}">Open</button>
+          ${renderRunCardCell('Log size', 'Current on-disk size of the resolved log file when available, otherwise the ingested size.', escapeHtml(formatBytes(sizeBytes)))}
+          ${renderRunCardCell('Log', 'Download the source log for this run. Archived logs can also be deleted here.', `<div class="logscan-action-stack">${logActions.join('')}</div>`)}
+          ${renderRunCardCell('Report', run.is_incomplete ? 'Open recommendations and diagnostics captured for this incomplete log.' : 'Open the recommendations recorded for the run.', `
+            <div class="logscan-action-stack">
+              <button type="button" class="btn nav-button btn-sm logscan-action-btn logscan-run-details"
+                data-run-key="${escapeHtml(runKey)}">Open</button>
+            </div>
           `)}
         </tr>
       `
@@ -1632,6 +1784,8 @@ $(document).ready(function () {
 
   function getSortValue (run, key) {
     switch (key) {
+      case 'status':
+        return run && run.is_incomplete ? 1 : 0
       case 'finished_at':
         return getSortTimestamp(run)
       case 'run_time_seconds':
@@ -1662,6 +1816,8 @@ $(document).ready(function () {
         return run.kometa_version || ''
       case 'section_runtimes':
         return getSectionTotal(run.section_runtimes)
+      case 'log_resolved_size':
+        return typeof run.log_resolved_size === 'number' ? run.log_resolved_size : 0
       case 'recommendations_count':
         return typeof run.recommendations_count === 'number' ? run.recommendations_count : 0
       default:
@@ -1782,10 +1938,11 @@ $(document).ready(function () {
 
   function updateRunCountDisplay (filtered) {
     if (!$runCount.length) return
-    const loaded = allRuns.length
-    const total = Number.isFinite(allRunsTotal) && allRunsTotal > 0 ? allRunsTotal : loaded
+    const loaded = allTableRuns.length
+    const total = (Number.isFinite(allRunsTotal) ? allRunsTotal : allRuns.length) +
+      (Number.isFinite(allIncompleteRunsTotal) ? allIncompleteRunsTotal : allIncompleteRuns.length)
     const filteredCount = filtered.length
-    let text = `Runs shown: ${filteredCount}`
+    let text = `Entries shown: ${filteredCount}`
     if (filteredCount !== loaded) {
       text += ` of ${loaded} loaded`
     }
@@ -1819,9 +1976,9 @@ $(document).ready(function () {
 
   function updateFilterOptions (state) {
     let changed = false
-    changed = updateConfigFilter(filterRuns(allRuns, { ...state, config: '' })) || changed
-    changed = updateCommandFilter(filterRuns(allRuns, { ...state, command: '' })) || changed
-    changed = updateDateRangeInputs(filterRuns(allRuns, { ...state, start: '', end: '' }), state) || changed
+    changed = updateConfigFilter(filterRuns(allTableRuns, { ...state, config: '' })) || changed
+    changed = updateCommandFilter(filterRuns(allTableRuns, { ...state, command: '' })) || changed
+    changed = updateDateRangeInputs(filterRuns(allTableRuns, { ...state, start: '', end: '' }), state) || changed
     changed = updateLibraryFilter(filterRuns(allRuns, { ...state, library: '' })) || changed
     return changed
   }
@@ -1834,6 +1991,7 @@ $(document).ready(function () {
       state = getFilterState()
     }
     const filtered = filterRuns(allRuns, state)
+    const filteredTableRuns = filterRuns(allTableRuns, state)
     currentFilteredRuns = filtered
     updateRunCountDisplay(filtered)
     renderSummary(filtered)
@@ -1843,7 +2001,7 @@ $(document).ready(function () {
     renderIssueTrends(filtered)
     updateLibraryFilter(filtered)
     renderLibraryInventory(filtered)
-    renderTable(sortRuns(filtered))
+    renderTable(sortRuns(filteredTableRuns))
     renderIngestHealth(lastIngestState)
     updateSortIndicators()
   }
@@ -1909,6 +2067,11 @@ $(document).ready(function () {
     $confirmReset.prop('disabled', disabled)
     $confirmReingest.prop('disabled', disabled)
     $confirmMissingDownload.prop('disabled', disabled)
+    $tableSelectAll.prop('disabled', disabled || getSelectableRuns(currentTableRuns).length === 0)
+    $tableSelectComplete.prop('disabled', disabled || getSelectableRunsByCompletion(currentTableRuns, false).length === 0)
+    $tableSelectIncomplete.prop('disabled', disabled || getSelectableRunsByCompletion(currentTableRuns, true).length === 0)
+    $tableClearSelection.prop('disabled', disabled || selectedRunKeys.size === 0)
+    $tableDeleteSelected.prop('disabled', disabled || selectedRunKeys.size === 0)
   }
 
   function setMissingDownloadVisible (visible, count) {
@@ -2169,13 +2332,19 @@ $(document).ready(function () {
       .then(res => res.json())
       .then(data => {
         allRuns = Array.isArray(data.runs) ? data.runs : []
+        allIncompleteRuns = Array.isArray(data.incomplete_runs) ? data.incomplete_runs : []
+        allTableRuns = allRuns.concat(allIncompleteRuns)
+        pruneSelectedRunKeys()
         allRunsTotal = Number.isFinite(data.total_runs) ? data.total_runs : allRuns.length
+        allIncompleteRunsTotal = Number.isFinite(data.total_incomplete_runs) ? data.total_incomplete_runs : allIncompleteRuns.length
+        latestArchiveStorage = data && data.archive_storage ? data.archive_storage : null
+        renderArchiveStorageSummary(latestArchiveStorage)
         if (data && data.ingest_health && (!lastIngestState || lastIngestState.status !== 'running')) {
           lastIngestState = data.ingest_health
         }
-        updateConfigFilter(allRuns)
-        updateCommandFilter(allRuns)
-        updateDateRangeInputs(allRuns, getFilterState())
+        updateConfigFilter(allTableRuns)
+        updateCommandFilter(allTableRuns)
+        updateDateRangeInputs(allTableRuns, getFilterState())
         loadPreferences()
           .then(() => {
             applyFiltersAndRender()
@@ -2197,10 +2366,94 @@ $(document).ready(function () {
         $issues.text('Unable to load issue trends.')
         $libraries.text('Unable to load library totals.')
         if ($tableSummary.length) $tableSummary.text('Unable to load runs.')
+        if ($tablePolicy.length) $tablePolicy.text('Unable to load archived log policy.')
         if ($tablePageInfo.length) $tablePageInfo.text('No rows')
         $tablePrev.prop('disabled', true)
         $tableNext.prop('disabled', true)
-        $tableBody.html('<tr><td colspan="10" class="text-muted">Unable to load runs.</td></tr>')
+        $tableBody.html('<tr><td colspan="14" class="text-muted">Unable to load runs.</td></tr>')
+        updateSelectionSummary()
+      })
+  }
+
+  function refreshAnalyticsPage (options = {}) {
+    const suppressStatus = Boolean(options && options.suppressStatus)
+    checkMissingDownload()
+    fetchRuns({ suppressStatus })
+    fetchReingestStatus()
+  }
+
+  function getSelectedRuns () {
+    if (!selectedRunKeys.size) return []
+    return getSelectableRuns(allTableRuns).filter(run => selectedRunKeys.has(run.run_key))
+  }
+
+  function openDeleteLogModal (runKeys, runLabel) {
+    const normalizedRunKeys = Array.isArray(runKeys)
+      ? runKeys.map(value => String(value || '').trim()).filter(Boolean)
+      : [String(runKeys || '').trim()].filter(Boolean)
+    if (!normalizedRunKeys.length) return
+    pendingDeleteRun = {
+      runKeys: normalizedRunKeys,
+      runLabel,
+      bulk: normalizedRunKeys.length > 1
+    }
+    if ($deleteLogBody.length) {
+      if (normalizedRunKeys.length === 1) {
+        $deleteLogBody.html(`Delete log for <strong>${escapeHtml(runLabel || normalizedRunKeys[0])}</strong> from disk and remove it from Analytics?`)
+      } else {
+        $deleteLogBody.html(`Delete <strong>${normalizedRunKeys.length} selected logs</strong> from disk and remove their runs from Analytics?`)
+      }
+    }
+    if (deleteLogModalEl) {
+      bootstrap.Modal.getOrCreateInstance(deleteLogModalEl).show()
+      return
+    }
+    const confirmText = normalizedRunKeys.length === 1
+      ? `Delete log for ${runLabel || normalizedRunKeys[0]}?`
+      : `Delete ${normalizedRunKeys.length} selected logs?`
+    if (window.confirm(confirmText)) {
+      handleDeleteLog()
+    }
+  }
+
+  function handleDeleteLog () {
+    if (!pendingDeleteRun || !Array.isArray(pendingDeleteRun.runKeys) || !pendingDeleteRun.runKeys.length) {
+      hideModal(deleteLogModalEl)
+      return
+    }
+    $confirmDeleteLog.prop('disabled', true)
+    fetch('/logscan/trends/log/delete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(
+        pendingDeleteRun.runKeys.length === 1
+          ? { run_key: pendingDeleteRun.runKeys[0] }
+          : { run_keys: pendingDeleteRun.runKeys }
+      )
+    })
+      .then(async res => {
+        const data = await res.json().catch(() => ({}))
+        if (!res.ok) {
+          throw new Error((data && data.error) || 'Delete failed')
+        }
+        hideModal(deleteLogModalEl)
+        const deletedKeys = Array.isArray(pendingDeleteRun.runKeys) ? pendingDeleteRun.runKeys : []
+        deletedKeys.forEach(runKey => selectedRunKeys.delete(runKey))
+        const deletedCount = Number.isFinite(data && data.deleted) ? data.deleted : deletedKeys.length
+        pendingDeleteRun = null
+        if (Array.isArray(data && data.failures) && data.failures.length) {
+          updateStatus(`${deletedCount} logs deleted. ${data.failures.length} failed.`)
+        } else {
+          updateStatus(deletedCount > 1 ? `${deletedCount} logs deleted.` : 'Log deleted.')
+        }
+        fetchRuns({ suppressStatus: true })
+      })
+      .catch(err => {
+        console.error(err)
+        updateStatus(err && err.message ? err.message : 'Failed to delete log.', true)
+      })
+      .finally(() => {
+        $confirmDeleteLog.prop('disabled', false)
       })
   }
 
@@ -2324,6 +2577,7 @@ $(document).ready(function () {
   })
   $confirmReset.on('click', handleReset)
   $confirmReingest.on('click', handleReingest)
+  $confirmDeleteLog.on('click', handleDeleteLog)
   $missingDownload.on('click', function (event) {
     event.preventDefault()
     if (!$missingDownload.length || $missingDownload.hasClass('d-none')) return
@@ -2347,6 +2601,43 @@ $(document).ready(function () {
     const runKey = $(this).data('runKey') || $(this).attr('data-run-key')
     showRunDetails(runKey)
   })
+  $tableBody.on('change', '.logscan-select-checkbox', function () {
+    const runKey = $(this).data('runKey') || $(this).attr('data-run-key')
+    if (!runKey) return
+    if ($(this).is(':checked')) {
+      selectedRunKeys.add(runKey)
+    } else {
+      selectedRunKeys.delete(runKey)
+    }
+    renderTable(currentTableRuns)
+  })
+  $tableBody.on('click', '.logscan-delete-log', function () {
+    const runKey = $(this).data('runKey') || $(this).attr('data-run-key')
+    const runLabel = $(this).data('runLabel') || $(this).attr('data-run-label') || runKey
+    if (!runKey) return
+    openDeleteLogModal(runKey, runLabel)
+  })
+  $tableSelectAll.on('click', function () {
+    getSelectableRuns(currentTableRuns).forEach(run => selectedRunKeys.add(run.run_key))
+    renderTable(currentTableRuns)
+  })
+  $tableSelectComplete.on('click', function () {
+    getSelectableRunsByCompletion(currentTableRuns, false).forEach(run => selectedRunKeys.add(run.run_key))
+    renderTable(currentTableRuns)
+  })
+  $tableSelectIncomplete.on('click', function () {
+    getSelectableRunsByCompletion(currentTableRuns, true).forEach(run => selectedRunKeys.add(run.run_key))
+    renderTable(currentTableRuns)
+  })
+  $tableClearSelection.on('click', function () {
+    selectedRunKeys.clear()
+    renderTable(currentTableRuns)
+  })
+  $tableDeleteSelected.on('click', function () {
+    const selectedRuns = getSelectedRuns()
+    if (!selectedRuns.length) return
+    openDeleteLogModal(selectedRuns.map(run => run.run_key), `${selectedRuns.length} selected logs`)
+  })
   $tableBody.on('click', '[data-section-details="1"]', function () {
     const runKey = $(this).data('runKey') || $(this).attr('data-run-key')
     showSectionDetails(runKey)
@@ -2363,8 +2654,10 @@ $(document).ready(function () {
     }
     applyFiltersAndRender()
   })
+  window.addEventListener('pageshow', function (event) {
+    if (!event || !event.persisted) return
+    refreshAnalyticsPage({ suppressStatus: true })
+  })
   renderCountsSeriesSelector()
-  checkMissingDownload()
-  fetchRuns()
-  fetchReingestStatus()
+  refreshAnalyticsPage()
 })

--- a/templates/001-start.html
+++ b/templates/001-start.html
@@ -167,6 +167,11 @@
         data-bs-target="#bulkDeleteModal">
         <i class="bi bi-trash3"></i> Delete Configs
       </button>
+
+      <button type="button" class="btn btn-outline-secondary" id="orphanedArtifactsButton" data-bs-toggle="modal"
+        data-bs-target="#orphanedArtifactsModal">
+        <i class="bi bi-hdd-stack"></i> Review File Drift
+      </button>
     </div>
   </div>
 </div>
@@ -238,6 +243,62 @@
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" autofocus>No, keep them</button>
         <button type="button" class="btn btn-danger" id="confirmBulkDeleteButton" disabled>Delete Selected</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="orphanedArtifactsModal" tabindex="-1" aria-labelledby="orphanedArtifactsModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="orphanedArtifactsModalLabel">
+          <i class="bi bi-hdd-stack me-2"></i>Review File Drift
+        </h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p class="small text-muted mb-2">
+          These config bundles exist on disk but are not referenced by the Quickstart database. Leave any unchecked to keep them on disk.
+        </p>
+        <div class="alert alert-warning py-2 small mb-3" role="alert">
+          This tool only deletes filesystem artifacts. It does not remove anything from the database.
+        </div>
+        <div id="orphanedArtifactsError" class="alert alert-danger d-none py-2 small" role="alert"></div>
+        <div class="form-check mb-2">
+          <input class="form-check-input" type="checkbox" id="orphanedArtifactsSelectAll">
+          <label class="form-check-label" for="orphanedArtifactsSelectAll">Select all orphaned config bundles</label>
+        </div>
+        <div id="orphanedArtifactsList" class="bulk-delete-list"></div>
+        <div class="small text-muted mt-2">Selected: <span id="orphanedArtifactsCount">0</span></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Keep for now</button>
+        <button type="button" class="btn btn-danger" id="confirmOrphanedArtifactsDelete" disabled>Delete Selected</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="orphanedArtifactsRestoreModal" tabindex="-1" aria-labelledby="orphanedArtifactsRestoreModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="orphanedArtifactsRestoreModalLabel">
+          <i class="bi bi-arrow-counterclockwise me-2"></i>Restore From Disk
+        </h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p class="small text-muted mb-2">
+          Choose one saved version to restore into the Quickstart database. Versions are sorted newest first.
+        </p>
+        <div id="orphanedArtifactsRestoreError" class="alert alert-danger d-none py-2 small" role="alert"></div>
+        <div id="orphanedArtifactsRestoreList" class="bulk-delete-list"></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" id="confirmOrphanedArtifactsRestore" disabled>Restore Selected Version</button>
       </div>
     </div>
   </div>

--- a/templates/905-analytics.html
+++ b/templates/905-analytics.html
@@ -148,6 +148,7 @@
           <button id="logscan-table-select-complete" type="button" class="btn nav-button btn-sm">Select complete</button>
           <button id="logscan-table-select-incomplete" type="button" class="btn nav-button btn-sm">Select incomplete</button>
           <button id="logscan-table-clear-selection" type="button" class="btn nav-button btn-sm">Clear</button>
+          <button id="logscan-table-compress-selected" type="button" class="btn nav-button btn-sm" disabled>Compress selected</button>
           <button id="logscan-table-delete-selected" type="button" class="btn nav-button nav-button-danger btn-sm" disabled>Delete selected</button>
           <div id="logscan-table-selection-summary" class="small text-muted">No logs selected.</div>
         </div>
@@ -380,6 +381,27 @@
       <div class="modal-footer">
         <button type="button" class="btn nav-button btn-sm" data-bs-dismiss="modal">Cancel</button>
         <button type="button" class="btn nav-button nav-button-danger btn-sm" id="logscan-confirm-delete-log">Delete</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="logscan-compress-log-modal" tabindex="-1" aria-labelledby="logscan-compress-log-title"
+  aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content bg-dark text-light border-secondary">
+      <div class="modal-header">
+        <h5 class="modal-title" id="logscan-compress-log-title">Compress Logs</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"
+          aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div id="logscan-compress-log-body">Compress this archived log as <code>.log.gz</code>?</div>
+        <div class="small text-muted mt-2">Only archived plain <code>.log</code> files are compressed. The active <code>meta.log</code> is never touched from this action.</div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn nav-button btn-sm" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn nav-button btn-sm" id="logscan-confirm-compress-log">Compress</button>
       </div>
     </div>
   </div>

--- a/templates/905-analytics.html
+++ b/templates/905-analytics.html
@@ -131,6 +131,7 @@
       <div>
         <h6 class="mb-1 text-uppercase">Recent Runs</h6>
         <div id="logscan-table-summary" class="small text-muted">Loading runs...</div>
+        <div id="logscan-table-policy" class="small text-muted">Loading archived log policy...</div>
       </div>
       <div class="logscan-table-actions">
         <button class="btn nav-button btn-sm collapsed" type="button" data-bs-toggle="collapse"
@@ -142,8 +143,17 @@
     </div>
     <div class="collapse" id="logscan-recent-runs-collapse">
       <div class="logscan-table-toolbar">
+        <div class="logscan-table-bulk-actions">
+          <button id="logscan-table-select-all" type="button" class="btn nav-button btn-sm">Select all</button>
+          <button id="logscan-table-select-complete" type="button" class="btn nav-button btn-sm">Select complete</button>
+          <button id="logscan-table-select-incomplete" type="button" class="btn nav-button btn-sm">Select incomplete</button>
+          <button id="logscan-table-clear-selection" type="button" class="btn nav-button btn-sm">Clear</button>
+          <button id="logscan-table-delete-selected" type="button" class="btn nav-button nav-button-danger btn-sm" disabled>Delete selected</button>
+          <div id="logscan-table-selection-summary" class="small text-muted">No logs selected.</div>
+        </div>
         <label class="small text-muted" for="logscan-table-sort-key">Sort by</label>
         <select id="logscan-table-sort-key" class="form-select form-select-sm w-auto">
+          <option value="status">Status</option>
           <option value="finished_at" selected>Finished</option>
           <option value="run_time_seconds">Runtime</option>
           <option value="config_name">Config</option>
@@ -160,6 +170,7 @@
           <option value="library_total">Total items</option>
           <option value="kometa_version">Kometa</option>
           <option value="section_runtimes">Section runtimes</option>
+          <option value="log_resolved_size">Log size</option>
           <option value="recommendations_count">Report</option>
         </select>
         <select id="logscan-table-sort-dir" class="form-select form-select-sm w-auto" aria-label="Sort direction">
@@ -182,6 +193,12 @@
         <table class="table table-dark table-sm align-middle mb-0" id="logscan-trends-table">
           <thead>
             <tr>
+              <th class="text-center">
+                <span class="text-nowrap">Select</span>
+              </th>
+              <th>
+                <span class="text-nowrap">Status</span>
+              </th>
               <th>
                 <button type="button" class="logscan-sort-button is-desc" data-sort="finished_at"
                   title="Sort by finished timestamp" aria-label="Sort by finished timestamp">
@@ -272,6 +289,17 @@
                   </span>
                 </button>
               </th>
+              <th>
+                <button type="button" class="logscan-sort-button" data-sort="log_resolved_size"
+                  title="Sort by log size" aria-label="Sort by log size">
+                  Log size
+                  <span class="logscan-sort-icons" aria-hidden="true">
+                    <span class="logscan-sort-up"></span>
+                    <span class="logscan-sort-down"></span>
+                  </span>
+                </button>
+              </th>
+              <th class="text-center">Log</th>
               <th class="text-center">
                 <button type="button" class="logscan-sort-button" data-sort="recommendations_count"
                   title="Sort by report count" aria-label="Sort by report count">
@@ -286,7 +314,7 @@
           </thead>
           <tbody>
             <tr>
-              <td colspan="10" class="text-muted">Loading runs...</td>
+              <td colspan="14" class="text-muted">Loading runs...</td>
             </tr>
           </tbody>
         </table>
@@ -331,6 +359,27 @@
       <div class="modal-footer">
         <button type="button" class="btn nav-button btn-sm" data-bs-dismiss="modal">Cancel</button>
         <button type="button" class="btn nav-button nav-button-danger btn-sm" id="logscan-confirm-reset">Reset</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="logscan-delete-log-modal" tabindex="-1" aria-labelledby="logscan-delete-log-title"
+  aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content bg-dark text-light border-secondary">
+      <div class="modal-header">
+        <h5 class="modal-title" id="logscan-delete-log-title">Delete Logs</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"
+          aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div id="logscan-delete-log-body">Delete this log from disk and remove it from Analytics?</div>
+        <div class="small text-muted mt-2">The live <code>meta.log</code> is never deleted from this action.</div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn nav-button btn-sm" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn nav-button nav-button-danger btn-sm" id="logscan-confirm-delete-log">Delete</button>
       </div>
     </div>
   </div>

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -348,6 +348,195 @@ def test_switch_config_returns_new_workspace_status(client, isolated_config_dir,
         assert sess["config_name"] == ready_config
 
 
+def test_clear_data_removes_config_artifacts(client, isolated_config_dir, app):
+    from modules import database
+    from pathlib import Path
+
+    config_name = "pytest_delete_me"
+    config_file = isolated_config_dir / f"{config_name}_config.yml"
+    archive_dir = isolated_config_dir / "archives" / config_name
+    archive_file = archive_dir / f"{config_name}_config_1.yml"
+    kometa_config = app.config["KOMETA_ROOT"]
+
+    config_file.write_text("test: true\n", encoding="utf-8")
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    archive_file.write_text("archived: true\n", encoding="utf-8")
+    kometa_path = Path(kometa_config) / "config"
+    kometa_path.mkdir(parents=True, exist_ok=True)
+    (kometa_path / f"{config_name}_config.yml").write_text("test: true\n", encoding="utf-8")
+
+    database.save_section_data(
+        name=config_name,
+        section="start",
+        validated=True,
+        user_entered=True,
+        data={"start": {"config_name": config_name}},
+    )
+
+    resp = client.get(f"/clear_data/{config_name}")
+    assert resp.status_code == 302
+    assert database.get_unique_config_names() == []
+    assert not config_file.exists()
+    assert not archive_dir.exists()
+    assert not (kometa_path / f"{config_name}_config.yml").exists()
+
+
+def test_bulk_delete_configs_removes_config_artifacts(client, isolated_config_dir, app):
+    from modules import database
+    from pathlib import Path
+
+    first = "pytest_bulk_one"
+    second = "pytest_bulk_two"
+    kometa_path = Path(app.config["KOMETA_ROOT"]) / "config"
+    kometa_path.mkdir(parents=True, exist_ok=True)
+
+    for name in (first, second):
+        (isolated_config_dir / f"{name}_config.yml").write_text("test: true\n", encoding="utf-8")
+        archive_dir = isolated_config_dir / "archives" / name
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        (archive_dir / f"{name}_config_1.yml").write_text("archived: true\n", encoding="utf-8")
+        (kometa_path / f"{name}_config.yml").write_text("test: true\n", encoding="utf-8")
+        database.save_section_data(
+            name=name,
+            section="start",
+            validated=True,
+            user_entered=True,
+            data={"start": {"config_name": name}},
+        )
+
+    with client.session_transaction() as sess:
+        sess["config_name"] = first
+
+    resp = client.post("/bulk-delete-configs", json={"names": [first, second]})
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert set(payload["deleted"]) == {first, second}
+    assert database.get_unique_config_names() == []
+
+    for name in (first, second):
+        assert not (isolated_config_dir / f"{name}_config.yml").exists()
+        assert not (isolated_config_dir / "archives" / name).exists()
+        assert not (kometa_path / f"{name}_config.yml").exists()
+
+
+def test_orphaned_config_artifacts_route_lists_disk_only_bundles(client, isolated_config_dir, app):
+    from modules import database
+    from pathlib import Path
+
+    keep_name = "keep_me"
+    orphan_name = "delete_me"
+    archive_dir = isolated_config_dir / "archives" / orphan_name
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    (archive_dir / f"{orphan_name}_config_1.yml").write_text("archive: true\n", encoding="utf-8")
+    (isolated_config_dir / f"{orphan_name}_config.yml").write_text("current: true\n", encoding="utf-8")
+
+    kometa_path = Path(app.config["KOMETA_ROOT"]) / "config"
+    kometa_path.mkdir(parents=True, exist_ok=True)
+    (kometa_path / f"{orphan_name}_config.yml").write_text("kometa: true\n", encoding="utf-8")
+
+    database.save_section_data(
+        name=keep_name,
+        section="start",
+        validated=True,
+        user_entered=True,
+        data={"start": {"config_name": keep_name}},
+    )
+
+    resp = client.get("/orphaned-config-artifacts")
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert len(payload["orphans"]) == 1
+    orphan = payload["orphans"][0]
+    assert orphan["name"] == orphan_name
+    assert orphan["has_current_file"] is True
+    assert orphan["has_kometa_copy"] is True
+    assert orphan["has_archive_dir"] is True
+    assert orphan["archive_count"] == 1
+
+
+def test_delete_orphaned_config_artifacts_route_removes_selected_bundle(client, isolated_config_dir, app):
+    from pathlib import Path
+
+    orphan_name = "delete_me"
+    archive_dir = isolated_config_dir / "archives" / orphan_name
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    (archive_dir / f"{orphan_name}_config_1.yml").write_text("archive: true\n", encoding="utf-8")
+    (isolated_config_dir / f"{orphan_name}_config.yml").write_text("current: true\n", encoding="utf-8")
+
+    kometa_path = Path(app.config["KOMETA_ROOT"]) / "config"
+    kometa_path.mkdir(parents=True, exist_ok=True)
+    (kometa_path / f"{orphan_name}_config.yml").write_text("kometa: true\n", encoding="utf-8")
+
+    resp = client.post("/orphaned-config-artifacts/delete", json={"names": [orphan_name]})
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert payload["deleted"] == [orphan_name]
+    assert not (isolated_config_dir / f"{orphan_name}_config.yml").exists()
+    assert not archive_dir.exists()
+    assert not (kometa_path / f"{orphan_name}_config.yml").exists()
+
+
+def test_orphaned_config_artifact_versions_returns_newest_first(client, isolated_config_dir):
+    import os
+    import time
+
+    orphan_name = "delete_me"
+    current_file = isolated_config_dir / f"{orphan_name}_config.yml"
+    archive_dir = isolated_config_dir / "archives" / orphan_name
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    older = archive_dir / f"{orphan_name}_config_1.yml"
+    newer = archive_dir / f"{orphan_name}_config_2.yml"
+
+    current_file.write_text("settings:\n  cache: false\n", encoding="utf-8")
+    older.write_text("settings:\n  cache: false\n", encoding="utf-8")
+    newer.write_text("settings:\n  cache: true\n", encoding="utf-8")
+
+    now = time.time()
+    os.utime(older, (now - 100, now - 100))
+    os.utime(current_file, (now - 50, now - 50))
+    os.utime(newer, (now, now))
+
+    resp = client.get(f"/orphaned-config-artifacts/versions?name={orphan_name}")
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert [item["filename"] for item in payload["versions"]] == [newer.name, current_file.name, older.name]
+
+
+def test_restore_orphaned_config_artifact_restores_selected_version(client, isolated_config_dir, app):
+    from modules import database
+
+    orphan_name = "delete_me"
+    current_file = isolated_config_dir / f"{orphan_name}_config.yml"
+    archive_dir = isolated_config_dir / "archives" / orphan_name
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    selected_version = archive_dir / f"{orphan_name}_config_1.yml"
+
+    current_file.write_text("settings:\n  cache: false\n", encoding="utf-8")
+    selected_version.write_text("settings:\n  cache: true\n", encoding="utf-8")
+
+    resp = client.post(
+        "/orphaned-config-artifacts/restore",
+        json={"name": orphan_name, "path": str(selected_version.resolve())},
+    )
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert payload["config_name"] == orphan_name
+    assert "settings" in payload["imported_sections"]
+
+    validated, user_entered, data = database.retrieve_section_data(orphan_name, "settings")
+    assert validated is False
+    assert user_entered is True
+    assert data["settings"]["cache"] is True
+
+    restored_text = current_file.read_text(encoding="utf-8")
+    assert "cache: true" in restored_text
+
+
 def test_list_uploaded_images_includes_builtin_guides(client):
     expected_by_type = {
         "movie": {"overlay_alignment_guide.png"},

--- a/tests/test_logscan_endpoints.py
+++ b/tests/test_logscan_endpoints.py
@@ -83,6 +83,439 @@ def test_logscan_trends_empty(client, isolated_config_dir):
     payload = resp.get_json()
     assert payload["total_runs"] == 0
     assert payload["runs"] == []
+    assert payload["archive_storage"]["archived_bytes"] == 0
+    assert payload["archive_storage"]["archived_files"] == 0
+    assert payload["archive_storage"]["extra_archived_files"] == 0
+    assert payload["archive_storage"]["retention_label"] == "Keep all archived logs"
+
+
+def test_logscan_trends_includes_archive_storage_and_run_file_metadata(client, isolated_config_dir, monkeypatch, qs_module):
+    archive_dir = isolated_config_dir / "cache" / "logscan" / "archive"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    log_path = archive_dir / "meta-2026-04-23.log"
+    extra_path = archive_dir / "meta-2026-04-22.log"
+    log_bytes = b"archived log contents\n"
+    extra_bytes = b"extra archived log\n"
+    log_path.write_bytes(log_bytes)
+    extra_path.write_bytes(extra_bytes)
+    stats = log_path.stat()
+    monkeypatch.setitem(qs_module.app.config, "QS_KOMETA_LOG_KEEP", 7)
+    qs_module.database.save_log_run(
+        {
+            "run_key": "run-archive-1",
+            "finished_at": "2026-04-23T10:00:00Z",
+            "config_name": "demo",
+            "created_at": "2026-04-23T10:00:00Z",
+            "log_mtime": stats.st_mtime,
+            "log_size": stats.st_size,
+        }
+    )
+    monkeypatch.setattr(
+        qs_module,
+        "_load_logscan_ingest_cache",
+        lambda: {"version": 1, "logs": {str(log_path.resolve()): {"run_key": "run-archive-1", "run_complete": True}}},
+    )
+
+    resp = client.get("/logscan/trends")
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["archive_storage"]["archived_files"] == 1
+    assert payload["archive_storage"]["archived_bytes"] == len(log_bytes)
+    assert payload["archive_storage"]["extra_archived_files"] == 1
+    assert payload["archive_storage"]["extra_archived_bytes"] == len(extra_bytes)
+    assert payload["archive_storage"]["disk_archived_files"] == 2
+    assert payload["archive_storage"]["retention_label"] == "Keep last 7 archived logs"
+    assert payload["runs"][0]["log_location"] == "archive"
+    assert payload["runs"][0]["log_available"] is True
+    assert payload["runs"][0]["log_can_delete"] is True
+    assert payload["runs"][0]["log_resolved_size"] == len(log_bytes)
+
+
+def test_logscan_trends_does_not_bind_historical_run_to_live_log(client, isolated_config_dir, monkeypatch, qs_module):
+    kometa_root = Path(qs_module.app.config["KOMETA_ROOT"])
+    log_dir = kometa_root / "config" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    live_path = log_dir / "meta.log"
+    log_bytes = b"same sized log\n"
+    live_path.write_bytes(log_bytes)
+    stats = live_path.stat()
+    qs_module.database.save_log_run(
+        {
+            "run_key": "run-historical-1",
+            "finished_at": "2026-04-23T09:00:00Z",
+            "config_name": "demo",
+            "created_at": "2026-04-23T09:00:00Z",
+            "log_mtime": stats.st_mtime,
+            "log_size": stats.st_size,
+        }
+    )
+    monkeypatch.setattr(qs_module, "_load_logscan_ingest_cache", lambda: {"version": 1, "logs": {}})
+
+    resp = client.get("/logscan/trends")
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["runs"][0]["log_available"] is False
+    assert payload["runs"][0]["log_location"] == "missing"
+
+
+def test_logscan_trends_includes_incomplete_runs_in_table_payload(client, isolated_config_dir, monkeypatch, qs_module):
+    archive_dir = isolated_config_dir / "cache" / "logscan" / "archive"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    incomplete_path = archive_dir / "meta-20260423-120000Z-10.log"
+    incomplete_path.write_text("incomplete log\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        qs_module,
+        "_get_logscan_incomplete_runs",
+        lambda limit=100, config_name=None: [
+            {
+                "run_key": "run-incomplete-1",
+                "config_name": "demo",
+                "created_at": "2026-04-23T12:00:00Z",
+                "log_mtime": incomplete_path.stat().st_mtime,
+                "log_size": incomplete_path.stat().st_size,
+                "run_complete": False,
+                "is_incomplete": True,
+                "resume_reason": "Run appears incomplete.",
+                "recommendations_count": 2,
+            }
+        ],
+    )
+    monkeypatch.setattr(qs_module, "_load_logscan_ingest_cache", lambda: {"version": 1, "logs": {str(incomplete_path.resolve()): {"run_key": "run-incomplete-1", "run_complete": False}}})
+
+    resp = client.get("/logscan/trends")
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["total_incomplete_runs"] == 1
+    assert len(payload["incomplete_runs"]) == 1
+    assert payload["incomplete_runs"][0]["is_incomplete"] is True
+    assert payload["incomplete_runs"][0]["log_location"] == "archive"
+    assert payload["incomplete_runs"][0]["log_can_delete"] is True
+    assert payload["archive_storage"]["archived_files"] == 1
+
+
+def test_logscan_trends_includes_incomplete_fallback_when_detailed_parse_fails(client, isolated_config_dir, monkeypatch, qs_module):
+    archive_dir = isolated_config_dir / "cache" / "logscan" / "archive"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    incomplete_path = archive_dir / "meta-fallback.log"
+    incomplete_path.write_text("cannot parse this fully\n", encoding="utf-8")
+    monkeypatch.setattr(qs_module, "_analyze_incomplete_log_for_resume", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        qs_module,
+        "_load_logscan_ingest_cache",
+        lambda: {"version": 1, "logs": {str(incomplete_path.resolve()): {"run_key": "run-fallback-1", "run_complete": False, "mtime": incomplete_path.stat().st_mtime, "size": incomplete_path.stat().st_size}}},
+    )
+
+    resp = client.get("/logscan/trends")
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["total_incomplete_runs"] == 1
+    assert payload["incomplete_runs"][0]["run_key"] == "run-fallback-1"
+    assert payload["incomplete_runs"][0]["is_incomplete"] is True
+    assert "preserved for investigation" in payload["incomplete_runs"][0]["resume_reason"].lower()
+
+
+def test_logscan_trends_uses_cached_incomplete_summary_without_reparse(client, isolated_config_dir, monkeypatch, qs_module):
+    archive_dir = isolated_config_dir / "cache" / "logscan" / "archive"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    incomplete_path = archive_dir / "meta-cached.log"
+    incomplete_path.write_text("cached incomplete\n", encoding="utf-8")
+    monkeypatch.setattr(
+        qs_module,
+        "_analyze_incomplete_log_for_resume",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not reparse cached incomplete entries")),
+    )
+    monkeypatch.setattr(
+        qs_module,
+        "_load_logscan_ingest_cache",
+        lambda: {
+            "version": 1,
+            "logs": {
+                str(incomplete_path.resolve()): {
+                    "run_key": "run-cached-1",
+                    "run_complete": False,
+                    "mtime": incomplete_path.stat().st_mtime,
+                    "size": incomplete_path.stat().st_size,
+                    "updated_at": "2026-04-23T22:00:00Z",
+                    "summary": {
+                        "run_key": "run-cached-1",
+                        "finished_at": "2026-04-23T21:59:00Z",
+                        "run_time_seconds": 123,
+                        "config_name": "demo",
+                        "run_command": "kometa.py --run --collections-only",
+                        "command_signature": "--run --collections-only",
+                        "log_counts": {"warning": 2, "error": 1},
+                        "analysis_counts": {"playlist_errors": 1},
+                    },
+                    "recommendations": [{"first_line": "INFO - Run incomplete", "message": "Review the log"}],
+                }
+            },
+        },
+    )
+
+    resp = client.get("/logscan/trends")
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["total_incomplete_runs"] == 1
+    row = payload["incomplete_runs"][0]
+    assert row["run_key"] == "run-cached-1"
+    assert row["config_name"] == "demo"
+    assert row["warning_count"] == 2
+    assert row["error_count"] == 1
+    assert row["recommendations_count"] == 1
+
+
+def test_logscan_trends_recommendations_support_incomplete_run(client, isolated_config_dir, monkeypatch, qs_module):
+    monkeypatch.setattr(qs_module.database, "get_log_run_recommendations", lambda run_key: [])
+    monkeypatch.setattr(
+        qs_module,
+        "_get_logscan_incomplete_run",
+        lambda run_key, config_name=None: {
+            "run_key": run_key,
+            "recommendations": [{"first_line": "INFO - Run incomplete", "summary": "Needs review"}],
+        },
+    )
+
+    resp = client.get("/logscan/trends/recommendations?run_key=run-incomplete-1")
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert len(payload["recommendations"]) == 1
+
+
+def test_logscan_trends_log_delete_supports_incomplete_run_without_db(client, isolated_config_dir, monkeypatch, qs_module):
+    archive_dir = isolated_config_dir / "cache" / "logscan" / "archive"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    log_path = archive_dir / "meta-incomplete.log"
+    log_path.write_text("delete incomplete\n", encoding="utf-8")
+    monkeypatch.setattr(qs_module.database, "get_log_run", lambda run_key: None)
+    monkeypatch.setattr(
+        qs_module,
+        "_get_logscan_incomplete_run",
+        lambda run_key, config_name=None: {
+            "run_key": run_key,
+            "log_mtime": log_path.stat().st_mtime,
+            "log_size": log_path.stat().st_size,
+            "is_incomplete": True,
+        },
+    )
+    monkeypatch.setattr(qs_module, "_load_logscan_ingest_cache", lambda: {"version": 1, "logs": {str(log_path.resolve()): {"run_key": "run-incomplete-1", "run_complete": False}}})
+
+    resp = client.post("/logscan/trends/log/delete", json={"run_key": "run-incomplete-1"})
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert payload["deleted_run"] is False
+    assert not log_path.exists()
+
+
+def test_logscan_trends_log_delete_supports_bulk_delete(client, isolated_config_dir, monkeypatch, qs_module):
+    archive_dir = isolated_config_dir / "cache" / "logscan" / "archive"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    first_log = archive_dir / "meta-bulk-1.log"
+    second_log = archive_dir / "meta-bulk-2.log"
+    first_log.write_text("bulk one\n", encoding="utf-8")
+    second_log.write_text("bulk two\n", encoding="utf-8")
+
+    run_map = {
+        "bulk-run-1": {
+            "run_key": "bulk-run-1",
+            "log_mtime": first_log.stat().st_mtime,
+            "log_size": first_log.stat().st_size,
+            "config_name": "demo",
+            "created_at": "2026-04-23T10:00:00Z",
+        },
+        "bulk-run-2": {
+            "run_key": "bulk-run-2",
+            "log_mtime": second_log.stat().st_mtime,
+            "log_size": second_log.stat().st_size,
+            "config_name": "demo",
+            "created_at": "2026-04-23T10:05:00Z",
+        },
+    }
+    deleted_run_keys = []
+
+    monkeypatch.setattr(qs_module.database, "get_log_run", lambda run_key: run_map.get(run_key))
+    monkeypatch.setattr(qs_module.database, "delete_log_run", lambda run_key: deleted_run_keys.append(run_key) or True)
+    monkeypatch.setattr(
+        qs_module,
+        "_load_logscan_ingest_cache",
+        lambda: {
+            "version": 1,
+            "logs": {
+                str(first_log.resolve()): {"run_key": "bulk-run-1", "run_complete": True},
+                str(second_log.resolve()): {"run_key": "bulk-run-2", "run_complete": True},
+            },
+        },
+    )
+    monkeypatch.setattr(qs_module, "_save_logscan_ingest_cache", lambda cache: None)
+
+    resp = client.post("/logscan/trends/log/delete", json={"run_keys": ["bulk-run-1", "bulk-run-2"]})
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["deleted"] == 2
+    assert payload["success"] is True
+    assert set(deleted_run_keys) == {"bulk-run-1", "bulk-run-2"}
+    assert not first_log.exists()
+    assert not second_log.exists()
+
+
+def test_logscan_trends_log_download(client, isolated_config_dir, monkeypatch, qs_module):
+    kometa_root = Path(qs_module.app.config["KOMETA_ROOT"])
+    log_dir = kometa_root / "config" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "meta-1.log"
+    log_path.write_text("hello from meta log\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        qs_module,
+        "_load_logscan_ingest_cache",
+        lambda: {"version": 1, "logs": {str(log_path.resolve()): {"run_key": "run-123", "run_complete": True}}},
+    )
+
+    resp = client.get("/logscan/trends/log?run_key=run-123")
+    assert resp.status_code == 200
+    assert resp.data.replace(b"\r\n", b"\n") == b"hello from meta log\n"
+
+
+def test_logscan_trends_log_delete_removes_archived_log_and_run(client, isolated_config_dir, monkeypatch, qs_module):
+    archive_dir = isolated_config_dir / "cache" / "logscan" / "archive"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    log_path = archive_dir / "meta-delete-me.log"
+    log_path.write_text("delete me\n", encoding="utf-8")
+    stats = log_path.stat()
+    qs_module.database.save_log_run(
+        {
+            "run_key": "run-delete-1",
+            "finished_at": "2026-04-23T11:00:00Z",
+            "config_name": "cleanup",
+            "created_at": "2026-04-23T11:00:00Z",
+            "log_mtime": stats.st_mtime,
+            "log_size": stats.st_size,
+        }
+    )
+    monkeypatch.setattr(
+        qs_module,
+        "_load_logscan_ingest_cache",
+        lambda: {"version": 1, "logs": {str(log_path.resolve()): {"run_key": "run-delete-1", "run_complete": True}}},
+    )
+
+    resp = client.post("/logscan/trends/log/delete", json={"run_key": "run-delete-1"})
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert payload["deleted_file"] is True
+    assert not log_path.exists()
+    assert qs_module.database.get_log_run("run-delete-1") is None
+
+
+def test_logscan_trends_log_delete_rejects_live_log(client, isolated_config_dir, monkeypatch, qs_module):
+    kometa_root = Path(qs_module.app.config["KOMETA_ROOT"])
+    log_dir = kometa_root / "config" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "meta.log"
+    log_path.write_text("still live\n", encoding="utf-8")
+    stats = log_path.stat()
+    qs_module.database.save_log_run(
+        {
+            "run_key": "run-live-1",
+            "finished_at": "2026-04-23T12:00:00Z",
+            "config_name": "live",
+            "created_at": "2026-04-23T12:00:00Z",
+            "log_mtime": stats.st_mtime,
+            "log_size": stats.st_size,
+        }
+    )
+    monkeypatch.setattr(
+        qs_module,
+        "_load_logscan_ingest_cache",
+        lambda: {"version": 1, "logs": {str(log_path.resolve()): {"run_key": "run-live-1", "run_complete": True}}},
+    )
+
+    resp = client.post("/logscan/trends/log/delete", json={"run_key": "run-live-1"})
+    assert resp.status_code == 409
+    assert log_path.exists()
+    assert qs_module.database.get_log_run("run-live-1") is not None
+
+
+def test_archive_log_file_uses_canonical_timestamp_size_name(isolated_config_dir, qs_module):
+    log_dir = isolated_config_dir / "kometa" / "config" / "logs"
+    archive_dir = isolated_config_dir / "cache" / "logscan" / "archive"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "meta-3.log"
+    log_path.write_bytes(b"abc123\n")
+    fixed_epoch = 1766595600  # 2025-12-24T17:00:00Z
+    os.utime(log_path, (fixed_epoch, fixed_epoch))
+
+    archived = qs_module._archive_log_file(log_path, archive_dir, log_dir=log_dir)
+
+    assert archived is not None
+    assert archived.name == "meta-20251224-170000Z-7.log"
+    assert archived.exists()
+    assert not log_path.exists()
+
+
+def test_archive_finished_live_meta_log_if_idle_moves_live_file_and_cache(isolated_config_dir, monkeypatch, qs_module):
+    kometa_root = Path(qs_module.app.config["KOMETA_ROOT"])
+    log_dir = kometa_root / "config" / "logs"
+    archive_dir = isolated_config_dir / "cache" / "logscan" / "archive"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    live_path = log_dir / "meta.log"
+    live_path.write_text("finished live run\n", encoding="utf-8")
+
+    cache = {
+        "version": 1,
+        "logs": {
+            str(live_path.resolve()): {
+                "mtime": live_path.stat().st_mtime,
+                "size": live_path.stat().st_size,
+                "run_key": "run-live-finished-1",
+                "run_complete": True,
+                "updated_at": "2026-04-23T20:00:00Z",
+            }
+        },
+    }
+    saved = {}
+
+    monkeypatch.setattr(qs_module.helpers, "is_kometa_running", lambda: False)
+    monkeypatch.setattr(qs_module, "_load_logscan_ingest_cache", lambda: cache)
+    monkeypatch.setattr(qs_module, "_save_logscan_ingest_cache", lambda value: saved.setdefault("cache", value))
+
+    archived = qs_module._archive_finished_live_meta_log_if_idle(log_dir=log_dir)
+
+    assert archived is not None
+    assert archived.exists()
+    assert archived.parent == archive_dir
+    assert not live_path.exists()
+    saved_cache = saved["cache"]
+    assert str(live_path.resolve()) not in saved_cache["logs"]
+    assert str(archived.resolve()) in saved_cache["logs"]
+    assert saved_cache["logs"][str(archived.resolve())]["run_key"] == "run-live-finished-1"
+
+
+def test_normalize_logscan_archive_filenames_renames_legacy_files_and_updates_cache(isolated_config_dir, monkeypatch, qs_module):
+    archive_dir = isolated_config_dir / "cache" / "logscan" / "archive"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    legacy_path = archive_dir / "meta-1.log"
+    legacy_path.write_bytes(b"legacy\n")
+    fixed_epoch = 1766595600  # 2025-12-24T17:00:00Z
+    os.utime(legacy_path, (fixed_epoch, fixed_epoch))
+    cache = {"version": 1, "logs": {str(legacy_path.resolve()): {"run_key": "run-legacy", "run_complete": True}}}
+    saved = {}
+
+    monkeypatch.setattr(qs_module, "_load_logscan_ingest_cache", lambda: cache)
+    monkeypatch.setattr(qs_module, "_save_logscan_ingest_cache", lambda value: saved.setdefault("cache", value))
+
+    result = qs_module._normalize_logscan_archive_filenames(archive_dir=archive_dir)
+
+    assert result["renamed"] == 1
+    renamed_path = archive_dir / "meta-20251224-170000Z-7.log"
+    assert renamed_path.exists()
+    assert not legacy_path.exists()
+    saved_cache = saved["cache"]
+    assert str(renamed_path.resolve()) in saved_cache["logs"]
+    assert str(legacy_path.resolve()) not in saved_cache["logs"]
 
 
 def test_logscan_progress_tracks_libraries(client, isolated_config_dir, monkeypatch, qs_module):

--- a/tests/test_logscan_endpoints.py
+++ b/tests/test_logscan_endpoints.py
@@ -1,3 +1,5 @@
+import copy
+import gzip
 import os
 import time
 from pathlib import Path
@@ -39,6 +41,7 @@ def test_logscan_analyze_caches_and_invalidates(client, isolated_config_dir, mon
     monkeypatch.setattr(qs_module.helpers, "is_kometa_running", lambda: False)
     monkeypatch.setattr(qs_module.database, "save_log_run", lambda *args, **kwargs: None)
     monkeypatch.setattr(qs_module, "_archive_rotated_logs", lambda *_: None)
+    monkeypatch.setattr(qs_module, "_archive_finished_live_meta_log_if_idle", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(qs_module, "_logscan_needs_reingest", lambda *_: False)
     monkeypatch.setattr(qs_module, "_start_logscan_auto_reingest", lambda *_: None)
     monkeypatch.setattr(qs_module.helpers, "get_kometa_root_path", lambda: kometa_root)
@@ -68,6 +71,7 @@ def test_logscan_analyze_malformed_log(client, isolated_config_dir, monkeypatch,
     monkeypatch.setattr(qs_module.helpers, "is_kometa_running", lambda: False)
     monkeypatch.setattr(qs_module.database, "save_log_run", lambda *args, **kwargs: None)
     monkeypatch.setattr(qs_module, "_archive_rotated_logs", lambda *_: None)
+    monkeypatch.setattr(qs_module, "_archive_finished_live_meta_log_if_idle", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(qs_module, "_logscan_needs_reingest", lambda *_: False)
     monkeypatch.setattr(qs_module, "_start_logscan_auto_reingest", lambda *_: None)
     monkeypatch.setattr(qs_module.helpers, "get_kometa_root_path", lambda: kometa_root)
@@ -315,6 +319,9 @@ def test_logscan_trends_log_delete_supports_bulk_delete(client, isolated_config_
     second_log = archive_dir / "meta-bulk-2.log"
     first_log.write_text("bulk one\n", encoding="utf-8")
     second_log.write_text("bulk two\n", encoding="utf-8")
+    first_stats = first_log.stat()
+    second_epoch = int(first_stats.st_mtime) + 2
+    os.utime(second_log, (second_epoch, second_epoch))
 
     run_map = {
         "bulk-run-1": {
@@ -357,6 +364,64 @@ def test_logscan_trends_log_delete_supports_bulk_delete(client, isolated_config_
     assert set(deleted_run_keys) == {"bulk-run-1", "bulk-run-2"}
     assert not first_log.exists()
     assert not second_log.exists()
+
+
+def test_logscan_trends_log_compress_supports_bulk_compress(client, isolated_config_dir, monkeypatch, qs_module):
+    archive_dir = isolated_config_dir / "cache" / "logscan" / "archive"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    first_log = archive_dir / "meta-bulk-1.log"
+    second_log = archive_dir / "meta-bulk-2.log"
+    first_log.write_text("bulk one\n", encoding="utf-8")
+    second_log.write_text("bulk two\n", encoding="utf-8")
+
+    run_map = {
+        "bulk-run-1": {
+            "run_key": "bulk-run-1",
+            "log_mtime": first_log.stat().st_mtime,
+            "log_size": first_log.stat().st_size,
+            "config_name": "demo",
+            "created_at": "2026-04-23T10:00:00Z",
+        },
+        "bulk-run-2": {
+            "run_key": "bulk-run-2",
+            "log_mtime": second_log.stat().st_mtime,
+            "log_size": second_log.stat().st_size,
+            "config_name": "demo",
+            "created_at": "2026-04-23T10:05:00Z",
+        },
+    }
+    saved_cache = {}
+    cache = {
+        "version": 1,
+        "logs": {
+            str(first_log.resolve()): {"run_key": "bulk-run-1", "run_complete": True},
+            str(second_log.resolve()): {"run_key": "bulk-run-2", "run_complete": True},
+        },
+    }
+
+    monkeypatch.setattr(qs_module.database, "get_log_run", lambda run_key: run_map.get(run_key))
+    monkeypatch.setattr(qs_module, "_load_logscan_ingest_cache", lambda: copy.deepcopy(cache))
+    monkeypatch.setattr(
+        qs_module,
+        "_save_logscan_ingest_cache",
+        lambda updated_cache: (
+            saved_cache.__setitem__("cache", copy.deepcopy(updated_cache)),
+            cache.clear(),
+            cache.update(copy.deepcopy(updated_cache)),
+        ),
+    )
+
+    resp = client.post("/logscan/trends/log/compress", json={"run_keys": ["bulk-run-1", "bulk-run-2"]})
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["compressed"] == 2
+    assert payload["success"] is True
+    assert not first_log.exists()
+    assert not second_log.exists()
+    compressed_paths = sorted(archive_dir.glob("*.log.gz"))
+    assert len(compressed_paths) == 2
+    for path in compressed_paths:
+        assert str(path.resolve()) in saved_cache["cache"]["logs"]
 
 
 def test_logscan_trends_log_download(client, isolated_config_dir, monkeypatch, qs_module):
@@ -408,6 +473,44 @@ def test_logscan_trends_log_delete_removes_archived_log_and_run(client, isolated
     assert qs_module.database.get_log_run("run-delete-1") is None
 
 
+def test_logscan_trends_log_compress_compresses_archived_log_and_updates_cache(client, isolated_config_dir, monkeypatch, qs_module):
+    archive_dir = isolated_config_dir / "cache" / "logscan" / "archive"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    log_path = archive_dir / "meta-compress-me.log"
+    log_path.write_text("compress me\n", encoding="utf-8")
+    stats = log_path.stat()
+    qs_module.database.save_log_run(
+        {
+            "run_key": "run-compress-1",
+            "finished_at": "2026-04-23T11:00:00Z",
+            "config_name": "cleanup",
+            "created_at": "2026-04-23T11:00:00Z",
+            "log_mtime": stats.st_mtime,
+            "log_size": stats.st_size,
+        }
+    )
+    saved_cache = {}
+    monkeypatch.setattr(
+        qs_module,
+        "_load_logscan_ingest_cache",
+        lambda: {"version": 1, "logs": {str(log_path.resolve()): {"run_key": "run-compress-1", "run_complete": True}}},
+    )
+    monkeypatch.setattr(qs_module, "_save_logscan_ingest_cache", lambda cache: saved_cache.__setitem__("cache", cache))
+
+    resp = client.post("/logscan/trends/log/compress", json={"run_key": "run-compress-1"})
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert payload["compressed_file"] is True
+    compressed_path = Path(payload["compressed_path"])
+    assert compressed_path.exists()
+    assert not log_path.exists()
+    with gzip.open(compressed_path, "rt", encoding="utf-8") as handle:
+        assert handle.read() == "compress me\n"
+    assert str(compressed_path.resolve()) in saved_cache["cache"]["logs"]
+    assert str(log_path.resolve()) not in saved_cache["cache"]["logs"]
+
+
 def test_logscan_trends_log_delete_rejects_live_log(client, isolated_config_dir, monkeypatch, qs_module):
     kometa_root = Path(qs_module.app.config["KOMETA_ROOT"])
     log_dir = kometa_root / "config" / "logs"
@@ -450,9 +553,12 @@ def test_archive_log_file_uses_canonical_timestamp_size_name(isolated_config_dir
     archived = qs_module._archive_log_file(log_path, archive_dir, log_dir=log_dir)
 
     assert archived is not None
-    assert archived.name == "meta-20251224-170000Z-7.log"
+    assert archived.name == "meta-20251224-170000Z-7.log.gz"
     assert archived.exists()
     assert not log_path.exists()
+    assert int(archived.stat().st_mtime) == fixed_epoch
+    with gzip.open(archived, "rt", encoding="utf-8") as handle:
+        assert handle.read() == "abc123\n"
 
 
 def test_archive_finished_live_meta_log_if_idle_moves_live_file_and_cache(isolated_config_dir, monkeypatch, qs_module):
@@ -492,6 +598,7 @@ def test_archive_finished_live_meta_log_if_idle_moves_live_file_and_cache(isolat
     assert str(live_path.resolve()) not in saved_cache["logs"]
     assert str(archived.resolve()) in saved_cache["logs"]
     assert saved_cache["logs"][str(archived.resolve())]["run_key"] == "run-live-finished-1"
+    assert archived.suffixes[-2:] == [".log", ".gz"]
 
 
 def test_normalize_logscan_archive_filenames_renames_legacy_files_and_updates_cache(isolated_config_dir, monkeypatch, qs_module):
@@ -516,6 +623,78 @@ def test_normalize_logscan_archive_filenames_renames_legacy_files_and_updates_ca
     saved_cache = saved["cache"]
     assert str(renamed_path.resolve()) in saved_cache["logs"]
     assert str(legacy_path.resolve()) not in saved_cache["logs"]
+
+
+def test_logscan_trends_log_download_supports_gzip_archive(client, isolated_config_dir, monkeypatch, qs_module):
+    archive_dir = isolated_config_dir / "cache" / "logscan" / "archive"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    log_path = archive_dir / "meta-download.log.gz"
+    with gzip.open(log_path, "wt", encoding="utf-8") as handle:
+        handle.write("hello from compressed log\n")
+
+    monkeypatch.setattr(
+        qs_module,
+        "_load_logscan_ingest_cache",
+        lambda: {"version": 1, "logs": {str(log_path.resolve()): {"run_key": "run-gz-download", "run_complete": True}}},
+    )
+
+    resp = client.get("/logscan/trends/log?run_key=run-gz-download")
+    assert resp.status_code == 200
+    assert resp.mimetype == "application/gzip"
+    assert gzip.decompress(resp.data).replace(b"\r\n", b"\n") == b"hello from compressed log\n"
+
+
+def test_logscan_trends_log_delete_removes_gzip_archived_log_and_run(client, isolated_config_dir, monkeypatch, qs_module):
+    archive_dir = isolated_config_dir / "cache" / "logscan" / "archive"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    log_path = archive_dir / "meta-delete-me.log.gz"
+    with gzip.open(log_path, "wt", encoding="utf-8") as handle:
+        handle.write("delete me compressed\n")
+    stats = log_path.stat()
+    qs_module.database.save_log_run(
+        {
+            "run_key": "run-delete-gz-1",
+            "finished_at": "2026-04-23T11:00:00Z",
+            "config_name": "cleanup",
+            "created_at": "2026-04-23T11:00:00Z",
+            "log_mtime": stats.st_mtime,
+            "log_size": stats.st_size,
+        }
+    )
+    monkeypatch.setattr(
+        qs_module,
+        "_load_logscan_ingest_cache",
+        lambda: {"version": 1, "logs": {str(log_path.resolve()): {"run_key": "run-delete-gz-1", "run_complete": True}}},
+    )
+
+    resp = client.post("/logscan/trends/log/delete", json={"run_key": "run-delete-gz-1"})
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert payload["deleted_file"] is True
+    assert not log_path.exists()
+    assert qs_module.database.get_log_run("run-delete-gz-1") is None
+
+
+def test_prune_logscan_archive_counts_gzip_archives(isolated_config_dir, monkeypatch, qs_module):
+    archive_dir = isolated_config_dir / "cache" / "logscan" / "archive"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    older = archive_dir / "meta-older.log.gz"
+    newer = archive_dir / "meta-newer.log.gz"
+    with gzip.open(older, "wt", encoding="utf-8") as handle:
+        handle.write("older\n")
+    with gzip.open(newer, "wt", encoding="utf-8") as handle:
+        handle.write("newer\n")
+    os.utime(older, (1766595600, 1766595600))
+    os.utime(newer, (1766599200, 1766599200))
+    monkeypatch.setitem(qs_module.app.config, "QS_KOMETA_LOG_KEEP", 1)
+    monkeypatch.setattr(qs_module, "_save_logscan_ingest_cache", lambda cache: None)
+
+    removed = qs_module._prune_logscan_archive(archive_dir)
+
+    assert removed == 1
+    assert not older.exists()
+    assert newer.exists()
 
 
 def test_logscan_progress_tracks_libraries(client, isolated_config_dir, monkeypatch, qs_module):
@@ -573,6 +752,37 @@ def test_logscan_reingest_ingests_day_runtime_log(client, isolated_config_dir, m
         ),
         encoding="utf-8",
     )
+
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_root_path", lambda: kometa_root)
+    monkeypatch.setattr(qs_module.logscan.LogscanAnalyzer, "preload_people_index", lambda self, *_args, **_kwargs: None)
+
+    resp = client.post("/logscan/trends/reingest", json={"reset": True})
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert payload["ingested"] >= 1
+    assert payload["skipped_incomplete"] == 0
+
+
+def test_logscan_reingest_ingests_gzip_archived_log(client, isolated_config_dir, monkeypatch, qs_module):
+    kometa_root = Path(qs_module.app.config["KOMETA_ROOT"])
+    log_dir = kometa_root / "config" / "logs"
+    archive_dir = isolated_config_dir / "cache" / "logscan" / "archive"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    log_path = archive_dir / "meta-1.log.gz"
+    with gzip.open(log_path, "wt", encoding="utf-8") as handle:
+        handle.write(
+            "\n".join(
+                [
+                    "[2026-04-14 09:37:06,901] [kometa.py:522]             [INFO]     |====================================================================================================|",
+                    "[2026-04-14 09:37:06,901] [kometa.py:522]             [INFO]     |                                            Finished Run                                            |",
+                    "[2026-04-14 09:37:06,901] [kometa.py:522]             [INFO]     |                                       Version: 2.3.1-build4                                        |",
+                    "[2026-04-14 09:37:06,902] [kometa.py:522]             [INFO]     |   Start Time: 07:16:22 2026-04-13     Finished: 09:36:53 2026-04-14     Run Time: 1 day, 2:20:31   |",
+                    "[2026-04-14 09:37:06,902] [kometa.py:522]             [INFO]     |====================================================================================================|",
+                ]
+            )
+        )
 
     monkeypatch.setattr(qs_module.helpers, "get_kometa_root_path", lambda: kometa_root)
     monkeypatch.setattr(qs_module.logscan.LogscanAnalyzer, "preload_people_index", lambda self, *_args, **_kwargs: None)


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

## Summary

This PR continues the `redo_webui` Quickstart overhaul with a focus on workflow clarity, dependency-driven readiness, import simplification, final-run ergonomics, and a much stronger Analytics/log management experience.

The main goals were to reduce confusing manual steps, make the workspace TODO model explainable, improve recovery when disk state and DB state drift apart, and turn Analytics into a usable operational surface for Kometa logs.

## Highlights

### Workflow / Navigation

- Reworked sidebar/menu grouping and readiness presentation.
- Improved dependency-driven TODO states for optional service pages.
- Added documentation for the dependency map in the README.
- Fixed several responsive/mobile navigation and layout issues.

### Import / Libraries / Playlists

- Simplified the end of the import flow and removed stale messaging.
- Improved post-import guidance and summary behavior.
- Moved playlist handling into the Libraries workflow and updated import/output logic accordingly.

### Final Validation

- Better separation between preparing Kometa and running Kometa.
- Improved gating around validation freshness and config readiness.
- If Kometa is already running:
  - de-emphasizes update/install checks
  - skips unsafe/unhelpful update-check behavior
  - suppresses misleading incomplete-run messaging

### Config Drift / Recovery

- Added a Start-page `Review File Drift` flow.
- Users can now inspect orphaned config bundles on disk, restore a selected version, or delete them.
- Avoided automatic startup cleanup so disk recovery stays user-driven.

### Analytics / Recent Runs

- Fixed multiple Analytics regressions and rendering/refresh issues.
- Recent Runs now shows both:
  - complete ingested runs
  - incomplete/skipped logs for investigation and cleanup
- Added clearer status signaling for complete vs incomplete entries.
- Added per-run and bulk log management:
  - download
  - delete
  - bulk select / bulk delete
- Added archived storage visibility and retention messaging directly in Analytics.

### Log Archiving / Gzip

- Standardized archive naming.
- Finished idle `meta.log` now gets archived instead of lingering as a fake current log.
- Added gzip support for archived logs:
  - resolver supports `.log` and `.log.gz`
  - reingest reads gzipped logs streamingly
  - completed archived logs are now written as `.log.gz`
  - delete/download/retention/storage summary all support gzipped archives
- Added user-driven compression in Analytics:
  - per-run `Compress`
  - bulk `Compress selected`
  - only for archived plain `.log` files
  - never touches live `meta.log`

### Dev / Docs

- Added `scripts/setup-dev.ps1`
- Added `-Setup` support to `scripts/run-tests.ps1`
- Updated README/testing guidance and screenshots

## Testing

Focused validation included:

- `node --check static\\local-js\\905-analytics.js`
- `python -m py_compile quickstart.py tests\\test_logscan_endpoints.py`
- `pytest tests\\test_logscan_endpoints.py`

Latest logscan/analytics slice result:
- `26 passed`

## Reviewer Focus

Recommended manual QA:
- import completion flow
- dependency-triggered optional pages
- Final Validation while Kometa is running vs stopped
- Start-page file drift review / restore
- Analytics Recent Runs:
  - complete vs incomplete rows
  - delete / bulk delete
  - compress / bulk compress
  - mixed `.log` + `.log.gz` archive handling


## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
