### PR TITLE
Playlist output order

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -141,13 +141,38 @@ def _format_playlist_files(libraries_list):
     }
 
 
-def _playlist_libraries_from_library_toggles(nested_libraries_data):
+def _ordered_selected_libraries(selected_names, ordered_library_names):
+    if not selected_names:
+        return []
+
+    ordered = []
+    seen = set()
+
+    for library_name in ordered_library_names or []:
+        if library_name in selected_names and library_name not in seen:
+            ordered.append(library_name)
+            seen.add(library_name)
+
+    for library_name in selected_names:
+        if library_name not in seen:
+            ordered.append(library_name)
+            seen.add(library_name)
+
+    return ordered
+
+
+def _library_names_in_output_order(libraries_section):
+    if isinstance(libraries_section, dict) and isinstance(libraries_section.get("libraries"), dict):
+        return list(libraries_section["libraries"].keys())
+    return []
+
+
+def _playlist_libraries_from_library_toggles(nested_libraries_data, ordered_library_names=None):
     if not isinstance(nested_libraries_data, dict):
         return False, []
 
     has_playlist_toggle = any(isinstance(key, str) and key.endswith("-playlist") for key in nested_libraries_data)
     playlist_libraries = []
-    seen = set()
 
     for key, value in nested_libraries_data.items():
         if not isinstance(key, str) or not key.endswith("-library"):
@@ -159,11 +184,10 @@ def _playlist_libraries_from_library_toggles(nested_libraries_data):
         if include_playlist is not True:
             continue
         library_name = str(value).strip()
-        if library_name and library_name not in seen:
+        if library_name:
             playlist_libraries.append(library_name)
-            seen.add(library_name)
 
-    return has_playlist_toggle, playlist_libraries
+    return has_playlist_toggle, _ordered_selected_libraries(playlist_libraries, ordered_library_names)
 
 
 def _legacy_playlist_libraries_from_settings():
@@ -177,22 +201,20 @@ def _legacy_playlist_libraries_from_settings():
     return [item.strip() for item in str(raw_libraries or "").split(",") if item.strip()]
 
 
-def _legacy_playlist_libraries_for_selected_libraries(nested_libraries_data):
+def _legacy_playlist_libraries_for_selected_libraries(nested_libraries_data, ordered_library_names=None):
     legacy_names = set(_legacy_playlist_libraries_from_settings())
     if not legacy_names or not isinstance(nested_libraries_data, dict):
         return []
 
     selected_libraries = []
-    seen = set()
     for key, value in nested_libraries_data.items():
         if not isinstance(key, str) or not key.endswith("-library"):
             continue
         library_name = str(value or "").strip()
-        if library_name and library_name in legacy_names and library_name not in seen:
+        if library_name and library_name in legacy_names:
             selected_libraries.append(library_name)
-            seen.add(library_name)
 
-    return selected_libraries
+    return _ordered_selected_libraries(selected_libraries, ordered_library_names)
 
 
 def _coerce_string_list(values):
@@ -2357,14 +2379,21 @@ def build_config(header_style="standard", config_name=None):
             show_top_level,
         )
         config_data["libraries"] = libraries_section
-        has_playlist_toggle, playlist_libraries = _playlist_libraries_from_library_toggles(nested_libraries_data)
+        ordered_library_names = _library_names_in_output_order(libraries_section)
+        has_playlist_toggle, playlist_libraries = _playlist_libraries_from_library_toggles(
+            nested_libraries_data,
+            ordered_library_names=ordered_library_names,
+        )
         if has_playlist_toggle:
             if playlist_libraries:
                 config_data["playlist_files"] = _format_playlist_files(playlist_libraries)
             else:
                 config_data.pop("playlist_files", None)
         else:
-            legacy_playlist_libraries = _legacy_playlist_libraries_for_selected_libraries(nested_libraries_data)
+            legacy_playlist_libraries = _legacy_playlist_libraries_for_selected_libraries(
+                nested_libraries_data,
+                ordered_library_names=ordered_library_names,
+            )
             if legacy_playlist_libraries:
                 config_data["playlist_files"] = _format_playlist_files(legacy_playlist_libraries)
         if app.config["QS_DEBUG"]:

--- a/static/local-js/900-final.js
+++ b/static/local-js/900-final.js
@@ -2678,11 +2678,18 @@ $(document).ready(function () {
   // Keep the run area hidden until Kometa validation completes.
   hideRunCommandSectionUntilValidated()
   checkKometaStatus()
-
-  // First-run: clear and replay a single current Kometa status pass.
-  if (document.getElementById('kometa-validation-log')) {
-    runKometaStatusPass(false)
-  }
+    .catch(() => null)
+    .finally(() => {
+      if (!document.getElementById('kometa-validation-log')) return
+      if (KOMETA_STATUS === 'running') return
+      runKometaStatusPass(false)
+        .finally(() => {
+          const stage = getFinalGateState().stage
+          if (stage === 'todo' || stage === 'freshness') return
+          if (KOMETA_STATUS === 'running' || KOMETA_UPDATING || KOMETA_VALIDATION_IN_PROGRESS) return
+          validateKometaRoot({ appendStatus: true })
+        })
+    })
 
   if (kometaActionsCollapse) {
     kometaActionsCollapse.addEventListener('show.bs.collapse', () => {

--- a/static/local-js/900-final.js
+++ b/static/local-js/900-final.js
@@ -2682,7 +2682,7 @@ $(document).ready(function () {
     .finally(() => {
       if (!document.getElementById('kometa-validation-log')) return
       if (KOMETA_STATUS === 'running') return
-      runKometaStatusPass(false)
+      Promise.resolve(runKometaStatusPass(false))
         .finally(() => {
           const stage = getFinalGateState().stage
           if (stage === 'todo' || stage === 'freshness') return

--- a/tests/test_ratings_yaml_contract.py
+++ b/tests/test_ratings_yaml_contract.py
@@ -13,6 +13,11 @@ def _template_vars_from_yaml(yaml_content):
     return ratings_entry.get("template_variables", {})
 
 
+def _parsed_yaml(yaml_content):
+    parser = YAML(typ="safe", pure=True)
+    return parser.load(yaml_content)
+
+
 def _build_library_payload(template_vars):
     data = {
         "mov-library_movies-library": "Movies",
@@ -201,3 +206,25 @@ def test_generated_playlist_files_get_header_without_legacy_playlist_page(monkey
     assert "#==================== Playlists ====================#" in yaml_content
     assert "playlist_files:" in yaml_content
     assert "- Movies" in yaml_content
+
+
+def test_playlist_files_follow_library_output_order(monkeypatch, qs_module):
+    payload = {
+        "validated": True,
+        "libraries": {
+            "sho-library_zshows-library": "Z Shows",
+            "sho-library_zshows-playlist": "true",
+            "mov-library_amovies-library": "A Movies",
+            "mov-library_amovies-playlist": "true",
+            "mov-library_bmovies-library": "B Movies",
+            "mov-library_bmovies-playlist": "true",
+        },
+    }
+
+    parsed = _parsed_yaml(_run_build_config_with_payload(qs_module, monkeypatch, payload))
+
+    library_order = list(parsed["libraries"].keys())
+    playlist_order = parsed["playlist_files"][0]["template_variables"]["libraries"]
+
+    assert library_order == ["A Movies", "B Movies", "Z Shows"]
+    assert playlist_order == library_order

--- a/tests/test_workspace_dependency_logic.py
+++ b/tests/test_workspace_dependency_logic.py
@@ -305,7 +305,7 @@ def test_mal_dependency_reason_cases(qs_module, libraries_data, expected_require
                 SONARR_TEMPLATE_COLLECTION_KEY: True,
             },
             True,
-            "sonarr_add_missing_anidb enabled",
+            "sonarr_add_missing_commonsense enabled",
             id="sonarr_template_collection_enabled",
         ),
         pytest.param(
@@ -478,7 +478,7 @@ def test_workspace_status_route_returns_all_dependency_reasons(client, monkeypat
                     TAUTULLI_COLLECTION_KEY: True,
                     OMDB_ATTRIBUTE_KEY: True,
                     MDBLIST_ATTRIBUTE_KEY: True,
-                    ANIDB_TEMPLATE_COLLECTION_KEY: True,
+                    ANIDB_ATTRIBUTE_KEY: True,
                     RADARR_TEMPLATE_COLLECTION_KEY: True,
                     SONARR_TEMPLATE_COLLECTION_KEY: True,
                     TRAKT_COLLECTION_KEY: True,


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Fixes Final Validation startup sequencing and playlist ordering. The Final page now checks running state before probing/validating Kometa, skips the prepare flow while a run is already active, and normalizes the startup promise chain so auto-validation reliably completes and Run Now becomes available again. It also makes generated playlist_files follow the same library order as the libraries section and updates stale dependency tests to match current template keys.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
