### PR TITLE
Remove section times imagemaid

### DIFF
--- a/static/local-js/905-analytics.js
+++ b/static/local-js/905-analytics.js
@@ -1941,6 +1941,7 @@ $(document).ready(function () {
       sectionCell += `<span class="logscan-section-summary">${escapeHtml(sectionSummary)}</span>`
       sectionCell += '</div>'
       const toolLabel = getRunToolLabel(run)
+      const isImageMaidRun = getRunToolName(run) === 'imagemaid'
       const progressLabel = getRunToolName(run) === 'imagemaid' ? 'Operation matrix' : 'Progress matrix'
       const progressHelpText = getRunToolName(run) === 'imagemaid'
         ? 'Stored ImageMaid operation matrix for this run, including observed scan/action timings, item counts, and outcomes.'
@@ -2027,7 +2028,7 @@ $(document).ready(function () {
           ${renderRunCardCell('Maintenance', 'Quickstart maintenance pauses recorded in meta.log for this run.', renderMaintenanceSummaryCell(run))}
           ${renderRunCardCell('Quiet periods', 'Emphasizes the longest unexplained delay between timestamped run log lines, with maintenance-related gaps available in the details view.', renderQuietPeriodCell(run))}
           ${renderRunCardCell(progressLabel, progressHelpText, renderProgressSnapshotCell(run, runKey), 'class="logscan-progress-cell"')}
-          ${renderRunCardCell('Section runtimes', 'Runtime totals parsed per run section when available.', sectionCell)}
+          ${isImageMaidRun ? '' : renderRunCardCell('Section runtimes', 'Runtime totals parsed per run section when available.', sectionCell)}
           ${renderRunCardCell('Log size', 'Current on-disk size of the resolved log file when available, otherwise the ingested size.', escapeHtml(formatBytes(sizeBytes)))}
           ${renderRunCardCell('Log', 'Download the source log for this run. Archived plain logs can also be compressed, and archived logs can be deleted here.', `<div class="logscan-action-stack">${logActions.join('')}</div>`)}
           ${renderRunCardCell('Report', run.is_incomplete ? 'Open recommendations and diagnostics captured for this incomplete log.' : 'Open the recommendations recorded for the run.', `

--- a/static/local-js/905-analytics.js
+++ b/static/local-js/905-analytics.js
@@ -1927,7 +1927,7 @@ $(document).ready(function () {
         details: sectionDetails
       })
       let sectionCell = `
-        <div class="logscan-card-inline">
+        <div class="logscan-card-inline2">
       `
       if (sectionDetails.length) {
         sectionCell += `

--- a/static/local-js/905-analytics.js
+++ b/static/local-js/905-analytics.js
@@ -1927,7 +1927,7 @@ $(document).ready(function () {
         details: sectionDetails
       })
       let sectionCell = `
-        <div class="logscan-card-inline2">
+        <div class="logscan-card-inline">
       `
       if (sectionDetails.length) {
         sectionCell += `


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Simplifies ImageMaid run cards in Analytics by hiding the redundant Section runtimes row for ImageMaid while keeping the data intact for the Operation matrix, sorting, and diagnostics. Kometa behavior is unchanged.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
