### PR TITLE
Fix analytics startup mode

### DIFF
--- a/quickstart.py
+++ b/quickstart.py
@@ -9844,6 +9844,15 @@ def _iso_from_mtime(value):
     return None
 
 
+def _extract_first_log_timestamp(content):
+    if not content:
+        return None
+    match = re.search(r"^\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d{3}\]", str(content), re.MULTILINE)
+    if not match:
+        return None
+    return match.group(1).strip()
+
+
 def _build_incomplete_resume_message(phase_current=None, current_library=None, finished_at=None):
     if phase_current and current_library:
         message = f"Run appears incomplete during {phase_current} in library '{current_library}'."
@@ -10063,6 +10072,7 @@ def _analyze_incomplete_log_for_resume(log_path, cache_entry=None, config_name=N
         content = _read_logscan_text(log_path, encoding="utf-8", errors="replace")
     except Exception:
         return None
+    started_at_fallback = _extract_first_log_timestamp(content)
 
     analyzer = logscan.LogscanAnalyzer()
     try:
@@ -10174,10 +10184,11 @@ def _analyze_incomplete_log_for_resume(log_path, cache_entry=None, config_name=N
     if not run_key:
         run_key_seed = f"incomplete|{log_path}|{mtime or 0}"
         run_key = hashlib.sha256(run_key_seed.encode("utf-8")).hexdigest()
+    started_at = summary.get("started_at") or started_at_fallback
 
     return {
         "run_key": run_key,
-        "started_at": summary.get("started_at"),
+        "started_at": started_at,
         "finished_at": summary.get("finished_at"),
         "run_time_seconds": summary.get("run_time_seconds"),
         "kometa_version": summary.get("kometa_version"),
@@ -10245,6 +10256,12 @@ def _build_incomplete_run_from_cache_entry(log_path, cache_entry=None, config_na
     created_at = summary.get("created_at")
     if not created_at:
         created_at = cache_entry.get("updated_at") or _iso_from_mtime(mtime)
+    started_at = summary.get("started_at")
+    if not started_at:
+        try:
+            started_at = _extract_first_log_timestamp(_read_logscan_text(path, encoding="utf-8", errors="replace"))
+        except Exception:
+            started_at = None
     original_command = summary.get("run_command") or ""
     if tool_name == "kometa":
         original_command = _inject_config_path_for_command(
@@ -10254,7 +10271,7 @@ def _build_incomplete_run_from_cache_entry(log_path, cache_entry=None, config_na
     return {
         "run_key": run_key,
         "tool_name": tool_name,
-        "started_at": summary.get("started_at"),
+        "started_at": started_at,
         "finished_at": summary.get("finished_at"),
         "run_time_seconds": summary.get("run_time_seconds"),
         "kometa_version": summary.get("kometa_version"),
@@ -10314,10 +10331,14 @@ def _build_incomplete_log_fallback(log_path, cache_entry=None, config_name=None)
         run_key_seed = f"incomplete|fallback|{path}|{mtime or 0}|{size or 0}"
         run_key = hashlib.sha256(run_key_seed.encode("utf-8")).hexdigest()
     created_at = cache_entry.get("updated_at") or _iso_from_mtime(mtime)
+    try:
+        started_at = _extract_first_log_timestamp(_read_logscan_text(path, encoding="utf-8", errors="replace"))
+    except Exception:
+        started_at = None
     return {
         "run_key": run_key,
         "tool_name": tool_name,
-        "started_at": None,
+        "started_at": started_at,
         "finished_at": None,
         "run_time_seconds": None,
         "kometa_version": "",
@@ -11025,6 +11046,10 @@ def _perform_logscan_reingest(reset, job_id=None, update_state=True):
                         if archived_path:
                             cache_dirty = True
                     continue
+                if not summary.get("started_at"):
+                    first_log_timestamp = _extract_first_log_timestamp(content)
+                    if first_log_timestamp:
+                        summary["started_at"] = first_log_timestamp
                 if not summary.get("run_complete"):
                     skipped_incomplete += 1
                     if len(sample_incomplete) < 5:

--- a/quickstart.py
+++ b/quickstart.py
@@ -1671,8 +1671,8 @@ def _is_within_maintenance_window(now_dt, start_min, end_min):
     return now_min >= start_min or now_min < end_min
 
 
-def _get_maintenance_window_from_db():
-    config_name = database.get_last_used_config_name()
+def _get_maintenance_window_from_db(config_name=None):
+    config_name = helpers.normalize_config_name_for_storage(config_name) or database.get_last_used_config_name()
     if not config_name:
         return None, None, None
     try:
@@ -1696,8 +1696,8 @@ def _get_maintenance_window_from_db():
         return None, None, None
 
 
-def _get_plex_credentials_from_db():
-    config_name = database.get_last_used_config_name()
+def _get_plex_credentials_from_db(config_name=None):
+    config_name = helpers.normalize_config_name_for_storage(config_name) or database.get_last_used_config_name()
     if not config_name:
         return None, None
     try:
@@ -1711,8 +1711,8 @@ def _get_plex_credentials_from_db():
         return None, None
 
 
-def _get_maintenance_window_live():
-    plex_url, plex_token = _get_plex_credentials_from_db()
+def _get_maintenance_window_live(config_name=None):
+    plex_url, plex_token = _get_plex_credentials_from_db(config_name=config_name)
     if not plex_url or not plex_token:
         return None, None, None
     start_hour, end_hour = helpers.get_plex_maintenance_hours(plex_url, plex_token)
@@ -1720,6 +1720,78 @@ def _get_maintenance_window_live():
         return None, None, None
     window_str = f"{start_hour:02d}:00 – {end_hour:02d}:00"
     return start_hour * 60, end_hour * 60, window_str
+
+
+def _get_active_maintenance_lookup_config_name():
+    def normalize_optional_config_name(value):
+        raw = str(value or "").strip()
+        if not raw:
+            return ""
+        return helpers.normalize_config_name_for_storage(raw)
+
+    kometa_running = bool(helpers.get_kometa_pid() and helpers.is_kometa_running())
+    imagemaid_running = bool(helpers.get_imagemaid_pid() and helpers.is_imagemaid_running())
+
+    try:
+        kometa_ctx = _get_run_context()
+    except Exception:
+        kometa_ctx = {}
+    kometa_config = normalize_optional_config_name((kometa_ctx or {}).get("config_name"))
+    if kometa_running and kometa_config:
+        return kometa_config
+
+    try:
+        imagemaid_ctx = _get_imagemaid_run_context()
+    except Exception:
+        imagemaid_ctx = {}
+    imagemaid_config = normalize_optional_config_name((imagemaid_ctx or {}).get("config_name"))
+    if imagemaid_running and imagemaid_config:
+        return imagemaid_config
+
+    pending = _peek_pending_kometa_start()
+    pending_config = normalize_optional_config_name((pending or {}).get("config_name"))
+    if pending_config:
+        return pending_config
+
+    return database.get_last_used_config_name()
+
+
+def _resolve_maintenance_window_live(config_name=None):
+    try:
+        return _get_maintenance_window_live(config_name=config_name)
+    except TypeError:
+        return _get_maintenance_window_live()
+
+
+def _resolve_maintenance_window_from_db(config_name=None):
+    try:
+        return _get_maintenance_window_from_db(config_name=config_name)
+    except TypeError:
+        return _get_maintenance_window_from_db()
+
+
+def _refresh_maintenance_window_availability():
+    maintenance_config_name = _get_active_maintenance_lookup_config_name()
+    start_min, end_min, window_str = _resolve_maintenance_window_live(config_name=maintenance_config_name)
+    if start_min is None or end_min is None:
+        start_min, end_min, window_str = _resolve_maintenance_window_from_db(config_name=maintenance_config_name)
+    window_unavailable = start_min is None or end_min is None
+
+    kometa_running = bool(helpers.get_kometa_pid() and helpers.is_kometa_running())
+    imagemaid_running = bool(helpers.get_imagemaid_pid() and helpers.is_imagemaid_running())
+    has_pending = bool(_peek_pending_kometa_start())
+    active = _is_within_maintenance_window(datetime.now(), start_min, end_min)
+
+    with MAINTENANCE_STATE_LOCK:
+        MAINTENANCE_STATE["active"] = active
+        MAINTENANCE_STATE["window"] = window_str
+        if window_unavailable and (kometa_running or imagemaid_running or has_pending):
+            if not MAINTENANCE_STATE.get("window_unavailable"):
+                MAINTENANCE_STATE["window_unavailable_since"] = datetime.now(timezone.utc).isoformat()
+            MAINTENANCE_STATE["window_unavailable"] = True
+        else:
+            MAINTENANCE_STATE["window_unavailable"] = False
+            MAINTENANCE_STATE["window_unavailable_since"] = None
 
 
 def _normalize_kometa_start_mode(raw_mode):
@@ -2029,6 +2101,20 @@ def _get_run_context():
         return dict(RUN_CONTEXT)
 
 
+def _clear_run_context():
+    with RUN_CONTEXT_LOCK:
+        RUN_CONTEXT["command"] = None
+        RUN_CONTEXT["selected_libraries"] = None
+        RUN_CONTEXT["run_option"] = None
+        RUN_CONTEXT["run_mode"] = "all"
+        RUN_CONTEXT["start_mode"] = "current"
+        RUN_CONTEXT["config_name"] = None
+        RUN_CONTEXT["config_path"] = None
+        RUN_CONTEXT["started_at"] = None
+        RUN_CONTEXT["updated_at"] = None
+        RUN_CONTEXT["stop_requested_at"] = None
+
+
 def _normalize_imagemaid_command_text(command):
     if isinstance(command, (list, tuple)):
         return " ".join(str(part) for part in command if str(part).strip())
@@ -2047,6 +2133,15 @@ def _update_imagemaid_run_context(command, mode=None, config_name=None):
 def _get_imagemaid_run_context():
     with IMAGEMAID_RUN_CONTEXT_LOCK:
         return dict(IMAGEMAID_RUN_CONTEXT)
+
+
+def _clear_imagemaid_run_context():
+    with IMAGEMAID_RUN_CONTEXT_LOCK:
+        IMAGEMAID_RUN_CONTEXT["command"] = None
+        IMAGEMAID_RUN_CONTEXT["mode"] = None
+        IMAGEMAID_RUN_CONTEXT["config_name"] = None
+        IMAGEMAID_RUN_CONTEXT["started_at"] = None
+        IMAGEMAID_RUN_CONTEXT["updated_at"] = None
 
 
 def _suspend_process_tree(proc):
@@ -2087,9 +2182,10 @@ def _maintenance_guard_loop(app_in):
     with app_in.app_context():
         while True:
             time.sleep(interval)
-            start_min, end_min, window_str = _get_maintenance_window_live()
+            maintenance_config_name = _get_active_maintenance_lookup_config_name()
+            start_min, end_min, window_str = _resolve_maintenance_window_live(config_name=maintenance_config_name)
             if start_min is None or end_min is None:
-                start_min, end_min, window_str = _get_maintenance_window_from_db()
+                start_min, end_min, window_str = _resolve_maintenance_window_from_db(config_name=maintenance_config_name)
             window_unavailable = start_min is None or end_min is None
             pid = helpers.get_kometa_pid()
             kometa_running = pid and helpers.is_kometa_running()
@@ -5686,7 +5782,35 @@ def step(name):
         if validation_errors:
             save_error = "Invalid values: " + " ".join(validation_errors)
         else:
-            persistence.save_settings(request.referrer, request.form)
+            save_source, save_source_name = persistence.extract_names(request.referrer or name)
+            if save_source_name == "imagemaid":
+                request_payload = request.form.to_dict(flat=True)
+                request_payload["config_name"] = (
+                    session.get("config_name")
+                    or request_payload.get("config_name")
+                    or request_payload.get("configSelector")
+                )
+                config_name = _resolve_request_config_name(request_payload)
+                existing_settings, _existing_section = _get_imagemaid_settings_section(config_name)
+                was_validated = helpers.booler(existing_settings.get("validated", False))
+                # Step navigation posts the page's native form field names (imagemaid_*),
+                # unlike the JSON autosave/validate routes, so save those directly.
+                form_payload = dict(request.form)
+                form_payload["config_name"] = config_name
+                changed = False
+                if form_payload:
+                    _saved_payload, changed = _save_imagemaid_settings_for_config(config_name, form_payload)
+                _settings_after, section_data = _get_imagemaid_settings_section(config_name)
+                if changed and was_validated:
+                    _persist_imagemaid_validation(
+                        config_name,
+                        section_data,
+                        False,
+                        reason="config_changed",
+                        details="Configuration changed. Validate ImageMaid again.",
+                    )
+            else:
+                persistence.save_settings(request.referrer, request.form)
             header_style = request.form.get("header_style", "single line")
 
     # --- Detect config change ---
@@ -8047,9 +8171,10 @@ def start_kometa():
 
     _update_run_context(command, start_mode=start_mode)
 
-    start_min, end_min, window_str = _get_maintenance_window_live()
+    maintenance_config_name = session.get("config_name")
+    start_min, end_min, window_str = _resolve_maintenance_window_live(config_name=maintenance_config_name)
     if start_min is None or end_min is None:
-        start_min, end_min, window_str = _get_maintenance_window_from_db()
+        start_min, end_min, window_str = _resolve_maintenance_window_from_db(config_name=maintenance_config_name)
     if _is_within_maintenance_window(datetime.now(), start_min, end_min):
         _set_pending_kometa_start(command, session.get("config_name"), start_mode=start_mode)
         return jsonify({"status": "queued", "maintenance_window": window_str, "start_mode": start_mode}), 202
@@ -8101,6 +8226,7 @@ def stop_kometa():
         except Exception:
             pass
         _clear_process_metric_cache(pid, "kometa")
+        _clear_run_context()
         try:
             _write_quickstart_stop_marker(helpers.get_kometa_root_path(), config_name=run_config_name, reason="user_stop")
         except Exception:
@@ -8119,6 +8245,7 @@ def stop_kometa():
             os.remove(pid_file)
         except Exception:
             pass
+        _clear_run_context()
         try:
             _write_quickstart_stop_marker(helpers.get_kometa_root_path(), config_name=session.get("config_name"), reason="process_missing")
         except Exception:
@@ -8130,6 +8257,10 @@ def stop_kometa():
 
 @app.route("/kometa-status", methods=["GET"])
 def kometa_status():
+    try:
+        _refresh_maintenance_window_availability()
+    except Exception:
+        pass
     pending = _peek_pending_kometa_start()
     pending_start = bool(pending)
     pending_requested_at = pending.get("requested_at") if pending else None
@@ -8151,6 +8282,7 @@ def kometa_status():
             _ingest_completed_live_logs("kometa")
         except Exception:
             pass
+        _clear_run_context()
         with MAINTENANCE_STATE_LOCK:
             maintenance_active = MAINTENANCE_STATE["active"]
             maintenance_paused = MAINTENANCE_STATE["paused"]
@@ -8254,6 +8386,7 @@ def kometa_status():
         except Exception:
             pass
         _clear_process_metric_cache(pid, "kometa")
+        _clear_run_context()
         with MAINTENANCE_STATE_LOCK:
             maintenance_active = MAINTENANCE_STATE["active"]
             maintenance_paused = MAINTENANCE_STATE["paused"]
@@ -8283,6 +8416,7 @@ def kometa_status():
             os.remove(helpers.get_kometa_pid_file())
         except Exception:
             pass
+        _clear_run_context()
         with MAINTENANCE_STATE_LOCK:
             maintenance_active = MAINTENANCE_STATE["active"]
             maintenance_paused = MAINTENANCE_STATE["paused"]
@@ -13490,17 +13624,20 @@ def _get_stored_plex_credentials_for_config(config_name):
 def _save_imagemaid_settings_for_config(config_name, form_payload):
     clean_data = persistence.clean_form_data(form_payload)
     data = helpers.build_config_dict("imagemaid", clean_data)
-    base_data = persistence.get_dummy_data("imagemaid")
     stored_validated, stored_user_entered, stored_payload = database.retrieve_section_data(config_name, "imagemaid")
     existing_payload = stored_payload if isinstance(stored_payload, dict) else {}
     existing_section = existing_payload.get("imagemaid", {}) if isinstance(existing_payload.get("imagemaid"), dict) else {}
+    canonical_existing_section = _canonicalize_imagemaid_section(existing_section)
+    canonical_new_section = _canonicalize_imagemaid_section(
+        data.get("imagemaid", {}) if isinstance(data.get("imagemaid"), dict) else {}
+    )
     payload = dict(existing_payload)
-    payload["imagemaid"] = data.get("imagemaid", {}) if isinstance(data.get("imagemaid"), dict) else {}
+    payload["imagemaid"] = canonical_new_section
     if "validated_at" in data:
         payload["validated_at"] = data.get("validated_at")
     elif existing_payload.get("validated_at") is not None:
         payload["validated_at"] = existing_payload.get("validated_at")
-    user_entered = data != base_data
+    user_entered = bool(canonical_new_section.get("plex_path"))
     database.save_section_data(
         name=config_name,
         section="imagemaid",
@@ -13508,8 +13645,59 @@ def _save_imagemaid_settings_for_config(config_name, form_payload):
         user_entered=user_entered,
         data=payload,
     )
-    changed = payload.get("imagemaid", {}) != existing_section
+    changed = canonical_new_section != canonical_existing_section
     return payload, changed
+
+
+def _canonicalize_imagemaid_section(section_data):
+    section = dict(section_data) if isinstance(section_data, dict) else {}
+    canonical = {
+        "branch_override": "",
+        "plex_path": "",
+        "mode": "report",
+        "timeout": 600,
+        "sleep": 60,
+        "photo_transcoder": False,
+        "empty_trash": False,
+        "clean_bundles": False,
+        "optimize_db": False,
+        "local_db": False,
+        "use_existing": False,
+        "ignore_running": False,
+        "trace": False,
+        "log_requests": False,
+        "no_verify_ssl": False,
+        "overlays_only": False,
+    }
+    canonical.update(section)
+
+    canonical["branch_override"] = helpers.normalize_imagemaid_branch_override(canonical.get("branch_override")) or ""
+    canonical["plex_path"] = str(canonical.get("plex_path") or "").strip()
+    canonical["mode"] = str(canonical.get("mode") or "report").strip().lower() or "report"
+
+    for numeric_key, default_value in (("timeout", 600), ("sleep", 60)):
+        raw_value = canonical.get(numeric_key)
+        try:
+            canonical[numeric_key] = int(raw_value)
+        except (TypeError, ValueError):
+            canonical[numeric_key] = default_value
+
+    for bool_key in (
+        "photo_transcoder",
+        "empty_trash",
+        "clean_bundles",
+        "optimize_db",
+        "local_db",
+        "use_existing",
+        "ignore_running",
+        "trace",
+        "log_requests",
+        "no_verify_ssl",
+        "overlays_only",
+    ):
+        canonical[bool_key] = helpers.booler(canonical.get(bool_key))
+
+    return canonical
 
 
 def _get_imagemaid_settings_section(config_name=None):
@@ -14137,8 +14325,11 @@ def autosave_imagemaid():
             reason="config_changed",
             details="Configuration changed. Validate ImageMaid again.",
         )
+        validated = False
+    else:
+        validated = helpers.booler(settings.get("validated", False))
 
-    return jsonify(success=True, validated=False)
+    return jsonify(success=True, changed=changed, validated=validated)
 
 
 @app.route("/start-imagemaid", methods=["POST"])
@@ -14194,9 +14385,9 @@ def start_imagemaid():
     if not is_valid:
         return jsonify({"error": details or "ImageMaid settings are not valid.", "status": "invalid", "reason": reason}), 400
 
-    start_min, end_min, window_str = _get_maintenance_window_live()
+    start_min, end_min, window_str = _resolve_maintenance_window_live(config_name=config_name)
     if start_min is None or end_min is None:
-        start_min, end_min, window_str = _get_maintenance_window_from_db()
+        start_min, end_min, window_str = _resolve_maintenance_window_from_db(config_name=config_name)
     if _is_within_maintenance_window(datetime.now(), start_min, end_min):
         try:
             _write_quickstart_imagemaid_maintenance_marker(
@@ -14269,6 +14460,7 @@ def stop_imagemaid():
             os.remove(pid_file)
         except Exception:
             pass
+        _clear_imagemaid_run_context()
         try:
             _write_quickstart_imagemaid_stop_marker(
                 helpers.get_imagemaid_root_path(),
@@ -14291,6 +14483,7 @@ def stop_imagemaid():
             os.remove(pid_file)
         except Exception:
             pass
+        _clear_imagemaid_run_context()
         try:
             _settings, section_data = _get_imagemaid_settings_section()
             imagemaid_mode = section_data.get("mode") if isinstance(section_data, dict) else None
@@ -14310,6 +14503,10 @@ def stop_imagemaid():
 
 @app.route("/imagemaid-status", methods=["GET"])
 def imagemaid_status():
+    try:
+        _refresh_maintenance_window_availability()
+    except Exception:
+        pass
     pid = helpers.get_imagemaid_pid()
     pid_file = Path(helpers.get_imagemaid_pid_file())
     imagemaid_ctx = _get_imagemaid_run_context()
@@ -14341,6 +14538,7 @@ def imagemaid_status():
             _ingest_completed_live_logs("imagemaid")
         except Exception:
             pass
+        _clear_imagemaid_run_context()
         return jsonify(
             status="not started",
             maintenance_active=maintenance_active,
@@ -14443,6 +14641,7 @@ def imagemaid_status():
                 except Exception:
                     pass
                 _clear_process_metric_cache(pid, "imagemaid")
+                _clear_imagemaid_run_context()
         if not within_grace:
             try:
                 _ingest_completed_live_logs("imagemaid")
@@ -14473,6 +14672,7 @@ def imagemaid_status():
         except Exception:
             pass
         _clear_process_metric_cache(pid, "imagemaid")
+        _clear_imagemaid_run_context()
         return jsonify(
             status="not started",
             maintenance_active=maintenance_active,

--- a/quickstart.py
+++ b/quickstart.py
@@ -1770,7 +1770,7 @@ def _resolve_maintenance_window_from_db(config_name=None):
         return _get_maintenance_window_from_db()
 
 
-def _refresh_maintenance_window_availability():
+def _refresh_maintenance_window_availability(preserve_active_state=False):
     maintenance_config_name = _get_active_maintenance_lookup_config_name()
     start_min, end_min, window_str = _resolve_maintenance_window_live(config_name=maintenance_config_name)
     if start_min is None or end_min is None:
@@ -1783,8 +1783,14 @@ def _refresh_maintenance_window_availability():
     active = _is_within_maintenance_window(datetime.now(), start_min, end_min)
 
     with MAINTENANCE_STATE_LOCK:
-        MAINTENANCE_STATE["active"] = active
-        MAINTENANCE_STATE["window"] = window_str
+        if preserve_active_state and (
+            MAINTENANCE_STATE.get("paused") or MAINTENANCE_STATE.get("imagemaid_paused")
+        ):
+            if window_str:
+                MAINTENANCE_STATE["window"] = window_str
+        else:
+            MAINTENANCE_STATE["active"] = active
+            MAINTENANCE_STATE["window"] = window_str
         if window_unavailable and (kometa_running or imagemaid_running or has_pending):
             if not MAINTENANCE_STATE.get("window_unavailable"):
                 MAINTENANCE_STATE["window_unavailable_since"] = datetime.now(timezone.utc).isoformat()
@@ -1841,16 +1847,28 @@ def _find_running_kometa_processes():
     except Exception:
         kometa_root = None
     matches = []
-    for proc in psutil.process_iter(["pid", "cmdline", "create_time"]):
+    for proc in psutil.process_iter():
         try:
-            cmdline = proc.info.get("cmdline") or []
+            cmdline = []
+            if hasattr(proc, "info"):
+                cmdline = proc.info.get("cmdline") or []
+            if not cmdline:
+                cmdline = proc.cmdline() or []
             joined = " ".join(cmdline)
         except Exception:
             continue
         if "kometa.py" not in joined:
             continue
         has_root = bool(kometa_root and kometa_root in joined)
-        create_time = proc.info.get("create_time") or 0
+        try:
+            create_time = proc.info.get("create_time") if hasattr(proc, "info") else None
+        except Exception:
+            create_time = None
+        if create_time is None:
+            try:
+                create_time = proc.create_time()
+            except Exception:
+                create_time = 0
         matches.append((has_root, create_time, proc))
     matches.sort(key=lambda item: (1 if item[0] else 0, item[1]), reverse=True)
     return [entry[2] for entry in matches]
@@ -1868,16 +1886,28 @@ def _find_running_imagemaid_processes():
     except Exception:
         imagemaid_root = None
     matches = []
-    for proc in psutil.process_iter(["pid", "cmdline", "create_time"]):
+    for proc in psutil.process_iter():
         try:
-            cmdline = proc.info.get("cmdline") or []
+            cmdline = []
+            if hasattr(proc, "info"):
+                cmdline = proc.info.get("cmdline") or []
+            if not cmdline:
+                cmdline = proc.cmdline() or []
             joined = " ".join(cmdline)
         except Exception:
             continue
         if "imagemaid.py" not in joined:
             continue
         has_root = bool(imagemaid_root and imagemaid_root in joined)
-        create_time = proc.info.get("create_time") or 0
+        try:
+            create_time = proc.info.get("create_time") if hasattr(proc, "info") else None
+        except Exception:
+            create_time = None
+        if create_time is None:
+            try:
+                create_time = proc.create_time()
+            except Exception:
+                create_time = 0
         matches.append((has_root, create_time, proc))
     matches.sort(key=lambda item: (1 if item[0] else 0, item[1]), reverse=True)
     return [entry[2] for entry in matches]
@@ -8258,7 +8288,7 @@ def stop_kometa():
 @app.route("/kometa-status", methods=["GET"])
 def kometa_status():
     try:
-        _refresh_maintenance_window_availability()
+        _refresh_maintenance_window_availability(preserve_active_state=True)
     except Exception:
         pass
     pending = _peek_pending_kometa_start()
@@ -14504,7 +14534,7 @@ def stop_imagemaid():
 @app.route("/imagemaid-status", methods=["GET"])
 def imagemaid_status():
     try:
-        _refresh_maintenance_window_availability()
+        _refresh_maintenance_window_availability(preserve_active_state=True)
     except Exception:
         pass
     pid = helpers.get_imagemaid_pid()

--- a/quickstart.py
+++ b/quickstart.py
@@ -2060,9 +2060,10 @@ def _maintenance_guard_loop(app_in):
                         window_label = f" ({window_str})" if window_str else ""
                         helpers.ts_log(f"Kometa paused due to Plex maintenance window{window_label}.", level="INFO")
                         try:
-                            _write_quickstart_maintenance_marker(helpers.get_kometa_root_path(), "paused", window=window_str)
+                            if not _write_quickstart_maintenance_marker(helpers.get_kometa_root_path(), "paused", window=window_str):
+                                helpers.ts_log("Failed to append Quickstart paused maintenance marker to meta.log.", level="WARNING")
                         except Exception:
-                            pass
+                            helpers.ts_log("Failed to append Quickstart paused maintenance marker to meta.log.", level="WARNING")
                         with MAINTENANCE_STATE_LOCK:
                             MAINTENANCE_STATE["paused"] = True
                             MAINTENANCE_STATE["paused_since"] = datetime.now(timezone.utc).isoformat()
@@ -2085,14 +2086,15 @@ def _maintenance_guard_loop(app_in):
                         except Exception:
                             paused_seconds = None
                     try:
-                        _write_quickstart_maintenance_marker(
+                        if not _write_quickstart_maintenance_marker(
                             helpers.get_kometa_root_path(),
                             "resumed",
                             window=window_str,
                             paused_seconds=paused_seconds,
-                        )
+                        ):
+                            helpers.ts_log("Failed to append Quickstart resumed maintenance marker to meta.log.", level="WARNING")
                     except Exception:
-                        pass
+                        helpers.ts_log("Failed to append Quickstart resumed maintenance marker to meta.log.", level="WARNING")
                     with MAINTENANCE_STATE_LOCK:
                         MAINTENANCE_STATE["paused"] = False
                         MAINTENANCE_STATE["paused_since"] = None
@@ -2111,6 +2113,7 @@ def _write_quickstart_run_marker(kometa_root, config_name=None, start_mode="curr
             f"config={safe_config} quickstart={qs_version} branch={qs_branch} "
             f"maintenance_markers=1 start_mode={safe_start_mode}"
         )
+        _reset_kometa_maintenance_sidecar(kometa_root)
         _append_quickstart_meta_log_line(kometa_root, marker)
     except Exception:
         pass
@@ -2124,6 +2127,33 @@ def _append_quickstart_meta_log_line(kometa_root, line):
         log_dir.mkdir(parents=True, exist_ok=True)
         log_path = log_dir / "meta.log"
         with log_path.open("a", encoding="utf-8", errors="ignore") as handle:
+            handle.write(str(line).rstrip() + "\n")
+        return True
+    except Exception:
+        return False
+
+
+def _get_kometa_maintenance_sidecar_path(kometa_root):
+    return Path(kometa_root) / "config" / "logs" / "meta.quickstart-maintenance.log"
+
+
+def _reset_kometa_maintenance_sidecar(kometa_root):
+    try:
+        sidecar_path = _get_kometa_maintenance_sidecar_path(kometa_root)
+        sidecar_path.parent.mkdir(parents=True, exist_ok=True)
+        sidecar_path.write_text("", encoding="utf-8")
+        return True
+    except Exception:
+        return False
+
+
+def _append_kometa_maintenance_sidecar_line(kometa_root, line):
+    if not line:
+        return False
+    try:
+        sidecar_path = _get_kometa_maintenance_sidecar_path(kometa_root)
+        sidecar_path.parent.mkdir(parents=True, exist_ok=True)
+        with sidecar_path.open("a", encoding="utf-8", errors="ignore") as handle:
             handle.write(str(line).rstrip() + "\n")
         return True
     except Exception:
@@ -2160,7 +2190,12 @@ def _write_quickstart_maintenance_marker(kometa_root, event, window=None, paused
         parts.append(f"window={str(window).strip()}")
     if event_name == "resumed" and isinstance(paused_seconds, (int, float)):
         parts.append(f"paused_seconds={max(0, int(paused_seconds))}")
-    return _append_quickstart_meta_log_line(kometa_root, " ".join(parts))
+    line = " ".join(parts)
+    meta_ok = _append_quickstart_meta_log_line(kometa_root, line)
+    sidecar_ok = _append_kometa_maintenance_sidecar_line(kometa_root, line)
+    if not meta_ok and sidecar_ok:
+        helpers.ts_log("Quickstart maintenance marker could not be appended to meta.log; preserved in sidecar instead.", level="WARNING")
+    return bool(meta_ok or sidecar_ok)
 
 
 def _write_quickstart_imagemaid_run_marker(imagemaid_root, mode=None, config_name=None, log_path=None):
@@ -8617,7 +8652,17 @@ def _read_logscan_text(path, encoding="utf-8", errors="replace"):
     if _is_logscan_gzip_path(path):
         with gzip.open(path, "rt", encoding=encoding, errors=errors) as handle:
             return handle.read()
-    return path.read_text(encoding=encoding, errors=errors)
+    content = path.read_text(encoding=encoding, errors=errors)
+    try:
+        if path.name.lower() == "meta.log":
+            sidecar_path = path.parent / "meta.quickstart-maintenance.log"
+            if sidecar_path.exists() and sidecar_path.is_file():
+                sidecar_content = sidecar_path.read_text(encoding=encoding, errors=errors).strip()
+                if sidecar_content:
+                    content = f"{content.rstrip()}\n{sidecar_content}\n"
+    except Exception:
+        pass
+    return content
 
 
 def _iter_logscan_text_lines(path, encoding="utf-8", errors="replace"):
@@ -9916,6 +9961,7 @@ def _build_incomplete_run_timing_summary(started_at=None, last_log_at=None, main
         "pause_count": int(summary.get("pause_count") or 0) if isinstance(summary.get("pause_count"), (int, float)) else 0,
         "pause_seconds": pause_seconds,
         "pause_label": _format_duration_brief(pause_seconds) if pause_seconds else "",
+        "pause_display": _format_duration_brief(pause_seconds) if pause_seconds else "Not observed",
         "observed_seconds": observed_seconds,
         "observed_label": _format_duration_brief(observed_seconds) if observed_seconds is not None else "",
         "active_seconds": active_seconds,
@@ -9993,36 +10039,35 @@ def _build_maintenance_event_rows(maintenance_summary=None):
     return rows
 
 
-def _build_incomplete_progress_snapshot(progress=None, last_log_at=None):
+def _build_incomplete_progress_snapshot(progress=None, last_log_at=None, config_data=None, original_command=""):
     progress = progress if isinstance(progress, dict) else {}
     libraries = progress.get("libraries") if isinstance(progress.get("libraries"), list) else []
     if not libraries:
         return {}
-
-    phase_order = [
-        ("operations", "Operations"),
-        ("metadata", "Metadata"),
-        ("collections", "Collections"),
-        ("overlays", "Overlays"),
-    ]
+    phase_lookup = {
+        "operations": "Operations",
+        "metadata": "Metadata",
+        "collections": "Collections",
+        "overlays": "Overlays",
+        "playlists": "Playlists",
+    }
     current_phase = str(progress.get("phase_current") or "").strip().lower()
     current_library = str(progress.get("current_library") or "").strip()
     preparation_seconds = progress.get("preparation_seconds")
     if not isinstance(preparation_seconds, (int, float)):
         preparation_seconds = progress.get("preparation_elapsed_seconds")
     current_phase_elapsed_seconds = progress.get("current_phase_elapsed_seconds") if isinstance(progress.get("current_phase_elapsed_seconds"), (int, float)) else None
-
-    columns = []
-    for phase_key, phase_label in phase_order:
-        include = current_phase == phase_key
-        if not include:
-            for entry in libraries:
-                durations = entry.get("durations") if isinstance(entry, dict) else {}
-                if isinstance(durations, dict) and isinstance(durations.get(phase_key), (int, float)):
-                    include = True
-                    break
-        if include:
-            columns.append({"key": phase_key, "label": phase_label})
+    explicit_phase = _detect_explicit_phase_from_command(original_command)
+    run_mode = explicit_phase if explicit_phase in ("collections", "operations", "metadata", "overlays", "playlists") else "all"
+    allowed_phases = _get_progress_run_order(config_data=config_data)
+    if not allowed_phases:
+        allowed_phases = ["operations", "metadata", "collections", "overlays"]
+    playlists_configured = bool(config_data.get("playlists")) if isinstance(config_data, dict) else False
+    if run_mode in ("collections", "overlays", "operations", "metadata", "playlists"):
+        allowed_phases = [run_mode]
+    elif "playlists" not in allowed_phases:
+        allowed_phases = allowed_phases + ["playlists"]
+    columns = [{"key": key, "label": phase_lookup.get(key, key.title())} for key in allowed_phases]
 
     rows = []
     totals = {column["key"]: 0 for column in columns}
@@ -10045,6 +10090,20 @@ def _build_incomplete_progress_snapshot(progress=None, last_log_at=None):
             label = ""
             tone = ""
             seconds = durations.get(phase_key)
+            if phase_key == "playlists":
+                playlist_total = progress.get("playlist_total_seconds") if isinstance(progress.get("playlist_total_seconds"), (int, float)) else None
+                playlist_running = bool(progress.get("playlist_running"))
+                playlist_elapsed = progress.get("playlist_elapsed_seconds") if isinstance(progress.get("playlist_elapsed_seconds"), (int, float)) else None
+                if playlist_running:
+                    label = _format_duration_brief(playlist_elapsed)
+                    tone = "primary"
+                elif isinstance(playlist_total, (int, float)) and (playlist_total > 0 or playlists_configured):
+                    label = _format_duration_brief(playlist_total)
+                    tone = "success" if label else ""
+                    if label:
+                        totals[phase_key] = max(0, int(playlist_total))
+                phase_cells.append({"label": label, "tone": tone})
+                continue
             if current_library and current_phase and current_library == name and current_phase == phase_key and isinstance(current_phase_elapsed_seconds, (int, float)):
                 label = _format_duration_brief(current_phase_elapsed_seconds)
                 tone = "primary"
@@ -10440,7 +10499,12 @@ def _analyze_incomplete_log_for_resume(log_path, cache_entry=None, config_name=N
         suggested_command=primary,
         progress_libraries=progress_libraries,
     )
-    progress_snapshot = _build_incomplete_progress_snapshot(progress, last_log_at=last_log_at)
+    progress_snapshot = _build_incomplete_progress_snapshot(
+        progress,
+        last_log_at=last_log_at,
+        config_data=config_data,
+        original_command=original_command,
+    )
     maintenance_events = _build_maintenance_event_rows(summary.get("maintenance_summary"))
 
     return {

--- a/quickstart.py
+++ b/quickstart.py
@@ -9853,6 +9853,241 @@ def _extract_first_log_timestamp(content):
     return match.group(1).strip()
 
 
+def _extract_last_log_timestamp(content):
+    if not content:
+        return None
+    matches = re.findall(r"^\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d{3}\]", str(content), re.MULTILINE)
+    if not matches:
+        return None
+    return str(matches[-1]).strip()
+
+
+def _parse_log_display_datetime(value):
+    if not value:
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        if parsed.tzinfo is not None:
+            parsed = parsed.astimezone().replace(tzinfo=None)
+        return parsed
+    except Exception:
+        pass
+    for fmt in ("%Y-%m-%d %H:%M:%S",):
+        try:
+            return datetime.strptime(raw, fmt)
+        except Exception:
+            continue
+    return None
+
+
+def _format_duration_brief(total_seconds):
+    if not isinstance(total_seconds, (int, float)):
+        return ""
+    seconds = max(0, int(total_seconds))
+    hours, remainder = divmod(seconds, 3600)
+    minutes, secs = divmod(remainder, 60)
+    parts = []
+    if hours:
+        parts.append(f"{hours}h")
+    if minutes:
+        parts.append(f"{minutes}m")
+    if secs or not parts:
+        parts.append(f"{secs}s")
+    return " ".join(parts)
+
+
+def _build_incomplete_run_timing_summary(started_at=None, last_log_at=None, maintenance_summary=None):
+    summary = maintenance_summary if isinstance(maintenance_summary, dict) else {}
+    started_dt = _parse_log_display_datetime(started_at)
+    last_log_dt = _parse_log_display_datetime(last_log_at)
+    pause_seconds = int(summary.get("pause_seconds") or 0) if isinstance(summary.get("pause_seconds"), (int, float)) else 0
+    observed_seconds = None
+    active_seconds = None
+    if started_dt and last_log_dt and last_log_dt >= started_dt:
+        observed_seconds = int((last_log_dt - started_dt).total_seconds())
+        active_seconds = max(0, observed_seconds - pause_seconds)
+    return {
+        "started_at": started_at or "",
+        "last_log_at": last_log_at or "",
+        "window": summary.get("window") or "",
+        "pause_count": int(summary.get("pause_count") or 0) if isinstance(summary.get("pause_count"), (int, float)) else 0,
+        "pause_seconds": pause_seconds,
+        "pause_label": _format_duration_brief(pause_seconds) if pause_seconds else "",
+        "observed_seconds": observed_seconds,
+        "observed_label": _format_duration_brief(observed_seconds) if observed_seconds is not None else "",
+        "active_seconds": active_seconds,
+        "active_label": _format_duration_brief(active_seconds) if active_seconds is not None else "",
+        "had_pause": bool(summary.get("had_pause")),
+    }
+
+
+def _dedupe_preserve_order(values):
+    seen = set()
+    ordered = []
+    for value in values or []:
+        name = str(value or "").strip()
+        if not name:
+            continue
+        lowered = name.casefold()
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        ordered.append(name)
+    return ordered
+
+
+def _build_incomplete_scope_summary(original_command="", suggested_command="", progress_libraries=None):
+    progress_libraries = progress_libraries if isinstance(progress_libraries, list) else []
+    original_selected = _extract_selected_libraries(original_command)[1] or []
+    recovery_selected = _extract_selected_libraries(suggested_command)[1] or []
+    progress_names = _dedupe_preserve_order(entry.get("name") for entry in progress_libraries if isinstance(entry, dict))
+    completed = _dedupe_preserve_order(
+        entry.get("name")
+        for entry in progress_libraries
+        if isinstance(entry, dict) and str(entry.get("status") or "").strip() == "Done"
+    )
+
+    original_scope = _dedupe_preserve_order(original_selected or progress_names)
+    recovery_scope = _dedupe_preserve_order(recovery_selected or original_scope)
+    pruned = []
+    if original_scope and recovery_scope:
+        recovery_lookup = {name.casefold() for name in recovery_scope}
+        pruned = [name for name in original_scope if name.casefold() not in recovery_lookup]
+
+    return {
+        "original_scope": original_scope,
+        "recovery_scope": recovery_scope,
+        "completed_libraries": completed,
+        "pruned_libraries": pruned,
+        "original_scope_label": " | ".join(original_scope) if original_scope else "",
+        "recovery_scope_label": " | ".join(recovery_scope) if recovery_scope else "",
+        "completed_label": " | ".join(completed) if completed else "",
+        "pruned_label": " | ".join(pruned) if pruned else "",
+    }
+
+
+def _build_maintenance_event_rows(maintenance_summary=None):
+    summary = maintenance_summary if isinstance(maintenance_summary, dict) else {}
+    rows = []
+    for event in summary.get("events") or []:
+        if not isinstance(event, dict):
+            continue
+        event_name = str(event.get("event") or "").strip().lower()
+        if event_name not in ("paused", "resumed"):
+            continue
+        label = "Paused" if event_name == "paused" else "Resumed"
+        at_value = str(event.get("local_at") or event.get("at") or "").strip()
+        pause_label = _format_duration_brief(event.get("paused_seconds")) if isinstance(event.get("paused_seconds"), (int, float)) else ""
+        window = str(event.get("window") or "").strip()
+        rows.append(
+            {
+                "label": label,
+                "at": at_value,
+                "pause_label": pause_label,
+                "window": window,
+            }
+        )
+    return rows
+
+
+def _build_incomplete_progress_snapshot(progress=None, last_log_at=None):
+    progress = progress if isinstance(progress, dict) else {}
+    libraries = progress.get("libraries") if isinstance(progress.get("libraries"), list) else []
+    if not libraries:
+        return {}
+
+    phase_order = [
+        ("operations", "Operations"),
+        ("metadata", "Metadata"),
+        ("collections", "Collections"),
+        ("overlays", "Overlays"),
+    ]
+    current_phase = str(progress.get("phase_current") or "").strip().lower()
+    current_library = str(progress.get("current_library") or "").strip()
+    preparation_seconds = progress.get("preparation_seconds")
+    if not isinstance(preparation_seconds, (int, float)):
+        preparation_seconds = progress.get("preparation_elapsed_seconds")
+    current_phase_elapsed_seconds = progress.get("current_phase_elapsed_seconds") if isinstance(progress.get("current_phase_elapsed_seconds"), (int, float)) else None
+
+    columns = []
+    for phase_key, phase_label in phase_order:
+        include = current_phase == phase_key
+        if not include:
+            for entry in libraries:
+                durations = entry.get("durations") if isinstance(entry, dict) else {}
+                if isinstance(durations, dict) and isinstance(durations.get(phase_key), (int, float)):
+                    include = True
+                    break
+        if include:
+            columns.append({"key": phase_key, "label": phase_label})
+
+    rows = []
+    totals = {column["key"]: 0 for column in columns}
+    visible_libraries = [entry for entry in libraries if str((entry or {}).get("status") or "").strip() != "Skipped"]
+    for entry in visible_libraries:
+        name = str(entry.get("name") or "").strip()
+        status = str(entry.get("status") or "Pending").strip() or "Pending"
+        status_class = "text-bg-secondary"
+        if status == "Done":
+            status_class = "text-bg-success"
+        elif status == "In progress":
+            status_class = "text-bg-primary"
+        elif status == "Stopped":
+            status_class = "text-bg-danger"
+
+        durations = entry.get("durations") if isinstance(entry.get("durations"), dict) else {}
+        phase_cells = []
+        for column in columns:
+            phase_key = column["key"]
+            label = ""
+            tone = ""
+            seconds = durations.get(phase_key)
+            if current_library and current_phase and current_library == name and current_phase == phase_key and isinstance(current_phase_elapsed_seconds, (int, float)):
+                label = _format_duration_brief(current_phase_elapsed_seconds)
+                tone = "primary"
+            elif isinstance(seconds, (int, float)):
+                label = _format_duration_brief(seconds)
+                tone = "success"
+                totals[phase_key] = totals.get(phase_key, 0) + int(seconds or 0)
+            phase_cells.append({"label": label, "tone": tone})
+
+        rows.append(
+            {
+                "name": name,
+                "type": str(entry.get("type") or "—").strip() or "—",
+                "status": status,
+                "status_class": status_class,
+                "phase_cells": phase_cells,
+            }
+        )
+
+    total_seconds = 0
+    if isinstance(preparation_seconds, (int, float)):
+        total_seconds += int(preparation_seconds or 0)
+    for value in totals.values():
+        if isinstance(value, (int, float)):
+            total_seconds += int(value or 0)
+
+    return {
+        "columns": columns,
+        "rows": rows,
+        "completed_count": progress.get("completed_count"),
+        "total_count": progress.get("total_count"),
+        "current_library": current_library,
+        "phase_current": current_phase,
+        "last_log_at": last_log_at or "",
+        "preparation_label": _format_duration_brief(preparation_seconds) if isinstance(preparation_seconds, (int, float)) else "",
+        "footer_cells": [
+            _format_duration_brief(totals.get(column["key"])) if isinstance(totals.get(column["key"]), (int, float)) and totals.get(column["key"]) > 0 else ""
+            for column in columns
+        ],
+        "total_label": _format_duration_brief(total_seconds) if total_seconds > 0 else "",
+    }
+
+
 def _build_incomplete_resume_message(phase_current=None, current_library=None, finished_at=None):
     if phase_current and current_library:
         message = f"Run appears incomplete during {phase_current} in library '{current_library}'."
@@ -9983,6 +10218,7 @@ def _build_resume_explanation(
     current_library=None,
     current_collection=None,
     finished_at=None,
+    progress_libraries=None,
 ):
     lines = []
     if finished_at:
@@ -10055,6 +10291,11 @@ def _build_resume_explanation(
 
     if current_library:
         lines.append(f"Detected in-progress library '{current_library}', so the suggestion scopes with --run-libraries.")
+
+    if isinstance(progress_libraries, list):
+        completed_libraries = [str(entry.get("name")).strip() for entry in progress_libraries if str(entry.get("status") or "").strip() == "Done" and str(entry.get("name") or "").strip()]
+        if completed_libraries:
+            lines.append(f"Completed libraries already seen in the log: {' | '.join(completed_libraries)}.")
 
     config_path = _extract_cli_option_value(suggested_command, "--config")
     if config_path:
@@ -10141,12 +10382,20 @@ def _analyze_incomplete_log_for_resume(log_path, cache_entry=None, config_name=N
     except Exception:
         current_collection = None
 
+    progress_libraries = progress.get("libraries") if isinstance(progress.get("libraries"), list) else []
+    last_log_at = _extract_last_log_timestamp(content)
+    timing_summary = _build_incomplete_run_timing_summary(
+        started_at=summary.get("started_at") or started_at_fallback,
+        last_log_at=last_log_at,
+        maintenance_summary=summary.get("maintenance_summary"),
+    )
+
     suggestions = _build_recovery_suggestions(
         original_command,
         phase_current=phase_current,
         current_library=current_library,
         current_collection=current_collection,
-        progress_libraries=progress.get("libraries"),
+        progress_libraries=progress_libraries,
     )
     primary = suggestions[0] if suggestions else ""
     scope_completed = not primary and not suggestions
@@ -10159,6 +10408,7 @@ def _analyze_incomplete_log_for_resume(log_path, cache_entry=None, config_name=N
             current_library=current_library,
             current_collection=current_collection,
             finished_at=summary.get("finished_at"),
+            progress_libraries=progress_libraries,
         )
     reason = _build_incomplete_resume_message(
         phase_current=phase_current,
@@ -10185,10 +10435,18 @@ def _analyze_incomplete_log_for_resume(log_path, cache_entry=None, config_name=N
         run_key_seed = f"incomplete|{log_path}|{mtime or 0}"
         run_key = hashlib.sha256(run_key_seed.encode("utf-8")).hexdigest()
     started_at = summary.get("started_at") or started_at_fallback
+    scope_summary = _build_incomplete_scope_summary(
+        original_command=original_command,
+        suggested_command=primary,
+        progress_libraries=progress_libraries,
+    )
+    progress_snapshot = _build_incomplete_progress_snapshot(progress, last_log_at=last_log_at)
+    maintenance_events = _build_maintenance_event_rows(summary.get("maintenance_summary"))
 
     return {
         "run_key": run_key,
         "started_at": started_at,
+        "last_log_at": last_log_at,
         "finished_at": summary.get("finished_at"),
         "run_time_seconds": summary.get("run_time_seconds"),
         "kometa_version": summary.get("kometa_version"),
@@ -10230,6 +10488,10 @@ def _analyze_incomplete_log_for_resume(log_path, cache_entry=None, config_name=N
         "resume_recommendations": suggestions,
         "resume_explanation": explanation,
         "resume_scope_completed": scope_completed,
+        "resume_timing_summary": timing_summary,
+        "resume_scope_summary": scope_summary,
+        "resume_progress_snapshot": progress_snapshot,
+        "resume_maintenance_events": maintenance_events,
     }
 
 
@@ -10541,6 +10803,10 @@ def _build_latest_incomplete_resume_hint():
         "context_mismatch": context_mismatch,
         "explanation": latest.get("resume_explanation") if isinstance(latest.get("resume_explanation"), list) else [],
         "scope_completed": bool(latest.get("resume_scope_completed")),
+        "timing_summary": latest.get("resume_timing_summary") if isinstance(latest.get("resume_timing_summary"), dict) else {},
+        "scope_summary": latest.get("resume_scope_summary") if isinstance(latest.get("resume_scope_summary"), dict) else {},
+        "progress_snapshot": latest.get("resume_progress_snapshot") if isinstance(latest.get("resume_progress_snapshot"), dict) else {},
+        "maintenance_events": latest.get("resume_maintenance_events") if isinstance(latest.get("resume_maintenance_events"), list) else [],
     }
 
 

--- a/quickstart.py
+++ b/quickstart.py
@@ -120,9 +120,12 @@ LOGSCAN_ANALYSIS_CACHE = {"mtime": None, "size": None, "data": None}
 LOGSCAN_PROGRESS_CACHE = {"mtime": None, "size": None, "data": None}
 KOMETA_CPU_CACHE = {}
 SYSTEM_CPU_CACHE = {"total": None, "idle": None}
+PROCESS_IO_CACHE = {"kometa": {}, "imagemaid": {}}
 MAINTENANCE_STATE = {
     "paused": False,
     "paused_since": None,
+    "imagemaid_paused": False,
+    "imagemaid_paused_since": None,
     "active": False,
     "window": None,
     "queued_started_at": None,
@@ -1581,6 +1584,68 @@ def _calculate_system_cpu_percent():
     return max(0.0, min(100.0, percent))
 
 
+def _calculate_process_io_stats(proc, cache_name):
+    bucket = PROCESS_IO_CACHE.setdefault(cache_name, {})
+    total_read = 0
+    total_write = 0
+    saw_counters = False
+
+    def _accumulate_io(target_proc):
+        nonlocal total_read, total_write, saw_counters
+        try:
+            counters = target_proc.io_counters()
+        except Exception:
+            return
+        read_bytes = getattr(counters, "read_bytes", None)
+        write_bytes = getattr(counters, "write_bytes", None)
+        if read_bytes is None or write_bytes is None:
+            return
+        saw_counters = True
+        total_read += max(0, int(read_bytes))
+        total_write += max(0, int(write_bytes))
+
+    _accumulate_io(proc)
+    try:
+        for child in proc.children(recursive=True):
+            _accumulate_io(child)
+    except Exception:
+        pass
+
+    if not saw_counters:
+        return None
+
+    now = time.time()
+    entry = bucket.get(proc.pid)
+    bucket[proc.pid] = {"time": now, "read": total_read, "write": total_write}
+
+    read_rate_mb_s = None
+    write_rate_mb_s = None
+    if entry:
+        elapsed = now - entry.get("time", now)
+        if elapsed > 0:
+            delta_read = total_read - entry.get("read", total_read)
+            delta_write = total_write - entry.get("write", total_write)
+            if delta_read >= 0:
+                read_rate_mb_s = delta_read / (1024 * 1024) / elapsed
+            if delta_write >= 0:
+                write_rate_mb_s = delta_write / (1024 * 1024) / elapsed
+
+    return {
+        "disk_read_mb": total_read / (1024 * 1024),
+        "disk_write_mb": total_write / (1024 * 1024),
+        "disk_read_rate_mb_s": read_rate_mb_s,
+        "disk_write_rate_mb_s": write_rate_mb_s,
+    }
+
+
+def _clear_process_metric_cache(pid, cache_name=None):
+    if pid is None:
+        return
+    KOMETA_CPU_CACHE.pop(pid, None)
+    if cache_name:
+        PROCESS_IO_CACHE.setdefault(cache_name, {}).pop(pid, None)
+
+
 def _parse_maintenance_window_minutes(window_str):
     if not window_str or "Unavailable" in str(window_str):
         return None
@@ -1614,6 +1679,14 @@ def _get_maintenance_window_from_db():
         _validated, _user_entered, data = database.retrieve_section_data(name=config_name, section="plex_telemetry")
         telemetry = data.get("plex_telemetry", {}) if isinstance(data, dict) else {}
         window_str = telemetry.get("maintenance_window")
+        if not window_str:
+            legacy_telemetry = persistence.retrieve_settings("plex_telemetry")
+            if isinstance(legacy_telemetry, dict):
+                window_str = legacy_telemetry.get("plex_telemetry", {}).get("maintenance_window")
+        if not window_str:
+            legacy_plex = persistence.retrieve_settings("010-plex")
+            if isinstance(legacy_plex, dict):
+                window_str = legacy_plex.get("plex", {}).get("telemetry", {}).get("maintenance_window")
         minutes = _parse_maintenance_window_minutes(window_str)
         if not minutes:
             return None, None, None
@@ -1855,6 +1928,7 @@ def _launch_imagemaid_command(command, mode=None, config_name=None):
         command_parts.insert(1, str(imagemaid_py))
 
     helpers.ts_log(f"argv={command_parts!r}", level="DEBUG")
+    _update_imagemaid_run_context(command_parts, mode=mode, config_name=config_name)
     launch_log_path = Path(helpers.get_imagemaid_launch_log_file())
     launch_log_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -1955,6 +2029,26 @@ def _get_run_context():
         return dict(RUN_CONTEXT)
 
 
+def _normalize_imagemaid_command_text(command):
+    if isinstance(command, (list, tuple)):
+        return " ".join(str(part) for part in command if str(part).strip())
+    return str(command or "").strip()
+
+
+def _update_imagemaid_run_context(command, mode=None, config_name=None):
+    with IMAGEMAID_RUN_CONTEXT_LOCK:
+        IMAGEMAID_RUN_CONTEXT["command"] = _normalize_imagemaid_command_text(command)
+        IMAGEMAID_RUN_CONTEXT["mode"] = (str(mode or "").strip().lower() or None)
+        IMAGEMAID_RUN_CONTEXT["config_name"] = (str(config_name or "").strip() or None)
+        IMAGEMAID_RUN_CONTEXT["started_at"] = datetime.now()
+        IMAGEMAID_RUN_CONTEXT["updated_at"] = datetime.now(timezone.utc).isoformat()
+
+
+def _get_imagemaid_run_context():
+    with IMAGEMAID_RUN_CONTEXT_LOCK:
+        return dict(IMAGEMAID_RUN_CONTEXT)
+
+
 def _suspend_process_tree(proc):
     try:
         for child in proc.children(recursive=True):
@@ -1993,20 +2087,32 @@ def _maintenance_guard_loop(app_in):
     with app_in.app_context():
         while True:
             time.sleep(interval)
-            pid = helpers.get_kometa_pid()
             start_min, end_min, window_str = _get_maintenance_window_live()
             if start_min is None or end_min is None:
                 start_min, end_min, window_str = _get_maintenance_window_from_db()
             window_unavailable = start_min is None or end_min is None
+            pid = helpers.get_kometa_pid()
             kometa_running = pid and helpers.is_kometa_running()
+            imagemaid_pid = helpers.get_imagemaid_pid()
+            imagemaid_running = imagemaid_pid and helpers.is_imagemaid_running()
+            if not imagemaid_running:
+                imagemaid_proc = _find_running_imagemaid_process()
+                if imagemaid_proc:
+                    imagemaid_running = True
+                    imagemaid_pid = imagemaid_proc.pid
+                    try:
+                        with open(helpers.get_imagemaid_pid_file(), "w", encoding="utf-8") as handle:
+                            handle.write(str(imagemaid_pid))
+                    except Exception:
+                        pass
             has_pending = bool(_peek_pending_kometa_start())
-            if window_unavailable and (kometa_running or has_pending):
+            if window_unavailable and (kometa_running or imagemaid_running or has_pending):
                 with MAINTENANCE_STATE_LOCK:
                     if not MAINTENANCE_STATE.get("window_unavailable"):
                         MAINTENANCE_STATE["window_unavailable"] = True
                         MAINTENANCE_STATE["window_unavailable_since"] = datetime.now(timezone.utc).isoformat()
                         helpers.ts_log(
-                            "Plex maintenance window unavailable; keeping Kometa paused/queued until Plex is reachable.",
+                            "Plex maintenance window unavailable; keeping Quickstart work paused/queued until Plex is reachable.",
                             level="WARNING",
                         )
             else:
@@ -2039,65 +2145,134 @@ def _maintenance_guard_loop(app_in):
                                 MAINTENANCE_STATE["queued_started_at"] = datetime.now(timezone.utc).isoformat()
                         else:
                             helpers.ts_log(f"Failed to start Kometa after maintenance: {result}", level="ERROR")
+            elif start_min is not None and end_min is not None:
+                try:
+                    proc = psutil.Process(pid)
+                except psutil.NoSuchProcess:
+                    with MAINTENANCE_STATE_LOCK:
+                        MAINTENANCE_STATE["paused"] = False
+                        MAINTENANCE_STATE["paused_since"] = None
+                else:
+                    if active:
+                        with MAINTENANCE_STATE_LOCK:
+                            already_paused = MAINTENANCE_STATE["paused"]
+                        if not already_paused and _suspend_process_tree(proc):
+                            window_label = f" ({window_str})" if window_str else ""
+                            helpers.ts_log(f"Kometa paused due to Plex maintenance window{window_label}.", level="INFO")
+                            try:
+                                if not _write_quickstart_maintenance_marker(helpers.get_kometa_root_path(), "paused", window=window_str):
+                                    helpers.ts_log("Failed to append Quickstart paused maintenance marker to meta.log.", level="WARNING")
+                            except Exception:
+                                helpers.ts_log("Failed to append Quickstart paused maintenance marker to meta.log.", level="WARNING")
+                            with MAINTENANCE_STATE_LOCK:
+                                MAINTENANCE_STATE["paused"] = True
+                                MAINTENANCE_STATE["paused_since"] = datetime.now(timezone.utc).isoformat()
+                    else:
+                        with MAINTENANCE_STATE_LOCK:
+                            was_paused = MAINTENANCE_STATE["paused"]
+                            paused_since = MAINTENANCE_STATE["paused_since"]
+                        if was_paused and _resume_process_tree(proc):
+                            window_label = f" ({window_str})" if window_str else ""
+                            helpers.ts_log(f"Plex maintenance ended{window_label}. Kometa resumed.", level="INFO")
+                            paused_seconds = None
+                            if paused_since:
+                                try:
+                                    paused_at = datetime.fromisoformat(str(paused_since).replace("Z", "+00:00"))
+                                    if paused_at.tzinfo is None:
+                                        paused_at = paused_at.replace(tzinfo=timezone.utc)
+                                    paused_seconds = max(0, int((datetime.now(timezone.utc) - paused_at).total_seconds()))
+                                except Exception:
+                                    paused_seconds = None
+                            try:
+                                if not _write_quickstart_maintenance_marker(
+                                    helpers.get_kometa_root_path(),
+                                    "resumed",
+                                    window=window_str,
+                                    paused_seconds=paused_seconds,
+                                ):
+                                    helpers.ts_log("Failed to append Quickstart resumed maintenance marker to meta.log.", level="WARNING")
+                            except Exception:
+                                helpers.ts_log("Failed to append Quickstart resumed maintenance marker to meta.log.", level="WARNING")
+                            with MAINTENANCE_STATE_LOCK:
+                                MAINTENANCE_STATE["paused"] = False
+                                MAINTENANCE_STATE["paused_since"] = None
+
+            if not imagemaid_running:
+                with MAINTENANCE_STATE_LOCK:
+                    MAINTENANCE_STATE["imagemaid_paused"] = False
+                    MAINTENANCE_STATE["imagemaid_paused_since"] = None
                 continue
 
             if start_min is None or end_min is None:
                 continue
 
             try:
-                proc = psutil.Process(pid)
+                imagemaid_proc = psutil.Process(imagemaid_pid)
             except psutil.NoSuchProcess:
                 with MAINTENANCE_STATE_LOCK:
-                    MAINTENANCE_STATE["paused"] = False
-                    MAINTENANCE_STATE["paused_since"] = None
+                    MAINTENANCE_STATE["imagemaid_paused"] = False
+                    MAINTENANCE_STATE["imagemaid_paused_since"] = None
                 continue
+
+            imagemaid_ctx = _get_imagemaid_run_context()
+            imagemaid_mode = imagemaid_ctx.get("mode")
+            imagemaid_config_name = imagemaid_ctx.get("config_name")
+            imagemaid_log_path = _get_latest_imagemaid_log_path()
 
             if active:
                 with MAINTENANCE_STATE_LOCK:
-                    already_paused = MAINTENANCE_STATE["paused"]
-                if not already_paused:
-                    if _suspend_process_tree(proc):
-                        window_label = f" ({window_str})" if window_str else ""
-                        helpers.ts_log(f"Kometa paused due to Plex maintenance window{window_label}.", level="INFO")
-                        try:
-                            if not _write_quickstart_maintenance_marker(helpers.get_kometa_root_path(), "paused", window=window_str):
-                                helpers.ts_log("Failed to append Quickstart paused maintenance marker to meta.log.", level="WARNING")
-                        except Exception:
-                            helpers.ts_log("Failed to append Quickstart paused maintenance marker to meta.log.", level="WARNING")
-                        with MAINTENANCE_STATE_LOCK:
-                            MAINTENANCE_STATE["paused"] = True
-                            MAINTENANCE_STATE["paused_since"] = datetime.now(timezone.utc).isoformat()
+                    imagemaid_already_paused = MAINTENANCE_STATE["imagemaid_paused"]
+                if not imagemaid_already_paused and _suspend_process_tree(imagemaid_proc):
+                    window_label = f" ({window_str})" if window_str else ""
+                    helpers.ts_log(f"ImageMaid paused due to Plex maintenance window{window_label}.", level="INFO")
+                    try:
+                        if not _write_quickstart_imagemaid_maintenance_marker(
+                            helpers.get_imagemaid_root_path(),
+                            "paused",
+                            mode=imagemaid_mode,
+                            config_name=imagemaid_config_name,
+                            window=window_str,
+                            log_path=imagemaid_log_path,
+                        ):
+                            helpers.ts_log("Failed to append Quickstart paused ImageMaid maintenance marker to the live log.", level="WARNING")
+                    except Exception:
+                        helpers.ts_log("Failed to append Quickstart paused ImageMaid maintenance marker to the live log.", level="WARNING")
+                    with MAINTENANCE_STATE_LOCK:
+                        MAINTENANCE_STATE["imagemaid_paused"] = True
+                        MAINTENANCE_STATE["imagemaid_paused_since"] = datetime.now(timezone.utc).isoformat()
                 continue
 
             with MAINTENANCE_STATE_LOCK:
-                was_paused = MAINTENANCE_STATE["paused"]
-                paused_since = MAINTENANCE_STATE["paused_since"]
-            if was_paused:
-                if _resume_process_tree(proc):
-                    window_label = f" ({window_str})" if window_str else ""
-                    helpers.ts_log(f"Plex maintenance ended{window_label}. Kometa resumed.", level="INFO")
-                    paused_seconds = None
-                    if paused_since:
-                        try:
-                            paused_at = datetime.fromisoformat(str(paused_since).replace("Z", "+00:00"))
-                            if paused_at.tzinfo is None:
-                                paused_at = paused_at.replace(tzinfo=timezone.utc)
-                            paused_seconds = max(0, int((datetime.now(timezone.utc) - paused_at).total_seconds()))
-                        except Exception:
-                            paused_seconds = None
+                imagemaid_was_paused = MAINTENANCE_STATE["imagemaid_paused"]
+                imagemaid_paused_since = MAINTENANCE_STATE["imagemaid_paused_since"]
+            if imagemaid_was_paused and _resume_process_tree(imagemaid_proc):
+                window_label = f" ({window_str})" if window_str else ""
+                helpers.ts_log(f"Plex maintenance ended{window_label}. ImageMaid resumed.", level="INFO")
+                imagemaid_paused_seconds = None
+                if imagemaid_paused_since:
                     try:
-                        if not _write_quickstart_maintenance_marker(
-                            helpers.get_kometa_root_path(),
-                            "resumed",
-                            window=window_str,
-                            paused_seconds=paused_seconds,
-                        ):
-                            helpers.ts_log("Failed to append Quickstart resumed maintenance marker to meta.log.", level="WARNING")
+                        paused_at = datetime.fromisoformat(str(imagemaid_paused_since).replace("Z", "+00:00"))
+                        if paused_at.tzinfo is None:
+                            paused_at = paused_at.replace(tzinfo=timezone.utc)
+                        imagemaid_paused_seconds = max(0, int((datetime.now(timezone.utc) - paused_at).total_seconds()))
                     except Exception:
-                        helpers.ts_log("Failed to append Quickstart resumed maintenance marker to meta.log.", level="WARNING")
-                    with MAINTENANCE_STATE_LOCK:
-                        MAINTENANCE_STATE["paused"] = False
-                        MAINTENANCE_STATE["paused_since"] = None
+                        imagemaid_paused_seconds = None
+                try:
+                    if not _write_quickstart_imagemaid_maintenance_marker(
+                        helpers.get_imagemaid_root_path(),
+                        "resumed",
+                        mode=imagemaid_mode,
+                        config_name=imagemaid_config_name,
+                        window=window_str,
+                        log_path=imagemaid_log_path,
+                        paused_seconds=imagemaid_paused_seconds,
+                    ):
+                        helpers.ts_log("Failed to append Quickstart resumed ImageMaid maintenance marker to the live log.", level="WARNING")
+                except Exception:
+                    helpers.ts_log("Failed to append Quickstart resumed ImageMaid maintenance marker to the live log.", level="WARNING")
+                with MAINTENANCE_STATE_LOCK:
+                    MAINTENANCE_STATE["imagemaid_paused"] = False
+                    MAINTENANCE_STATE["imagemaid_paused_since"] = None
 
 
 def _write_quickstart_run_marker(kometa_root, config_name=None, start_mode="current"):
@@ -2160,6 +2335,14 @@ def _append_kometa_maintenance_sidecar_line(kometa_root, line):
         return False
 
 
+def _is_logscan_maintenance_sidecar(path):
+    try:
+        name = Path(path).name.lower()
+    except Exception:
+        return False
+    return name in {"meta.quickstart-maintenance.log", "imagemaid.quickstart-maintenance.log"}
+
+
 def _append_quickstart_imagemaid_log_line(imagemaid_root, line, log_path=None):
     if not line:
         return False
@@ -2169,6 +2352,33 @@ def _append_quickstart_imagemaid_log_line(imagemaid_root, line, log_path=None):
         log_dir.mkdir(parents=True, exist_ok=True)
         target = Path(log_path) if log_path else (log_dir / "imagemaid.log")
         with target.open("a", encoding="utf-8", errors="ignore") as handle:
+            handle.write(str(line).rstrip() + "\n")
+        return True
+    except Exception:
+        return False
+
+
+def _get_imagemaid_maintenance_sidecar_path(imagemaid_root):
+    return Path(imagemaid_root) / "config" / "logs" / "imagemaid.quickstart-maintenance.log"
+
+
+def _reset_imagemaid_maintenance_sidecar(imagemaid_root):
+    try:
+        sidecar_path = _get_imagemaid_maintenance_sidecar_path(imagemaid_root)
+        sidecar_path.parent.mkdir(parents=True, exist_ok=True)
+        sidecar_path.write_text("", encoding="utf-8")
+        return True
+    except Exception:
+        return False
+
+
+def _append_imagemaid_maintenance_sidecar_line(imagemaid_root, line):
+    if not line:
+        return False
+    try:
+        sidecar_path = _get_imagemaid_maintenance_sidecar_path(imagemaid_root)
+        sidecar_path.parent.mkdir(parents=True, exist_ok=True)
+        with sidecar_path.open("a", encoding="utf-8", errors="ignore") as handle:
             handle.write(str(line).rstrip() + "\n")
         return True
     except Exception:
@@ -2192,7 +2402,7 @@ def _write_quickstart_maintenance_marker(kometa_root, event, window=None, paused
         parts.append(f"paused_seconds={max(0, int(paused_seconds))}")
     line = " ".join(parts)
     meta_ok = _append_quickstart_meta_log_line(kometa_root, line)
-    sidecar_ok = _append_kometa_maintenance_sidecar_line(kometa_root, line)
+    sidecar_ok = _append_kometa_maintenance_sidecar_line(kometa_root, line) if not meta_ok else False
     if not meta_ok and sidecar_ok:
         helpers.ts_log("Quickstart maintenance marker could not be appended to meta.log; preserved in sidecar instead.", level="WARNING")
     return bool(meta_ok or sidecar_ok)
@@ -2207,6 +2417,7 @@ def _write_quickstart_imagemaid_run_marker(imagemaid_root, mode=None, config_nam
         safe_config = (config_name or "default").strip() or "default"
         timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
         marker = f"[Quickstart] Run marker: started={timestamp} " f"config={safe_config} quickstart={qs_version} branch={qs_branch} " f"tool=imagemaid mode={safe_mode}"
+        _reset_imagemaid_maintenance_sidecar(imagemaid_root)
         return _append_quickstart_imagemaid_log_line(imagemaid_root, marker, log_path=log_path)
     except Exception:
         return False
@@ -2247,9 +2458,9 @@ def _write_quickstart_imagemaid_stop_marker(imagemaid_root, mode=None, config_na
         return False
 
 
-def _write_quickstart_imagemaid_maintenance_marker(imagemaid_root, event, mode=None, config_name=None, window=None, log_path=None):
+def _write_quickstart_imagemaid_maintenance_marker(imagemaid_root, event, mode=None, config_name=None, window=None, log_path=None, paused_seconds=None):
     event_name = str(event or "").strip().lower()
-    if event_name not in {"blocked_start"}:
+    if event_name not in {"blocked_start", "paused", "resumed"}:
         return False
     try:
         version_info = app.config.get("VERSION_CHECK") or {}
@@ -2271,7 +2482,14 @@ def _write_quickstart_imagemaid_maintenance_marker(imagemaid_root, event, mode=N
         ]
         if window:
             parts.append(f"window={str(window).strip()}")
-        return _append_quickstart_imagemaid_log_line(imagemaid_root, " ".join(parts), log_path=log_path)
+        if event_name == "resumed" and isinstance(paused_seconds, (int, float)):
+            parts.append(f"paused_seconds={max(0, int(paused_seconds))}")
+        line = " ".join(parts)
+        meta_ok = _append_quickstart_imagemaid_log_line(imagemaid_root, line, log_path=log_path)
+        sidecar_ok = _append_imagemaid_maintenance_sidecar_line(imagemaid_root, line) if not meta_ok else False
+        if not meta_ok and sidecar_ok:
+            helpers.ts_log("ImageMaid maintenance marker could not be appended to the live log; preserved in sidecar instead.", level="WARNING")
+        return bool(meta_ok or sidecar_ok)
     except Exception:
         return False
 
@@ -2741,7 +2959,7 @@ logscan_reingest_state = {
 # Bump this integer when a release needs a one-time Analytics reset + log reingest
 # on startup. Quickstart persists the highest successful level to config/.env so
 # skipped releases still catch up automatically.
-REQUIRED_LOGSCAN_MIGRATION_LEVEL = 2
+REQUIRED_LOGSCAN_MIGRATION_LEVEL = 4
 LOGSCAN_STARTUP_MIGRATIONS_ENV = "QS_LOGSCAN_STARTUP_MIGRATIONS"
 LOGSCAN_MIGRATION_LEVEL_DONE_ENV = "QS_LOGSCAN_MIGRATION_LEVEL_DONE"
 LOGSCAN_STARTUP_MIGRATION_JOB_ID = "startup-logscan-migration"
@@ -2861,6 +3079,14 @@ RUN_CONTEXT = {
     "started_at": None,
     "updated_at": None,
     "stop_requested_at": None,
+}
+IMAGEMAID_RUN_CONTEXT_LOCK = threading.Lock()
+IMAGEMAID_RUN_CONTEXT = {
+    "command": None,
+    "mode": None,
+    "config_name": None,
+    "started_at": None,
+    "updated_at": None,
 }
 
 # Ensure json-schema files are up to date at startup
@@ -6773,7 +6999,33 @@ def validate_plex():
     valid, message = url_validation.validate_url(data.get("plex_url"), allow_local=True)
     if not valid:
         return jsonify({"valid": False, "error": f"Plex URL: {message}"}), 400
-    return validations.validate_plex_server(data)
+    plex_response = validations.validate_plex_server(data)
+    plex_data = plex_response.get_json() if isinstance(plex_response, Flask.response_class) else plex_response
+    if not isinstance(plex_data, dict) or not plex_data.get("validated"):
+        return plex_response
+
+    config_name = _resolve_request_config_name(data)
+    telemetry = {}
+    try:
+        telemetry = helpers.get_plex_metadata(plex_url=data.get("plex_url"), plex_token=data.get("plex_token")) or {}
+        if telemetry:
+            persistence.save_settings("plex_telemetry", telemetry)
+            if config_name:
+                try:
+                    database.save_section_data(
+                        name=config_name,
+                        section="plex_telemetry",
+                        validated=True,
+                        user_entered=False,
+                        data={"plex_telemetry": telemetry},
+                    )
+                except Exception as e:
+                    helpers.ts_log(f"Failed to persist Plex telemetry during validation for {config_name}: {e}", level="WARNING")
+    except Exception as e:
+        helpers.ts_log(f"Failed to fetch Plex telemetry during validation: {e}", level="WARNING")
+
+    merged = {**plex_data, **telemetry}
+    return jsonify(merged)
 
 
 @app.route("/path-validation-rules", methods=["GET"])
@@ -6837,6 +7089,16 @@ def refresh_plex_libraries():
                 }
             }
             persistence.save_settings("plex_telemetry", cached_telemetry)
+            try:
+                database.save_section_data(
+                    name=config_name,
+                    section="plex_telemetry",
+                    validated=True,
+                    user_entered=False,
+                    data={"plex_telemetry": cached_telemetry},
+                )
+            except Exception as e:
+                helpers.ts_log(f"Failed to persist cached Plex telemetry for {config_name}: {e}", level="WARNING")
             return jsonify(cached_refresh)
 
         # Validate Plex server and get updated libraries
@@ -6858,6 +7120,16 @@ def refresh_plex_libraries():
         # Get fresh telemetry using helpers and store it
         telemetry = helpers.get_plex_metadata(plex_url=plex_url, plex_token=plex_token)
         persistence.save_settings("plex_telemetry", telemetry)
+        try:
+            database.save_section_data(
+                name=config_name,
+                section="plex_telemetry",
+                validated=True,
+                user_entered=False,
+                data={"plex_telemetry": telemetry},
+            )
+        except Exception as e:
+            helpers.ts_log(f"Failed to persist Plex telemetry for {config_name}: {e}", level="WARNING")
 
         # Merge both plex_data and telemetry for response
         merged_response = {**plex_data, **telemetry}
@@ -7828,7 +8100,7 @@ def stop_kometa():
             os.remove(pid_file)
         except Exception:
             pass
-        KOMETA_CPU_CACHE.pop(pid, None)
+        _clear_process_metric_cache(pid, "kometa")
         try:
             _write_quickstart_stop_marker(helpers.get_kometa_root_path(), config_name=run_config_name, reason="user_stop")
         except Exception:
@@ -7913,6 +8185,7 @@ def kometa_status():
                 started_at = datetime.fromtimestamp(started_at_ts).isoformat()
                 elapsed_seconds = max(0, int(time.time() - started_at_ts))
                 cpu_percent = _calculate_process_cpu_percent(proc)
+                io_stats = _calculate_process_io_stats(proc, "kometa") or {}
                 mem_rss = proc.memory_info().rss
                 try:
                     for child in proc.children(recursive=True):
@@ -7945,6 +8218,10 @@ def kometa_status():
                     cpu_percent=round(cpu_percent, 1) if cpu_percent is not None else None,
                     memory_rss_mb=round(mem_rss_mb, 1),
                     memory_percent=round(mem_percent, 2) if mem_percent is not None else None,
+                    disk_read_mb=round(io_stats.get("disk_read_mb"), 1) if io_stats.get("disk_read_mb") is not None else None,
+                    disk_write_mb=round(io_stats.get("disk_write_mb"), 1) if io_stats.get("disk_write_mb") is not None else None,
+                    disk_read_rate_mb_s=round(io_stats.get("disk_read_rate_mb_s"), 2) if io_stats.get("disk_read_rate_mb_s") is not None else None,
+                    disk_write_rate_mb_s=round(io_stats.get("disk_write_rate_mb_s"), 2) if io_stats.get("disk_write_rate_mb_s") is not None else None,
                     system_cpu_percent=round(system_cpu_percent, 1) if system_cpu_percent is not None else None,
                     system_memory_percent=round(vm.percent, 1),
                     system_memory_used_mb=round(system_mem_used_mb, 1),
@@ -7976,7 +8253,7 @@ def kometa_status():
             _ingest_completed_live_logs("kometa")
         except Exception:
             pass
-        KOMETA_CPU_CACHE.pop(pid, None)
+        _clear_process_metric_cache(pid, "kometa")
         with MAINTENANCE_STATE_LOCK:
             maintenance_active = MAINTENANCE_STATE["active"]
             maintenance_paused = MAINTENANCE_STATE["paused"]
@@ -8001,7 +8278,7 @@ def kometa_status():
             active_command=ctx.get("command"),
         )
     except psutil.NoSuchProcess:
-        KOMETA_CPU_CACHE.pop(pid, None)
+        _clear_process_metric_cache(pid, "kometa")
         try:
             os.remove(helpers.get_kometa_pid_file())
         except Exception:
@@ -8660,6 +8937,12 @@ def _read_logscan_text(path, encoding="utf-8", errors="replace"):
                 sidecar_content = sidecar_path.read_text(encoding=encoding, errors=errors).strip()
                 if sidecar_content:
                     content = f"{content.rstrip()}\n{sidecar_content}\n"
+        elif path.suffix.lower() == ".log":
+            sidecar_path = path.parent / "imagemaid.quickstart-maintenance.log"
+            if sidecar_path.exists() and sidecar_path.is_file():
+                sidecar_content = sidecar_path.read_text(encoding=encoding, errors=errors).strip()
+                if sidecar_content:
+                    content = f"{content.rstrip()}\n{sidecar_content}\n"
     except Exception:
         pass
     return content
@@ -8993,6 +9276,8 @@ def _analyze_imagemaid_log_content(content, log_path=None):
     )
     timestamp_pattern = re.compile(r"^\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),")
     total_runtime_pattern = re.compile(r"\|\s*Total Runtime\s*\|\s*(.*?)\s*\|?$", re.IGNORECASE)
+    summary_header_pattern = re.compile(r"\|\s*=+\s*(.*?)\s*=+\s*\|?$")
+    summary_runtime_row_pattern = re.compile(r"\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|?$")
 
     started_at = None
     config_name = ""
@@ -9005,8 +9290,12 @@ def _analyze_imagemaid_log_content(content, log_path=None):
     finished_at = None
     finished_seen = False
     run_time_seconds = None
+    cache_count = 0
+    debug_count = 0
+    info_count = 0
     warning_count = 0
     error_count = 0
+    critical_count = 0
     trace_count = 0
     quickstart_run_marker = False
     local_version = ""
@@ -9034,6 +9323,8 @@ def _analyze_imagemaid_log_content(content, log_path=None):
     no_verify_ssl_enabled = False
     overlays_only_enabled = False
     current_runtime_section = ""
+    summary_section = ""
+    summary_section_runtimes = {}
     operation_started = {
         "empty_trash": False,
         "clean_bundles": False,
@@ -9044,10 +9335,18 @@ def _analyze_imagemaid_log_content(content, log_path=None):
         timestamp_match = timestamp_pattern.search(line)
         if timestamp_match and not first_timestamp:
             first_timestamp = timestamp_match.group(1)
+        if "[CACHE]" in line:
+            cache_count += 1
+        if "[DEBUG]" in line:
+            debug_count += 1
+        if "[INFO]" in line:
+            info_count += 1
         if "[WARNING]" in line:
             warning_count += 1
         if "[ERROR]" in line:
             error_count += 1
+        if "[CRITICAL]" in line:
+            critical_count += 1
         if "Traceback" in line:
             trace_count += 1
         stripped_line = line.strip().strip("|").strip()
@@ -9081,6 +9380,53 @@ def _analyze_imagemaid_log_content(content, log_path=None):
             if timestamp_match:
                 finished_at = timestamp_match.group(1)
 
+        summary_header_match = summary_header_pattern.search(line)
+        if summary_header_match:
+            header_text = str(summary_header_match.group(1) or "").strip().lower()
+            if header_text in {
+                "database",
+                "reporting bloat images",
+                "remove phototranscoder images",
+                "remove imagemaid restore bloat images",
+                "empty trash plex operation",
+                "clean bundles plex operation",
+                "optimize db plex operation",
+                "imagemaid summary",
+            }:
+                summary_section = header_text
+
+        summary_runtime_match = summary_runtime_row_pattern.search(line)
+        if summary_runtime_match:
+            summary_label = str(summary_runtime_match.group(1) or "").strip().lower()
+            parsed_summary_runtime = _parse_imagemaid_runtime_seconds(summary_runtime_match.group(2))
+            if parsed_summary_runtime is not None:
+                if summary_section == "database":
+                    if summary_label == "downloaded":
+                        summary_section_runtimes["database_download"] = parsed_summary_runtime
+                    elif summary_label == "query":
+                        summary_section_runtimes["database_query"] = parsed_summary_runtime
+                elif summary_section == "reporting bloat images":
+                    if summary_label == "scan time":
+                        summary_section_runtimes["report_bloat_scan"] = parsed_summary_runtime
+                    elif summary_label == "report time":
+                        summary_section_runtimes["report_bloat_action"] = parsed_summary_runtime
+                elif summary_section == "remove phototranscoder images":
+                    if summary_label == "scan time":
+                        summary_section_runtimes["photo_transcoder_scan"] = parsed_summary_runtime
+                    elif summary_label == "remove time":
+                        summary_section_runtimes["photo_transcoder_remove"] = parsed_summary_runtime
+                elif summary_section == "remove imagemaid restore bloat images":
+                    if summary_label == "scan time":
+                        summary_section_runtimes["restore_dir_scan"] = parsed_summary_runtime
+                    elif summary_label == "remove time":
+                        summary_section_runtimes["restore_dir_action"] = parsed_summary_runtime
+                elif summary_section == "empty trash plex operation" and summary_label == "runtime":
+                    summary_section_runtimes["empty_trash_action"] = parsed_summary_runtime
+                elif summary_section == "clean bundles plex operation" and summary_label == "runtime":
+                    summary_section_runtimes["clean_bundles_action"] = parsed_summary_runtime
+                elif summary_section == "optimize db plex operation" and summary_label == "runtime":
+                    summary_section_runtimes["optimize_db_action"] = parsed_summary_runtime
+
         runtime_match = total_runtime_pattern.search(line)
         if runtime_match:
             parsed_runtime = _parse_imagemaid_runtime_seconds(runtime_match.group(1))
@@ -9102,10 +9448,13 @@ def _analyze_imagemaid_log_content(content, log_path=None):
 
         if "Downloading Database via the Plex API" in line:
             database_section_seen = True
+            current_runtime_section = "database_download"
         if "Downloaded New Database" in line:
             database_downloaded_new = True
         if "Database File Could not Downloaded" in line:
             database_download_failed = True
+        if "Database Opened Querying For In-Use Images" in line or "Querying For In-Use Images" in line:
+            current_runtime_section = "database_query"
 
         if "PhotoTranscoder set to True" in line:
             photo_transcoder_enabled = True
@@ -9140,10 +9489,20 @@ def _analyze_imagemaid_log_content(content, log_path=None):
             current_runtime_section = "restore_scan"
         elif "Removing ImageMaid Restore Bloat Images" in line or ("Removing Complete:" in line and "ImageMaid Restore Bloat Images" in line):
             current_runtime_section = "restore_action"
+        elif "Scanning Metadata Directory For Bloat Images" in line:
+            current_runtime_section = "report_bloat_scan"
+        elif "Reporting Bloat Images" in line or ("Reporting Complete:" in line and "Bloat Images" in line):
+            current_runtime_section = "report_bloat_action"
         elif "Scanning for PhotoTranscoder Images" in line or ("Scanning Complete:" in line and "PhotoTranscoder Images" in line):
             current_runtime_section = "photo_scan"
         elif "Removing PhotoTranscoder Images" in line or ("Remove Complete:" in line and "PhotoTranscoder Images" in line):
             current_runtime_section = "photo_remove"
+        elif "Empty Trash Plex Operation Started" in line:
+            current_runtime_section = "empty_trash_action"
+        elif "Clean Bundles Plex Operation Started" in line:
+            current_runtime_section = "clean_bundles_action"
+        elif "Optimize DB Plex Operation Started" in line:
+            current_runtime_section = "optimize_db_action"
 
         restore_found_match = re.search(
             r"Found\s+(\d+)\s+Bloat Images in the ImageMaid Directory to Remove",
@@ -9189,14 +9548,28 @@ def _analyze_imagemaid_log_content(content, log_path=None):
         if runtime_line_match:
             parsed_runtime = _parse_imagemaid_runtime_seconds(runtime_line_match.group(1))
             if parsed_runtime is not None:
-                if current_runtime_section == "restore_scan":
+                if current_runtime_section == "database_download":
+                    summary_section_runtimes.setdefault("database_download", parsed_runtime)
+                elif current_runtime_section == "database_query":
+                    summary_section_runtimes.setdefault("database_query", parsed_runtime)
+                elif current_runtime_section == "restore_scan":
                     restore_scan_runtime = parsed_runtime
                 elif current_runtime_section == "restore_action":
                     restore_action_runtime = parsed_runtime
+                elif current_runtime_section == "report_bloat_scan":
+                    summary_section_runtimes.setdefault("report_bloat_scan", parsed_runtime)
+                elif current_runtime_section == "report_bloat_action":
+                    summary_section_runtimes.setdefault("report_bloat_action", parsed_runtime)
                 elif current_runtime_section == "photo_scan":
                     photo_scan_runtime = parsed_runtime
                 elif current_runtime_section == "photo_remove":
                     photo_remove_runtime = parsed_runtime
+                elif current_runtime_section == "empty_trash_action":
+                    summary_section_runtimes.setdefault("empty_trash_action", parsed_runtime)
+                elif current_runtime_section == "clean_bundles_action":
+                    summary_section_runtimes.setdefault("clean_bundles_action", parsed_runtime)
+                elif current_runtime_section == "optimize_db_action":
+                    summary_section_runtimes.setdefault("optimize_db_action", parsed_runtime)
 
     if finished_seen and not finished_at:
         finished_at = _iso_from_mtime(stats.st_mtime if stats else None)
@@ -9257,6 +9630,14 @@ def _analyze_imagemaid_log_content(content, log_path=None):
     run_key_seed = f"imagemaid|{timestamp_seed}|{mode}|{path.name if path else 'imagemaid.log'}"
     created_at = finished_at or started_at or _iso_from_mtime(stats.st_mtime if stats else None)
     section_runtimes = {}
+    if summary_section_runtimes.get("database_download") is not None:
+        section_runtimes["database_download"] = summary_section_runtimes["database_download"]
+    if summary_section_runtimes.get("database_query") is not None:
+        section_runtimes["database_query"] = summary_section_runtimes["database_query"]
+    if summary_section_runtimes.get("report_bloat_scan") is not None:
+        section_runtimes["report_bloat_scan"] = summary_section_runtimes["report_bloat_scan"]
+    if summary_section_runtimes.get("report_bloat_action") is not None:
+        section_runtimes["report_bloat_action"] = summary_section_runtimes["report_bloat_action"]
     if restore_scan_runtime is not None:
         section_runtimes["restore_dir_scan"] = restore_scan_runtime
     if restore_action_runtime is not None:
@@ -9265,6 +9646,12 @@ def _analyze_imagemaid_log_content(content, log_path=None):
         section_runtimes["photo_transcoder_scan"] = photo_scan_runtime
     if photo_remove_runtime is not None:
         section_runtimes["photo_transcoder_remove"] = photo_remove_runtime
+    if summary_section_runtimes.get("empty_trash_action") is not None:
+        section_runtimes["empty_trash_action"] = summary_section_runtimes["empty_trash_action"]
+    if summary_section_runtimes.get("clean_bundles_action") is not None:
+        section_runtimes["clean_bundles_action"] = summary_section_runtimes["clean_bundles_action"]
+    if summary_section_runtimes.get("optimize_db_action") is not None:
+        section_runtimes["optimize_db_action"] = summary_section_runtimes["optimize_db_action"]
     total_found_files = restore_found_files + photo_found_files
     total_removed_files = restore_removed_files + photo_removed_files
     total_recovered_bytes = restore_recovered_bytes + photo_recovered_bytes
@@ -9315,11 +9702,12 @@ def _analyze_imagemaid_log_content(content, log_path=None):
         "section_runtimes": section_runtimes,
         "log_size": int(stats.st_size) if stats else None,
         "log_counts": {
-            "debug": 0,
-            "info": 0,
+            "cache": cache_count,
+            "debug": debug_count,
+            "info": info_count,
             "warning": warning_count,
             "error": error_count,
-            "critical": 0,
+            "critical": critical_count,
             "trace": trace_count,
         },
         "analysis_counts": analysis_counts,
@@ -9329,7 +9717,7 @@ def _analyze_imagemaid_log_content(content, log_path=None):
         "quiet_period_summary": {},
         "quickstart_run_marker": quickstart_run_marker,
         "config_line_count": None,
-        "cache_line_count": None,
+        "cache_line_count": cache_count,
         "created_at": created_at,
         "run_complete": run_complete,
         "completion_reason": completion_reason,
@@ -9397,6 +9785,8 @@ def _iter_logscan_candidate_files(log_dir=None, include_archive=True, include_co
             for pattern in patterns:
                 for path in base_dir.glob(pattern):
                     if not path.is_file():
+                        continue
+                    if _is_logscan_maintenance_sidecar(path):
                         continue
                     suffixes = [suffix.lower() for suffix in path.suffixes]
                     if suffixes and suffixes[-1] in (".zip", ".7z"):
@@ -9634,6 +10024,26 @@ def _normalize_logscan_archive_filenames(archive_dir=None):
     errors = []
     cache_dirty = False
 
+    archive_dirs = []
+    if archive_dir:
+        archive_dirs.append(Path(archive_dir))
+    else:
+        archive_dirs.extend([_get_logscan_archive_dir("kometa"), _get_logscan_archive_dir("imagemaid"), _get_logscan_archive_root_dir()])
+
+    for current_archive_dir in archive_dirs:
+        if not current_archive_dir.exists():
+            continue
+        for sidecar_path in current_archive_dir.glob("*.quickstart-maintenance.log"):
+            try:
+                source_key = str(sidecar_path.resolve())
+                sidecar_path.unlink()
+                if source_key in cache_logs:
+                    cache_logs.pop(source_key, None)
+                    cache_dirty = True
+                renamed += 1
+            except Exception as exc:
+                errors.append(f"Failed to remove archived maintenance sidecar {sidecar_path}: {exc}")
+
     for path in sorted(_iter_logscan_candidate_files(include_archive=True, include_compressed=True), key=lambda item: item.name.lower()):
         if _classify_logscan_file_location(path) != "archive":
             continue
@@ -9642,13 +10052,25 @@ def _normalize_logscan_archive_filenames(archive_dir=None):
             current_tool = _detect_logscan_tool_from_path(path)
             target_archive_dir = Path(archive_dir) if archive_dir else _get_logscan_archive_dir(current_tool)
             target_archive_dir.mkdir(parents=True, exist_ok=True)
-            target = _build_logscan_archive_destination(path, target_archive_dir, stats=stats)
+            target = _build_logscan_archive_destination(
+                path,
+                target_archive_dir,
+                stats=stats,
+                preferred_suffix=".log.gz" if not _is_logscan_gzip_path(path) else None,
+            )
             if target.resolve() == path.resolve():
                 skipped += 1
                 continue
             source_key = str(path.resolve())
             target_key = str(target.resolve())
-            shutil.move(str(path), str(target))
+            if _is_logscan_gzip_path(path):
+                shutil.move(str(path), str(target))
+            else:
+                archived_path = _archive_log_file(path, target_archive_dir)
+                if not archived_path:
+                    raise RuntimeError("archive compression failed")
+                target = archived_path
+                target_key = str(target.resolve())
             if source_key in cache_logs:
                 cache_logs[target_key] = cache_logs.pop(source_key)
                 cache_dirty = True
@@ -11085,6 +11507,8 @@ def _archive_log_file(path, archive_dir, log_dir=None, allow_live_meta=False):
         path = Path(path)
         if not path.exists() or not path.is_file():
             return None
+        if _is_logscan_maintenance_sidecar(path):
+            return None
         if path.name.lower() == "meta.log" and not allow_live_meta:
             return None
         if log_dir and path.resolve().parent != Path(log_dir).resolve():
@@ -11226,6 +11650,8 @@ def _prune_logscan_archive(archive_dir):
     candidates = []
     for path in archive_dir.glob("*.log*"):
         if not path.is_file():
+            continue
+        if _is_logscan_maintenance_sidecar(path):
             continue
         suffixes = [suffix.lower() for suffix in path.suffixes]
         if suffixes and suffixes[-1] in (".zip", ".7z"):
@@ -13008,22 +13434,94 @@ def _imagemaid_settings_to_form_payload(payload):
         "overlays_only",
     ]
     form_payload = {}
+    config_name = helpers.normalize_config_name_for_storage(payload.get("config_name"))
+    if config_name:
+        form_payload["config_name"] = config_name
     for key in keys:
         if key in payload:
             form_payload[f"imagemaid_{key}"] = payload.get(key)
     return form_payload
 
 
-def _get_imagemaid_settings_section():
-    settings = persistence.retrieve_settings("915-imagemaid") or {}
+def _resolve_request_config_name(payload=None):
+    normalized = helpers.normalize_config_name_for_storage((payload or {}).get("config_name")) if isinstance(payload, dict) else ""
+    if normalized:
+        if has_request_context():
+            session["config_name"] = normalized
+        return normalized
+    resolved = session.get("config_name") or persistence.ensure_session_config_name()
+    if has_request_context() and resolved:
+        session["config_name"] = resolved
+    return resolved
+
+
+def _retrieve_settings_for_config(config_name, target):
+    source, source_name = persistence.extract_names(target)
+    stored_validated, stored_user_entered, stored_payload = database.retrieve_section_data(config_name, source_name)
+    payload = stored_payload if isinstance(stored_payload, dict) else {}
+    section = payload.get(source_name, {}) if isinstance(payload.get(source_name), dict) else {}
+    if not section:
+        section = persistence.get_dummy_data(source_name)
+    return {
+        "validated": helpers.booler(stored_validated),
+        "user_entered": helpers.booler(stored_user_entered),
+        "validated_at": payload.get("validated_at") if isinstance(payload, dict) else None,
+        source_name: section,
+    }
+
+
+def _get_stored_plex_credentials_for_config(config_name):
+    try:
+        stored_validated, stored_user_entered, stored_payload = database.retrieve_section_data(name=config_name, section="plex")
+        payload = stored_payload if isinstance(stored_payload, dict) else {}
+        plex_settings = payload.get("plex", {})
+        if not plex_settings:
+            plex_settings = persistence.get_dummy_data("plex")
+        plex_url = plex_settings.get("url")
+        plex_token = plex_settings.get("token")
+        if plex_url and plex_token:
+            return plex_url, plex_token
+    except Exception as exc:
+        if app.config["QS_DEBUG"]:
+            helpers.ts_log(f"Failed to retrieve Plex credentials for config {config_name}: {exc}", level="ERROR")
+    return None, None
+
+
+def _save_imagemaid_settings_for_config(config_name, form_payload):
+    clean_data = persistence.clean_form_data(form_payload)
+    data = helpers.build_config_dict("imagemaid", clean_data)
+    base_data = persistence.get_dummy_data("imagemaid")
+    stored_validated, stored_user_entered, stored_payload = database.retrieve_section_data(config_name, "imagemaid")
+    existing_payload = stored_payload if isinstance(stored_payload, dict) else {}
+    existing_section = existing_payload.get("imagemaid", {}) if isinstance(existing_payload.get("imagemaid"), dict) else {}
+    payload = dict(existing_payload)
+    payload["imagemaid"] = data.get("imagemaid", {}) if isinstance(data.get("imagemaid"), dict) else {}
+    if "validated_at" in data:
+        payload["validated_at"] = data.get("validated_at")
+    elif existing_payload.get("validated_at") is not None:
+        payload["validated_at"] = existing_payload.get("validated_at")
+    user_entered = data != base_data
+    database.save_section_data(
+        name=config_name,
+        section="imagemaid",
+        validated=helpers.booler(stored_validated),
+        user_entered=user_entered,
+        data=payload,
+    )
+    changed = payload.get("imagemaid", {}) != existing_section
+    return payload, changed
+
+
+def _get_imagemaid_settings_section(config_name=None):
+    resolved_config = config_name or persistence.ensure_session_config_name()
+    settings = _retrieve_settings_for_config(resolved_config, "915-imagemaid") or {}
     section = settings.get("imagemaid", {}) if isinstance(settings, dict) else {}
     if not isinstance(section, dict):
         section = {}
     return settings, section
 
 
-def _persist_imagemaid_validation(section_data, is_valid, reason=None, details=None):
-    config_name = persistence.ensure_session_config_name()
+def _persist_imagemaid_validation(config_name, section_data, is_valid, reason=None, details=None):
     stored_validated, user_entered, stored_payload = database.retrieve_section_data(config_name, "imagemaid")
     payload = stored_payload if isinstance(stored_payload, dict) else {}
     payload["imagemaid"] = section_data if isinstance(section_data, dict) else {}
@@ -13159,16 +13657,25 @@ def _build_imagemaid_command(section_data, plex_url, plex_token, imagemaid_root=
     return subprocess.list2cmdline(parts)
 
 
-def _validate_imagemaid_settings(section_data):
+def _validate_imagemaid_settings(section_data, config_name=None):
+    if config_name:
+        resolved_config = config_name
+    elif has_request_context():
+        resolved_config = session.get("config_name") or persistence.ensure_session_config_name()
+    else:
+        resolved_config = None
     mode = str(section_data.get("mode") or "report").strip().lower() or "report"
     valid_modes = {"report", "move", "restore", "clear", "remove", "nothing"}
     if mode not in valid_modes:
         return False, "invalid_mode", f"ImageMaid mode must be one of: {', '.join(sorted(valid_modes))}."
 
-    plex_settings = persistence.retrieve_settings("010-plex") or {}
+    plex_settings = _retrieve_settings_for_config(resolved_config, "010-plex") if resolved_config else (persistence.retrieve_settings("010-plex") or {})
     if not helpers.booler(plex_settings.get("validated", False)):
         return False, "missing_plex_validation", "Validate the Plex page before running ImageMaid."
-    plex_url, plex_token = persistence.get_stored_plex_credentials("010-plex")
+    if resolved_config:
+        plex_url, plex_token = _get_stored_plex_credentials_for_config(resolved_config)
+    else:
+        plex_url, plex_token = persistence.get_stored_plex_credentials()
     if not plex_url or not plex_token:
         return False, "missing_credentials", "Saved Plex URL/token are required."
     valid_path, reason, details = _validate_imagemaid_plex_path(
@@ -13196,13 +13703,36 @@ def _get_latest_imagemaid_log_path():
     log_dir = helpers.get_imagemaid_root_path() / "config" / "logs"
     if not log_dir.exists():
         return None
-    candidates = sorted(log_dir.glob("*.log"), key=lambda path: path.stat().st_mtime, reverse=True)
+    candidates = sorted(
+        [path for path in log_dir.glob("*.log") if path.name.lower() != "imagemaid.quickstart-maintenance.log"],
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
     return candidates[0] if candidates else None
 
 
 def _read_text_tail(path, max_lines=200):
-    with Path(path).open("r", encoding="utf-8", errors="replace") as handle:
-        return "".join(deque(handle, maxlen=max_lines))
+    content = _read_logscan_text(path, encoding="utf-8", errors="replace")
+    return "".join(deque(content.splitlines(keepends=True), maxlen=max_lines))
+
+
+def _read_text_tail_payload(path, max_lines=200):
+    path_obj = Path(path)
+    content = _read_logscan_text(path_obj, encoding="utf-8", errors="replace")
+    lines = content.splitlines()
+    tail_text = "\n".join(lines[-max_lines:]) if lines else ""
+    if tail_text and content.endswith("\n"):
+        tail_text += "\n"
+    try:
+        stats = path_obj.stat()
+        log_age_seconds = max(0, int(time.time() - stats.st_mtime))
+    except Exception:
+        log_age_seconds = None
+    return {
+        "text": tail_text,
+        "total_lines": len(lines),
+        "log_age_seconds": log_age_seconds,
+    }
 
 
 def _sanitize_imagemaid_log_tail(text):
@@ -13575,15 +14105,16 @@ def update_imagemaid_progress():
 @app.route("/validate-imagemaid", methods=["POST"])
 def validate_imagemaid():
     payload = request.get_json(silent=True) or {}
+    config_name = _resolve_request_config_name(payload)
     form_payload = _imagemaid_settings_to_form_payload(payload)
     if form_payload:
-        persistence.save_settings("915-imagemaid", form_payload)
+        _save_imagemaid_settings_for_config(config_name, form_payload)
 
-    settings, section_data = _get_imagemaid_settings_section()
-    is_valid, reason, details = _validate_imagemaid_settings(section_data)
-    _persist_imagemaid_validation(section_data, is_valid, reason=reason, details=details)
+    settings, section_data = _get_imagemaid_settings_section(config_name)
+    is_valid, reason, details = _validate_imagemaid_settings(section_data, config_name=config_name)
+    _persist_imagemaid_validation(config_name, section_data, is_valid, reason=reason, details=details)
 
-    plex_url, plex_token = persistence.get_stored_plex_credentials("010-plex")
+    plex_url, plex_token = _get_stored_plex_credentials_for_config(config_name)
     preview_command = _build_imagemaid_command(section_data, plex_url or "", plex_token or "", redact=True)
     return jsonify(success=is_valid, validated=is_valid, reason=reason, details=details, command_preview=preview_command), (200 if is_valid else 400)
 
@@ -13591,13 +14122,16 @@ def validate_imagemaid():
 @app.route("/autosave-imagemaid", methods=["POST"])
 def autosave_imagemaid():
     payload = request.get_json(silent=True) or {}
+    config_name = _resolve_request_config_name(payload)
     form_payload = _imagemaid_settings_to_form_payload(payload)
+    changed = False
     if form_payload:
-        persistence.save_settings("915-imagemaid", form_payload)
+        _saved_payload, changed = _save_imagemaid_settings_for_config(config_name, form_payload)
 
-    settings, section_data = _get_imagemaid_settings_section()
-    if helpers.booler(settings.get("validated", False)):
+    settings, section_data = _get_imagemaid_settings_section(config_name)
+    if changed and helpers.booler(settings.get("validated", False)):
         _persist_imagemaid_validation(
+            config_name,
             section_data,
             False,
             reason="config_changed",
@@ -13609,11 +14143,11 @@ def autosave_imagemaid():
 
 @app.route("/start-imagemaid", methods=["POST"])
 def start_imagemaid():
-    config_name = session.get("config_name") or persistence.ensure_session_config_name()
     payload = request.get_json(silent=True) or {}
+    config_name = _resolve_request_config_name(payload)
     form_payload = _imagemaid_settings_to_form_payload(payload)
     if form_payload:
-        persistence.save_settings("915-imagemaid", form_payload)
+        _save_imagemaid_settings_for_config(config_name, form_payload)
 
     if helpers.is_imagemaid_running():
         pid = helpers.get_imagemaid_pid()
@@ -13654,9 +14188,9 @@ def start_imagemaid():
             response["phase"] = job.get("phase")
         return jsonify(response), 409
 
-    settings, section_data = _get_imagemaid_settings_section()
-    is_valid, reason, details = _validate_imagemaid_settings(section_data)
-    _persist_imagemaid_validation(section_data, is_valid, reason=reason, details=details)
+    settings, section_data = _get_imagemaid_settings_section(config_name)
+    is_valid, reason, details = _validate_imagemaid_settings(section_data, config_name=config_name)
+    _persist_imagemaid_validation(config_name, section_data, is_valid, reason=reason, details=details)
     if not is_valid:
         return jsonify({"error": details or "ImageMaid settings are not valid.", "status": "invalid", "reason": reason}), 400
 
@@ -13687,7 +14221,7 @@ def start_imagemaid():
             409,
         )
 
-    plex_url, plex_token = persistence.get_stored_plex_credentials("010-plex")
+    plex_url, plex_token = _get_stored_plex_credentials_for_config(config_name)
     command = _build_imagemaid_command_parts(section_data, plex_url, plex_token, redact=False)
     ok, result = _launch_imagemaid_command(command, mode=section_data.get("mode"), config_name=config_name)
     if ok:
@@ -13778,6 +14312,12 @@ def stop_imagemaid():
 def imagemaid_status():
     pid = helpers.get_imagemaid_pid()
     pid_file = Path(helpers.get_imagemaid_pid_file())
+    imagemaid_ctx = _get_imagemaid_run_context()
+    with MAINTENANCE_STATE_LOCK:
+        maintenance_active = MAINTENANCE_STATE["active"]
+        maintenance_window = MAINTENANCE_STATE["window"]
+        maintenance_paused = MAINTENANCE_STATE["imagemaid_paused"]
+        maintenance_paused_since = MAINTENANCE_STATE["imagemaid_paused_since"]
 
     def pid_file_age_seconds():
         try:
@@ -13801,7 +14341,13 @@ def imagemaid_status():
             _ingest_completed_live_logs("imagemaid")
         except Exception:
             pass
-        return jsonify(status="not started")
+        return jsonify(
+            status="not started",
+            maintenance_active=maintenance_active,
+            maintenance_paused=maintenance_paused,
+            maintenance_window=maintenance_window,
+            maintenance_paused_since=maintenance_paused_since,
+        )
 
     try:
         proc = psutil.Process(pid)
@@ -13824,12 +14370,57 @@ def imagemaid_status():
                 cmdline = ""
             if "imagemaid.py" in cmdline:
                 started_at = datetime.fromtimestamp(started_at_ts).isoformat()
-                return jsonify(status="running", pid=pid, started_at=started_at, started_at_ts=started_at_ts, elapsed_seconds=elapsed_seconds)
+                cpu_percent = _calculate_process_cpu_percent(proc)
+                io_stats = _calculate_process_io_stats(proc, "imagemaid") or {}
+                mem_rss = proc.memory_info().rss
+                try:
+                    for child in proc.children(recursive=True):
+                        try:
+                            mem_rss += child.memory_info().rss
+                        except Exception:
+                            continue
+                except Exception:
+                    pass
+                mem_rss_mb = mem_rss / (1024 * 1024)
+                system_cpu_percent = _calculate_system_cpu_percent()
+                vm = psutil.virtual_memory()
+                system_mem_used_mb = (vm.total - vm.available) / (1024 * 1024)
+                system_mem_total_mb = vm.total / (1024 * 1024)
+                mem_percent = (mem_rss / vm.total) * 100.0 if vm.total else None
+                return jsonify(
+                    status="running",
+                    pid=pid,
+                    started_at=started_at,
+                    started_at_ts=started_at_ts,
+                    elapsed_seconds=elapsed_seconds,
+                    cpu_percent=round(cpu_percent, 1) if cpu_percent is not None else None,
+                    memory_rss_mb=round(mem_rss_mb, 1),
+                    memory_percent=round(mem_percent, 2) if mem_percent is not None else None,
+                    disk_read_mb=round(io_stats.get("disk_read_mb"), 1) if io_stats.get("disk_read_mb") is not None else None,
+                    disk_write_mb=round(io_stats.get("disk_write_mb"), 1) if io_stats.get("disk_write_mb") is not None else None,
+                    disk_read_rate_mb_s=round(io_stats.get("disk_read_rate_mb_s"), 2) if io_stats.get("disk_read_rate_mb_s") is not None else None,
+                    disk_write_rate_mb_s=round(io_stats.get("disk_write_rate_mb_s"), 2) if io_stats.get("disk_write_rate_mb_s") is not None else None,
+                    system_cpu_percent=round(system_cpu_percent, 1) if system_cpu_percent is not None else None,
+                    system_memory_percent=round(vm.percent, 1),
+                    system_memory_used_mb=round(system_mem_used_mb, 1),
+                    system_memory_total_mb=round(system_mem_total_mb, 1),
+                    maintenance_active=maintenance_active,
+                    maintenance_paused=maintenance_paused,
+                    maintenance_window=maintenance_window,
+                    maintenance_paused_since=maintenance_paused_since,
+                    active_command=imagemaid_ctx.get("command"),
+                    mode=imagemaid_ctx.get("mode"),
+                    config_name=imagemaid_ctx.get("config_name"),
+                )
             if within_grace:
                 payload = {"status": "starting", "pid": pid, "elapsed_seconds": elapsed_seconds}
                 if started_at_ts is not None:
                     payload["started_at"] = datetime.fromtimestamp(started_at_ts).isoformat()
                     payload["started_at_ts"] = started_at_ts
+                payload["maintenance_active"] = maintenance_active
+                payload["maintenance_paused"] = maintenance_paused
+                payload["maintenance_window"] = maintenance_window
+                payload["maintenance_paused_since"] = maintenance_paused_since
                 return jsonify(payload)
         try:
             rc = proc.wait(timeout=0.1)
@@ -13839,6 +14430,10 @@ def imagemaid_status():
                 if started_at_ts is not None:
                     payload["started_at"] = datetime.fromtimestamp(started_at_ts).isoformat()
                     payload["started_at_ts"] = started_at_ts
+                payload["maintenance_active"] = maintenance_active
+                payload["maintenance_paused"] = maintenance_paused
+                payload["maintenance_window"] = maintenance_window
+                payload["maintenance_paused_since"] = maintenance_paused_since
                 return jsonify(payload)
             rc = None
         finally:
@@ -13847,37 +14442,71 @@ def imagemaid_status():
                     os.remove(pid_file)
                 except Exception:
                     pass
+                _clear_process_metric_cache(pid, "imagemaid")
         if not within_grace:
             try:
                 _ingest_completed_live_logs("imagemaid")
             except Exception:
                 pass
-        return jsonify(status="done", return_code=rc if rc is not None else -1)
+        return jsonify(
+            status="done",
+            return_code=rc if rc is not None else -1,
+            maintenance_active=maintenance_active,
+            maintenance_paused=maintenance_paused,
+            maintenance_window=maintenance_window,
+            maintenance_paused_since=maintenance_paused_since,
+        )
     except psutil.NoSuchProcess:
         age = pid_file_age_seconds()
         if age is not None and age < IMAGEMAID_STARTUP_GRACE_SECONDS:
-            return jsonify(status="starting", pid=pid, elapsed_seconds=max(0, int(age)))
+            return jsonify(
+                status="starting",
+                pid=pid,
+                elapsed_seconds=max(0, int(age)),
+                maintenance_active=maintenance_active,
+                maintenance_paused=maintenance_paused,
+                maintenance_window=maintenance_window,
+                maintenance_paused_since=maintenance_paused_since,
+            )
         try:
             os.remove(pid_file)
         except Exception:
             pass
-        return jsonify(status="not started")
+        _clear_process_metric_cache(pid, "imagemaid")
+        return jsonify(
+            status="not started",
+            maintenance_active=maintenance_active,
+            maintenance_paused=maintenance_paused,
+            maintenance_window=maintenance_window,
+            maintenance_paused_since=maintenance_paused_since,
+        )
 
 
 @app.route("/tail-imagemaid-log", methods=["GET"])
 def tail_imagemaid_log():
     latest_log = _get_latest_imagemaid_log_path()
     path = latest_log if latest_log and Path(latest_log).exists() else None
+    try:
+        lines_param = str(request.args.get("lines", "2000")).strip().lower()
+        max_lines = None
+        if lines_param not in ("all", "full"):
+            max_lines = max(1, min(int(lines_param), 20000))
+    except Exception:
+        max_lines = 2000
 
     if not path or not Path(path).exists():
         return jsonify({"error": "No ImageMaid log found."}), 404
     try:
-        text = _sanitize_imagemaid_log_tail(_read_text_tail(path))
+        payload = _read_text_tail_payload(path, max_lines=max_lines)
+        text = _sanitize_imagemaid_log_tail(payload.get("text"))
         return jsonify(
             {
                 "success": True,
                 "path": str(path),
                 "text": text,
+                "total_lines": payload.get("total_lines"),
+                "log_age_seconds": payload.get("log_age_seconds"),
+                "requested_lines": "all" if max_lines is None else max_lines,
             }
         )
     except Exception as e:

--- a/quickstart.py
+++ b/quickstart.py
@@ -1783,9 +1783,7 @@ def _refresh_maintenance_window_availability(preserve_active_state=False):
     active = _is_within_maintenance_window(datetime.now(), start_min, end_min)
 
     with MAINTENANCE_STATE_LOCK:
-        if preserve_active_state and (
-            MAINTENANCE_STATE.get("paused") or MAINTENANCE_STATE.get("imagemaid_paused")
-        ):
+        if preserve_active_state and (MAINTENANCE_STATE.get("paused") or MAINTENANCE_STATE.get("imagemaid_paused")):
             if window_str:
                 MAINTENANCE_STATE["window"] = window_str
         else:
@@ -2154,8 +2152,8 @@ def _normalize_imagemaid_command_text(command):
 def _update_imagemaid_run_context(command, mode=None, config_name=None):
     with IMAGEMAID_RUN_CONTEXT_LOCK:
         IMAGEMAID_RUN_CONTEXT["command"] = _normalize_imagemaid_command_text(command)
-        IMAGEMAID_RUN_CONTEXT["mode"] = (str(mode or "").strip().lower() or None)
-        IMAGEMAID_RUN_CONTEXT["config_name"] = (str(config_name or "").strip() or None)
+        IMAGEMAID_RUN_CONTEXT["mode"] = str(mode or "").strip().lower() or None
+        IMAGEMAID_RUN_CONTEXT["config_name"] = str(config_name or "").strip() or None
         IMAGEMAID_RUN_CONTEXT["started_at"] = datetime.now()
         IMAGEMAID_RUN_CONTEXT["updated_at"] = datetime.now(timezone.utc).isoformat()
 
@@ -5815,11 +5813,7 @@ def step(name):
             save_source, save_source_name = persistence.extract_names(request.referrer or name)
             if save_source_name == "imagemaid":
                 request_payload = request.form.to_dict(flat=True)
-                request_payload["config_name"] = (
-                    session.get("config_name")
-                    or request_payload.get("config_name")
-                    or request_payload.get("configSelector")
-                )
+                request_payload["config_name"] = session.get("config_name") or request_payload.get("config_name") or request_payload.get("configSelector")
                 config_name = _resolve_request_config_name(request_payload)
                 existing_settings, _existing_section = _get_imagemaid_settings_section(config_name)
                 was_validated = helpers.booler(existing_settings.get("validated", False))
@@ -10576,11 +10570,7 @@ def _build_incomplete_scope_summary(original_command="", suggested_command="", p
     original_selected = _extract_selected_libraries(original_command)[1] or []
     recovery_selected = _extract_selected_libraries(suggested_command)[1] or []
     progress_names = _dedupe_preserve_order(entry.get("name") for entry in progress_libraries if isinstance(entry, dict))
-    completed = _dedupe_preserve_order(
-        entry.get("name")
-        for entry in progress_libraries
-        if isinstance(entry, dict) and str(entry.get("status") or "").strip() == "Done"
-    )
+    completed = _dedupe_preserve_order(entry.get("name") for entry in progress_libraries if isinstance(entry, dict) and str(entry.get("status") or "").strip() == "Done")
 
     original_scope = _dedupe_preserve_order(original_selected or progress_names)
     recovery_scope = _dedupe_preserve_order(recovery_selected or original_scope)
@@ -10726,8 +10716,7 @@ def _build_incomplete_progress_snapshot(progress=None, last_log_at=None, config_
         "last_log_at": last_log_at or "",
         "preparation_label": _format_duration_brief(preparation_seconds) if isinstance(preparation_seconds, (int, float)) else "",
         "footer_cells": [
-            _format_duration_brief(totals.get(column["key"])) if isinstance(totals.get(column["key"]), (int, float)) and totals.get(column["key"]) > 0 else ""
-            for column in columns
+            _format_duration_brief(totals.get(column["key"])) if isinstance(totals.get(column["key"]), (int, float)) and totals.get(column["key"]) > 0 else "" for column in columns
         ],
         "total_label": _format_duration_brief(total_seconds) if total_seconds > 0 else "",
     }
@@ -10938,7 +10927,9 @@ def _build_resume_explanation(
         lines.append(f"Detected in-progress library '{current_library}', so the suggestion scopes with --run-libraries.")
 
     if isinstance(progress_libraries, list):
-        completed_libraries = [str(entry.get("name")).strip() for entry in progress_libraries if str(entry.get("status") or "").strip() == "Done" and str(entry.get("name") or "").strip()]
+        completed_libraries = [
+            str(entry.get("name")).strip() for entry in progress_libraries if str(entry.get("status") or "").strip() == "Done" and str(entry.get("name") or "").strip()
+        ]
         if completed_libraries:
             lines.append(f"Completed libraries already seen in the log: {' | '.join(completed_libraries)}.")
 
@@ -13658,9 +13649,7 @@ def _save_imagemaid_settings_for_config(config_name, form_payload):
     existing_payload = stored_payload if isinstance(stored_payload, dict) else {}
     existing_section = existing_payload.get("imagemaid", {}) if isinstance(existing_payload.get("imagemaid"), dict) else {}
     canonical_existing_section = _canonicalize_imagemaid_section(existing_section)
-    canonical_new_section = _canonicalize_imagemaid_section(
-        data.get("imagemaid", {}) if isinstance(data.get("imagemaid"), dict) else {}
-    )
+    canonical_new_section = _canonicalize_imagemaid_section(data.get("imagemaid", {}) if isinstance(data.get("imagemaid"), dict) else {})
     payload = dict(existing_payload)
     payload["imagemaid"] = canonical_new_section
     if "validated_at" in data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ cachelib==0.13.0
 Flask==3.1.3
 Flask-Session==0.8.0
 GitPython==3.1.49
-gunicorn==25.3.0
+gunicorn==26.0.0
 jsonschema==4.26.0
 namesgenerator==0.3
 pillow==12.2.0

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -2316,6 +2316,38 @@ div#loading {
     width: 1rem;
 }
 
+.logscan-select-switch {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    margin: 0;
+    min-height: 1.5rem;
+}
+
+.logscan-select-switch .form-check-input {
+    cursor: pointer;
+    margin: 0;
+}
+
+.logscan-select-switch .form-check-label {
+    color: var(--theme-text-muted);
+    cursor: pointer;
+    font-size: 0.82rem;
+    line-height: 1;
+    margin: 0;
+}
+
+.logscan-select-switch .form-check-input:checked + .form-check-label {
+    color: #74f0c6;
+}
+
+#logscan-table-select-complete.is-active,
+#logscan-table-select-incomplete.is-active {
+    background: rgba(0, 188, 140, 0.18);
+    border-color: rgba(0, 188, 140, 0.55);
+    color: #74f0c6;
+}
+
 .qs-workspace-main-panel .table-responsive.logscan-runs-card-table table tr.logscan-row-selected {
     border-color: rgba(0, 188, 140, 0.8);
     box-shadow: 0 0 0 1px rgba(0, 188, 140, 0.32);
@@ -2620,9 +2652,29 @@ div#loading {
     color: #f9c74f;
 }
 
+.logscan-count-chip--cache {
+    background: rgba(139, 92, 246, 0.14);
+    color: #c4b5fd;
+}
+
+.logscan-count-chip--debug {
+    background: rgba(107, 114, 128, 0.18);
+    color: #d1d5db;
+}
+
+.logscan-count-chip--info {
+    background: rgba(56, 189, 248, 0.14);
+    color: #7dd3fc;
+}
+
 .logscan-count-chip--error {
     background: rgba(249, 65, 68, 0.14);
     color: #ff6b6e;
+}
+
+.logscan-count-chip--critical {
+    background: rgba(244, 63, 94, 0.18);
+    color: #fda4af;
 }
 
 .logscan-count-chip--trace {
@@ -3611,6 +3663,10 @@ div#loading {
     flex-wrap: wrap;
 }
 
+.start-link-row-buttons {
+    margin-top: 0.6rem;
+}
+
 .start-link-row-buttons .btn {
     min-width: 0;
 }
@@ -3680,7 +3736,7 @@ div#loading {
 
 .start-link-row a:hover,
 .start-link-row a:focus {
-    text-decoration: underline;
+    text-decoration: none;
 }
 
 .qs-imagemaid-intro-alert {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -3332,6 +3332,47 @@ div#loading {
     width: 100%;
 }
 
+#incomplete-run-alert .qs-incomplete-run-metrics {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+    gap: 0.6rem;
+}
+
+#incomplete-run-alert .qs-incomplete-run-metric {
+    padding: 0.55rem 0.7rem;
+    border: 1px solid rgba(244, 191, 62, 0.22);
+    border-radius: 0.55rem;
+    background: rgba(18, 14, 4, 0.38);
+}
+
+#incomplete-run-alert .qs-incomplete-run-metric-label {
+    display: block;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: rgba(255, 214, 106, 0.82);
+}
+
+#incomplete-run-alert .qs-incomplete-run-metric-value {
+    display: block;
+    margin-top: 0.2rem;
+    color: #f5e4a8;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+.qs-recovery-command-output-secondary {
+    border-color: rgba(255, 214, 102, 0.18) !important;
+    background: rgba(21, 17, 7, 0.58) !important;
+    color: #f0ddb0 !important;
+}
+
+#incomplete-run-alert .qs-incomplete-progress-table td,
+#incomplete-run-alert .qs-incomplete-progress-table th {
+    vertical-align: middle;
+}
+
 #run-recovery-command {
     background-color: #f2bf3f;
     border-color: #f2bf3f;

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -613,17 +613,17 @@ function qsBuildKometaActiveWorkEntry () {
   const unavailableBlocksWork = Boolean(data.window_unavailable) && (Boolean(data.pending_start) || Boolean(data.maintenance_paused) || !running)
 
   if (unavailableBlocksWork) {
-    const since = data.window_unavailable_since ? `Since ${qsFormatTimestamp(data.window_unavailable_since)}` : 'Maintenance window unavailable'
+    const since = data.window_unavailable_since ? `Since ${qsFormatTimestamp(data.window_unavailable_since)}` : 'Maintenance window data unavailable'
     return {
       key: 'kometa-window-unavailable',
-      title: 'Kometa start blocked',
+      title: 'Maintenance window data unavailable',
       chip: 'Waiting',
       state: 'warn',
       meta: windowLabel ? `${since} • Window ${windowLabel}` : since,
       href,
       titleAttr: windowLabel
-        ? `Kometa start is blocked because the configured Plex maintenance window ${windowLabel} is unavailable.`
-        : 'Kometa start is blocked because the configured Plex maintenance window is unavailable.'
+        ? `Quickstart cannot read the configured Plex maintenance window ${windowLabel} while work is active.`
+        : 'Quickstart cannot read the configured Plex maintenance window while work is active.'
     }
   }
 
@@ -963,7 +963,7 @@ function qsHandleMaintenanceStatus (data) {
       const label = unavailableBadge.querySelector('span')
       unavailableBadge.classList.remove('d-none')
       if (label) {
-        label.innerHTML = `<i class="bi bi-exclamation-triangle me-1"></i> Plex maintenance window unavailable${sinceLabel}`
+        label.innerHTML = `<i class="bi bi-exclamation-triangle me-1"></i> Plex maintenance window data unavailable${sinceLabel}`
       }
     } else {
       unavailableBadge.classList.add('d-none')

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -610,7 +610,7 @@ function qsBuildKometaActiveWorkEntry () {
   const href = '/step/900-kometa'
   const status = String(data.status || '').trim().toLowerCase()
   const running = status === 'running'
-  const unavailableBlocksWork = Boolean(data.window_unavailable) && (Boolean(data.pending_start) || Boolean(data.maintenance_paused) || !running)
+  const unavailableBlocksWork = Boolean(data.window_unavailable) && (Boolean(data.pending_start) || Boolean(data.maintenance_paused) || running)
 
   if (unavailableBlocksWork) {
     const since = data.window_unavailable_since ? `Since ${qsFormatTimestamp(data.window_unavailable_since)}` : 'Maintenance window data unavailable'

--- a/static/local-js/001-start.js
+++ b/static/local-js/001-start.js
@@ -79,6 +79,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const configSwitchSelect = document.getElementById('configSwitchSelect')
   const configSelector = document.getElementById('configSelector')
   const activeConfigInput = document.getElementById('qs-active-config-input')
+  const startStepLinks = Array.from(document.querySelectorAll('.qs-start-step-link[href^="/step/"]'))
   const newConfigInput = document.getElementById('newConfigName')
   const saveConfigRow = document.getElementById('saveConfigRow')
   const saveConfigButton = document.getElementById('saveConfigButton')
@@ -118,6 +119,25 @@ document.addEventListener('DOMContentLoaded', function () {
   const importConfigName = document.getElementById('importConfigName')
   const importModeNew = document.getElementById('importModeNew')
   const importModeMerge = document.getElementById('importModeMerge')
+
+  startStepLinks.forEach((link) => {
+    if (link.dataset.qsStartNavBound === '1') return
+    link.dataset.qsStartNavBound = '1'
+    link.addEventListener('click', (event) => {
+      const href = String(link.getAttribute('href') || '').trim()
+      if (!href || !href.startsWith('/step/')) return
+      event.preventDefault()
+      const targetLabel = String(link.dataset.qsTargetLabel || link.textContent || '').trim()
+      if (typeof window.loading === 'function') {
+        window.loading('jump', targetLabel)
+      } else if (typeof window.showNavigationLoadingOverlay === 'function') {
+        window.showNavigationLoadingOverlay('jump', targetLabel)
+      }
+      window.setTimeout(() => {
+        window.location.assign(href)
+      }, 60)
+    })
+  })
   const importMergeBaseSection = document.getElementById('importMergeBaseSection')
   const importMergeBaseConfig = document.getElementById('importMergeBaseConfig')
   const importPlexCredentials = document.getElementById('importPlexCredentials')

--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -31,6 +31,7 @@ let logscanAnalyzeInFlight = false
 let runProgressInFlight = false
 let activeRunCommandOverride = null
 let activeRunCommandMode = null
+let latestKometaStatusPayload = null
 const KOMETA_BRANCH_OVERRIDE_STORAGE_KEY = 'qs-kometa-branch-override'
 let kometaUpdatePollInterval = null
 let kometaUpdateJobId = null
@@ -1918,6 +1919,34 @@ $(document).ready(function () {
       }
     }
 
+    const maintenanceRow = document.getElementById('run-maintenance-row')
+    if (maintenanceRow) {
+      const statusData = latestKometaStatusPayload || {}
+      const windowLabel = statusData.maintenance_window ? ` (${statusData.maintenance_window})` : ''
+      if (statusData.maintenance_paused) {
+        let pauseLabel = 'Paused'
+        const pausedSince = statusData.maintenance_paused_since ? new Date(statusData.maintenance_paused_since) : null
+        if (pausedSince && !Number.isNaN(pausedSince.getTime())) {
+          const elapsedSeconds = Math.max(0, Math.floor((Date.now() - pausedSince.getTime()) / 1000))
+          pauseLabel = formatRunSeconds(elapsedSeconds) || 'Paused'
+        }
+        maintenanceRow.innerHTML = `
+          <span class="me-2 fw-semibold">Maintenance</span>
+          <span class="badge text-bg-warning text-dark">Paused${windowLabel}</span>
+          <span class="badge text-bg-secondary">${pauseLabel}</span>
+        `
+        maintenanceRow.classList.remove('d-none')
+      } else if (statusData.maintenance_active) {
+        maintenanceRow.innerHTML = `
+          <span class="me-2 fw-semibold">Maintenance</span>
+          <span class="badge text-bg-warning text-dark">Window Active${windowLabel}</span>
+        `
+        maintenanceRow.classList.remove('d-none')
+      } else {
+        maintenanceRow.classList.add('d-none')
+      }
+    }
+
     const allowed = Array.isArray(payload.allowed_phases) && payload.allowed_phases.length
       ? new Set(payload.allowed_phases)
       : null
@@ -2081,6 +2110,10 @@ $(document).ready(function () {
     const container = document.getElementById('run-progress')
     if (container) {
       container.classList.add('d-none')
+    }
+    const maintenanceRow = document.getElementById('run-maintenance-row')
+    if (maintenanceRow) {
+      maintenanceRow.classList.add('d-none')
     }
     if (resetCache) {
       lastRunProgressPayload = null
@@ -3393,6 +3426,7 @@ $(document).ready(function () {
     return fetch('/kometa-status')
       .then(res => res.json())
       .then(data => {
+        latestKometaStatusPayload = data || null
         KOMETA_STATUS = data.status || null
         KOMETA_PENDING_START = Boolean(data.pending_start && data.status !== 'running')
         const $updateBtn = $updateKometaBtn
@@ -3419,6 +3453,9 @@ $(document).ready(function () {
         updateRunStatus(data)
         if (typeof window.QS_handleMaintenanceStatus === 'function') {
           window.QS_handleMaintenanceStatus(data)
+        }
+        if (lastRunProgressPayload && data.status === 'running') {
+          renderRunProgress(lastRunProgressPayload)
         }
 
         if (data.pending_start && data.status !== 'running') {

--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -2613,7 +2613,8 @@ $(document).ready(function () {
   const SPARKLINE_MAX_POINTS = 40
   const runSparkState = {
     cpu: { system: [], kometa: [] },
-    mem: { system: [], kometa: [] }
+    mem: { system: [], kometa: [] },
+    io: { read: [], write: [] }
   }
 
   function clampPercent (value) {
@@ -2644,22 +2645,42 @@ $(document).ready(function () {
     }).join(' ')
   }
 
+  function buildSparklinePointsScaled (series, maxValue) {
+    if (!series.length) return ''
+    const safeMax = typeof maxValue === 'number' && Number.isFinite(maxValue) && maxValue > 0 ? maxValue : 1
+    const normalized = series.map(value => {
+      if (typeof value !== 'number' || !Number.isFinite(value)) return 0
+      return Math.max(0, Math.min(100, (value / safeMax) * 100))
+    })
+    return buildSparklinePoints(normalized)
+  }
+
   function renderRunSparklines () {
     if (!$runStatusSparklines.length) return
     const hasData = runSparkState.cpu.system.length || runSparkState.cpu.kometa.length ||
-      runSparkState.mem.system.length || runSparkState.mem.kometa.length
+      runSparkState.mem.system.length || runSparkState.mem.kometa.length ||
+      runSparkState.io.read.length || runSparkState.io.write.length
     $runStatusSparklines.toggleClass('d-none', !hasData)
     if (!hasData) {
       if ($runSparkCpuSystem.length) $runSparkCpuSystem.attr('points', '')
       if ($runSparkCpuKometa.length) $runSparkCpuKometa.attr('points', '')
       if ($runSparkMemSystem.length) $runSparkMemSystem.attr('points', '')
       if ($runSparkMemKometa.length) $runSparkMemKometa.attr('points', '')
+      const $runSparkIoRead = $('#run-spark-io-read')
+      const $runSparkIoWrite = $('#run-spark-io-write')
+      if ($runSparkIoRead.length) $runSparkIoRead.attr('points', '')
+      if ($runSparkIoWrite.length) $runSparkIoWrite.attr('points', '')
       return
     }
     if ($runSparkCpuSystem.length) $runSparkCpuSystem.attr('points', buildSparklinePoints(runSparkState.cpu.system))
     if ($runSparkCpuKometa.length) $runSparkCpuKometa.attr('points', buildSparklinePoints(runSparkState.cpu.kometa))
     if ($runSparkMemSystem.length) $runSparkMemSystem.attr('points', buildSparklinePoints(runSparkState.mem.system))
     if ($runSparkMemKometa.length) $runSparkMemKometa.attr('points', buildSparklinePoints(runSparkState.mem.kometa))
+    const $runSparkIoRead = $('#run-spark-io-read')
+    const $runSparkIoWrite = $('#run-spark-io-write')
+    const ioMax = Math.max(0, ...runSparkState.io.read, ...runSparkState.io.write)
+    if ($runSparkIoRead.length) $runSparkIoRead.attr('points', buildSparklinePointsScaled(runSparkState.io.read, ioMax))
+    if ($runSparkIoWrite.length) $runSparkIoWrite.attr('points', buildSparklinePointsScaled(runSparkState.io.write, ioMax))
   }
 
   function resetRunSparklines () {
@@ -2667,6 +2688,8 @@ $(document).ready(function () {
     runSparkState.cpu.kometa = []
     runSparkState.mem.system = []
     runSparkState.mem.kometa = []
+    runSparkState.io.read = []
+    runSparkState.io.write = []
     renderRunSparklines()
   }
 
@@ -2679,10 +2702,18 @@ $(document).ready(function () {
     const cpuKometa = clampPercent(data.cpu_percent)
     const memSystem = clampPercent(data.system_memory_percent)
     const memKometa = clampPercent(data.memory_percent)
+    const ioRead = (typeof data.disk_read_rate_mb_s === 'number' && Number.isFinite(data.disk_read_rate_mb_s))
+      ? Math.max(0, data.disk_read_rate_mb_s)
+      : null
+    const ioWrite = (typeof data.disk_write_rate_mb_s === 'number' && Number.isFinite(data.disk_write_rate_mb_s))
+      ? Math.max(0, data.disk_write_rate_mb_s)
+      : null
     pushSparkValue(runSparkState.cpu.system, cpuSystem)
     pushSparkValue(runSparkState.cpu.kometa, cpuKometa)
     pushSparkValue(runSparkState.mem.system, memSystem)
     pushSparkValue(runSparkState.mem.kometa, memKometa)
+    pushSparkValue(runSparkState.io.read, ioRead)
+    pushSparkValue(runSparkState.io.write, ioWrite)
     renderRunSparklines()
   }
 
@@ -2717,8 +2748,23 @@ $(document).ready(function () {
       const sysPct = (typeof data.system_memory_percent === 'number' && Number.isFinite(data.system_memory_percent))
         ? `${data.system_memory_percent.toFixed(1)}%`
         : 'n/a'
+      const formatDiskMb = (valueMb) => {
+        if (typeof valueMb !== 'number' || !Number.isFinite(valueMb)) return 'n/a'
+        if (valueMb >= 1024) return `${(valueMb / 1024).toFixed(1)} GB`
+        return `${valueMb.toFixed(1)} MB`
+      }
+      const formatDiskRate = (valueMbS) => {
+        if (typeof valueMbS !== 'number' || !Number.isFinite(valueMbS)) return 'n/a'
+        if (valueMbS >= 1024) return `${(valueMbS / 1024).toFixed(2)} GB/s`
+        return `${valueMbS.toFixed(2)} MB/s`
+      }
+      const hasDiskData = [data.disk_read_mb, data.disk_write_mb, data.disk_read_rate_mb_s, data.disk_write_rate_mb_s]
+        .some(value => typeof value === 'number' && Number.isFinite(value))
+      const diskText = hasDiskData
+        ? ` | Disk: R ${formatDiskRate(data.disk_read_rate_mb_s)} • W ${formatDiskRate(data.disk_write_rate_mb_s)} • ${formatDiskMb(data.disk_read_mb)} read • ${formatDiskMb(data.disk_write_mb)} written`
+        : ''
       $runStatusTimer.text(`Running since: ${startedAt} • Elapsed: ${elapsed || 'n/a'}`)
-      $runStatusMetrics.text(`Kometa: ${cpuText} CPU • ${memRss} (${memPct}) | System: ${sysCpu} CPU • ${sysUsed} / ${sysTotal} (${sysPct})`)
+      $runStatusMetrics.text(`Kometa: ${cpuText} CPU • ${memRss} (${memPct}) | System: ${sysCpu} CPU • ${sysUsed} / ${sysTotal} (${sysPct})${diskText}`)
     } else if (data && data.status === 'done') {
       $runStatusTimer.text('Kometa run complete.')
       $runStatusMetrics.text('')

--- a/static/local-js/905-analytics.js
+++ b/static/local-js/905-analytics.js
@@ -95,6 +95,7 @@ $(document).ready(function () {
   let allIncompleteRunsTotal = 0
   let latestArchiveStorage = null
   let tablePage = 1
+  let tableStatusFilter = 'all'
   const selectedRunKeys = new Set()
   const sortState = { key: 'finished_at', dir: 'desc' }
   let lastIngestState = null
@@ -581,6 +582,43 @@ $(document).ready(function () {
   function getCount (run, key) {
     const value = run && typeof run[key] === 'number' ? run[key] : 0
     return Number.isFinite(value) ? value : 0
+  }
+
+  function renderRunCountChips (run) {
+    if (getRunToolName(run) === 'imagemaid') {
+      const cache = getCount(run, 'cache_line_count')
+      const debug = getCount(run, 'debug_count')
+      const info = getCount(run, 'info_count')
+      const warnings = getCount(run, 'warning_count')
+      const errors = getCount(run, 'error_count')
+      const critical = getCount(run, 'critical_count')
+      const traces = getCount(run, 'trace_count')
+      const total = cache + debug + info + warnings + errors + critical + traces
+      return [
+        renderCountChip('C', 'Cache lines', cache, 'cache'),
+        renderCountChip('D', 'Debug lines', debug, 'debug'),
+        renderCountChip('I', 'Info lines', info, 'info'),
+        renderCountChip('W', 'Warnings', warnings, 'warning'),
+        renderCountChip('E', 'Errors', errors, 'error'),
+        renderCountChip('Cr', 'Critical lines', critical, 'critical'),
+        renderCountChip('T', 'Tracebacks', traces, 'trace'),
+        renderCountChip('Tot', 'Total counted lines', total, 'total')
+      ].join('')
+    }
+
+    const warnings = getCount(run, 'warning_count')
+    const errors = getCount(run, 'error_count')
+    const traces = getCount(run, 'trace_count')
+    const libraryTotals = getRunLibraryTotals(run)
+    return [
+      renderCountChip('W', 'Warnings', warnings, 'warning'),
+      renderCountChip('E', 'Errors', errors, 'error'),
+      renderCountChip('T', 'Tracebacks', traces, 'trace'),
+      renderCountChip('M', 'Movies', libraryTotals.movies, 'movie'),
+      renderCountChip('S', 'Shows', libraryTotals.shows, 'show'),
+      renderCountChip('Ep', 'Episodes', libraryTotals.episodes, 'episode'),
+      renderCountChip('Tot', 'Total items', libraryTotals.total, 'total')
+    ].join('')
   }
 
   function getIssueCount (run, key, fallbackKey) {
@@ -1651,10 +1689,23 @@ $(document).ready(function () {
     }
     if ($tableSelectComplete.length) {
       $tableSelectComplete.prop('disabled', visibleCompleteSelectable === 0)
+      $tableSelectComplete.toggleClass('is-active', tableStatusFilter === 'complete')
     }
     if ($tableSelectIncomplete.length) {
       $tableSelectIncomplete.prop('disabled', visibleIncompleteSelectable === 0)
+      $tableSelectIncomplete.toggleClass('is-active', tableStatusFilter === 'incomplete')
     }
+  }
+
+  function filterTableRunsByStatus (runs) {
+    if (!Array.isArray(runs) || !runs.length) return []
+    if (tableStatusFilter === 'complete') {
+      return runs.filter(run => !run.is_incomplete)
+    }
+    if (tableStatusFilter === 'incomplete') {
+      return runs.filter(run => Boolean(run.is_incomplete))
+    }
+    return runs
   }
 
   function updateTableSummary (total, pageSize, pageCount) {
@@ -1702,19 +1753,7 @@ $(document).ready(function () {
       const commandTitle = run.run_command
         ? `Original: ${run.run_command}`
         : (run.command_signature ? `Signature: ${run.command_signature}` : '')
-      const warnings = getCount(run, 'warning_count')
-      const errors = getCount(run, 'error_count')
-      const traces = getCount(run, 'trace_count')
-      const libraryTotals = getRunLibraryTotals(run)
-      const countChips = [
-        renderCountChip('W', 'Warnings', warnings, 'warning'),
-        renderCountChip('E', 'Errors', errors, 'error'),
-        renderCountChip('T', 'Tracebacks', traces, 'trace'),
-        renderCountChip('M', 'Movies', libraryTotals.movies, 'movie'),
-        renderCountChip('S', 'Shows', libraryTotals.shows, 'show'),
-        renderCountChip('Ep', 'Episodes', libraryTotals.episodes, 'episode'),
-        renderCountChip('Tot', 'Total items', libraryTotals.total, 'total')
-      ].join('')
+      const countChips = renderRunCountChips(run)
       const configLineCount = (typeof run.config_line_count === 'number' && Number.isFinite(run.config_line_count))
         ? run.config_line_count
         : 'n/a'
@@ -1799,11 +1838,14 @@ $(document).ready(function () {
         <tr class="${isSelected ? 'logscan-row-selected' : ''}">
           ${renderRunCardCell('Select', 'Select this archived log for bulk actions.', `
             <span class="logscan-select-wrap">
-              <input type="checkbox" class="form-check-input logscan-select-checkbox"
-                data-run-key="${escapeHtml(runKey)}"
-                ${isSelected ? 'checked' : ''}
-                ${isSelectable ? '' : 'disabled'}
-                aria-label="Select ${escapeHtml(runLabel)}">
+              <span class="form-check form-switch logscan-select-switch">
+                <input type="checkbox" class="form-check-input logscan-select-toggle-input"
+                  data-run-key="${escapeHtml(runKey)}"
+                  ${isSelected ? 'checked' : ''}
+                  ${isSelectable ? '' : 'disabled'}
+                  aria-label="Select ${escapeHtml(runLabel)}">
+                <label class="form-check-label">${isSelected ? 'Selected' : 'Select'}</label>
+              </span>
             </span>
           `, 'class="logscan-select-cell"')}
           ${renderRunCardCell('Status', 'Complete runs are included in charts. Incomplete logs are shown here for investigation and file management.', `<span class="${run.is_incomplete ? 'text-warning' : 'text-success'} fw-semibold">${escapeHtml(statusDisplay)}</span>${startModeBadge}`, 'class="text-nowrap"')}
@@ -2532,7 +2574,7 @@ $(document).ready(function () {
       state = getFilterState()
     }
     const filtered = filterRuns(allRuns, state)
-    const filteredTableRuns = filterRuns(allTableRuns, state)
+    const filteredTableRuns = filterTableRunsByStatus(filterRuns(allTableRuns, state))
     currentFilteredRuns = filtered
     updateRunCountDisplay(filtered)
     renderSummary(filtered)
@@ -3463,6 +3505,7 @@ $(document).ready(function () {
   $resetFilters.on('click', function () {
     $limit.val('500')
     tablePage = 1
+    tableStatusFilter = 'all'
     $configFilter.val('')
     $toolFilter.val('')
     $timeRange.val('all')
@@ -3536,7 +3579,7 @@ $(document).ready(function () {
     const runKey = $(this).data('runKey') || $(this).attr('data-run-key')
     showRunDetails(runKey)
   })
-  $tableBody.on('change', '.logscan-select-checkbox', function () {
+  $tableBody.on('change', '.logscan-select-toggle-input', function () {
     const runKey = $(this).data('runKey') || $(this).attr('data-run-key')
     if (!runKey) return
     if ($(this).is(':checked')) {
@@ -3563,12 +3606,14 @@ $(document).ready(function () {
     renderTable(currentTableRuns)
   })
   $tableSelectComplete.on('click', function () {
-    getSelectableRunsByCompletion(currentTableRuns, false).forEach(run => selectedRunKeys.add(run.run_key))
-    renderTable(currentTableRuns)
+    tableStatusFilter = tableStatusFilter === 'complete' ? 'all' : 'complete'
+    tablePage = 1
+    applyFiltersAndRender()
   })
   $tableSelectIncomplete.on('click', function () {
-    getSelectableRunsByCompletion(currentTableRuns, true).forEach(run => selectedRunKeys.add(run.run_key))
-    renderTable(currentTableRuns)
+    tableStatusFilter = tableStatusFilter === 'incomplete' ? 'all' : 'incomplete'
+    tablePage = 1
+    applyFiltersAndRender()
   })
   $tableClearSelection.on('click', function () {
     selectedRunKeys.clear()

--- a/static/local-js/915-imagemaid.js
+++ b/static/local-js/915-imagemaid.js
@@ -40,6 +40,8 @@ $(document).ready(function () {
   let lastImageMaidLogPayload = null
   let lastImageMaidLogText = ''
   let lastImageMaidLogPath = ''
+  let imagemaidLastPayloadSignature = ''
+  let imagemaidDirty = false
   const SPARKLINE_MAX_POINTS = 40
   const SPARKLINE_WIDTH = 180
   const SPARKLINE_HEIGHT = 48
@@ -353,6 +355,28 @@ $(document).ready(function () {
     }
   }
 
+  function buildPayloadSignature (payload = collectPayload()) {
+    return JSON.stringify({
+      config_name: String(payload.config_name || '').trim(),
+      branch_override: String(payload.branch_override || '').trim(),
+      plex_path: String(payload.plex_path || '').trim(),
+      mode: String(payload.mode || 'report').trim().toLowerCase(),
+      timeout: String(payload.timeout || '').trim(),
+      sleep: String(payload.sleep || '').trim(),
+      photo_transcoder: Boolean(payload.photo_transcoder),
+      empty_trash: Boolean(payload.empty_trash),
+      clean_bundles: Boolean(payload.clean_bundles),
+      optimize_db: Boolean(payload.optimize_db),
+      local_db: Boolean(payload.local_db),
+      use_existing: Boolean(payload.use_existing),
+      ignore_running: Boolean(payload.ignore_running),
+      trace: Boolean(payload.trace),
+      log_requests: Boolean(payload.log_requests),
+      no_verify_ssl: imagemaidSupportsNoVerifySsl ? Boolean(payload.no_verify_ssl) : false,
+      overlays_only: imagemaidSupportsOverlaysOnly ? Boolean(payload.overlays_only) : false
+    })
+  }
+
   function escapeCommandValue (value) {
     return `"${String(value || '').replaceAll('"', '\\"')}"`
   }
@@ -439,7 +463,7 @@ $(document).ready(function () {
       return
     }
 
-    if (!imagemaidValidated) {
+    if (imagemaidDirty || !imagemaidValidated) {
       els.runGate.removeClass('d-none alert-secondary alert-danger').addClass('alert-warning')
       els.runGateTitle.text('Validate ImageMaid first')
       els.runGateText.text('Configuration changed or has not been validated yet. Validate ImageMaid to unlock the command preview and run controls.')
@@ -493,7 +517,7 @@ $(document).ready(function () {
     syncRunGate()
   }
 
-  function queueAutosave () {
+  function queueAutosave (payload = collectPayload(), signature = buildPayloadSignature(payload)) {
     if (autosaveTimer) clearTimeout(autosaveTimer)
     autosaveTimer = setTimeout(() => {
       if (imagemaidAutosaveInFlight) {
@@ -504,8 +528,40 @@ $(document).ready(function () {
       fetch('/autosave-imagemaid', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(collectPayload())
+        body: JSON.stringify(payload)
       })
+        .then(async (res) => ({ ok: res.ok, body: await res.json().catch(() => ({})) }))
+        .then(({ ok, body }) => {
+          if (!ok || !body || body.success === false) return
+          imagemaidLastPayloadSignature = signature
+          imagemaidDirty = false
+          if (body.changed) {
+            imagemaidValidated = Boolean(body.validated)
+            restoreFolderModeConflict = false
+            imagemaidUpdateCheckCompleted = false
+            imagemaidUpdateCheckSkipped = false
+            imagemaidUpdateAvailable = false
+            setValidationState('idle', 'Configuration changed. Validate ImageMaid again.')
+            syncPrepareSummary({
+              imagemaid_installed: imagemaidInstalled,
+              venv_python_exists: imagemaidVenvReady,
+              imagemaid_running: imagemaidRunning,
+              local_branch: els.localBranchStatus.text(),
+              local_sha: els.localShaStatus.text(),
+              effective_branch: imagemaidEffectiveBranch,
+              branch_source_url: els.branchSourceUrl.text(),
+              zip_source_url: els.zipSourceUrl.text(),
+              imagemaid_root_display: els.installPath.text()
+            }, {
+              updateAvailable: false,
+              updateCheckCompleted: false,
+              updateCheckSkipped: false
+            })
+          } else if (body.validated) {
+            imagemaidValidated = true
+            setValidationState('ok', 'ImageMaid is ready to run.')
+          }
+        })
         .catch(() => {})
         .finally(() => {
           imagemaidAutosaveInFlight = false
@@ -1007,6 +1063,8 @@ $(document).ready(function () {
       .then(async (res) => ({ ok: res.ok, body: await res.json() }))
       .then(({ ok, body }) => {
         imagemaidValidated = Boolean(body && body.validated)
+        imagemaidDirty = false
+        imagemaidLastPayloadSignature = buildPayloadSignature()
         restoreFolderModeConflict = Boolean(body && body.reason === 'restore_dir_blocks_mode')
         if (body && body.command_preview) {
           els.commandPreview.val(body.command_preview)
@@ -1024,6 +1082,7 @@ $(document).ready(function () {
       })
       .catch(() => {
         imagemaidValidated = false
+        imagemaidDirty = false
         restoreFolderModeConflict = false
         updateModeHelp()
         setValidationState('error', 'ImageMaid validation failed.')
@@ -1187,33 +1246,30 @@ $(document).ready(function () {
   }
 
   function onConfigChanged () {
-    const currentMode = String(els.mode.val() || 'report').trim().toLowerCase()
+    const payload = collectPayload()
+    const nextSignature = buildPayloadSignature(payload)
+    const currentMode = String(payload.mode || 'report').trim().toLowerCase()
+    if (!imagemaidLastPayloadSignature) {
+      imagemaidLastPayloadSignature = nextSignature
+      lastImageMaidMode = currentMode
+      updatePreviewFromPayload()
+      updateModeHelp()
+      return
+    }
+    if (nextSignature === imagemaidLastPayloadSignature) {
+      imagemaidDirty = false
+      updatePreviewFromPayload()
+      updateModeHelp()
+      syncRunGate()
+      return
+    }
+    imagemaidDirty = true
     const switchedToBlockedMode = lastImageMaidMode !== currentMode && ['report', 'move', 'remove'].includes(currentMode)
     lastImageMaidMode = currentMode
-    restoreFolderModeConflict = false
-    imagemaidValidated = false
-    imagemaidUpdateCheckCompleted = false
-    imagemaidUpdateCheckSkipped = false
-    imagemaidUpdateAvailable = false
-    setValidationState('idle', 'Configuration changed. Validate ImageMaid again.')
-    syncPrepareSummary({
-      imagemaid_installed: imagemaidInstalled,
-      venv_python_exists: imagemaidVenvReady,
-      imagemaid_running: imagemaidRunning,
-      local_branch: els.localBranchStatus.text(),
-      local_sha: els.localShaStatus.text(),
-      effective_branch: imagemaidEffectiveBranch,
-      branch_source_url: els.branchSourceUrl.text(),
-      zip_source_url: els.zipSourceUrl.text(),
-      imagemaid_root_display: els.installPath.text()
-    }, {
-      updateAvailable: false,
-      updateCheckCompleted: false,
-      updateCheckSkipped: false
-    })
     updatePreviewFromPayload()
     updateModeHelp()
-    queueAutosave()
+    syncRunGate()
+    queueAutosave(payload, nextSignature)
     if (switchedToBlockedMode && String($('#imagemaid_plex_path').val() || '').trim()) {
       validateImageMaid()
     }
@@ -1306,6 +1362,7 @@ $(document).ready(function () {
   syncOptionalCapabilityRows()
   syncBranchSummary()
   syncUpdateButtonLabel()
+  imagemaidLastPayloadSignature = buildPayloadSignature()
   els.tailLabel.text(imagemaidTailSize === 'all' ? 'all' : imagemaidTailSize)
   imagemaidLogAutoScroll = els.logAutoscroll.is(':checked')
   syncLogLevelButtons()

--- a/static/local-js/915-imagemaid.js
+++ b/static/local-js/915-imagemaid.js
@@ -33,6 +33,22 @@ $(document).ready(function () {
   let imagemaidValidationInFlight = false
   let imagemaidStatusInFlight = false
   let imagemaidLogInFlight = false
+  let imagemaidLogPollingPaused = false
+  let imagemaidLogAutoScroll = true
+  let imagemaidTailSize = '2000'
+  let lastImageMaidStatusPayload = null
+  let lastImageMaidLogPayload = null
+  let lastImageMaidLogText = ''
+  let lastImageMaidLogPath = ''
+  const SPARKLINE_MAX_POINTS = 40
+  const SPARKLINE_WIDTH = 180
+  const SPARKLINE_HEIGHT = 48
+  const SPARKLINE_PADDING = 6
+  const imagemaidSparkState = {
+    cpu: { system: [], imagemaid: [] },
+    mem: { system: [], imagemaid: [] },
+    io: { read: [], write: [] }
+  }
 
   const moveModalEl = document.getElementById('imagemaid-move-confirm-modal')
   if (moveModalEl && typeof bootstrap !== 'undefined') {
@@ -73,8 +89,22 @@ $(document).ready(function () {
     runGateText: $('#imagemaid-run-gate-text'),
     runSurface: $('#imagemaid-run-surface'),
     runState: $('#imagemaid-run-state'),
+    runStatusRow: $('#imagemaid-run-status-row'),
+    runStatusTimer: $('#imagemaid-run-status-timer'),
+    runStatusMetrics: $('#imagemaid-run-status-metrics'),
+    runStatusLog: $('#imagemaid-run-status-log'),
+    runStatusSparklines: $('#imagemaid-run-status-sparklines'),
+    runMaintenanceRow: $('#imagemaid-run-maintenance-row'),
     runStatus: $('#imagemaid-run-status'),
     runLog: $('#imagemaid-run-log'),
+    logAutoscroll: $('#imagemaid-log-autoscroll'),
+    logTailSize: $('#imagemaid-log-tail-size'),
+    tailLabel: $('#imagemaid-tail-label'),
+    downloadLog: $('#imagemaid-download-log'),
+    pauseLogPolling: $('#imagemaid-pause-log-polling'),
+    logFilter: $('#imagemaid-log-filter'),
+    logLevelButtons: $('.imagemaid-log-level-btn'),
+    logStatValues: $('[data-imagemaid-log-stat]'),
     commandPreview: $('#imagemaid-command-preview'),
     updateBtn: $('#update-imagemaid-btn'),
     forceUpdateToggle: $('#force-update-imagemaid'),
@@ -95,17 +125,22 @@ $(document).ready(function () {
     noVerifySsl: $('#imagemaid-no-verify-ssl-row'),
     overlaysOnly: $('#imagemaid-overlays-only-row')
   }
+  const $runSparkCpuSystem = $('#imagemaid-run-spark-cpu-system')
+  const $runSparkCpuImageMaid = $('#imagemaid-run-spark-cpu-imagemaid')
+  const $runSparkMemSystem = $('#imagemaid-run-spark-mem-system')
+  const $runSparkMemImageMaid = $('#imagemaid-run-spark-mem-imagemaid')
 
   function syncMaintenanceBadge (data) {
     if (!els.maintenanceBadge.length) return
     maintenanceActive = Boolean(data && data.maintenance_active)
     maintenanceWindowLabel = data && data.maintenance_window ? ` (${data.maintenance_window})` : ''
-    const active = maintenanceActive
+    const paused = Boolean(data && data.maintenance_paused)
+    const active = maintenanceActive || paused
     const windowLabel = maintenanceWindowLabel
     if (active) {
       els.maintenanceBadge.removeClass('d-none')
       const textEl = els.maintenanceBadge.find('span').last()
-      if (textEl.length) textEl.text(`Blocked by Plex maintenance${windowLabel}`)
+      if (textEl.length) textEl.text(`${paused ? 'Paused for' : 'Blocked by'} Plex maintenance${windowLabel}`)
     } else {
       els.maintenanceBadge.addClass('d-none')
     }
@@ -291,7 +326,14 @@ $(document).ready(function () {
   }
 
   function collectPayload () {
+    const activeConfig = String(
+      window.pageInfo?.config_name ||
+      $('#qs-active-config-input').val() ||
+      $('.qs-main-page-meta-value').first().text() ||
+      ''
+    ).trim()
     return {
+      config_name: activeConfig,
       branch_override: String($('#imagemaid_branch_override').val() || '').trim(),
       plex_path: String($('#imagemaid_plex_path').val() || '').trim(),
       mode: String($('#imagemaid_mode').val() || 'report').trim(),
@@ -479,6 +521,268 @@ $(document).ready(function () {
     return !document.hidden
   }
 
+  function formatRunSeconds (seconds) {
+    if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds < 0) return ''
+    const total = Math.max(0, Math.floor(seconds))
+    const hours = Math.floor(total / 3600)
+    const minutes = Math.floor((total % 3600) / 60)
+    const secs = total % 60
+    if (hours > 0) return `${hours}h ${minutes}m ${secs}s`
+    if (minutes > 0) return `${minutes}m ${secs}s`
+    return `${secs}s`
+  }
+
+  function formatTimestampLocal (value) {
+    if (!value) return ''
+    if (typeof window.QS_formatTimestamp === 'function') return window.QS_formatTimestamp(value)
+    const date = new Date(value)
+    if (Number.isNaN(date.getTime())) return String(value)
+    return date.toLocaleString()
+  }
+
+  function clampPercent (value) {
+    if (typeof value !== 'number' || !Number.isFinite(value)) return null
+    return Math.max(0, Math.min(100, value))
+  }
+
+  function pushSparkValue (series, value) {
+    if (value == null) {
+      if (!series.length) return
+      series.push(series[series.length - 1])
+    } else {
+      series.push(value)
+    }
+    if (series.length > SPARKLINE_MAX_POINTS) series.shift()
+  }
+
+  function buildSparklinePoints (series) {
+    if (!series.length) return ''
+    const width = SPARKLINE_WIDTH - SPARKLINE_PADDING * 2
+    const height = SPARKLINE_HEIGHT - SPARKLINE_PADDING * 2
+    const step = series.length > 1 ? width / (series.length - 1) : 0
+    return series.map((value, idx) => {
+      const x = SPARKLINE_PADDING + (idx * step)
+      const y = SPARKLINE_PADDING + (height - (height * (value / 100)))
+      return `${x.toFixed(1)},${y.toFixed(1)}`
+    }).join(' ')
+  }
+
+  function buildSparklinePointsScaled (series, maxValue) {
+    if (!series.length) return ''
+    const safeMax = typeof maxValue === 'number' && Number.isFinite(maxValue) && maxValue > 0 ? maxValue : 1
+    const normalized = series.map(value => {
+      if (typeof value !== 'number' || !Number.isFinite(value)) return 0
+      return Math.max(0, Math.min(100, (value / safeMax) * 100))
+    })
+    return buildSparklinePoints(normalized)
+  }
+
+  function renderRunSparklines () {
+    if (!els.runStatusSparklines.length) return
+    const hasData = imagemaidSparkState.cpu.system.length || imagemaidSparkState.cpu.imagemaid.length ||
+      imagemaidSparkState.mem.system.length || imagemaidSparkState.mem.imagemaid.length ||
+      imagemaidSparkState.io.read.length || imagemaidSparkState.io.write.length
+    els.runStatusSparklines.toggleClass('d-none', !hasData)
+    $runSparkCpuSystem.attr('points', hasData ? buildSparklinePoints(imagemaidSparkState.cpu.system) : '')
+    $runSparkCpuImageMaid.attr('points', hasData ? buildSparklinePoints(imagemaidSparkState.cpu.imagemaid) : '')
+    $runSparkMemSystem.attr('points', hasData ? buildSparklinePoints(imagemaidSparkState.mem.system) : '')
+    $runSparkMemImageMaid.attr('points', hasData ? buildSparklinePoints(imagemaidSparkState.mem.imagemaid) : '')
+    const $runSparkIoRead = $('#imagemaid-run-spark-io-read')
+    const $runSparkIoWrite = $('#imagemaid-run-spark-io-write')
+    const ioMax = Math.max(0, ...imagemaidSparkState.io.read, ...imagemaidSparkState.io.write)
+    $runSparkIoRead.attr('points', hasData ? buildSparklinePointsScaled(imagemaidSparkState.io.read, ioMax) : '')
+    $runSparkIoWrite.attr('points', hasData ? buildSparklinePointsScaled(imagemaidSparkState.io.write, ioMax) : '')
+  }
+
+  function resetRunSparklines () {
+    imagemaidSparkState.cpu.system = []
+    imagemaidSparkState.cpu.imagemaid = []
+    imagemaidSparkState.mem.system = []
+    imagemaidSparkState.mem.imagemaid = []
+    imagemaidSparkState.io.read = []
+    imagemaidSparkState.io.write = []
+    renderRunSparklines()
+  }
+
+  function updateRunSparklines (data) {
+    if (!data || String(data.status || '').trim().toLowerCase() !== 'running') {
+      resetRunSparklines()
+      return
+    }
+    pushSparkValue(imagemaidSparkState.cpu.system, clampPercent(data.system_cpu_percent))
+    pushSparkValue(imagemaidSparkState.cpu.imagemaid, clampPercent(data.cpu_percent))
+    pushSparkValue(imagemaidSparkState.mem.system, clampPercent(data.system_memory_percent))
+    pushSparkValue(imagemaidSparkState.mem.imagemaid, clampPercent(data.memory_percent))
+    const ioRead = (typeof data.disk_read_rate_mb_s === 'number' && Number.isFinite(data.disk_read_rate_mb_s))
+      ? Math.max(0, data.disk_read_rate_mb_s)
+      : null
+    const ioWrite = (typeof data.disk_write_rate_mb_s === 'number' && Number.isFinite(data.disk_write_rate_mb_s))
+      ? Math.max(0, data.disk_write_rate_mb_s)
+      : null
+    pushSparkValue(imagemaidSparkState.io.read, ioRead)
+    pushSparkValue(imagemaidSparkState.io.write, ioWrite)
+    renderRunSparklines()
+  }
+
+  function syncRunStatusVisibility () {
+    if (!els.runStatusRow.length) return
+    const hasText = Boolean(els.runStatusTimer.text() || els.runStatusMetrics.text() || els.runStatusLog.text())
+    els.runStatusRow.toggleClass('d-none', !hasText)
+  }
+
+  function updateRunStatusDetails (data) {
+    if (!els.runStatusRow.length) return
+    const status = String((data && data.status) || '').trim().toLowerCase()
+    if (status === 'running' || status === 'starting') {
+      const startedAt = formatTimestampLocal(data.started_at)
+      const elapsed = formatRunSeconds(data.elapsed_seconds)
+      const formatMem = (valueMb) => {
+        if (typeof valueMb !== 'number' || !Number.isFinite(valueMb)) return 'n/a'
+        if (valueMb >= 1024) return `${(valueMb / 1024).toFixed(1)} GB`
+        return `${valueMb.toFixed(1)} MB`
+      }
+      const cpuText = typeof data.cpu_percent === 'number' && Number.isFinite(data.cpu_percent) ? `${data.cpu_percent.toFixed(1)}%` : 'n/a'
+      const memRss = formatMem(data.memory_rss_mb)
+      const memPct = typeof data.memory_percent === 'number' && Number.isFinite(data.memory_percent) ? `${data.memory_percent.toFixed(1)}%` : 'n/a'
+      const sysCpu = typeof data.system_cpu_percent === 'number' && Number.isFinite(data.system_cpu_percent) ? `${data.system_cpu_percent.toFixed(1)}%` : 'n/a'
+      const sysUsed = formatMem(data.system_memory_used_mb)
+      const sysTotal = formatMem(data.system_memory_total_mb)
+      const sysPct = typeof data.system_memory_percent === 'number' && Number.isFinite(data.system_memory_percent) ? `${data.system_memory_percent.toFixed(1)}%` : 'n/a'
+      const formatDiskMb = (valueMb) => {
+        if (typeof valueMb !== 'number' || !Number.isFinite(valueMb)) return 'n/a'
+        if (valueMb >= 1024) return `${(valueMb / 1024).toFixed(1)} GB`
+        return `${valueMb.toFixed(1)} MB`
+      }
+      const formatDiskRate = (valueMbS) => {
+        if (typeof valueMbS !== 'number' || !Number.isFinite(valueMbS)) return 'n/a'
+        if (valueMbS >= 1024) return `${(valueMbS / 1024).toFixed(2)} GB/s`
+        return `${valueMbS.toFixed(2)} MB/s`
+      }
+      const hasDiskData = [data.disk_read_mb, data.disk_write_mb, data.disk_read_rate_mb_s, data.disk_write_rate_mb_s]
+        .some(value => typeof value === 'number' && Number.isFinite(value))
+      const diskText = hasDiskData
+        ? ` | Disk: R ${formatDiskRate(data.disk_read_rate_mb_s)} • W ${formatDiskRate(data.disk_write_rate_mb_s)} • ${formatDiskMb(data.disk_read_mb)} read • ${formatDiskMb(data.disk_write_mb)} written`
+        : ''
+      els.runStatusTimer.text(`${status === 'starting' ? 'Starting' : 'Running since'}: ${startedAt || 'n/a'}${elapsed ? ` • Elapsed: ${elapsed}` : ''}`)
+      els.runStatusMetrics.text(`ImageMaid: ${cpuText} CPU • ${memRss} (${memPct}) | System: ${sysCpu} CPU • ${sysUsed} / ${sysTotal} (${sysPct})${diskText}`)
+    } else if (status === 'done') {
+      els.runStatusTimer.text('ImageMaid run complete.')
+      els.runStatusMetrics.text('')
+    } else {
+      els.runStatusTimer.text('')
+      els.runStatusMetrics.text('')
+    }
+    updateRunSparklines(data)
+    syncRunStatusVisibility()
+  }
+
+  function updateMaintenanceRow (data) {
+    if (!els.runMaintenanceRow.length) return
+    const windowLabel = data && data.maintenance_window ? ` (${data.maintenance_window})` : ''
+    if (data && data.maintenance_paused) {
+      let pauseLabel = 'Paused'
+      const pausedSince = data.maintenance_paused_since ? new Date(data.maintenance_paused_since) : null
+      if (pausedSince && !Number.isNaN(pausedSince.getTime())) {
+        const elapsedSeconds = Math.max(0, Math.floor((Date.now() - pausedSince.getTime()) / 1000))
+        pauseLabel = formatRunSeconds(elapsedSeconds) || 'Paused'
+      }
+      els.runMaintenanceRow.html(`
+        <span class="me-2 fw-semibold">Maintenance</span>
+        <span class="badge text-bg-warning text-dark">Paused${windowLabel}</span>
+        <span class="badge text-bg-secondary">${pauseLabel}</span>
+      `).removeClass('d-none')
+      return
+    }
+    if (data && data.maintenance_active) {
+      els.runMaintenanceRow.html(`
+        <span class="me-2 fw-semibold">Maintenance</span>
+        <span class="badge text-bg-warning text-dark">Window Active${windowLabel}</span>
+      `).removeClass('d-none')
+      return
+    }
+    els.runMaintenanceRow.addClass('d-none').empty()
+  }
+
+  function computeLogStats (text, matcher) {
+    const stats = { filter: 0, cache: 0, debug: 0, info: 0, warn: 0, error: 0, crit: 0, trace: 0 }
+    const lines = String(text || '').split(/\r?\n/)
+    lines.forEach(line => {
+      if (!line) return
+      if (matcher && !matcher(line)) return
+      stats.filter += 1
+      const upper = line.toUpperCase()
+      if (upper.includes('[CACHE]') || /\bCACHE\b/.test(upper)) stats.cache += 1
+      if (upper.includes('[DEBUG]')) stats.debug += 1
+      if (upper.includes('[INFO]')) stats.info += 1
+      if (upper.includes('[WARNING]') || upper.includes('[WARN]')) stats.warn += 1
+      if (upper.includes('[ERROR]')) stats.error += 1
+      if (upper.includes('[CRITICAL]') || upper.includes('[CRIT]')) stats.crit += 1
+      if (upper.includes('[TRACE]')) stats.trace += 1
+    })
+    return stats
+  }
+
+  function updateLogStatBadges (stats) {
+    els.logStatValues.each(function () {
+      const key = String($(this).data('imagemaid-log-stat') || '').trim()
+      $(this).text(String((stats && stats[key]) || 0))
+    })
+  }
+
+  function syncLogLevelButtons () {
+    const activeFilter = String(els.logFilter.val() || '').trim()
+    els.logLevelButtons.each(function () {
+      const level = String($(this).data('level') || '').trim()
+      const isActive = Boolean(level) && level === activeFilter
+      $(this)
+        .toggleClass('btn-primary', isActive)
+        .toggleClass('btn-outline-secondary', !isActive)
+        .attr('aria-pressed', isActive ? 'true' : 'false')
+    })
+  }
+
+  function applyLogFilter () {
+    const payload = lastImageMaidLogPayload || {}
+    const rawText = String(payload.text || lastImageMaidLogText || '')
+    const filterText = String(els.logFilter.val() || '').trim()
+    let filteredText = rawText
+    let textMatcher = null
+    if (filterText) {
+      try {
+        const regex = new RegExp(filterText, 'i')
+        textMatcher = line => regex.test(line)
+      } catch (_) {
+        const lowered = filterText.toLowerCase()
+        textMatcher = line => String(line || '').toLowerCase().includes(lowered)
+      }
+    }
+    const matcher = textMatcher || null
+    if (matcher) {
+      filteredText = rawText.split(/\r?\n/).filter(line => matcher(line)).join('\n')
+    }
+    els.runLog.text(filteredText || (rawText ? 'No lines matched the current filter.' : 'ImageMaid log is empty.'))
+    updateLogStatBadges(computeLogStats(rawText, matcher))
+    syncLogLevelButtons()
+    if (imagemaidLogAutoScroll && els.runLog.length) {
+      els.runLog.scrollTop(els.runLog[0].scrollHeight)
+    }
+  }
+
+  function updateLogRecency (payload) {
+    if (!els.runStatusLog.length) return
+    if (!payload || typeof payload.log_age_seconds !== 'number') {
+      els.runStatusLog.text('')
+      syncRunStatusVisibility()
+      return
+    }
+    const ageText = formatRunSeconds(payload.log_age_seconds) || 'n/a'
+    const totalLines = typeof payload.total_lines === 'number' && Number.isFinite(payload.total_lines)
+      ? payload.total_lines.toLocaleString()
+      : '0'
+    els.runStatusLog.text(`${lastImageMaidLogPath ? `${lastImageMaidLogPath.split(/[\\\\/]/).pop()} updated ` : 'Log updated '}${ageText} ago • ${totalLines} lines`)
+    syncRunStatusVisibility()
+  }
+
   function setRunState (state, message) {
     if (state === 'running') {
       imagemaidRunning = true
@@ -516,6 +820,9 @@ $(document).ready(function () {
       els.stopBtn.prop('disabled', true)
     }
     if (message) els.runStatus.text(message)
+    if (!imagemaidRunning && !imagemaidStarting) {
+      updateMaintenanceRow(lastImageMaidStatusPayload)
+    }
     syncRunGate()
   }
 
@@ -729,20 +1036,32 @@ $(document).ready(function () {
 
   function loadLog (force = false) {
     if (imagemaidLogInFlight) return Promise.resolve(null)
-    if (!force && (!shouldPollImageMaidPage() || (!imagemaidRunning && !imagemaidStarting))) return Promise.resolve(null)
+    if (!force && (imagemaidLogPollingPaused || !shouldPollImageMaidPage() || (!imagemaidRunning && !imagemaidStarting))) return Promise.resolve(null)
     imagemaidLogInFlight = true
-    return fetch('/tail-imagemaid-log')
+    return fetch(`/tail-imagemaid-log?lines=${encodeURIComponent(imagemaidTailSize)}`)
       .then(async (res) => ({ ok: res.ok, body: await res.json() }))
       .then(({ ok, body }) => {
         if (!ok || !body.success) {
+          lastImageMaidLogPayload = null
+          lastImageMaidLogText = ''
+          lastImageMaidLogPath = ''
           els.runLog.text((body && body.error) || 'No ImageMaid log found yet.')
+          updateLogStatBadges({ filter: 0, cache: 0, debug: 0, info: 0, warn: 0, error: 0, crit: 0, trace: 0 })
+          updateLogRecency(null)
           return
         }
-        els.runLog.text(body.text || 'ImageMaid log is empty.')
-        els.runLog.scrollTop(els.runLog[0].scrollHeight)
+        lastImageMaidLogPayload = body
+        lastImageMaidLogText = String(body.text || '')
+        lastImageMaidLogPath = String(body.path || '')
+        const requested = String(body.requested_lines || imagemaidTailSize)
+        els.tailLabel.text(requested.toLowerCase() === 'all' ? 'all' : requested)
+        updateLogRecency(body)
+        applyLogFilter()
       })
       .catch(() => {
+        lastImageMaidLogPayload = null
         els.runLog.text('Failed to load the ImageMaid log.')
+        updateLogRecency(null)
       })
       .finally(() => {
         imagemaidLogInFlight = false
@@ -757,19 +1076,26 @@ $(document).ready(function () {
       .then(async (res) => ({ ok: res.ok, body: await res.json() }))
       .then(({ ok, body }) => {
         if (!ok) return
+        lastImageMaidStatusPayload = body
+        syncMaintenanceBadge(body)
+        updateRunStatusDetails(body)
+        updateMaintenanceRow(body)
+        if (body && body.active_command && (String(body.status || '').trim().toLowerCase() === 'running' || String(body.status || '').trim().toLowerCase() === 'starting')) {
+          els.commandPreview.val(body.active_command)
+        }
         if (typeof window.QS_handleImageMaidStatus === 'function') {
           window.QS_handleImageMaidStatus(body)
         }
         const status = String(body.status || '').trim().toLowerCase()
         if (status === 'running') {
-          const elapsed = typeof body.elapsed_seconds === 'number' ? `Elapsed ${body.elapsed_seconds}s.` : 'ImageMaid is currently running.'
+          const elapsed = typeof body.elapsed_seconds === 'number' ? `Elapsed ${formatRunSeconds(body.elapsed_seconds) || `${body.elapsed_seconds}s`}.` : 'ImageMaid is currently running.'
           setRunState('running', elapsed)
           loadLog(true)
           return
         }
         if (status === 'starting') {
           imagemaidStartupDeadline = Date.now() + 10000
-          const elapsed = typeof body.elapsed_seconds === 'number' ? `ImageMaid is still starting (${body.elapsed_seconds}s).` : 'ImageMaid is still starting.'
+          const elapsed = typeof body.elapsed_seconds === 'number' ? `ImageMaid is still starting (${formatRunSeconds(body.elapsed_seconds) || `${body.elapsed_seconds}s`}).` : 'ImageMaid is still starting.'
           setRunState('starting', elapsed)
           loadLog(true)
           return
@@ -781,10 +1107,13 @@ $(document).ready(function () {
         }
         if (status === 'done') {
           setRunState('idle', 'ImageMaid finished.')
+          updatePreviewFromPayload()
           loadLog(true)
           return
         }
         setRunState('idle', 'ImageMaid is not running.')
+        updatePreviewFromPayload()
+        updateRunStatusDetails(body)
       })
       .catch(() => {})
       .finally(() => {
@@ -930,6 +1259,43 @@ $(document).ready(function () {
 
   $('#imagemaid_mode, #imagemaid_plex_path, #imagemaid_timeout, #imagemaid_sleep, #imagemaid_branch_override').on('input change', onConfigChanged)
   $('#imagemaid_photo_transcoder, #imagemaid_empty_trash, #imagemaid_clean_bundles, #imagemaid_optimize_db, #imagemaid_local_db, #imagemaid_use_existing, #imagemaid_ignore_running, #imagemaid_trace, #imagemaid_log_requests, #imagemaid_no_verify_ssl, #imagemaid_overlays_only').on('change', onConfigChanged)
+  els.logAutoscroll.on('change', function () {
+    imagemaidLogAutoScroll = $(this).is(':checked')
+  })
+  els.logTailSize.on('change', function () {
+    const next = String($(this).val() || '2000').trim().toLowerCase()
+    imagemaidTailSize = next === 'all' ? 'all' : (['200', '2000', '20000'].includes(next) ? next : '2000')
+    els.tailLabel.text(imagemaidTailSize === 'all' ? 'all' : imagemaidTailSize)
+    loadLog(true)
+  })
+  els.logFilter.on('input', applyLogFilter)
+  els.logLevelButtons.on('click', function () {
+    const nextLevel = String($(this).data('level') || '').trim()
+    const currentFilter = String(els.logFilter.val() || '').trim()
+    els.logFilter.val(currentFilter === nextLevel ? '' : nextLevel)
+    applyLogFilter()
+  })
+  els.pauseLogPolling.on('click', function () {
+    imagemaidLogPollingPaused = !imagemaidLogPollingPaused
+    if (imagemaidLogPollingPaused) {
+      $(this).html('<i class="bi bi-play-circle me-1"></i> Resume')
+    } else {
+      $(this).html('<i class="bi bi-pause-circle me-1"></i> Pause')
+      loadLog(true)
+    }
+  })
+  els.downloadLog.on('click', function () {
+    const text = String((lastImageMaidLogPayload && lastImageMaidLogPayload.text) || lastImageMaidLogText || '')
+    const blob = new Blob([text], { type: 'text/plain;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = lastImageMaidLogPath ? lastImageMaidLogPath.split(/[\\/]/).pop() : 'imagemaid.log'
+    document.body.appendChild(anchor)
+    anchor.click()
+    anchor.remove()
+    URL.revokeObjectURL(url)
+  })
 
   if (window.PathValidation && typeof PathValidation.attach === 'function') {
     PathValidation.attach(document)
@@ -940,6 +1306,9 @@ $(document).ready(function () {
   syncOptionalCapabilityRows()
   syncBranchSummary()
   syncUpdateButtonLabel()
+  els.tailLabel.text(imagemaidTailSize === 'all' ? 'all' : imagemaidTailSize)
+  imagemaidLogAutoScroll = els.logAutoscroll.is(':checked')
+  syncLogLevelButtons()
   setValidationState(imagemaidValidated ? 'ok' : 'idle', String(els.validationStatus.text() || '').trim())
   probeRoot()
   updateStatus(true)
@@ -951,4 +1320,5 @@ $(document).ready(function () {
     }
   })
   setInterval(() => updateStatus(), 7000)
+  setInterval(() => loadLog(), 5000)
 })

--- a/templates/001-navigation.html
+++ b/templates/001-navigation.html
@@ -251,7 +251,7 @@
                 <a id="qs-maintenance-unavailable-badge" class="d-none qs-header-status-pill" href="{{ url_for('step', name='900-kometa') }}"
                   title="Open Kometa">
                   <span class="badge rounded-pill text-bg-warning text-dark px-3 py-2">
-                    <i class="bi bi-exclamation-triangle me-1"></i> Plex maintenance window unavailable
+                    <i class="bi bi-exclamation-triangle me-1"></i> Plex maintenance window data unavailable
                   </span>
                 </a>
                 <a id="qs-queued-badge" class="d-none qs-header-status-pill" href="{{ url_for('step', name='900-kometa') }}"

--- a/templates/001-start.html
+++ b/templates/001-start.html
@@ -52,11 +52,11 @@
                 {% else %}
                 <p class="small text-muted mb-3">Plex, TMDb, libraries, or final validation still need attention before this config is fully ready for Kometa.</p>
                 {% endif %}
-                <div class="start-link-row start-link-row-buttons">
-                  <a class="btn btn-sm nav-button" href="/step/900-kometa">Open Run Page</a>
-                  <a class="btn btn-sm nav-button" href="#" data-bs-toggle="modal" data-bs-target="#exampleModal">More Info...</a>
-                  <a class="btn btn-sm nav-button" href="https://kometa.wiki/en/{{ version_info.kometa_branch }}/" target="_blank" rel="noreferrer">Wiki</a>
-                </div>
+                  <div class="start-link-row start-link-row-buttons">
+                   <a class="btn btn-sm nav-button qs-start-step-link" href="/step/900-kometa" data-qs-target-label="Kometa">Open Run Page</a>
+                   <a class="btn btn-sm nav-button" href="#" data-bs-toggle="modal" data-bs-target="#exampleModal">More Info...</a>
+                   <a class="btn btn-sm nav-button" href="https://kometa.wiki/en/{{ version_info.kometa_branch }}/" target="_blank" rel="noreferrer">Wiki</a>
+                  </div>
               </div>
             </div>
             <div class="col-lg-6">
@@ -72,11 +72,11 @@
                 {% else %}
                 <p class="small text-muted mb-3">ImageMaid settings for this config still need validation before the run page is truly ready to launch.</p>
                 {% endif %}
-                <div class="start-link-row start-link-row-buttons">
-                  <a class="btn btn-sm nav-button" href="/step/915-imagemaid">Open Run Page</a>
-                  <a class="btn btn-sm nav-button" href="#" data-bs-toggle="modal" data-bs-target="#imageMaidInfoModal">More Info...</a>
-                  <a class="btn btn-sm nav-button" href="https://kometa.wiki/en/{{ version_info.kometa_branch }}/kometa/scripts/imagemaid/" target="_blank" rel="noreferrer">Wiki</a>
-                </div>
+                  <div class="start-link-row start-link-row-buttons">
+                   <a class="btn btn-sm nav-button qs-start-step-link" href="/step/915-imagemaid" data-qs-target-label="ImageMaid">Open Run Page</a>
+                   <a class="btn btn-sm nav-button" href="#" data-bs-toggle="modal" data-bs-target="#imageMaidInfoModal">More Info...</a>
+                   <a class="btn btn-sm nav-button" href="https://kometa.wiki/en/{{ version_info.kometa_branch }}/kometa/scripts/imagemaid/" target="_blank" rel="noreferrer">Wiki</a>
+                  </div>
               </div>
             </div>
           </div>

--- a/templates/900-kometa.html
+++ b/templates/900-kometa.html
@@ -761,10 +761,10 @@
                         <span class="qs-incomplete-run-metric-value">{{ incomplete_resume_hint.timing_summary.observed_label }}</span>
                       </div>
                       {% endif %}
-                      {% if incomplete_resume_hint.timing_summary.had_pause and incomplete_resume_hint.timing_summary.pause_label %}
+                      {% if incomplete_resume_hint.timing_summary.pause_display %}
                       <div class="qs-incomplete-run-metric">
                         <span class="qs-incomplete-run-metric-label">Maintenance pause</span>
-                        <span class="qs-incomplete-run-metric-value">{{ incomplete_resume_hint.timing_summary.pause_label }}</span>
+                        <span class="qs-incomplete-run-metric-value">{{ incomplete_resume_hint.timing_summary.pause_display }}</span>
                       </div>
                       {% endif %}
                       {% if incomplete_resume_hint.timing_summary.had_pause and incomplete_resume_hint.timing_summary.active_label %}
@@ -808,7 +808,7 @@
                       <button type="button" id="copy-recovery-command"
                         class="btn btn-outline-secondary btn-sm d-flex align-items-center gap-2">
                         <i class="bi bi-files" id="copy-recovery-icon"></i>
-                        <span id="copy-recovery-text">Copy command</span>
+                        <span id="copy-recovery-text">Copy</span>
                       </button>
                     </div>
                     <code id="recovery-command-output" class="d-block w-100 text-wrap qs-recovery-command-output" style="white-space: pre-wrap; word-break: break-word;">{{ incomplete_resume_hint.suggested_command }}</code>
@@ -938,6 +938,7 @@
           <div id="run-progress-bar" class="progress-bar" role="progressbar" style="width: 0%"></div>
         </div>
         <div id="run-prep-row" class="mb-2 d-none"></div>
+        <div id="run-maintenance-row" class="mb-2 d-none"></div>
         <div class="table-responsive" data-qs-sticky-first="true">
                   <table class="table table-sm table-striped mb-0">
                     <thead>

--- a/templates/900-kometa.html
+++ b/templates/900-kometa.html
@@ -1028,7 +1028,7 @@
           <span id="run-status-timer"></span>
           <span id="run-status-metrics"></span>
           <span id="run-status-log"></span>
-          <div class="d-flex align-items-center gap-2 flex-wrap" id="run-status-sparklines">
+          <div class="d-flex align-items-start gap-2 flex-wrap" id="run-status-sparklines">
             <div class="run-sparkline">
               <div class="run-sparkline-header">
                 <span class="run-sparkline-label">CPU</span>
@@ -1039,6 +1039,14 @@
                 <polyline id="run-spark-cpu-kometa" class="run-sparkline-kometa" points=""></polyline>
               </svg>
               <div class="run-sparkline-axis-x">Time</div>
+              <div class="run-sparkline-legend">
+                <span class="run-sparkline-legend-item">
+                  <span class="run-sparkline-swatch run-sparkline-swatch-system"></span>System
+                </span>
+                <span class="run-sparkline-legend-item">
+                  <span class="run-sparkline-swatch run-sparkline-swatch-kometa"></span>Kometa
+                </span>
+              </div>
             </div>
             <div class="run-sparkline">
               <div class="run-sparkline-header">
@@ -1050,14 +1058,33 @@
                 <polyline id="run-spark-mem-kometa" class="run-sparkline-kometa" points=""></polyline>
               </svg>
               <div class="run-sparkline-axis-x">Time</div>
+              <div class="run-sparkline-legend">
+                <span class="run-sparkline-legend-item">
+                  <span class="run-sparkline-swatch run-sparkline-swatch-system"></span>System
+                </span>
+                <span class="run-sparkline-legend-item">
+                  <span class="run-sparkline-swatch run-sparkline-swatch-kometa"></span>Kometa
+                </span>
+              </div>
             </div>
-            <div class="run-sparkline-legend">
-              <span class="run-sparkline-legend-item">
-                <span class="run-sparkline-swatch run-sparkline-swatch-system"></span>System
-              </span>
-              <span class="run-sparkline-legend-item">
-                <span class="run-sparkline-swatch run-sparkline-swatch-kometa"></span>Kometa
-              </span>
+            <div class="run-sparkline">
+              <div class="run-sparkline-header">
+                <span class="run-sparkline-label">Disk I/O</span>
+                <span class="run-sparkline-axis">MB/s</span>
+              </div>
+              <svg id="run-spark-io" viewBox="0 0 180 48" width="180" height="48" aria-hidden="true">
+                <polyline id="run-spark-io-read" class="run-sparkline-system" points=""></polyline>
+                <polyline id="run-spark-io-write" class="run-sparkline-kometa" points=""></polyline>
+              </svg>
+              <div class="run-sparkline-axis-x">Time</div>
+              <div class="run-sparkline-legend">
+                <span class="run-sparkline-legend-item">
+                  <span class="run-sparkline-swatch run-sparkline-swatch-system"></span>Read
+                </span>
+                <span class="run-sparkline-legend-item">
+                <span class="run-sparkline-swatch run-sparkline-swatch-kometa"></span>Write
+                </span>
+              </div>
             </div>
           </div>
         </div>

--- a/templates/900-kometa.html
+++ b/templates/900-kometa.html
@@ -722,15 +722,6 @@
               {% if incomplete_resume_hint %}
               <div class="alert alert-warning mt-3 mb-2" id="incomplete-run-alert" role="alert">
                 <div class="d-flex flex-column gap-2">
-                  {% if (incomplete_resume_hint.suggested_command or incomplete_resume_hint.original_command) and not incomplete_resume_hint.scope_completed %}
-                  <div class="d-flex justify-content-end">
-                    <button type="button" id="copy-recovery-command"
-                      class="btn btn-outline-secondary btn-sm d-flex align-items-center gap-2">
-                      <i class="bi bi-files" id="copy-recovery-icon"></i>
-                      <span id="copy-recovery-text">Copy</span>
-                    </button>
-                  </div>
-                  {% endif %}
                   <div class="qs-incomplete-run-body">
                     <div class="fw-semibold mb-1">Previous run looks incomplete</div>
                     <div class="small mb-1">{{ incomplete_resume_hint.message }}</div>
@@ -750,22 +741,176 @@
                       Warning: this incomplete run was recorded under a different config name than the one currently loaded.
                     </div>
                     {% endif %}
+                    {% if incomplete_resume_hint.timing_summary %}
+                    <div class="qs-incomplete-run-metrics mt-2">
+                      {% if incomplete_resume_hint.timing_summary.started_at %}
+                      <div class="qs-incomplete-run-metric">
+                        <span class="qs-incomplete-run-metric-label">Started</span>
+                        <span class="qs-incomplete-run-metric-value">{{ incomplete_resume_hint.timing_summary.started_at }}</span>
+                      </div>
+                      {% endif %}
+                      {% if incomplete_resume_hint.timing_summary.last_log_at %}
+                      <div class="qs-incomplete-run-metric">
+                        <span class="qs-incomplete-run-metric-label">Last log line</span>
+                        <span class="qs-incomplete-run-metric-value">{{ incomplete_resume_hint.timing_summary.last_log_at }}</span>
+                      </div>
+                      {% endif %}
+                      {% if incomplete_resume_hint.timing_summary.observed_label %}
+                      <div class="qs-incomplete-run-metric">
+                        <span class="qs-incomplete-run-metric-label">Observed span</span>
+                        <span class="qs-incomplete-run-metric-value">{{ incomplete_resume_hint.timing_summary.observed_label }}</span>
+                      </div>
+                      {% endif %}
+                      {% if incomplete_resume_hint.timing_summary.had_pause and incomplete_resume_hint.timing_summary.pause_label %}
+                      <div class="qs-incomplete-run-metric">
+                        <span class="qs-incomplete-run-metric-label">Maintenance pause</span>
+                        <span class="qs-incomplete-run-metric-value">{{ incomplete_resume_hint.timing_summary.pause_label }}</span>
+                      </div>
+                      {% endif %}
+                      {% if incomplete_resume_hint.timing_summary.had_pause and incomplete_resume_hint.timing_summary.active_label %}
+                      <div class="qs-incomplete-run-metric">
+                        <span class="qs-incomplete-run-metric-label">Active runtime</span>
+                        <span class="qs-incomplete-run-metric-value">{{ incomplete_resume_hint.timing_summary.active_label }}</span>
+                      </div>
+                      {% endif %}
+                      {% if incomplete_resume_hint.timing_summary.window %}
+                      <div class="qs-incomplete-run-metric">
+                        <span class="qs-incomplete-run-metric-label">Maintenance window</span>
+                        <span class="qs-incomplete-run-metric-value">{{ incomplete_resume_hint.timing_summary.window }}</span>
+                      </div>
+                      {% endif %}
+                    </div>
+                    {% endif %}
+                    {% if incomplete_resume_hint.maintenance_events %}
+                    <div class="small mt-2">
+                      <span class="fw-semibold">Maintenance events</span>
+                      {% for event in incomplete_resume_hint.maintenance_events %}
+                      <div class="mt-1">
+                        <span class="badge text-bg-secondary me-1">{{ event.label }}</span>
+                        <span>{{ event.at }}</span>
+                        {% if event.pause_label %}
+                        <span class="text-muted">({{ event.pause_label }})</span>
+                        {% endif %}
+                        {% if event.window %}
+                        <span class="text-muted">window {{ event.window }}</span>
+                        {% endif %}
+                      </div>
+                      {% endfor %}
+                    </div>
+                    {% endif %}
+                    {% if incomplete_resume_hint.original_command %}
+                    <div class="small mt-3 mb-1 fw-semibold">Original logged command</div>
+                    <code class="d-block w-100 text-wrap qs-recovery-command-output qs-recovery-command-output-secondary" style="white-space: pre-wrap; word-break: break-word;">{{ incomplete_resume_hint.original_command }}</code>
+                    {% endif %}
                     {% if incomplete_resume_hint.suggested_command %}
-                    <div class="small mt-2 mb-1 fw-semibold">Suggested recovery command</div>
+                    <div class="d-flex align-items-center justify-content-between gap-2 flex-wrap small mt-3 mb-1">
+                      <div class="fw-semibold">Recovery command</div>
+                      <button type="button" id="copy-recovery-command"
+                        class="btn btn-outline-secondary btn-sm d-flex align-items-center gap-2">
+                        <i class="bi bi-files" id="copy-recovery-icon"></i>
+                        <span id="copy-recovery-text">Copy command</span>
+                      </button>
+                    </div>
                     <code id="recovery-command-output" class="d-block w-100 text-wrap qs-recovery-command-output" style="white-space: pre-wrap; word-break: break-word;">{{ incomplete_resume_hint.suggested_command }}</code>
-                    {% elif incomplete_resume_hint.original_command and not incomplete_resume_hint.scope_completed %}
-                    <div class="small mt-2 mb-1 fw-semibold">Last run command from log</div>
-                    <code id="recovery-command-output" class="d-block w-100 text-wrap qs-recovery-command-output" style="white-space: pre-wrap; word-break: break-word;">{{ incomplete_resume_hint.original_command }}</code>
                     {% elif incomplete_resume_hint.scope_completed %}
                     <div class="small mt-2 text-muted">Recovery not offered because the original scope appears fully completed.</div>
+                    {% elif incomplete_resume_hint.original_command %}
+                    <div class="small mt-3 text-muted">Recovery command could not be narrowed further, so the last logged command is shown above.</div>
+                    {% endif %}
+                    {% if incomplete_resume_hint.scope_summary %}
+                    <div class="qs-incomplete-run-metrics mt-3">
+                      {% if incomplete_resume_hint.scope_summary.completed_label %}
+                      <div class="qs-incomplete-run-metric">
+                        <span class="qs-incomplete-run-metric-label">Completed in log</span>
+                        <span class="qs-incomplete-run-metric-value">{{ incomplete_resume_hint.scope_summary.completed_label }}</span>
+                      </div>
+                      {% endif %}
+                      {% if incomplete_resume_hint.scope_summary.pruned_label %}
+                      <div class="qs-incomplete-run-metric">
+                        <span class="qs-incomplete-run-metric-label">Removed from recovery</span>
+                        <span class="qs-incomplete-run-metric-value">{{ incomplete_resume_hint.scope_summary.pruned_label }}</span>
+                      </div>
+                      {% endif %}
+                      {% if incomplete_resume_hint.scope_summary.recovery_scope_label and incomplete_resume_hint.suggested_command %}
+                      <div class="qs-incomplete-run-metric">
+                        <span class="qs-incomplete-run-metric-label">Recovery will run</span>
+                        <span class="qs-incomplete-run-metric-value">{{ incomplete_resume_hint.scope_summary.recovery_scope_label }}</span>
+                      </div>
+                      {% endif %}
+                    </div>
+                    {% endif %}
+                    {% if incomplete_resume_hint.progress_snapshot and incomplete_resume_hint.progress_snapshot.rows %}
+                    <div class="small mt-3 mb-1 fw-semibold">Progress seen before interruption</div>
+                    {% if incomplete_resume_hint.progress_snapshot.preparation_label %}
+                    <div class="small mb-2">
+                      <span class="fw-semibold me-2">Preparation</span>
+                      <span class="badge text-bg-primary">{{ incomplete_resume_hint.progress_snapshot.preparation_label }}</span>
+                    </div>
+                    {% endif %}
+                    <div class="table-responsive" data-qs-sticky-first="true">
+                      <table class="table table-sm table-striped mb-0 qs-incomplete-progress-table">
+                        <thead>
+                          <tr>
+                            <th>Library</th>
+                            <th>Type</th>
+                            <th>Status</th>
+                            {% for column in incomplete_resume_hint.progress_snapshot.columns %}
+                            <th class="text-end">{{ column.label }}</th>
+                            {% endfor %}
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {% for row in incomplete_resume_hint.progress_snapshot.rows %}
+                          <tr>
+                            <td>{{ row.name }}</td>
+                            <td>{{ row.type }}</td>
+                            <td><span class="badge {{ row.status_class }}">{{ row.status }}</span></td>
+                            {% for cell in row.phase_cells %}
+                            <td class="text-end">
+                              {% if cell.label %}
+                              <span class="badge {{ 'text-bg-primary' if cell.tone == 'primary' else 'text-bg-success' }}">{{ cell.label }}</span>
+                              {% else %}
+                              <span class="text-muted small">—</span>
+                              {% endif %}
+                            </td>
+                            {% endfor %}
+                          </tr>
+                          {% endfor %}
+                        </tbody>
+                        <tfoot class="table-group-divider">
+                          <tr>
+                            <td class="fw-semibold">Total</td>
+                            <td>—</td>
+                            <td>
+                              {% if incomplete_resume_hint.progress_snapshot.total_label %}
+                              <span class="badge text-bg-success">{{ incomplete_resume_hint.progress_snapshot.total_label }}</span>
+                              {% else %}
+                              <span class="text-muted small">—</span>
+                              {% endif %}
+                            </td>
+                            {% for label in incomplete_resume_hint.progress_snapshot.footer_cells %}
+                            <td class="text-end">
+                              {% if label %}
+                              <span class="badge text-bg-success">{{ label }}</span>
+                              {% else %}
+                              <span class="text-muted small">—</span>
+                              {% endif %}
+                            </td>
+                            {% endfor %}
+                          </tr>
+                        </tfoot>
+                      </table>
+                    </div>
                     {% endif %}
                     {% if incomplete_resume_hint.explanation %}
-                    <div class="small mt-2 mb-1 fw-semibold">Why this suggestion</div>
-                    <ul class="small mb-1 ps-3">
-                      {% for note in incomplete_resume_hint.explanation %}
-                      <li>{{ note }}</li>
-                      {% endfor %}
-                    </ul>
+                    <details class="small mt-3">
+                      <summary class="fw-semibold">Recovery notes</summary>
+                      <ul class="small mb-1 ps-3 mt-2">
+                        {% for note in incomplete_resume_hint.explanation %}
+                        <li>{{ note }}</li>
+                        {% endfor %}
+                      </ul>
+                    </details>
                     {% endif %}
                   </div>
                 </div>

--- a/templates/905-analytics.html
+++ b/templates/905-analytics.html
@@ -202,9 +202,9 @@
     <div class="collapse" id="logscan-recent-runs-collapse">
       <div class="logscan-table-toolbar">
         <div class="logscan-table-bulk-actions">
-          <button id="logscan-table-select-all" type="button" class="btn nav-button btn-sm">Select all</button>
-          <button id="logscan-table-select-complete" type="button" class="btn nav-button btn-sm">Select complete</button>
-          <button id="logscan-table-select-incomplete" type="button" class="btn nav-button btn-sm">Select incomplete</button>
+          <button id="logscan-table-select-all" type="button" class="btn nav-button btn-sm">Select visible</button>
+          <button id="logscan-table-select-complete" type="button" class="btn nav-button btn-sm">Complete</button>
+          <button id="logscan-table-select-incomplete" type="button" class="btn nav-button btn-sm">Incomplete</button>
           <button id="logscan-table-clear-selection" type="button" class="btn nav-button btn-sm">Clear</button>
           <button id="logscan-table-compress-selected" type="button" class="btn nav-button btn-sm" disabled>Compress selected</button>
           <button id="logscan-table-delete-selected" type="button" class="btn nav-button nav-button-danger btn-sm" disabled>Delete selected</button>

--- a/templates/915-imagemaid.html
+++ b/templates/915-imagemaid.html
@@ -308,8 +308,110 @@
             </button>
           </div>
 
-          <div class="small text-muted mb-2" id="imagemaid-run-status">ImageMaid is not running.</div>
-          <pre id="imagemaid-run-log" class="bg-black text-light small rounded p-3 mb-0" style="min-height: 220px; max-height: 360px; overflow:auto;">No ImageMaid log loaded.</pre>
+          <div class="d-flex flex-wrap align-items-center gap-3 mb-2 small text-muted" id="imagemaid-run-status-row">
+            <span id="imagemaid-run-status-timer"></span>
+            <span id="imagemaid-run-status-metrics"></span>
+            <span id="imagemaid-run-status-log"></span>
+            <div class="d-flex align-items-start gap-2 flex-wrap d-none" id="imagemaid-run-status-sparklines">
+              <div class="run-sparkline">
+                <div class="run-sparkline-header">
+                  <span class="run-sparkline-label">CPU</span>
+                  <span class="run-sparkline-axis">0-100%</span>
+                </div>
+                <svg id="imagemaid-run-spark-cpu" viewBox="0 0 180 48" width="180" height="48" aria-hidden="true">
+                  <polyline id="imagemaid-run-spark-cpu-system" class="run-sparkline-system" points=""></polyline>
+                  <polyline id="imagemaid-run-spark-cpu-imagemaid" class="run-sparkline-kometa" points=""></polyline>
+                </svg>
+                <div class="run-sparkline-axis-x">Time</div>
+                <div class="run-sparkline-legend">
+                  <span class="run-sparkline-legend-item">
+                    <span class="run-sparkline-swatch run-sparkline-swatch-system"></span>System
+                  </span>
+                  <span class="run-sparkline-legend-item">
+                    <span class="run-sparkline-swatch run-sparkline-swatch-kometa"></span>ImageMaid
+                  </span>
+                </div>
+              </div>
+              <div class="run-sparkline">
+                <div class="run-sparkline-header">
+                  <span class="run-sparkline-label">Memory</span>
+                  <span class="run-sparkline-axis">0-100%</span>
+                </div>
+                <svg id="imagemaid-run-spark-mem" viewBox="0 0 180 48" width="180" height="48" aria-hidden="true">
+                  <polyline id="imagemaid-run-spark-mem-system" class="run-sparkline-system" points=""></polyline>
+                  <polyline id="imagemaid-run-spark-mem-imagemaid" class="run-sparkline-kometa" points=""></polyline>
+                </svg>
+                <div class="run-sparkline-axis-x">Time</div>
+                <div class="run-sparkline-legend">
+                  <span class="run-sparkline-legend-item">
+                    <span class="run-sparkline-swatch run-sparkline-swatch-system"></span>System
+                  </span>
+                  <span class="run-sparkline-legend-item">
+                    <span class="run-sparkline-swatch run-sparkline-swatch-kometa"></span>ImageMaid
+                  </span>
+                </div>
+              </div>
+              <div class="run-sparkline">
+                <div class="run-sparkline-header">
+                  <span class="run-sparkline-label">Disk I/O</span>
+                  <span class="run-sparkline-axis">MB/s</span>
+                </div>
+                <svg id="imagemaid-run-spark-io" viewBox="0 0 180 48" width="180" height="48" aria-hidden="true">
+                  <polyline id="imagemaid-run-spark-io-read" class="run-sparkline-system" points=""></polyline>
+                  <polyline id="imagemaid-run-spark-io-write" class="run-sparkline-kometa" points=""></polyline>
+                </svg>
+                <div class="run-sparkline-axis-x">Time</div>
+                <div class="run-sparkline-legend">
+                  <span class="run-sparkline-legend-item">
+                    <span class="run-sparkline-swatch run-sparkline-swatch-system"></span>Read
+                  </span>
+                  <span class="run-sparkline-legend-item">
+                    <span class="run-sparkline-swatch run-sparkline-swatch-kometa"></span>Write
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div id="imagemaid-run-maintenance-row" class="mb-2 d-none"></div>
+          <div class="small text-muted mb-2 d-none" id="imagemaid-run-status">ImageMaid is not running.</div>
+
+          <div class="d-flex flex-wrap align-items-center gap-3 mb-2 small text-muted">
+            <span>Showing last <span id="imagemaid-tail-label">2000</span> lines from the log</span>
+            <div class="form-check form-switch m-0">
+              <input class="form-check-input" type="checkbox" id="imagemaid-log-autoscroll" checked>
+              <label class="form-check-label" for="imagemaid-log-autoscroll">Auto-scroll</label>
+            </div>
+              <div class="d-flex align-items-center gap-2">
+                <label class="mb-0" for="imagemaid-log-tail-size">Tail size</label>
+                <select id="imagemaid-log-tail-size" class="form-select form-select-sm" style="width: 110px;">
+                  <option value="200">200</option>
+                  <option value="2000" selected>2000</option>
+                  <option value="20000">20000</option>
+                  <option value="all">All</option>
+                </select>
+              </div>
+            <button type="button" class="btn btn-outline-secondary btn-sm" id="imagemaid-download-log">
+              <i class="bi bi-download me-1"></i> Download log
+            </button>
+            <button type="button" class="btn btn-outline-secondary btn-sm" id="imagemaid-pause-log-polling">
+              <i class="bi bi-pause-circle me-1"></i> Pause
+            </button>
+          </div>
+          <div class="mb-2">
+            <label class="form-label mb-1" for="imagemaid-log-filter">Filter</label>
+            <input type="text" class="form-control" id="imagemaid-log-filter" placeholder="Regex or text">
+          </div>
+          <div class="d-flex flex-wrap gap-2 mb-2 small" id="imagemaid-log-stats">
+            <span class="btn btn-sm btn-dark disabled">FILTER <span data-imagemaid-log-stat="filter">0</span></span>
+            <button type="button" class="btn btn-sm btn-outline-secondary imagemaid-log-level-btn" data-level="CACHE">CACHE <span data-imagemaid-log-stat="cache">0</span></button>
+            <button type="button" class="btn btn-sm btn-outline-secondary imagemaid-log-level-btn" data-level="[DEBUG]">DEBUG <span data-imagemaid-log-stat="debug">0</span></button>
+            <button type="button" class="btn btn-sm btn-outline-secondary imagemaid-log-level-btn" data-level="[INFO]">INFO <span data-imagemaid-log-stat="info">0</span></button>
+            <button type="button" class="btn btn-sm btn-outline-secondary imagemaid-log-level-btn" data-level="[WARNING]">WARN <span data-imagemaid-log-stat="warn">0</span></button>
+            <button type="button" class="btn btn-sm btn-outline-secondary imagemaid-log-level-btn" data-level="[ERROR]">ERROR <span data-imagemaid-log-stat="error">0</span></button>
+            <button type="button" class="btn btn-sm btn-outline-secondary imagemaid-log-level-btn" data-level="[CRITICAL]">CRIT <span data-imagemaid-log-stat="crit">0</span></button>
+            <button type="button" class="btn btn-sm btn-outline-secondary imagemaid-log-level-btn" data-level="[TRACE]">TRACE <span data-imagemaid-log-stat="trace">0</span></button>
+          </div>
+          <pre id="imagemaid-run-log" class="bg-black text-light small rounded p-3 mb-0" style="min-height: 220px; max-height: 360px; overflow:auto; white-space: pre;">No ImageMaid log loaded.</pre>
         </div>
       </div>
     </div>

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -167,6 +167,44 @@ def test_validate_plex_bad_token(client, monkeypatch, qs_module):
     assert "bad token" in payload["error"]
 
 
+def test_validate_plex_persists_telemetry_for_current_config(client, monkeypatch, qs_module):
+    calls = {"save_settings": 0, "save_section": 0}
+
+    def fake_validate(_data):
+        return qs_module.jsonify(
+            {
+                "validated": True,
+                "db_cache": 2048,
+                "user_list": ["User One"],
+                "music_libraries": [],
+                "movie_libraries": ["Movies"],
+                "show_libraries": ["Shows"],
+                "has_plex_pass": True,
+            }
+        )
+
+    telemetry = {
+        "server_name": "Test Plex",
+        "maintenance_window": "02:00 – 05:00",
+        "platform": "Windows",
+    }
+
+    monkeypatch.setattr(qs_module.validations, "validate_plex_server", fake_validate)
+    monkeypatch.setattr(qs_module.helpers, "get_plex_metadata", lambda **_kwargs: telemetry)
+    monkeypatch.setattr(qs_module.persistence, "save_settings", lambda *_args, **_kwargs: calls.__setitem__("save_settings", calls["save_settings"] + 1))
+    monkeypatch.setattr(qs_module.database, "save_section_data", lambda **_kwargs: calls.__setitem__("save_section", calls["save_section"] + 1))
+
+    with client.session_transaction() as sess:
+        sess["config_name"] = "pytest_validate_plex"
+
+    resp = client.post("/validate_plex", json={"plex_url": "http://localhost:32400", "plex_token": "token"})
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["validated"] is True
+    assert payload["maintenance_window"] == "02:00 – 05:00"
+    assert calls == {"save_settings": 1, "save_section": 1}
+
+
 def test_validate_plex_fetches_sections_once(app, monkeypatch, qs_module):
     qs_module.helpers.clear_plex_discovery_cache()
     calls = {"sections": 0}

--- a/tests/test_logscan_endpoints.py
+++ b/tests/test_logscan_endpoints.py
@@ -1385,9 +1385,7 @@ def test_analyze_imagemaid_log_content_parses_summary_section_runtimes(qs_module
     assert section_runtimes["photo_transcoder_remove"] == 0
 
 
-def test_analyze_incomplete_kometa_log_for_resume_uses_first_runtime_timestamp_for_started_at(
-    qs_module, isolated_config_dir, monkeypatch
-):
+def test_analyze_incomplete_kometa_log_for_resume_uses_first_runtime_timestamp_for_started_at(qs_module, isolated_config_dir, monkeypatch):
     log_path = isolated_config_dir / "kometa" / "config" / "logs" / "meta.log"
     log_path.parent.mkdir(parents=True, exist_ok=True)
     log_path.write_text(
@@ -1431,9 +1429,7 @@ def test_analyze_incomplete_kometa_log_for_resume_uses_first_runtime_timestamp_f
     assert result["started_at"] == "2026-04-29 15:08:28"
 
 
-def test_build_incomplete_run_from_cache_entry_uses_first_runtime_timestamp_for_started_at(
-    qs_module, isolated_config_dir
-):
+def test_build_incomplete_run_from_cache_entry_uses_first_runtime_timestamp_for_started_at(qs_module, isolated_config_dir):
     log_path = isolated_config_dir / "cache" / "logscan" / "archive" / "kometa" / "meta-cached.log"
     log_path.parent.mkdir(parents=True, exist_ok=True)
     log_path.write_text(

--- a/tests/test_logscan_endpoints.py
+++ b/tests/test_logscan_endpoints.py
@@ -777,12 +777,29 @@ def test_normalize_logscan_archive_filenames_renames_legacy_files_and_updates_ca
     result = qs_module._normalize_logscan_archive_filenames()
 
     assert result["renamed"] == 1
-    renamed_path = archive_dir / "meta-20251224-170000Z-7.log"
+    renamed_path = archive_dir / "meta-20251224-170000Z-7.log.gz"
     assert renamed_path.exists()
     assert not legacy_path.exists()
     saved_cache = saved["cache"]
     assert str(renamed_path.resolve()) in saved_cache["logs"]
     assert str(legacy_path.resolve()) not in saved_cache["logs"]
+
+
+def test_normalize_logscan_archive_filenames_removes_archived_maintenance_sidecar(isolated_config_dir, monkeypatch, qs_module):
+    archive_dir = isolated_config_dir / "cache" / "logscan" / "archive" / "kometa"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    sidecar_path = archive_dir / "meta.quickstart-maintenance.log"
+    sidecar_path.write_text("sidecar marker\n", encoding="utf-8")
+    cache = {"version": 1, "logs": {str(sidecar_path.resolve()): {"run_key": "run-sidecar", "run_complete": False}}}
+    saved = {}
+
+    monkeypatch.setattr(qs_module, "_load_logscan_ingest_cache", lambda: cache)
+    monkeypatch.setattr(qs_module, "_save_logscan_ingest_cache", lambda value: saved.setdefault("cache", value))
+
+    result = qs_module._normalize_logscan_archive_filenames()
+
+    assert result["renamed"] == 1
+    assert not sidecar_path.exists()
 
 
 def test_normalize_logscan_archive_filenames_collapses_repeated_kometa_archive_stem(isolated_config_dir, monkeypatch, qs_module):
@@ -1119,7 +1136,10 @@ def test_logscan_reingest_ingests_imagemaid_log(client, isolated_config_dir, mon
         "\n".join(
             [
                 "[Quickstart] Run marker: started=2026-04-28T20:13:55Z config=demo tool=imagemaid mode=report",
+                "[2026-04-28 20:13:56,001] [imagemaid.py:93]           [DEBUG]    | --photo-transcoder (PHOTO_TRANSCODER): True                                                         |",
                 "| Running in Report Mode with Empty Trash, Clean Bundles, Optimize DB, and PhotoTrancoder set to True |",
+                "[2026-04-28 20:16:58,010] [imagemaid.py:214]          [WARNING]  | Example warning before finish                                                                       |",
+                "[2026-04-28 20:16:59,010] [imagemaid.py:214]          [CRITICAL] | Example critical before finish                                                                      |",
                 "[2026-04-28 20:17:00,274] [imagemaid.py:453]          [INFO]     |======================================== ImageMaid Finished ========================================|",
                 "[2026-04-28 20:17:00,275] [imagemaid.py:453]          [INFO]     | Total Runtime      | 0:03:05                                                                       |",
                 "[2026-04-28 20:17:00,275] [imagemaid.py:453]          [INFO]     |====================================================================================================|",
@@ -1142,6 +1162,10 @@ def test_logscan_reingest_ingests_imagemaid_log(client, isolated_config_dir, mon
     imagemaid_runs = [run for run in runs if run.get("tool_name") == "imagemaid"]
     assert imagemaid_runs
     assert imagemaid_runs[0]["kometa_version"] == qs_module.helpers.get_imagemaid_local_version()
+    assert imagemaid_runs[0]["debug_count"] == 1
+    assert imagemaid_runs[0]["info_count"] == 3
+    assert imagemaid_runs[0]["warning_count"] == 1
+    assert imagemaid_runs[0]["critical_count"] == 1
 
 
 def test_logscan_reingest_archives_completed_imagemaid_live_log(client, isolated_config_dir, monkeypatch, qs_module):
@@ -1318,6 +1342,47 @@ def test_analyze_imagemaid_log_content_uses_first_runtime_timestamp_for_started_
     assert summary["finished_at"] == "2026-04-29 15:08:35"
     assert summary["run_time_seconds"] == 5
     assert summary["config_name"] == "unknown"
+
+
+def test_analyze_imagemaid_log_content_parses_summary_section_runtimes(qs_module):
+    result = qs_module._analyze_imagemaid_log_content(
+        "\n".join(
+            [
+                "[2026-05-06 07:45:19,459] [imagemaid.py:244]          [INFO]     | Downloading Database via the Plex API. First Plex will make a backup of your database.             |",
+                "[2026-05-06 07:50:48,649] [imagemaid.py:290]          [INFO]     | Runtime: 0:05:29                                                                                   |",
+                "[2026-05-06 07:50:48,779] [imagemaid.py:297]          [INFO]     | Database Opened Querying For In-Use Images                                                         |",
+                "[2026-05-06 07:50:49,327] [imagemaid.py:304]          [INFO]     | Runtime: 0:00:00                                                                                   |",
+                "[2026-05-06 07:50:49,330] [imagemaid.py:311]          [INFO]     | Scanning Metadata Directory For Bloat Images: p:\\Plex\\Metadata                                     |",
+                "[2026-05-06 07:56:08,253] [imagemaid.py:317]          [INFO]     | Runtime: 0:05:18                                                                                   |",
+                "[2026-05-06 07:56:08,253] [imagemaid.py:322]          [INFO]     | Reporting Bloat Images                                                                             |",
+                "[2026-05-06 07:56:08,404] [imagemaid.py:354]          [INFO]     | Runtime: 0:00:00                                                                                   |",
+                "[2026-05-06 07:56:08,407] [imagemaid.py:415]          [INFO]     | Scanning for PhotoTranscoder Images                                                                |",
+                "[2026-05-06 07:56:09,910] [imagemaid.py:418]          [INFO]     | Runtime: 0:00:01                                                                                   |",
+                "[2026-05-06 07:56:09,911] [imagemaid.py:421]          [INFO]     | Removing PhotoTranscoder Images                                                                    |",
+                "[2026-05-06 07:56:09,913] [imagemaid.py:435]          [INFO]     | Runtime: 0:00:00                                                                                   |",
+                "[2026-05-06 07:56:09,914] [imagemaid.py:473]          [INFO]     |============================================= Database =============================================|",
+                "[2026-05-06 07:56:09,916] [imagemaid.py:473]          [INFO]     | Downloaded         | 0:05:29                                                                       |",
+                "[2026-05-06 07:56:09,917] [imagemaid.py:473]          [INFO]     | Query              | 0:00:00                                                                       |",
+                "[2026-05-06 07:56:09,917] [imagemaid.py:473]          [INFO]     |====================================== Reporting Bloat Images ======================================|",
+                "[2026-05-06 07:56:09,918] [imagemaid.py:473]          [INFO]     | Scan Time          | 0:05:18                                                                       |",
+                "[2026-05-06 07:56:09,918] [imagemaid.py:473]          [INFO]     | Report Time        | 0:00:00                                                                       |",
+                "[2026-05-06 07:56:09,919] [imagemaid.py:473]          [INFO]     |================================== Remove PhotoTranscoder Images ===================================|",
+                "[2026-05-06 07:56:09,920] [imagemaid.py:473]          [INFO]     | Scan Time          | 0:00:01                                                                       |",
+                "[2026-05-06 07:56:09,920] [imagemaid.py:473]          [INFO]     | Remove Time        | 0:00:00                                                                       |",
+                "[2026-05-06 07:56:09,922] [imagemaid.py:473]          [INFO]     | Total Runtime      | 0:10:50                                                                       |",
+            ]
+        ),
+        log_path="imagemaid.log",
+    )
+
+    assert result is not None
+    section_runtimes = result["summary"]["section_runtimes"]
+    assert section_runtimes["database_download"] == 329
+    assert section_runtimes["database_query"] == 0
+    assert section_runtimes["report_bloat_scan"] == 318
+    assert section_runtimes["report_bloat_action"] == 0
+    assert section_runtimes["photo_transcoder_scan"] == 1
+    assert section_runtimes["photo_transcoder_remove"] == 0
 
 
 def test_analyze_incomplete_kometa_log_for_resume_uses_first_runtime_timestamp_for_started_at(

--- a/tests/test_logscan_endpoints.py
+++ b/tests/test_logscan_endpoints.py
@@ -1320,6 +1320,87 @@ def test_analyze_imagemaid_log_content_uses_first_runtime_timestamp_for_started_
     assert summary["config_name"] == "unknown"
 
 
+def test_analyze_incomplete_kometa_log_for_resume_uses_first_runtime_timestamp_for_started_at(
+    qs_module, isolated_config_dir, monkeypatch
+):
+    log_path = isolated_config_dir / "kometa" / "config" / "logs" / "meta.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text(
+        "\n".join(
+            [
+                "[2026-04-29 15:08:28,897] [kometa.py:93] [INFO] | Starting work |",
+                "[2026-04-29 15:08:35,001] [collections.py:453] [INFO] | Running Demo Collection in Library |",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    class _IncompleteAnalyzer:
+        def analyze_content(self, content, log_path=None, config_name=None, include_people_scan=False):
+            return {
+                "summary": {
+                    "run_key": "run-incomplete-kometa-1",
+                    "tool_name": "kometa",
+                    "run_complete": False,
+                    "started_at": None,
+                    "finished_at": None,
+                    "config_name": config_name or "demo",
+                    "run_command": "python kometa.py --run --config C:\\Quickstart\\config\\demo.yml",
+                    "log_size": len(content or ""),
+                },
+                "recommendations": [],
+            }
+
+        def extract_progress(self, *_args, **_kwargs):
+            return {}
+
+        def _strip_divider_wrappers(self, value):
+            return value
+
+    monkeypatch.setattr(qs_module.logscan, "LogscanAnalyzer", _IncompleteAnalyzer)
+    monkeypatch.setattr(qs_module, "_build_recovery_suggestions", lambda *_args, **_kwargs: [])
+
+    result = qs_module._analyze_incomplete_log_for_resume(log_path, config_name="demo")
+
+    assert result is not None
+    assert result["started_at"] == "2026-04-29 15:08:28"
+
+
+def test_build_incomplete_run_from_cache_entry_uses_first_runtime_timestamp_for_started_at(
+    qs_module, isolated_config_dir
+):
+    log_path = isolated_config_dir / "cache" / "logscan" / "archive" / "kometa" / "meta-cached.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text(
+        "\n".join(
+            [
+                "[2026-04-29 15:08:28,897] [kometa.py:93] [INFO] | Starting work |",
+                "[2026-04-29 15:08:35,001] [collections.py:453] [INFO] | Running Demo Collection in Library |",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = qs_module._build_incomplete_run_from_cache_entry(
+        log_path,
+        cache_entry={
+            "run_key": "run-incomplete-cached-1",
+            "tool_name": "kometa",
+            "run_complete": False,
+            "summary": {
+                "run_key": "run-incomplete-cached-1",
+                "tool_name": "kometa",
+                "started_at": None,
+                "config_name": "demo",
+                "run_command": "python kometa.py --run",
+            },
+        },
+        config_name="demo",
+    )
+
+    assert result["started_at"] == "2026-04-29 15:08:28"
+
+
 def test_analyze_imagemaid_log_content_infers_saved_config_name(qs_module, isolated_config_dir):
     qs_module.database.save_section_data(
         name="demo_report",

--- a/tests/test_more_paths.py
+++ b/tests/test_more_paths.py
@@ -160,6 +160,64 @@ def test_maintenance_guard_pauses_running_imagemaid(monkeypatch, qs_module, tmp_
         assert qs_module.MAINTENANCE_STATE["imagemaid_paused_since"] is not None
 
 
+def test_refresh_maintenance_window_availability_prefers_active_imagemaid_config(monkeypatch, qs_module):
+    _reset_maintenance_state(qs_module)
+
+    seen = {"config_name": None}
+
+    monkeypatch.setattr(qs_module, "_get_run_context", lambda: {})
+    monkeypatch.setattr(qs_module, "_get_imagemaid_run_context", lambda: {"config_name": "imagemaid_cfg"})
+    monkeypatch.setattr(qs_module, "_peek_pending_kometa_start", lambda: None)
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_pid", lambda: None)
+    monkeypatch.setattr(qs_module.helpers, "is_kometa_running", lambda: False)
+    monkeypatch.setattr(qs_module.helpers, "get_imagemaid_pid", lambda: 5555)
+    monkeypatch.setattr(qs_module.helpers, "is_imagemaid_running", lambda: True)
+
+    def fake_live(config_name=None):
+        seen["config_name"] = config_name
+        return 120, 300, "02:00 – 05:00"
+
+    monkeypatch.setattr(qs_module, "_get_maintenance_window_live", fake_live)
+    monkeypatch.setattr(qs_module, "_get_maintenance_window_from_db", lambda config_name=None: (None, None, None))
+    monkeypatch.setattr(qs_module, "_is_within_maintenance_window", lambda *_: False)
+
+    qs_module._refresh_maintenance_window_availability()
+
+    assert seen["config_name"] == "imagemaid_cfg"
+    with qs_module.MAINTENANCE_STATE_LOCK:
+        assert qs_module.MAINTENANCE_STATE["window"] == "02:00 – 05:00"
+        assert qs_module.MAINTENANCE_STATE["window_unavailable"] is False
+
+
+def test_refresh_maintenance_window_availability_ignores_stale_kometa_context(monkeypatch, qs_module):
+    _reset_maintenance_state(qs_module)
+
+    seen = {"config_name": None}
+
+    monkeypatch.setattr(qs_module, "_get_run_context", lambda: {"config_name": "stale_kometa_cfg"})
+    monkeypatch.setattr(qs_module, "_get_imagemaid_run_context", lambda: {"config_name": "imagemaid_cfg"})
+    monkeypatch.setattr(qs_module, "_peek_pending_kometa_start", lambda: None)
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_pid", lambda: None)
+    monkeypatch.setattr(qs_module.helpers, "is_kometa_running", lambda: False)
+    monkeypatch.setattr(qs_module.helpers, "get_imagemaid_pid", lambda: 5555)
+    monkeypatch.setattr(qs_module.helpers, "is_imagemaid_running", lambda: True)
+
+    def fake_live(config_name=None):
+        seen["config_name"] = config_name
+        return 120, 300, "02:00 – 05:00"
+
+    monkeypatch.setattr(qs_module, "_get_maintenance_window_live", fake_live)
+    monkeypatch.setattr(qs_module, "_get_maintenance_window_from_db", lambda config_name=None: (None, None, None))
+    monkeypatch.setattr(qs_module, "_is_within_maintenance_window", lambda *_: False)
+
+    qs_module._refresh_maintenance_window_availability()
+
+    assert seen["config_name"] == "imagemaid_cfg"
+    with qs_module.MAINTENANCE_STATE_LOCK:
+        assert qs_module.MAINTENANCE_STATE["window"] == "02:00 – 05:00"
+        assert qs_module.MAINTENANCE_STATE["window_unavailable"] is False
+
+
 def test_maintenance_guard_resumes_paused_imagemaid(monkeypatch, qs_module, tmp_path):
     _reset_maintenance_state(qs_module)
     paused_at = time.time() - 90

--- a/tests/test_more_paths.py
+++ b/tests/test_more_paths.py
@@ -21,6 +21,8 @@ def _reset_maintenance_state(qs_module):
             {
                 "paused": False,
                 "paused_since": None,
+                "imagemaid_paused": False,
+                "imagemaid_paused_since": None,
                 "active": False,
                 "window": None,
                 "queued_started_at": None,
@@ -98,3 +100,123 @@ def test_maintenance_guard_starts_queued_run(monkeypatch, qs_module):
     assert qs_module._peek_pending_kometa_start() is None
     with qs_module.MAINTENANCE_STATE_LOCK:
         assert qs_module.MAINTENANCE_STATE["queued_started_at"] is not None
+
+
+def test_maintenance_guard_pauses_running_imagemaid(monkeypatch, qs_module, tmp_path):
+    _reset_maintenance_state(qs_module)
+
+    imagemaid_log = tmp_path / "imagemaid.log"
+    imagemaid_log.write_text("ImageMaid running\n", encoding="utf-8")
+
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_pid", lambda: None)
+    monkeypatch.setattr(qs_module.helpers, "is_kometa_running", lambda: False)
+    monkeypatch.setattr(qs_module.helpers, "get_imagemaid_pid", lambda: 5555)
+    monkeypatch.setattr(qs_module.helpers, "is_imagemaid_running", lambda: True)
+    monkeypatch.setattr(qs_module.helpers, "get_imagemaid_root_path", lambda: tmp_path)
+    monkeypatch.setattr(qs_module, "_find_running_imagemaid_process", lambda: None)
+    monkeypatch.setattr(qs_module, "_get_latest_imagemaid_log_path", lambda: imagemaid_log)
+    monkeypatch.setattr(qs_module, "_get_maintenance_window_live", lambda: (120, 300, "02:00-05:00"))
+    monkeypatch.setattr(qs_module, "_get_maintenance_window_from_db", lambda: (120, 300, "02:00-05:00"))
+    monkeypatch.setattr(qs_module, "_is_within_maintenance_window", lambda *_: True)
+    monkeypatch.setattr(qs_module, "_get_imagemaid_run_context", lambda: {"mode": "report", "config_name": "demo"})
+
+    class _FakePsutilProc:
+        pid = 5555
+
+    monkeypatch.setattr(qs_module.psutil, "Process", lambda pid: _FakePsutilProc())
+
+    calls = {"suspend": 0, "marker": 0}
+
+    monkeypatch.setattr(qs_module, "_suspend_process_tree", lambda proc: calls.__setitem__("suspend", calls["suspend"] + 1) or True)
+
+    def fake_marker(root, event, **kwargs):
+        calls["marker"] += 1
+        assert event == "paused"
+        assert kwargs["mode"] == "report"
+        assert kwargs["config_name"] == "demo"
+        assert kwargs["window"] == "02:00-05:00"
+        return True
+
+    monkeypatch.setattr(qs_module, "_write_quickstart_imagemaid_maintenance_marker", fake_marker)
+
+    ticks = {"count": 0}
+
+    def fake_sleep(_):
+        ticks["count"] += 1
+        if ticks["count"] > 1:
+            raise StopIteration()
+
+    monkeypatch.setattr(qs_module.time, "sleep", fake_sleep)
+
+    try:
+        qs_module._maintenance_guard_loop(qs_module.app)
+    except StopIteration:
+        pass
+
+    assert calls["suspend"] == 1
+    assert calls["marker"] == 1
+    with qs_module.MAINTENANCE_STATE_LOCK:
+        assert qs_module.MAINTENANCE_STATE["imagemaid_paused"] is True
+        assert qs_module.MAINTENANCE_STATE["imagemaid_paused_since"] is not None
+
+
+def test_maintenance_guard_resumes_paused_imagemaid(monkeypatch, qs_module, tmp_path):
+    _reset_maintenance_state(qs_module)
+    paused_at = time.time() - 90
+    with qs_module.MAINTENANCE_STATE_LOCK:
+        qs_module.MAINTENANCE_STATE["imagemaid_paused"] = True
+        qs_module.MAINTENANCE_STATE["imagemaid_paused_since"] = time.strftime("%Y-%m-%dT%H:%M:%S+00:00", time.gmtime(paused_at))
+
+    imagemaid_log = tmp_path / "imagemaid.log"
+    imagemaid_log.write_text("ImageMaid paused\n", encoding="utf-8")
+
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_pid", lambda: None)
+    monkeypatch.setattr(qs_module.helpers, "is_kometa_running", lambda: False)
+    monkeypatch.setattr(qs_module.helpers, "get_imagemaid_pid", lambda: 5555)
+    monkeypatch.setattr(qs_module.helpers, "is_imagemaid_running", lambda: True)
+    monkeypatch.setattr(qs_module.helpers, "get_imagemaid_root_path", lambda: tmp_path)
+    monkeypatch.setattr(qs_module, "_find_running_imagemaid_process", lambda: None)
+    monkeypatch.setattr(qs_module, "_get_latest_imagemaid_log_path", lambda: imagemaid_log)
+    monkeypatch.setattr(qs_module, "_get_maintenance_window_live", lambda: (120, 300, "02:00-05:00"))
+    monkeypatch.setattr(qs_module, "_get_maintenance_window_from_db", lambda: (120, 300, "02:00-05:00"))
+    monkeypatch.setattr(qs_module, "_is_within_maintenance_window", lambda *_: False)
+    monkeypatch.setattr(qs_module, "_get_imagemaid_run_context", lambda: {"mode": "move", "config_name": "demo"})
+
+    class _FakePsutilProc:
+        pid = 5555
+
+    monkeypatch.setattr(qs_module.psutil, "Process", lambda pid: _FakePsutilProc())
+    monkeypatch.setattr(qs_module, "_resume_process_tree", lambda proc: True)
+
+    calls = {"marker": 0}
+
+    def fake_marker(root, event, **kwargs):
+        calls["marker"] += 1
+        assert event == "resumed"
+        assert kwargs["mode"] == "move"
+        assert kwargs["config_name"] == "demo"
+        assert kwargs["window"] == "02:00-05:00"
+        assert isinstance(kwargs["paused_seconds"], int)
+        assert kwargs["paused_seconds"] >= 60
+        return True
+
+    monkeypatch.setattr(qs_module, "_write_quickstart_imagemaid_maintenance_marker", fake_marker)
+
+    ticks = {"count": 0}
+
+    def fake_sleep(_):
+        ticks["count"] += 1
+        if ticks["count"] > 1:
+            raise StopIteration()
+
+    monkeypatch.setattr(qs_module.time, "sleep", fake_sleep)
+
+    try:
+        qs_module._maintenance_guard_loop(qs_module.app)
+    except StopIteration:
+        pass
+
+    assert calls["marker"] == 1
+    with qs_module.MAINTENANCE_STATE_LOCK:
+        assert qs_module.MAINTENANCE_STATE["imagemaid_paused"] is False
+        assert qs_module.MAINTENANCE_STATE["imagemaid_paused_since"] is None

--- a/tests/test_resume_hint.py
+++ b/tests/test_resume_hint.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-
+from pathlib import Path
 import pytest
 from flask import session
 
@@ -94,8 +94,19 @@ def test_build_incomplete_run_timing_summary_accounts_for_maintenance_pause(qs_m
 
     assert summary["observed_label"] == "2h 30m"
     assert summary["pause_label"] == "1h"
+    assert summary["pause_display"] == "1h"
     assert summary["active_label"] == "1h 30m"
     assert summary["window"] == "02:00-05:00"
+
+
+def test_build_incomplete_run_timing_summary_marks_missing_maintenance_as_not_observed(qs_module):
+    summary = qs_module._build_incomplete_run_timing_summary(
+        started_at="2026-05-05 01:00:00",
+        last_log_at="2026-05-05 03:30:00",
+        maintenance_summary={},
+    )
+
+    assert summary["pause_display"] == "Not observed"
 
 
 def test_build_incomplete_scope_summary_reports_completed_and_pruned_libraries(qs_module):
@@ -139,12 +150,14 @@ def test_build_incomplete_progress_snapshot_exposes_rows_and_totals(qs_module):
             ],
         },
         last_log_at="2026-05-05 03:30:00",
+        config_data={"playlists": {"daily": {}}, "settings": {"run_order": ["operations", "metadata", "collections", "overlays"]}},
+        original_command="kometa.py --run --config <config>",
     )
 
-    assert [column["key"] for column in snapshot["columns"]] == ["operations", "collections"]
+    assert [column["key"] for column in snapshot["columns"]] == ["operations", "metadata", "collections", "overlays", "playlists"]
     assert snapshot["preparation_label"] == "30s"
     assert snapshot["rows"][0]["phase_cells"][0]["label"] == "2m"
-    assert snapshot["rows"][1]["phase_cells"][1]["label"] == "1m 30s"
+    assert snapshot["rows"][1]["phase_cells"][2]["label"] == "1m 30s"
     assert snapshot["total_label"] == "7m 30s"
 
 
@@ -330,6 +343,34 @@ def test_build_latest_incomplete_resume_hint_marks_completed_scope(monkeypatch, 
     assert isinstance(hint, dict)
     assert hint["scope_completed"] is True
     assert hint["suggested_command"] == ""
+
+
+def test_read_logscan_text_appends_live_kometa_maintenance_sidecar(tmp_path, qs_module):
+    log_dir = tmp_path / "config" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    meta_path = log_dir / "meta.log"
+    sidecar_path = log_dir / "meta.quickstart-maintenance.log"
+    meta_path.write_text("[2026-05-05 01:00:00,000] [kometa.py:1] [INFO] | Start\n", encoding="utf-8")
+    sidecar_path.write_text("[Quickstart] Maintenance marker: event=paused at=2026-05-05T06:00:00Z local_at=2026-05-05T02:00:00 window=02:00-05:00\n", encoding="utf-8")
+
+    content = qs_module._read_logscan_text(meta_path, encoding="utf-8", errors="replace")
+
+    assert "Maintenance marker" in content
+    assert content.count("Maintenance marker") == 1
+
+
+def test_write_quickstart_maintenance_marker_falls_back_to_sidecar(monkeypatch, tmp_path, qs_module):
+    kometa_root = tmp_path
+    monkeypatch.setattr(qs_module, "_append_quickstart_meta_log_line", lambda *_args, **_kwargs: False)
+
+    ok = qs_module._write_quickstart_maintenance_marker(kometa_root, "paused", window="02:00-05:00")
+
+    assert ok is True
+    sidecar_path = qs_module._get_kometa_maintenance_sidecar_path(kometa_root)
+    assert sidecar_path.exists()
+    sidecar_text = sidecar_path.read_text(encoding="utf-8")
+    assert "event=paused" in sidecar_text
+    assert "window=02:00-05:00" in sidecar_text
 
 
 def test_resume_explanation_calls_out_scoped_resume_for_collections(qs_module):

--- a/tests/test_resume_hint.py
+++ b/tests/test_resume_hint.py
@@ -59,6 +59,10 @@ def test_build_latest_incomplete_resume_hint_exposes_explanation(monkeypatch, qs
                 "incomplete_log_name": "meta.log",
                 "config_name": "testcfg",
                 "resume_explanation": ["Reason one", "Reason two"],
+                "resume_timing_summary": {"started_at": "2026-05-05 01:00:00"},
+                "resume_scope_summary": {"completed_label": "Movies"},
+                "resume_progress_snapshot": {"rows": [{"name": "Movies"}]},
+                "resume_maintenance_events": [{"label": "Paused", "at": "2026-05-05 02:00:00"}],
             }
         ],
     )
@@ -70,6 +74,78 @@ def test_build_latest_incomplete_resume_hint_exposes_explanation(monkeypatch, qs
     assert isinstance(hint, dict)
     assert hint["log_name"] == "meta.log"
     assert hint["explanation"] == ["Reason one", "Reason two"]
+    assert hint["timing_summary"]["started_at"] == "2026-05-05 01:00:00"
+    assert hint["scope_summary"]["completed_label"] == "Movies"
+    assert hint["progress_snapshot"]["rows"][0]["name"] == "Movies"
+    assert hint["maintenance_events"][0]["label"] == "Paused"
+
+
+def test_build_incomplete_run_timing_summary_accounts_for_maintenance_pause(qs_module):
+    summary = qs_module._build_incomplete_run_timing_summary(
+        started_at="2026-05-05 01:00:00",
+        last_log_at="2026-05-05 03:30:00",
+        maintenance_summary={
+            "had_pause": True,
+            "pause_count": 1,
+            "pause_seconds": 3600,
+            "window": "02:00-05:00",
+        },
+    )
+
+    assert summary["observed_label"] == "2h 30m"
+    assert summary["pause_label"] == "1h"
+    assert summary["active_label"] == "1h 30m"
+    assert summary["window"] == "02:00-05:00"
+
+
+def test_build_incomplete_scope_summary_reports_completed_and_pruned_libraries(qs_module):
+    summary = qs_module._build_incomplete_scope_summary(
+        original_command="kometa.py --run --config <config>",
+        suggested_command='kometa.py --run --run-libraries "Movies|TV Shows" --resume "Top Picks" --config <config>',
+        progress_libraries=[
+            {"name": "Anime", "status": "Done"},
+            {"name": "Movies", "status": "In progress"},
+            {"name": "TV Shows", "status": "Pending"},
+        ],
+    )
+
+    assert summary["completed_label"] == "Anime"
+    assert summary["pruned_label"] == "Anime"
+    assert summary["recovery_scope_label"] == "Movies | TV Shows"
+
+
+def test_build_incomplete_progress_snapshot_exposes_rows_and_totals(qs_module):
+    snapshot = qs_module._build_incomplete_progress_snapshot(
+        {
+            "phase_current": "collections",
+            "current_library": "Movies",
+            "completed_count": 1,
+            "total_count": 2,
+            "current_phase_elapsed_seconds": 90,
+            "preparation_seconds": 30,
+            "libraries": [
+                {
+                    "name": "Anime",
+                    "type": "show",
+                    "status": "Done",
+                    "durations": {"operations": 120, "collections": 240},
+                },
+                {
+                    "name": "Movies",
+                    "type": "movie",
+                    "status": "In progress",
+                    "durations": {"operations": 60},
+                },
+            ],
+        },
+        last_log_at="2026-05-05 03:30:00",
+    )
+
+    assert [column["key"] for column in snapshot["columns"]] == ["operations", "collections"]
+    assert snapshot["preparation_label"] == "30s"
+    assert snapshot["rows"][0]["phase_cells"][0]["label"] == "2m"
+    assert snapshot["rows"][1]["phase_cells"][1]["label"] == "1m 30s"
+    assert snapshot["total_label"] == "7m 30s"
 
 
 def test_resume_explanation_calls_out_resume_not_used_for_operations(qs_module):

--- a/tests/test_start_stop.py
+++ b/tests/test_start_stop.py
@@ -91,6 +91,16 @@ def test_kometa_status_includes_active_command_and_start_mode(client, monkeypatc
     monkeypatch.setattr(qs_module.helpers, "get_kometa_pid", lambda: 4321)
     monkeypatch.setattr(qs_module, "_calculate_process_cpu_percent", lambda proc: 1.25)
     monkeypatch.setattr(qs_module, "_calculate_system_cpu_percent", lambda: 4.5)
+    monkeypatch.setattr(
+        qs_module,
+        "_calculate_process_io_stats",
+        lambda proc, cache_name: {
+            "disk_read_mb": 256.5,
+            "disk_write_mb": 128.25,
+            "disk_read_rate_mb_s": 12.5,
+            "disk_write_rate_mb_s": 3.75,
+        },
+    )
 
     class _FakeMemInfo:
         rss = 64 * 1024 * 1024
@@ -134,6 +144,10 @@ def test_kometa_status_includes_active_command_and_start_mode(client, monkeypatc
     assert data["status"] == "running"
     assert data["start_mode"] == "recovery"
     assert data["active_command"] == 'python kometa.py --collections-only --resume "Emmys 1999"'
+    assert data["disk_read_mb"] == 256.5
+    assert data["disk_write_mb"] == 128.2
+    assert data["disk_read_rate_mb_s"] == 12.5
+    assert data["disk_write_rate_mb_s"] == 3.75
 
 
 def test_start_kometa_blocked_when_kometa_update_running(client, monkeypatch, qs_module):
@@ -204,6 +218,34 @@ def test_start_imagemaid_starts_when_valid(client, monkeypatch, qs_module):
     assert data["pid"] == 2468
     assert seen["config_name"]
     assert seen["mode"] == "report"
+
+
+def test_start_imagemaid_uses_explicit_config_name(client, monkeypatch, qs_module):
+    with client.session_transaction() as session_state:
+        session_state["config_name"] = "pytest_source_config"
+
+    monkeypatch.setattr(qs_module.helpers, "is_imagemaid_running", lambda: False)
+    monkeypatch.setattr(qs_module.helpers, "get_imagemaid_pid", lambda: None)
+    monkeypatch.setattr(qs_module, "_find_running_imagemaid_process", lambda: None)
+    monkeypatch.setattr(qs_module.helpers, "is_kometa_running", lambda: False)
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_pid", lambda: None)
+    monkeypatch.setattr(qs_module, "_get_maintenance_window_live", lambda: (60, 120, "01:00-02:00"))
+    monkeypatch.setattr(qs_module, "_is_within_maintenance_window", lambda *_: False)
+    monkeypatch.setattr(qs_module, "_validate_imagemaid_settings", lambda *_args, **_kwargs: (True, None, None))
+    monkeypatch.setattr(qs_module, "_persist_imagemaid_validation", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(qs_module.persistence, "get_stored_plex_credentials", lambda *_args, **_kwargs: ("http://plex:32400", "token"))
+    monkeypatch.setattr(qs_module, "_build_imagemaid_command", lambda *_args, **_kwargs: "python imagemaid.py --mode report")
+    seen = {}
+
+    def fake_launch(command, mode=None, config_name=None):
+        seen["config_name"] = config_name
+        return True, 2468
+
+    monkeypatch.setattr(qs_module, "_launch_imagemaid_command", fake_launch)
+
+    resp = client.post("/start-imagemaid", json={"config_name": "pytest_target_config", "plex_path": "P:\\Plex", "mode": "report"})
+    assert resp.status_code == 200
+    assert seen["config_name"] == "pytest_target_config"
 
 
 def test_start_imagemaid_surfaces_immediate_exit(client, monkeypatch, qs_module):
@@ -292,6 +334,86 @@ def test_imagemaid_status_reports_starting_during_startup_grace(client, tmp_path
     data = resp.get_json()
     assert data["status"] == "starting"
     assert data["pid"] == 4321
+
+
+def test_imagemaid_status_reports_metrics_and_maintenance(client, tmp_path, monkeypatch, qs_module):
+    pid_file = tmp_path / "imagemaid.pid"
+    pid_file.write_text("4321", encoding="utf-8")
+
+    class _FakeMemInfo:
+        rss = 48 * 1024 * 1024
+
+    class _FakeVM:
+        total = 8 * 1024 * 1024 * 1024
+        available = 6 * 1024 * 1024 * 1024
+        percent = 25.0
+
+    class FakeProc:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def create_time(self):
+            return qs_module.time.time() - 12
+
+        def is_running(self):
+            return True
+
+        def status(self):
+            return qs_module.psutil.STATUS_RUNNING
+
+        def cmdline(self):
+            return ["python", "imagemaid.py", "--mode", "report"]
+
+        def memory_info(self):
+            return _FakeMemInfo()
+
+        def children(self, recursive=True):
+            return []
+
+    monkeypatch.setattr(qs_module.helpers, "get_imagemaid_pid", lambda: 4321)
+    monkeypatch.setattr(qs_module.helpers, "get_imagemaid_pid_file", lambda: str(pid_file))
+    monkeypatch.setattr(qs_module, "_find_running_imagemaid_process", lambda: None)
+    monkeypatch.setattr(qs_module.psutil, "Process", FakeProc)
+    monkeypatch.setattr(qs_module.psutil, "virtual_memory", lambda: _FakeVM())
+    monkeypatch.setattr(qs_module, "_calculate_process_cpu_percent", lambda proc: 1.75)
+    monkeypatch.setattr(qs_module, "_calculate_system_cpu_percent", lambda: 5.5)
+    monkeypatch.setattr(
+        qs_module,
+        "_calculate_process_io_stats",
+        lambda proc, cache_name: {
+            "disk_read_mb": 512.0,
+            "disk_write_mb": 96.0,
+            "disk_read_rate_mb_s": 8.5,
+            "disk_write_rate_mb_s": 1.25,
+        },
+    )
+    monkeypatch.setattr(qs_module, "_get_imagemaid_run_context", lambda: {"command": "python imagemaid.py --mode report", "mode": "report", "config_name": "demo"})
+    with qs_module.MAINTENANCE_STATE_LOCK:
+        qs_module.MAINTENANCE_STATE["active"] = True
+        qs_module.MAINTENANCE_STATE["window"] = "02:00-05:00"
+        qs_module.MAINTENANCE_STATE["imagemaid_paused"] = True
+        qs_module.MAINTENANCE_STATE["imagemaid_paused_since"] = "2026-05-05T06:00:00+00:00"
+
+    resp = client.get("/imagemaid-status")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["status"] == "running"
+    assert data["cpu_percent"] == 1.8
+    assert data["memory_rss_mb"] == 48.0
+    assert data["system_cpu_percent"] == 5.5
+    assert data["disk_read_mb"] == 512.0
+    assert data["disk_write_mb"] == 96.0
+    assert data["disk_read_rate_mb_s"] == 8.5
+    assert data["disk_write_rate_mb_s"] == 1.25
+    assert data["maintenance_active"] is True
+    assert data["maintenance_paused"] is True
+    assert data["maintenance_window"] == "02:00-05:00"
+    assert data["active_command"] == "python imagemaid.py --mode report"
+    with qs_module.MAINTENANCE_STATE_LOCK:
+        qs_module.MAINTENANCE_STATE["active"] = False
+        qs_module.MAINTENANCE_STATE["window"] = None
+        qs_module.MAINTENANCE_STATE["imagemaid_paused"] = False
+        qs_module.MAINTENANCE_STATE["imagemaid_paused_since"] = None
 
 
 def test_validate_imagemaid_restore_requires_restore_dir(tmp_path, monkeypatch, qs_module):
@@ -578,6 +700,152 @@ def test_autosave_imagemaid_persists_settings(client, isolated_config_dir):
     assert saved["imagemaid"]["photo_transcoder"] is True
 
 
+def test_autosave_imagemaid_targets_explicit_config_name(client, isolated_config_dir):
+    import modules.database as database
+
+    with client.session_transaction() as session_state:
+        session_state["config_name"] = "pytest_source_config"
+
+    resp = client.post(
+        "/autosave-imagemaid",
+        json={
+            "config_name": "pytest_target_config",
+            "plex_path": "P:\\Plex",
+            "mode": "move",
+            "branch_override": "develop",
+            "timeout": "45",
+            "sleep": "5",
+            "photo_transcoder": True,
+            "empty_trash": True,
+            "clean_bundles": True,
+            "optimize_db": True,
+            "local_db": True,
+            "use_existing": True,
+            "ignore_running": True,
+            "trace": True,
+            "log_requests": True,
+            "no_verify_ssl": True,
+            "overlays_only": True,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["success"] is True
+
+    source_validated, source_user_entered, source_saved = database.retrieve_section_data("pytest_source_config", "imagemaid")
+    assert source_saved is None
+    assert source_validated is False
+    assert source_user_entered is False
+
+    _, target_user_entered, target_saved = database.retrieve_section_data("pytest_target_config", "imagemaid")
+    assert target_user_entered is True
+    assert target_saved["imagemaid"]["plex_path"] == "P:\\Plex"
+    assert target_saved["imagemaid"]["mode"] == "move"
+    assert target_saved["imagemaid"]["branch_override"] == "develop"
+    assert target_saved["imagemaid"]["timeout"] == 45
+    assert target_saved["imagemaid"]["sleep"] == 5
+    assert target_saved["imagemaid"]["photo_transcoder"] is True
+    assert target_saved["imagemaid"]["empty_trash"] is True
+    assert target_saved["imagemaid"]["clean_bundles"] is True
+    assert target_saved["imagemaid"]["optimize_db"] is True
+    assert target_saved["imagemaid"]["local_db"] is True
+    assert target_saved["imagemaid"]["use_existing"] is True
+    assert target_saved["imagemaid"]["ignore_running"] is True
+    assert target_saved["imagemaid"]["trace"] is True
+    assert target_saved["imagemaid"]["log_requests"] is True
+    assert target_saved["imagemaid"]["no_verify_ssl"] is True
+    assert target_saved["imagemaid"]["overlays_only"] is True
+
+
+def test_autosave_imagemaid_does_not_clear_validation_when_payload_is_unchanged(client, isolated_config_dir):
+    import modules.database as database
+
+    with client.session_transaction() as session_state:
+        session_state["config_name"] = "pytest_imagemaid_unchanged"
+
+    database.save_section_data(
+        name="pytest_imagemaid_unchanged",
+        section="imagemaid",
+        validated=True,
+        user_entered=True,
+        data={
+            "imagemaid": {
+                "plex_path": "P:\\Plex",
+                "mode": "report",
+                "timeout": 600,
+                "sleep": 60,
+                "photo_transcoder": True,
+            },
+            "validated_at": "2026-05-06T00:00:00+00:00",
+            "validation_status": "validated",
+            "validation_updated_at": "2026-05-06T00:00:00+00:00",
+        },
+    )
+
+    resp = client.post(
+        "/autosave-imagemaid",
+        json={
+            "config_name": "pytest_imagemaid_unchanged",
+            "plex_path": "P:\\Plex",
+            "mode": "report",
+            "timeout": "600",
+            "sleep": "60",
+            "photo_transcoder": True,
+        },
+    )
+    assert resp.status_code == 200
+
+    validated, user_entered, saved = database.retrieve_section_data("pytest_imagemaid_unchanged", "imagemaid")
+    assert validated is True
+    assert user_entered is True
+    assert saved["validation_status"] == "validated"
+    assert saved["validated_at"] == "2026-05-06T00:00:00+00:00"
+
+
+def test_validate_imagemaid_targets_explicit_config_name(client, isolated_config_dir, monkeypatch, qs_module):
+    import modules.database as database
+
+    with client.session_transaction() as session_state:
+        session_state["config_name"] = "pytest_source_config"
+
+    seen = {}
+
+    def fake_validate(section_data, config_name=None):
+        seen["config_name"] = config_name
+        return True, None, None
+
+    monkeypatch.setattr(qs_module, "_validate_imagemaid_settings", fake_validate)
+    monkeypatch.setattr(qs_module, "_persist_imagemaid_validation", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(qs_module, "_get_stored_plex_credentials_for_config", lambda *_args, **_kwargs: ("http://plex:32400", "token"))
+    monkeypatch.setattr(qs_module, "_build_imagemaid_command", lambda *_args, **_kwargs: "python imagemaid.py --mode report")
+
+    resp = client.post(
+        "/validate-imagemaid",
+        json={
+            "config_name": "pytest_target_config",
+            "plex_path": "P:\\Plex",
+            "mode": "move",
+            "clean_bundles": True,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["success"] is True
+    assert data["validated"] is True
+    assert seen["config_name"] == "pytest_target_config"
+
+    source_validated, source_user_entered, source_saved = database.retrieve_section_data("pytest_source_config", "imagemaid")
+    assert source_saved is None
+    assert source_validated is False
+    assert source_user_entered is False
+
+    _, target_user_entered, target_saved = database.retrieve_section_data("pytest_target_config", "imagemaid")
+    assert target_user_entered is True
+    assert target_saved["imagemaid"]["plex_path"] == "P:\\Plex"
+    assert target_saved["imagemaid"]["mode"] == "move"
+    assert target_saved["imagemaid"]["clean_bundles"] is True
+
+
 def test_tail_imagemaid_log_reads_runtime_log_only(client, isolated_config_dir, monkeypatch, qs_module):
     imagemaid_root = isolated_config_dir / "imagemaid"
     log_dir = imagemaid_root / "config" / "logs"
@@ -630,6 +898,27 @@ def test_tail_imagemaid_log_hides_executor_shutdown_noise(client, isolated_confi
     assert "Exception ignored in:" not in data["text"]
     assert "weakref_cb" not in data["text"]
     assert "AttributeError: 'NoneType' object has no attribute 'debug'" not in data["text"]
+
+
+def test_tail_imagemaid_log_appends_maintenance_sidecar(client, isolated_config_dir, qs_module):
+    imagemaid_root = isolated_config_dir / "imagemaid"
+    log_dir = imagemaid_root / "config" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    qs_module.app.config["IMAGEMAID_ROOT"] = str(imagemaid_root)
+
+    regular_log = log_dir / "imagemaid.log"
+    regular_log.write_text("runtime log line\n", encoding="utf-8")
+    sidecar_log = log_dir / "imagemaid.quickstart-maintenance.log"
+    sidecar_log.write_text("[Quickstart] Maintenance marker: event=paused tool=imagemaid\n", encoding="utf-8")
+
+    resp = client.get("/tail-imagemaid-log?lines=50")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["success"] is True
+    assert "runtime log line" in data["text"]
+    assert "event=paused" in data["text"]
+    assert data["requested_lines"] == 50
+    assert data["total_lines"] == 2
 
 
 def test_stop_imagemaid_writes_stop_marker(tmp_path, client, monkeypatch, qs_module):

--- a/tests/test_start_stop.py
+++ b/tests/test_start_stop.py
@@ -150,6 +150,28 @@ def test_kometa_status_includes_active_command_and_start_mode(client, monkeypatc
     assert data["disk_write_rate_mb_s"] == 3.75
 
 
+def test_imagemaid_status_clears_stale_run_context_when_not_running(client, monkeypatch, qs_module):
+    monkeypatch.setattr(qs_module.helpers, "get_imagemaid_pid", lambda: None)
+    monkeypatch.setattr(qs_module.helpers, "get_imagemaid_pid_file", lambda: "missing.pid")
+    monkeypatch.setattr(qs_module, "_find_running_imagemaid_process", lambda: None)
+    monkeypatch.setattr(qs_module, "_ingest_completed_live_logs", lambda tool: None)
+
+    with qs_module.IMAGEMAID_RUN_CONTEXT_LOCK:
+        qs_module.IMAGEMAID_RUN_CONTEXT["command"] = "python imagemaid.py --mode report"
+        qs_module.IMAGEMAID_RUN_CONTEXT["mode"] = "report"
+        qs_module.IMAGEMAID_RUN_CONTEXT["config_name"] = "imagemaid_cfg"
+
+    resp = client.get("/imagemaid-status")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["status"] == "not started"
+
+    with qs_module.IMAGEMAID_RUN_CONTEXT_LOCK:
+        assert qs_module.IMAGEMAID_RUN_CONTEXT["command"] is None
+        assert qs_module.IMAGEMAID_RUN_CONTEXT["mode"] is None
+        assert qs_module.IMAGEMAID_RUN_CONTEXT["config_name"] is None
+
+
 def test_start_kometa_blocked_when_kometa_update_running(client, monkeypatch, qs_module):
     monkeypatch.setattr(qs_module.helpers, "is_kometa_running", lambda: False)
     monkeypatch.setattr(qs_module.helpers, "get_kometa_pid", lambda: None)
@@ -731,6 +753,8 @@ def test_autosave_imagemaid_targets_explicit_config_name(client, isolated_config
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["success"] is True
+    assert data["changed"] is True
+    assert data["validated"] is False
 
     source_validated, source_user_entered, source_saved = database.retrieve_section_data("pytest_source_config", "imagemaid")
     assert source_saved is None
@@ -770,6 +794,7 @@ def test_autosave_imagemaid_does_not_clear_validation_when_payload_is_unchanged(
         user_entered=True,
         data={
             "imagemaid": {
+                "branch_override": "master",
                 "plex_path": "P:\\Plex",
                 "mode": "report",
                 "timeout": 600,
@@ -786,20 +811,46 @@ def test_autosave_imagemaid_does_not_clear_validation_when_payload_is_unchanged(
         "/autosave-imagemaid",
         json={
             "config_name": "pytest_imagemaid_unchanged",
+            "branch_override": "master",
             "plex_path": "P:\\Plex",
             "mode": "report",
             "timeout": "600",
             "sleep": "60",
             "photo_transcoder": True,
+            "empty_trash": False,
+            "clean_bundles": False,
+            "optimize_db": False,
+            "local_db": False,
+            "use_existing": False,
+            "ignore_running": False,
+            "trace": False,
+            "log_requests": False,
+            "no_verify_ssl": False,
+            "overlays_only": False,
         },
     )
     assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["success"] is True
+    assert data["changed"] is False
+    assert data["validated"] is True
 
     validated, user_entered, saved = database.retrieve_section_data("pytest_imagemaid_unchanged", "imagemaid")
     assert validated is True
     assert user_entered is True
     assert saved["validation_status"] == "validated"
     assert saved["validated_at"] == "2026-05-06T00:00:00+00:00"
+    assert saved["imagemaid"]["branch_override"] == "master"
+    assert saved["imagemaid"]["empty_trash"] is False
+    assert saved["imagemaid"]["clean_bundles"] is False
+    assert saved["imagemaid"]["optimize_db"] is False
+    assert saved["imagemaid"]["local_db"] is False
+    assert saved["imagemaid"]["use_existing"] is False
+    assert saved["imagemaid"]["ignore_running"] is False
+    assert saved["imagemaid"]["trace"] is False
+    assert saved["imagemaid"]["log_requests"] is False
+    assert saved["imagemaid"]["no_verify_ssl"] is False
+    assert saved["imagemaid"]["overlays_only"] is False
 
 
 def test_validate_imagemaid_targets_explicit_config_name(client, isolated_config_dir, monkeypatch, qs_module):
@@ -844,6 +895,114 @@ def test_validate_imagemaid_targets_explicit_config_name(client, isolated_config
     assert target_saved["imagemaid"]["plex_path"] == "P:\\Plex"
     assert target_saved["imagemaid"]["mode"] == "move"
     assert target_saved["imagemaid"]["clean_bundles"] is True
+
+
+def test_validate_imagemaid_survives_navigation_to_sponsor_and_back(client, isolated_config_dir, monkeypatch, qs_module):
+    import modules.database as database
+
+    config_name = "pytest_imagemaid_nav"
+    with client.session_transaction() as session_state:
+        session_state["config_name"] = config_name
+
+    monkeypatch.setattr(qs_module, "_validate_imagemaid_settings", lambda *_args, **_kwargs: (True, None, None))
+    monkeypatch.setattr(qs_module, "_get_stored_plex_credentials_for_config", lambda *_args, **_kwargs: ("http://plex:32400", "token"))
+    monkeypatch.setattr(qs_module, "_build_imagemaid_command", lambda *_args, **_kwargs: "python imagemaid.py --mode report")
+
+    resp = client.post(
+        "/validate-imagemaid",
+        json={
+            "config_name": config_name,
+            "plex_path": "P:\\Plex",
+            "mode": "report",
+            "timeout": "600",
+            "sleep": "60",
+            "photo_transcoder": True,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["validated"] is True
+
+    validated, user_entered, saved = database.retrieve_section_data(config_name, "imagemaid")
+    assert validated is True
+    assert user_entered is True
+    assert saved["validation_status"] == "validated"
+
+    sponsor_resp = client.get("/step/910-sponsor")
+    assert sponsor_resp.status_code == 200
+
+    imagemaid_resp = client.get("/step/915-imagemaid")
+    assert imagemaid_resp.status_code == 200
+    body = imagemaid_resp.get_data(as_text=True)
+    assert 'data-validated="true"' in body
+
+    validated_after, user_entered_after, saved_after = database.retrieve_section_data(config_name, "imagemaid")
+    assert validated_after is True
+    assert user_entered_after is True
+    assert saved_after["validation_status"] == "validated"
+
+
+def test_step_navigation_from_imagemaid_to_sponsor_preserves_validation_when_unchanged(client, isolated_config_dir):
+    import modules.database as database
+
+    config_name = "pytest_imagemaid_jump"
+    with client.session_transaction() as session_state:
+        session_state["config_name"] = config_name
+
+    database.save_section_data(
+        name=config_name,
+        section="imagemaid",
+        validated=True,
+        user_entered=True,
+        data={
+            "imagemaid": {
+                "branch_override": "",
+                "plex_path": "P:\\Plex",
+                "mode": "report",
+                "timeout": 600,
+                "sleep": 60,
+                "photo_transcoder": True,
+                "empty_trash": False,
+                "clean_bundles": False,
+                "optimize_db": False,
+                "local_db": False,
+                "use_existing": False,
+                "ignore_running": False,
+                "trace": False,
+                "log_requests": False,
+                "no_verify_ssl": False,
+                "overlays_only": False,
+            },
+            "validated_at": "2026-05-06T00:00:00+00:00",
+            "validation_status": "validated",
+            "validation_updated_at": "2026-05-06T00:00:00+00:00",
+        },
+    )
+
+    resp = client.post(
+        "/step/910-sponsor",
+        base_url="http://localhost",
+        headers={"Referer": "http://localhost/step/915-imagemaid"},
+        data={
+            "configSelector": config_name,
+            "imagemaid_branch_override": "",
+            "imagemaid_plex_path": "P:\\Plex",
+            "imagemaid_mode": "report",
+            "imagemaid_timeout": "600",
+            "imagemaid_sleep": "60",
+            "imagemaid_photo_transcoder": "on",
+        },
+    )
+    assert resp.status_code == 200
+
+    validated, user_entered, saved = database.retrieve_section_data(config_name, "imagemaid")
+    assert validated is True
+    assert user_entered is True
+    assert saved["validation_status"] == "validated"
+    assert saved["imagemaid"]["plex_path"] == "P:\\Plex"
+    assert saved["imagemaid"]["mode"] == "report"
+    assert saved["imagemaid"]["photo_transcoder"] is True
+    assert saved["imagemaid"]["empty_trash"] is False
 
 
 def test_tail_imagemaid_log_reads_runtime_log_only(client, isolated_config_dir, monkeypatch, qs_module):


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Fixes a broad set of workflow regressions across ImageMaid, Kometa, Analytics, and the Start page. The branch stabilizes ImageMaid config persistence and validation across navigation, improves Kometa incomplete-run recovery and recovery-run visibility, adds start_mode through ingestion into Analytics, expands maintenance handling with sidecar-based marker support, improves run-time metrics/logging UX, and cleans up several Analytics/Start-page UI behaviors including filters, counts, status cards, and config-management flow.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
