### PR TITLE
fix yaml leak

### DIFF
--- a/modules/database.py
+++ b/modules/database.py
@@ -7,6 +7,38 @@ from contextlib import closing
 
 from modules import helpers
 
+TRANSIENT_SECTION_KEYS = {
+    "configSelector",
+    "config_name",
+    "newConfigName",
+    "importMode",
+}
+
+
+def _strip_transient_section_keys(value):
+    changed = False
+
+    if isinstance(value, dict):
+        cleaned = {}
+        for key, item in value.items():
+            if key in TRANSIENT_SECTION_KEYS:
+                changed = True
+                continue
+            cleaned_item, item_changed = _strip_transient_section_keys(item)
+            cleaned[key] = cleaned_item
+            changed = changed or item_changed
+        return cleaned, changed
+
+    if isinstance(value, list):
+        cleaned = []
+        for item in value:
+            cleaned_item, item_changed = _strip_transient_section_keys(item)
+            cleaned.append(cleaned_item)
+            changed = changed or item_changed
+        return cleaned, changed
+
+    return value, False
+
 
 def get_database_path():
     return os.path.join(helpers.CONFIG_DIR, "quickstart.sqlite")
@@ -57,6 +89,15 @@ def retrieve_section_data(name, section):
             row = cursor.fetchone()
             if row:
                 unpickled = pickle.loads(row["data"])
+                cleaned_data, changed = _strip_transient_section_keys(unpickled)
+                if changed:
+                    cursor.execute(
+                        """UPDATE section_data
+                            SET data = ?
+                            WHERE name == ? AND section == ?""",
+                        (pickle.dumps(cleaned_data), name, section),
+                    )
+                    unpickled = cleaned_data
                 if has_app_context() and app.config["QS_DEBUG"]:
                     helpers.ts_log(f"Retrieved data for name={name}, section={section}: {unpickled}", level="DEBUG")
                 return (
@@ -81,6 +122,8 @@ def retrieve_config_sections(name):
             for row in rows:
                 try:
                     data_blob = pickle.loads(row["data"]) if row["data"] is not None else None
+                    if data_blob is not None:
+                        data_blob, _changed = _strip_transient_section_keys(data_blob)
                 except Exception:
                     data_blob = None
                 sections.append(
@@ -92,6 +135,35 @@ def retrieve_config_sections(name):
                     }
                 )
     return sections
+
+
+def sanitize_all_section_data():
+    updated = 0
+    with sqlite3.connect(get_database_path(), detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES) as connection:
+        connection.row_factory = sqlite3.Row
+        with closing(connection.cursor()) as cursor:
+            cursor.execute(persisted_section_table_create())
+            cursor.execute("""SELECT name, section, data FROM section_data""")
+            rows = cursor.fetchall()
+            for row in rows:
+                raw_data = row["data"]
+                if raw_data is None:
+                    continue
+                try:
+                    data_blob = pickle.loads(raw_data)
+                except Exception:
+                    continue
+                cleaned_blob, changed = _strip_transient_section_keys(data_blob)
+                if not changed:
+                    continue
+                cursor.execute(
+                    """UPDATE section_data
+                        SET data = ?
+                        WHERE name == ? AND section == ?""",
+                    (pickle.dumps(cleaned_blob), row["name"], row["section"]),
+                )
+                updated += 1
+    return updated
 
 
 def retrieve_validated_map(name, sections=None):

--- a/modules/persistence.py
+++ b/modules/persistence.py
@@ -19,6 +19,13 @@ _ISO_3166_1_REGIONS = None
 _ISO_639_2_LANGUAGES = None
 _DUMMY_CONFIG_CACHE = None
 
+TRANSIENT_FORM_FIELDS = {
+    "configSelector",
+    "config_name",
+    "newConfigName",
+    "importMode",
+}
+
 
 def _get_iso_reference_lists():
     global _ISO_639_1_LANGUAGES
@@ -75,6 +82,8 @@ def clean_form_data(form_data):
     clean_data = {}
 
     for key, value in form_data.items():
+        if key in TRANSIENT_FORM_FIELDS:
+            continue
         # Handle asset_directory as a list
         if key == "asset_directory" or key.endswith("-attribute_asset_directory"):
             if isinstance(value, list):

--- a/quickstart.py
+++ b/quickstart.py
@@ -2812,6 +2812,9 @@ RUN_CONTEXT = {
 
 # Ensure json-schema files are up to date at startup
 helpers.ensure_json_schema()
+sanitized_section_count = database.sanitize_all_section_data()
+if sanitized_section_count:
+    helpers.ts_log(f"Sanitized transient config-manager fields from {sanitized_section_count} persisted section(s).", level="INFO")
 
 parser = argparse.ArgumentParser(description="Run Quickstart Flask App")
 parser.add_argument("--port", type=int, help="Specify the port number to run the server")

--- a/static/local-js/001-start.js
+++ b/static/local-js/001-start.js
@@ -78,6 +78,7 @@ function setButtonSpinner (button, text) {
 document.addEventListener('DOMContentLoaded', function () {
   const configSwitchSelect = document.getElementById('configSwitchSelect')
   const configSelector = document.getElementById('configSelector')
+  const activeConfigInput = document.getElementById('qs-active-config-input')
   const newConfigInput = document.getElementById('newConfigName')
   const saveConfigRow = document.getElementById('saveConfigRow')
   const saveConfigButton = document.getElementById('saveConfigButton')
@@ -243,6 +244,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
   function setSelectedConfigOption (name) {
     if (!name) return
+    if (activeConfigInput) {
+      activeConfigInput.value = name
+    }
     if (configSelector) {
       configSelector.value = name
     }

--- a/templates/001-navigation.html
+++ b/templates/001-navigation.html
@@ -1,4 +1,5 @@
 <form method="post" id="configForm" name="configForm">
+  <input type="hidden" id="qs-active-config-input" name="configSelector" value="{{ page_info.config_name }}">
   {% import "partials/_workspace_macros.html" as workspace %}
   {% set qs_is_docker = version_info and version_info.running_on and ('Docker' in version_info.running_on) %}
   {% set hide_step_nav = page_info.get('hide_step_nav', False) %}

--- a/templates/partials/_config_workspace_modal.html
+++ b/templates/partials/_config_workspace_modal.html
@@ -1,5 +1,6 @@
 {% set show_new_config = page_info['config_name'] not in available_configs %}
 {% set can_merge = available_configs | length > 0 %}
+<form id="qs-config-workspace-form" class="d-none" aria-hidden="true"></form>
 
 <div class="modal fade" id="configSwitchModal" tabindex="-1" aria-labelledby="configSwitchModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered modal-lg modal-dialog-scrollable">
@@ -44,7 +45,7 @@
           </div>
 
           <div class="form-floating mb-2">
-            <select id="configSelector" name="configSelector" class="form-select" onchange="toggleConfigInput(this)">
+            <select id="configSelector" name="configSelector" form="qs-config-workspace-form" class="form-select" onchange="toggleConfigInput(this)">
               <option value="add_config" {% if page_info['config_name'] not in available_configs %}selected{% endif %}>
                 Add Config
               </option>
@@ -58,7 +59,7 @@
           </div>
 
           <div id="newConfigInput" class="form-floating mb-2 {{ '' if show_new_config else 'd-none' }}">
-            <input type="text" id="newConfigName" name="newConfigName" class="form-control" placeholder="Enter a new config name"
+            <input type="text" id="newConfigName" name="newConfigName" form="qs-config-workspace-form" class="form-control" placeholder="Enter a new config name"
               value="{% if page_info['config_name'] not in available_configs %}{{ page_info['config_name'] }}{% else %}{{ page_info['new_config_name'] }}{% endif %}">
             <label for="newConfigName">New Config Name</label>
           </div>
@@ -255,11 +256,11 @@
         <div class="border rounded p-2 mt-3" id="importModeSection">
           <div class="small text-muted mb-1">Import Mode</div>
           <div class="form-check">
-            <input class="form-check-input" type="radio" name="importMode" id="importModeNew" value="new" checked>
+            <input class="form-check-input" type="radio" name="importMode" form="qs-config-workspace-form" id="importModeNew" value="new" checked>
             <label class="form-check-label" for="importModeNew">Create a new config from this file</label>
           </div>
           <div class="form-check mt-1">
-            <input class="form-check-input" type="radio" name="importMode" id="importModeMerge" value="merge" {% if not can_merge %}disabled{% endif %}>
+            <input class="form-check-input" type="radio" name="importMode" form="qs-config-workspace-form" id="importModeMerge" value="merge" {% if not can_merge %}disabled{% endif %}>
             <label class="form-check-label" for="importModeMerge">
               Merge into a base config (creates a new config)
               {% if not can_merge %}<span class="text-muted">No configs available</span>{% endif %}

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -685,3 +685,74 @@ def test_clone_test_libraries_start_returns_job_payload_immediately(client, tmp_
     assert payload["started_at"]
     assert started["started"] is True
     assert started["daemon"] is True
+
+
+def test_step_post_ignores_global_config_manager_fields_in_saved_section(client, isolated_config_dir):
+    from modules import database
+
+    config_name = "pytest_leak_guard"
+    resp = client.post(
+        "/step/100-anidb",
+        data={
+            "configSelector": config_name,
+            "newConfigName": "should_not_persist",
+            "importMode": "new",
+            "language": "en",
+            "cache_expiration": "60",
+            "enable_mature": "true",
+        },
+        headers={"Referer": "http://localhost/step/100-anidb"},
+    )
+
+    assert resp.status_code in (200, 302)
+
+    validated, user_entered, data = database.retrieve_section_data(config_name, "anidb")
+    assert validated is False
+    assert user_entered is True
+    assert data["anidb"]["language"] == "en"
+    assert data["anidb"]["cache_expiration"] == 60
+    assert data["anidb"]["enable_mature"] is True
+    assert "configSelector" not in data["anidb"]
+    assert "newConfigName" not in data["anidb"]
+    assert "importMode" not in data["anidb"]
+
+
+def test_retrieve_settings_sanitizes_already_persisted_transient_fields(client, isolated_config_dir, app):
+    from modules import database, persistence
+    from flask import session
+
+    config_name = "pytest_existing_leak_guard"
+    database.save_section_data(
+        section="anidb",
+        validated=True,
+        user_entered=True,
+        name=config_name,
+        data={
+            "anidb": {
+                "configSelector": config_name,
+                "newConfigName": "should_not_persist",
+                "importMode": "new",
+                "language": "en",
+                "cache_expiration": 60,
+                "enable_mature": True,
+            },
+            "validated_at": "2026-05-03T00:00:00Z",
+        },
+    )
+
+    with app.test_request_context("/step/100-anidb"):
+        session["config_name"] = config_name
+        settings = persistence.retrieve_settings("100-anidb")
+        assert settings["anidb"]["language"] == "en"
+        assert settings["anidb"]["cache_expiration"] == 60
+        assert settings["anidb"]["enable_mature"] is True
+        assert "configSelector" not in settings["anidb"]
+        assert "newConfigName" not in settings["anidb"]
+        assert "importMode" not in settings["anidb"]
+
+    validated, user_entered, stored = database.retrieve_section_data(config_name, "anidb")
+    assert validated is True
+    assert user_entered is True
+    assert "configSelector" not in stored["anidb"]
+    assert "newConfigName" not in stored["anidb"]
+    assert "importMode" not in stored["anidb"]


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Fixes leaked config-manager fields polluting saved section data and breaking Kometa validation. This filters transient modal fields from future saves, auto-sanitizes already-persisted rows on read and startup, adds regression coverage for both paths, and cleans up the associated Start/config-manager integration.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
