### PR TITLE
rebuild db logic for analytics

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -36,6 +36,7 @@ PyQt
 pytest
 quickstart
 Radarr
+reingests
 Reingest
 repo
 scm

--- a/README.md
+++ b/README.md
@@ -84,6 +84,26 @@ This reduces the chance of Plex background maintenance colliding with long Komet
 - **Stable run tracking:** Runs are deduped with a stable `run_key` and cached in `config/cache/logscan/ingest_cache.json`.
 - **Missing people requests:** Deduped output is written to `config/cache/logscan/meta_people_missing.log` (metadata in `meta_people_missing.json`).
 - **UI helpers:** Sortable table headers, config filter, analytics breakdowns, and per-run “Report” recommendations.
+- **Startup migrations:** Quickstart can perform a one-time Analytics reset + reingest on startup when a release needs historical log data rebuilt for a new feature.
+
+#### Startup Analytics Migrations
+
+Quickstart supports versioned one-time Analytics migrations for releases that need existing `meta*.log*` history reprocessed without requiring you to open the Analytics page manually.
+
+- `QS_LOGSCAN_STARTUP_MIGRATIONS=1`
+  Default is enabled. Set this to `0` in `config/.env` if you need to temporarily suppress automatic startup migrations.
+- `QS_LOGSCAN_MIGRATION_LEVEL_DONE=0`
+  Quickstart writes this value back to `config/.env` after a startup migration succeeds. It records the highest migration level already applied on that installation.
+- `REQUIRED_LOGSCAN_MIGRATION_LEVEL`
+  This is a code constant in `quickstart.py`. Release builds bump this integer when they need a one-time reset + reingest for a new Analytics capability.
+
+How it works:
+
+- On startup, Quickstart compares `QS_LOGSCAN_MIGRATION_LEVEL_DONE` with the code's `REQUIRED_LOGSCAN_MIGRATION_LEVEL`.
+- If the completed level is lower, Quickstart starts a background Analytics migration that resets trend data and reingests all available Kometa logs.
+- If a user skips releases, the higher required level still triggers the migration automatically on the next startup.
+- If this is a first-time Quickstart setup and no Kometa logs exist yet, Quickstart defers the migration instead of marking it complete. The migration remains pending until logs exist on a future startup.
+- If a reingest is already running, Analytics reconnects to the active job instead of starting a second one.
 
 ### Logscan Analyzer & Analytics Page
 - **Logscan Analyzer:** Parses Kometa `meta.log` files to surface errors, run summaries, and missing items.
@@ -135,6 +155,7 @@ Special thanks to [meisnate12](https://github.com/meisnate12), [bullmoose20](htt
   - [Automatic Updates](#automatic-updates)
   - [Themes \& Personalization](#themes--personalization)
   - [Analytics](#analytics)
+    - [Startup Analytics Migrations](#startup-analytics-migrations)
   - [Logscan Analyzer \& Analytics Page](#logscan-analyzer--analytics-page)
   - [Import Existing Config](#import-existing-config)
   - [Quickstart Scope](#quickstart-scope)

--- a/quickstart.py
+++ b/quickstart.py
@@ -2266,6 +2266,14 @@ logscan_reingest_state = {
     "job_id": None,
 }
 
+# Bump this integer when a release needs a one-time Analytics reset + log reingest
+# on startup. Quickstart persists the highest successful level to config/.env so
+# skipped releases still catch up automatically.
+REQUIRED_LOGSCAN_MIGRATION_LEVEL = 1
+LOGSCAN_STARTUP_MIGRATIONS_ENV = "QS_LOGSCAN_STARTUP_MIGRATIONS"
+LOGSCAN_MIGRATION_LEVEL_DONE_ENV = "QS_LOGSCAN_MIGRATION_LEVEL_DONE"
+LOGSCAN_STARTUP_MIGRATION_JOB_ID = "startup-logscan-migration"
+
 session_ttl = _get_session_lifetime_seconds()
 app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(seconds=session_ttl)
 app.config["SESSION_REFRESH_EACH_REQUEST"] = True
@@ -7951,6 +7959,8 @@ def _reset_logscan_reingest_state():
             {
                 "status": "idle",
                 "job_id": None,
+                "trigger": None,
+                "migration_level": None,
             }
         )
 
@@ -9495,6 +9505,167 @@ def _perform_logscan_reingest(reset, job_id=None, update_state=True):
         logscan_ingest_lock.release()
 
 
+def _logscan_startup_migrations_enabled():
+    raw = str(os.getenv(LOGSCAN_STARTUP_MIGRATIONS_ENV, "1") or "").strip().lower()
+    return raw not in {"0", "false", "no", "off"}
+
+
+def _get_logscan_migration_level_done():
+    raw = str(os.getenv(LOGSCAN_MIGRATION_LEVEL_DONE_ENV, "0") or "").strip()
+    try:
+        return max(0, int(raw))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _set_logscan_migration_level_done(level):
+    normalized = str(max(0, int(level)))
+    helpers.update_env_variable(LOGSCAN_MIGRATION_LEVEL_DONE_ENV, normalized)
+    os.environ[LOGSCAN_MIGRATION_LEVEL_DONE_ENV] = normalized
+
+
+def _get_pending_logscan_startup_migration():
+    enabled = _logscan_startup_migrations_enabled()
+    completed_level = _get_logscan_migration_level_done()
+    required_level = max(0, int(REQUIRED_LOGSCAN_MIGRATION_LEVEL or 0))
+    state = {
+        "enabled": enabled,
+        "completed_level": completed_level,
+        "required_level": required_level,
+        "should_run": False,
+        "reason": "up_to_date",
+    }
+    if not enabled:
+        state["reason"] = "disabled"
+        return state
+    if required_level <= 0:
+        state["reason"] = "not_configured"
+        return state
+    if completed_level >= required_level:
+        state["reason"] = "up_to_date"
+        return state
+    kometa_root = helpers.get_kometa_root_path()
+    log_dir = kometa_root / "config" / "logs"
+    if not log_dir.exists():
+        state["reason"] = "waiting_for_logs"
+        return state
+    candidate_files = _get_logscan_log_files(log_dir=log_dir, include_archive=True)
+    if not candidate_files:
+        state["reason"] = "waiting_for_logs"
+        return state
+    state["should_run"] = True
+    state["reason"] = "pending"
+    state["candidate_files"] = len(candidate_files)
+    return state
+
+
+def _run_logscan_startup_migration(app_in, required_level, completed_level):
+    helpers.ts_log(
+        (
+            f"Starting one-time Analytics migration level {required_level} "
+            f"(completed level: {completed_level}). Quickstart will reset stored "
+            "trend data and reingest Kometa logs in the background."
+        ),
+        level="INFO",
+    )
+    try:
+        with app_in.app_context():
+            result = _perform_logscan_reingest(
+                reset=True,
+                job_id=LOGSCAN_STARTUP_MIGRATION_JOB_ID,
+                update_state=True,
+            )
+        if result.get("success"):
+            _set_logscan_migration_level_done(required_level)
+            helpers.ts_log(
+                (
+                    f"Completed Analytics migration level {required_level}. "
+                    f"Persisted {LOGSCAN_MIGRATION_LEVEL_DONE_ENV}={required_level}."
+                ),
+                level="INFO",
+            )
+        else:
+            helpers.ts_log(
+                (
+                    f"Analytics migration level {required_level} did not complete: "
+                    f"{result.get('error', 'Unknown error')}."
+                ),
+                level="WARNING",
+            )
+        return result
+    except Exception as exc:
+        _update_logscan_reingest_state(
+            status="error",
+            error=f"Startup Analytics migration failed: {exc}",
+            finished_at=datetime.now(timezone.utc).isoformat(),
+        )
+        helpers.ts_log(f"Startup Analytics migration failed: {exc}", level="ERROR")
+        return {"success": False, "error": str(exc)}
+
+
+def _start_pending_logscan_startup_migration(app_in):
+    state = _get_pending_logscan_startup_migration()
+    if not state.get("should_run"):
+        reason = state.get("reason")
+        required_level = state.get("required_level", 0)
+        completed_level = state.get("completed_level", 0)
+        if reason == "disabled":
+            helpers.ts_log(
+                (
+                    f"Skipping startup Analytics migration because "
+                    f"{LOGSCAN_STARTUP_MIGRATIONS_ENV}=0."
+                ),
+                level="INFO",
+            )
+        elif reason == "waiting_for_logs":
+            helpers.ts_log(
+                (
+                    f"Deferring Analytics migration level {required_level} until Kometa "
+                    "log files exist. This is expected on a first-time Quickstart setup."
+                ),
+                level="INFO",
+            )
+        elif required_level > 0 and completed_level >= required_level:
+            helpers.ts_log(
+                f"Analytics migration level {required_level} already applied.", level="DEBUG"
+            )
+        return state
+
+    started_at = datetime.now(timezone.utc).isoformat()
+    _update_logscan_reingest_state(
+        status="running",
+        job_id=LOGSCAN_STARTUP_MIGRATION_JOB_ID,
+        trigger="startup_migration",
+        migration_level=state["required_level"],
+        started_at=started_at,
+        finished_at=None,
+        total=0,
+        scanned=0,
+        ingested=0,
+        duplicates=0,
+        skipped_incomplete=0,
+        skipped_invalid=0,
+        errors=0,
+        current_file=None,
+        missing_people_unique=0,
+        missing_people_logs=0,
+        missing_people_log_ready=False,
+        missing_people_log_lines=0,
+        sample_incomplete=[],
+        sample_errors=[],
+    )
+    thread = threading.Thread(
+        target=_run_logscan_startup_migration,
+        args=(app_in, state["required_level"], state["completed_level"]),
+        daemon=True,
+        name="logscan-startup-migration",
+    )
+    thread.start()
+    state["started"] = True
+    state["job_id"] = LOGSCAN_STARTUP_MIGRATION_JOB_ID
+    return state
+
+
 def _run_logscan_reingest_job(job_id, reset):
     try:
         with app.app_context():
@@ -9525,7 +9696,19 @@ def logscan_trends_reingest():
     reset = data.get("reset") is True
     background = data.get("background") is True
     if logscan_ingest_lock.locked():
-        return jsonify({"error": "Reingest already running."}), 409
+        snapshot = _logscan_reingest_snapshot()
+        return (
+            jsonify(
+                {
+                    "error": "Reingest already running.",
+                    "job_id": snapshot.get("job_id"),
+                    "status": snapshot.get("status") or "running",
+                    "trigger": snapshot.get("trigger"),
+                    "migration_level": snapshot.get("migration_level"),
+                }
+            ),
+            409,
+        )
     if background:
         snapshot = _logscan_reingest_snapshot()
         if snapshot.get("status") == "running":
@@ -9535,6 +9718,8 @@ def logscan_trends_reingest():
                         "error": "Reingest already running.",
                         "job_id": snapshot.get("job_id"),
                         "status": snapshot.get("status"),
+                        "trigger": snapshot.get("trigger"),
+                        "migration_level": snapshot.get("migration_level"),
                     }
                 ),
                 409,
@@ -11266,6 +11451,8 @@ if __name__ == "__main__":
 
     maintenance_thread = threading.Thread(target=_maintenance_guard_loop, args=(app,), daemon=True)
     maintenance_thread.start()
+
+    _start_pending_logscan_startup_migration(app)
 
     def get_lan_ip():
         try:

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -4734,6 +4734,27 @@ body {
     display: flex;
 }
 
+.qs-header-status-pill {
+    display: flex;
+    text-decoration: none;
+}
+
+.qs-header-status-pill:hover,
+.qs-header-status-pill:focus {
+    text-decoration: none;
+}
+
+.qs-header-status-pill .badge {
+    transition: transform 0.16s ease, filter 0.16s ease, box-shadow 0.16s ease;
+}
+
+.qs-header-status-pill:hover .badge,
+.qs-header-status-pill:focus .badge {
+    transform: translateY(-1px);
+    filter: brightness(1.03);
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--theme-primary) 36%, transparent);
+}
+
 .qs-main-page-title {
     margin: 0.08rem 0 0.1rem;
     font-size: clamp(1.45rem, 1.22rem + 0.7vw, 2rem);

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -547,6 +547,9 @@ const QS_MAINTENANCE_TOAST_INTERVAL_MS = 45000
 let qsLastMaintenanceToastAt = 0
 let qsLastMaintenancePaused = false
 let qsLastQueuedStartedAt = null
+const QS_LOGSCAN_REINGEST_POLL_INTERVAL_MS = 15000
+let qsLastLogscanReingestStatus = 'idle'
+let qsLastLogscanReingestJobId = null
 
 function qsFormatLocalTime () {
   const now = new Date()
@@ -668,6 +671,74 @@ function qsHandleMaintenanceStatus (data) {
 window.QS_handleMaintenanceStatus = qsHandleMaintenanceStatus
 window.QS_formatTimestamp = qsFormatTimestamp
 
+function qsHandleLogscanReingestStatus (data) {
+  const badge = document.getElementById('qs-logscan-reingest-badge')
+  if (!badge) return
+  const label = badge.querySelector('span')
+  const status = String((data && data.status) || 'idle').trim().toLowerCase()
+  const trigger = data && data.trigger === 'startup_migration' ? 'startup_migration' : 'manual'
+  const migrationLevel = Number.isFinite(data && data.migration_level) ? data.migration_level : null
+  const jobId = String((data && data.job_id) || '').trim() || null
+  const currentFile = String((data && data.current_file) || '').trim()
+  const previousStatus = qsLastLogscanReingestStatus
+  const previousJobId = qsLastLogscanReingestJobId
+
+  const setBadgeTone = (...classes) => {
+    if (!label) return
+    label.classList.remove('text-bg-primary', 'text-bg-info', 'text-bg-warning', 'text-bg-danger', 'text-dark')
+    label.classList.add(...classes)
+  }
+
+  if (status === 'running') {
+    badge.classList.remove('d-none')
+    const prefix = trigger === 'startup_migration' ? 'Startup Analytics migration' : 'Analytics reingest'
+    const suffix = migrationLevel ? ` (level ${migrationLevel})` : ''
+    if (label) {
+      label.innerHTML = trigger === 'startup_migration'
+        ? `<i class="bi bi-arrow-repeat me-1"></i> ${prefix}${suffix}`
+        : '<i class="bi bi-arrow-repeat me-1"></i> Analytics reingest running'
+    }
+    if (trigger === 'startup_migration') {
+      setBadgeTone('text-bg-warning', 'text-dark')
+    } else {
+      setBadgeTone('text-bg-primary')
+    }
+    badge.title = currentFile
+      ? `${prefix}${suffix} is running. Current file: ${currentFile}. Open Analytics.`
+      : `${prefix}${suffix} is running. Open Analytics.`
+
+    if (typeof showToast === 'function' && (previousStatus !== 'running' || previousJobId !== jobId)) {
+      showToast(
+        'info',
+        trigger === 'startup_migration'
+          ? `Startup Analytics migration${suffix} is rebuilding trends in the background.`
+          : 'Analytics reingest is running in the background.'
+      )
+    }
+  } else if (status === 'error') {
+    badge.classList.remove('d-none')
+    if (label) {
+      label.innerHTML = '<i class="bi bi-exclamation-octagon me-1"></i> Analytics reingest failed'
+    }
+    setBadgeTone('text-bg-danger')
+    badge.title = data && data.error ? `Analytics reingest failed: ${data.error}` : 'Analytics reingest failed. Open Analytics.'
+    if (typeof showToast === 'function' && previousStatus === 'running') {
+      showToast('danger', data && data.error ? data.error : 'Analytics reingest failed.')
+    }
+  } else {
+    badge.classList.add('d-none')
+    badge.title = 'Open Analytics'
+    if (typeof showToast === 'function' && previousStatus === 'running' && status === 'complete') {
+      showToast('success', trigger === 'startup_migration' ? 'Startup Analytics migration complete.' : 'Analytics reingest complete.')
+    }
+  }
+
+  qsLastLogscanReingestStatus = status
+  qsLastLogscanReingestJobId = jobId
+}
+
+window.QS_handleLogscanReingestStatus = qsHandleLogscanReingestStatus
+
 ;(function qsMaintenancePoll () {
   const poll = () => {
     fetch('/kometa-status')
@@ -678,6 +749,17 @@ window.QS_formatTimestamp = qsFormatTimestamp
   // Slight delay to avoid racing early page initialization
   setTimeout(poll, 1200)
   setInterval(poll, QS_MAINTENANCE_TOAST_INTERVAL_MS)
+})()
+
+;(function qsLogscanReingestPoll () {
+  const poll = () => {
+    fetch('/logscan/trends/reingest/status')
+      .then(res => res.json())
+      .then(data => qsHandleLogscanReingestStatus(data))
+      .catch(() => {})
+  }
+  setTimeout(poll, 1800)
+  setInterval(poll, QS_LOGSCAN_REINGEST_POLL_INTERVAL_MS)
 })()
 
 function getValidatedInput () {

--- a/static/local-js/905-analytics.js
+++ b/static/local-js/905-analytics.js
@@ -90,6 +90,7 @@ $(document).ready(function () {
   const sortState = { key: 'finished_at', dir: 'desc' }
   let lastIngestState = null
   let analyticsPrefs = null
+  const defaultReingestButtonLabel = $reingest.text().trim() || 'Reingest logs'
 
   function escapeHtml (value) {
     return String(value || '')
@@ -2160,6 +2161,11 @@ $(document).ready(function () {
     if ($status.length) $status.text(message)
   }
 
+  function setReingestButtonLabel (label) {
+    if (!$reingest.length) return
+    $reingest.text(label || defaultReingestButtonLabel)
+  }
+
   function setProgressVisible (visible) {
     if (!$progress.length) return
     if (visible) {
@@ -2321,11 +2327,13 @@ $(document).ready(function () {
     ].join(' | ')
     lastIngestState = data
     renderIngestHealth(lastIngestState)
-    updateStatus(`Reingest complete. ${summary}`)
+    const isStartupMigration = data && data.trigger === 'startup_migration'
+    updateStatus(`${isStartupMigration ? 'Startup Analytics migration complete.' : 'Reingest complete.'} ${summary}`)
     fetchRuns({ suppressStatus: true })
     setMissingDownloadVisible(Boolean(data.missing_people_log_ready), data.missing_people_unique)
     setProgressVisible(false)
     setControlsDisabled(false)
+    setReingestButtonLabel(defaultReingestButtonLabel)
   }
 
   function stopReingestPolling () {
@@ -2334,6 +2342,7 @@ $(document).ready(function () {
       reingestPollTimer = null
     }
     reingestJobId = null
+    setReingestButtonLabel(defaultReingestButtonLabel)
   }
 
   function fetchReingestStatus (jobId) {
@@ -2342,9 +2351,19 @@ $(document).ready(function () {
       .then(res => res.json().then(data => ({ ok: res.ok, data })))
       .then(({ ok, data }) => {
         if (!ok || !data) return
+        if (typeof window.QS_handleLogscanReingestStatus === 'function') {
+          window.QS_handleLogscanReingestStatus(data)
+        }
         if (data.status === 'running') {
+          const isStartupMigration = data.trigger === 'startup_migration'
+          const migrationLevel = Number.isFinite(data.migration_level) ? data.migration_level : null
           updateProgressFromState(data)
-          updateStatus('Reingesting logs...')
+          updateStatus(
+            isStartupMigration
+              ? `Startup Analytics migration is rebuilding trends${migrationLevel ? ` (level ${migrationLevel})` : ''}. Reingest controls are locked until it finishes.`
+              : 'Reingesting logs...'
+          )
+          setReingestButtonLabel(isStartupMigration ? 'Startup migration running...' : 'Reingest running...')
           if (!reingestPollTimer) {
             reingestJobId = data.job_id || jobId || null
             setProgressVisible(true)
@@ -2363,6 +2382,7 @@ $(document).ready(function () {
           updateStatus(data.error || 'Reingest failed.')
           setProgressVisible(false)
           setControlsDisabled(false)
+          setReingestButtonLabel(defaultReingestButtonLabel)
         }
       })
       .catch(err => {
@@ -2375,6 +2395,7 @@ $(document).ready(function () {
     reingestJobId = jobId || null
     setProgressVisible(true)
     setControlsDisabled(true)
+    setReingestButtonLabel('Reingest running...')
     fetchReingestStatus(reingestJobId)
     reingestPollTimer = setInterval(() => fetchReingestStatus(reingestJobId), 1500)
   }
@@ -2529,7 +2550,7 @@ $(document).ready(function () {
         loadPreferences()
           .then(() => {
             applyFiltersAndRender()
-            if (!suppressStatus) {
+            if (!suppressStatus && (!lastIngestState || lastIngestState.status !== 'running')) {
               updateStatus(`Last updated: ${formatTimestamp(new Date().toISOString())}`)
             }
           })

--- a/templates/001-navigation.html
+++ b/templates/001-navigation.html
@@ -193,26 +193,36 @@
             <div class="qs-main-page-topline">
               <div class="qs-main-page-eyebrow">Quickstart</div>
               <div class="qs-main-page-status-pills">
-                <div id="qs-running-badge" class="d-none">
+                <a id="qs-running-badge" class="d-none qs-header-status-pill" href="{{ url_for('step', name='900-final') }}"
+                  title="Open Final Validation">
                   <span class="badge rounded-pill text-bg-success px-3 py-2">
                     <i class="bi bi-play-circle me-1"></i> Kometa running
                   </span>
-                </div>
-                <div id="qs-maintenance-badge" class="d-none">
+                </a>
+                <a id="qs-maintenance-badge" class="d-none qs-header-status-pill" href="{{ url_for('step', name='900-final') }}"
+                  title="Open Final Validation">
                   <span class="badge rounded-pill text-bg-warning text-dark px-3 py-2">
                     <i class="bi bi-pause-circle me-1"></i> Kometa paused for Plex maintenance
                   </span>
-                </div>
-                <div id="qs-maintenance-unavailable-badge" class="d-none">
+                </a>
+                <a id="qs-maintenance-unavailable-badge" class="d-none qs-header-status-pill" href="{{ url_for('step', name='900-final') }}"
+                  title="Open Final Validation">
                   <span class="badge rounded-pill text-bg-warning text-dark px-3 py-2">
                     <i class="bi bi-exclamation-triangle me-1"></i> Plex maintenance window unavailable
                   </span>
-                </div>
-                <div id="qs-queued-badge" class="d-none">
+                </a>
+                <a id="qs-queued-badge" class="d-none qs-header-status-pill" href="{{ url_for('step', name='900-final') }}"
+                  title="Open Final Validation">
                   <span class="badge rounded-pill text-bg-info text-dark px-3 py-2">
                     <i class="bi bi-hourglass-split me-1"></i> Kometa start queued
                   </span>
-                </div>
+                </a>
+                <a id="qs-logscan-reingest-badge" class="d-none qs-header-status-pill" href="{{ url_for('logscan_trends_page') }}"
+                  title="Open Analytics">
+                  <span class="badge rounded-pill text-bg-primary px-3 py-2">
+                    <i class="bi bi-arrow-repeat me-1"></i> Analytics reingest running
+                  </span>
+                </a>
               </div>
             </div>
             <h2 class="qs-main-page-title">{{ page_info['title'] }}</h2>

--- a/tests/test_logscan_endpoints.py
+++ b/tests/test_logscan_endpoints.py
@@ -960,3 +960,86 @@ def test_logscan_reingest_ingests_gzip_archived_log(client, isolated_config_dir,
     assert payload["success"] is True
     assert payload["ingested"] >= 1
     assert payload["skipped_incomplete"] == 0
+
+
+def test_logscan_startup_migration_defers_without_logs(isolated_config_dir, monkeypatch, qs_module):
+    kometa_root = Path(qs_module.app.config["KOMETA_ROOT"])
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_root_path", lambda: kometa_root)
+    monkeypatch.setenv(qs_module.LOGSCAN_STARTUP_MIGRATIONS_ENV, "1")
+    monkeypatch.setenv(qs_module.LOGSCAN_MIGRATION_LEVEL_DONE_ENV, "0")
+    monkeypatch.setattr(qs_module, "REQUIRED_LOGSCAN_MIGRATION_LEVEL", 4)
+
+    state = qs_module._get_pending_logscan_startup_migration()
+
+    assert state["should_run"] is False
+    assert state["reason"] == "waiting_for_logs"
+    assert state["required_level"] == 4
+    assert state["completed_level"] == 0
+
+
+def test_logscan_startup_migration_runs_when_level_pending(isolated_config_dir, monkeypatch, qs_module):
+    kometa_root = Path(qs_module.app.config["KOMETA_ROOT"])
+    log_dir = kometa_root / "config" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / "meta-1.log").write_text("placeholder", encoding="utf-8")
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_root_path", lambda: kometa_root)
+    monkeypatch.setenv(qs_module.LOGSCAN_STARTUP_MIGRATIONS_ENV, "1")
+    monkeypatch.setenv(qs_module.LOGSCAN_MIGRATION_LEVEL_DONE_ENV, "1")
+    monkeypatch.setattr(qs_module, "REQUIRED_LOGSCAN_MIGRATION_LEVEL", 3)
+
+    state = qs_module._get_pending_logscan_startup_migration()
+
+    assert state["should_run"] is True
+    assert state["reason"] == "pending"
+    assert state["required_level"] == 3
+    assert state["completed_level"] == 1
+    assert state["candidate_files"] >= 1
+
+
+def test_run_logscan_startup_migration_persists_completed_level(monkeypatch, qs_module):
+    updates = {}
+    monkeypatch.setenv(qs_module.LOGSCAN_MIGRATION_LEVEL_DONE_ENV, "0")
+    monkeypatch.setattr(
+        qs_module.helpers,
+        "update_env_variable",
+        lambda key, value: updates.__setitem__(key, value),
+    )
+    monkeypatch.setattr(
+        qs_module.helpers,
+        "ts_log",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        qs_module,
+        "_perform_logscan_reingest",
+        lambda reset, job_id=None, update_state=True: {"success": True, "ingested": 2},
+    )
+
+    result = qs_module._run_logscan_startup_migration(qs_module.app, required_level=5, completed_level=0)
+
+    assert result["success"] is True
+    assert updates[qs_module.LOGSCAN_MIGRATION_LEVEL_DONE_ENV] == "5"
+    assert os.environ[qs_module.LOGSCAN_MIGRATION_LEVEL_DONE_ENV] == "5"
+
+
+def test_logscan_reingest_route_conflict_returns_active_job_metadata(client, monkeypatch, qs_module):
+    qs_module._reset_logscan_reingest_state()
+    qs_module._update_logscan_reingest_state(
+        status="running",
+        job_id="startup-logscan-migration",
+        trigger="startup_migration",
+        migration_level=6,
+    )
+    acquired = qs_module.logscan_ingest_lock.acquire(blocking=False)
+    assert acquired is True
+    try:
+        resp = client.post("/logscan/trends/reingest", json={"reset": False, "background": True})
+    finally:
+        qs_module.logscan_ingest_lock.release()
+        qs_module._reset_logscan_reingest_state()
+
+    assert resp.status_code == 409
+    payload = resp.get_json()
+    assert payload["job_id"] == "startup-logscan-migration"
+    assert payload["trigger"] == "startup_migration"
+    assert payload["migration_level"] == 6


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Adds versioned startup Analytics migrations so releases can trigger a one-time reset and full log reingest automatically, controlled by .env and safe for skipped releases. The migration defers cleanly on first-time installs with no Kometa logs yet, persists the completed migration level after success, and documents the full env/release workflow in the README.

It also improves reingest visibility across the UI by adding a persistent global header pill for active Analytics reingests or startup migrations, making the existing Kometa state pills clickable links to Final Validation, and ensuring the Analytics page reconnects to any active reingest instead of allowing the user to feel like a second one might start.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
