### PR TITLE
add maint and quiet periods start time

### DIFF
--- a/modules/database.py
+++ b/modules/database.py
@@ -156,6 +156,7 @@ def get_last_used_config_name():
 def log_runs_table_create():
     return """CREATE TABLE IF NOT EXISTS log_runs (
         run_key TEXT PRIMARY KEY,
+        started_at TEXT,
         finished_at TEXT,
         run_time_seconds INTEGER,
         kometa_version TEXT,
@@ -176,6 +177,9 @@ def log_runs_table_create():
         trace_count INTEGER,
         analysis_counts TEXT,
         library_counts TEXT,
+        maintenance_summary TEXT,
+        maintenance_had_pause INTEGER,
+        quiet_period_summary TEXT,
         quickstart_run_marker INTEGER,
         config_line_count INTEGER,
         cache_line_count INTEGER,
@@ -194,6 +198,7 @@ def _ensure_log_runs_columns(cursor):
         if name:
             existing.add(name)
     columns = {
+        "started_at": "TEXT",
         "config_name": "TEXT",
         "config_hash": "TEXT",
         "run_command": "TEXT",
@@ -202,6 +207,9 @@ def _ensure_log_runs_columns(cursor):
         "recommendations": "TEXT",
         "analysis_counts": "TEXT",
         "library_counts": "TEXT",
+        "maintenance_summary": "TEXT",
+        "maintenance_had_pause": "INTEGER",
+        "quiet_period_summary": "TEXT",
         "quickstart_run_marker": "INTEGER",
         "config_line_count": "INTEGER",
         "cache_line_count": "INTEGER",
@@ -232,6 +240,13 @@ def save_log_run(summary, recommendations=None):
     library_counts = summary.get("library_counts")
     if isinstance(library_counts, dict):
         library_counts = json.dumps(library_counts, ensure_ascii=True)
+    maintenance_summary = summary.get("maintenance_summary")
+    if isinstance(maintenance_summary, dict):
+        maintenance_summary = json.dumps(maintenance_summary, ensure_ascii=True)
+    maintenance_had_pause = 1 if (summary.get("maintenance_had_pause") or (summary.get("maintenance_summary") or {}).get("had_pause")) else 0
+    quiet_period_summary = summary.get("quiet_period_summary")
+    if isinstance(quiet_period_summary, dict):
+        quiet_period_summary = json.dumps(quiet_period_summary, ensure_ascii=True)
     quickstart_run_marker = 1 if summary.get("quickstart_run_marker") else 0
     config_line_count = summary.get("config_line_count")
     cache_line_count = summary.get("cache_line_count")
@@ -242,6 +257,7 @@ def save_log_run(summary, recommendations=None):
             cursor.execute(
                 """INSERT OR IGNORE INTO log_runs (
                     run_key,
+                    started_at,
                     finished_at,
                     run_time_seconds,
                     kometa_version,
@@ -262,13 +278,17 @@ def save_log_run(summary, recommendations=None):
                     trace_count,
                     analysis_counts,
                     library_counts,
+                    maintenance_summary,
+                    maintenance_had_pause,
+                    quiet_period_summary,
                     quickstart_run_marker,
                     config_line_count,
                     cache_line_count,
                     created_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     run_key,
+                    summary.get("started_at"),
                     summary.get("finished_at"),
                     summary.get("run_time_seconds"),
                     summary.get("kometa_version"),
@@ -289,6 +309,9 @@ def save_log_run(summary, recommendations=None):
                     counts.get("trace", 0),
                     analysis_counts,
                     library_counts,
+                    maintenance_summary,
+                    maintenance_had_pause,
+                    quiet_period_summary,
                     quickstart_run_marker,
                     config_line_count,
                     cache_line_count,
@@ -340,6 +363,19 @@ def _decode_log_run_row(row):
             decoded["library_counts"] = json.loads(library_counts)
         except json.JSONDecodeError:
             decoded["library_counts"] = None
+    maintenance_summary = decoded.get("maintenance_summary")
+    if isinstance(maintenance_summary, str):
+        try:
+            decoded["maintenance_summary"] = json.loads(maintenance_summary)
+        except json.JSONDecodeError:
+            decoded["maintenance_summary"] = None
+    quiet_period_summary = decoded.get("quiet_period_summary")
+    if isinstance(quiet_period_summary, str):
+        try:
+            decoded["quiet_period_summary"] = json.loads(quiet_period_summary)
+        except json.JSONDecodeError:
+            decoded["quiet_period_summary"] = None
+    decoded["maintenance_had_pause"] = bool(decoded.get("maintenance_had_pause"))
     decoded["quickstart_run_marker"] = bool(decoded.get("quickstart_run_marker"))
     return decoded
 
@@ -350,11 +386,12 @@ def get_log_runs(limit=100):
         with closing(connection.cursor()) as cursor:
             _ensure_log_runs_columns(cursor)
             cursor.execute(
-                """SELECT run_key, finished_at, run_time_seconds, kometa_version, kometa_newest_version,
+                """SELECT run_key, started_at, finished_at, run_time_seconds, kometa_version, kometa_newest_version,
                           config_name, config_hash, run_command, command_signature, section_runtimes,
                           recommendations, log_mtime, log_size, debug_count, info_count, warning_count,
                           error_count, critical_count, trace_count, analysis_counts, library_counts,
-                          quickstart_run_marker, config_line_count, cache_line_count, created_at
+                          maintenance_summary, maintenance_had_pause, quiet_period_summary, quickstart_run_marker,
+                          config_line_count, cache_line_count, created_at
                    FROM log_runs
                    ORDER BY created_at DESC
                    LIMIT ?""",
@@ -372,11 +409,12 @@ def get_log_run(run_key):
         with closing(connection.cursor()) as cursor:
             _ensure_log_runs_columns(cursor)
             cursor.execute(
-                """SELECT run_key, finished_at, run_time_seconds, kometa_version, kometa_newest_version,
+                """SELECT run_key, started_at, finished_at, run_time_seconds, kometa_version, kometa_newest_version,
                           config_name, config_hash, run_command, command_signature, section_runtimes,
                           recommendations, log_mtime, log_size, debug_count, info_count, warning_count,
                           error_count, critical_count, trace_count, analysis_counts, library_counts,
-                          quickstart_run_marker, config_line_count, cache_line_count, created_at
+                          maintenance_summary, maintenance_had_pause, quiet_period_summary, quickstart_run_marker,
+                          config_line_count, cache_line_count, created_at
                    FROM log_runs
                    WHERE run_key == ?
                    LIMIT 1""",

--- a/modules/logscan.py
+++ b/modules/logscan.py
@@ -3088,8 +3088,7 @@ class LogscanAnalyzer:
             return summary
 
         marker_re = re.compile(
-            r"\[Quickstart\]\s+Maintenance marker:\s+event=(paused|resumed)\s+at=([^\s]+)"
-            r"(?:\s+local_at=([^\s]+))?(?:\s+window=([^\s]+))?(?:\s+paused_seconds=(\d+))?",
+            r"\[Quickstart\]\s+Maintenance marker:\s+event=(paused|resumed)\s+at=([^\s]+)" r"(?:\s+local_at=([^\s]+))?(?:\s+window=([^\s]+))?(?:\s+paused_seconds=(\d+))?",
             re.IGNORECASE,
         )
         open_pause_at = None

--- a/modules/logscan.py
+++ b/modules/logscan.py
@@ -71,6 +71,7 @@ class LogscanAnalyzer:
         self.current_kometa_version = None
         self.kometa_newest_version = None
         self.run_time = None
+        self.started_at = None
         self.finished_at = None
         self.plex_timeout = None
         self.checkfiles_flg = None
@@ -782,6 +783,9 @@ class LogscanAnalyzer:
         parsed_run_time = self._parse_run_time_from_line(run_time_line)
         if parsed_run_time and run_time_is_final:
             self.run_time = parsed_run_time
+            start_match = re.search(r"Start Time:\s*(.*?)\s+Finished:", run_time_line)
+            if start_match:
+                self.started_at = start_match.group(1).strip()
             timestamp_match = re.search(r"\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),", run_time_line)
             if timestamp_match:
                 self.finished_at = timestamp_match.group(1).strip()
@@ -2222,6 +2226,15 @@ class LogscanAnalyzer:
             return parsed.strftime("%Y-%m-%d %H:%M:%S")
         return finished_at
 
+    def _normalize_started_at(self, started_at):
+        parsed = self._parse_finished_datetime(started_at)
+        now = datetime.now()
+        if parsed and parsed > now + timedelta(days=1):
+            parsed = None
+        if parsed:
+            return parsed.strftime("%Y-%m-%d %H:%M:%S")
+        return started_at
+
     def _parse_hms_to_seconds(self, value):
         if not value:
             return None
@@ -3042,6 +3055,199 @@ class LogscanAnalyzer:
         match = re.search(r"\[Quickstart\]\s+Run marker:.*", content)
         return match.group(0) if match else None
 
+    def extract_quickstart_marker_capabilities(self, content):
+        capabilities = {"maintenance_markers": False}
+        marker = self.extract_quickstart_marker(content)
+        if not marker:
+            return capabilities
+        if re.search(r"\bmaintenance_markers=1\b", marker):
+            capabilities["maintenance_markers"] = True
+        return capabilities
+
+    def _parse_log_timestamp(self, line):
+        if not line or not line.startswith("["):
+            return None
+        match = re.match(r"\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d{3}\]", line)
+        if not match:
+            return None
+        try:
+            return datetime.strptime(match.group(1), "%Y-%m-%d %H:%M:%S")
+        except Exception:
+            return None
+
+    def extract_maintenance_summary(self, content):
+        summary = {
+            "had_pause": False,
+            "pause_count": 0,
+            "pause_seconds": 0,
+            "open_pause": False,
+            "window": None,
+            "events": [],
+        }
+        if not content:
+            return summary
+
+        marker_re = re.compile(
+            r"\[Quickstart\]\s+Maintenance marker:\s+event=(paused|resumed)\s+at=([^\s]+)"
+            r"(?:\s+local_at=([^\s]+))?(?:\s+window=([^\s]+))?(?:\s+paused_seconds=(\d+))?",
+            re.IGNORECASE,
+        )
+        open_pause_at = None
+        open_pause_window = None
+        open_pause_local_at = None
+
+        for line in content.splitlines():
+            match = marker_re.search(line)
+            if not match:
+                continue
+            event = str(match.group(1) or "").strip().lower()
+            raw_ts = str(match.group(2) or "").strip()
+            local_at = str(match.group(3) or "").strip() or None
+            window = str(match.group(4) or "").strip() or None
+            paused_seconds_raw = match.group(5)
+            event_ts = None
+            try:
+                event_ts = datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
+                if event_ts.tzinfo is not None:
+                    event_ts = event_ts.astimezone(timezone.utc)
+            except Exception:
+                event_ts = None
+            paused_seconds = None
+            if paused_seconds_raw is not None:
+                try:
+                    paused_seconds = max(0, int(paused_seconds_raw))
+                except Exception:
+                    paused_seconds = None
+
+            summary["events"].append(
+                {
+                    "event": event,
+                    "at": raw_ts,
+                    "local_at": local_at,
+                    "window": window,
+                    "paused_seconds": paused_seconds,
+                }
+            )
+            if window:
+                summary["window"] = window
+
+            if event == "paused":
+                summary["had_pause"] = True
+                summary["pause_count"] += 1
+                open_pause_at = event_ts
+                open_pause_window = window
+                open_pause_local_at = local_at
+                continue
+
+            if event == "resumed":
+                summary["had_pause"] = True
+                if paused_seconds is None and open_pause_at and event_ts:
+                    try:
+                        paused_seconds = max(0, int((event_ts - open_pause_at).total_seconds()))
+                    except Exception:
+                        paused_seconds = None
+                if paused_seconds is not None:
+                    summary["pause_seconds"] += paused_seconds
+                open_pause_at = None
+                open_pause_window = None
+                open_pause_local_at = None
+
+        if open_pause_at is not None:
+            summary["open_pause"] = True
+            summary["had_pause"] = True
+            if not summary["window"] and open_pause_window:
+                summary["window"] = open_pause_window
+            if summary["events"] and not summary["events"][-1].get("local_at") and open_pause_local_at:
+                summary["events"][-1]["local_at"] = open_pause_local_at
+
+        return summary
+
+    def extract_quiet_period_summary(self, content, maintenance_summary=None):
+        summary = {
+            "longest_gap_seconds": 0,
+            "longest_gap_started_at": None,
+            "longest_gap_ended_at": None,
+            "gaps_over_300": 0,
+            "gaps_over_900": 0,
+            "gaps_over_1800": 0,
+            "longest_gap_maintenance_overlap": "unknown",
+        }
+        if not content:
+            return summary
+
+        capabilities = self.extract_quickstart_marker_capabilities(content)
+        maintenance_supported = bool(capabilities.get("maintenance_markers"))
+        timestamps = []
+        for line in content.splitlines():
+            line_ts = self._parse_log_timestamp(line)
+            if line_ts is not None:
+                timestamps.append(line_ts)
+        if len(timestamps) < 2:
+            if maintenance_supported:
+                summary["longest_gap_maintenance_overlap"] = "none"
+            return summary
+
+        maintenance_summary = maintenance_summary if isinstance(maintenance_summary, dict) else {}
+        maintenance_intervals = []
+        open_start = None
+        for event in maintenance_summary.get("events") or []:
+            if not isinstance(event, dict):
+                continue
+            local_at = str(event.get("local_at") or "").strip()
+            event_name = str(event.get("event") or "").strip().lower()
+            event_ts = None
+            if local_at:
+                try:
+                    event_ts = datetime.fromisoformat(local_at)
+                except Exception:
+                    event_ts = None
+            if event_ts is None:
+                continue
+            if event_name == "paused":
+                open_start = event_ts
+            elif event_name == "resumed" and open_start is not None:
+                maintenance_intervals.append((open_start, event_ts))
+                open_start = None
+        if open_start is not None:
+            maintenance_intervals.append((open_start, None))
+
+        longest_start = None
+        longest_end = None
+        for previous_ts, current_ts in zip(timestamps, timestamps[1:]):
+            gap_seconds = max(0, int((current_ts - previous_ts).total_seconds()))
+            if gap_seconds <= 0:
+                continue
+            if gap_seconds >= 300:
+                summary["gaps_over_300"] += 1
+            if gap_seconds >= 900:
+                summary["gaps_over_900"] += 1
+            if gap_seconds >= 1800:
+                summary["gaps_over_1800"] += 1
+            if gap_seconds > summary["longest_gap_seconds"]:
+                summary["longest_gap_seconds"] = gap_seconds
+                longest_start = previous_ts
+                longest_end = current_ts
+
+        if longest_start is not None and longest_end is not None:
+            summary["longest_gap_started_at"] = longest_start.isoformat()
+            summary["longest_gap_ended_at"] = longest_end.isoformat()
+            overlap = False
+            for interval_start, interval_end in maintenance_intervals:
+                if interval_end is None:
+                    if longest_end > interval_start:
+                        overlap = True
+                        break
+                    continue
+                if longest_start < interval_end and longest_end > interval_start:
+                    overlap = True
+                    break
+            if overlap:
+                summary["longest_gap_maintenance_overlap"] = "confirmed"
+            elif maintenance_supported:
+                summary["longest_gap_maintenance_overlap"] = "none"
+
+        return summary
+
     def extract_config_line_count(self, content):
         if not content:
             return 0
@@ -3195,6 +3401,7 @@ class LogscanAnalyzer:
         command_signature=None,
         section_runtimes=None,
     ):
+        started_at = self._normalize_started_at(self.started_at)
         finished_at = self.finished_at
         if not finished_at and finished_runs:
             last_run = finished_runs[-1]
@@ -3242,6 +3449,7 @@ class LogscanAnalyzer:
 
         return {
             "run_key": run_key,
+            "started_at": started_at,
             "finished_at": finished_at,
             "run_time_seconds": run_time_seconds,
             "run_complete": run_complete,
@@ -3264,6 +3472,7 @@ class LogscanAnalyzer:
         self.reset_server_versions()
         self.checkfiles_flg = None
         self.run_time = None
+        self.started_at = None
         self.finished_at = None
         self.plex_timeout = None
         self.current_kometa_version = None
@@ -3298,6 +3507,8 @@ class LogscanAnalyzer:
         config_line_count = self.extract_config_line_count(raw_content)
         cache_line_count = sum(1 for line in raw_content.splitlines() if "from Cache" in line)
         library_counts = self.extract_library_counts(cleaned_content)
+        maintenance_summary = self.extract_maintenance_summary(raw_content)
+        quiet_period_summary = self.extract_quiet_period_summary(raw_content, maintenance_summary=maintenance_summary)
 
         missing_people = []
         missing_people_message = None
@@ -3338,6 +3549,8 @@ class LogscanAnalyzer:
             summary["analysis_counts"] = analysis_counts
             summary["quickstart_run_marker"] = bool(quickstart_marker)
             summary["library_counts"] = library_counts
+            summary["maintenance_summary"] = maintenance_summary
+            summary["quiet_period_summary"] = quiet_period_summary
             summary["config_line_count"] = config_line_count
             summary["cache_line_count"] = cache_line_count
         if summary and not summary.get("run_complete"):

--- a/quickstart.py
+++ b/quickstart.py
@@ -1770,10 +1770,7 @@ def _write_quickstart_run_marker(kometa_root, config_name=None):
         qs_branch = version_info.get("branch") or "unknown"
         safe_config = (config_name or "default").strip() or "default"
         timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-        marker = (
-            f"[Quickstart] Run marker: started={timestamp} "
-            f"config={safe_config} quickstart={qs_version} branch={qs_branch} maintenance_markers=1"
-        )
+        marker = f"[Quickstart] Run marker: started={timestamp} " f"config={safe_config} quickstart={qs_version} branch={qs_branch} maintenance_markers=1"
         _append_quickstart_meta_log_line(kometa_root, marker)
     except Exception:
         pass

--- a/quickstart.py
+++ b/quickstart.py
@@ -1724,6 +1724,10 @@ def _maintenance_guard_loop(app_in):
                     if _suspend_process_tree(proc):
                         window_label = f" ({window_str})" if window_str else ""
                         helpers.ts_log(f"Kometa paused due to Plex maintenance window{window_label}.", level="INFO")
+                        try:
+                            _write_quickstart_maintenance_marker(helpers.get_kometa_root_path(), "paused", window=window_str)
+                        except Exception:
+                            pass
                         with MAINTENANCE_STATE_LOCK:
                             MAINTENANCE_STATE["paused"] = True
                             MAINTENANCE_STATE["paused_since"] = datetime.now(timezone.utc).isoformat()
@@ -1731,10 +1735,29 @@ def _maintenance_guard_loop(app_in):
 
             with MAINTENANCE_STATE_LOCK:
                 was_paused = MAINTENANCE_STATE["paused"]
+                paused_since = MAINTENANCE_STATE["paused_since"]
             if was_paused:
                 if _resume_process_tree(proc):
                     window_label = f" ({window_str})" if window_str else ""
                     helpers.ts_log(f"Plex maintenance ended{window_label}. Kometa resumed.", level="INFO")
+                    paused_seconds = None
+                    if paused_since:
+                        try:
+                            paused_at = datetime.fromisoformat(str(paused_since).replace("Z", "+00:00"))
+                            if paused_at.tzinfo is None:
+                                paused_at = paused_at.replace(tzinfo=timezone.utc)
+                            paused_seconds = max(0, int((datetime.now(timezone.utc) - paused_at).total_seconds()))
+                        except Exception:
+                            paused_seconds = None
+                    try:
+                        _write_quickstart_maintenance_marker(
+                            helpers.get_kometa_root_path(),
+                            "resumed",
+                            window=window_str,
+                            paused_seconds=paused_seconds,
+                        )
+                    except Exception:
+                        pass
                     with MAINTENANCE_STATE_LOCK:
                         MAINTENANCE_STATE["paused"] = False
                         MAINTENANCE_STATE["paused_since"] = None
@@ -1742,19 +1765,50 @@ def _maintenance_guard_loop(app_in):
 
 def _write_quickstart_run_marker(kometa_root, config_name=None):
     try:
-        log_dir = Path(kometa_root) / "config" / "logs"
-        log_dir.mkdir(parents=True, exist_ok=True)
-        log_path = log_dir / "meta.log"
         version_info = app.config.get("VERSION_CHECK") or {}
         qs_version = version_info.get("local_version") or "unknown"
         qs_branch = version_info.get("branch") or "unknown"
         safe_config = (config_name or "default").strip() or "default"
-        timestamp = datetime.now(timezone.utc).isoformat()
-        marker = f"[Quickstart] Run marker: started={timestamp} " f"config={safe_config} quickstart={qs_version} branch={qs_branch}"
-        with log_path.open("a", encoding="utf-8", errors="ignore") as handle:
-            handle.write(marker + "\n")
+        timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        marker = (
+            f"[Quickstart] Run marker: started={timestamp} "
+            f"config={safe_config} quickstart={qs_version} branch={qs_branch} maintenance_markers=1"
+        )
+        _append_quickstart_meta_log_line(kometa_root, marker)
     except Exception:
         pass
+
+
+def _append_quickstart_meta_log_line(kometa_root, line):
+    if not line:
+        return False
+    try:
+        log_dir = Path(kometa_root) / "config" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / "meta.log"
+        with log_path.open("a", encoding="utf-8", errors="ignore") as handle:
+            handle.write(str(line).rstrip() + "\n")
+        return True
+    except Exception:
+        return False
+
+
+def _write_quickstart_maintenance_marker(kometa_root, event, window=None, paused_seconds=None):
+    event_name = str(event or "").strip().lower()
+    if event_name not in {"paused", "resumed"}:
+        return False
+    local_at = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+    parts = [
+        "[Quickstart] Maintenance marker:",
+        f"event={event_name}",
+        f"at={datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')}",
+        f"local_at={local_at}",
+    ]
+    if window:
+        parts.append(f"window={str(window).strip()}")
+    if event_name == "resumed" and isinstance(paused_seconds, (int, float)):
+        parts.append(f"paused_seconds={max(0, int(paused_seconds))}")
+    return _append_quickstart_meta_log_line(kometa_root, " ".join(parts))
 
 
 def _schedule_quickstart_run_marker(kometa_root, config_name=None, timeout_seconds=20):
@@ -8025,7 +8079,7 @@ def _classify_logscan_file_location(path, log_dir=None):
         pass
     try:
         resolved.relative_to(live_dir)
-        return "live"
+        return "live" if resolved.name.lower() == "meta.log" else "archive"
     except ValueError:
         pass
     return "other"
@@ -8567,6 +8621,7 @@ def _analyze_incomplete_log_for_resume(log_path, cache_entry=None, config_name=N
 
     return {
         "run_key": run_key,
+        "started_at": summary.get("started_at"),
         "finished_at": summary.get("finished_at"),
         "run_time_seconds": summary.get("run_time_seconds"),
         "kometa_version": summary.get("kometa_version"),
@@ -8588,6 +8643,9 @@ def _analyze_incomplete_log_for_resume(log_path, cache_entry=None, config_name=N
         "trace_count": counts.get("trace", 0),
         "analysis_counts": summary.get("analysis_counts") if isinstance(summary.get("analysis_counts"), dict) else {},
         "library_counts": summary.get("library_counts") if isinstance(summary.get("library_counts"), dict) else {},
+        "maintenance_summary": summary.get("maintenance_summary") if isinstance(summary.get("maintenance_summary"), dict) else {},
+        "maintenance_had_pause": bool((summary.get("maintenance_summary") or {}).get("had_pause")),
+        "quiet_period_summary": summary.get("quiet_period_summary") if isinstance(summary.get("quiet_period_summary"), dict) else {},
         "quickstart_run_marker": bool(summary.get("quickstart_run_marker")),
         "config_line_count": summary.get("config_line_count"),
         "cache_line_count": summary.get("cache_line_count"),
@@ -8634,6 +8692,7 @@ def _build_incomplete_run_from_cache_entry(log_path, cache_entry=None, config_na
     )
     return {
         "run_key": run_key,
+        "started_at": summary.get("started_at"),
         "finished_at": summary.get("finished_at"),
         "run_time_seconds": summary.get("run_time_seconds"),
         "kometa_version": summary.get("kometa_version"),
@@ -8655,6 +8714,9 @@ def _build_incomplete_run_from_cache_entry(log_path, cache_entry=None, config_na
         "trace_count": counts.get("trace", 0),
         "analysis_counts": summary.get("analysis_counts") if isinstance(summary.get("analysis_counts"), dict) else {},
         "library_counts": summary.get("library_counts") if isinstance(summary.get("library_counts"), dict) else {},
+        "maintenance_summary": summary.get("maintenance_summary") if isinstance(summary.get("maintenance_summary"), dict) else {},
+        "maintenance_had_pause": bool((summary.get("maintenance_summary") or {}).get("had_pause")),
+        "quiet_period_summary": summary.get("quiet_period_summary") if isinstance(summary.get("quiet_period_summary"), dict) else {},
         "quickstart_run_marker": bool(summary.get("quickstart_run_marker")),
         "config_line_count": summary.get("config_line_count"),
         "cache_line_count": summary.get("cache_line_count"),
@@ -8690,6 +8752,7 @@ def _build_incomplete_log_fallback(log_path, cache_entry=None, config_name=None)
     created_at = cache_entry.get("updated_at") or _iso_from_mtime(mtime)
     return {
         "run_key": run_key,
+        "started_at": None,
         "finished_at": None,
         "run_time_seconds": None,
         "kometa_version": "",
@@ -8711,6 +8774,9 @@ def _build_incomplete_log_fallback(log_path, cache_entry=None, config_name=None)
         "trace_count": 0,
         "analysis_counts": {},
         "library_counts": {},
+        "maintenance_summary": {},
+        "maintenance_had_pause": False,
+        "quiet_period_summary": {},
         "quickstart_run_marker": False,
         "config_line_count": None,
         "cache_line_count": None,
@@ -9057,6 +9123,38 @@ def _archive_rotated_logs(log_dir):
     return archived
 
 
+def _archive_rotated_log_and_update_cache(path, cache_logs, archive_dir, run_key=None, run_complete=False):
+    try:
+        source_path = Path(path).resolve()
+    except Exception:
+        return None
+    if source_path.name.lower() == "meta.log":
+        return None
+    archived_path = _archive_log_file(source_path, archive_dir, log_dir=source_path.parent)
+    if not archived_path:
+        return None
+    try:
+        archived_stats = archived_path.stat()
+        archived_key = str(archived_path.resolve())
+    except Exception:
+        return None
+    source_key = str(source_path)
+    existing_entry = cache_logs.get(source_key, {}) if isinstance(cache_logs, dict) else {}
+    if not isinstance(existing_entry, dict):
+        existing_entry = {}
+    updated_entry = dict(existing_entry)
+    updated_entry["mtime"] = archived_stats.st_mtime
+    updated_entry["size"] = archived_stats.st_size
+    updated_entry["run_complete"] = bool(run_complete)
+    updated_entry["updated_at"] = datetime.now(timezone.utc).isoformat()
+    if run_key:
+        updated_entry["run_key"] = run_key
+    if isinstance(cache_logs, dict):
+        cache_logs.pop(source_key, None)
+        cache_logs[archived_key] = updated_entry
+    return archived_path
+
+
 def _prune_logscan_archive(archive_dir):
     keep_limit = app.config.get("QS_KOMETA_LOG_KEEP", 0)
     if keep_limit <= 0:
@@ -9199,6 +9297,16 @@ def _perform_logscan_reingest(reset, job_id=None, update_state=True):
                 summary = result.get("summary") if isinstance(result, dict) else None
                 if not summary:
                     skipped_invalid += 1
+                    if path.parent.resolve() == log_dir.resolve() and path.name.lower() != "meta.log":
+                        archived_path = _archive_rotated_log_and_update_cache(
+                            path,
+                            cache_logs,
+                            archive_dir,
+                            run_key=cached_run_key,
+                            run_complete=False,
+                        )
+                        if archived_path:
+                            cache_dirty = True
                     continue
                 if not summary.get("run_complete"):
                     skipped_incomplete += 1
@@ -9215,6 +9323,7 @@ def _perform_logscan_reingest(reset, job_id=None, update_state=True):
                         "updated_at": datetime.now(timezone.utc).isoformat(),
                         "summary": {
                             "run_key": summary.get("run_key"),
+                            "started_at": summary.get("started_at"),
                             "finished_at": summary.get("finished_at"),
                             "run_time_seconds": summary.get("run_time_seconds"),
                             "kometa_version": summary.get("kometa_version"),
@@ -9228,6 +9337,8 @@ def _perform_logscan_reingest(reset, job_id=None, update_state=True):
                             "log_counts": summary.get("log_counts") if isinstance(summary.get("log_counts"), dict) else {},
                             "analysis_counts": summary.get("analysis_counts") if isinstance(summary.get("analysis_counts"), dict) else {},
                             "library_counts": summary.get("library_counts") if isinstance(summary.get("library_counts"), dict) else {},
+                            "maintenance_summary": summary.get("maintenance_summary") if isinstance(summary.get("maintenance_summary"), dict) else {},
+                            "quiet_period_summary": summary.get("quiet_period_summary") if isinstance(summary.get("quiet_period_summary"), dict) else {},
                             "quickstart_run_marker": bool(summary.get("quickstart_run_marker")),
                             "config_line_count": summary.get("config_line_count"),
                             "cache_line_count": summary.get("cache_line_count"),
@@ -9236,6 +9347,16 @@ def _perform_logscan_reingest(reset, job_id=None, update_state=True):
                         "recommendations": incomplete_recommendations,
                     }
                     cache_dirty = True
+                    if path.parent.resolve() == log_dir.resolve() and path.name.lower() != "meta.log":
+                        archived_path = _archive_rotated_log_and_update_cache(
+                            path,
+                            cache_logs,
+                            archive_dir,
+                            run_key=summary.get("run_key"),
+                            run_complete=False,
+                        )
+                        if archived_path:
+                            cache_dirty = True
                     continue
                 missing_people = result.get("missing_people") if isinstance(result, dict) else None
                 if missing_people:

--- a/static/local-js/905-analytics.js
+++ b/static/local-js/905-analytics.js
@@ -299,6 +299,12 @@ $(document).ready(function () {
     return created || 'n/a'
   }
 
+  function getDisplayStarted (run) {
+    if (!run) return 'n/a'
+    const started = formatTimestamp(run.started_at)
+    return started || 'n/a'
+  }
+
   function getSectionTotal (sectionRuntimes) {
     if (!sectionRuntimes || typeof sectionRuntimes !== 'object') return 0
     return Object.values(sectionRuntimes).reduce((sum, value) => {
@@ -326,6 +332,95 @@ $(document).ready(function () {
       return `Displayed from section runtimes (${formatSeconds(parts.sectionTotal)}) because the parsed run total was ${formatSeconds(parts.raw)}. Reingest logs after this update to refresh stored run totals.`
     }
     return 'Total run time parsed from the Kometa run summary.'
+  }
+
+  function getMaintenanceSummary (run) {
+    const summary = run && run.maintenance_summary && typeof run.maintenance_summary === 'object'
+      ? run.maintenance_summary
+      : {}
+    return {
+      hadPause: Boolean(run && run.maintenance_had_pause) || Boolean(summary.had_pause),
+      pauseCount: Number.isFinite(summary.pause_count) ? summary.pause_count : 0,
+      pauseSeconds: Number.isFinite(summary.pause_seconds) ? summary.pause_seconds : 0,
+      openPause: Boolean(summary.open_pause),
+      window: summary.window || '',
+      events: Array.isArray(summary.events) ? summary.events : []
+    }
+  }
+
+  function getMaintenanceSortValue (run) {
+    const summary = getMaintenanceSummary(run)
+    if (!summary.hadPause) return 0
+    const seconds = Number.isFinite(summary.pauseSeconds) ? summary.pauseSeconds : 0
+    const count = Number.isFinite(summary.pauseCount) ? summary.pauseCount : 0
+    return (seconds * 100) + count + (summary.openPause ? 1 : 0)
+  }
+
+  function renderMaintenanceSummaryCell (run) {
+    const summary = getMaintenanceSummary(run)
+    if (!summary.hadPause) {
+      return '<span class="text-muted">No pause</span>'
+    }
+    const parts = [`Paused ${summary.pauseCount || 1}x`]
+    if (summary.pauseSeconds > 0) {
+      parts.push(formatSeconds(summary.pauseSeconds))
+    }
+    if (summary.openPause) {
+      parts.push('open')
+    }
+    const detailParts = []
+    if (summary.window) {
+      detailParts.push(`Window: ${summary.window}`)
+    }
+    if (summary.events.length) {
+      detailParts.push(`Events: ${summary.events.map(event => event.event).join(', ')}`)
+    }
+    const title = detailParts.join(' | ')
+    return `<span title="${escapeHtml(title)}">${escapeHtml(parts.join(' • '))}</span>`
+  }
+
+  function getQuietPeriodSummary (run) {
+    const summary = run && run.quiet_period_summary && typeof run.quiet_period_summary === 'object'
+      ? run.quiet_period_summary
+      : {}
+    return {
+      longestGapSeconds: Number.isFinite(summary.longest_gap_seconds) ? summary.longest_gap_seconds : 0,
+      longestGapStartedAt: summary.longest_gap_started_at || '',
+      longestGapEndedAt: summary.longest_gap_ended_at || '',
+      gapsOver300: Number.isFinite(summary.gaps_over_300) ? summary.gaps_over_300 : 0,
+      gapsOver900: Number.isFinite(summary.gaps_over_900) ? summary.gaps_over_900 : 0,
+      gapsOver1800: Number.isFinite(summary.gaps_over_1800) ? summary.gaps_over_1800 : 0,
+      maintenanceOverlap: summary.longest_gap_maintenance_overlap || 'unknown'
+    }
+  }
+
+  function getQuietPeriodSortValue (run) {
+    return getQuietPeriodSummary(run).longestGapSeconds
+  }
+
+  function renderQuietPeriodCell (run) {
+    const summary = getQuietPeriodSummary(run)
+    if (summary.longestGapSeconds <= 0) {
+      return '<span class="text-muted">No gaps</span>'
+    }
+    const parts = [`Longest ${formatSeconds(summary.longestGapSeconds)}`]
+    if (summary.gapsOver900 > 0) {
+      parts.push(`${summary.gapsOver900}x>15m`)
+    } else if (summary.gapsOver300 > 0) {
+      parts.push(`${summary.gapsOver300}x>5m`)
+    }
+    const detailParts = []
+    if (summary.longestGapStartedAt && summary.longestGapEndedAt) {
+      detailParts.push(`Gap: ${summary.longestGapStartedAt} -> ${summary.longestGapEndedAt}`)
+    }
+    if (summary.gapsOver1800 > 0) {
+      detailParts.push(`>30m: ${summary.gapsOver1800}`)
+    }
+    if (summary.maintenanceOverlap) {
+      detailParts.push(`Maintenance overlap: ${summary.maintenanceOverlap}`)
+    }
+    const title = detailParts.join(' | ')
+    return `<span title="${escapeHtml(title)}">${escapeHtml(parts.join(' • '))}</span>`
   }
 
   function getCountsTotal (run) {
@@ -1279,7 +1374,7 @@ $(document).ready(function () {
     $tablePrev.prop('disabled', tablePage <= 1 || total === 0)
     $tableNext.prop('disabled', tablePage >= pageCount || total === 0)
     if (!total) {
-      $tableBody.html('<tr><td colspan="14" class="text-muted">No runs match the current filters.</td></tr>')
+      $tableBody.html('<tr><td colspan="17" class="text-muted">No runs match the current filters.</td></tr>')
       return
     }
     sectionDetailsByRunKey.clear()
@@ -1341,6 +1436,7 @@ $(document).ready(function () {
       const isSelectable = isRunSelectable(run)
       const isSelected = isSelectable && selectedRunKeys.has(runKey)
       const statusDisplay = run.is_incomplete ? 'Incomplete' : 'Complete'
+      const startedDisplay = escapeHtml(getDisplayStarted(run))
       const finishedDisplay = escapeHtml(getDisplayFinished(run))
       const sizeBytes = typeof run.log_resolved_size === 'number'
         ? run.log_resolved_size
@@ -1393,6 +1489,7 @@ $(document).ready(function () {
             </span>
           `, 'class="logscan-select-cell"')}
           ${renderRunCardCell('Status', 'Complete runs are included in charts. Incomplete logs are shown here for investigation and file management.', escapeHtml(statusDisplay), run.is_incomplete ? 'class="text-nowrap text-warning fw-semibold"' : 'class="text-nowrap text-success fw-semibold"')}
+          ${renderRunCardCell('Started', 'Timestamp parsed from the Start Time value in the completed Kometa run summary.', startedDisplay, 'class="text-nowrap"')}
           ${renderRunCardCell('Finished', 'Timestamp of the run finishing. Incomplete logs are shown here for investigation only and are excluded from charts.', finishedDisplay, 'class="text-nowrap"')}
           ${renderRunCardCell('Runtime', getRuntimeHelpText(run), escapeHtml(formatSeconds(runtimeParts.effective)))}
           ${renderRunCardCell('Config', 'Config name detected for the run.', escapeHtml(run.config_name || 'default'))}
@@ -1401,6 +1498,8 @@ $(document).ready(function () {
           ${renderRunCardCell('Command', 'Sanitized Kometa command line.', `<span class="logscan-command" title="${escapeHtml(commandTitle)}">${escapeHtml(command)}</span>`)}
           ${renderRunCardCell('Counts', 'W warnings, E errors, T tracebacks, M movies, S shows, Ep episodes, Tot total library items.', `<span class="logscan-count-chip-row">${countChips}</span>`)}
           ${renderRunCardCell('Kometa', 'Version detected for the run, plus newest version when different.', escapeHtml(kometaDisplay))}
+          ${renderRunCardCell('Maintenance', 'Quickstart maintenance pauses recorded in meta.log for this run.', renderMaintenanceSummaryCell(run))}
+          ${renderRunCardCell('Quiet periods', 'Longest delays between timestamped Kometa log lines for this run.', renderQuietPeriodCell(run))}
           ${renderRunCardCell('Section runtimes', 'Runtime totals parsed per Kometa section.', sectionCell)}
           ${renderRunCardCell('Log size', 'Current on-disk size of the resolved log file when available, otherwise the ingested size.', escapeHtml(formatBytes(sizeBytes)))}
           ${renderRunCardCell('Log', 'Download the source log for this run. Archived plain logs can also be compressed, and archived logs can be deleted here.', `<div class="logscan-action-stack">${logActions.join('')}</div>`)}
@@ -1827,6 +1926,12 @@ $(document).ready(function () {
     switch (key) {
       case 'status':
         return run && run.is_incomplete ? 1 : 0
+      case 'started_at':
+        if (run && run.started_at) {
+          const parsed = new Date(run.started_at)
+          if (!Number.isNaN(parsed.getTime())) return parsed.getTime()
+        }
+        return null
       case 'finished_at':
         return getSortTimestamp(run)
       case 'run_time_seconds':
@@ -1855,6 +1960,10 @@ $(document).ready(function () {
         return getRunLibraryTotals(run).total
       case 'kometa_version':
         return run.kometa_version || ''
+      case 'maintenance':
+        return getMaintenanceSortValue(run)
+      case 'quiet_periods':
+        return getQuietPeriodSortValue(run)
       case 'section_runtimes':
         return getSectionTotal(run.section_runtimes)
       case 'log_resolved_size':
@@ -2442,7 +2551,7 @@ $(document).ready(function () {
         if ($tablePageInfo.length) $tablePageInfo.text('No rows')
         $tablePrev.prop('disabled', true)
         $tableNext.prop('disabled', true)
-        $tableBody.html('<tr><td colspan="14" class="text-muted">Unable to load runs.</td></tr>')
+        $tableBody.html('<tr><td colspan="17" class="text-muted">Unable to load runs.</td></tr>')
         updateSelectionSummary()
       })
   }

--- a/templates/905-analytics.html
+++ b/templates/905-analytics.html
@@ -155,6 +155,7 @@
         <label class="small text-muted" for="logscan-table-sort-key">Sort by</label>
         <select id="logscan-table-sort-key" class="form-select form-select-sm w-auto">
           <option value="status">Status</option>
+          <option value="started_at">Started</option>
           <option value="finished_at" selected>Finished</option>
           <option value="run_time_seconds">Runtime</option>
           <option value="config_name">Config</option>
@@ -170,6 +171,8 @@
           <option value="library_episodes">Episodes</option>
           <option value="library_total">Total items</option>
           <option value="kometa_version">Kometa</option>
+          <option value="maintenance">Maintenance</option>
+          <option value="quiet_periods">Quiet periods</option>
           <option value="section_runtimes">Section runtimes</option>
           <option value="log_resolved_size">Log size</option>
           <option value="recommendations_count">Report</option>
@@ -199,6 +202,16 @@
               </th>
               <th>
                 <span class="text-nowrap">Status</span>
+              </th>
+              <th>
+                <button type="button" class="logscan-sort-button" data-sort="started_at"
+                  title="Sort by started timestamp" aria-label="Sort by started timestamp">
+                  Started
+                  <span class="logscan-sort-icons" aria-hidden="true">
+                    <span class="logscan-sort-up"></span>
+                    <span class="logscan-sort-down"></span>
+                  </span>
+                </button>
               </th>
               <th>
                 <button type="button" class="logscan-sort-button is-desc" data-sort="finished_at"
@@ -281,6 +294,26 @@
                 </button>
               </th>
               <th>
+                <button type="button" class="logscan-sort-button" data-sort="maintenance"
+                  title="Sort by maintenance pauses" aria-label="Sort by maintenance pauses">
+                  Maintenance
+                  <span class="logscan-sort-icons" aria-hidden="true">
+                    <span class="logscan-sort-up"></span>
+                    <span class="logscan-sort-down"></span>
+                  </span>
+                </button>
+              </th>
+              <th>
+                <button type="button" class="logscan-sort-button" data-sort="quiet_periods"
+                  title="Sort by longest quiet period" aria-label="Sort by longest quiet period">
+                  Quiet Periods
+                  <span class="logscan-sort-icons" aria-hidden="true">
+                    <span class="logscan-sort-up"></span>
+                    <span class="logscan-sort-down"></span>
+                  </span>
+                </button>
+              </th>
+              <th>
                 <button type="button" class="logscan-sort-button" data-sort="section_runtimes"
                   title="Sort by section runtimes" aria-label="Sort by section runtimes">
                   Section Runtimes
@@ -315,7 +348,7 @@
           </thead>
           <tbody>
             <tr>
-              <td colspan="14" class="text-muted">Loading runs...</td>
+              <td colspan="17" class="text-muted">Loading runs...</td>
             </tr>
           </tbody>
         </table>
@@ -461,32 +494,32 @@
               <div class="accordion-body">
                 <div class="logscan-pref-list">
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-daily-runs" data-pref-group="panels" data-pref-key="daily_runs">
                     <label class="form-check-label" for="logscan-pref-daily-runs">Daily runs</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-issue-trends" data-pref-group="panels" data-pref-key="issue_trends">
                     <label class="form-check-label" for="logscan-pref-issue-trends">Issue trends</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-library-inventory" data-pref-group="panels" data-pref-key="library_inventory">
                     <label class="form-check-label" for="logscan-pref-library-inventory">Library inventory</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-runtime-distribution" data-pref-group="panels" data-pref-key="runtime_distribution">
                     <label class="form-check-label" for="logscan-pref-runtime-distribution">Runtime distribution</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-summary" data-pref-group="panels" data-pref-key="summary">
                     <label class="form-check-label" for="logscan-pref-summary">Summary + ingest health</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-counts-mix" data-pref-group="panels" data-pref-key="counts_mix">
                     <label class="form-check-label" for="logscan-pref-counts-mix">Log levels + cache</label>
                   </div>
@@ -506,7 +539,7 @@
               <div class="accordion-body">
                 <div class="logscan-pref-list">
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-people-posters" data-pref-group="issues" data-pref-key="people_posters">
                     <label class="form-check-label" for="logscan-pref-people-posters">Missing people posters</label>
                   </div>
@@ -526,77 +559,77 @@
               <div class="accordion-body">
                 <div class="logscan-pref-list">
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-anidb-auth" data-pref-group="issues" data-pref-key="anidb_auth">
                     <label class="form-check-label" for="logscan-pref-anidb-auth">AniDB auth errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-flixpatrol-errors" data-pref-group="issues" data-pref-key="flixpatrol_errors">
                     <label class="form-check-label" for="logscan-pref-flixpatrol-errors">FlixPatrol errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-flixpatrol-paywall" data-pref-group="issues" data-pref-key="flixpatrol_paywall">
                     <label class="form-check-label" for="logscan-pref-flixpatrol-paywall">FlixPatrol paywall</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-lsio-errors" data-pref-group="issues" data-pref-key="lsio_errors">
                     <label class="form-check-label" for="logscan-pref-lsio-errors">LSIO errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-mal-connection-errors" data-pref-group="issues" data-pref-key="mal_connection_errors">
                     <label class="form-check-label" for="logscan-pref-mal-connection-errors">MAL connection errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-mdblist-api-limit-errors" data-pref-group="issues" data-pref-key="mdblist_api_limit_errors">
                     <label class="form-check-label" for="logscan-pref-mdblist-api-limit-errors">MDBList API limit</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-mdblist-attr-errors" data-pref-group="issues" data-pref-key="mdblist_attr_errors">
                     <label class="form-check-label" for="logscan-pref-mdblist-attr-errors">MDBList attribute errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-mdblist-errors" data-pref-group="issues" data-pref-key="mdblist_errors">
                     <label class="form-check-label" for="logscan-pref-mdblist-errors">MDBList errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-omdb-api-limit-errors" data-pref-group="issues" data-pref-key="omdb_api_limit_errors">
                     <label class="form-check-label" for="logscan-pref-omdb-api-limit-errors">OMDb API limit</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-omdb-errors" data-pref-group="issues" data-pref-key="omdb_errors">
                     <label class="form-check-label" for="logscan-pref-omdb-errors">OMDb errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-tautulli-apikey-errors" data-pref-group="issues" data-pref-key="tautulli_apikey_errors">
                     <label class="form-check-label" for="logscan-pref-tautulli-apikey-errors">Tautulli API key errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-tautulli-url-errors" data-pref-group="issues" data-pref-key="tautulli_url_errors">
                     <label class="form-check-label" for="logscan-pref-tautulli-url-errors">Tautulli URL errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-tmdb-api-errors" data-pref-group="issues" data-pref-key="tmdb_api_errors">
                     <label class="form-check-label" for="logscan-pref-tmdb-api-errors">TMDb API errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-tmdb-fail-errors" data-pref-group="issues" data-pref-key="tmdb_fail_errors">
                     <label class="form-check-label" for="logscan-pref-tmdb-fail-errors">TMDb connection failures</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-trakt-connection-errors" data-pref-group="issues" data-pref-key="trakt_connection_errors">
                     <label class="form-check-label" for="logscan-pref-trakt-connection-errors">Trakt connection errors</label>
                   </div>
@@ -616,42 +649,42 @@
               <div class="accordion-body">
                 <div class="logscan-pref-list">
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-config-bad-version" data-pref-group="issues" data-pref-key="config_bad_version">
                     <label class="form-check-label" for="logscan-pref-config-bad-version">Bad version found</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-config-api-blank" data-pref-group="issues" data-pref-key="config_api_blank">
                     <label class="form-check-label" for="logscan-pref-config-api-blank">Blank API keys</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-config-cache-false" data-pref-group="issues" data-pref-key="config_cache_false">
                     <label class="form-check-label" for="logscan-pref-config-cache-false">Cache false warnings</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-config-delete-unmanaged" data-pref-group="issues" data-pref-key="config_delete_unmanaged">
                     <label class="form-check-label" for="logscan-pref-config-delete-unmanaged">Delete unmanaged warnings</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-config-mass-update" data-pref-group="issues" data-pref-key="config_mass_update">
                     <label class="form-check-label" for="logscan-pref-config-mass-update">Mass update warnings</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-config-missing-path" data-pref-group="issues" data-pref-key="config_missing_path">
                     <label class="form-check-label" for="logscan-pref-config-missing-path">Missing paths</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-config-other-award" data-pref-group="issues" data-pref-key="config_other_award">
                     <label class="form-check-label" for="logscan-pref-config-other-award">Other awards errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-config-to-be-configured" data-pref-group="issues" data-pref-key="config_to_be_configured">
                     <label class="form-check-label" for="logscan-pref-config-to-be-configured">"To be configured" builders</label>
                   </div>
@@ -671,22 +704,22 @@
               <div class="accordion-body">
                 <div class="logscan-pref-list">
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-plex-library-errors" data-pref-group="issues" data-pref-key="plex_library_errors">
                     <label class="form-check-label" for="logscan-pref-plex-library-errors">Plex library errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-plex-regex-errors" data-pref-group="issues" data-pref-key="plex_regex_errors">
                     <label class="form-check-label" for="logscan-pref-plex-regex-errors">Plex regex errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-plex-rounding-errors" data-pref-group="issues" data-pref-key="plex_rounding_errors">
                     <label class="form-check-label" for="logscan-pref-plex-rounding-errors">Plex rounding errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-plex-url-errors" data-pref-group="issues" data-pref-key="plex_url_errors">
                     <label class="form-check-label" for="logscan-pref-plex-url-errors">Plex URL errors</label>
                   </div>
@@ -706,52 +739,52 @@
               <div class="accordion-body">
                 <div class="logscan-pref-list">
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-metadata-attribute-errors" data-pref-group="issues" data-pref-key="metadata_attribute_errors">
                     <label class="form-check-label" for="logscan-pref-metadata-attribute-errors">Metadata attribute errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-metadata-load-errors" data-pref-group="issues" data-pref-key="metadata_load_errors">
                     <label class="form-check-label" for="logscan-pref-metadata-load-errors">Metadata load errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-overlay-apply-errors" data-pref-group="issues" data-pref-key="overlay_apply_errors">
                     <label class="form-check-label" for="logscan-pref-overlay-apply-errors">Overlay apply errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-overlay-font-missing" data-pref-group="issues" data-pref-key="overlay_font_missing">
                     <label class="form-check-label" for="logscan-pref-overlay-font-missing">Overlay font missing</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-overlay-image-missing" data-pref-group="issues" data-pref-key="overlay_image_missing">
                     <label class="form-check-label" for="logscan-pref-overlay-image-missing">Overlay image missing</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-overlay-level-errors" data-pref-group="issues" data-pref-key="overlay_level_errors">
                     <label class="form-check-label" for="logscan-pref-overlay-level-errors">Overlay level errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-overlay-load-errors" data-pref-group="issues" data-pref-key="overlay_load_errors">
                     <label class="form-check-label" for="logscan-pref-overlay-load-errors">Overlay load errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-overlays-bloat" data-pref-group="issues" data-pref-key="overlays_bloat">
                     <label class="form-check-label" for="logscan-pref-overlays-bloat">Overlays bloat warnings</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-playlist-errors" data-pref-group="issues" data-pref-key="playlist_errors">
                     <label class="form-check-label" for="logscan-pref-playlist-errors">Playlist errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-playlist-load-errors" data-pref-group="issues" data-pref-key="playlist_load_errors">
                     <label class="form-check-label" for="logscan-pref-playlist-load-errors">Playlist load errors</label>
                   </div>
@@ -771,17 +804,17 @@
               <div class="accordion-body">
                 <div class="logscan-pref-list">
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-convert-issues" data-pref-group="issues" data-pref-key="convert_issues">
                     <label class="form-check-label" for="logscan-pref-convert-issues">Convert errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-image-corrupt" data-pref-group="issues" data-pref-key="image_corrupt">
                     <label class="form-check-label" for="logscan-pref-image-corrupt">Corrupt images</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-image-size" data-pref-group="issues" data-pref-key="image_size">
                     <label class="form-check-label" for="logscan-pref-image-size">Image size warnings</label>
                   </div>
@@ -801,17 +834,17 @@
               <div class="accordion-body">
                 <div class="logscan-pref-list">
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-runtime-checkfiles" data-pref-group="issues" data-pref-key="runtime_checkfiles">
                     <label class="form-check-label" for="logscan-pref-runtime-checkfiles">checkFiles flagged</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-runtime-run-order" data-pref-group="issues" data-pref-key="runtime_run_order">
                     <label class="form-check-label" for="logscan-pref-runtime-run-order">Run order errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-runtime-timeout" data-pref-group="issues" data-pref-key="runtime_timeout">
                     <label class="form-check-label" for="logscan-pref-runtime-timeout">Timeout errors</label>
                   </div>
@@ -831,17 +864,17 @@
               <div class="accordion-body">
                 <div class="logscan-pref-list">
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-update-git" data-pref-group="issues" data-pref-key="update_git">
                     <label class="form-check-label" for="logscan-pref-update-git">Kometa git errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-update-kometa" data-pref-group="issues" data-pref-key="update_kometa">
                     <label class="form-check-label" for="logscan-pref-update-kometa">New Kometa version</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-update-plexapi" data-pref-group="issues" data-pref-key="update_plexapi">
                     <label class="form-check-label" for="logscan-pref-update-plexapi">New PlexAPI version</label>
                   </div>
@@ -861,22 +894,22 @@
               <div class="accordion-body">
                 <div class="logscan-pref-list">
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-platform-db-cache" data-pref-group="issues" data-pref-key="platform_db_cache">
                     <label class="form-check-label" for="logscan-pref-platform-db-cache">DB cache recommendation</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-platform-kometa-time" data-pref-group="issues" data-pref-key="platform_kometa_time">
                     <label class="form-check-label" for="logscan-pref-platform-kometa-time">Kometa time recommendation</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-platform-memory" data-pref-group="issues" data-pref-key="platform_memory">
                     <label class="form-check-label" for="logscan-pref-platform-memory">Memory recommendation</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-platform-wsl" data-pref-group="issues" data-pref-key="platform_wsl">
                     <label class="form-check-label" for="logscan-pref-platform-wsl">WSL detected</label>
                   </div>
@@ -896,22 +929,22 @@
               <div class="accordion-body">
                 <div class="logscan-pref-list">
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-anidb-69" data-pref-group="issues" data-pref-key="anidb_69">
                     <label class="form-check-label" for="logscan-pref-anidb-69">AniDB 69 errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-misc-internal-server" data-pref-group="issues" data-pref-key="misc_internal_server">
                     <label class="form-check-label" for="logscan-pref-misc-internal-server">Internal server errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-misc-pmm-legacy" data-pref-group="issues" data-pref-key="misc_pmm_legacy">
                     <label class="form-check-label" for="logscan-pref-misc-pmm-legacy">Legacy PMM errors</label>
                   </div>
                   <div class="form-check form-switch">
-                    <input class="form-check-input logscan-pref-input" type="checkbox" role="switch"
+                    <input class="form-check-input logscan-pref-input" type="checkbox"
                       id="logscan-pref-misc-no-items" data-pref-group="issues" data-pref-key="misc_no_items">
                     <label class="form-check-label" for="logscan-pref-misc-no-items">No items found</label>
                   </div>

--- a/tests/test_logscan_endpoints.py
+++ b/tests/test_logscan_endpoints.py
@@ -136,6 +136,47 @@ def test_logscan_trends_includes_archive_storage_and_run_file_metadata(client, i
     assert payload["runs"][0]["log_resolved_size"] == len(log_bytes)
 
 
+def test_logscan_trends_returns_maintenance_summary_for_saved_runs(client, isolated_config_dir, qs_module):
+    qs_module.database.save_log_run(
+        {
+            "run_key": "run-maint-1",
+            "finished_at": "2026-04-23T10:00:00Z",
+            "config_name": "demo",
+            "created_at": "2026-04-23T10:00:00Z",
+            "maintenance_summary": {
+                "had_pause": True,
+                "pause_count": 1,
+                "pause_seconds": 300,
+                "open_pause": False,
+                "window": "01:00-02:00",
+                "events": [],
+            },
+            "quiet_period_summary": {
+                "longest_gap_seconds": 1200,
+                "longest_gap_started_at": "2026-04-23T01:00:00",
+                "longest_gap_ended_at": "2026-04-23T01:20:00",
+                "gaps_over_300": 2,
+                "gaps_over_900": 1,
+                "gaps_over_1800": 0,
+                "longest_gap_maintenance_overlap": "confirmed",
+            },
+        }
+    )
+
+    resp = client.get("/logscan/trends")
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    row = payload["runs"][0]
+    assert row["maintenance_had_pause"] is True
+    assert row["maintenance_summary"]["had_pause"] is True
+    assert row["maintenance_summary"]["pause_count"] == 1
+    assert row["maintenance_summary"]["pause_seconds"] == 300
+    assert row["maintenance_summary"]["window"] == "01:00-02:00"
+    assert row["quiet_period_summary"]["longest_gap_seconds"] == 1200
+    assert row["quiet_period_summary"]["gaps_over_900"] == 1
+    assert row["quiet_period_summary"]["longest_gap_maintenance_overlap"] == "confirmed"
+
+
 def test_logscan_trends_does_not_bind_historical_run_to_live_log(client, isolated_config_dir, monkeypatch, qs_module):
     kometa_root = Path(qs_module.app.config["KOMETA_ROOT"])
     log_dir = kometa_root / "config" / "logs"
@@ -614,6 +655,17 @@ def test_archive_finished_live_meta_log_if_idle_moves_live_file_and_cache(isolat
     assert archived.suffixes[-2:] == [".log", ".gz"]
 
 
+def test_classify_rotated_log_in_live_dir_as_archive(isolated_config_dir, qs_module):
+    kometa_root = Path(qs_module.app.config["KOMETA_ROOT"])
+    log_dir = kometa_root / "config" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    rotated_path = log_dir / "meta-2.log"
+    rotated_path.write_text("stale rotated log\n", encoding="utf-8")
+
+    assert qs_module._classify_logscan_file_location(rotated_path, log_dir=log_dir) == "archive"
+    assert qs_module._classify_logscan_file_location(log_dir / "meta.log", log_dir=log_dir) == "live"
+
+
 def test_normalize_logscan_archive_filenames_renames_legacy_files_and_updates_cache(isolated_config_dir, monkeypatch, qs_module):
     archive_dir = isolated_config_dir / "cache" / "logscan" / "archive"
     archive_dir.mkdir(parents=True, exist_ok=True)
@@ -833,6 +885,50 @@ def test_logscan_reingest_ingests_day_runtime_log(client, isolated_config_dir, m
     assert payload["success"] is True
     assert payload["ingested"] >= 1
     assert payload["skipped_incomplete"] == 0
+
+
+def test_logscan_reingest_archives_incomplete_rotated_live_log(client, isolated_config_dir, monkeypatch, qs_module):
+    kometa_root = Path(qs_module.app.config["KOMETA_ROOT"])
+    log_dir = kometa_root / "config" / "logs"
+    archive_dir = isolated_config_dir / "cache" / "logscan" / "archive"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "meta-2.log"
+    log_path.write_text("incomplete rotated log\n", encoding="utf-8")
+    saved = {}
+
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_root_path", lambda: kometa_root)
+    monkeypatch.setattr(qs_module.logscan.LogscanAnalyzer, "preload_people_index", lambda self, *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        qs_module.logscan.LogscanAnalyzer,
+        "analyze_content",
+        lambda self, *_args, **_kwargs: {
+            "summary": {
+                "run_key": "run-incomplete-rotated-1",
+                "run_complete": False,
+            },
+            "recommendations": [],
+        },
+    )
+    monkeypatch.setattr(qs_module, "_save_logscan_ingest_cache", lambda cache: saved.__setitem__("cache", copy.deepcopy(cache)))
+
+    resp = client.post("/logscan/trends/reingest", json={"reset": True})
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert payload["skipped_incomplete"] == 1
+    assert not log_path.exists()
+
+    archived_paths = list(archive_dir.glob("*.log.gz"))
+    assert len(archived_paths) == 1
+    archived_path = archived_paths[0]
+    assert archived_path.exists()
+
+    saved_cache = saved["cache"]["logs"]
+    assert str(log_path.resolve()) not in saved_cache
+    assert str(archived_path.resolve()) in saved_cache
+    assert saved_cache[str(archived_path.resolve())]["run_complete"] is False
+    assert saved_cache[str(archived_path.resolve())]["run_key"] == "run-incomplete-rotated-1"
 
 
 def test_logscan_reingest_ingests_gzip_archived_log(client, isolated_config_dir, monkeypatch, qs_module):

--- a/tests/test_logscan_runtime_parse.py
+++ b/tests/test_logscan_runtime_parse.py
@@ -22,6 +22,7 @@ def test_analyze_content_marks_complete_for_day_runtime():
     summary = result.get("summary")
     assert isinstance(summary, dict)
     assert summary.get("run_complete") is True
+    assert summary.get("started_at") == "2026-04-13 07:16:22"
     assert summary.get("run_time_seconds") == (1 * 24 * 3600) + (2 * 3600) + (20 * 60) + 31
 
 
@@ -69,3 +70,98 @@ def test_extract_progress_playlist_runtime_when_logged_from_playlists_module():
     progress = analyzer.extract_progress(content, library_list=[{"name": "Movies", "type": "movie"}])
     assert progress.get("playlist_total_seconds") == 7
     assert progress.get("playlists_detected") is True
+
+
+def test_analyze_content_extracts_quickstart_maintenance_summary():
+    analyzer = LogscanAnalyzer()
+    content = "\n".join(
+        [
+            "[Quickstart] Run marker: started=2026-04-18T10:00:00Z config=demo quickstart=1.0.0 branch=develop maintenance_markers=1",
+            "[2026-04-18 10:10:00,000] [kometa.py:100] [INFO] | Resumed Work |",
+            "[Quickstart] Maintenance marker: event=paused at=2026-04-18T10:05:00Z local_at=2026-04-18T10:05:00 window=01:00-02:00",
+            "[Quickstart] Maintenance marker: event=resumed at=2026-04-18T10:10:00Z local_at=2026-04-18T10:10:00 window=01:00-02:00 paused_seconds=300",
+            "[2026-04-18 10:15:00,000] [kometa.py:522] [INFO] |                                            Finished Run                                            |",
+            "[2026-04-18 10:15:00,000] [kometa.py:522] [INFO] |   Start Time: 10:00:00 2026-04-18     Finished: 10:15:00 2026-04-18     Run Time: 0:15:00   |",
+        ]
+    )
+
+    result = analyzer.analyze_content(content, include_people_scan=False)
+    summary = result.get("summary")
+
+    assert isinstance(summary, dict)
+    assert summary.get("run_complete") is True
+    assert summary.get("maintenance_summary") == {
+        "had_pause": True,
+        "pause_count": 1,
+        "pause_seconds": 300,
+        "open_pause": False,
+        "window": "01:00-02:00",
+        "events": [
+            {
+                "event": "paused",
+                "at": "2026-04-18T10:05:00Z",
+                "local_at": "2026-04-18T10:05:00",
+                "window": "01:00-02:00",
+                "paused_seconds": None,
+            },
+            {
+                "event": "resumed",
+                "at": "2026-04-18T10:10:00Z",
+                "local_at": "2026-04-18T10:10:00",
+                "window": "01:00-02:00",
+                "paused_seconds": 300,
+            },
+        ],
+    }
+    assert summary.get("quiet_period_summary") == {
+        "longest_gap_seconds": 300,
+        "longest_gap_started_at": "2026-04-18T10:10:00",
+        "longest_gap_ended_at": "2026-04-18T10:15:00",
+        "gaps_over_300": 1,
+        "gaps_over_900": 0,
+        "gaps_over_1800": 0,
+        "longest_gap_maintenance_overlap": "none",
+    }
+
+
+def test_analyze_content_marks_quiet_period_overlap_as_confirmed_when_gap_matches_maintenance():
+    analyzer = LogscanAnalyzer()
+    content = "\n".join(
+        [
+            "[Quickstart] Run marker: started=2026-04-18T10:00:00Z config=demo quickstart=1.0.0 branch=develop maintenance_markers=1",
+            "[2026-04-18 10:00:00,000] [kometa.py:100] [INFO] | Starting Run |",
+            "[Quickstart] Maintenance marker: event=paused at=2026-04-18T10:05:00Z local_at=2026-04-18T10:05:00 window=01:00-02:00",
+            "[Quickstart] Maintenance marker: event=resumed at=2026-04-18T10:20:00Z local_at=2026-04-18T10:20:00 window=01:00-02:00 paused_seconds=900",
+            "[2026-04-18 10:20:00,000] [kometa.py:101] [INFO] | Resumed Work |",
+            "[2026-04-18 10:25:00,000] [kometa.py:522] [INFO] |                                            Finished Run                                            |",
+            "[2026-04-18 10:25:00,000] [kometa.py:522] [INFO] |   Start Time: 10:00:00 2026-04-18     Finished: 10:25:00 2026-04-18     Run Time: 0:25:00   |",
+        ]
+    )
+
+    result = analyzer.analyze_content(content, include_people_scan=False)
+    quiet_summary = result["summary"]["quiet_period_summary"]
+
+    assert quiet_summary["longest_gap_seconds"] == 1200
+    assert quiet_summary["gaps_over_300"] == 2
+    assert quiet_summary["gaps_over_900"] == 1
+    assert quiet_summary["longest_gap_maintenance_overlap"] == "confirmed"
+
+
+def test_analyze_content_marks_historical_quiet_period_overlap_as_unknown_without_capability_marker():
+    analyzer = LogscanAnalyzer()
+    content = "\n".join(
+        [
+            "[2026-04-18 10:00:00,000] [kometa.py:100] [INFO] | Starting Run |",
+            "[2026-04-18 10:20:00,000] [kometa.py:101] [INFO] | Working |",
+            "[2026-04-18 10:25:00,000] [kometa.py:522] [INFO] |                                            Finished Run                                            |",
+            "[2026-04-18 10:25:00,000] [kometa.py:522] [INFO] |   Start Time: 10:00:00 2026-04-18     Finished: 10:25:00 2026-04-18     Run Time: 0:25:00   |",
+        ]
+    )
+
+    result = analyzer.analyze_content(content, include_people_scan=False)
+    quiet_summary = result["summary"]["quiet_period_summary"]
+
+    assert quiet_summary["longest_gap_seconds"] == 1200
+    assert quiet_summary["gaps_over_300"] == 2
+    assert quiet_summary["gaps_over_900"] == 1
+    assert quiet_summary["longest_gap_maintenance_overlap"] == "unknown"

--- a/tests/test_next_set.py
+++ b/tests/test_next_set.py
@@ -83,7 +83,7 @@ def test_kometa_status_reconnects_pid_file(tmp_path, client, monkeypatch, qs_mod
     assert pid_file.read_text().strip() == "2222"
 
 
-def test_maintenance_guard_pause_and_resume(monkeypatch, qs_module):
+def test_maintenance_guard_pause_and_resume(tmp_path, monkeypatch, qs_module):
     _reset_maintenance_state(qs_module)
     qs_module._clear_pending_kometa_start()
 
@@ -93,6 +93,7 @@ def test_maintenance_guard_pause_and_resume(monkeypatch, qs_module):
     monkeypatch.setattr(qs_module, "_get_maintenance_window_live", lambda: (60, 120, "01:00-02:00"))
     monkeypatch.setattr(qs_module, "_get_maintenance_window_from_db", lambda: (60, 120, "01:00-02:00"))
     monkeypatch.setattr(qs_module, "_is_within_maintenance_window", lambda *_: active_flag["value"])
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_root_path", lambda: tmp_path)
     monkeypatch.setattr(qs_module.psutil, "Process", lambda pid: _FakePsutilProc(pid))
     monkeypatch.setattr(qs_module, "_suspend_process_tree", lambda *_: True)
     monkeypatch.setattr(qs_module, "_resume_process_tree", lambda *_: True)
@@ -120,3 +121,9 @@ def test_maintenance_guard_pause_and_resume(monkeypatch, qs_module):
         assert qs_module.MAINTENANCE_STATE["paused"] is False
         assert qs_module.MAINTENANCE_STATE["paused_since"] is None
         assert qs_module.MAINTENANCE_STATE["window"] == "01:00-02:00"
+
+    meta_log = tmp_path / "config" / "logs" / "meta.log"
+    assert meta_log.exists()
+    marker_lines = meta_log.read_text(encoding="utf-8").splitlines()
+    assert any("[Quickstart] Maintenance marker: event=paused" in line for line in marker_lines)
+    assert any("[Quickstart] Maintenance marker: event=resumed" in line for line in marker_lines)


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

This branch expands Logscan and Analytics in three areas: it adds maintenance pause markers to meta.log and surfaces per-run maintenance summaries in Analytics, computes quiet-period diagnostics for both historical and new logs, and improves run-history fidelity by treating rotated meta-#.log files as archived rather than live and archiving incomplete rotated logs during reingest. It also adds a sortable Started column to Analytics by parsing the Start Time value from Kometa’s completed Finished Run block, while keeping incomplete-run timing behavior unchanged.


## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
