### PR TITLE
Quiet period details

### DIFF
--- a/modules/logscan.py
+++ b/modules/logscan.py
@@ -3318,9 +3318,7 @@ class LogscanAnalyzer:
             if longest_unexplained_current_entry:
                 summary["longest_unexplained_gap_end_line"] = longest_unexplained_current_entry.get("line_number")
                 summary["longest_unexplained_gap_first_line"] = longest_unexplained_current_entry.get("line")
-            summary["longest_unexplained_gap_maintenance_overlap"] = _get_gap_overlap(
-                longest_unexplained_start, longest_unexplained_end
-            )
+            summary["longest_unexplained_gap_maintenance_overlap"] = _get_gap_overlap(longest_unexplained_start, longest_unexplained_end)
         elif maintenance_supported and summary["longest_gap_seconds"] > 0:
             summary["longest_unexplained_gap_maintenance_overlap"] = "none"
 

--- a/modules/logscan.py
+++ b/modules/logscan.py
@@ -3166,6 +3166,10 @@ class LogscanAnalyzer:
             "longest_gap_seconds": 0,
             "longest_gap_started_at": None,
             "longest_gap_ended_at": None,
+            "longest_gap_start_line": None,
+            "longest_gap_end_line": None,
+            "longest_gap_last_line": None,
+            "longest_gap_first_line": None,
             "gaps_over_300": 0,
             "gaps_over_900": 0,
             "gaps_over_1800": 0,
@@ -3176,12 +3180,18 @@ class LogscanAnalyzer:
 
         capabilities = self.extract_quickstart_marker_capabilities(content)
         maintenance_supported = bool(capabilities.get("maintenance_markers"))
-        timestamps = []
-        for line in content.splitlines():
+        timestamp_entries = []
+        for line_number, line in enumerate(content.splitlines(), start=1):
             line_ts = self._parse_log_timestamp(line)
             if line_ts is not None:
-                timestamps.append(line_ts)
-        if len(timestamps) < 2:
+                timestamp_entries.append(
+                    {
+                        "timestamp": line_ts,
+                        "line_number": line_number,
+                        "line": line.strip(),
+                    }
+                )
+        if len(timestamp_entries) < 2:
             if maintenance_supported:
                 summary["longest_gap_maintenance_overlap"] = "none"
             return summary
@@ -3212,7 +3222,11 @@ class LogscanAnalyzer:
 
         longest_start = None
         longest_end = None
-        for previous_ts, current_ts in zip(timestamps, timestamps[1:]):
+        longest_previous_entry = None
+        longest_current_entry = None
+        for previous_entry, current_entry in zip(timestamp_entries, timestamp_entries[1:]):
+            previous_ts = previous_entry["timestamp"]
+            current_ts = current_entry["timestamp"]
             gap_seconds = max(0, int((current_ts - previous_ts).total_seconds()))
             if gap_seconds <= 0:
                 continue
@@ -3226,10 +3240,18 @@ class LogscanAnalyzer:
                 summary["longest_gap_seconds"] = gap_seconds
                 longest_start = previous_ts
                 longest_end = current_ts
+                longest_previous_entry = previous_entry
+                longest_current_entry = current_entry
 
         if longest_start is not None and longest_end is not None:
             summary["longest_gap_started_at"] = longest_start.isoformat()
             summary["longest_gap_ended_at"] = longest_end.isoformat()
+            if longest_previous_entry:
+                summary["longest_gap_start_line"] = longest_previous_entry.get("line_number")
+                summary["longest_gap_last_line"] = longest_previous_entry.get("line")
+            if longest_current_entry:
+                summary["longest_gap_end_line"] = longest_current_entry.get("line_number")
+                summary["longest_gap_first_line"] = longest_current_entry.get("line")
             overlap = False
             for interval_start, interval_end in maintenance_intervals:
                 if interval_end is None:

--- a/modules/logscan.py
+++ b/modules/logscan.py
@@ -3174,6 +3174,17 @@ class LogscanAnalyzer:
             "gaps_over_900": 0,
             "gaps_over_1800": 0,
             "longest_gap_maintenance_overlap": "unknown",
+            "longest_unexplained_gap_seconds": 0,
+            "longest_unexplained_gap_started_at": None,
+            "longest_unexplained_gap_ended_at": None,
+            "longest_unexplained_gap_start_line": None,
+            "longest_unexplained_gap_end_line": None,
+            "longest_unexplained_gap_last_line": None,
+            "longest_unexplained_gap_first_line": None,
+            "longest_unexplained_gap_maintenance_overlap": "unknown",
+            "confirmed_maintenance_gaps_over_300": 0,
+            "unexplained_gaps_over_300": 0,
+            "notable_gaps": [],
         }
         if not content:
             return summary
@@ -3220,10 +3231,31 @@ class LogscanAnalyzer:
         if open_start is not None:
             maintenance_intervals.append((open_start, None))
 
+        def _get_gap_overlap(start_ts, end_ts):
+            overlap = False
+            for interval_start, interval_end in maintenance_intervals:
+                if interval_end is None:
+                    if end_ts > interval_start:
+                        overlap = True
+                        break
+                    continue
+                if start_ts < interval_end and end_ts > interval_start:
+                    overlap = True
+                    break
+            if overlap:
+                return "confirmed"
+            if maintenance_supported:
+                return "none"
+            return "unknown"
+
         longest_start = None
         longest_end = None
         longest_previous_entry = None
         longest_current_entry = None
+        longest_unexplained_start = None
+        longest_unexplained_end = None
+        longest_unexplained_previous_entry = None
+        longest_unexplained_current_entry = None
         for previous_entry, current_entry in zip(timestamp_entries, timestamp_entries[1:]):
             previous_ts = previous_entry["timestamp"]
             current_ts = current_entry["timestamp"]
@@ -3236,12 +3268,35 @@ class LogscanAnalyzer:
                 summary["gaps_over_900"] += 1
             if gap_seconds >= 1800:
                 summary["gaps_over_1800"] += 1
+            overlap_label = _get_gap_overlap(previous_ts, current_ts)
+            gap_detail = {
+                "gap_seconds": gap_seconds,
+                "started_at": previous_ts.isoformat(),
+                "ended_at": current_ts.isoformat(),
+                "start_line": previous_entry.get("line_number"),
+                "end_line": current_entry.get("line_number"),
+                "last_line": previous_entry.get("line"),
+                "first_line": current_entry.get("line"),
+                "maintenance_overlap": overlap_label,
+            }
+            if gap_seconds >= 300:
+                summary["notable_gaps"].append(gap_detail)
+                if overlap_label == "confirmed":
+                    summary["confirmed_maintenance_gaps_over_300"] += 1
+                else:
+                    summary["unexplained_gaps_over_300"] += 1
             if gap_seconds > summary["longest_gap_seconds"]:
                 summary["longest_gap_seconds"] = gap_seconds
                 longest_start = previous_ts
                 longest_end = current_ts
                 longest_previous_entry = previous_entry
                 longest_current_entry = current_entry
+            if overlap_label != "confirmed" and gap_seconds > summary["longest_unexplained_gap_seconds"]:
+                summary["longest_unexplained_gap_seconds"] = gap_seconds
+                longest_unexplained_start = previous_ts
+                longest_unexplained_end = current_ts
+                longest_unexplained_previous_entry = previous_entry
+                longest_unexplained_current_entry = current_entry
 
         if longest_start is not None and longest_end is not None:
             summary["longest_gap_started_at"] = longest_start.isoformat()
@@ -3252,20 +3307,22 @@ class LogscanAnalyzer:
             if longest_current_entry:
                 summary["longest_gap_end_line"] = longest_current_entry.get("line_number")
                 summary["longest_gap_first_line"] = longest_current_entry.get("line")
-            overlap = False
-            for interval_start, interval_end in maintenance_intervals:
-                if interval_end is None:
-                    if longest_end > interval_start:
-                        overlap = True
-                        break
-                    continue
-                if longest_start < interval_end and longest_end > interval_start:
-                    overlap = True
-                    break
-            if overlap:
-                summary["longest_gap_maintenance_overlap"] = "confirmed"
-            elif maintenance_supported:
-                summary["longest_gap_maintenance_overlap"] = "none"
+            summary["longest_gap_maintenance_overlap"] = _get_gap_overlap(longest_start, longest_end)
+
+        if longest_unexplained_start is not None and longest_unexplained_end is not None:
+            summary["longest_unexplained_gap_started_at"] = longest_unexplained_start.isoformat()
+            summary["longest_unexplained_gap_ended_at"] = longest_unexplained_end.isoformat()
+            if longest_unexplained_previous_entry:
+                summary["longest_unexplained_gap_start_line"] = longest_unexplained_previous_entry.get("line_number")
+                summary["longest_unexplained_gap_last_line"] = longest_unexplained_previous_entry.get("line")
+            if longest_unexplained_current_entry:
+                summary["longest_unexplained_gap_end_line"] = longest_unexplained_current_entry.get("line_number")
+                summary["longest_unexplained_gap_first_line"] = longest_unexplained_current_entry.get("line")
+            summary["longest_unexplained_gap_maintenance_overlap"] = _get_gap_overlap(
+                longest_unexplained_start, longest_unexplained_end
+            )
+        elif maintenance_supported and summary["longest_gap_seconds"] > 0:
+            summary["longest_unexplained_gap_maintenance_overlap"] = "none"
 
         return summary
 

--- a/quickstart.py
+++ b/quickstart.py
@@ -2269,7 +2269,7 @@ logscan_reingest_state = {
 # Bump this integer when a release needs a one-time Analytics reset + log reingest
 # on startup. Quickstart persists the highest successful level to config/.env so
 # skipped releases still catch up automatically.
-REQUIRED_LOGSCAN_MIGRATION_LEVEL = 1
+REQUIRED_LOGSCAN_MIGRATION_LEVEL = 2
 LOGSCAN_STARTUP_MIGRATIONS_ENV = "QS_LOGSCAN_STARTUP_MIGRATIONS"
 LOGSCAN_MIGRATION_LEVEL_DONE_ENV = "QS_LOGSCAN_MIGRATION_LEVEL_DONE"
 LOGSCAN_STARTUP_MIGRATION_JOB_ID = "startup-logscan-migration"

--- a/static/local-js/905-analytics.js
+++ b/static/local-js/905-analytics.js
@@ -388,11 +388,25 @@ $(document).ready(function () {
       longestGapSeconds: Number.isFinite(summary.longest_gap_seconds) ? summary.longest_gap_seconds : 0,
       longestGapStartedAt: summary.longest_gap_started_at || '',
       longestGapEndedAt: summary.longest_gap_ended_at || '',
+      longestGapStartLine: Number.isFinite(summary.longest_gap_start_line) ? summary.longest_gap_start_line : null,
+      longestGapEndLine: Number.isFinite(summary.longest_gap_end_line) ? summary.longest_gap_end_line : null,
+      longestGapLastLine: summary.longest_gap_last_line || '',
+      longestGapFirstLine: summary.longest_gap_first_line || '',
       gapsOver300: Number.isFinite(summary.gaps_over_300) ? summary.gaps_over_300 : 0,
       gapsOver900: Number.isFinite(summary.gaps_over_900) ? summary.gaps_over_900 : 0,
       gapsOver1800: Number.isFinite(summary.gaps_over_1800) ? summary.gaps_over_1800 : 0,
       maintenanceOverlap: summary.longest_gap_maintenance_overlap || 'unknown'
     }
+  }
+
+  function getQuietPeriodOutcome (run, summary) {
+    if (run && run.is_incomplete) return 'incomplete'
+    const finishedAt = run && run.finished_at ? Date.parse(run.finished_at) : NaN
+    const longestGapEndedAt = summary && summary.longestGapEndedAt ? Date.parse(summary.longestGapEndedAt) : NaN
+    if (Number.isFinite(finishedAt) && Number.isFinite(longestGapEndedAt) && finishedAt === longestGapEndedAt) {
+      return 'completed'
+    }
+    return 'resumed'
   }
 
   function getQuietPeriodSortValue (run) {
@@ -421,7 +435,13 @@ $(document).ready(function () {
       detailParts.push(`Maintenance overlap: ${summary.maintenanceOverlap}`)
     }
     const title = detailParts.join(' | ')
-    return `<span title="${escapeHtml(title)}">${escapeHtml(parts.join(' • '))}</span>`
+    return `
+      <div class="logscan-action-stack">
+        <span title="${escapeHtml(title)}">${escapeHtml(parts.join(' • '))}</span>
+        <button type="button" class="btn nav-button btn-sm logscan-action-btn logscan-quiet-period-details"
+          data-run-key="${escapeHtml(String(run && run.run_key ? run.run_key : ''))}">Open</button>
+      </div>
+    `
   }
 
   function getCountsTotal (run) {
@@ -2524,6 +2544,56 @@ $(document).ready(function () {
     }
   }
 
+  function showQuietPeriodDetails (runKey) {
+    const run = allTableRuns.find(entry => entry && entry.run_key === runKey)
+    const summary = getQuietPeriodSummary(run)
+    if (!run || summary.longestGapSeconds <= 0) return
+    if ($runDetailsTitle.length) {
+      $runDetailsTitle.text('Quiet Period Details')
+    }
+    if ($runDetailsBody.length) {
+      const longestGap = formatSeconds(summary.longestGapSeconds)
+      const startedAt = formatTimestamp(summary.longestGapStartedAt) || 'n/a'
+      const endedAt = formatTimestamp(summary.longestGapEndedAt) || 'n/a'
+      const lineWindow = summary.longestGapStartLine && summary.longestGapEndLine
+        ? `${summary.longestGapStartLine} → ${summary.longestGapEndLine}`
+        : 'n/a'
+      const outcome = getQuietPeriodOutcome(run, summary)
+      const counts = []
+      if (summary.gapsOver300 > 0) counts.push(`>5m: ${summary.gapsOver300}`)
+      if (summary.gapsOver900 > 0) counts.push(`>15m: ${summary.gapsOver900}`)
+      if (summary.gapsOver1800 > 0) counts.push(`>30m: ${summary.gapsOver1800}`)
+      const beforeLine = summary.longestGapLastLine
+        ? `<pre class="small mb-0"><code>${escapeHtml(summary.longestGapLastLine)}</code></pre>`
+        : '<div class="small text-muted">Unavailable</div>'
+      const afterLine = summary.longestGapFirstLine
+        ? `<pre class="small mb-0"><code>${escapeHtml(summary.longestGapFirstLine)}</code></pre>`
+        : '<div class="small text-muted">Unavailable</div>'
+      $runDetailsBody.html(`
+        <div class="mb-3">
+          <div class="fw-semibold mb-2">Summary</div>
+          <div class="small text-muted">Longest quiet period: ${escapeHtml(longestGap)}</div>
+          <div class="small text-muted">Window: ${escapeHtml(startedAt)} to ${escapeHtml(endedAt)}</div>
+          <div class="small text-muted">Lines: ${escapeHtml(lineWindow)}</div>
+          <div class="small text-muted">Maintenance overlap: ${escapeHtml(summary.maintenanceOverlap || 'unknown')}</div>
+          <div class="small text-muted">Run outcome: ${escapeHtml(outcome)}</div>
+          <div class="small text-muted">Gap counts: ${escapeHtml(counts.join(' • ') || 'Longest gap only')}</div>
+        </div>
+        <div class="mb-3">
+          <div class="fw-semibold mb-1">Last line before gap</div>
+          ${beforeLine}
+        </div>
+        <div>
+          <div class="fw-semibold mb-1">First line after gap</div>
+          ${afterLine}
+        </div>
+      `)
+    }
+    if (runDetailsModalEl) {
+      bootstrap.Modal.getOrCreateInstance(runDetailsModalEl).show()
+    }
+  }
+
   function fetchRuns (options = {}) {
     const suppressStatus = options && options.suppressStatus
     const rawLimit = String($limit.val() || '25').toLowerCase()
@@ -2956,6 +3026,10 @@ $(document).ready(function () {
   $tableBody.on('click', '[data-section-details="1"]', function () {
     const runKey = $(this).data('runKey') || $(this).attr('data-run-key')
     showSectionDetails(runKey)
+  })
+  $tableBody.on('click', '.logscan-quiet-period-details', function () {
+    const runKey = $(this).data('runKey') || $(this).attr('data-run-key')
+    showQuietPeriodDetails(runKey)
   })
   $('#logscan-trends-table thead').on('click', '.logscan-sort-button', function () {
     const key = $(this).data('sort')

--- a/static/local-js/905-analytics.js
+++ b/static/local-js/905-analytics.js
@@ -395,7 +395,18 @@ $(document).ready(function () {
       gapsOver300: Number.isFinite(summary.gaps_over_300) ? summary.gaps_over_300 : 0,
       gapsOver900: Number.isFinite(summary.gaps_over_900) ? summary.gaps_over_900 : 0,
       gapsOver1800: Number.isFinite(summary.gaps_over_1800) ? summary.gaps_over_1800 : 0,
-      maintenanceOverlap: summary.longest_gap_maintenance_overlap || 'unknown'
+      maintenanceOverlap: summary.longest_gap_maintenance_overlap || 'unknown',
+      longestUnexplainedGapSeconds: Number.isFinite(summary.longest_unexplained_gap_seconds) ? summary.longest_unexplained_gap_seconds : 0,
+      longestUnexplainedGapStartedAt: summary.longest_unexplained_gap_started_at || '',
+      longestUnexplainedGapEndedAt: summary.longest_unexplained_gap_ended_at || '',
+      longestUnexplainedGapStartLine: Number.isFinite(summary.longest_unexplained_gap_start_line) ? summary.longest_unexplained_gap_start_line : null,
+      longestUnexplainedGapEndLine: Number.isFinite(summary.longest_unexplained_gap_end_line) ? summary.longest_unexplained_gap_end_line : null,
+      longestUnexplainedGapLastLine: summary.longest_unexplained_gap_last_line || '',
+      longestUnexplainedGapFirstLine: summary.longest_unexplained_gap_first_line || '',
+      longestUnexplainedGapOverlap: summary.longest_unexplained_gap_maintenance_overlap || 'unknown',
+      confirmedMaintenanceGapsOver300: Number.isFinite(summary.confirmed_maintenance_gaps_over_300) ? summary.confirmed_maintenance_gaps_over_300 : 0,
+      unexplainedGapsOver300: Number.isFinite(summary.unexplained_gaps_over_300) ? summary.unexplained_gaps_over_300 : 0,
+      notableGaps: Array.isArray(summary.notable_gaps) ? summary.notable_gaps : []
     }
   }
 
@@ -410,7 +421,7 @@ $(document).ready(function () {
   }
 
   function getQuietPeriodSortValue (run) {
-    return getQuietPeriodSummary(run).longestGapSeconds
+    return getQuietPeriodSummary(run).longestUnexplainedGapSeconds
   }
 
   function renderQuietPeriodCell (run) {
@@ -418,21 +429,30 @@ $(document).ready(function () {
     if (summary.longestGapSeconds <= 0) {
       return '<span class="text-muted">No gaps</span>'
     }
-    const parts = [`Longest ${formatSeconds(summary.longestGapSeconds)}`]
-    if (summary.gapsOver900 > 0) {
-      parts.push(`${summary.gapsOver900}x>15m`)
-    } else if (summary.gapsOver300 > 0) {
-      parts.push(`${summary.gapsOver300}x>5m`)
+    const parts = []
+    if (summary.longestUnexplainedGapSeconds > 0) {
+      parts.push(`Unexplained ${formatSeconds(summary.longestUnexplainedGapSeconds)}`)
+    } else {
+      parts.push('No unexplained gaps')
+    }
+    if (summary.longestGapSeconds > 0 && summary.longestGapSeconds !== summary.longestUnexplainedGapSeconds && summary.maintenanceOverlap === 'confirmed') {
+      parts.push(`Maint ${formatSeconds(summary.longestGapSeconds)}`)
+    }
+    if (summary.unexplainedGapsOver300 > 0) {
+      parts.push(`${summary.unexplainedGapsOver300} unexplained`)
     }
     const detailParts = []
+    if (summary.longestUnexplainedGapStartedAt && summary.longestUnexplainedGapEndedAt) {
+      detailParts.push(`Longest unexplained: ${summary.longestUnexplainedGapStartedAt} -> ${summary.longestUnexplainedGapEndedAt}`)
+    }
     if (summary.longestGapStartedAt && summary.longestGapEndedAt) {
-      detailParts.push(`Gap: ${summary.longestGapStartedAt} -> ${summary.longestGapEndedAt}`)
+      detailParts.push(`Longest overall: ${summary.longestGapStartedAt} -> ${summary.longestGapEndedAt}`)
     }
     if (summary.gapsOver1800 > 0) {
       detailParts.push(`>30m: ${summary.gapsOver1800}`)
     }
-    if (summary.maintenanceOverlap) {
-      detailParts.push(`Maintenance overlap: ${summary.maintenanceOverlap}`)
+    if (summary.confirmedMaintenanceGapsOver300 > 0) {
+      detailParts.push(`Maintenance gaps: ${summary.confirmedMaintenanceGapsOver300}`)
     }
     const title = detailParts.join(' | ')
     return `
@@ -1520,7 +1540,7 @@ $(document).ready(function () {
           ${renderRunCardCell('Counts', 'W warnings, E errors, T tracebacks, M movies, S shows, Ep episodes, Tot total library items.', `<span class="logscan-count-chip-row">${countChips}</span>`)}
           ${renderRunCardCell('Kometa', 'Version detected for the run, plus newest version when different.', escapeHtml(kometaDisplay))}
           ${renderRunCardCell('Maintenance', 'Quickstart maintenance pauses recorded in meta.log for this run.', renderMaintenanceSummaryCell(run))}
-          ${renderRunCardCell('Quiet periods', 'Longest delays between timestamped Kometa log lines for this run.', renderQuietPeriodCell(run))}
+          ${renderRunCardCell('Quiet periods', 'Emphasizes the longest unexplained delay between timestamped Kometa log lines, with maintenance-related gaps available in the details view.', renderQuietPeriodCell(run))}
           ${renderRunCardCell('Section runtimes', 'Runtime totals parsed per Kometa section.', sectionCell)}
           ${renderRunCardCell('Log size', 'Current on-disk size of the resolved log file when available, otherwise the ingested size.', escapeHtml(formatBytes(sizeBytes)))}
           ${renderRunCardCell('Log', 'Download the source log for this run. Archived plain logs can also be compressed, and archived logs can be deleted here.', `<div class="logscan-action-stack">${logActions.join('')}</div>`)}
@@ -2552,40 +2572,110 @@ $(document).ready(function () {
       $runDetailsTitle.text('Quiet Period Details')
     }
     if ($runDetailsBody.length) {
-      const longestGap = formatSeconds(summary.longestGapSeconds)
-      const startedAt = formatTimestamp(summary.longestGapStartedAt) || 'n/a'
-      const endedAt = formatTimestamp(summary.longestGapEndedAt) || 'n/a'
-      const lineWindow = summary.longestGapStartLine && summary.longestGapEndLine
-        ? `${summary.longestGapStartLine} → ${summary.longestGapEndLine}`
-        : 'n/a'
-      const outcome = getQuietPeriodOutcome(run, summary)
+      const renderGapBlock = (title, gapSeconds, startedAtRaw, endedAtRaw, startLine, endLine, overlap, lastLine, firstLine) => {
+        if (!(gapSeconds > 0)) {
+          return `
+            <div class="mb-3">
+              <div class="fw-semibold mb-1">${escapeHtml(title)}</div>
+              <div class="small text-muted">None detected.</div>
+            </div>
+          `
+        }
+        const startedAt = formatTimestamp(startedAtRaw) || 'n/a'
+        const endedAt = formatTimestamp(endedAtRaw) || 'n/a'
+        const lineWindow = startLine && endLine ? `${startLine} → ${endLine}` : 'n/a'
+        const beforeLine = lastLine
+          ? `<pre class="small mb-0"><code>${escapeHtml(lastLine)}</code></pre>`
+          : '<div class="small text-muted">Unavailable</div>'
+        const afterLine = firstLine
+          ? `<pre class="small mb-0"><code>${escapeHtml(firstLine)}</code></pre>`
+          : '<div class="small text-muted">Unavailable</div>'
+        return `
+          <div class="mb-3">
+            <div class="fw-semibold mb-1">${escapeHtml(title)}</div>
+            <div class="small text-muted">Duration: ${escapeHtml(formatSeconds(gapSeconds))}</div>
+            <div class="small text-muted">Window: ${escapeHtml(startedAt)} to ${escapeHtml(endedAt)}</div>
+            <div class="small text-muted">Lines: ${escapeHtml(lineWindow)}</div>
+            <div class="small text-muted">Maintenance overlap: ${escapeHtml(overlap || 'unknown')}</div>
+          </div>
+          <div class="mb-3">
+            <div class="fw-semibold mb-1">Last line before gap</div>
+            ${beforeLine}
+          </div>
+          <div class="mb-3">
+            <div class="fw-semibold mb-1">First line after gap</div>
+            ${afterLine}
+          </div>
+        `
+      }
+      const outcome = getQuietPeriodOutcome(run, {
+        longestGapEndedAt: summary.longestUnexplainedGapEndedAt || summary.longestGapEndedAt
+      })
       const counts = []
-      if (summary.gapsOver300 > 0) counts.push(`>5m: ${summary.gapsOver300}`)
-      if (summary.gapsOver900 > 0) counts.push(`>15m: ${summary.gapsOver900}`)
-      if (summary.gapsOver1800 > 0) counts.push(`>30m: ${summary.gapsOver1800}`)
-      const beforeLine = summary.longestGapLastLine
-        ? `<pre class="small mb-0"><code>${escapeHtml(summary.longestGapLastLine)}</code></pre>`
-        : '<div class="small text-muted">Unavailable</div>'
-      const afterLine = summary.longestGapFirstLine
-        ? `<pre class="small mb-0"><code>${escapeHtml(summary.longestGapFirstLine)}</code></pre>`
-        : '<div class="small text-muted">Unavailable</div>'
+      if (summary.gapsOver300 > 0) counts.push(`All >5m: ${summary.gapsOver300}`)
+      if (summary.gapsOver900 > 0) counts.push(`All >15m: ${summary.gapsOver900}`)
+      if (summary.gapsOver1800 > 0) counts.push(`All >30m: ${summary.gapsOver1800}`)
+      counts.push(`Confirmed maintenance: ${summary.confirmedMaintenanceGapsOver300}`)
+      counts.push(`Unexplained: ${summary.unexplainedGapsOver300}`)
+      const notableRows = summary.notableGaps.length
+        ? summary.notableGaps.map(gap => {
+          const gapWindow = `${formatTimestamp(gap.started_at) || gap.started_at} to ${formatTimestamp(gap.ended_at) || gap.ended_at}`
+          const lineWindow = gap.start_line && gap.end_line ? `${gap.start_line} → ${gap.end_line}` : 'n/a'
+          return `
+              <tr>
+                <td>${escapeHtml(formatSeconds(gap.gap_seconds))}</td>
+                <td>${escapeHtml(gapWindow)}</td>
+                <td>${escapeHtml(lineWindow)}</td>
+                <td>${escapeHtml(gap.maintenance_overlap || 'unknown')}</td>
+              </tr>
+            `
+        }).join('')
+        : '<tr><td colspan="4" class="text-muted">No notable gaps recorded.</td></tr>'
       $runDetailsBody.html(`
         <div class="mb-3">
           <div class="fw-semibold mb-2">Summary</div>
-          <div class="small text-muted">Longest quiet period: ${escapeHtml(longestGap)}</div>
-          <div class="small text-muted">Window: ${escapeHtml(startedAt)} to ${escapeHtml(endedAt)}</div>
-          <div class="small text-muted">Lines: ${escapeHtml(lineWindow)}</div>
-          <div class="small text-muted">Maintenance overlap: ${escapeHtml(summary.maintenanceOverlap || 'unknown')}</div>
+          <div class="small text-muted">Longest unexplained quiet period: ${escapeHtml(formatSeconds(summary.longestUnexplainedGapSeconds) || 'n/a')}</div>
+          <div class="small text-muted">Longest overall quiet period: ${escapeHtml(formatSeconds(summary.longestGapSeconds) || 'n/a')}</div>
           <div class="small text-muted">Run outcome: ${escapeHtml(outcome)}</div>
           <div class="small text-muted">Gap counts: ${escapeHtml(counts.join(' • ') || 'Longest gap only')}</div>
         </div>
-        <div class="mb-3">
-          <div class="fw-semibold mb-1">Last line before gap</div>
-          ${beforeLine}
-        </div>
+        ${renderGapBlock(
+          'Longest unexplained quiet period',
+          summary.longestUnexplainedGapSeconds,
+          summary.longestUnexplainedGapStartedAt,
+          summary.longestUnexplainedGapEndedAt,
+          summary.longestUnexplainedGapStartLine,
+          summary.longestUnexplainedGapEndLine,
+          summary.longestUnexplainedGapOverlap,
+          summary.longestUnexplainedGapLastLine,
+          summary.longestUnexplainedGapFirstLine
+        )}
+        ${renderGapBlock(
+          'Longest overall quiet period',
+          summary.longestGapSeconds,
+          summary.longestGapStartedAt,
+          summary.longestGapEndedAt,
+          summary.longestGapStartLine,
+          summary.longestGapEndLine,
+          summary.maintenanceOverlap,
+          summary.longestGapLastLine,
+          summary.longestGapFirstLine
+        )}
         <div>
-          <div class="fw-semibold mb-1">First line after gap</div>
-          ${afterLine}
+          <div class="fw-semibold mb-2">Notable quiet periods (&gt;5m)</div>
+          <div class="table-responsive">
+            <table class="table table-dark table-sm align-middle mb-0">
+              <thead>
+                <tr>
+                  <th>Duration</th>
+                  <th>Window</th>
+                  <th>Lines</th>
+                  <th>Overlap</th>
+                </tr>
+              </thead>
+              <tbody>${notableRows}</tbody>
+            </table>
+          </div>
         </div>
       `)
     }

--- a/tests/test_logscan_endpoints.py
+++ b/tests/test_logscan_endpoints.py
@@ -163,6 +163,17 @@ def test_logscan_trends_returns_maintenance_summary_for_saved_runs(client, isola
                 "gaps_over_900": 1,
                 "gaps_over_1800": 0,
                 "longest_gap_maintenance_overlap": "confirmed",
+                "longest_unexplained_gap_seconds": 420,
+                "longest_unexplained_gap_started_at": "2026-04-23T03:10:00",
+                "longest_unexplained_gap_ended_at": "2026-04-23T03:17:00",
+                "longest_unexplained_gap_start_line": 2110,
+                "longest_unexplained_gap_end_line": 2111,
+                "longest_unexplained_gap_last_line": "[2026-04-23 03:10:00,000] [operations.py:200] [INFO] | Before unexplained gap |",
+                "longest_unexplained_gap_first_line": "[2026-04-23 03:17:00,000] [operations.py:201] [INFO] | After unexplained gap |",
+                "longest_unexplained_gap_maintenance_overlap": "none",
+                "confirmed_maintenance_gaps_over_300": 1,
+                "unexplained_gaps_over_300": 1,
+                "notable_gaps": [],
             },
         }
     )
@@ -179,6 +190,8 @@ def test_logscan_trends_returns_maintenance_summary_for_saved_runs(client, isola
     assert row["quiet_period_summary"]["longest_gap_seconds"] == 1200
     assert row["quiet_period_summary"]["longest_gap_start_line"] == 1842
     assert row["quiet_period_summary"]["longest_gap_end_line"] == 1843
+    assert row["quiet_period_summary"]["longest_unexplained_gap_seconds"] == 420
+    assert row["quiet_period_summary"]["confirmed_maintenance_gaps_over_300"] == 1
     assert row["quiet_period_summary"]["gaps_over_900"] == 1
     assert row["quiet_period_summary"]["longest_gap_maintenance_overlap"] == "confirmed"
 

--- a/tests/test_logscan_endpoints.py
+++ b/tests/test_logscan_endpoints.py
@@ -155,6 +155,10 @@ def test_logscan_trends_returns_maintenance_summary_for_saved_runs(client, isola
                 "longest_gap_seconds": 1200,
                 "longest_gap_started_at": "2026-04-23T01:00:00",
                 "longest_gap_ended_at": "2026-04-23T01:20:00",
+                "longest_gap_start_line": 1842,
+                "longest_gap_end_line": 1843,
+                "longest_gap_last_line": "[2026-04-23 01:00:00,000] [operations.py:100] [INFO] | Working before gap |",
+                "longest_gap_first_line": "[2026-04-23 01:20:00,000] [operations.py:101] [INFO] | Working after gap |",
                 "gaps_over_300": 2,
                 "gaps_over_900": 1,
                 "gaps_over_1800": 0,
@@ -173,6 +177,8 @@ def test_logscan_trends_returns_maintenance_summary_for_saved_runs(client, isola
     assert row["maintenance_summary"]["pause_seconds"] == 300
     assert row["maintenance_summary"]["window"] == "01:00-02:00"
     assert row["quiet_period_summary"]["longest_gap_seconds"] == 1200
+    assert row["quiet_period_summary"]["longest_gap_start_line"] == 1842
+    assert row["quiet_period_summary"]["longest_gap_end_line"] == 1843
     assert row["quiet_period_summary"]["gaps_over_900"] == 1
     assert row["quiet_period_summary"]["longest_gap_maintenance_overlap"] == "confirmed"
 

--- a/tests/test_logscan_runtime_parse.py
+++ b/tests/test_logscan_runtime_parse.py
@@ -117,6 +117,10 @@ def test_analyze_content_extracts_quickstart_maintenance_summary():
         "longest_gap_seconds": 300,
         "longest_gap_started_at": "2026-04-18T10:10:00",
         "longest_gap_ended_at": "2026-04-18T10:15:00",
+        "longest_gap_start_line": 2,
+        "longest_gap_end_line": 5,
+        "longest_gap_last_line": "[2026-04-18 10:10:00,000] [kometa.py:100] [INFO] | Resumed Work |",
+        "longest_gap_first_line": "[2026-04-18 10:15:00,000] [kometa.py:522] [INFO] |                                            Finished Run                                            |",
         "gaps_over_300": 1,
         "gaps_over_900": 0,
         "gaps_over_1800": 0,
@@ -142,6 +146,8 @@ def test_analyze_content_marks_quiet_period_overlap_as_confirmed_when_gap_matche
     quiet_summary = result["summary"]["quiet_period_summary"]
 
     assert quiet_summary["longest_gap_seconds"] == 1200
+    assert quiet_summary["longest_gap_start_line"] == 2
+    assert quiet_summary["longest_gap_end_line"] == 5
     assert quiet_summary["gaps_over_300"] == 2
     assert quiet_summary["gaps_over_900"] == 1
     assert quiet_summary["longest_gap_maintenance_overlap"] == "confirmed"
@@ -162,6 +168,8 @@ def test_analyze_content_marks_historical_quiet_period_overlap_as_unknown_withou
     quiet_summary = result["summary"]["quiet_period_summary"]
 
     assert quiet_summary["longest_gap_seconds"] == 1200
+    assert quiet_summary["longest_gap_start_line"] == 1
+    assert quiet_summary["longest_gap_end_line"] == 2
     assert quiet_summary["gaps_over_300"] == 2
     assert quiet_summary["gaps_over_900"] == 1
     assert quiet_summary["longest_gap_maintenance_overlap"] == "unknown"

--- a/tests/test_logscan_runtime_parse.py
+++ b/tests/test_logscan_runtime_parse.py
@@ -125,6 +125,28 @@ def test_analyze_content_extracts_quickstart_maintenance_summary():
         "gaps_over_900": 0,
         "gaps_over_1800": 0,
         "longest_gap_maintenance_overlap": "none",
+        "longest_unexplained_gap_seconds": 300,
+        "longest_unexplained_gap_started_at": "2026-04-18T10:10:00",
+        "longest_unexplained_gap_ended_at": "2026-04-18T10:15:00",
+        "longest_unexplained_gap_start_line": 2,
+        "longest_unexplained_gap_end_line": 5,
+        "longest_unexplained_gap_last_line": "[2026-04-18 10:10:00,000] [kometa.py:100] [INFO] | Resumed Work |",
+        "longest_unexplained_gap_first_line": "[2026-04-18 10:15:00,000] [kometa.py:522] [INFO] |                                            Finished Run                                            |",
+        "longest_unexplained_gap_maintenance_overlap": "none",
+        "confirmed_maintenance_gaps_over_300": 0,
+        "unexplained_gaps_over_300": 1,
+        "notable_gaps": [
+            {
+                "gap_seconds": 300,
+                "started_at": "2026-04-18T10:10:00",
+                "ended_at": "2026-04-18T10:15:00",
+                "start_line": 2,
+                "end_line": 5,
+                "last_line": "[2026-04-18 10:10:00,000] [kometa.py:100] [INFO] | Resumed Work |",
+                "first_line": "[2026-04-18 10:15:00,000] [kometa.py:522] [INFO] |                                            Finished Run                                            |",
+                "maintenance_overlap": "none",
+            }
+        ],
     }
 
 
@@ -148,6 +170,11 @@ def test_analyze_content_marks_quiet_period_overlap_as_confirmed_when_gap_matche
     assert quiet_summary["longest_gap_seconds"] == 1200
     assert quiet_summary["longest_gap_start_line"] == 2
     assert quiet_summary["longest_gap_end_line"] == 5
+    assert quiet_summary["longest_unexplained_gap_seconds"] == 300
+    assert quiet_summary["longest_unexplained_gap_start_line"] == 5
+    assert quiet_summary["longest_unexplained_gap_end_line"] == 6
+    assert quiet_summary["confirmed_maintenance_gaps_over_300"] == 1
+    assert quiet_summary["unexplained_gaps_over_300"] == 1
     assert quiet_summary["gaps_over_300"] == 2
     assert quiet_summary["gaps_over_900"] == 1
     assert quiet_summary["longest_gap_maintenance_overlap"] == "confirmed"
@@ -170,6 +197,8 @@ def test_analyze_content_marks_historical_quiet_period_overlap_as_unknown_withou
     assert quiet_summary["longest_gap_seconds"] == 1200
     assert quiet_summary["longest_gap_start_line"] == 1
     assert quiet_summary["longest_gap_end_line"] == 2
+    assert quiet_summary["longest_unexplained_gap_seconds"] == 1200
+    assert quiet_summary["unexplained_gaps_over_300"] == 2
     assert quiet_summary["gaps_over_300"] == 2
     assert quiet_summary["gaps_over_900"] == 1
     assert quiet_summary["longest_gap_maintenance_overlap"] == "unknown"


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Adds richer quiet-period diagnostics to Analytics. The main Quiet periods cell now emphasizes the longest unexplained gap rather than the raw longest gap, while the details modal shows both the longest unexplained and longest overall gaps, maintenance overlap, line numbers, before/after log lines, inferred run outcome, and a table of notable quiet periods over 5 minutes.

To support that UI, Logscan now persists additional quiet-period detail for each run, including line-number-aware gap metadata and a list of notable gaps. This branch is intended to be applied with a full historical reset + reingest so existing runs get the new quiet-period detail consistently.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
