### PR TITLE
UI tweaks

### DIFF
--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -2202,6 +2202,48 @@ def delete_config_artifacts(config_name: str | None, kometa_root: str | Path | N
     return {"removed": removed, "errors": errors, "config_name": normalized}
 
 
+def delete_orphaned_artifact_bundle(bundle: dict | None) -> dict:
+    bundle = bundle if isinstance(bundle, dict) else {}
+    bundle_name = normalize_config_name_for_storage(bundle.get("name"))
+    removed: list[str] = []
+    errors: list[str] = []
+    raw_paths = bundle.get("paths")
+    candidate_paths = []
+
+    if isinstance(raw_paths, list):
+        for raw_path in raw_paths:
+            text = str(raw_path or "").strip()
+            if text:
+                candidate_paths.append(text)
+
+    seen: set[str] = set()
+    for raw_path in candidate_paths:
+        try:
+            target = Path(raw_path).resolve()
+        except Exception as exc:
+            errors.append(f"Failed to resolve {raw_path}: {exc}")
+            continue
+        target_key = str(target)
+        if target_key in seen:
+            continue
+        seen.add(target_key)
+        try:
+            if not target.exists():
+                continue
+            if target.is_dir():
+                shutil.rmtree(target)
+            else:
+                target.unlink()
+            removed.append(target_key)
+        except Exception as exc:
+            errors.append(f"Failed to remove {target}: {exc}")
+
+    if not removed and not errors:
+        errors.append(f"No filesystem artifacts were removed for {bundle_name}.")
+
+    return {"removed": removed, "errors": errors, "config_name": bundle_name}
+
+
 def list_orphaned_config_artifacts(active_config_names: list[str] | None = None, kometa_root: str | Path | None = None) -> dict:
     config_dir = Path(CONFIG_DIR)
     archive_root = config_dir / "archives"

--- a/quickstart.py
+++ b/quickstart.py
@@ -3128,11 +3128,7 @@ def delete_orphaned_config_artifacts():
     if inventory.get("errors"):
         return jsonify(success=False, message="Unable to inspect config storage.", errors=inventory["errors"]), 500
 
-    orphan_bundles = {
-        item.get("name"): item
-        for item in inventory.get("orphans", [])
-        if isinstance(item, dict) and item.get("name")
-    }
+    orphan_bundles = {item.get("name"): item for item in inventory.get("orphans", []) if isinstance(item, dict) and item.get("name")}
     orphan_names = set(orphan_bundles)
     invalid = [name for name in selected if name not in orphan_names]
     if invalid:

--- a/quickstart.py
+++ b/quickstart.py
@@ -3128,7 +3128,12 @@ def delete_orphaned_config_artifacts():
     if inventory.get("errors"):
         return jsonify(success=False, message="Unable to inspect config storage.", errors=inventory["errors"]), 500
 
-    orphan_names = {item.get("name") for item in inventory.get("orphans", []) if item.get("name")}
+    orphan_bundles = {
+        item.get("name"): item
+        for item in inventory.get("orphans", [])
+        if isinstance(item, dict) and item.get("name")
+    }
+    orphan_names = set(orphan_bundles)
     invalid = [name for name in selected if name not in orphan_names]
     if invalid:
         return jsonify(success=False, message="Only orphaned config bundles can be deleted here.", invalid=invalid), 400
@@ -3136,7 +3141,7 @@ def delete_orphaned_config_artifacts():
     deleted = []
     errors = []
     for name in selected:
-        result = helpers.delete_config_artifacts(name, kometa_root=app.config.get("KOMETA_ROOT", "."))
+        result = helpers.delete_orphaned_artifact_bundle(orphan_bundles.get(name))
         if result.get("errors"):
             errors.extend(result["errors"])
         else:

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -412,6 +412,14 @@ html[data-theme="dark"] body {
     border-color: var(--theme-border);
 }
 
+.logscan-confirm-modal-dialog {
+    max-width: 34rem;
+}
+
+.logscan-confirm-modal-dialog .modal-body {
+    flex: 0 0 auto;
+}
+
 code {
     font-size: 0.875em;
     color: var(--theme-primary);
@@ -2454,9 +2462,13 @@ div#loading {
 
 .logscan-card-value {
     color: var(--theme-text);
+    display: block;
     font-weight: 700;
     line-height: 1.35;
     min-width: 0;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
 }
 
 .logscan-card-value .text-muted {
@@ -4615,6 +4627,9 @@ body {
     border: 1px solid var(--theme-border);
     border-radius: 0.7rem;
     background: rgba(0, 0, 0, 0.26);
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
     padding: 0.65rem 0.85rem;
     margin-bottom: var(--qs-space-2);
 }
@@ -5590,4 +5605,10 @@ html[data-qs-viewport="mobile"] .modal.qs-mobile-panel-target .modal-content {
     border-radius: 0;
     min-height: 100dvh;
     border: 0;
+}
+
+html[data-qs-viewport="mobile"] .logscan-confirm-modal-dialog {
+    width: calc(100vw - 1rem);
+    max-width: calc(100vw - 1rem);
+    margin: 0.5rem auto;
 }

--- a/static/local-js/001-start.js
+++ b/static/local-js/001-start.js
@@ -93,11 +93,17 @@ document.addEventListener('DOMContentLoaded', function () {
   const orphanedArtifactsList = document.getElementById('orphanedArtifactsList')
   const orphanedArtifactsSelectAll = document.getElementById('orphanedArtifactsSelectAll')
   const orphanedArtifactsCount = document.getElementById('orphanedArtifactsCount')
+  const orphanedArtifactsStatus = document.getElementById('orphanedArtifactsStatus')
+  const orphanedArtifactsSuccess = document.getElementById('orphanedArtifactsSuccess')
   const orphanedArtifactsError = document.getElementById('orphanedArtifactsError')
+  const cancelOrphanedArtifactsDelete = document.getElementById('cancelOrphanedArtifactsDelete')
   const confirmOrphanedArtifactsDelete = document.getElementById('confirmOrphanedArtifactsDelete')
   const orphanedArtifactsRestoreModalEl = document.getElementById('orphanedArtifactsRestoreModal')
   const orphanedArtifactsRestoreList = document.getElementById('orphanedArtifactsRestoreList')
+  const orphanedArtifactsRestoreStatus = document.getElementById('orphanedArtifactsRestoreStatus')
+  const orphanedArtifactsRestoreSuccess = document.getElementById('orphanedArtifactsRestoreSuccess')
   const orphanedArtifactsRestoreError = document.getElementById('orphanedArtifactsRestoreError')
+  const cancelOrphanedArtifactsRestore = document.getElementById('cancelOrphanedArtifactsRestore')
   const confirmOrphanedArtifactsRestore = document.getElementById('confirmOrphanedArtifactsRestore')
   const configActionModalElement = document.getElementById('configActionModal')
   const renameConfigModalEl = document.getElementById('renameConfigModal')
@@ -352,25 +358,43 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   function setOrphanedArtifactsError (message) {
-    if (!orphanedArtifactsError) return
-    if (!message) {
-      orphanedArtifactsError.classList.add('d-none')
-      orphanedArtifactsError.textContent = ''
-      return
-    }
-    orphanedArtifactsError.classList.remove('d-none')
-    orphanedArtifactsError.textContent = message
+    setInlineAlert(orphanedArtifactsError, message)
   }
 
   function setOrphanedArtifactsRestoreError (message) {
-    if (!orphanedArtifactsRestoreError) return
+    setInlineAlert(orphanedArtifactsRestoreError, message)
+  }
+
+  function setInlineAlert (element, message) {
+    if (!element) return
     if (!message) {
-      orphanedArtifactsRestoreError.classList.add('d-none')
-      orphanedArtifactsRestoreError.textContent = ''
+      element.classList.add('d-none')
+      element.textContent = ''
       return
     }
-    orphanedArtifactsRestoreError.classList.remove('d-none')
-    orphanedArtifactsRestoreError.textContent = message
+    element.classList.remove('d-none')
+    element.textContent = message
+  }
+
+  function setOrphanedArtifactsBusy (isBusy) {
+    if (confirmOrphanedArtifactsDelete) confirmOrphanedArtifactsDelete.disabled = isBusy || confirmOrphanedArtifactsDelete.disabled
+    if (cancelOrphanedArtifactsDelete) cancelOrphanedArtifactsDelete.disabled = isBusy
+    if (orphanedArtifactsSelectAll) orphanedArtifactsSelectAll.disabled = isBusy || orphanedArtifactsSelectAll.disabled
+    if (orphanedArtifactsModalEl) {
+      orphanedArtifactsModalEl.querySelectorAll('.btn-close, .orphaned-artifact-checkbox, .orphaned-artifact-restore')
+        .forEach(el => { el.disabled = isBusy })
+    }
+    if (!isBusy) updateOrphanedArtifactsState()
+  }
+
+  function setOrphanedArtifactsRestoreBusy (isBusy) {
+    if (confirmOrphanedArtifactsRestore) confirmOrphanedArtifactsRestore.disabled = isBusy || confirmOrphanedArtifactsRestore.disabled
+    if (cancelOrphanedArtifactsRestore) cancelOrphanedArtifactsRestore.disabled = isBusy
+    if (orphanedArtifactsRestoreModalEl) {
+      orphanedArtifactsRestoreModalEl.querySelectorAll('.btn-close, .orphaned-artifact-version-radio')
+        .forEach(el => { el.disabled = isBusy })
+    }
+    if (!isBusy) updateOrphanedArtifactsRestoreState()
   }
 
   function updateOrphanedArtifactsState () {
@@ -496,9 +520,16 @@ document.addEventListener('DOMContentLoaded', function () {
     if (!orphanedArtifactsRestoreModalEl || !orphanedArtifactsRestoreList) return
     orphanedRestoreTarget = String(name || '').trim()
     if (!orphanedRestoreTarget) return
+    setInlineAlert(orphanedArtifactsRestoreStatus, '')
+    setInlineAlert(orphanedArtifactsRestoreSuccess, '')
     setOrphanedArtifactsRestoreError('')
     orphanedArtifactsRestoreList.replaceChildren()
-    if (confirmOrphanedArtifactsRestore) confirmOrphanedArtifactsRestore.disabled = true
+    if (confirmOrphanedArtifactsRestore) {
+      confirmOrphanedArtifactsRestore.disabled = true
+      confirmOrphanedArtifactsRestore.textContent = 'Restore Selected Version'
+    }
+    if (cancelOrphanedArtifactsRestore) cancelOrphanedArtifactsRestore.disabled = false
+    orphanedArtifactsRestoreModalEl.querySelectorAll('.btn-close').forEach(el => { el.disabled = false })
 
     const title = document.getElementById('orphanedArtifactsRestoreModalLabel')
     if (title) title.innerHTML = `<i class="bi bi-arrow-counterclockwise me-2"></i>Restore ${orphanedRestoreTarget}`
@@ -541,7 +572,14 @@ document.addEventListener('DOMContentLoaded', function () {
   async function renderOrphanedArtifactsList () {
     if (!orphanedArtifactsList) return
     orphanedArtifactsList.replaceChildren()
+    setInlineAlert(orphanedArtifactsStatus, '')
+    setInlineAlert(orphanedArtifactsSuccess, '')
     setOrphanedArtifactsError('')
+    if (confirmOrphanedArtifactsDelete) confirmOrphanedArtifactsDelete.textContent = 'Delete Selected'
+    if (cancelOrphanedArtifactsDelete) cancelOrphanedArtifactsDelete.disabled = false
+    if (orphanedArtifactsModalEl) {
+      orphanedArtifactsModalEl.querySelectorAll('.btn-close').forEach(el => { el.disabled = false })
+    }
 
     const loading = document.createElement('div')
     loading.className = 'small text-muted'
@@ -738,9 +776,11 @@ document.addEventListener('DOMContentLoaded', function () {
         return
       }
 
-      confirmOrphanedArtifactsDelete.disabled = true
-      const originalText = confirmOrphanedArtifactsDelete.textContent
-      confirmOrphanedArtifactsDelete.textContent = 'Deleting...'
+      setInlineAlert(orphanedArtifactsSuccess, '')
+      setOrphanedArtifactsError('')
+      setInlineAlert(orphanedArtifactsStatus, `Deleting ${selected.length} orphaned config bundle(s)...`)
+      setOrphanedArtifactsBusy(true)
+      setButtonSpinner(confirmOrphanedArtifactsDelete, 'Deleting...')
 
       try {
         const res = await fetch('/orphaned-config-artifacts/delete', {
@@ -752,13 +792,16 @@ document.addEventListener('DOMContentLoaded', function () {
         if (!res.ok || !data.success) {
           throw new Error((data.errors && data.errors[0]) || data.message || 'Failed to delete orphaned config bundles.')
         }
+        setInlineAlert(orphanedArtifactsStatus, '')
+        await renderOrphanedArtifactsList()
+        setInlineAlert(orphanedArtifactsSuccess, `Deleted ${data.deleted.length} orphaned config bundle(s).`)
+        confirmOrphanedArtifactsDelete.textContent = 'Delete Selected'
+        setOrphanedArtifactsBusy(false)
         showToast('success', `Deleted ${data.deleted.length} orphaned config bundle(s).`)
-        const modal = bootstrap.Modal.getInstance(orphanedArtifactsModalEl)
-        if (modal) modal.hide()
-        setTimeout(() => window.location.reload(), 900)
       } catch (err) {
-        confirmOrphanedArtifactsDelete.disabled = false
-        confirmOrphanedArtifactsDelete.textContent = originalText
+        setInlineAlert(orphanedArtifactsStatus, '')
+        setOrphanedArtifactsBusy(false)
+        confirmOrphanedArtifactsDelete.textContent = 'Delete Selected'
         setOrphanedArtifactsError(err.message || 'Failed to delete orphaned config bundles.')
         showToast('error', err.message || 'Failed to delete orphaned config bundles.')
       }
@@ -784,9 +827,11 @@ document.addEventListener('DOMContentLoaded', function () {
         return
       }
 
-      confirmOrphanedArtifactsRestore.disabled = true
-      const originalText = confirmOrphanedArtifactsRestore.textContent
-      confirmOrphanedArtifactsRestore.textContent = 'Restoring...'
+      setInlineAlert(orphanedArtifactsRestoreSuccess, '')
+      setOrphanedArtifactsRestoreError('')
+      setInlineAlert(orphanedArtifactsRestoreStatus, `Restoring '${orphanedRestoreTarget}' from disk...`)
+      setOrphanedArtifactsRestoreBusy(true)
+      setButtonSpinner(confirmOrphanedArtifactsRestore, 'Restoring...')
 
       try {
         const res = await fetch('/orphaned-config-artifacts/restore', {
@@ -798,13 +843,19 @@ document.addEventListener('DOMContentLoaded', function () {
         if (!res.ok || !data.success) {
           throw new Error(data.message || 'Failed to restore config bundle.')
         }
+        setInlineAlert(orphanedArtifactsRestoreStatus, '')
+        setInlineAlert(orphanedArtifactsRestoreSuccess, `Restored '${data.config_name}'. Reloading the workspace...`)
+        setButtonIconAndText(confirmOrphanedArtifactsRestore, 'bi bi-check2', 'Restored')
         showToast('success', `Restored '${data.config_name}' from disk.`)
-        const modal = bootstrap.Modal.getInstance(orphanedArtifactsRestoreModalEl)
-        if (modal) modal.hide()
-        setTimeout(() => window.location.reload(), 900)
+        window.setTimeout(() => {
+          const modal = bootstrap.Modal.getInstance(orphanedArtifactsRestoreModalEl)
+          if (modal) modal.hide()
+        }, 1400)
+        window.setTimeout(() => window.location.reload(), 2600)
       } catch (err) {
-        confirmOrphanedArtifactsRestore.disabled = false
-        confirmOrphanedArtifactsRestore.textContent = originalText
+        setInlineAlert(orphanedArtifactsRestoreStatus, '')
+        setOrphanedArtifactsRestoreBusy(false)
+        confirmOrphanedArtifactsRestore.textContent = 'Restore Selected Version'
         setOrphanedArtifactsRestoreError(err.message || 'Failed to restore config bundle.')
         showToast('error', err.message || 'Failed to restore config bundle.')
       }

--- a/static/local-js/905-analytics.js
+++ b/static/local-js/905-analytics.js
@@ -47,9 +47,17 @@ $(document).ready(function () {
   const $missingDownload = $('#logscan-trends-missing-download')
   const $confirmMissingDownload = $('#logscan-confirm-missing-download')
   const $deleteLogBody = $('#logscan-delete-log-body')
+  const $deleteLogStatus = $('#logscan-delete-log-status')
+  const $deleteLogSuccess = $('#logscan-delete-log-success')
+  const $deleteLogError = $('#logscan-delete-log-error')
   const $confirmDeleteLog = $('#logscan-confirm-delete-log')
+  const $cancelDeleteLog = $('#logscan-cancel-delete-log')
   const $compressLogBody = $('#logscan-compress-log-body')
+  const $compressLogStatus = $('#logscan-compress-log-status')
+  const $compressLogSuccess = $('#logscan-compress-log-success')
+  const $compressLogError = $('#logscan-compress-log-error')
   const $confirmCompressLog = $('#logscan-confirm-compress-log')
+  const $cancelCompressLog = $('#logscan-cancel-compress-log')
   const $runDetailsBody = $('#logscan-run-details-body')
   const $runDetailsTitle = $('#logscan-run-details-title')
   const $preferencesSave = $('#logscan-preferences-save')
@@ -2084,6 +2092,36 @@ $(document).ready(function () {
     if (instance) instance.hide()
   }
 
+  function setButtonSpinner ($button, text) {
+    if (!$button || !$button.length) return
+    $button.html(`<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>${escapeHtml(text)}`)
+  }
+
+  function setModalAlert ($el, message) {
+    if (!$el || !$el.length) return
+    if (!message) {
+      $el.addClass('d-none').text('')
+      return
+    }
+    $el.removeClass('d-none').text(message)
+  }
+
+  function setDeleteModalBusy (busy) {
+    $confirmDeleteLog.prop('disabled', busy)
+    $cancelDeleteLog.prop('disabled', busy)
+    if (deleteLogModalEl) {
+      $(deleteLogModalEl).find('.btn-close').prop('disabled', busy)
+    }
+  }
+
+  function setCompressModalBusy (busy) {
+    $confirmCompressLog.prop('disabled', busy)
+    $cancelCompressLog.prop('disabled', busy)
+    if (compressLogModalEl) {
+      $(compressLogModalEl).find('.btn-close').prop('disabled', busy)
+    }
+  }
+
   function setControlsDisabled (disabled) {
     $reset.prop('disabled', disabled)
     $reingest.prop('disabled', disabled)
@@ -2467,6 +2505,11 @@ $(document).ready(function () {
         $deleteLogBody.html(`Delete <strong>${normalizedRunKeys.length} selected logs</strong> from disk and remove their runs from Analytics?`)
       }
     }
+    setModalAlert($deleteLogStatus, '')
+    setModalAlert($deleteLogSuccess, '')
+    setModalAlert($deleteLogError, '')
+    $confirmDeleteLog.text('Delete')
+    setDeleteModalBusy(false)
     if (deleteLogModalEl) {
       bootstrap.Modal.getOrCreateInstance(deleteLogModalEl).show()
       return
@@ -2484,7 +2527,13 @@ $(document).ready(function () {
       hideModal(deleteLogModalEl)
       return
     }
-    $confirmDeleteLog.prop('disabled', true)
+    let deleteSucceeded = false
+    const deleteCount = pendingDeleteRun.runKeys.length
+    setModalAlert($deleteLogSuccess, '')
+    setModalAlert($deleteLogError, '')
+    setModalAlert($deleteLogStatus, deleteCount > 1 ? `Deleting ${deleteCount} logs...` : 'Deleting log...')
+    setDeleteModalBusy(true)
+    setButtonSpinner($confirmDeleteLog, 'Deleting...')
     fetch('/logscan/trends/log/delete', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -2499,24 +2548,32 @@ $(document).ready(function () {
         if (!res.ok) {
           throw new Error((data && data.error) || 'Delete failed')
         }
-        hideModal(deleteLogModalEl)
         const deletedKeys = Array.isArray(pendingDeleteRun.runKeys) ? pendingDeleteRun.runKeys : []
         deletedKeys.forEach(runKey => selectedRunKeys.delete(runKey))
         const deletedCount = Number.isFinite(data && data.deleted) ? data.deleted : deletedKeys.length
+        deleteSucceeded = true
         pendingDeleteRun = null
+        setModalAlert($deleteLogStatus, '')
+        setModalAlert($deleteLogSuccess, deletedCount > 1 ? `${deletedCount} logs deleted. Updating Analytics...` : 'Log deleted. Updating Analytics...')
         if (Array.isArray(data && data.failures) && data.failures.length) {
           updateStatus(`${deletedCount} logs deleted. ${data.failures.length} failed.`)
         } else {
           updateStatus(deletedCount > 1 ? `${deletedCount} logs deleted.` : 'Log deleted.')
         }
+        window.setTimeout(() => hideModal(deleteLogModalEl), 650)
         fetchRuns({ suppressStatus: true })
       })
       .catch(err => {
         console.error(err)
+        setModalAlert($deleteLogStatus, '')
+        setModalAlert($deleteLogError, err && err.message ? err.message : 'Failed to delete log.')
         updateStatus(err && err.message ? err.message : 'Failed to delete log.', true)
       })
       .finally(() => {
-        $confirmDeleteLog.prop('disabled', false)
+        if (!deleteSucceeded) {
+          $confirmDeleteLog.text('Delete')
+          setDeleteModalBusy(false)
+        }
       })
   }
 
@@ -2525,7 +2582,13 @@ $(document).ready(function () {
       hideModal(compressLogModalEl)
       return
     }
-    $confirmCompressLog.prop('disabled', true)
+    let compressSucceeded = false
+    const compressCount = pendingCompressRun.runKeys.length
+    setModalAlert($compressLogSuccess, '')
+    setModalAlert($compressLogError, '')
+    setModalAlert($compressLogStatus, compressCount > 1 ? `Compressing ${compressCount} logs...` : 'Compressing log...')
+    setCompressModalBusy(true)
+    setButtonSpinner($confirmCompressLog, 'Compressing...')
     fetch('/logscan/trends/log/compress', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -2540,22 +2603,30 @@ $(document).ready(function () {
         if (!res.ok) {
           throw new Error((data && data.error) || 'Compress failed')
         }
-        hideModal(compressLogModalEl)
         const compressedCount = Number.isFinite(data && data.compressed) ? data.compressed : pendingCompressRun.runKeys.length
+        compressSucceeded = true
         pendingCompressRun = null
+        setModalAlert($compressLogStatus, '')
+        setModalAlert($compressLogSuccess, compressedCount > 1 ? `${compressedCount} logs compressed. Updating Analytics...` : 'Log compressed. Updating Analytics...')
         if (Array.isArray(data && data.failures) && data.failures.length) {
           updateStatus(`${compressedCount} logs compressed. ${data.failures.length} failed.`)
         } else {
           updateStatus(compressedCount > 1 ? `${compressedCount} logs compressed.` : 'Log compressed.')
         }
+        window.setTimeout(() => hideModal(compressLogModalEl), 650)
         fetchRuns({ suppressStatus: true })
       })
       .catch(err => {
         console.error(err)
+        setModalAlert($compressLogStatus, '')
+        setModalAlert($compressLogError, err && err.message ? err.message : 'Failed to compress log.')
         updateStatus(err && err.message ? err.message : 'Failed to compress log.', true)
       })
       .finally(() => {
-        $confirmCompressLog.prop('disabled', false)
+        if (!compressSucceeded) {
+          $confirmCompressLog.text('Compress')
+          setCompressModalBusy(false)
+        }
       })
   }
 

--- a/templates/001-start.html
+++ b/templates/001-start.html
@@ -1,8 +1,7 @@
 {% extends "000-base.html" %} {% block content %}
 {% include "001-navigation.html" %}
 {% include "modals/" + page_info['template_name'] + ".html" ignore missing %}
-<div class="row g-3 start-hero">
-  <div class="col-lg-12">
+<div class="start-hero">
     <div class="card h-100 border-secondary start-card">
       <div class="card-body">
         <div class="d-flex align-items-center justify-content-center gap-2 mb-3 start-warning">
@@ -100,7 +99,6 @@
         </div>
       </div>
     </div>
-  </div>
 </div>
 
 <div class="card border-secondary start-card mt-4">

--- a/templates/001-start.html
+++ b/templates/001-start.html
@@ -262,6 +262,8 @@
         <div class="alert alert-warning py-2 small mb-3" role="alert">
           This tool only deletes filesystem artifacts. It does not remove anything from the database.
         </div>
+        <div id="orphanedArtifactsStatus" class="alert alert-info d-none py-2 small" role="status"></div>
+        <div id="orphanedArtifactsSuccess" class="alert alert-success d-none py-2 small" role="status"></div>
         <div id="orphanedArtifactsError" class="alert alert-danger d-none py-2 small" role="alert"></div>
         <div class="form-check mb-2">
           <input class="form-check-input" type="checkbox" id="orphanedArtifactsSelectAll">
@@ -271,7 +273,7 @@
         <div class="small text-muted mt-2">Selected: <span id="orphanedArtifactsCount">0</span></div>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Keep for now</button>
+        <button type="button" class="btn btn-secondary" id="cancelOrphanedArtifactsDelete" data-bs-dismiss="modal">Keep for now</button>
         <button type="button" class="btn btn-danger" id="confirmOrphanedArtifactsDelete" disabled>Delete Selected</button>
       </div>
     </div>
@@ -291,11 +293,13 @@
         <p class="small text-muted mb-2">
           Choose one saved version to restore into the Quickstart database. Versions are sorted newest first.
         </p>
+        <div id="orphanedArtifactsRestoreStatus" class="alert alert-info d-none py-2 small" role="status"></div>
+        <div id="orphanedArtifactsRestoreSuccess" class="alert alert-success d-none py-2 small" role="status"></div>
         <div id="orphanedArtifactsRestoreError" class="alert alert-danger d-none py-2 small" role="alert"></div>
         <div id="orphanedArtifactsRestoreList" class="bulk-delete-list"></div>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-secondary" id="cancelOrphanedArtifactsRestore" data-bs-dismiss="modal">Cancel</button>
         <button type="button" class="btn btn-primary" id="confirmOrphanedArtifactsRestore" disabled>Restore Selected Version</button>
       </div>
     </div>

--- a/templates/905-analytics.html
+++ b/templates/905-analytics.html
@@ -367,7 +367,7 @@
 
 <div class="modal fade" id="logscan-delete-log-modal" tabindex="-1" aria-labelledby="logscan-delete-log-title"
   aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered">
+  <div class="modal-dialog modal-dialog-centered logscan-confirm-modal-dialog">
     <div class="modal-content bg-dark text-light border-secondary">
       <div class="modal-header">
         <h5 class="modal-title" id="logscan-delete-log-title">Delete Logs</h5>
@@ -377,9 +377,12 @@
       <div class="modal-body">
         <div id="logscan-delete-log-body">Delete this log from disk and remove it from Analytics?</div>
         <div class="small text-muted mt-2">The live <code>meta.log</code> is never deleted from this action.</div>
+        <div id="logscan-delete-log-status" class="alert alert-info d-none py-2 small mt-3 mb-0" role="status"></div>
+        <div id="logscan-delete-log-success" class="alert alert-success d-none py-2 small mt-3 mb-0" role="status"></div>
+        <div id="logscan-delete-log-error" class="alert alert-danger d-none py-2 small mt-3 mb-0" role="alert"></div>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn nav-button btn-sm" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn nav-button btn-sm" id="logscan-cancel-delete-log" data-bs-dismiss="modal">Cancel</button>
         <button type="button" class="btn nav-button nav-button-danger btn-sm" id="logscan-confirm-delete-log">Delete</button>
       </div>
     </div>
@@ -388,7 +391,7 @@
 
 <div class="modal fade" id="logscan-compress-log-modal" tabindex="-1" aria-labelledby="logscan-compress-log-title"
   aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered">
+  <div class="modal-dialog modal-dialog-centered logscan-confirm-modal-dialog">
     <div class="modal-content bg-dark text-light border-secondary">
       <div class="modal-header">
         <h5 class="modal-title" id="logscan-compress-log-title">Compress Logs</h5>
@@ -398,9 +401,12 @@
       <div class="modal-body">
         <div id="logscan-compress-log-body">Compress this archived log as <code>.log.gz</code>?</div>
         <div class="small text-muted mt-2">Only archived plain <code>.log</code> files are compressed. The active <code>meta.log</code> is never touched from this action.</div>
+        <div id="logscan-compress-log-status" class="alert alert-info d-none py-2 small mt-3 mb-0" role="status"></div>
+        <div id="logscan-compress-log-success" class="alert alert-success d-none py-2 small mt-3 mb-0" role="status"></div>
+        <div id="logscan-compress-log-error" class="alert alert-danger d-none py-2 small mt-3 mb-0" role="alert"></div>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn nav-button btn-sm" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn nav-button btn-sm" id="logscan-cancel-compress-log" data-bs-dismiss="modal">Cancel</button>
         <button type="button" class="btn nav-button btn-sm" id="logscan-confirm-compress-log">Compress</button>
       </div>
     </div>

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -479,6 +479,19 @@ def test_delete_orphaned_config_artifacts_route_removes_selected_bundle(client, 
     assert not (kometa_path / f"{orphan_name}_config.yml").exists()
 
 
+def test_delete_orphaned_config_artifacts_route_removes_copy_named_yaml(client, isolated_config_dir):
+    copied_path = isolated_config_dir / "bullmoose20_config - Copy (10)_config.yml"
+    copied_name = "bullmoose20_config_-_copy_(10)"
+    copied_path.write_text("current: true\n", encoding="utf-8")
+
+    resp = client.post("/orphaned-config-artifacts/delete", json={"names": [copied_name]})
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert payload["deleted"] == [copied_name.lower().replace(" ", "_")]
+    assert not copied_path.exists()
+
+
 def test_orphaned_config_artifact_versions_returns_newest_first(client, isolated_config_dir):
     import os
     import time


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

## Summary

This PR continues the `redo_webui` Quickstart cleanup with a focus on workflow clarity, file-drift recovery, final-page polish, and a much stronger Analytics/log management experience.

## Highlights

- Improved dependency-driven readiness/TODO behavior for optional service pages.
- Added README dependency appendix and updated docs/screenshots.
- Simplified import completion flow and improved post-import messaging.
- Moved playlist handling into the Libraries workflow and updated import/output behavior.
- Refined Final Validation behavior, especially when Kometa is already running.
- Added Start-page `Review File Drift` tooling to inspect orphaned config bundles on disk, restore selected versions, or delete filesystem-only artifacts.
- Fixed orphaned-file deletion so it removes the exact scanned filesystem paths, including copy-style filenames.
- Expanded Analytics Recent Runs to include incomplete/skipped logs for investigation and cleanup.
- Added per-run and bulk log actions:
  - download
  - delete
  - compress
- Added archived log storage visibility and retention messaging directly in Analytics.
- Standardized archive naming and improved handling of finished idle `meta.log`.
- Added gzip support for archived logs:
  - supports both `.log` and `.log.gz`
  - reingest reads gzipped logs streamingly
  - completed archives are now written as `.log.gz`
  - delete/download/retention/storage summary all support gzipped archives
- Added user-driven bulk compression for archived plain logs.
- Improved mobile/responsive behavior across Start, Analytics, and modal flows.
- Added better in-modal progress/success/error states for file drift and Analytics delete/compress actions.


## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
