### PR TITLE
improve kometa updates

### DIFF
--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -1822,6 +1822,34 @@ def _cleanup_kometa_backup(backup_dir: Path, logs: list[str]):
         logs.append(f"? Failed to remove Kometa backup: {e}")
 
 
+def _clear_directory_contents(dest_dir: Path, logs: list[str]) -> bool:
+    logs.append(f"🧹 Removing existing Kometa contents from: {dest_dir}")
+    removed_count = 0
+    failed_paths = []
+
+    for child in list(dest_dir.iterdir()):
+        try:
+            if child.is_file() or child.is_symlink():
+                child.unlink()
+            else:
+                shutil.rmtree(child)
+            removed_count += 1
+        except Exception as e:
+            failed_paths.append((child, e))
+            logs.append(f"❌ Failed to remove existing path: {child} ({e})")
+
+    leftovers = list(dest_dir.iterdir())
+    if leftovers:
+        for leftover in leftovers:
+            if all(str(leftover) != str(path) for path, _err in failed_paths):
+                logs.append(f"❌ Existing path still present after cleanup: {leftover}")
+        logs.append("❌ Aborting extraction because the Kometa directory is not empty after cleanup.")
+        return False
+
+    logs.append(f"🧹 Removed {removed_count} existing entr{'y' if removed_count == 1 else 'ies'}.")
+    return True
+
+
 def _extract_zip_bytes(zip_bytes: bytes, dest_dir: Path, logs: list[str]) -> bool:
     try:
         _ensure_dir(dest_dir)
@@ -1836,16 +1864,8 @@ def _extract_zip_bytes(zip_bytes: bytes, dest_dir: Path, logs: list[str]) -> boo
             with tempfile.TemporaryDirectory(dir=tmp_base) as td:
                 tmp_root = Path(td) / root_name
                 zf.extractall(Path(td))
-                # Wipe current contents (keep dest_dir itself)
-                logs.append(f"🧹 Removing existing Kometa contents from: {dest_dir}")
-                removed_count = 0
-                for child in dest_dir.iterdir():
-                    removed_count += 1
-                    if child.is_file() or child.is_symlink():
-                        child.unlink(missing_ok=True)
-                    else:
-                        shutil.rmtree(child, ignore_errors=True)
-                logs.append(f"🧹 Removed {removed_count} existing entr{'y' if removed_count == 1 else 'ies'}.")
+                if not _clear_directory_contents(dest_dir, logs):
+                    return False
                 # Copy over
                 for item in tmp_root.iterdir():
                     target = dest_dir / item.name
@@ -2001,14 +2021,14 @@ def _pip_install(python_bin: Path, kometa_dir: Path, logs: list[str]) -> bool:
     return True
 
 
-def perform_kometa_update_zip_only(config_root: str | Path, branch: str = "nightly", force: bool = False):
+def perform_kometa_update_zip_only(config_root: str | Path, branch: str = "nightly", force: bool = False, logs=None):
     """
     Update Kometa by downloading/extracting the branch ZIP into:
         {config_root}/kometa
     Uses upstream commit SHA to skip when up-to-date unless force is True.
     Works identically for local, PyInstaller, and Docker installs.
     """
-    logs = []
+    logs = logs if logs is not None else []
     try:
         config_root = Path(config_root).resolve()
         kometa_dir = config_root / "kometa"

--- a/quickstart.py
+++ b/quickstart.py
@@ -61,6 +61,8 @@ from typing import Dict, Any
 # A very simple in-memory progress store
 CLONE_PROGRESS: Dict[str, Dict[str, Any]] = {}
 ACTIVE_TEST_LIB_JOB: Dict[str, Any] = {}
+KOMETA_UPDATE_PROGRESS: Dict[str, Dict[str, Any]] = {}
+ACTIVE_KOMETA_UPDATE_JOB: Dict[str, Any] = {}
 LOG_STATS_CACHE = {"mtime": None, "size": None, "stats": None}
 LOGSCAN_ANALYSIS_CACHE = {"mtime": None, "size": None, "data": None}
 LOGSCAN_PROGRESS_CACHE = {"mtime": None, "size": None, "data": None}
@@ -10354,7 +10356,6 @@ def update_kometa():
     if helpers.is_kometa_running():
         pid = helpers.get_kometa_pid()
         return jsonify({"success": False, "error": f"Kometa is currently running (PID {pid}). Stop it before updating."}), 409
-    logs = []
     try:
         cfg_dir = helpers.CONFIG_DIR
 
@@ -10367,7 +10368,79 @@ def update_kometa():
         qs_branch = data.get("branch") or helpers.detect_git_branch(app.root_path)
         kometa_branch = branch_override or ("master" if qs_branch == "master" else "nightly")
         force_update = helpers.booler(data.get("force", False))
+        background = data.get("background") is True
 
+        if background:
+            active_job_id = ACTIVE_KOMETA_UPDATE_JOB.get("job_id")
+            if active_job_id:
+                info = KOMETA_UPDATE_PROGRESS.get(active_job_id) or {}
+                phase = info.get("phase")
+                if phase and phase not in ["done", "error"]:
+                    return (
+                        jsonify(success=True, active=True, existing_job=True, job_id=active_job_id, phase=phase),
+                        200,
+                    )
+                ACTIVE_KOMETA_UPDATE_JOB.clear()
+
+            job_id = str(uuid.uuid4())
+            KOMETA_UPDATE_PROGRESS[job_id] = {
+                "phase": "queued",
+                "lines": [],
+                "done": False,
+                "success": False,
+                "up_to_date": False,
+                "skipped": False,
+                "force": force_update,
+                "qs_branch": qs_branch,
+                "kometa_branch": kometa_branch,
+            }
+            ACTIVE_KOMETA_UPDATE_JOB["job_id"] = job_id
+            ACTIVE_KOMETA_UPDATE_JOB["started_at"] = time.time()
+
+            def worker():
+                progress = KOMETA_UPDATE_PROGRESS[job_id]
+
+                class _ProgressLog(list):
+                    def append(self_inner, item):
+                        super().append(item)
+                        progress["lines"].append(item)
+
+                logs = _ProgressLog()
+                progress["phase"] = "running"
+                logs.append(f"🔎 Quickstart branch: {qs_branch}")
+                if branch_override:
+                    logs.append(f"⚠️ Kometa branch override selected: {branch_override}")
+                else:
+                    logs.append("ℹ️ Kometa branch selection: auto")
+                logs.append(f"⚙️ Kometa branch selected: {kometa_branch} (ZIP mode)")
+                if force_update:
+                    logs.append("Force update enabled.")
+
+                try:
+                    result = helpers.perform_kometa_update_zip_only(cfg_dir, branch=kometa_branch, force=force_update, logs=logs)
+                    try:
+                        helpers.invalidate_cached_kometa_update(cfg_dir)
+                    except Exception:
+                        pass
+                    progress["success"] = bool(result.get("success", False))
+                    progress["up_to_date"] = bool(result.get("up_to_date", False))
+                    progress["skipped"] = bool(result.get("skipped", False))
+                    progress["phase"] = "done" if progress["success"] else "error"
+                    progress["done"] = True
+                except Exception as e:
+                    progress["lines"].append("Exception during Kometa update.")
+                    helpers.ts_log(f"Kometa update failed: {e}", level="ERROR")
+                    progress["phase"] = "error"
+                    progress["done"] = True
+                    progress["success"] = False
+                finally:
+                    if ACTIVE_KOMETA_UPDATE_JOB.get("job_id") == job_id:
+                        ACTIVE_KOMETA_UPDATE_JOB.clear()
+
+            threading.Thread(target=worker, daemon=True).start()
+            return jsonify(success=True, active=True, job_id=job_id, phase="queued"), 200
+
+        logs = []
         logs.append(f"🔎 Quickstart branch: {qs_branch}")
         if branch_override:
             logs.append(f"⚠️ Kometa branch override selected: {branch_override}")
@@ -10377,19 +10450,18 @@ def update_kometa():
         if force_update:
             logs.append("Force update enabled.")
 
-        result = helpers.perform_kometa_update_zip_only(cfg_dir, branch=kometa_branch, force=force_update)
+        result = helpers.perform_kometa_update_zip_only(cfg_dir, branch=kometa_branch, force=force_update, logs=logs)
         try:
             helpers.invalidate_cached_kometa_update(cfg_dir)
         except Exception:
             pass
-        logs.extend(result.get("log", []))
         status = 200 if result.get("success") else 500
 
         return (
             jsonify(
                 {
                     "success": result.get("success", False),
-                    "log": logs,
+                    "log": list(logs),
                     "qs_branch": qs_branch,
                     "kometa_branch": kometa_branch,
                     "up_to_date": result.get("up_to_date", False),
@@ -10402,8 +10474,37 @@ def update_kometa():
 
     except Exception as e:
         helpers.ts_log(f"Kometa update failed: {e}", level="ERROR")
-        logs.append("Exception during Kometa update.")
-        return jsonify({"success": False, "log": logs}), 500
+        return jsonify({"success": False, "log": ["Exception during Kometa update."]}), 500
+
+
+@app.route("/update-kometa-progress", methods=["GET"])
+def update_kometa_progress():
+    job_id = request.args.get("job_id", "").strip()
+    since = request.args.get("since", "0").strip()
+    if not job_id:
+        return jsonify(success=False, error="Missing job_id."), 400
+    info = KOMETA_UPDATE_PROGRESS.get(job_id)
+    if not info:
+        return jsonify(success=False, error="Unknown job_id."), 404
+    try:
+        start_idx = max(int(since or "0"), 0)
+    except ValueError:
+        start_idx = 0
+    lines = list(info.get("lines") or [])
+    return jsonify(
+        success=True,
+        job_id=job_id,
+        phase=info.get("phase"),
+        done=bool(info.get("done")),
+        update_success=bool(info.get("success")),
+        up_to_date=bool(info.get("up_to_date")),
+        skipped=bool(info.get("skipped")),
+        force=bool(info.get("force")),
+        qs_branch=info.get("qs_branch"),
+        kometa_branch=info.get("kometa_branch"),
+        lines=lines[start_idx:],
+        next_index=len(lines),
+    )
 
 
 def _normalize_test_libraries_path(raw_path, base_dir):

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -3483,16 +3483,34 @@ div#loading {
     pointer-events: none;
 }
 
+.log-filter-row {
+    flex: 1 1 100%;
+    min-width: 0;
+}
+
+.log-filter-row .input-group {
+    flex: 1 1 220px;
+    width: min(100%, 260px) !important;
+    min-width: 0;
+}
+
 .log-level-wrap {
-    display: inline-flex;
-    align-items: stretch;
+    display: block;
+    flex: 1 1 100%;
+    width: 100%;
+    min-width: 0;
+    overflow-x: auto;
+    padding-bottom: 0.2rem;
+    -webkit-overflow-scrolling: touch;
 }
 
 .log-level-grid {
     display: grid;
-    grid-template-columns: minmax(80px, auto) 1fr;
+    grid-template-columns: minmax(88px, auto) minmax(0, 1fr);
     gap: 4px 10px;
     align-items: center;
+    width: max-content;
+    min-width: 100%;
 }
 
 .log-level-row-label {
@@ -3506,22 +3524,25 @@ div#loading {
 
 .log-level-counts {
   display: grid;
-  grid-template-columns: repeat(7, minmax(0, 1fr));
+  grid-template-columns: repeat(7, minmax(72px, 72px));
   gap: 6px;
   font-size: 0.75rem;
   color: var(--theme-text-muted);
   text-align: center;
   font-variant-numeric: tabular-nums;
+  min-width: 0;
 }
 
 .log-level-buttons {
   display: grid;
-  grid-template-columns: repeat(7, minmax(0, 1fr));
+  grid-template-columns: repeat(7, minmax(72px, 72px));
   gap: 6px;
+  min-width: 0;
 }
 
 .log-level-buttons .btn {
   width: 100%;
+  min-width: 0;
 }
 
 /* -------------------- */
@@ -4689,7 +4710,7 @@ body {
 .qs-main-page-topline {
     display: flex;
     align-items: center;
-    justify-content: flex-start;
+    justify-content: space-between;
     gap: 0.6rem;
 }
 
@@ -4698,6 +4719,19 @@ body {
     text-transform: uppercase;
     letter-spacing: 0.08em;
     color: var(--theme-text-muted);
+}
+
+.qs-main-page-status-pills {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.45rem;
+    flex-wrap: wrap;
+    margin-left: auto;
+}
+
+.qs-main-page-status-pills > div {
+    display: flex;
 }
 
 .qs-main-page-title {
@@ -4715,7 +4749,7 @@ body {
     max-width: 100%;
     font-size: 0.86rem;
     color: var(--theme-text-muted);
-    line-height: 1;
+    line-height: 1.2;
 }
 
 .qs-main-page-meta-icon {
@@ -4737,6 +4771,7 @@ body {
 }
 
 .qs-main-page-meta-value {
+    display: inline-block;
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -4746,7 +4781,8 @@ body {
     color: var(--theme-text);
     letter-spacing: normal;
     text-transform: none;
-    line-height: 1;
+    line-height: 1.2;
+    padding-bottom: 0.08rem;
 }
 
 .qs-main-config-chip {
@@ -5337,6 +5373,33 @@ body {
         border-radius: 0 var(--bs-border-radius-sm) var(--bs-border-radius-sm) 0 !important;
     }
 
+    .log-filter-row {
+        align-items: stretch !important;
+    }
+
+    .log-filter-row .input-group {
+        width: 100% !important;
+    }
+
+    .log-level-grid {
+        grid-template-columns: minmax(0, 1fr);
+        gap: 6px;
+    }
+
+    .log-level-row-label {
+        text-align: left;
+        padding-right: 0;
+        margin-top: 0.25rem;
+    }
+
+    .log-level-buttons {
+        grid-template-columns: repeat(7, minmax(72px, 72px));
+    }
+
+    .log-level-counts {
+        grid-template-columns: repeat(7, minmax(72px, 72px));
+    }
+
     .logscan-control-action {
         justify-content: center;
     }
@@ -5448,6 +5511,17 @@ body {
     .qs-main-page-meta {
         align-items: flex-start;
         max-width: 100%;
+    }
+
+    .qs-main-page-topline {
+        align-items: flex-start;
+        flex-wrap: wrap;
+    }
+
+    .qs-main-page-status-pills {
+        width: 100%;
+        justify-content: flex-start;
+        margin-left: 0;
     }
 
     .qs-main-page-meta-value {

--- a/static/local-js/900-final.js
+++ b/static/local-js/900-final.js
@@ -27,6 +27,9 @@ let logscanPollCounter = 0
 let finalLogscanAnalyzeTriggered = false
 let lastRunProgressPayload = null
 const KOMETA_BRANCH_OVERRIDE_STORAGE_KEY = 'qs-kometa-branch-override'
+let kometaUpdatePollInterval = null
+let kometaUpdateJobId = null
+let kometaUpdateLogIndex = 0
 
 const _qsEnvEl = document.getElementById('qs-env')
 const runningOn = (_qsEnvEl && _qsEnvEl.dataset.runningOn) ? _qsEnvEl.dataset.runningOn : ''
@@ -67,6 +70,7 @@ $(document).ready(function () {
   const $kometaBranchOverride = $('#kometa-branch-override')
   const $kometaBranchSelection = $('#kometa-branch-selection')
   const $kometaEffectiveBranch = $('#kometa-effective-branch')
+  const $kometaUpdatePhaseBadge = $('#kometa-update-phase-badge')
   const $kometaLocalVersionStatus = $('#kometa-local-version-status')
   const $kometaRemoteVersionStatus = $('#kometa-remote-version-status')
   const $kometaVersionSourceUrl = $('#kometa-version-source-url')
@@ -105,6 +109,7 @@ $(document).ready(function () {
   let kometaRemoteVersionStatus = ''
   let kometaRemoteVersionChecked = false
   let kometaRemoteVersionSkipped = false
+  let kometaUpdatePhaseStatus = 'idle'
 
   function readMetaFlag (id, datasetKey, attrKey) {
     const el = document.getElementById(id)
@@ -270,6 +275,7 @@ $(document).ready(function () {
     updateConfigOutputHeaderBadges()
     updateRunCommandHeaderBadge()
     updateLogscanHeaderBadge()
+    syncKometaBranchRollupBadge()
   }
 
   function getFinalGateState () {
@@ -517,10 +523,12 @@ $(document).ready(function () {
   }
   updateHeaderStyleLabel(headerSelect ? headerSelect.value : '')
   $('#open-kometa-actions-button').on('click', function () {
+    if (KOMETA_STATUS === 'running') return
     if (!kometaActionsCollapse || typeof bootstrap === 'undefined' || !bootstrap.Collapse) return
     bootstrap.Collapse.getOrCreateInstance(kometaActionsCollapse, { toggle: false }).show()
   })
   $('#open-kometa-actions-panel-button').on('click', function () {
+    if (KOMETA_STATUS === 'running') return
     if (!kometaActionsCollapse || typeof bootstrap === 'undefined' || !bootstrap.Collapse) return
     bootstrap.Collapse.getOrCreateInstance(kometaActionsCollapse, { toggle: false }).show()
   })
@@ -694,6 +702,10 @@ $(document).ready(function () {
     if (!showYAML) {
       title = 'Fix validation before building the run command'
       message = 'Resolve the current validation issues first. The run command will appear after the config validates cleanly.'
+      showButton = false
+    } else if (KOMETA_STATUS === 'running') {
+      title = 'Kometa is currently running'
+      message = 'Run output and stop controls are active below. Prepare Kometa is locked until the current run finishes.'
       showButton = false
     } else if (KOMETA_UPDATING) {
       title = 'Kometa update in progress'
@@ -901,9 +913,10 @@ $(document).ready(function () {
     if (checkbox.length) checkbox.on('change', buildCommand)
   })
 
-  function validateKometaRoot () {
+  function validateKometaRoot (options = {}) {
     if (KOMETA_VALIDATION_IN_PROGRESS) return
     KOMETA_VALIDATION_IN_PROGRESS = true
+    setKometaUpdatePhaseBadge('validating')
     if (typeof showNavigationLoadingOverlay === 'function') {
       showNavigationLoadingOverlay('kometa-check')
     }
@@ -916,11 +929,19 @@ $(document).ready(function () {
     const configName = $out.data('config-filename')
     const defaultRootPosix = ($out.data('kometa-root-default') || '').toString().trim()
     const defaultRootDisplay = ($out.data('kometa-root-default-display') || defaultRootPosix)
+    const appendStatus = Boolean(options.appendStatus)
 
-    $logBox.text(
-      '🔄 Please wait while we validate your Kometa installation...\n' +
-      'This may take a few seconds as we verify the folder structure, Python environment, and Kometa information.\n\n'
-    )
+    if (appendStatus) {
+      $logBox.append(
+        '\n🔄 Re-validating Kometa after update...\n' +
+        'This may take a few seconds as we verify the folder structure, Python environment, and Kometa information.\n\n'
+      )
+    } else {
+      $logBox.text(
+        '🔄 Please wait while we validate your Kometa installation...\n' +
+        'This may take a few seconds as we verify the folder structure, Python environment, and Kometa information.\n\n'
+      )
+    }
     if ($spinner.length) $spinner.show()
     $runNow.prop('disabled', true)
 
@@ -977,9 +998,11 @@ $(document).ready(function () {
             hideRunCommandSectionUntilValidated()
             $runNow.prop('disabled', true)
           }
+          if (!KOMETA_UPDATING) setKometaUpdatePhaseBadge(KOMETA_VALIDATED ? 'ready' : 'idle')
         } else {
           KOMETA_INSTALLED = false
           KOMETA_VALIDATED = false
+          if (!KOMETA_UPDATING) setKometaUpdatePhaseBadge('failed')
           hideRunCommandSectionUntilValidated()
           $runNow.prop('disabled', true)
         }
@@ -997,6 +1020,7 @@ $(document).ready(function () {
           KOMETA_INSTALLED = false
         }
         KOMETA_VALIDATED = false
+        if (!KOMETA_UPDATING) setKometaUpdatePhaseBadge('failed')
         hideRunCommandSectionUntilValidated()
         $runNow.prop('disabled', true)
         if ($spinner.length) $spinner.hide()
@@ -1243,19 +1267,130 @@ $(document).ready(function () {
 
     $kometaVersionSourceUrl.text(getKometaVersionSourceUrlValue(effective))
     $kometaZipSourceUrl.text(getKometaZipSourceUrlValue(effective))
+    syncKometaBranchRollupBadge()
   }
 
-  function setKometaStatusLog (lines) {
+  function setKometaUpdatePhaseBadge (phase) {
+    if (!$kometaUpdatePhaseBadge.length) return
+
+    const phaseMap = {
+      idle: { label: 'Idle', klass: 'text-bg-secondary' },
+      checking: { label: 'Checking', klass: 'text-bg-info' },
+      queued: { label: 'Starting', klass: 'text-bg-primary' },
+      downloading: { label: 'Downloading', klass: 'text-bg-primary' },
+      extracting: { label: 'Extracting', klass: 'text-bg-warning' },
+      preserving: { label: 'Preserving data', klass: 'text-bg-warning' },
+      venv: { label: 'Preparing venv', klass: 'text-bg-info' },
+      dependencies: { label: 'Installing deps', klass: 'text-bg-warning' },
+      validating: { label: 'Validating', klass: 'text-bg-info' },
+      ready: { label: 'Ready', klass: 'text-bg-success' },
+      failed: { label: 'Failed', klass: 'text-bg-danger' }
+    }
+
+    const normalized = Object.prototype.hasOwnProperty.call(phaseMap, phase) ? phase : 'idle'
+    const next = phaseMap[normalized]
+    kometaUpdatePhaseStatus = normalized
+    $kometaUpdatePhaseBadge
+      .removeClass('text-bg-secondary text-bg-info text-bg-primary text-bg-warning text-bg-success text-bg-danger')
+      .addClass(next.klass)
+      .text(next.label)
+  }
+
+  function inferKometaUpdatePhaseFromLine (line) {
+    const text = String(line || '').trim()
+    if (!text) return null
+    const lower = text.toLowerCase()
+
+    if (
+      lower.startsWith('❌') ||
+      lower.includes(' update failed') ||
+      lower.includes('error occurred during kometa update') ||
+      lower.includes('aborting extraction') ||
+      lower.includes('failed to fetch kometa update progress')
+    ) {
+      return 'failed'
+    }
+    if (
+      lower.includes('kometa root validated successfully') ||
+      lower.includes('kometa root is valid and ready') ||
+      lower.includes('kometa update completed successfully') ||
+      lower.includes('kometa is already up to date') ||
+      lower.includes('kometa updated via zip')
+    ) {
+      return 'ready'
+    }
+    if (
+      lower.includes('re-validating kometa after update') ||
+      lower.includes('please wait while we validate') ||
+      lower.includes('validate your kometa installation')
+    ) {
+      return 'validating'
+    }
+    if (lower.includes('installing requirements') || lower.includes('upgrading pip')) {
+      return 'dependencies'
+    }
+    if (
+      lower.includes('creating virtual environment') ||
+      lower.includes('existing kometa-venv looks invalid') ||
+      lower.includes('venv python') ||
+      lower.includes('pyvenv.cfg')
+    ) {
+      return 'venv'
+    }
+    if (
+      lower.includes('backed up kometa logs/cache') ||
+      lower.includes('restored kometa logs/cache') ||
+      lower.includes('kometa backup')
+    ) {
+      return 'preserving'
+    }
+    if (
+      (lower.includes('removed ') && lower.includes('existing entr')) ||
+      lower.includes('removing existing kometa contents') ||
+      lower.includes('existing path still present after cleanup') ||
+      lower.includes('extracted version file') ||
+      lower.includes('extracted to:')
+    ) {
+      return 'extracting'
+    }
+    if (lower.includes('downloading ') && lower.includes('.zip')) {
+      return 'downloading'
+    }
+    if (
+      lower.includes('resolving upstream sha') ||
+      (lower.includes('upstream ') && lower.includes(' sha')) ||
+      lower.includes('refreshing kometa status') ||
+      lower.includes('checking kometa') ||
+      lower.includes('kometa branch selected') ||
+      lower.includes('quickstart branch:') ||
+      lower.includes('remote version source') ||
+      lower.includes('kometa branch override selected') ||
+      lower.includes('kometa branch selection: auto')
+    ) {
+      return 'checking'
+    }
+
+    return null
+  }
+
+  function updateKometaUpdatePhaseFromLine (line) {
+    const phase = inferKometaUpdatePhaseFromLine(line)
+    if (phase) setKometaUpdatePhaseBadge(phase)
+  }
+
+  function setKometaStatusLog (lines, phase = null) {
     const $logBox = $('#kometa-validation-log')
     const text = Array.isArray(lines) ? lines.join('\n') : String(lines || '')
     $logBox.text(text ? `${text}\n` : '')
     if ($logBox[0]) $logBox[0].scrollTop = $logBox[0].scrollHeight
+    if (phase) setKometaUpdatePhaseBadge(phase)
   }
 
   function appendKometaStatusLine (line) {
     const $logBox = $('#kometa-validation-log')
     $logBox.append(`${line}\n`)
     if ($logBox[0]) $logBox[0].scrollTop = $logBox[0].scrollHeight
+    updateKometaUpdatePhaseFromLine(line)
   }
 
   function syncKometaBranchOverrideWarning () {
@@ -1288,20 +1423,56 @@ $(document).ready(function () {
       '',
       '🔍 Checking Kometa path and local install state...'
     ]
-    setKometaStatusLog(lines)
+    setKometaStatusLog(lines, 'checking')
     invalidateKometaUpdateStatus()
     return probeKometaRoot()
       .then((res) => {
         if (!res || !res.kometa_installed) {
           appendKometaStatusLine('')
           appendKometaStatusLine('ℹ️ Remote update check skipped because Kometa is not installed.')
+          if (!KOMETA_UPDATING) setKometaUpdatePhaseBadge('idle')
           return res
         }
         appendKometaStatusLine('')
         appendKometaStatusLine('🔎 Checking Kometa update status...')
         return checkKometaUpdate(forceRefresh)
       })
-      .catch(() => null)
+      .then((result) => {
+        if (!KOMETA_UPDATING) setKometaUpdatePhaseBadge(KOMETA_INSTALLED ? 'ready' : 'idle')
+        return result
+      })
+      .catch(() => {
+        if (!KOMETA_UPDATING) setKometaUpdatePhaseBadge('failed')
+        return null
+      })
+  }
+
+  function stopKometaUpdatePolling () {
+    if (kometaUpdatePollInterval) {
+      clearInterval(kometaUpdatePollInterval)
+      kometaUpdatePollInterval = null
+    }
+  }
+
+  function pollKometaUpdateProgress () {
+    if (!kometaUpdateJobId) return Promise.resolve(null)
+    return fetch(`/update-kometa-progress?job_id=${encodeURIComponent(kometaUpdateJobId)}&since=${encodeURIComponent(String(kometaUpdateLogIndex))}`)
+      .then(async res => {
+        const data = await res.json()
+        if (!res.ok) throw new Error(data.error || 'Failed to fetch Kometa update progress.')
+        return data
+      })
+      .then(data => {
+        if (data.phase === 'queued') setKometaUpdatePhaseBadge('queued')
+        if (data.phase === 'error') setKometaUpdatePhaseBadge('failed')
+        const lines = Array.isArray(data.lines) ? data.lines : []
+        lines.forEach(line => appendKometaStatusLine(line))
+        if (typeof data.next_index === 'number') kometaUpdateLogIndex = data.next_index
+        if (data.done) {
+          stopKometaUpdatePolling()
+        }
+        return data
+      })
   }
 
   function getKometaRollupStatus () {
@@ -1331,6 +1502,25 @@ $(document).ready(function () {
     badge.classList.add(`qs-validation-rollup-badge--${state}`)
   }
 
+  function syncKometaBranchRollupBadge () {
+    const badge = document.getElementById('kometa-branch-rollup-badge')
+    if (!badge) return
+
+    const selected = getKometaBranchOverride()
+    const effective = getEffectiveKometaBranch()
+    const label = (selected || 'auto').toUpperCase()
+
+    badge.textContent = label
+    badge.classList.remove('text-bg-secondary', 'text-bg-warning', 'text-dark')
+    if (selected) {
+      badge.classList.add('text-bg-warning', 'text-dark')
+      badge.setAttribute('title', `Kometa branch override selected: ${selected}. Effective branch: ${effective}.`)
+    } else {
+      badge.classList.add('text-bg-secondary')
+      badge.setAttribute('title', `Kometa branch mode: auto. Effective branch: ${effective}.`)
+    }
+  }
+
   if (kometaActionsCollapse) {
     kometaActionsCollapse.addEventListener('shown.bs.collapse', syncKometaUpdateAttention)
     kometaActionsCollapse.addEventListener('hidden.bs.collapse', syncKometaUpdateAttention)
@@ -1346,6 +1536,13 @@ $(document).ready(function () {
     if (isRunning) {
       kometaActionsToggle.classList.add('collapsed')
       kometaActionsToggle.setAttribute('aria-expanded', 'false')
+      kometaActionsToggle.setAttribute('title', 'Kometa is running. Prepare Kometa is locked until the run finishes.')
+      kometaActionsToggle.disabled = true
+      kometaActionsToggle.classList.add('disabled')
+    } else {
+      kometaActionsToggle.removeAttribute('title')
+      kometaActionsToggle.disabled = false
+      kometaActionsToggle.classList.remove('disabled')
     }
   }
 
@@ -1390,6 +1587,7 @@ $(document).ready(function () {
     const accordion = $('#run-command-output-accordion')
     const box = $('#run-command-box')
 
+    clearRunCommandPlaceholderState()
     accordion.removeClass('d-none')
     $('#run-command-output-collapse').addClass('show')
     $('#run-command-output-heading .accordion-button').removeClass('collapsed').attr('aria-expanded', 'true')
@@ -1749,8 +1947,10 @@ $(document).ready(function () {
     KOMETA_VALIDATED = false
     KOMETA_UPDATE_CHECK_SKIPPED = false
     KOMETA_UPDATE_CHECK_COMPLETED = false
+    setKometaUpdatePhaseBadge('queued')
     syncKometaRollupBadge()
     hideRunCommandSectionUntilValidated()
+    syncFinalAccordionRollups()
     const prevRunNowHtml = $runNow.html()
     const prevRunNowDisabled = $runNow.prop('disabled')
 
@@ -1778,6 +1978,9 @@ $(document).ready(function () {
     let postUpdateLabel = null
     const cleanupUI = () => {
       clearInterval(heartbeatId)
+      stopKometaUpdatePolling()
+      kometaUpdateJobId = null
+      kometaUpdateLogIndex = 0
       KOMETA_UPDATING = false
       $runBox.removeClass('opacity-50 position-relative')
       $runNow.prop('disabled', prevRunNowDisabled).html(prevRunNowHtml)
@@ -1787,6 +1990,7 @@ $(document).ready(function () {
       $kometaBranchOverride.prop('disabled', false)
       syncUpdateButtonLabel()
       updateRunNowState()
+      syncFinalAccordionRollups()
       if (postUpdateLabel) {
         $btn.html(postUpdateLabel)
         setTimeout(syncUpdateButtonLabel, 6000)
@@ -1796,23 +2000,73 @@ $(document).ready(function () {
     fetch('/update-kometa', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ branch: qsBranch, branch_override: branchOverride, force: forceUpdate })
+      body: JSON.stringify({ branch: qsBranch, branch_override: branchOverride, force: forceUpdate, background: true })
     })
       .then(async res => {
         const data = await res.json()
         if (res.status === 409) {
+          setKometaUpdatePhaseBadge('failed')
           showToast('warning', data.error || 'Kometa is running; stop it before updating.')
           $logBox.append(`${data.error || 'Update blocked: Kometa running.'}\n`)
           if ($logBox[0]) $logBox[0].scrollTop = $logBox[0].scrollHeight
           return { success: false, log: data.log || [], blocked: true }
         }
+        if (!res.ok) {
+          throw new Error(data.error || 'Kometa update failed to start.')
+        }
         return data
       })
       .then(data => {
         if (!data) return
-        if (Array.isArray(data.log)) {
-          data.log.forEach(line => $logBox.append(`${line}\n`))
-          if ($logBox[0]) $logBox[0].scrollTop = $logBox[0].scrollHeight
+        if (data.success && data.job_id) {
+          kometaUpdateJobId = data.job_id
+          kometaUpdateLogIndex = 0
+          stopKometaUpdatePolling()
+          const finalize = (progress) => {
+            if (!progress || !progress.done) return false
+            KOMETA_LOCAL_CHECK_COMPLETED = false
+            KOMETA_UPDATE_AVAILABLE = false
+            $('#kometa-update-box').addClass('d-none')
+            syncUpdateButtonLabel()
+            const elapsed = formatElapsed(Date.now() - startTs)
+            if (progress.update_success) {
+              if (progress.up_to_date) {
+                showToast('info', 'Kometa is already up to date.')
+                postUpdateLabel = '<i class="bi bi-check-circle me-1"></i> Up to date'
+                appendKometaStatusLine('Kometa is already up to date.')
+                setKometaUpdatePhaseBadge('ready')
+              } else {
+                showToast('success', `Kometa update completed in ${elapsed}.`)
+                appendKometaStatusLine('Kometa update completed successfully.')
+                setKometaUpdatePhaseBadge('validating')
+              }
+              validateKometaRoot({ appendStatus: true })
+            } else {
+              showToast('error', 'Kometa update failed.')
+              appendKometaStatusLine('Kometa update failed.')
+              setKometaUpdatePhaseBadge('failed')
+              validateKometaRoot({ appendStatus: true })
+            }
+            cleanupUI()
+            syncKometaRollupBadge()
+            return true
+          }
+          return pollKometaUpdateProgress()
+            .then(progress => {
+              if (finalize(progress)) return
+              kometaUpdatePollInterval = setInterval(() => {
+                pollKometaUpdateProgress()
+                  .then(finalize)
+                  .catch(err => {
+                    console.error(err)
+                    appendKometaStatusLine(`❌ ${err.message || 'Failed to fetch Kometa update progress.'}`)
+                    setKometaUpdatePhaseBadge('failed')
+                    stopKometaUpdatePolling()
+                    cleanupUI()
+                    syncKometaRollupBadge()
+                  })
+              }, 800)
+            })
         }
         if (data.success) {
           KOMETA_LOCAL_CHECK_COMPLETED = false
@@ -1829,11 +2083,11 @@ $(document).ready(function () {
             $logBox.append('Kometa update completed successfully.\n')
           }
           if ($logBox[0]) $logBox[0].scrollTop = $logBox[0].scrollHeight
-          validateKometaRoot()
+          validateKometaRoot({ appendStatus: true })
         } else if (!data.blocked) {
           showToast('error', data.error || 'Kometa update failed.')
           $logBox.append('Kometa update failed.\n')
-          validateKometaRoot()
+          validateKometaRoot({ appendStatus: true })
           if ($logBox[0]) $logBox[0].scrollTop = $logBox[0].scrollHeight
         }
       })
@@ -1841,9 +2095,8 @@ $(document).ready(function () {
         console.error(err)
         showToast('error', 'Error during Kometa update.')
         $logBox.append('Error occurred during Kometa update.\n')
+        setKometaUpdatePhaseBadge('failed')
         if ($logBox[0]) $logBox[0].scrollTop = $logBox[0].scrollHeight
-      })
-      .finally(() => {
         cleanupUI()
         syncKometaRollupBadge()
       })
@@ -1862,6 +2115,7 @@ $(document).ready(function () {
   loadSavedKometaBranchOverride()
   syncKometaBranchOverrideWarning()
   syncKometaSourceStatus()
+  setKometaUpdatePhaseBadge(kometaUpdatePhaseStatus)
   syncUpdateButtonLabel()
   syncKometaRollupBadge()
 
@@ -2434,6 +2688,12 @@ $(document).ready(function () {
     kometaActionsCollapse.addEventListener('show.bs.collapse', () => {
       const stage = getFinalGateState().stage
       if (stage === 'todo' || stage === 'freshness') return
+      if (KOMETA_STATUS === 'running') {
+        if (typeof bootstrap !== 'undefined' && bootstrap.Collapse) {
+          bootstrap.Collapse.getOrCreateInstance(kometaActionsCollapse, { toggle: false }).hide()
+        }
+        return
+      }
       if (!KOMETA_INSTALLED || KOMETA_VALIDATED || KOMETA_VALIDATION_IN_PROGRESS || KOMETA_UPDATING) return
       validateKometaRoot()
     })
@@ -2441,6 +2701,10 @@ $(document).ready(function () {
 
   if (runCommandCollapse) {
     runCommandCollapse.addEventListener('show.bs.collapse', () => {
+      if (KOMETA_STATUS === 'running') {
+        clearRunCommandPlaceholderState()
+        return
+      }
       if (!KOMETA_VALIDATED) {
         setRunCommandPlaceholderState()
       }

--- a/templates/000-base.html
+++ b/templates/000-base.html
@@ -76,26 +76,6 @@
   <script type="text/javascript" src="{{ url_for('static', filename='local-js/urlValidation.js') }}"></script>
   <div class="header-container text-center">
     <img src="{{ url_for('static', filename='images/logo.webp') }}" alt="QUICKSTART" class="header-image" />
-    <div id="qs-running-badge" class="d-none mt-2">
-      <span class="badge rounded-pill text-bg-success px-3 py-2">
-        <i class="bi bi-play-circle me-1"></i> Kometa running
-      </span>
-    </div>
-    <div id="qs-maintenance-badge" class="d-none mt-2">
-      <span class="badge rounded-pill text-bg-warning text-dark px-3 py-2">
-        <i class="bi bi-pause-circle me-1"></i> Kometa paused for Plex maintenance
-      </span>
-    </div>
-    <div id="qs-maintenance-unavailable-badge" class="d-none mt-2">
-      <span class="badge rounded-pill text-bg-warning text-dark px-3 py-2">
-        <i class="bi bi-exclamation-triangle me-1"></i> Plex maintenance window unavailable
-      </span>
-    </div>
-    <div id="qs-queued-badge" class="d-none mt-2">
-      <span class="badge rounded-pill text-bg-info text-dark px-3 py-2">
-        <i class="bi bi-hourglass-split me-1"></i> Kometa start queued
-      </span>
-    </div>
   </div>
 
   <div class="qs-page-shell">

--- a/templates/001-navigation.html
+++ b/templates/001-navigation.html
@@ -192,6 +192,28 @@
           <div class="qs-main-page-header">
             <div class="qs-main-page-topline">
               <div class="qs-main-page-eyebrow">Quickstart</div>
+              <div class="qs-main-page-status-pills">
+                <div id="qs-running-badge" class="d-none">
+                  <span class="badge rounded-pill text-bg-success px-3 py-2">
+                    <i class="bi bi-play-circle me-1"></i> Kometa running
+                  </span>
+                </div>
+                <div id="qs-maintenance-badge" class="d-none">
+                  <span class="badge rounded-pill text-bg-warning text-dark px-3 py-2">
+                    <i class="bi bi-pause-circle me-1"></i> Kometa paused for Plex maintenance
+                  </span>
+                </div>
+                <div id="qs-maintenance-unavailable-badge" class="d-none">
+                  <span class="badge rounded-pill text-bg-warning text-dark px-3 py-2">
+                    <i class="bi bi-exclamation-triangle me-1"></i> Plex maintenance window unavailable
+                  </span>
+                </div>
+                <div id="qs-queued-badge" class="d-none">
+                  <span class="badge rounded-pill text-bg-info text-dark px-3 py-2">
+                    <i class="bi bi-hourglass-split me-1"></i> Kometa start queued
+                  </span>
+                </div>
+              </div>
             </div>
             <h2 class="qs-main-page-title">{{ page_info['title'] }}</h2>
             <div class="qs-main-page-meta">

--- a/templates/900-final.html
+++ b/templates/900-final.html
@@ -370,6 +370,9 @@
           <span id="kometa-update-rollup-badge" class="badge ms-2 qs-validation-rollup-badge qs-validation-rollup-badge--unknown">
             Not checked
           </span>
+          <span id="kometa-branch-rollup-badge" class="badge ms-2 text-bg-secondary" title="Kometa branch mode">
+            AUTO
+          </span>
         </button>
       </h2>
       <div id="kometa-actions-collapse" class="accordion-collapse collapse" aria-labelledby="kometa-actions-heading"
@@ -401,6 +404,7 @@
               <div class="alert alert-light border small py-2 px-3 mb-2" role="status">
                 <div><strong>Selection:</strong> <span id="kometa-branch-selection">Auto</span></div>
                 <div><strong>Effective branch:</strong> <code id="kometa-effective-branch">nightly</code></div>
+                <div><strong>Update phase:</strong> <span id="kometa-update-phase-badge" class="badge text-bg-secondary">Idle</span></div>
                 <div><strong>Local version:</strong> <span id="kometa-local-version-status">Unknown</span></div>
                 <div><strong>Remote version:</strong> <span id="kometa-remote-version-status">Not checked</span></div>
                 <div><strong>Remote VERSION source:</strong> <code id="kometa-version-source-url"></code></div>

--- a/tests/test_update_flows.py
+++ b/tests/test_update_flows.py
@@ -227,7 +227,7 @@ def test_update_kometa_branch_override_uses_selected_branch(client, monkeypatch,
     monkeypatch.setattr(helpers, "detect_git_branch", lambda *_: "master", raising=False)
     captured = {"branch": None}
 
-    def fake_update(_config_root, branch="nightly", force=False):
+    def fake_update(_config_root, branch="nightly", force=False, logs=None):
         captured["branch"] = branch
         return {"success": True, "log": ["ok"], "up_to_date": False}
 
@@ -294,6 +294,37 @@ def test_extract_zip_bytes_replaces_existing_contents(isolated_config_dir):
     assert (dest_dir / "VERSION").read_text(encoding="utf-8").strip() == "9.9.9-develop1"
     assert any("Removing existing Kometa contents" in line for line in logs)
     assert any("Extracted VERSION file: 9.9.9-develop1" in line for line in logs)
+
+
+def test_extract_zip_bytes_aborts_when_existing_directory_cannot_be_removed(isolated_config_dir, monkeypatch):
+    dest_dir = isolated_config_dir / "kometa"
+    blocked_dir = dest_dir / ".github"
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    blocked_dir.mkdir(parents=True, exist_ok=True)
+    (blocked_dir / "stale.txt").write_text("stale", encoding="utf-8")
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("Kometa-develop/VERSION", "9.9.9-develop1")
+        zf.writestr("Kometa-develop/kometa.py", "# stub")
+
+    real_rmtree = helpers.shutil.rmtree
+
+    def fake_rmtree(path, *args, **kwargs):
+        if str(path) == str(blocked_dir):
+            raise PermissionError("blocked")
+        return real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(helpers.shutil, "rmtree", fake_rmtree)
+
+    logs = []
+    ok = helpers._extract_zip_bytes(buf.getvalue(), dest_dir, logs)
+
+    assert ok is False
+    assert blocked_dir.exists()
+    assert not (dest_dir / "VERSION").exists()
+    assert any("Failed to remove existing path" in line and ".github" in line for line in logs)
+    assert any("Kometa directory is not empty after cleanup" in line for line in logs)
 
 
 def test_perform_kometa_update_zip_only_writes_branch_metadata(tmp_path, monkeypatch):


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Fixes Final Validation state handling when returning to the page during an active Kometa run. Prepare Kometa is now locked while Kometa is running, the stale “prepare/validate” Run Command placeholder is cleared as soon as running state is detected, and the page no longer suggests preparing Kometa when a run is already in progress.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
