### PR TITLE
kometa branch selector

### DIFF
--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -62,6 +62,7 @@ PLEX_DISCOVERY_CACHE_TTL_SECONDS = int(os.environ.get("QS_PLEX_DISCOVERY_CACHE_T
 _PLEX_DISCOVERY_CACHE = {}
 KOMETA_UPDATE_CACHE_TTL_SECONDS = int(os.environ.get("QS_KOMETA_UPDATE_CACHE_TTL_SECONDS", "600"))
 _KOMETA_UPDATE_CACHE = {}
+KOMETA_BRANCH_OVERRIDES = {"master", "develop", "nightly"}
 
 
 def _plex_discovery_cache_key(kind, plex_url, plex_token):
@@ -120,18 +121,30 @@ def clear_plex_discovery_cache():
     _PLEX_DISCOVERY_CACHE.clear()
 
 
-def _kometa_update_cache_key(kometa_root, branch, local_version):
+def _kometa_update_cache_key(kometa_root, branch, local_version, local_sha=None, local_branch=None):
     try:
         root = str(Path(kometa_root).resolve())
     except Exception:
         root = str(kometa_root or "")
-    return root, str(branch or "").strip(), str(local_version or "").strip()
+    return root, str(branch or "").strip(), str(local_version or "").strip(), str(local_sha or "").strip(), str(local_branch or "").strip()
 
 
-def get_cached_kometa_update(kometa_root=None, force_refresh=False):
-    branch = get_kometa_branch()
+def normalize_kometa_branch_override(value):
+    branch = str(value or "").strip().lower()
+    return branch if branch in KOMETA_BRANCH_OVERRIDES else ""
+
+
+def resolve_kometa_update_branch(branch_override=None):
+    branch = normalize_kometa_branch_override(branch_override)
+    return branch or get_kometa_branch()
+
+
+def get_cached_kometa_update(kometa_root=None, force_refresh=False, branch_override=None):
+    branch = resolve_kometa_update_branch(branch_override)
     local_version = get_kometa_local_version(kometa_root)
-    key = _kometa_update_cache_key(kometa_root or ".", branch, local_version)
+    local_sha = get_kometa_local_sha(kometa_root)
+    local_branch = get_kometa_local_branch(kometa_root)
+    key = _kometa_update_cache_key(kometa_root or ".", branch, local_version, local_sha=local_sha, local_branch=local_branch)
 
     if not force_refresh:
         entry = _KOMETA_UPDATE_CACHE.get(key)
@@ -143,7 +156,7 @@ def get_cached_kometa_update(kometa_root=None, force_refresh=False):
                 return payload
             _KOMETA_UPDATE_CACHE.pop(key, None)
 
-    payload = check_kometa_update(kometa_root)
+    payload = check_kometa_update(kometa_root, branch_override=branch_override)
     if isinstance(payload, dict):
         payload = copy.deepcopy(payload)
         payload["cached"] = False
@@ -154,7 +167,10 @@ def get_cached_kometa_update(kometa_root=None, force_refresh=False):
         return payload
     return {
         "local_version": local_version,
+        "local_sha": local_sha,
+        "local_branch": local_branch,
         "remote_version": None,
+        "remote_sha": None,
         "branch": branch,
         "update_available": False,
         "cached": False,
@@ -1243,16 +1259,55 @@ def get_kometa_local_version(kometa_root=None):
     return "unknown"
 
 
-def check_kometa_update(kometa_root=None):
-    branch = get_kometa_branch()
+def get_kometa_local_sha(kometa_root=None):
+    if kometa_root is None:
+        kometa_root = Path(app.config.get("KOMETA_ROOT", "."))
+    else:
+        kometa_root = Path(kometa_root)
+
+    return _read_text(kometa_root / ".kometa_sha")
+
+
+def get_kometa_local_branch(kometa_root=None):
+    if kometa_root is None:
+        kometa_root = Path(app.config.get("KOMETA_ROOT", "."))
+    else:
+        kometa_root = Path(kometa_root)
+
+    return normalize_kometa_branch_override(_read_text(kometa_root / ".kometa_branch"))
+
+
+def get_kometa_remote_sha(branch="nightly"):
+    return _get_upstream_sha(branch, [])
+
+
+def check_kometa_update(kometa_root=None, branch_override=None):
+    branch = resolve_kometa_update_branch(branch_override)
     local_version = get_kometa_local_version(kometa_root)
+    local_sha = get_kometa_local_sha(kometa_root)
+    local_branch = get_kometa_local_branch(kometa_root)
     remote_version = get_kometa_remote_version(branch)
-    update_available = remote_version and remote_version != local_version
+    remote_sha = get_kometa_remote_sha(branch)
+    branch_mismatch = bool(local_branch and local_branch != branch)
+
+    if local_sha and remote_sha:
+        update_available = local_sha != remote_sha
+        comparison_basis = "sha"
+    else:
+        update_available = bool(remote_version and remote_version != local_version)
+        comparison_basis = "version"
+        if branch_mismatch:
+            update_available = True
 
     return {
         "local_version": local_version,
+        "local_sha": local_sha,
+        "local_branch": local_branch,
         "remote_version": remote_version,
+        "remote_sha": remote_sha,
         "branch": branch,
+        "branch_mismatch": branch_mismatch,
+        "comparison_basis": comparison_basis,
         "update_available": update_available,
     }
 
@@ -1668,6 +1723,7 @@ def _write_text(p: Path, s: str):
 def _get_upstream_sha(branch: str, logs: list[str]) -> str | None:
     try:
         url = GITHUB_API_BRANCH.format(branch=branch)
+        logs.append(f"🔎 Resolving upstream SHA from: {url}")
         r = requests.get(url, timeout=20)
         if r.status_code != 200:
             logs.append(f"❌ GitHub API {r.status_code} for {url}")
@@ -1686,7 +1742,7 @@ def _get_upstream_sha(branch: str, logs: list[str]) -> str | None:
 def _download_zip(branch: str, logs: list[str]) -> bytes | None:
     try:
         url = GITHUB_ZIP_URL.format(branch=branch)
-        logs.append(f"📥 Downloading {branch}.zip…")
+        logs.append(f"📥 Downloading {branch}.zip from: {url}")
         r = requests.get(url, timeout=60)
         if r.status_code != 200:
             logs.append(f"❌ ZIP download failed ({r.status_code})")
@@ -1781,11 +1837,15 @@ def _extract_zip_bytes(zip_bytes: bytes, dest_dir: Path, logs: list[str]) -> boo
                 tmp_root = Path(td) / root_name
                 zf.extractall(Path(td))
                 # Wipe current contents (keep dest_dir itself)
+                logs.append(f"🧹 Removing existing Kometa contents from: {dest_dir}")
+                removed_count = 0
                 for child in dest_dir.iterdir():
+                    removed_count += 1
                     if child.is_file() or child.is_symlink():
                         child.unlink(missing_ok=True)
                     else:
                         shutil.rmtree(child, ignore_errors=True)
+                logs.append(f"🧹 Removed {removed_count} existing entr{'y' if removed_count == 1 else 'ies'}.")
                 # Copy over
                 for item in tmp_root.iterdir():
                     target = dest_dir / item.name
@@ -1793,6 +1853,11 @@ def _extract_zip_bytes(zip_bytes: bytes, dest_dir: Path, logs: list[str]) -> boo
                         shutil.copytree(item, target, dirs_exist_ok=True)
                     else:
                         shutil.copy2(item, target)
+        version_file = dest_dir / "VERSION"
+        if version_file.exists():
+            version_value = _read_text(version_file)
+            if version_value:
+                logs.append(f"📦 Extracted VERSION file: {version_value}")
         logs.append(f"📦 Extracted to: {dest_dir}")
         return True
     except Exception as e:
@@ -1948,6 +2013,7 @@ def perform_kometa_update_zip_only(config_root: str | Path, branch: str = "night
         config_root = Path(config_root).resolve()
         kometa_dir = config_root / "kometa"
         sha_file = kometa_dir / ".kometa_sha"
+        branch_file = kometa_dir / ".kometa_branch"
 
         logs.append(f"⚙️ ZIP updater → branch '{branch}'")
         _ensure_dir(kometa_dir)
@@ -1989,6 +2055,7 @@ def perform_kometa_update_zip_only(config_root: str | Path, branch: str = "night
             return {"success": False, "log": logs}
 
         _write_text(sha_file, upstream_sha)
+        _write_text(branch_file, branch)
         logs.append("✅ Kometa updated via ZIP.")
         return {"success": True, "log": logs}
 

--- a/quickstart.py
+++ b/quickstart.py
@@ -10239,6 +10239,8 @@ def probe_kometa_root():
 def check_kometa_update():
     payload = request.get_json(silent=True) or {}
     root_path = str(payload.get("path", "")).strip()
+    branch_override_raw = payload.get("branch_override")
+    branch_override = helpers.normalize_kometa_branch_override(branch_override_raw)
     logs = []
 
     def log(msg):
@@ -10248,6 +10250,10 @@ def check_kometa_update():
     if not root_path:
         log("❌ No path provided.")
         return jsonify(success=False, error="No path provided.", log=logs), 400
+
+    if branch_override_raw and not branch_override:
+        log(f"❌ Invalid Kometa branch override: {branch_override_raw}")
+        return jsonify(success=False, error="Invalid Kometa branch override.", log=logs), 400
 
     p = _resolve_user_dir(root_path)
     if not p:
@@ -10292,10 +10298,36 @@ def check_kometa_update():
             200,
         )
 
-    update_info = helpers.get_cached_kometa_update(p, force_refresh=helpers.booler(payload.get("force", False)))
+    if branch_override:
+        log(f"⚠️ Kometa branch override selected: {branch_override}")
+    else:
+        log("ℹ️ Kometa branch selection: auto")
+
+    update_info = helpers.get_cached_kometa_update(
+        p,
+        force_refresh=helpers.booler(payload.get("force", False)),
+        branch_override=branch_override,
+    )
     local_version = update_info.get("local_version") or state["kometa_version"]
     remote_version = update_info.get("remote_version") or ""
+    remote_branch = update_info.get("branch") or "nightly"
+    local_branch = update_info.get("local_branch") or "unknown"
+    local_sha = update_info.get("local_sha") or ""
+    remote_sha = update_info.get("remote_sha") or ""
+    comparison_basis = update_info.get("comparison_basis") or "version"
+    remote_version_url = helpers.GITHUB_BASE_URL + f"/{remote_branch}/VERSION"
+    log(f"🌐 Remote VERSION source: {remote_version_url}")
+    log(f"ℹ️ Installed Kometa branch metadata: {local_branch}")
+    if local_sha:
+        log(f"🔎 Local Kometa SHA: {local_sha[:12]}")
+    if remote_sha:
+        log(f"🔎 Remote Kometa SHA: {remote_sha[:12]}")
+    log(f"ℹ️ Update comparison basis: {comparison_basis}")
+    if update_info.get("cached"):
+        log("ℹ️ Using cached Kometa update lookup.")
     if update_info.get("update_available"):
+        if update_info.get("branch_mismatch"):
+            log(f"⚠️ Installed branch '{local_branch}' differs from selected branch '{remote_branch}'.")
         log(f"⬆️ Update available: {local_version} → {remote_version}")
     else:
         log(f"✅ Kometa is up to date: {local_version}")
@@ -10328,11 +10360,19 @@ def update_kometa():
 
         # (optional) allow the caller to pass qs branch; otherwise detect from repo
         data = request.get_json(silent=True) or {}
+        branch_override_raw = data.get("branch_override")
+        branch_override = helpers.normalize_kometa_branch_override(branch_override_raw)
+        if branch_override_raw and not branch_override:
+            return jsonify({"success": False, "error": "Invalid Kometa branch override.", "log": ["❌ Invalid Kometa branch override."]}), 400
         qs_branch = data.get("branch") or helpers.detect_git_branch(app.root_path)
-        kometa_branch = "master" if qs_branch == "master" else "nightly"
+        kometa_branch = branch_override or ("master" if qs_branch == "master" else "nightly")
         force_update = helpers.booler(data.get("force", False))
 
         logs.append(f"🔎 Quickstart branch: {qs_branch}")
+        if branch_override:
+            logs.append(f"⚠️ Kometa branch override selected: {branch_override}")
+        else:
+            logs.append("ℹ️ Kometa branch selection: auto")
         logs.append(f"⚙️ Kometa branch selected: {kometa_branch} (ZIP mode)")
         if force_update:
             logs.append("Force update enabled.")

--- a/static/local-js/900-final.js
+++ b/static/local-js/900-final.js
@@ -26,6 +26,7 @@ let lastLogscanPayload = null
 let logscanPollCounter = 0
 let finalLogscanAnalyzeTriggered = false
 let lastRunProgressPayload = null
+const KOMETA_BRANCH_OVERRIDE_STORAGE_KEY = 'qs-kometa-branch-override'
 
 const _qsEnvEl = document.getElementById('qs-env')
 const runningOn = (_qsEnvEl && _qsEnvEl.dataset.runningOn) ? _qsEnvEl.dataset.runningOn : ''
@@ -63,6 +64,13 @@ $(document).ready(function () {
   const $logscanSections = $('#logscan-sections')
   const $updateKometaBtn = $('#update-kometa-btn')
   const $forceUpdateToggle = $('#force-kometa-update')
+  const $kometaBranchOverride = $('#kometa-branch-override')
+  const $kometaBranchSelection = $('#kometa-branch-selection')
+  const $kometaEffectiveBranch = $('#kometa-effective-branch')
+  const $kometaLocalVersionStatus = $('#kometa-local-version-status')
+  const $kometaRemoteVersionStatus = $('#kometa-remote-version-status')
+  const $kometaVersionSourceUrl = $('#kometa-version-source-url')
+  const $kometaZipSourceUrl = $('#kometa-zip-source-url')
   const $runStatusRow = $('#run-status-row')
   const $runStatusTimer = $('#run-status-timer')
   const $runStatusMetrics = $('#run-status-metrics')
@@ -90,8 +98,13 @@ $(document).ready(function () {
   const kometaActionsHeading = document.getElementById('kometa-actions-heading')
   const kometaActionsCollapse = document.getElementById('kometa-actions-collapse')
   const kometaActionsToggle = document.getElementById('kometa-actions-toggle')
+  const kometaBranchOverrideWarning = document.getElementById('kometa-branch-override-warning')
   const runCommandCollapse = document.getElementById('run-command-output-collapse')
   let headerStyleSubmitting = false
+  let kometaLocalVersionStatus = 'Unknown'
+  let kometaRemoteVersionStatus = ''
+  let kometaRemoteVersionChecked = false
+  let kometaRemoteVersionSkipped = false
 
   function readMetaFlag (id, datasetKey, attrKey) {
     const el = document.getElementById(id)
@@ -1002,15 +1015,12 @@ $(document).ready(function () {
   }
 
   function probeKometaRoot () {
-    const $logBox = $('#kometa-validation-log')
     const $out = $('#run-command-output')
     const defaultRootPosix = ($out.data('kometa-root-default') || '').toString().trim()
     const defaultRootDisplay = ($out.data('kometa-root-default-display') || defaultRootPosix)
-    if (!defaultRootPosix) return
+    if (!defaultRootPosix) return Promise.resolve(null)
 
-    $logBox.text('🔍 Checking Kometa path and local install state...\n\n')
-
-    $.ajax({
+    return $.ajax({
       type: 'POST',
       url: '/probe-kometa-root',
       contentType: 'application/json',
@@ -1018,7 +1028,7 @@ $(document).ready(function () {
       success: (res) => {
         KOMETA_LOCAL_CHECK_COMPLETED = true
         KOMETA_INSTALLED = !!res.kometa_installed
-        if (Array.isArray(res.log)) res.log.forEach(line => $logBox.append(`${line}\n`))
+        if (Array.isArray(res.log)) res.log.forEach(line => appendKometaStatusLine(line))
 
         const kometaRootDisplay = (res.kometa_root_display || res.kometa_root || defaultRootDisplay)
         const venvPythonDisplay = (res.venv_python_display || res.venv_python || 'python3')
@@ -1030,6 +1040,7 @@ $(document).ready(function () {
         $out.data('kometa-root-posix', kometaRootPosix)
         $out.data('venv-python-posix', venvPythonPosix)
         $('#kometa-install-path').text(kometaRootDisplay)
+        syncKometaSourceStatus({ localVersion: res.kometa_version || 'Unknown' })
 
         if (!KOMETA_INSTALLED) {
           KOMETA_VALIDATED = false
@@ -1044,7 +1055,8 @@ $(document).ready(function () {
         KOMETA_INSTALLED = false
         KOMETA_VALIDATED = false
         const msg = xhr?.responseJSON?.error || 'Unable to probe the Kometa path.'
-        $logBox.append(`❌ ${msg}\n`)
+        appendKometaStatusLine(`❌ ${msg}`)
+        syncKometaSourceStatus({ localVersion: 'Unknown' })
         hideRunCommandSectionUntilValidated()
         syncUpdateButtonLabel()
         syncKometaRollupBadge()
@@ -1053,18 +1065,15 @@ $(document).ready(function () {
   }
 
   function checkKometaUpdate (forceRefresh = false) {
-    const $logBox = $('#kometa-validation-log')
     const $out = $('#run-command-output')
     const defaultRootPosix = ($out.data('kometa-root-default') || '').toString().trim()
+    const branchOverride = getKometaBranchOverride()
     if (!defaultRootPosix) return Promise.resolve(null)
-
-    $logBox.append('\n🔎 Checking Kometa update status...\n')
-    if ($logBox[0]) $logBox[0].scrollTop = $logBox[0].scrollHeight
 
     return fetch('/check-kometa-update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ path: defaultRootPosix, force: forceRefresh })
+      body: JSON.stringify({ path: defaultRootPosix, force: forceRefresh, branch_override: branchOverride })
     })
       .then(async res => {
         const data = await res.json()
@@ -1077,7 +1086,13 @@ $(document).ready(function () {
         KOMETA_UPDATE_CHECK_COMPLETED = !!data.update_check_completed
         KOMETA_UPDATE_CHECK_SKIPPED = !!data.kometa_update_check_skipped
         KOMETA_UPDATE_AVAILABLE = !!data.kometa_update_available
-        if (Array.isArray(data.log)) data.log.forEach(line => $logBox.append(`${line}\n`))
+        if (Array.isArray(data.log)) data.log.forEach(line => appendKometaStatusLine(line))
+        syncKometaSourceStatus({
+          localVersion: data.local_version || kometaLocalVersionStatus,
+          remoteVersion: data.remote_version || '',
+          checked: Boolean(data.update_check_completed),
+          skipped: Boolean(data.kometa_update_check_skipped)
+        })
 
         if (data.local_version && data.remote_version && data.kometa_update_available) {
           $('#kometa-update-box').removeClass('d-none')
@@ -1089,14 +1104,13 @@ $(document).ready(function () {
 
         syncUpdateButtonLabel()
         syncKometaRollupBadge()
-        if ($logBox[0]) $logBox[0].scrollTop = $logBox[0].scrollHeight
         return data
       })
       .catch(err => {
-        $logBox.append(`❌ ${err.message || 'Failed to check Kometa update status.'}\n`)
+        appendKometaStatusLine(`❌ ${err.message || 'Failed to check Kometa update status.'}`)
+        syncKometaSourceStatus({ checked: false, skipped: false, remoteVersion: '' })
         syncUpdateButtonLabel()
         syncKometaRollupBadge()
-        if ($logBox[0]) $logBox[0].scrollTop = $logBox[0].scrollHeight
         throw err
       })
   }
@@ -1149,6 +1163,145 @@ $(document).ready(function () {
       kometaActionsToggle.classList.toggle('kometa-update-attention', needsAttention)
     }
     syncKometaRollupBadge()
+  }
+
+  function getKometaBranchOverride () {
+    const raw = ($kometaBranchOverride.val() || '').toString().trim().toLowerCase()
+    return ['master', 'develop', 'nightly'].includes(raw) ? raw : ''
+  }
+
+  function getQuickstartBranch () {
+    return ($updateKometaBtn.data('qs-branch') || 'master').toString().trim().toLowerCase()
+  }
+
+  function getAutoKometaBranch () {
+    return getQuickstartBranch() === 'master' ? 'master' : 'nightly'
+  }
+
+  function getEffectiveKometaBranch () {
+    return getKometaBranchOverride() || getAutoKometaBranch()
+  }
+
+  function getKometaVersionSourceUrlValue (branch) {
+    return `https://raw.githubusercontent.com/Kometa-Team/Kometa/${branch}/VERSION`
+  }
+
+  function getKometaZipSourceUrlValue (branch) {
+    return `https://codeload.github.com/kometa-team/Kometa/zip/refs/heads/${branch}`
+  }
+
+  function loadSavedKometaBranchOverride () {
+    try {
+      const saved = window.localStorage.getItem(KOMETA_BRANCH_OVERRIDE_STORAGE_KEY) || ''
+      if (['master', 'develop', 'nightly'].includes(saved)) {
+        $kometaBranchOverride.val(saved)
+      } else {
+        $kometaBranchOverride.val('')
+      }
+    } catch (_) {
+      $kometaBranchOverride.val('')
+    }
+  }
+
+  function saveKometaBranchOverride () {
+    try {
+      const value = getKometaBranchOverride()
+      if (value) window.localStorage.setItem(KOMETA_BRANCH_OVERRIDE_STORAGE_KEY, value)
+      else window.localStorage.removeItem(KOMETA_BRANCH_OVERRIDE_STORAGE_KEY)
+    } catch (_) {}
+  }
+
+  function syncKometaSourceStatus (options = {}) {
+    if (Object.prototype.hasOwnProperty.call(options, 'localVersion')) {
+      kometaLocalVersionStatus = options.localVersion || 'Unknown'
+    }
+    if (Object.prototype.hasOwnProperty.call(options, 'remoteVersion')) {
+      kometaRemoteVersionStatus = options.remoteVersion || ''
+    }
+    if (Object.prototype.hasOwnProperty.call(options, 'checked')) {
+      kometaRemoteVersionChecked = Boolean(options.checked)
+    }
+    if (Object.prototype.hasOwnProperty.call(options, 'skipped')) {
+      kometaRemoteVersionSkipped = Boolean(options.skipped)
+    }
+
+    const selected = getKometaBranchOverride()
+    const effective = getEffectiveKometaBranch()
+    const selectionLabel = selected ? `Override (${selected})` : 'Auto'
+
+    $kometaBranchSelection.text(selectionLabel)
+    $kometaEffectiveBranch.text(effective)
+    $kometaLocalVersionStatus.text(kometaLocalVersionStatus || 'Unknown')
+
+    if (kometaRemoteVersionSkipped) {
+      $kometaRemoteVersionStatus.text('Skipped while running')
+    } else if (kometaRemoteVersionChecked) {
+      $kometaRemoteVersionStatus.text(kometaRemoteVersionStatus || 'Unknown')
+    } else {
+      $kometaRemoteVersionStatus.text('Not checked')
+    }
+
+    $kometaVersionSourceUrl.text(getKometaVersionSourceUrlValue(effective))
+    $kometaZipSourceUrl.text(getKometaZipSourceUrlValue(effective))
+  }
+
+  function setKometaStatusLog (lines) {
+    const $logBox = $('#kometa-validation-log')
+    const text = Array.isArray(lines) ? lines.join('\n') : String(lines || '')
+    $logBox.text(text ? `${text}\n` : '')
+    if ($logBox[0]) $logBox[0].scrollTop = $logBox[0].scrollHeight
+  }
+
+  function appendKometaStatusLine (line) {
+    const $logBox = $('#kometa-validation-log')
+    $logBox.append(`${line}\n`)
+    if ($logBox[0]) $logBox[0].scrollTop = $logBox[0].scrollHeight
+  }
+
+  function syncKometaBranchOverrideWarning () {
+    if (!kometaBranchOverrideWarning) return
+    kometaBranchOverrideWarning.classList.toggle('d-none', !getKometaBranchOverride())
+  }
+
+  function invalidateKometaUpdateStatus () {
+    KOMETA_UPDATE_AVAILABLE = false
+    KOMETA_UPDATE_CHECK_COMPLETED = false
+    KOMETA_UPDATE_CHECK_SKIPPED = false
+    kometaRemoteVersionStatus = ''
+    kometaRemoteVersionChecked = false
+    kometaRemoteVersionSkipped = false
+    $('#kometa-update-box').addClass('d-none')
+    syncKometaSourceStatus()
+    syncUpdateButtonLabel()
+    syncKometaRollupBadge()
+  }
+
+  function runKometaStatusPass (forceRefresh = false) {
+    const selection = getKometaBranchOverride()
+    const effective = getEffectiveKometaBranch()
+    const lines = [
+      '🔄 Refreshing Kometa status...',
+      `ℹ️ Selected Kometa branch mode: ${selection || 'auto'}`,
+      `ℹ️ Effective Kometa branch: ${effective}`,
+      `🌐 Remote VERSION source: ${getKometaVersionSourceUrlValue(effective)}`,
+      `📥 Kometa ZIP source: ${getKometaZipSourceUrlValue(effective)}`,
+      '',
+      '🔍 Checking Kometa path and local install state...'
+    ]
+    setKometaStatusLog(lines)
+    invalidateKometaUpdateStatus()
+    return probeKometaRoot()
+      .then((res) => {
+        if (!res || !res.kometa_installed) {
+          appendKometaStatusLine('')
+          appendKometaStatusLine('ℹ️ Remote update check skipped because Kometa is not installed.')
+          return res
+        }
+        appendKometaStatusLine('')
+        appendKometaStatusLine('🔎 Checking Kometa update status...')
+        return checkKometaUpdate(forceRefresh)
+      })
+      .catch(() => null)
   }
 
   function getKometaRollupStatus () {
@@ -1563,13 +1716,15 @@ $(document).ready(function () {
     const $runNow = $('#run-now')
     const $stopNow = $('#stop-now')
     const $runBox = $('#run-command-box')
-    const branch = $btn.data('branch') || 'master'
+    const qsBranch = $btn.data('qs-branch') || 'master'
+    const branchOverride = getKometaBranchOverride()
     const forceUpdate = $forceUpdateToggle.is(':checked')
 
     if (KOMETA_INSTALLED && !forceUpdate && !KOMETA_UPDATE_AVAILABLE) {
       $btn.prop('disabled', true).html('<i class="bi bi-arrow-repeat me-1"></i> Checking...')
       $forceUpdateToggle.prop('disabled', true)
-      checkKometaUpdate(true)
+      $kometaBranchOverride.prop('disabled', true)
+      runKometaStatusPass(true)
         .then((data) => {
           if (!data) return
           if (data.kometa_update_available) {
@@ -1584,6 +1739,7 @@ $(document).ready(function () {
         .finally(() => {
           $btn.prop('disabled', false)
           $forceUpdateToggle.prop('disabled', false)
+          $kometaBranchOverride.prop('disabled', false)
           syncUpdateButtonLabel()
         })
       return
@@ -1607,6 +1763,7 @@ $(document).ready(function () {
       : (KOMETA_INSTALLED ? 'Checking for updates...' : 'Installing...')
     $btn.prop('disabled', true).html(`<i class="bi bi-arrow-repeat me-1"></i> ${inProgressLabel}`)
     $forceUpdateToggle.prop('disabled', true)
+    $kometaBranchOverride.prop('disabled', true)
     $logBox.append('\nInitializing/Updating Kometa...\n')
     if ($logBox[0]) $logBox[0].scrollTop = $logBox[0].scrollHeight
 
@@ -1627,6 +1784,7 @@ $(document).ready(function () {
       $stopNow.prop('disabled', false)
       $btn.prop('disabled', false)
       $forceUpdateToggle.prop('disabled', false)
+      $kometaBranchOverride.prop('disabled', false)
       syncUpdateButtonLabel()
       updateRunNowState()
       if (postUpdateLabel) {
@@ -1638,7 +1796,7 @@ $(document).ready(function () {
     fetch('/update-kometa', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ branch, force: forceUpdate })
+      body: JSON.stringify({ branch: qsBranch, branch_override: branchOverride, force: forceUpdate })
     })
       .then(async res => {
         const data = await res.json()
@@ -1696,6 +1854,14 @@ $(document).ready(function () {
   $forceUpdateToggle.on('change', function () {
     if (!KOMETA_UPDATING) syncUpdateButtonLabel()
   })
+  $kometaBranchOverride.on('change', function () {
+    saveKometaBranchOverride()
+    syncKometaBranchOverrideWarning()
+    if (!KOMETA_UPDATING) runKometaStatusPass(true)
+  })
+  loadSavedKometaBranchOverride()
+  syncKometaBranchOverrideWarning()
+  syncKometaSourceStatus()
   syncUpdateButtonLabel()
   syncKometaRollupBadge()
 
@@ -2259,9 +2425,9 @@ $(document).ready(function () {
   hideRunCommandSectionUntilValidated()
   checkKometaStatus()
 
-  // First-run: only probe local install state. Heavy prepare is user-driven.
+  // First-run: clear and replay a single current Kometa status pass.
   if (document.getElementById('kometa-validation-log')) {
-    probeKometaRoot()
+    runKometaStatusPass(false)
   }
 
   if (kometaActionsCollapse) {

--- a/templates/900-final.html
+++ b/templates/900-final.html
@@ -384,9 +384,31 @@
                 Kometa will be installed/updated in:
                 <code id="kometa-install-path">{{ kometa_default_display }}</code>
               </div>
+              <div class="row g-2 align-items-end mb-2">
+                <div class="col-sm-6 col-lg-4">
+                  <label class="form-label form-label-sm mb-1" for="kometa-branch-override">Kometa Branch</label>
+                  <select id="kometa-branch-override" class="form-select form-select-sm">
+                    <option value="">Auto (default)</option>
+                    <option value="master">master</option>
+                    <option value="develop">develop</option>
+                    <option value="nightly">nightly</option>
+                  </select>
+                </div>
+              </div>
+              <div id="kometa-branch-override-warning" class="alert alert-warning small py-2 px-3 mb-2 d-none" role="alert">
+                Branch override is enabled. This bypasses Quickstart's default Kometa branch selection and will install or check the selected branch directly.
+              </div>
+              <div class="alert alert-light border small py-2 px-3 mb-2" role="status">
+                <div><strong>Selection:</strong> <span id="kometa-branch-selection">Auto</span></div>
+                <div><strong>Effective branch:</strong> <code id="kometa-effective-branch">nightly</code></div>
+                <div><strong>Local version:</strong> <span id="kometa-local-version-status">Unknown</span></div>
+                <div><strong>Remote version:</strong> <span id="kometa-remote-version-status">Not checked</span></div>
+                <div><strong>Remote VERSION source:</strong> <code id="kometa-version-source-url"></code></div>
+                <div><strong>Kometa ZIP source:</strong> <code id="kometa-zip-source-url"></code></div>
+              </div>
               <div class="d-flex flex-wrap align-items-center gap-3">
                 <button id="update-kometa-btn" type="button" class="btn btn-primary btn-sm"
-                  data-branch="{{ version_info.branch }}">
+                  data-qs-branch="{{ version_info.branch }}">
                   <i class="bi bi-arrow-clockwise me-1"></i> Check for Kometa Updates
                 </button>
                 <div class="form-check form-switch small">

--- a/tests/test_update_flows.py
+++ b/tests/test_update_flows.py
@@ -1,3 +1,6 @@
+import io
+import zipfile
+
 import requests
 
 from modules import helpers
@@ -7,6 +10,8 @@ def test_cached_kometa_update_reuses_lookup(tmp_path, monkeypatch):
     root = tmp_path / "kometa"
     root.mkdir()
     (root / "VERSION").write_text("1.2.3", encoding="utf-8")
+    (root / ".kometa_sha").write_text("localsha", encoding="utf-8")
+    (root / ".kometa_branch").write_text("nightly", encoding="utf-8")
 
     helpers.invalidate_cached_kometa_update(root)
     calls = {"count": 0}
@@ -17,6 +22,7 @@ def test_cached_kometa_update_reuses_lookup(tmp_path, monkeypatch):
 
     monkeypatch.setattr(helpers, "detect_git_branch", lambda *_args, **_kwargs: "develop", raising=False)
     monkeypatch.setattr(helpers, "get_kometa_remote_version", fake_remote)
+    monkeypatch.setattr(helpers, "get_kometa_remote_sha", lambda _branch: "remotesha")
 
     first = helpers.get_cached_kometa_update(root)
     second = helpers.get_cached_kometa_update(root)
@@ -140,6 +146,64 @@ def test_check_kometa_update_installed_uses_cached_lookup(client, isolated_confi
     assert payload["cached"] is True
     assert payload["local_version"] == "1.0.0"
     assert payload["remote_version"] == "1.0.1"
+    assert any("Remote VERSION source" in line for line in payload["log"])
+    assert any("Using cached Kometa update lookup." in line for line in payload["log"])
+
+
+def test_check_kometa_update_branch_override_uses_selected_branch(client, isolated_config_dir, monkeypatch):
+    kometa_root = isolated_config_dir / "kometa-override"
+    kometa_root.mkdir(parents=True, exist_ok=True)
+    (kometa_root / "kometa.py").write_text("# stub", encoding="utf-8")
+    (kometa_root / "requirements.txt").write_text("requests\n", encoding="utf-8")
+    (kometa_root / "VERSION").write_text("1.0.0", encoding="utf-8")
+
+    monkeypatch.setattr(helpers, "is_kometa_running", lambda: False)
+    captured = {"branch_override": None}
+
+    def fake_cached(_root, force_refresh=False, branch_override=None):
+        captured["branch_override"] = branch_override
+        return {
+            "local_version": "1.0.0",
+            "local_branch": "nightly",
+            "local_sha": "abc123nightly",
+            "remote_version": "1.1.0-develop5",
+            "remote_sha": "def456develop",
+            "update_available": True,
+            "cached": False,
+            "branch": "develop",
+            "comparison_basis": "sha",
+        }
+
+    monkeypatch.setattr(helpers, "get_cached_kometa_update", fake_cached)
+
+    resp = client.post("/check-kometa-update", json={"path": str(kometa_root), "branch_override": "develop"})
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert captured["branch_override"] == "develop"
+    assert any("Kometa branch override selected: develop" in line for line in payload["log"])
+    assert any("/develop/VERSION" in line for line in payload["log"])
+    assert any("Local Kometa SHA" in line for line in payload["log"])
+    assert any("Remote Kometa SHA" in line for line in payload["log"])
+
+
+def test_check_kometa_update_detects_sha_difference_even_when_versions_match(monkeypatch, tmp_path):
+    root = tmp_path / "kometa"
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "VERSION").write_text("2.3.1", encoding="utf-8")
+    (root / ".kometa_sha").write_text("mastersha", encoding="utf-8")
+    (root / ".kometa_branch").write_text("master", encoding="utf-8")
+
+    monkeypatch.setattr(helpers, "get_kometa_remote_version", lambda _branch: "2.3.1")
+    monkeypatch.setattr(helpers, "get_kometa_remote_sha", lambda _branch: "developsha")
+
+    result = helpers.check_kometa_update(root, branch_override="develop")
+    assert result["update_available"] is True
+    assert result["comparison_basis"] == "sha"
+    assert result["local_branch"] == "master"
+    assert result["branch"] == "develop"
+    assert result["local_sha"] == "mastersha"
+    assert result["remote_sha"] == "developsha"
 
 
 def test_update_kometa_invalidates_cached_update(client, monkeypatch, qs_module):
@@ -158,6 +222,26 @@ def test_update_kometa_invalidates_cached_update(client, monkeypatch, qs_module)
     assert invalidated["path"] == helpers.CONFIG_DIR
 
 
+def test_update_kometa_branch_override_uses_selected_branch(client, monkeypatch, qs_module):
+    monkeypatch.setattr(helpers, "is_kometa_running", lambda: False)
+    monkeypatch.setattr(helpers, "detect_git_branch", lambda *_: "master", raising=False)
+    captured = {"branch": None}
+
+    def fake_update(_config_root, branch="nightly", force=False):
+        captured["branch"] = branch
+        return {"success": True, "log": ["ok"], "up_to_date": False}
+
+    monkeypatch.setattr(helpers, "perform_kometa_update_zip_only", fake_update)
+
+    resp = client.post("/update-kometa", json={"branch_override": "develop", "force": False})
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert payload["kometa_branch"] == "develop"
+    assert captured["branch"] == "develop"
+    assert any("Kometa branch override selected: develop" in line for line in payload["log"])
+
+
 def test_get_upstream_sha_non_200(monkeypatch):
     class _Resp:
         status_code = 500
@@ -169,6 +253,7 @@ def test_get_upstream_sha_non_200(monkeypatch):
     logs = []
     sha = helpers._get_upstream_sha("nightly", logs)
     assert sha is None
+    assert any("Resolving upstream SHA from:" in line for line in logs)
     assert any("GitHub API" in line for line in logs)
 
 
@@ -180,6 +265,7 @@ def test_download_zip_timeout(monkeypatch):
     logs = []
     data = helpers._download_zip("nightly", logs)
     assert data is None
+    assert any("Downloading nightly.zip from:" in line for line in logs)
     assert any("Exception during ZIP download" in line for line in logs)
 
 
@@ -188,3 +274,43 @@ def test_extract_zip_bytes_invalid(isolated_config_dir):
     ok = helpers._extract_zip_bytes(b"not-a-zip", isolated_config_dir / "kometa", logs)
     assert ok is False
     assert any("Extraction failed" in line for line in logs)
+
+
+def test_extract_zip_bytes_replaces_existing_contents(isolated_config_dir):
+    dest_dir = isolated_config_dir / "kometa"
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    (dest_dir / "old.txt").write_text("stale", encoding="utf-8")
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("Kometa-develop/VERSION", "9.9.9-develop1")
+        zf.writestr("Kometa-develop/kometa.py", "# stub")
+
+    logs = []
+    ok = helpers._extract_zip_bytes(buf.getvalue(), dest_dir, logs)
+
+    assert ok is True
+    assert not (dest_dir / "old.txt").exists()
+    assert (dest_dir / "VERSION").read_text(encoding="utf-8").strip() == "9.9.9-develop1"
+    assert any("Removing existing Kometa contents" in line for line in logs)
+    assert any("Extracted VERSION file: 9.9.9-develop1" in line for line in logs)
+
+
+def test_perform_kometa_update_zip_only_writes_branch_metadata(tmp_path, monkeypatch):
+    config_root = tmp_path / "config"
+    kometa_dir = config_root / "kometa"
+    kometa_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(helpers, "_get_upstream_sha", lambda branch, logs: "sha123")
+    monkeypatch.setattr(helpers, "_download_zip", lambda branch, logs: b"zip-bytes")
+    monkeypatch.setattr(helpers, "_extract_zip_bytes", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(helpers, "_backup_kometa_runtime_assets", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(helpers, "_restore_kometa_runtime_assets", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(helpers, "_cleanup_kometa_backup", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(helpers, "_ensure_venv", lambda *_args, **_kwargs: (kometa_dir / "python", kometa_dir / "pip"))
+    monkeypatch.setattr(helpers, "_pip_install", lambda *_args, **_kwargs: True)
+
+    result = helpers.perform_kometa_update_zip_only(config_root, branch="develop", force=False)
+    assert result["success"] is True
+    assert (kometa_dir / ".kometa_sha").read_text(encoding="utf-8").strip() == "sha123"
+    assert (kometa_dir / ".kometa_branch").read_text(encoding="utf-8").strip() == "develop"


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Adds a Kometa branch override to Final Validation with Auto, master, develop, and nightly, while preserving the existing default branch mapping. It also improves updater transparency by showing the exact remote VERSION and ZIP sources, persists installed branch/SHA metadata for accurate branch-aware update checks, and refactors the Kometa status console to clear and replay a single current status pass on load and branch changes instead of accumulating stale output.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
