### PR TITLE
Fix responsive popup modals

### DIFF
--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -60,6 +60,8 @@ MAX_LOG_BACKUPS = 10
 RESTART_NOTICE_FILE = os.path.join(CONFIG_DIR, ".restart_notice.json")
 PLEX_DISCOVERY_CACHE_TTL_SECONDS = int(os.environ.get("QS_PLEX_DISCOVERY_CACHE_TTL_SECONDS", "300"))
 _PLEX_DISCOVERY_CACHE = {}
+KOMETA_UPDATE_CACHE_TTL_SECONDS = int(os.environ.get("QS_KOMETA_UPDATE_CACHE_TTL_SECONDS", "600"))
+_KOMETA_UPDATE_CACHE = {}
 
 
 def _plex_discovery_cache_key(kind, plex_url, plex_token):
@@ -116,6 +118,60 @@ def set_cached_plex_refresh(plex_url, plex_token, payload):
 
 def clear_plex_discovery_cache():
     _PLEX_DISCOVERY_CACHE.clear()
+
+
+def _kometa_update_cache_key(kometa_root, branch, local_version):
+    try:
+        root = str(Path(kometa_root).resolve())
+    except Exception:
+        root = str(kometa_root or "")
+    return root, str(branch or "").strip(), str(local_version or "").strip()
+
+
+def get_cached_kometa_update(kometa_root=None, force_refresh=False):
+    branch = get_kometa_branch()
+    local_version = get_kometa_local_version(kometa_root)
+    key = _kometa_update_cache_key(kometa_root or ".", branch, local_version)
+
+    if not force_refresh:
+        entry = _KOMETA_UPDATE_CACHE.get(key)
+        if entry:
+            age = time.monotonic() - entry.get("created_at", 0)
+            if age <= KOMETA_UPDATE_CACHE_TTL_SECONDS:
+                payload = copy.deepcopy(entry.get("payload") or {})
+                payload["cached"] = True
+                return payload
+            _KOMETA_UPDATE_CACHE.pop(key, None)
+
+    payload = check_kometa_update(kometa_root)
+    if isinstance(payload, dict):
+        payload = copy.deepcopy(payload)
+        payload["cached"] = False
+        _KOMETA_UPDATE_CACHE[key] = {
+            "created_at": time.monotonic(),
+            "payload": copy.deepcopy(payload),
+        }
+        return payload
+    return {
+        "local_version": local_version,
+        "remote_version": None,
+        "branch": branch,
+        "update_available": False,
+        "cached": False,
+    }
+
+
+def invalidate_cached_kometa_update(kometa_root=None):
+    if kometa_root is None:
+        _KOMETA_UPDATE_CACHE.clear()
+        return
+    try:
+        target_root = str(Path(kometa_root).resolve())
+    except Exception:
+        target_root = str(kometa_root or "")
+    for key in list(_KOMETA_UPDATE_CACHE.keys()):
+        if key[0] == target_root:
+            _KOMETA_UPDATE_CACHE.pop(key, None)
 
 
 def normalize_id(name, existing_ids):

--- a/modules/logscan.py
+++ b/modules/logscan.py
@@ -2388,7 +2388,7 @@ class LogscanAnalyzer:
             return "metadata"
         return None
 
-    def extract_progress(self, content, library_list=None, selected_libraries=None, previous=None, run_started_at=None):
+    def extract_progress(self, content, library_list=None, selected_libraries=None, previous=None, run_started_at=None, now_ts=None, is_running=False):
         library_entries = []
         if library_list:
             for entry in library_list:
@@ -2521,6 +2521,13 @@ class LogscanAnalyzer:
         lines = content.splitlines()
 
         effective_started_at = run_started_at
+        effective_now = now_ts
+        if effective_now is not None:
+            try:
+                if effective_now.tzinfo is not None:
+                    effective_now = effective_now.astimezone().replace(tzinfo=None)
+            except Exception:
+                effective_now = None
         if effective_started_at is None:
             marker_re = re.compile(r"\[Quickstart\]\s+Run marker:\s+started=([^\s]+)")
             for line in lines:
@@ -2922,15 +2929,16 @@ class LogscanAnalyzer:
                 _finish_phase(name, phase_key, last_ts)
 
         current_phase_elapsed = None
-        if current_library and last_ts:
+        live_reference_ts = effective_now if is_running and effective_now is not None else last_ts
+        if current_library and live_reference_ts:
             open_phase = phase_open.get(current_library)
             if open_phase:
                 start_ts = phase_start.get((current_library, open_phase))
                 if start_ts:
                     effective_start = start_ts
-                    if last_log_cutoff and start_ts < last_log_cutoff:
+                    if last_log_cutoff and start_ts < last_log_cutoff and live_reference_ts > last_log_cutoff:
                         effective_start = last_log_cutoff
-                    delta = max(0, int((last_ts - effective_start).total_seconds()))
+                    delta = max(0, int((live_reference_ts - effective_start).total_seconds()))
                     base = 0
                     if current_library in library_durations:
                         base = int(library_durations[current_library].get(open_phase, 0) or 0)
@@ -2943,15 +2951,17 @@ class LogscanAnalyzer:
                 preparation_locked = True
         elif not preparation_locked and preparation_seconds is None:
             prep_start = effective_started_at or first_log_ts
-            if prep_start and last_ts and last_ts > prep_start:
-                preparation_elapsed_seconds = max(0, int((last_ts - prep_start).total_seconds()))
+            prep_reference_ts = effective_now if is_running and effective_now is not None else last_ts
+            if prep_start and prep_reference_ts and prep_reference_ts > prep_start:
+                preparation_elapsed_seconds = max(0, int((prep_reference_ts - prep_start).total_seconds()))
 
         playlist_elapsed_seconds = None
-        if playlist_running and last_ts and playlist_started_at:
+        playlist_reference_ts = effective_now if is_running and effective_now is not None else last_ts
+        if playlist_running and playlist_reference_ts and playlist_started_at:
             effective_start = playlist_started_at
-            if last_log_cutoff and playlist_started_at < last_log_cutoff:
+            if last_log_cutoff and playlist_started_at < last_log_cutoff and playlist_reference_ts > last_log_cutoff:
                 effective_start = last_log_cutoff
-            delta = max(0, int((last_ts - effective_start).total_seconds()))
+            delta = max(0, int((playlist_reference_ts - effective_start).total_seconds()))
             playlist_elapsed_seconds = playlist_total_seconds + delta
 
         if finished_run_seen:

--- a/quickstart.py
+++ b/quickstart.py
@@ -10092,21 +10092,6 @@ def validate_kometa_root():
 
     log("✅ Kometa root is valid and ready.")
 
-    kometa_update_check_skipped = helpers.is_kometa_running()
-    if kometa_update_check_skipped:
-        kometa_update_info = {
-            "local_version": kometa_version,
-            "remote_version": "",
-            "update_available": False,
-        }
-        log("ℹ️ Kometa is currently running; update check skipped.")
-    else:
-        kometa_update_info = helpers.check_kometa_update(p)
-        if kometa_update_info["update_available"]:
-            log(f"⬆️ Update available: {kometa_update_info['local_version']} → {kometa_update_info['remote_version']}")
-        else:
-            log(f"✅ Kometa is up to date: {kometa_update_info['local_version']}")
-
     return (
         jsonify(
             success=True,
@@ -10117,14 +10102,128 @@ def validate_kometa_root():
             kometa_root_display=kometa_root_display,
             venv_python_display=str(python_bin),
             kometa_version=kometa_version,
-            local_version=kometa_update_info["local_version"],
-            remote_version=kometa_update_info["remote_version"],
-            kometa_update_available=kometa_update_info["update_available"],
-            kometa_update_check_skipped=kometa_update_check_skipped,
             log=logs,
         ),
         200,
     )
+
+
+def _probe_kometa_root_state(path_obj):
+    p = Path(path_obj)
+    kometa_root_posix = p.as_posix()
+    kometa_root_display = str(p)
+    is_windows = sys.platform.startswith("win")
+    venv_dir = p / "kometa-venv"
+    bin_dir = venv_dir / ("Scripts" if is_windows else "bin")
+    python_bin = bin_dir / ("python.exe" if is_windows else "python")
+    version_path = p / "VERSION"
+    kometa_py = p / "kometa.py"
+    requirements = p / "requirements.txt"
+    config_dir = p / "config"
+    version_value = "Unknown"
+    if version_path.exists():
+        try:
+            version_value = version_path.read_text(encoding="utf-8").strip() or "Unknown"
+        except Exception:
+            version_value = "Unknown"
+
+    return {
+        "kometa_root": kometa_root_posix,
+        "kometa_root_display": kometa_root_display,
+        "venv_python": python_bin.as_posix(),
+        "venv_python_display": str(python_bin),
+        "kometa_version": version_value,
+        "root_exists": p.exists(),
+        "config_dir_exists": config_dir.exists(),
+        "kometa_installed": kometa_py.exists() and requirements.exists(),
+        "venv_exists": venv_dir.exists(),
+        "venv_python_exists": python_bin.exists(),
+        "kometa_running": helpers.is_kometa_running(),
+    }
+
+
+@app.route("/probe-kometa-root", methods=["POST"])
+def probe_kometa_root():
+    payload = request.get_json(silent=True) or {}
+    root_path = str(payload.get("path", "")).strip()
+    logs = []
+
+    def log(msg):
+        print(msg, file=sys.stderr)
+        logs.append(msg)
+
+    if not root_path:
+        log("❌ No path provided.")
+        return jsonify(success=False, error="No path provided.", log=logs), 400
+
+    p = _resolve_user_dir(root_path)
+    if not p:
+        log("❌ Invalid path provided.")
+        return jsonify(success=False, error="Invalid path provided.", log=logs), 400
+
+    session["kometa_root"] = p.as_posix()
+    app.config["KOMETA_ROOT"] = str(p)
+
+    state = _probe_kometa_root_state(p)
+    log(f"🔍 Probing Kometa path: {state['kometa_root_display']}")
+    if not state["root_exists"]:
+        log("ℹ️ Kometa root does not exist yet. Install required.")
+    elif not state["kometa_installed"]:
+        log("ℹ️ Kometa files not found yet. Install required.")
+    else:
+        log("✅ Kometa files detected locally.")
+        if state["kometa_version"]:
+            log(f"📦 Local Kometa version: {state['kometa_version']}")
+        if state["venv_python_exists"]:
+            log(f"🐍 Kometa venv python detected at: {state['venv_python_display']}")
+        else:
+            log("ℹ️ Kometa venv python not present yet. Prepare step still needed.")
+    if state["kometa_running"]:
+        log("ℹ️ Kometa is currently running.")
+
+    return jsonify(success=True, log=logs, **state), 200
+
+
+@app.route("/check-kometa-update", methods=["POST"])
+def check_kometa_update():
+    payload = request.get_json(silent=True) or {}
+    root_path = str(payload.get("path", "")).strip()
+    logs = []
+
+    def log(msg):
+        print(msg, file=sys.stderr)
+        logs.append(msg)
+
+    if not root_path:
+        log("❌ No path provided.")
+        return jsonify(success=False, error="No path provided.", log=logs), 400
+
+    p = _resolve_user_dir(root_path)
+    if not p:
+        log("❌ Invalid path provided.")
+        return jsonify(success=False, error="Invalid path provided.", log=logs), 400
+
+    session["kometa_root"] = p.as_posix()
+    app.config["KOMETA_ROOT"] = str(p)
+
+    state = _probe_kometa_root_state(p)
+    if not state["kometa_installed"]:
+        log("ℹ️ Kometa is not installed yet; update check skipped.")
+        return jsonify(success=True, log=logs, update_check_completed=False, kometa_update_check_skipped=False, local_version=state["kometa_version"], remote_version="", kometa_update_available=False, cached=False, **state), 200
+
+    if state["kometa_running"]:
+        log("ℹ️ Kometa is currently running; update check skipped.")
+        return jsonify(success=True, log=logs, update_check_completed=True, kometa_update_check_skipped=True, local_version=state["kometa_version"], remote_version="", kometa_update_available=False, cached=False, **state), 200
+
+    update_info = helpers.get_cached_kometa_update(p, force_refresh=helpers.booler(payload.get("force", False)))
+    local_version = update_info.get("local_version") or state["kometa_version"]
+    remote_version = update_info.get("remote_version") or ""
+    if update_info.get("update_available"):
+        log(f"⬆️ Update available: {local_version} → {remote_version}")
+    else:
+        log(f"✅ Kometa is up to date: {local_version}")
+
+    return jsonify(success=True, log=logs, update_check_completed=True, kometa_update_check_skipped=False, local_version=local_version, remote_version=remote_version, kometa_update_available=bool(update_info.get("update_available")), cached=bool(update_info.get("cached")), **state), 200
 
 
 @app.route("/update-kometa", methods=["POST"])
@@ -10149,6 +10248,10 @@ def update_kometa():
             logs.append("Force update enabled.")
 
         result = helpers.perform_kometa_update_zip_only(cfg_dir, branch=kometa_branch, force=force_update)
+        try:
+            helpers.invalidate_cached_kometa_update(cfg_dir)
+        except Exception:
+            pass
         logs.extend(result.get("log", []))
         status = 200 if result.get("success") else 500
 

--- a/quickstart.py
+++ b/quickstart.py
@@ -7692,6 +7692,54 @@ def logscan_progress():
 
         cached = LOGSCAN_PROGRESS_CACHE
 
+        def _coerce_progress_datetime(value):
+            if not value:
+                return None
+            try:
+                ts = value if isinstance(value, datetime) else datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+                if ts.tzinfo is not None:
+                    ts = ts.astimezone().replace(tzinfo=None)
+                return ts
+            except Exception:
+                return None
+
+        def refresh_live_progress_elapsed(data, running, started_at):
+            if not isinstance(data, dict) or not running:
+                return data
+            data = deepcopy(data)
+            now_ts = datetime.now()
+
+            prep_locked = data.get("preparation_seconds")
+            if not isinstance(prep_locked, (int, float)):
+                prep_start = _coerce_progress_datetime(started_at)
+                if prep_start and now_ts > prep_start:
+                    data["preparation_elapsed_seconds"] = max(0, int((now_ts - prep_start).total_seconds()))
+
+            current_library = data.get("current_library")
+            phase_current = data.get("phase_current")
+            phase_starts = data.get("phase_starts") or {}
+            if current_library and phase_current and isinstance(phase_starts, dict):
+                phase_key = f"{current_library}||{phase_current}"
+                start_ts = _coerce_progress_datetime(phase_starts.get(phase_key))
+                if start_ts:
+                    base = 0
+                    for entry in data.get("libraries") or []:
+                        if entry.get("name") == current_library:
+                            durations = entry.get("durations") or {}
+                            if isinstance(durations.get(phase_current), (int, float)):
+                                base = int(durations.get(phase_current) or 0)
+                            break
+                    data["current_phase_elapsed_seconds"] = base + max(0, int((now_ts - start_ts).total_seconds()))
+
+            if data.get("playlist_running"):
+                playlist_started_at = _coerce_progress_datetime(data.get("playlist_started_at"))
+                if playlist_started_at:
+                    playlist_total = data.get("playlist_total_seconds")
+                    base = int(playlist_total or 0) if isinstance(playlist_total, (int, float)) else 0
+                    data["playlist_elapsed_seconds"] = base + max(0, int((now_ts - playlist_started_at).total_seconds()))
+
+            return data
+
         def normalize_progress_for_stopped(data, running, stopped_requested):
             if not isinstance(data, dict) or running:
                 return data
@@ -7729,6 +7777,7 @@ def logscan_progress():
 
         if log_stats and cached.get("mtime") == log_stats.st_mtime and cached.get("size") == log_stats.st_size:
             data = cached.get("data") or {}
+            data = refresh_live_progress_elapsed(data, running, started_at)
             data = normalize_progress_for_stopped(data, running, stopped_requested)
             return jsonify(data)
 
@@ -7747,6 +7796,8 @@ def logscan_progress():
             selected_libraries=selected,
             previous=LOGSCAN_PROGRESS_CACHE.get("data"),
             run_started_at=started_at,
+            now_ts=datetime.now(timezone.utc),
+            is_running=running,
         )
         phase_order = _get_progress_run_order(config_data=config_data)
         allowed_phases = phase_order or ["operations", "metadata", "collections", "overlays"]

--- a/quickstart.py
+++ b/quickstart.py
@@ -10260,11 +10260,37 @@ def check_kometa_update():
     state = _probe_kometa_root_state(p)
     if not state["kometa_installed"]:
         log("ℹ️ Kometa is not installed yet; update check skipped.")
-        return jsonify(success=True, log=logs, update_check_completed=False, kometa_update_check_skipped=False, local_version=state["kometa_version"], remote_version="", kometa_update_available=False, cached=False, **state), 200
+        return (
+            jsonify(
+                success=True,
+                log=logs,
+                update_check_completed=False,
+                kometa_update_check_skipped=False,
+                local_version=state["kometa_version"],
+                remote_version="",
+                kometa_update_available=False,
+                cached=False,
+                **state,
+            ),
+            200,
+        )
 
     if state["kometa_running"]:
         log("ℹ️ Kometa is currently running; update check skipped.")
-        return jsonify(success=True, log=logs, update_check_completed=True, kometa_update_check_skipped=True, local_version=state["kometa_version"], remote_version="", kometa_update_available=False, cached=False, **state), 200
+        return (
+            jsonify(
+                success=True,
+                log=logs,
+                update_check_completed=True,
+                kometa_update_check_skipped=True,
+                local_version=state["kometa_version"],
+                remote_version="",
+                kometa_update_available=False,
+                cached=False,
+                **state,
+            ),
+            200,
+        )
 
     update_info = helpers.get_cached_kometa_update(p, force_refresh=helpers.booler(payload.get("force", False)))
     local_version = update_info.get("local_version") or state["kometa_version"]
@@ -10274,7 +10300,20 @@ def check_kometa_update():
     else:
         log(f"✅ Kometa is up to date: {local_version}")
 
-    return jsonify(success=True, log=logs, update_check_completed=True, kometa_update_check_skipped=False, local_version=local_version, remote_version=remote_version, kometa_update_available=bool(update_info.get("update_available")), cached=bool(update_info.get("cached")), **state), 200
+    return (
+        jsonify(
+            success=True,
+            log=logs,
+            update_check_completed=True,
+            kometa_update_check_skipped=False,
+            local_version=local_version,
+            remote_version=remote_version,
+            kometa_update_available=bool(update_info.get("update_available")),
+            cached=bool(update_info.get("cached")),
+            **state,
+        ),
+        200,
+    )
 
 
 @app.route("/update-kometa", methods=["POST"])

--- a/quickstart.py
+++ b/quickstart.py
@@ -176,8 +176,6 @@ QS_MAL_REQUIRED_STEP_KEY = "140-mal"
 QS_TAUTULLI_DEP_COLLECTION_IDS = {"collection_tautulli"}
 QS_TRAKT_DEP_COLLECTION_IDS = {"collection_trakt"}
 QS_MAL_DEP_COLLECTION_IDS = {"collection_myanimelist"}
-QS_ANIDB_DEP_COLLECTION_IDS = {"collection_use_anidb"}
-QS_ANIDB_DEP_TEMPLATE_COLLECTION_IDS = {"use_anidb"}
 QS_OMDB_DEP_SOURCE_PREFIXES = ("omdb",)
 QS_MDBLIST_DEP_SOURCE_PREFIXES = ("mdb",)
 QS_ANIDB_DEP_SOURCE_PREFIXES = ("anidb",)
@@ -643,23 +641,11 @@ def _libraries_data_anidb_dependency_reasons(libraries_data):
         libraries_data,
         QS_ANIDB_DEP_SOURCE_PREFIXES,
     )
-    collection_reasons = _libraries_data_collection_dependency_reasons(
-        libraries_data,
-        QS_ANIDB_DEP_COLLECTION_IDS,
-        "AniDB Popular collection enabled",
-    )
-    template_collection_reasons = _libraries_data_template_collection_dependency_reasons(
-        libraries_data,
-        QS_ANIDB_DEP_TEMPLATE_COLLECTION_IDS,
-        "AniDB Popular collection enabled",
-    )
     overlay_reasons = _libraries_data_overlay_rating_dependency_reasons(
         libraries_data,
         QS_ANIDB_OVERLAY_IMAGE_VALUES,
     )
-    merged_reasons = attribute_reasons + [reason for reason in collection_reasons if reason not in attribute_reasons]
-    merged_reasons += [reason for reason in template_collection_reasons if reason not in merged_reasons]
-    return merged_reasons + [reason for reason in overlay_reasons if reason not in merged_reasons]
+    return attribute_reasons + [reason for reason in overlay_reasons if reason not in attribute_reasons]
 
 
 def _libraries_data_radarr_dependency_reasons(libraries_data):

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -3241,6 +3241,58 @@ div#loading {
     pointer-events: auto;
 }
 
+#run-command-box,
+#incomplete-run-alert {
+    min-width: 0;
+    max-width: 100%;
+    overflow-x: hidden;
+}
+
+#incomplete-run-alert .d-flex {
+    min-width: 0;
+}
+
+#incomplete-run-alert .me-2 {
+    min-width: 0;
+    flex: 1 1 18rem;
+}
+
+#incomplete-run-alert code,
+#incomplete-run-alert li,
+#incomplete-run-alert .small {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+#incomplete-run-alert code {
+    white-space: normal;
+}
+
+#recovery-command-output,
+#run-command-output {
+    display: block;
+    max-width: 100%;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+@media (max-width: 767.98px) {
+    #incomplete-run-alert .d-flex {
+        flex-direction: column;
+        align-items: stretch !important;
+    }
+
+    #incomplete-run-alert .me-2 {
+        flex-basis: auto;
+        margin-right: 0 !important;
+    }
+
+    #copy-recovery-command {
+        align-self: flex-start;
+        max-width: 100%;
+    }
+}
+
 .rotate-icon {
     transition: transform 0.3s ease;
 }
@@ -5416,6 +5468,25 @@ body {
         white-space: nowrap;
     }
 
+    #header-style-rollup-badge,
+    #validation-status-rollup-badge,
+    #config-output-rollup-badge,
+    #config-output-lines-badge,
+    #kometa-update-rollup-badge,
+    #heading-mode-rollup-badge,
+    #heading-runopt-rollup-badge,
+    #heading-modeflags-rollup-badge,
+    #heading-logflags-rollup-badge,
+    #heading-otherflags-rollup-badge,
+    #run-command-rollup-badge,
+    #logscan-rollup-badge {
+        min-width: fit-content;
+        max-width: none;
+        flex: 0 0 auto;
+        overflow: visible;
+        text-overflow: clip;
+    }
+
     #plexInfoAccordion .accordion-button {
         position: relative;
         display: grid;
@@ -5605,6 +5676,84 @@ html[data-qs-viewport="mobile"] .modal.qs-mobile-panel-target .modal-content {
     border-radius: 0;
     min-height: 100dvh;
     border: 0;
+}
+
+html[data-qs-viewport="mobile"][data-qs-template]:not([data-qs-template="025-libraries"]):not([data-qs-template="900-final"]):not([data-qs-template="905-analytics"]) #configForm .qs-workspace-main-panel .row > .col,
+html[data-qs-viewport="mobile"][data-qs-template]:not([data-qs-template="025-libraries"]):not([data-qs-template="900-final"]):not([data-qs-template="905-analytics"]) #configForm .qs-workspace-main-panel .row > [class*="col-"] {
+    flex: 0 0 100%;
+    max-width: 100%;
+    width: 100%;
+}
+
+html[data-qs-viewport="mobile"][data-qs-template]:not([data-qs-template="025-libraries"]):not([data-qs-template="900-final"]):not([data-qs-template="905-analytics"]) #configForm .qs-workspace-main-panel .input-group:not(.page-search-group):not(.font-input-group):not(.rating-image-input-group):not(.logscan-date-range) {
+    flex-wrap: wrap;
+    align-items: stretch;
+}
+
+html[data-qs-viewport="mobile"][data-qs-template]:not([data-qs-template="025-libraries"]):not([data-qs-template="900-final"]):not([data-qs-template="905-analytics"]) #configForm .qs-workspace-main-panel .input-group:not(.page-search-group):not(.font-input-group):not(.rating-image-input-group):not(.logscan-date-range) > .input-group-text:first-child {
+    flex: 0 0 100%;
+    width: 100% !important;
+    max-width: 100%;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+    white-space: normal;
+    line-height: 1.25;
+    border-top-right-radius: var(--bs-border-radius);
+    border-bottom-left-radius: 0;
+}
+
+html[data-qs-viewport="mobile"][data-qs-template]:not([data-qs-template="025-libraries"]):not([data-qs-template="900-final"]):not([data-qs-template="905-analytics"]) #configForm .qs-workspace-main-panel .input-group:not(.page-search-group):not(.font-input-group):not(.rating-image-input-group):not(.logscan-date-range) > .input-group-text:first-child .text-info,
+html[data-qs-viewport="mobile"][data-qs-template]:not([data-qs-template="025-libraries"]):not([data-qs-template="900-final"]):not([data-qs-template="905-analytics"]) #configForm .qs-workspace-main-panel .input-group:not(.page-search-group):not(.font-input-group):not(.rating-image-input-group):not(.logscan-date-range) > .input-group-text:first-child .bi-info-circle-fill {
+    margin-left: auto !important;
+    flex: 0 0 auto;
+}
+
+html[data-qs-viewport="mobile"][data-qs-template]:not([data-qs-template="025-libraries"]):not([data-qs-template="900-final"]):not([data-qs-template="905-analytics"]) #configForm .qs-workspace-main-panel .input-group:not(.page-search-group):not(.font-input-group):not(.rating-image-input-group):not(.logscan-date-range) > .form-control,
+html[data-qs-viewport="mobile"][data-qs-template]:not([data-qs-template="025-libraries"]):not([data-qs-template="900-final"]):not([data-qs-template="905-analytics"]) #configForm .qs-workspace-main-panel .input-group:not(.page-search-group):not(.font-input-group):not(.rating-image-input-group):not(.logscan-date-range) > .form-select {
+    min-width: 0;
+    flex: 1 1 12rem;
+    width: 1%;
+}
+
+html[data-qs-viewport="mobile"][data-qs-template]:not([data-qs-template="025-libraries"]):not([data-qs-template="900-final"]):not([data-qs-template="905-analytics"]) #configForm .qs-workspace-main-panel .input-group:not(.page-search-group):not(.font-input-group):not(.rating-image-input-group):not(.logscan-date-range) > .btn {
+    flex: 0 0 auto;
+}
+
+html[data-qs-viewport="mobile"][data-qs-template]:not([data-qs-template="025-libraries"]):not([data-qs-template="900-final"]):not([data-qs-template="905-analytics"]) #configForm .qs-workspace-main-panel .input-group:not(.page-search-group):not(.font-input-group):not(.rating-image-input-group):not(.logscan-date-range):not(:has(> .form-control, > .form-select)) > .btn:first-of-type {
+    border-top-left-radius: var(--bs-border-radius);
+    border-bottom-left-radius: var(--bs-border-radius);
+}
+
+html[data-qs-viewport="mobile"][data-qs-template]:not([data-qs-template="025-libraries"]):not([data-qs-template="900-final"]):not([data-qs-template="905-analytics"]) #configForm .qs-workspace-main-panel .input-group:not(.page-search-group):not(.font-input-group):not(.rating-image-input-group):not(.logscan-date-range):not(:has(> .form-control, > .form-select)) > .btn:last-of-type {
+    border-top-right-radius: var(--bs-border-radius);
+    border-bottom-right-radius: var(--bs-border-radius);
+}
+
+html[data-qs-viewport="mobile"][data-qs-template]:not([data-qs-template="025-libraries"]):not([data-qs-template="900-final"]):not([data-qs-template="905-analytics"]) #configForm .qs-workspace-main-panel .input-group:not(.page-search-group):not(.font-input-group):not(.rating-image-input-group):not(.logscan-date-range):not(:has(> .form-control, > .form-select)) > .btn:only-child {
+    border-radius: var(--bs-border-radius) !important;
+}
+
+html[data-qs-viewport="mobile"][data-qs-template]:not([data-qs-template="025-libraries"]):not([data-qs-template="900-final"]):not([data-qs-template="905-analytics"]) #configForm .qs-workspace-main-panel .status-message {
+    overflow-wrap: anywhere;
+}
+
+html[data-qs-viewport="mobile"][data-qs-template]:not([data-qs-template="025-libraries"]):not([data-qs-template="900-final"]):not([data-qs-template="905-analytics"]) #configForm .qs-workspace-main-panel .form-check.form-switch {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.85rem;
+    padding-left: 0;
+}
+
+html[data-qs-viewport="mobile"][data-qs-template]:not([data-qs-template="025-libraries"]):not([data-qs-template="900-final"]):not([data-qs-template="905-analytics"]) #configForm .qs-workspace-main-panel .form-check.form-switch .form-check-input {
+    flex: 0 0 auto;
+    margin-left: 0;
+    margin-top: 0.25rem;
+}
+
+html[data-qs-viewport="mobile"][data-qs-template]:not([data-qs-template="025-libraries"]):not([data-qs-template="900-final"]):not([data-qs-template="905-analytics"]) #configForm .qs-workspace-main-panel .form-check.form-switch .form-check-label {
+    min-width: 0;
+    overflow-wrap: anywhere;
 }
 
 html[data-qs-viewport="mobile"] .logscan-confirm-modal-dialog {

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -13356,33 +13356,6 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
-            "key": "use_anidb",
-            "label": "AniDB Popular",
-            "tooltip": "Collection of the most Popular Anime on AniDB.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "radarr_add_missing_anidb",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_anidb",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
             "key": "use_commonsense",
             "label": "Common Sense Selection",
             "tooltip": "Collection of Common Sense Selection Movies/Shows.",
@@ -13414,7 +13387,10 @@
             "label": "Metacritic Must See Movies",
             "tooltip": "Collection of Metacritic Must See Movies.",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "media_types": [
+              "movie"
+            ]
           },
           {
             "key": "radarr_add_missing_metacritic",
@@ -13427,21 +13403,14 @@
             ]
           },
           {
-            "key": "sonarr_add_missing_metacritic",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
             "key": "use_stevenlu",
             "label": "StevenLu's Popular Movies",
             "tooltip": "Collection of StevenLu's Popular Movies.",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "media_types": [
+              "movie"
+            ]
           },
           {
             "key": "radarr_add_missing_stevenlu",
@@ -13454,21 +13423,14 @@
             ]
           },
           {
-            "key": "sonarr_add_missing_stevenlu",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
             "key": "use_pirated",
             "label": "Top 10 Pirated Movies of the Week",
             "tooltip": "Collection of the Top 10 Pirated Movies of the Week.",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "media_types": [
+              "movie"
+            ]
           },
           {
             "key": "radarr_add_missing_pirated",
@@ -13478,16 +13440,6 @@
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_pirated",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
             ]
           },
           {

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -3207,10 +3207,10 @@ document.addEventListener('DOMContentLoaded', () => {
     '#quickstartSettingsModal',
     '#fontPickerModal',
     '#zoomPreviewModal',
-    '#stop-kometa-modal',
     '[id$="-overlay-toolbox-help-modal"]',
     '[id$="-overlay-canvas-modal"]',
-    '[id^="logscan-"][id$="-modal"]'
+    '#logscan-preferences-modal',
+    '#logscan-run-details-modal'
   ]
 
   let scheduledRefresh = null

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -155,7 +155,9 @@ const QS_NAV_LOADING_QUOTES = [
   'Loading… your expectations may vary.',
   'Please wait… our developers are dancing while waiting too.',
   'You’re not stuck, the page is just contemplating existence.',
-  'This text is taking longer to write than the page.'
+  'This text is taking longer to write than the page.',
+  'It\'s only typing...',
+  'That\'s a fixable problem...'
 ]
 
 let qsNavLoadingQuoteTimer = null

--- a/static/local-js/900-final.js
+++ b/static/local-js/900-final.js
@@ -6,8 +6,9 @@ let KOMETA_VALIDATED = false
 let KOMETA_VALIDATION_IN_PROGRESS = false
 let KOMETA_UPDATE_AVAILABLE = false
 let KOMETA_UPDATE_CHECK_SKIPPED = false
+let KOMETA_UPDATE_CHECK_COMPLETED = false
 let KOMETA_INSTALLED = false
-let KOMETA_CHECK_COMPLETED = false
+let KOMETA_LOCAL_CHECK_COMPLETED = false
 // Polling handles (hoist to top so all handlers see them safely)
 let kometaInterval = null
 let kometaStatusInterval = null
@@ -89,6 +90,7 @@ $(document).ready(function () {
   const kometaActionsHeading = document.getElementById('kometa-actions-heading')
   const kometaActionsCollapse = document.getElementById('kometa-actions-collapse')
   const kometaActionsToggle = document.getElementById('kometa-actions-toggle')
+  const runCommandCollapse = document.getElementById('run-command-output-collapse')
   let headerStyleSubmitting = false
 
   function readMetaFlag (id, datasetKey, attrKey) {
@@ -501,6 +503,14 @@ $(document).ready(function () {
     headerSelect.addEventListener('change', () => setActiveGridCard(headerSelect.value))
   }
   updateHeaderStyleLabel(headerSelect ? headerSelect.value : '')
+  $('#open-kometa-actions-button').on('click', function () {
+    if (!kometaActionsCollapse || typeof bootstrap === 'undefined' || !bootstrap.Collapse) return
+    bootstrap.Collapse.getOrCreateInstance(kometaActionsCollapse, { toggle: false }).show()
+  })
+  $('#open-kometa-actions-panel-button').on('click', function () {
+    if (!kometaActionsCollapse || typeof bootstrap === 'undefined' || !bootstrap.Collapse) return
+    bootstrap.Collapse.getOrCreateInstance(kometaActionsCollapse, { toggle: false }).show()
+  })
 
   function updateLibraryVisibility (mainOption) {
     const librarySection = $('#library-multiselect').closest('.mb-2')
@@ -653,6 +663,58 @@ $(document).ready(function () {
   function isRunCommandValid () {
     const cmd = $('#run-command-output').text().trim()
     return Boolean(cmd) && !cmd.startsWith('??')
+  }
+
+  function setRunCommandPlaceholderState () {
+    const $panel = $('#run-command-panel-message')
+    const $panelTitle = $('#run-command-panel-title')
+    const $panelText = $('#run-command-panel-text')
+    const $panelButton = $('#open-kometa-actions-panel-button')
+    const $box = $('#run-command-box')
+
+    if (!$panel.length) return
+
+    let title = 'Run command is not ready yet'
+    let message = 'Open Prepare Kometa to install, validate, or update the local Kometa setup before running.'
+    let showButton = true
+
+    if (!showYAML) {
+      title = 'Fix validation before building the run command'
+      message = 'Resolve the current validation issues first. The run command will appear after the config validates cleanly.'
+      showButton = false
+    } else if (KOMETA_UPDATING) {
+      title = 'Kometa update in progress'
+      message = 'Wait for the current install or update to finish. The run command will appear automatically afterward.'
+    } else if (KOMETA_VALIDATION_IN_PROGRESS) {
+      title = 'Preparing Kometa'
+      message = 'Quickstart is validating the Kometa folder and environment now. The run command will appear automatically when ready.'
+    } else if (!KOMETA_LOCAL_CHECK_COMPLETED) {
+      title = 'Checking Kometa state'
+      message = 'Quickstart is probing the local Kometa path. Wait for that check to finish, then prepare Kometa if needed.'
+      showButton = false
+    } else if (!KOMETA_INSTALLED) {
+      title = 'Install Kometa to build the run command'
+      message = 'Kometa is not installed in the selected path yet. Open Prepare Kometa to install it first.'
+    } else if (!KOMETA_VALIDATED) {
+      title = 'Validate Kometa to build the run command'
+      message = 'Next step: open Prepare Kometa, let Quickstart validate the Kometa folder and environment, then this command will be generated here.'
+    }
+
+    $panelTitle.text(title)
+    $panelText.text(message)
+    $panelButton.toggleClass('d-none', !showButton)
+    $panel.removeClass('d-none')
+    $box.addClass('d-none').removeClass('fade-in')
+  }
+
+  function clearRunCommandPlaceholderState () {
+    $('#run-command-panel-message').addClass('d-none')
+    $('#run-command-placeholder').addClass('d-none')
+    $('#open-kometa-actions-button').addClass('d-none')
+    $('#run-command-box').removeClass('d-none')
+    $('#run-command-box .form-label').removeClass('d-none')
+    $('#run-command-box pre').removeClass('d-none')
+    $('#copy-command').removeClass('d-none')
   }
 
   function updateRunNowState () {
@@ -856,39 +918,13 @@ $(document).ready(function () {
       // ✅ send the *normalized* path to the backend
       data: JSON.stringify({ path: defaultRootPosix, config_name: configName }),
       success: (res) => {
-        KOMETA_CHECK_COMPLETED = true
+        KOMETA_LOCAL_CHECK_COMPLETED = true
         if (Array.isArray(res.log)) res.log.forEach(line => $logBox.append(`${line}\n`))
 
         if (res.success) {
           KOMETA_INSTALLED = true
           $logBox.append('✅ Kometa root validated successfully.\n')
           if (res.kometa_version) $logBox.append(`📦 Local Kometa version: ${res.kometa_version}\n`)
-
-          if (res.kometa_update_check_skipped) {
-            KOMETA_UPDATE_CHECK_SKIPPED = true
-            KOMETA_UPDATE_AVAILABLE = false
-            $('#kometa-update-box').addClass('d-none')
-            syncUpdateButtonLabel()
-          } else if (res.remote_version && res.local_version) {
-            KOMETA_UPDATE_CHECK_SKIPPED = false
-            const hadUpdate = KOMETA_UPDATE_AVAILABLE
-            if (res.kometa_update_available) {
-              KOMETA_UPDATE_AVAILABLE = true
-              $logBox.append(`⬆️ Update available: ${res.local_version} → ${res.remote_version}\n`)
-              $('#kometa-update-box').removeClass('d-none')
-              $('#kometa-local-version').text(res.local_version)
-              $('#kometa-remote-version').text(res.remote_version)
-              syncUpdateButtonLabel()
-              if (!hadUpdate) {
-                showToast('warning', `Kometa update available: ${res.local_version} → ${res.remote_version}.`)
-              }
-            } else {
-              KOMETA_UPDATE_AVAILABLE = false
-              $logBox.append('✅ Kometa is up to date.\n')
-              $('#kometa-update-box').addClass('d-none')
-              syncUpdateButtonLabel()
-            }
-          }
 
           // ✅ Prefer display paths for UI; keep posix for internal if needed
           const kometaRootDisplay = (res.kometa_root_display || res.kometa_root || defaultRootDisplay)
@@ -936,10 +972,11 @@ $(document).ready(function () {
         }
 
         if ($spinner.length) $spinner.hide()
+        syncUpdateButtonLabel()
         syncKometaRollupBadge()
       },
       error: (xhr) => {
-        KOMETA_CHECK_COMPLETED = true
+        KOMETA_LOCAL_CHECK_COMPLETED = true
         const msg = xhr?.responseJSON?.error || 'The Kometa root path is invalid or inaccessible. Please try again.'
         $logBox.append(`❌ ${msg}\n`)
         const lowered = String(msg || '').toLowerCase()
@@ -962,6 +999,106 @@ $(document).ready(function () {
         }
       }
     })
+  }
+
+  function probeKometaRoot () {
+    const $logBox = $('#kometa-validation-log')
+    const $out = $('#run-command-output')
+    const defaultRootPosix = ($out.data('kometa-root-default') || '').toString().trim()
+    const defaultRootDisplay = ($out.data('kometa-root-default-display') || defaultRootPosix)
+    if (!defaultRootPosix) return
+
+    $logBox.text('🔍 Checking Kometa path and local install state...\n\n')
+
+    $.ajax({
+      type: 'POST',
+      url: '/probe-kometa-root',
+      contentType: 'application/json',
+      data: JSON.stringify({ path: defaultRootPosix }),
+      success: (res) => {
+        KOMETA_LOCAL_CHECK_COMPLETED = true
+        KOMETA_INSTALLED = !!res.kometa_installed
+        if (Array.isArray(res.log)) res.log.forEach(line => $logBox.append(`${line}\n`))
+
+        const kometaRootDisplay = (res.kometa_root_display || res.kometa_root || defaultRootDisplay)
+        const venvPythonDisplay = (res.venv_python_display || res.venv_python || 'python3')
+        const kometaRootPosix = (res.kometa_root || defaultRootPosix)
+        const venvPythonPosix = (res.venv_python || venvPythonDisplay)
+
+        $out.data('kometa-root', kometaRootDisplay)
+        $out.data('venv-python', venvPythonDisplay)
+        $out.data('kometa-root-posix', kometaRootPosix)
+        $out.data('venv-python-posix', venvPythonPosix)
+        $('#kometa-install-path').text(kometaRootDisplay)
+
+        if (!KOMETA_INSTALLED) {
+          KOMETA_VALIDATED = false
+          hideRunCommandSectionUntilValidated()
+        }
+
+        syncUpdateButtonLabel()
+        syncKometaRollupBadge()
+      },
+      error: (xhr) => {
+        KOMETA_LOCAL_CHECK_COMPLETED = true
+        KOMETA_INSTALLED = false
+        KOMETA_VALIDATED = false
+        const msg = xhr?.responseJSON?.error || 'Unable to probe the Kometa path.'
+        $logBox.append(`❌ ${msg}\n`)
+        hideRunCommandSectionUntilValidated()
+        syncUpdateButtonLabel()
+        syncKometaRollupBadge()
+      }
+    })
+  }
+
+  function checkKometaUpdate (forceRefresh = false) {
+    const $logBox = $('#kometa-validation-log')
+    const $out = $('#run-command-output')
+    const defaultRootPosix = ($out.data('kometa-root-default') || '').toString().trim()
+    if (!defaultRootPosix) return Promise.resolve(null)
+
+    $logBox.append('\n🔎 Checking Kometa update status...\n')
+    if ($logBox[0]) $logBox[0].scrollTop = $logBox[0].scrollHeight
+
+    return fetch('/check-kometa-update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: defaultRootPosix, force: forceRefresh })
+    })
+      .then(async res => {
+        const data = await res.json()
+        if (!res.ok) throw new Error(data.error || 'Failed to check Kometa update status.')
+        return data
+      })
+      .then(data => {
+        KOMETA_LOCAL_CHECK_COMPLETED = true
+        KOMETA_INSTALLED = !!data.kometa_installed
+        KOMETA_UPDATE_CHECK_COMPLETED = !!data.update_check_completed
+        KOMETA_UPDATE_CHECK_SKIPPED = !!data.kometa_update_check_skipped
+        KOMETA_UPDATE_AVAILABLE = !!data.kometa_update_available
+        if (Array.isArray(data.log)) data.log.forEach(line => $logBox.append(`${line}\n`))
+
+        if (data.local_version && data.remote_version && data.kometa_update_available) {
+          $('#kometa-update-box').removeClass('d-none')
+          $('#kometa-local-version').text(data.local_version)
+          $('#kometa-remote-version').text(data.remote_version)
+        } else {
+          $('#kometa-update-box').addClass('d-none')
+        }
+
+        syncUpdateButtonLabel()
+        syncKometaRollupBadge()
+        if ($logBox[0]) $logBox[0].scrollTop = $logBox[0].scrollHeight
+        return data
+      })
+      .catch(err => {
+        $logBox.append(`❌ ${err.message || 'Failed to check Kometa update status.'}\n`)
+        syncUpdateButtonLabel()
+        syncKometaRollupBadge()
+        if ($logBox[0]) $logBox[0].scrollTop = $logBox[0].scrollHeight
+        throw err
+      })
   }
 
   if ($('#run-command-output').length > 0) {
@@ -1017,8 +1154,11 @@ $(document).ready(function () {
   function getKometaRollupStatus () {
     if (KOMETA_UPDATING) return { state: 'unknown', label: 'Updating...' }
     if (KOMETA_VALIDATION_IN_PROGRESS) return { state: 'unknown', label: 'Checking...' }
-    if (!KOMETA_CHECK_COMPLETED) return { state: 'unknown', label: 'Not checked' }
+    if (!KOMETA_LOCAL_CHECK_COMPLETED) return { state: 'unknown', label: 'Not checked' }
     if (!KOMETA_INSTALLED) return { state: 'error', label: 'Install needed' }
+    if (!KOMETA_UPDATE_CHECK_COMPLETED) {
+      return { state: KOMETA_VALIDATED ? 'ok' : 'warn', label: KOMETA_VALIDATED ? 'Prepared' : 'Prepare needed' }
+    }
     if (KOMETA_UPDATE_CHECK_SKIPPED) return { state: 'unknown', label: 'Skipped while running' }
     if (KOMETA_UPDATE_AVAILABLE) return { state: 'warn', label: 'Update available' }
     return { state: 'ok', label: 'Up to date' }
@@ -1086,11 +1226,10 @@ $(document).ready(function () {
 
   function hideRunCommandSectionUntilValidated () {
     const accordion = $('#run-command-output-accordion')
-    const box = $('#run-command-box')
-    accordion.addClass('d-none')
+    accordion.removeClass('d-none')
     $('#run-command-output-collapse').removeClass('show')
     $('#run-command-output-heading .accordion-button').addClass('collapsed').attr('aria-expanded', 'false')
-    box.removeClass('fade-in').addClass('d-none') // Hide instantly
+    setRunCommandPlaceholderState()
     $('#run-now').prop('disabled', true).html('<i class="bi bi-hourglass-split me-1"></i> Waiting...')
   }
 
@@ -1108,6 +1247,7 @@ $(document).ready(function () {
   }
 
   function showRunCommandSectionAfterValidated () {
+    clearRunCommandPlaceholderState()
     revealRunCommandSection()
     $('#run-now').html('<i class="bi bi-play-fill me-1"></i> Run Now')
     try { buildCommand() } catch (_) {}
@@ -1400,7 +1540,7 @@ $(document).ready(function () {
     const label = force
       ? (KOMETA_INSTALLED ? 'Force Update Kometa' : 'Force Install Kometa')
       : (KOMETA_INSTALLED
-          ? (KOMETA_UPDATE_AVAILABLE ? 'Update Available' : 'Check for Kometa Updates')
+          ? (KOMETA_UPDATE_AVAILABLE ? 'Update Available' : (KOMETA_UPDATE_CHECK_COMPLETED ? 'Up to date' : 'Check for Kometa Updates'))
           : 'Install Kometa')
     return `<i class="bi bi-arrow-clockwise me-1"></i> ${label}`
   }
@@ -1426,9 +1566,33 @@ $(document).ready(function () {
     const branch = $btn.data('branch') || 'master'
     const forceUpdate = $forceUpdateToggle.is(':checked')
 
+    if (KOMETA_INSTALLED && !forceUpdate && !KOMETA_UPDATE_AVAILABLE) {
+      $btn.prop('disabled', true).html('<i class="bi bi-arrow-repeat me-1"></i> Checking...')
+      $forceUpdateToggle.prop('disabled', true)
+      checkKometaUpdate(true)
+        .then((data) => {
+          if (!data) return
+          if (data.kometa_update_available) {
+            showToast('warning', `Kometa update available: ${data.local_version} → ${data.remote_version}.`)
+          } else if (!data.kometa_update_check_skipped) {
+            showToast('success', 'Kometa is already up to date.')
+          }
+        })
+        .catch(() => {
+          showToast('error', 'Failed to check Kometa update status.')
+        })
+        .finally(() => {
+          $btn.prop('disabled', false)
+          $forceUpdateToggle.prop('disabled', false)
+          syncUpdateButtonLabel()
+        })
+      return
+    }
+
     KOMETA_UPDATING = true
     KOMETA_VALIDATED = false
     KOMETA_UPDATE_CHECK_SKIPPED = false
+    KOMETA_UPDATE_CHECK_COMPLETED = false
     syncKometaRollupBadge()
     hideRunCommandSectionUntilValidated()
     const prevRunNowHtml = $runNow.html()
@@ -1493,6 +1657,7 @@ $(document).ready(function () {
           if ($logBox[0]) $logBox[0].scrollTop = $logBox[0].scrollHeight
         }
         if (data.success) {
+          KOMETA_LOCAL_CHECK_COMPLETED = false
           KOMETA_UPDATE_AVAILABLE = false
           $('#kometa-update-box').addClass('d-none')
           syncUpdateButtonLabel()
@@ -2094,9 +2259,26 @@ $(document).ready(function () {
   hideRunCommandSectionUntilValidated()
   checkKometaStatus()
 
-  // First-run: validate Kometa root once the log box is present.
-  if (document.getElementById('kometa-validation-log') && getFinalGateState().stage !== 'todo' && getFinalGateState().stage !== 'freshness') {
-    validateKometaRoot()
+  // First-run: only probe local install state. Heavy prepare is user-driven.
+  if (document.getElementById('kometa-validation-log')) {
+    probeKometaRoot()
+  }
+
+  if (kometaActionsCollapse) {
+    kometaActionsCollapse.addEventListener('show.bs.collapse', () => {
+      const stage = getFinalGateState().stage
+      if (stage === 'todo' || stage === 'freshness') return
+      if (!KOMETA_INSTALLED || KOMETA_VALIDATED || KOMETA_VALIDATION_IN_PROGRESS || KOMETA_UPDATING) return
+      validateKometaRoot()
+    })
+  }
+
+  if (runCommandCollapse) {
+    runCommandCollapse.addEventListener('show.bs.collapse', () => {
+      if (!KOMETA_VALIDATED) {
+        setRunCommandPlaceholderState()
+      }
+    })
   }
 
   if (document.getElementById('header-style')) {

--- a/templates/000-base.html
+++ b/templates/000-base.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark" data-theme="{{ config.get('QS_THEME', 'kometa') }}">
+<html lang="en" data-bs-theme="dark" data-theme="{{ config.get('QS_THEME', 'kometa') }}"
+  data-qs-template="{{ page_info.get('template_name', '') if page_info else '' }}">
 
 <head>
   <meta charset="UTF-8" />

--- a/templates/900-final.html
+++ b/templates/900-final.html
@@ -366,7 +366,7 @@
       <h2 class="accordion-header" id="kometa-actions-heading">
         <button id="kometa-actions-toggle" class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
           data-bs-target="#kometa-actions-collapse" aria-expanded="false" aria-controls="kometa-actions-collapse">
-          Prepare Kometa Install / Update
+            Prepare Kometa
           <span id="kometa-update-rollup-badge" class="badge ms-2 qs-validation-rollup-badge qs-validation-rollup-badge--unknown">
             Not checked
           </span>
@@ -378,7 +378,7 @@
           <div id="kometa-actions">
             <div class="alert alert-secondary mb-0">
               <div class="small text-muted mb-2">
-                Validate the local Kometa folder and apply updates before starting a run.
+                  Install, validate, or update the local Kometa setup before starting a run.
               </div>
               <div class="mb-2">
                 Kometa will be installed/updated in:
@@ -650,7 +650,25 @@
         <div id="run-command-output-collapse" class="accordion-collapse collapse"
           aria-labelledby="run-command-output-heading" data-bs-parent="#run-command-output-accordion">
           <div class="accordion-body">
+            <div id="run-command-panel-message" class="alert alert-secondary mb-3" role="status">
+              <div class="fw-semibold mb-1" id="run-command-panel-title">Run command is not ready yet</div>
+              <div class="small mb-2" id="run-command-panel-text">
+                Open Prepare Kometa to install, validate, or update the local Kometa setup before running.
+              </div>
+              <button type="button" id="open-kometa-actions-panel-button" class="btn btn-outline-info btn-sm">
+                Open Prepare Kometa
+              </button>
+            </div>
             <div id="run-command-box" class="position-relative border rounded bg-body-tertiary p-3 d-none">
+              <div id="run-command-placeholder" class="alert alert-secondary mb-3 d-none" role="status">
+                <div class="fw-semibold mb-1" id="run-command-placeholder-title">Run command is not ready yet</div>
+                <div class="small mb-2" id="run-command-placeholder-message">
+                  Open Prepare Kometa to install, validate, or update the local Kometa setup before running.
+                </div>
+                <button type="button" id="open-kometa-actions-button" class="btn btn-outline-info btn-sm">
+                  Open Prepare Kometa
+                </button>
+              </div>
               <p class="form-label">Command</p>
               <pre class="mb-0 text-wrap" style="white-space: pre-wrap; word-break: break-word;">
 {% set running_on = version_info.running_on | default('') %}
@@ -664,9 +682,9 @@
       data-kometa-root-default-display="{{ kometa_default_display }}">
 </code>
 </pre>
-              <button type="button" id="copy-command"
-                class="btn btn-outline-secondary btn-sm position-absolute top-0 end-0 m-2 d-flex align-items-center gap-2">
-                <i class="bi bi-files" id="copy-icon"></i>
+                <button type="button" id="copy-command"
+                  class="btn btn-outline-secondary btn-sm position-absolute top-0 end-0 m-2 d-flex align-items-center gap-2">
+                  <i class="bi bi-files" id="copy-icon"></i>
                 <span id="copy-text">Copy</span>
               </button>
               {% if incomplete_resume_hint %}

--- a/tests/test_logscan_endpoints.py
+++ b/tests/test_logscan_endpoints.py
@@ -1,4 +1,5 @@
 import copy
+from datetime import datetime
 import gzip
 import os
 import time
@@ -745,6 +746,64 @@ def test_logscan_progress_tracks_libraries(client, isolated_config_dir, monkeypa
     statuses = {entry["name"]: entry["status"] for entry in payload["libraries"]}
     assert statuses["Movies"] == "Done"
     assert statuses["TV Shows"] == "In progress"
+
+
+def test_logscan_progress_cached_running_payload_keeps_live_elapsed(client, isolated_config_dir, monkeypatch, qs_module):
+    kometa_root = Path(qs_module.app.config["KOMETA_ROOT"])
+    log_dir = kometa_root / "config" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "meta.log"
+    log_path.write_text("still running\n", encoding="utf-8")
+    stats = log_path.stat()
+
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_root_path", lambda: kometa_root)
+    monkeypatch.setattr(qs_module.helpers, "is_kometa_running", lambda: True)
+    monkeypatch.setattr(qs_module, "_load_progress_config", lambda *_args, **_kwargs: {})
+
+    started_at = "2026-04-24T21:00:00"
+    phase_started_at = "2026-04-24T21:05:00"
+    playlist_started_at = "2026-04-24T21:10:00"
+    qs_module.LOGSCAN_PROGRESS_CACHE.update(
+        {
+            "mtime": stats.st_mtime,
+            "size": stats.st_size,
+            "data": {
+                "current_library": "Movies",
+                "phase_current": "collections",
+                "phase_starts": {"Movies||collections": phase_started_at},
+                "libraries": [{"name": "Movies", "type": "movie", "status": "In progress", "durations": {"collections": 12}}],
+                "playlist_running": True,
+                "playlist_started_at": playlist_started_at,
+                "playlist_total_seconds": 5,
+                "preparation_seconds": None,
+                "preparation_elapsed_seconds": None,
+                "run_started_at": started_at,
+            },
+        }
+    )
+    with qs_module.RUN_CONTEXT_LOCK:
+        qs_module.RUN_CONTEXT["started_at"] = datetime.fromisoformat(started_at)
+        qs_module.RUN_CONTEXT["selected_libraries"] = ["Movies"]
+        qs_module.RUN_CONTEXT["config_path"] = None
+        qs_module.RUN_CONTEXT["run_mode"] = "all"
+        qs_module.RUN_CONTEXT["stop_requested_at"] = None
+
+    class _FakeDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            fixed = cls(2026, 4, 24, 21, 15, 0)
+            if tz is not None:
+                return fixed.replace(tzinfo=tz)
+            return fixed
+
+    monkeypatch.setattr(qs_module, "datetime", _FakeDateTime)
+
+    resp = client.get("/logscan/progress")
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["preparation_elapsed_seconds"] == 900
+    assert payload["current_phase_elapsed_seconds"] == 612
+    assert payload["playlist_elapsed_seconds"] == 305
 
 
 def test_logscan_reingest_ingests_day_runtime_log(client, isolated_config_dir, monkeypatch, qs_module):

--- a/tests/test_update_flows.py
+++ b/tests/test_update_flows.py
@@ -3,6 +3,29 @@ import requests
 from modules import helpers
 
 
+def test_cached_kometa_update_reuses_lookup(tmp_path, monkeypatch):
+    root = tmp_path / "kometa"
+    root.mkdir()
+    (root / "VERSION").write_text("1.2.3", encoding="utf-8")
+
+    helpers.invalidate_cached_kometa_update(root)
+    calls = {"count": 0}
+
+    def fake_remote(_branch):
+        calls["count"] += 1
+        return "1.2.4"
+
+    monkeypatch.setattr(helpers, "detect_git_branch", lambda *_args, **_kwargs: "develop", raising=False)
+    monkeypatch.setattr(helpers, "get_kometa_remote_version", fake_remote)
+
+    first = helpers.get_cached_kometa_update(root)
+    second = helpers.get_cached_kometa_update(root)
+
+    assert first["update_available"] is True
+    assert second["cached"] is True
+    assert calls["count"] == 1
+
+
 def test_update_quickstart_success(client, monkeypatch, qs_module):
     monkeypatch.setattr(
         helpers,
@@ -72,6 +95,67 @@ def test_update_kometa_failure_result(client, monkeypatch, qs_module):
     payload = resp.get_json()
     assert payload["success"] is False
     assert payload["kometa_branch"] == "master"
+
+
+def test_check_kometa_update_not_installed_returns_install_needed(client, isolated_config_dir):
+    kometa_root = isolated_config_dir / "kometa-missing"
+    kometa_root.mkdir(parents=True, exist_ok=True)
+
+    resp = client.post("/check-kometa-update", json={"path": str(kometa_root)})
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert payload["kometa_installed"] is False
+    assert payload["update_check_completed"] is False
+    assert payload["kometa_update_available"] is False
+
+
+def test_check_kometa_update_installed_uses_cached_lookup(client, isolated_config_dir, monkeypatch):
+    kometa_root = isolated_config_dir / "kometa-installed"
+    kometa_root.mkdir(parents=True, exist_ok=True)
+    (kometa_root / "kometa.py").write_text("# stub", encoding="utf-8")
+    (kometa_root / "requirements.txt").write_text("requests\n", encoding="utf-8")
+    (kometa_root / "VERSION").write_text("1.0.0", encoding="utf-8")
+
+    monkeypatch.setattr(helpers, "is_kometa_running", lambda: False)
+    monkeypatch.setattr(
+        helpers,
+        "get_cached_kometa_update",
+        lambda *_args, **_kwargs: {
+            "local_version": "1.0.0",
+            "remote_version": "1.0.1",
+            "update_available": True,
+            "cached": True,
+            "branch": "nightly",
+        },
+    )
+
+    resp = client.post("/check-kometa-update", json={"path": str(kometa_root)})
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert payload["kometa_installed"] is True
+    assert payload["update_check_completed"] is True
+    assert payload["kometa_update_available"] is True
+    assert payload["cached"] is True
+    assert payload["local_version"] == "1.0.0"
+    assert payload["remote_version"] == "1.0.1"
+
+
+def test_update_kometa_invalidates_cached_update(client, monkeypatch, qs_module):
+    monkeypatch.setattr(helpers, "is_kometa_running", lambda: False)
+    monkeypatch.setattr(helpers, "detect_git_branch", lambda *_: "develop", raising=False)
+    monkeypatch.setattr(
+        helpers,
+        "perform_kometa_update_zip_only",
+        lambda *_args, **_kwargs: {"success": True, "log": ["ok"], "up_to_date": False},
+    )
+    invalidated = {"path": None}
+    monkeypatch.setattr(helpers, "invalidate_cached_kometa_update", lambda path=None: invalidated.__setitem__("path", path))
+
+    resp = client.post("/update-kometa", json={"force": False})
+    assert resp.status_code == 200
+    assert invalidated["path"] == helpers.CONFIG_DIR
 
 
 def test_get_upstream_sha_non_200(monkeypatch):

--- a/tests/test_workspace_dependency_logic.py
+++ b/tests/test_workspace_dependency_logic.py
@@ -5,8 +5,6 @@ TRAKT_COLLECTION_KEY = "sho-library_tv-collection_trakt"
 OMDB_ATTRIBUTE_KEY = "mov-library_movies-attribute_mass_content_rating_update_omdb"
 MDBLIST_ATTRIBUTE_KEY = "mov-library_movies-attribute_mass_user_rating_update_mdb_tomatoes"
 ANIDB_ATTRIBUTE_KEY = "sho-library_anime-attribute_mass_original_title_update_anidb_official"
-ANIDB_COLLECTION_KEY = "sho-library_anime-collection_use_anidb"
-ANIDB_TEMPLATE_COLLECTION_KEY = "sho-library_anime-template_collection_other_chart_use_anidb"
 RADARR_ATTRIBUTE_KEY = "mov-library_movies-attribute_radarr_add_all"
 RADARR_CUSTOM_KEY = "mov-library_movies-attribute_radarr_remove_by_tag_custom"
 RADARR_COLLECTION_KEY = "mov-library_movies-collection_radarr_add_missing_best"
@@ -14,7 +12,7 @@ RADARR_TEMPLATE_COLLECTION_KEY = "mov-library_movies-template_collection_oscars_
 SONARR_ATTRIBUTE_KEY = "sho-library_tv-attribute_sonarr_add_all"
 SONARR_CUSTOM_KEY = "sho-library_tv-attribute_sonarr_remove_by_tag_custom"
 SONARR_COLLECTION_KEY = "sho-library_tv-collection_sonarr_add_missing_best"
-SONARR_TEMPLATE_COLLECTION_KEY = "sho-library_tv-template_collection_other_chart_sonarr_add_missing_anidb"
+SONARR_TEMPLATE_COLLECTION_KEY = "sho-library_tv-template_collection_other_chart_sonarr_add_missing_commonsense"
 MAL_COLLECTION_KEY = "mov-library_anime-collection_myanimelist"
 MDBLIST_OVERLAY_ENABLED_KEY = "mov-library_movies-movie-overlay_ratings"
 MDBLIST_OVERLAY_IMAGE_KEY = "mov-library_movies-movie-template_overlay_ratings[rating1_image]"
@@ -198,26 +196,6 @@ def test_mal_dependency_reason_cases(qs_module, libraries_data, expected_require
             True,
             "mass_genre_update order includes anidb_3_0",
             id="anidb_order_enabled",
-        ),
-        pytest.param(
-            "_libraries_data_anidb_dependency_reasons",
-            {
-                "sho-library_anime-library": "Anime Shows",
-                ANIDB_COLLECTION_KEY: True,
-            },
-            True,
-            "AniDB Popular collection enabled",
-            id="anidb_collection_enabled",
-        ),
-        pytest.param(
-            "_libraries_data_anidb_dependency_reasons",
-            {
-                "sho-library_anime-library": "Anime Shows",
-                ANIDB_TEMPLATE_COLLECTION_KEY: True,
-            },
-            True,
-            "AniDB Popular collection enabled",
-            id="anidb_template_collection_enabled",
         ),
         pytest.param(
             "_libraries_data_anidb_dependency_reasons",
@@ -1185,48 +1163,6 @@ def test_libraries_anidb_dependency_hint_endpoint_returns_reasons(client, monkey
     assert any("mass_genre_update order includes anidb_rating" in reason for reason in payload["reasons"])
 
 
-def test_libraries_anidb_dependency_hint_endpoint_collection_returns_reasons(client, monkeypatch, qs_module):
-    monkeypatch.setattr(qs_module.persistence, "retrieve_settings", lambda _target: {"libraries": {}})
-
-    resp = client.post(
-        "/libraries_anidb_dependency_hint",
-        json={
-            "source_library_id": "sho-library_anime",
-            "source_payload": {
-                "sho-library_anime-library": "Anime Shows",
-                ANIDB_COLLECTION_KEY: "true",
-            },
-        },
-    )
-
-    assert resp.status_code == 200
-    payload = resp.get_json()
-    assert payload["success"] is True
-    assert payload["required"] is True
-    assert any("AniDB Popular collection enabled" in reason for reason in payload["reasons"])
-
-
-def test_libraries_anidb_dependency_hint_endpoint_template_collection_returns_reasons(client, monkeypatch, qs_module):
-    monkeypatch.setattr(qs_module.persistence, "retrieve_settings", lambda _target: {"libraries": {}})
-
-    resp = client.post(
-        "/libraries_anidb_dependency_hint",
-        json={
-            "source_library_id": "sho-library_anime",
-            "source_payload": {
-                "sho-library_anime-library": "Anime Shows",
-                ANIDB_TEMPLATE_COLLECTION_KEY: "true",
-            },
-        },
-    )
-
-    assert resp.status_code == 200
-    payload = resp.get_json()
-    assert payload["success"] is True
-    assert payload["required"] is True
-    assert any("AniDB Popular collection enabled" in reason for reason in payload["reasons"])
-
-
 def test_libraries_anidb_dependency_hint_endpoint_overlay_returns_reasons(client, monkeypatch, qs_module):
     monkeypatch.setattr(qs_module.persistence, "retrieve_settings", lambda _target: {"libraries": {}})
 
@@ -1370,7 +1306,7 @@ def test_libraries_sonarr_dependency_hint_endpoint_template_collection_returns_r
     payload = resp.get_json()
     assert payload["success"] is True
     assert payload["required"] is True
-    assert any("sonarr_add_missing_anidb enabled" in reason for reason in payload["reasons"])
+    assert any("sonarr_add_missing_commonsense enabled" in reason for reason in payload["reasons"])
 
 
 def test_libraries_sonarr_dependency_hint_endpoint_disabled_payload_returns_empty(client, monkeypatch, qs_module):


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

## Summary

This PR improves Quickstart’s mobile UX, Final Validation flow, config/file-drift handling, and Analytics log management.

## Highlights

- Fixed multiple mobile layout issues across config pages and Final Validation:
  - stacked legacy input groups more cleanly on iPhone
  - fixed token/check button border-radius issues on Trakt/MAL
  - fixed badge truncation and content spill/overflow on mobile
  - fixed non-fullscreen confirm modal behavior on iPhone

- Improved Final Validation behavior:
  - split Kometa page-load behavior into a cheap local probe vs. explicit prepare/update actions
  - added cached Kometa update lookup
  - stopped auto-running the heavy prepare/update path on page load
  - first-time/missing-Kometa state now shows `Install needed` without doing pip/update work
  - clarified Final page wording and rollup states (`Prepare needed`, `Prepared`, etc.)
  - made Run Command show actionable guidance instead of appearing blank when Kometa is not ready

- Strengthened Start-page file drift tools:
  - review orphaned config bundles on disk
  - restore a selected version
  - delete exact scanned filesystem artifacts correctly, including copy-style filenames
  - improved modal progress/success/error states without forced page reloads

- Expanded Analytics log management:
  - Recent Runs now includes incomplete/skipped logs for investigation
  - added per-run and bulk delete/compress/download
  - added archive storage visibility and retention messaging
  - standardized archive naming
  - added `.log.gz` support for archive discovery, reingest, download, delete, retention, and storage totals

- Updated chart/dependency data:
  - removed stale AniDB wiring from `Other Charts`
  - kept Common Sense as movies/shows
  - made Metacritic, StevenLu, and Pirated movie-only

- Added small UX polish items:
  - updated shared spinner quote pool
  - improved modal feedback and action messaging

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
