### PR TITLE
added metacritic must see for tv

### DIFF
--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -13384,13 +13384,10 @@
           },
           {
             "key": "use_metacritic",
-            "label": "Metacritic Must See Movies",
-            "tooltip": "Collection of Metacritic Must See Movies.",
+            "label": "Metacritic Must See",
+            "tooltip": "Collection of Metacritic Must See Movies/Shows.",
             "type": "toggle",
-            "default": true,
-            "media_types": [
-              "movie"
-            ]
+            "default": true
           },
           {
             "key": "radarr_add_missing_metacritic",
@@ -13400,6 +13397,16 @@
             "type": "toggle",
             "media_types": [
               "movie"
+            ]
+          },
+          {
+            "key": "sonarr_add_missing_metacritic",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
             ]
           },
           {

--- a/tests/test_workspace_dependency_logic.py
+++ b/tests/test_workspace_dependency_logic.py
@@ -310,6 +310,16 @@ def test_mal_dependency_reason_cases(qs_module, libraries_data, expected_require
             id="sonarr_template_collection_enabled",
         ),
         pytest.param(
+            "_libraries_data_sonarr_dependency_reasons",
+            {
+                "sho-library_tv-library": "TV Shows",
+                "sho-library_tv-template_collection_other_chart_sonarr_add_missing_metacritic": True,
+            },
+            True,
+            "sonarr_add_missing_metacritic enabled",
+            id="sonarr_metacritic_template_collection_enabled",
+        ),
+        pytest.param(
             "_libraries_data_trakt_dependency_reasons",
             {
                 "sho-library_tv-library": "TV Shows",


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Exposes Metacritic Must See show support in Quickstart’s Other Charts options. This updates the Quickstart collection metadata, adds the Sonarr missing-items toggle for shows, and includes a regression test for the new template child key.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
