### PR TITLE
Add metadata files

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Kometa Quickstart is more than just a YAML generator - it's a full interactive e
 - **Dependency-Aware Optional Pages:** Optional pages such as Tautulli, OMDb, MDBList, AniDB, Radarr, Sonarr, Trakt, and MyAnimeList become required when selected library features need them
 - **TODO Sidebar:** Outstanding dependency and validation tasks are grouped into clickable cards that save the current page and open the affected setup page
 - **Library-Scoped Playlists:** Playlist file selection now lives on the Libraries page so playlists stay tied to the libraries included in the generated YAML
-- **Library Metadata Files:** Add multiple `metadata_files` entries per library with mixed `file`, `url`, `git`, and `repo` sources, import them from existing configs, and validate that each entry resolves to a non-empty YAML file before output
+- **Library Metadata Files:** Add multiple `metadata_files` entries per library with mixed `file`, `folder`, `url`, `git`, and `repo` sources, import them from existing configs, and validate that each entry resolves to non-empty YAML before output
 - **Custom Repo Awareness:** `repo` metadata files are dependency-aware and point back to `Settings -> Custom Repo` when that base path is missing
 - **Filtered Page Search:** Find matches on Libraries and Settings pages and auto-expand matching sections
 - **Settings Cog:** Quick access to runtime controls like debug mode and port changes from anywhere
@@ -137,7 +137,7 @@ How it works:
 - **Preview required:** Quickstart always runs a preview before import and shows a line‑by‑line report (`imported / not imported`) with filters (All/Imported/Not Imported/Comments) and a downloadable report.
 - **Plex credentials prompt:** If the import contains libraries, Plex validation is required for mapping. Quickstart will prompt for Plex URL/token if none are present; if the credentials in the file fail validation, you’ll be prompted to correct them and re‑run Preview.
 - **Library mapping:** Imported library names must be mapped to Plex libraries (or ignored) before confirming the import; you can re‑preview after mapping.
-- **Metadata file import:** Library `metadata_files` import supports `file`, `url`, `git`, and `repo` entries. Quickstart currently validates file resolution and YAML parsing, but it does not fully validate Kometa metadata schema yet.
+- **Metadata file import:** Library `metadata_files` import supports `file`, `folder`, `url`, `git`, and `repo` entries. Quickstart currently validates file or folder resolution and YAML parsing, but it does not fully validate Kometa metadata schema yet.
 - **After import:** Quickstart stays on the Welcome page, runs bulk validation automatically, then refreshes the workspace status for the imported config.
 
 #### What happens after import?

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Kometa Quickstart is more than just a YAML generator - it's a full interactive e
 - **Dependency-Aware Optional Pages:** Optional pages such as Tautulli, OMDb, MDBList, AniDB, Radarr, Sonarr, Trakt, and MyAnimeList become required when selected library features need them
 - **TODO Sidebar:** Outstanding dependency and validation tasks are grouped into clickable cards that save the current page and open the affected setup page
 - **Library-Scoped Playlists:** Playlist file selection now lives on the Libraries page so playlists stay tied to the libraries included in the generated YAML
+- **Library Metadata Files:** Add multiple `metadata_files` entries per library with mixed `file`, `url`, `git`, and `repo` sources, import them from existing configs, and validate that each entry resolves to a non-empty YAML file before output
+- **Custom Repo Awareness:** `repo` metadata files are dependency-aware and point back to `Settings -> Custom Repo` when that base path is missing
 - **Filtered Page Search:** Find matches on Libraries and Settings pages and auto-expand matching sections
 - **Settings Cog:** Quick access to runtime controls like debug mode and port changes from anywhere
 
@@ -135,6 +137,7 @@ How it works:
 - **Preview required:** Quickstart always runs a preview before import and shows a line‑by‑line report (`imported / not imported`) with filters (All/Imported/Not Imported/Comments) and a downloadable report.
 - **Plex credentials prompt:** If the import contains libraries, Plex validation is required for mapping. Quickstart will prompt for Plex URL/token if none are present; if the credentials in the file fail validation, you’ll be prompted to correct them and re‑run Preview.
 - **Library mapping:** Imported library names must be mapped to Plex libraries (or ignored) before confirming the import; you can re‑preview after mapping.
+- **Metadata file import:** Library `metadata_files` import supports `file`, `url`, `git`, and `repo` entries. Quickstart currently validates file resolution and YAML parsing, but it does not fully validate Kometa metadata schema yet.
 - **After import:** Quickstart stays on the Welcome page, runs bulk validation automatically, then refreshes the workspace status for the imported config.
 
 #### What happens after import?
@@ -157,6 +160,10 @@ After you confirm an import, Quickstart saves the new config, shows a compact su
 - **Network access:** Quickstart only contacts external services for validation, remote asset fetches, update checks, and explicit update or sync actions.
 
 Quickstart is a guided Web UI that helps you create a configuration file for Kometa and run supported Kometa-Team companion apps like ImageMaid from the same workspace.
+
+### Development Transparency
+- Through December 2025, development used limited to no AI assistance.
+- After December 2025, some features, fixes, and UI tweaks were added with help from Codex.
 
 Special thanks to [meisnate12](https://github.com/meisnate12), [bullmoose20](https://github.com/bullmoose20), [chazlarson](https://github.com/chazlarson), and [Yozora](https://github.com/yozoraXCII) for their contributions to this tool.
 

--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -346,7 +346,7 @@ def extract_library_name(key):
     # known section marker. This avoids greedy matches when template variable
     # keys themselves contain hyphens (e.g. `use_South-Eastern Asia`).
     match = re.match(
-        r"^(?:mov|sho)-library_(.+?)-(?:library$|collection_|template_|attribute_|overlay_|top_level_)",
+        r"^(?:mov|sho)-library_(.+?)-(?:library$|collection_|template_|attribute_|overlay_|top_level_|metadata_files$)",
         key,
     )
     return match.group(1) if match else None

--- a/modules/importer.py
+++ b/modules/importer.py
@@ -1278,14 +1278,20 @@ def prepare_import_payload(
                         if "file" in entry:
                             entry_type = "file"
                             location = entry.get("file")
+                        elif "git" in entry:
+                            entry_type = "git"
+                            location = entry.get("git")
+                        elif "repo" in entry:
+                            entry_type = "repo"
+                            location = entry.get("repo")
                         elif "url" in entry:
                             entry_type = "url"
                             location = entry.get("url")
-                    if entry_type not in {"file", "url"}:
+                    if entry_type not in {"file", "url", "git", "repo"}:
                         report.add(
                             "unmapped",
                             f"libraries.{lib_name}.metadata_files[{idx}]",
-                            "Only file and url metadata files are supported.",
+                            "Only file, url, git, and repo metadata files are supported.",
                         )
                         continue
                     location = str(location or "").strip()

--- a/modules/importer.py
+++ b/modules/importer.py
@@ -1278,6 +1278,9 @@ def prepare_import_payload(
                         if "file" in entry:
                             entry_type = "file"
                             location = entry.get("file")
+                        elif "folder" in entry:
+                            entry_type = "folder"
+                            location = entry.get("folder")
                         elif "git" in entry:
                             entry_type = "git"
                             location = entry.get("git")
@@ -1287,11 +1290,11 @@ def prepare_import_payload(
                         elif "url" in entry:
                             entry_type = "url"
                             location = entry.get("url")
-                    if entry_type not in {"file", "url", "git", "repo"}:
+                    if entry_type not in {"file", "folder", "url", "git", "repo"}:
                         report.add(
                             "unmapped",
                             f"libraries.{lib_name}.metadata_files[{idx}]",
-                            "Only file, url, git, and repo metadata files are supported.",
+                            "Only file, folder, url, git, and repo metadata files are supported.",
                         )
                         continue
                     location = str(location or "").strip()

--- a/modules/importer.py
+++ b/modules/importer.py
@@ -1268,6 +1268,43 @@ def prepare_import_payload(
             elif overlay_files is not None:
                 report.add("unmapped", f"libraries.{lib_name}.overlay_files", "Unsupported overlay_files format.")
 
+            metadata_files = lib_cfg.get("metadata_files")
+            if isinstance(metadata_files, list):
+                imported_metadata_files = []
+                for idx, entry in enumerate(metadata_files):
+                    entry_type = None
+                    location = None
+                    if isinstance(entry, dict):
+                        if "file" in entry:
+                            entry_type = "file"
+                            location = entry.get("file")
+                        elif "url" in entry:
+                            entry_type = "url"
+                            location = entry.get("url")
+                    if entry_type not in {"file", "url"}:
+                        report.add(
+                            "unmapped",
+                            f"libraries.{lib_name}.metadata_files[{idx}]",
+                            "Only file and url metadata files are supported.",
+                        )
+                        continue
+                    location = str(location or "").strip()
+                    if not location:
+                        report.add(
+                            "unmapped",
+                            f"libraries.{lib_name}.metadata_files[{idx}]",
+                            "Metadata file location is required.",
+                        )
+                        continue
+                    imported_metadata_files.append({"type": entry_type, "location": location})
+                    report.add("imported", f"libraries.{lib_name}.metadata_files[{idx}].{entry_type}")
+
+                if imported_metadata_files:
+                    libraries_data[f"{lib_id}-metadata_files"] = json.dumps(imported_metadata_files, ensure_ascii=True)
+                    report.add("imported", f"libraries.{lib_name}.metadata_files")
+            elif metadata_files is not None:
+                report.add("unmapped", f"libraries.{lib_name}.metadata_files", "Unsupported metadata_files format.")
+
             # Library settings
             settings_section = lib_cfg.get("settings")
             if isinstance(settings_section, dict):
@@ -1362,7 +1399,7 @@ def prepare_import_payload(
             elif operations is not None:
                 report.add("unmapped", f"libraries.{lib_name}.operations", "Unsupported operations format.")
 
-            handled_keys = {"collection_files", "overlay_files", "template_variables", "settings", "operations"}
+            handled_keys = {"collection_files", "overlay_files", "metadata_files", "template_variables", "settings", "operations"}
             handled_keys.update(top_level_map.keys())
             for key in lib_cfg.keys():
                 if key in handled_keys:

--- a/modules/output.py
+++ b/modules/output.py
@@ -975,7 +975,7 @@ def _parse_metadata_file_entries(raw_value):
             continue
         entry_type = str(entry.get("type") or "").strip().lower()
         location = str(entry.get("location") or "").strip()
-        if entry_type not in {"file", "url", "git", "repo"} or not location:
+        if entry_type not in {"file", "folder", "url", "git", "repo"} or not location:
             continue
         normalized.append({entry_type: location})
 

--- a/modules/output.py
+++ b/modules/output.py
@@ -1853,7 +1853,8 @@ def build_libraries_section(
         metadata_group = movie_metadata_files.get(helpers.extract_library_name(library_key), {}) if library_type == "mov" else show_metadata_files.get(
             helpers.extract_library_name(library_key), {}
         )
-        metadata_entries = _parse_metadata_file_entries(metadata_group.get(f"{library_key}-metadata_files"))
+        library_prefix = library_key[: -len("-library")] if isinstance(library_key, str) and library_key.endswith("-library") else library_key
+        metadata_entries = _parse_metadata_file_entries(metadata_group.get(f"{library_prefix}-metadata_files"))
         if metadata_entries:
             entry["metadata_files"] = metadata_entries
 
@@ -2127,6 +2128,8 @@ def reorder_library_section(library_data):
     - `report_path` appears first.
     - `remove_overlays` and `reset_overlays` come next.
     - `template_variables` next.
+    - `metadata_files` appears before `collection_files`.
+    - `collection_files` appears before `overlay_files`.
     - `settings` appears before `operations`.
     - Keys inside `operations` are ordered as per Kometa Wiki.
     - Other keys retain their natural order.
@@ -2147,11 +2150,19 @@ def reorder_library_section(library_data):
     if "template_variables" in library_data:
         reordered_data["template_variables"] = library_data["template_variables"]
 
-    # 4. Then library settings
+    # 4. Then library-level metadata/collections/overlays in explicit YAML order
+    if "metadata_files" in library_data:
+        reordered_data["metadata_files"] = library_data["metadata_files"]
+    if "collection_files" in library_data:
+        reordered_data["collection_files"] = library_data["collection_files"]
+    if "overlay_files" in library_data:
+        reordered_data["overlay_files"] = library_data["overlay_files"]
+
+    # 5. Then library settings
     if "settings" in library_data:
         reordered_data["settings"] = library_data["settings"]
 
-    # 5. Reorder operations
+    # 6. Reorder operations
     operations_order = [
         "assets_for_all",
         "assets_for_all_collections",
@@ -2196,7 +2207,7 @@ def reorder_library_section(library_data):
                 ordered_ops[k] = v
         reordered_data["operations"] = ordered_ops
 
-    # 6. Finally add any other keys that weren't handled
+    # 7. Finally add any other keys that weren't handled
     for key, value in library_data.items():
         if key not in reordered_data:
             reordered_data[key] = value

--- a/modules/output.py
+++ b/modules/output.py
@@ -975,7 +975,7 @@ def _parse_metadata_file_entries(raw_value):
             continue
         entry_type = str(entry.get("type") or "").strip().lower()
         location = str(entry.get("location") or "").strip()
-        if entry_type not in {"file", "url"} or not location:
+        if entry_type not in {"file", "url", "git", "repo"} or not location:
             continue
         normalized.append({entry_type: location})
 

--- a/modules/output.py
+++ b/modules/output.py
@@ -1850,8 +1850,10 @@ def build_libraries_section(
 
                     entry["overlay_files"] = overlay_entries
 
-        metadata_group = movie_metadata_files.get(helpers.extract_library_name(library_key), {}) if library_type == "mov" else show_metadata_files.get(
-            helpers.extract_library_name(library_key), {}
+        metadata_group = (
+            movie_metadata_files.get(helpers.extract_library_name(library_key), {})
+            if library_type == "mov"
+            else show_metadata_files.get(helpers.extract_library_name(library_key), {})
         )
         library_prefix = library_key[: -len("-library")] if isinstance(library_key, str) and library_key.endswith("-library") else library_key
         metadata_entries = _parse_metadata_file_entries(metadata_group.get(f"{library_prefix}-metadata_files"))

--- a/modules/output.py
+++ b/modules/output.py
@@ -952,6 +952,37 @@ def _collapse_collection_data_template_vars(config_data):
     return config_data
 
 
+def _parse_metadata_file_entries(raw_value):
+    if isinstance(raw_value, list):
+        entries = raw_value
+    elif isinstance(raw_value, str):
+        text = raw_value.strip()
+        if not text:
+            return []
+        try:
+            entries = json.loads(text)
+        except Exception:
+            return []
+    else:
+        return []
+
+    if not isinstance(entries, list):
+        return []
+
+    normalized = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        entry_type = str(entry.get("type") or "").strip().lower()
+        location = str(entry.get("location") or "").strip()
+        if entry_type not in {"file", "url"} or not location:
+            continue
+        normalized.append({entry_type: location})
+
+    normalized.sort(key=lambda item: (next(iter(item.keys())), next(iter(item.values())).casefold()))
+    return normalized
+
+
 def build_libraries_section(
     movie_libraries,
     show_libraries,
@@ -961,6 +992,8 @@ def build_libraries_section(
     show_overlays,
     movie_attributes,
     show_attributes,
+    movie_metadata_files,
+    show_metadata_files,
     movie_templates,
     show_templates,
     movie_top_level,
@@ -1817,6 +1850,13 @@ def build_libraries_section(
 
                     entry["overlay_files"] = overlay_entries
 
+        metadata_group = movie_metadata_files.get(helpers.extract_library_name(library_key), {}) if library_type == "mov" else show_metadata_files.get(
+            helpers.extract_library_name(library_key), {}
+        )
+        metadata_entries = _parse_metadata_file_entries(metadata_group.get(f"{library_key}-metadata_files"))
+        if metadata_entries:
+            entry["metadata_files"] = metadata_entries
+
         # Template Variables
         template_key = helpers.extract_library_name(library_key)
         template_data = templates.get(template_key, {})
@@ -2365,6 +2405,8 @@ def build_config(header_style="standard", config_name=None):
         show_overlays = group_by_library("overlay_", show_library_names, normalize_overlays=True)
         movie_attributes = group_by_library("attribute_", movie_library_names)
         show_attributes = group_by_library("attribute_", show_library_names)
+        movie_metadata_files = group_by_library("metadata_files", movie_library_names)
+        show_metadata_files = group_by_library("metadata_files", show_library_names)
         movie_templates = group_by_library("template_variables", movie_library_names)
         show_templates = group_by_library("template_variables", show_library_names)
         movie_top_level = group_by_library("top_level_", movie_library_names)
@@ -2380,6 +2422,8 @@ def build_config(header_style="standard", config_name=None):
             helpers.ts_log(f"Extracted Show Overlays: {show_overlays}", level="DEBUG")
             helpers.ts_log(f"Extracted Movie Attributes: {movie_attributes}", level="DEBUG")
             helpers.ts_log(f"Extracted Show Attributes: {show_attributes}", level="DEBUG")
+            helpers.ts_log(f"Extracted Movie Metadata Files: {movie_metadata_files}", level="DEBUG")
+            helpers.ts_log(f"Extracted Show Metadata Files: {show_metadata_files}", level="DEBUG")
             helpers.ts_log(f"Extracted Movie Templates: {movie_templates}", level="DEBUG")
             helpers.ts_log(f"Extracted Show Templates: {show_templates}", level="DEBUG")
             helpers.ts_log(f"Extracted Movie Top Level: {movie_top_level}", level="DEBUG")
@@ -2395,6 +2439,8 @@ def build_config(header_style="standard", config_name=None):
             show_overlays,
             movie_attributes,
             show_attributes,
+            movie_metadata_files,
+            show_metadata_files,
             movie_templates,
             show_templates,
             movie_top_level,
@@ -2563,6 +2609,8 @@ def build_config(header_style="standard", config_name=None):
 
             elif stripped.startswith("collection_files:"):
                 output.append(art("Collections"))
+            elif stripped.startswith("metadata_files:"):
+                output.append(art("Metadata Files"))
             elif stripped.startswith("overlay_files:"):
                 output.append(art("Overlays"))
 

--- a/modules/validations.py
+++ b/modules/validations.py
@@ -1,3 +1,4 @@
+import os
 import re
 import urllib.parse
 from json import JSONDecodeError
@@ -88,6 +89,48 @@ def _validate_yaml_location(location, label):
     return _validate_yaml_text(yaml_text, label)
 
 
+def _validate_yaml_folder(location, label):
+    valid, message = path_validation.validate_path(
+        location,
+        {"allow_relative": True, "must_exist": True, "mode": "input_dir"},
+    )
+    if not valid:
+        return False, f"{label}: {message}"
+
+    try:
+        entries = sorted(os.listdir(location), key=str.casefold)
+    except OSError as exc:
+        return False, f"{label}: Unable to read folder. {exc}"
+
+    yaml_files = [
+        os.path.join(location, entry)
+        for entry in entries
+        if os.path.isfile(os.path.join(location, entry)) and entry.lower().endswith((".yml", ".yaml"))
+    ]
+    if not yaml_files:
+        return False, f"{label}: Folder must contain at least one top-level .yml or .yaml file."
+
+    for yaml_file in yaml_files:
+        try:
+            with open(yaml_file, "r", encoding="utf-8") as handle:
+                yaml_text = handle.read()
+        except OSError as exc:
+            return False, f"{label}: Unable to read file {os.path.basename(yaml_file)}. {exc}"
+
+        valid, message = _validate_yaml_text(yaml_text, f"{label} file {os.path.basename(yaml_file)}")
+        if not valid:
+            return False, message
+
+    validated_files = len(yaml_files)
+    file_names = [os.path.basename(yaml_file) for yaml_file in yaml_files]
+    suffix = "" if validated_files == 1 else "s"
+    return True, None, {
+        "validated_files": validated_files,
+        "files": file_names,
+        "message": f"Validated {validated_files} YAML file{suffix} in folder."
+    }
+
+
 def _normalize_custom_repo_base(custom_repo):
     repo = str(custom_repo or "").strip()
     if not repo or repo.lower() == "none":
@@ -105,55 +148,81 @@ def _saved_custom_repo_base():
     return _normalize_custom_repo_base(settings_section.get("custom_repo"))
 
 
+def _normalize_metadata_validation_result(result):
+    if isinstance(result, tuple):
+        if len(result) == 3:
+            valid, message, details = result
+            return bool(valid), message, details or {}
+        if len(result) == 2:
+            valid, message = result
+            return bool(valid), message, {}
+    return False, "Validation failed.", {}
+
+
 def validate_metadata_file_payload(data):
     metadata_file_type = str(data.get("metadata_file_type") or "").strip().lower()
     metadata_file_location = str(data.get("metadata_file_location") or "").strip()
 
-    if metadata_file_type not in {"file", "url", "git", "repo"}:
-        return False, "Metadata file type must be file, url, git, or repo."
+    if metadata_file_type not in {"file", "folder", "url", "git", "repo"}:
+        return False, "Metadata file type must be file, folder, url, git, or repo.", {}
 
     if not metadata_file_location:
-        return False, "Metadata file location is required."
+        return False, "Metadata file location is required.", {}
 
     if metadata_file_type == "url":
         if not metadata_file_location.lower().startswith(("http://", "https://")):
-            return False, "Metadata file URL must start with http:// or https://."
+            return False, "Metadata file URL must start with http:// or https://.", {}
         label = "Metadata file URL"
-        return _validate_yaml_location(metadata_file_location, label)
+        return _normalize_metadata_validation_result(_validate_yaml_location(metadata_file_location, label))
+
+    if metadata_file_type == "folder":
+        if metadata_file_location.lower().startswith(("http://", "https://")):
+            return False, "Metadata folder path must be a local folder path.", {}
+        label = "Metadata folder path"
+        return _normalize_metadata_validation_result(_validate_yaml_folder(metadata_file_location, label))
 
     if metadata_file_type == "file":
         if metadata_file_location.lower().startswith(("http://", "https://")):
-            return False, "Metadata file path must be a local file path."
+            return False, "Metadata file path must be a local file path.", {}
         label = "Metadata file path"
-        return _validate_yaml_location(metadata_file_location, label)
+        return _normalize_metadata_validation_result(_validate_yaml_location(metadata_file_location, label))
 
     if metadata_file_location.lower().startswith(("http://", "https://")):
-        return False, f"Metadata file {metadata_file_type} value must not be a full URL."
+        return False, f"Metadata file {metadata_file_type} value must not be a full URL.", {}
 
     if metadata_file_type == "git":
         valid, message = _validate_yaml_location_suffix(metadata_file_location, "Metadata file git path")
         if not valid:
-            return False, message
-        return _validate_yaml_location(
-            f"https://raw.githubusercontent.com/Kometa-Team/Community-Configs/master/{metadata_file_location}",
-            "Metadata file git path",
+            return False, message, {}
+        return _normalize_metadata_validation_result(
+            _validate_yaml_location(
+                f"https://raw.githubusercontent.com/Kometa-Team/Community-Configs/master/{metadata_file_location}",
+                "Metadata file git path",
+            )
         )
 
     custom_repo_base = _saved_custom_repo_base()
     if not custom_repo_base:
-        return False, "Metadata file repo entries require Custom Repo to be configured and saved first within the Settings page."
+        return False, "Metadata file repo entries require Custom Repo to be configured and saved first within the Settings page.", {}
     valid, message = _validate_yaml_location_suffix(metadata_file_location, "Metadata file repo path")
     if not valid:
-        return False, message
+        return False, message, {}
     resolved_repo_location = f"{custom_repo_base}{metadata_file_location}"
-    return _validate_yaml_location(resolved_repo_location, "Metadata file repo path")
+    return _normalize_metadata_validation_result(_validate_yaml_location(resolved_repo_location, "Metadata file repo path"))
 
 
 def validate_metadata_file_server(data):
-    valid, message = validate_metadata_file_payload(data)
+    valid, message, details = validate_metadata_file_payload(data)
     if not valid:
         return jsonify({"valid": False, "error": message}), 400
-    return jsonify({"valid": True})
+    payload = {"valid": True}
+    if details.get("message"):
+        payload["message"] = details["message"]
+    if "validated_files" in details:
+        payload["validated_files"] = details["validated_files"]
+    if isinstance(details.get("files"), list):
+        payload["files"] = details["files"]
+    return jsonify(payload)
 
 
 def validate_plex_server(data):

--- a/modules/validations.py
+++ b/modules/validations.py
@@ -8,7 +8,7 @@ from flask import current_app as app
 from flask import jsonify, flash
 from plexapi.server import PlexServer
 
-from modules import iso, helpers, path_validation, url_validation
+from modules import iso, helpers, path_validation, persistence, url_validation
 
 
 def validate_iso3166_1(code):
@@ -88,26 +88,65 @@ def _validate_yaml_location(location, label):
     return _validate_yaml_text(yaml_text, label)
 
 
+def _normalize_custom_repo_base(custom_repo):
+    repo = str(custom_repo or "").strip()
+    if not repo or repo.lower() == "none":
+        return None
+    if "https://github.com/" in repo:
+        repo = repo.replace("https://github.com/", "https://raw.githubusercontent.com/").replace("/tree/", "/")
+        if not repo.endswith("/"):
+            repo += "/"
+    return repo
+
+
+def _saved_custom_repo_base():
+    settings_data = persistence.retrieve_settings("150-settings") or {}
+    settings_section = settings_data.get("settings", {}) if isinstance(settings_data, dict) else {}
+    return _normalize_custom_repo_base(settings_section.get("custom_repo"))
+
+
 def validate_metadata_file_payload(data):
     metadata_file_type = str(data.get("metadata_file_type") or "").strip().lower()
     metadata_file_location = str(data.get("metadata_file_location") or "").strip()
 
-    if metadata_file_type not in {"file", "url"}:
-        return False, "Metadata file type must be file or url."
+    if metadata_file_type not in {"file", "url", "git", "repo"}:
+        return False, "Metadata file type must be file, url, git, or repo."
 
     if not metadata_file_location:
-        return False, "Metadata file path or URL is required."
+        return False, "Metadata file location is required."
 
     if metadata_file_type == "url":
         if not metadata_file_location.lower().startswith(("http://", "https://")):
             return False, "Metadata file URL must start with http:// or https://."
         label = "Metadata file URL"
-    else:
+        return _validate_yaml_location(metadata_file_location, label)
+
+    if metadata_file_type == "file":
         if metadata_file_location.lower().startswith(("http://", "https://")):
             return False, "Metadata file path must be a local file path."
         label = "Metadata file path"
+        return _validate_yaml_location(metadata_file_location, label)
 
-    return _validate_yaml_location(metadata_file_location, label)
+    if metadata_file_location.lower().startswith(("http://", "https://")):
+        return False, f"Metadata file {metadata_file_type} value must not be a full URL."
+
+    if metadata_file_type == "git":
+        valid, message = _validate_yaml_location_suffix(metadata_file_location, "Metadata file git path")
+        if not valid:
+            return False, message
+        return _validate_yaml_location(
+            f"https://raw.githubusercontent.com/Kometa-Team/Community-Configs/master/{metadata_file_location}",
+            "Metadata file git path",
+        )
+
+    custom_repo_base = _saved_custom_repo_base()
+    if not custom_repo_base:
+        return False, "Metadata file repo entries require Custom Repo to be configured and saved first within the Settings page."
+    valid, message = _validate_yaml_location_suffix(metadata_file_location, "Metadata file repo path")
+    if not valid:
+        return False, message
+    resolved_repo_location = f"{custom_repo_base}{metadata_file_location}"
+    return _validate_yaml_location(resolved_repo_location, "Metadata file repo path")
 
 
 def validate_metadata_file_server(data):

--- a/modules/validations.py
+++ b/modules/validations.py
@@ -102,11 +102,7 @@ def _validate_yaml_folder(location, label):
     except OSError as exc:
         return False, f"{label}: Unable to read folder. {exc}"
 
-    yaml_files = [
-        os.path.join(location, entry)
-        for entry in entries
-        if os.path.isfile(os.path.join(location, entry)) and entry.lower().endswith((".yml", ".yaml"))
-    ]
+    yaml_files = [os.path.join(location, entry) for entry in entries if os.path.isfile(os.path.join(location, entry)) and entry.lower().endswith((".yml", ".yaml"))]
     if not yaml_files:
         return False, f"{label}: Folder must contain at least one top-level .yml or .yaml file."
 
@@ -124,11 +120,7 @@ def _validate_yaml_folder(location, label):
     validated_files = len(yaml_files)
     file_names = [os.path.basename(yaml_file) for yaml_file in yaml_files]
     suffix = "" if validated_files == 1 else "s"
-    return True, None, {
-        "validated_files": validated_files,
-        "files": file_names,
-        "message": f"Validated {validated_files} YAML file{suffix} in folder."
-    }
+    return True, None, {"validated_files": validated_files, "files": file_names, "message": f"Validated {validated_files} YAML file{suffix} in folder."}
 
 
 def _normalize_custom_repo_base(custom_repo):

--- a/modules/validations.py
+++ b/modules/validations.py
@@ -52,6 +52,71 @@ def _validate_yaml_location_suffix(location, label):
     return True, None
 
 
+def _validate_yaml_location(location, label):
+    valid, message = _validate_yaml_location_suffix(location, label)
+    if not valid:
+        return False, message
+
+    if str(location).strip().lower().startswith(("http://", "https://")):
+        valid, message = url_validation.validate_url(location, allow_local=True)
+        if not valid:
+            return False, f"{label}: {message}"
+
+        try:
+            response = requests.get(location, timeout=10)
+        except requests.RequestException as exc:
+            return False, f"Connection error: {str(exc)}"
+
+        if response.status_code >= 400:
+            return False, f"Failed to fetch {label} ({response.status_code} [{response.reason}])."
+
+        return _validate_yaml_text(response.text, label)
+
+    valid, message = path_validation.validate_path(
+        location,
+        {"allow_relative": True, "must_exist": True, "mode": "input_file"},
+    )
+    if not valid:
+        return False, f"{label}: {message}"
+
+    try:
+        with open(location, "r", encoding="utf-8") as handle:
+            yaml_text = handle.read()
+    except OSError as exc:
+        return False, f"{label}: Unable to read file. {exc}"
+
+    return _validate_yaml_text(yaml_text, label)
+
+
+def validate_metadata_file_payload(data):
+    metadata_file_type = str(data.get("metadata_file_type") or "").strip().lower()
+    metadata_file_location = str(data.get("metadata_file_location") or "").strip()
+
+    if metadata_file_type not in {"file", "url"}:
+        return False, "Metadata file type must be file or url."
+
+    if not metadata_file_location:
+        return False, "Metadata file path or URL is required."
+
+    if metadata_file_type == "url":
+        if not metadata_file_location.lower().startswith(("http://", "https://")):
+            return False, "Metadata file URL must start with http:// or https://."
+        label = "Metadata file URL"
+    else:
+        if metadata_file_location.lower().startswith(("http://", "https://")):
+            return False, "Metadata file path must be a local file path."
+        label = "Metadata file path"
+
+    return _validate_yaml_location(metadata_file_location, label)
+
+
+def validate_metadata_file_server(data):
+    valid, message = validate_metadata_file_payload(data)
+    if not valid:
+        return jsonify({"valid": False, "error": message}), 400
+    return jsonify({"valid": True})
+
+
 def validate_plex_server(data):
     plex_url = data.get("plex_url")
     plex_token = data.get("plex_token")
@@ -299,43 +364,7 @@ def validate_apprise_server(data):
     if not apprise_location:
         return jsonify({"valid": False, "error": "Apprise YAML path or URL is required."}), 400
 
-    valid, message = _validate_yaml_location_suffix(apprise_location, "Apprise location")
-    if not valid:
-        return jsonify({"valid": False, "error": message}), 400
-
-    if apprise_location.lower().startswith(("http://", "https://")):
-        valid, message = url_validation.validate_url(apprise_location, allow_local=True)
-        if not valid:
-            return jsonify({"valid": False, "error": f"Apprise URL: {message}"}), 400
-
-        try:
-            response = requests.get(apprise_location, timeout=10)
-        except requests.RequestException as e:
-            return jsonify({"valid": False, "error": f"Connection error: {str(e)}"}), 400
-
-        if response.status_code >= 400:
-            return jsonify({"valid": False, "error": f"Failed to fetch Apprise YAML ({response.status_code} [{response.reason}])."}), 400
-
-        valid, message = _validate_yaml_text(response.text, "Apprise URL")
-        if not valid:
-            return jsonify({"valid": False, "error": message}), 400
-
-        return jsonify({"valid": True})
-
-    valid, message = path_validation.validate_path(
-        apprise_location,
-        {"allow_relative": True, "must_exist": True, "mode": "input_file"},
-    )
-    if not valid:
-        return jsonify({"valid": False, "error": f"Apprise path: {message}"}), 400
-
-    try:
-        with open(apprise_location, "r", encoding="utf-8") as handle:
-            yaml_text = handle.read()
-    except OSError as exc:
-        return jsonify({"valid": False, "error": f"Apprise path: Unable to read file. {exc}"}), 400
-
-    valid, message = _validate_yaml_text(yaml_text, "Apprise file")
+    valid, message = _validate_yaml_location(apprise_location, "Apprise location")
     if not valid:
         return jsonify({"valid": False, "error": message}), 400
 

--- a/quickstart.py
+++ b/quickstart.py
@@ -586,12 +586,14 @@ def _validate_library_metadata_files(libraries_data, selected_library_ids):
             continue
 
         for idx, entry in enumerate(entries, start=1):
-            valid, message, _details = validations._normalize_metadata_validation_result(validations.validate_metadata_file_payload(
-                {
-                    "metadata_file_type": entry.get("type"),
-                    "metadata_file_location": entry.get("location"),
-                }
-            ))
+            valid, message, _details = validations._normalize_metadata_validation_result(
+                validations.validate_metadata_file_payload(
+                    {
+                        "metadata_file_type": entry.get("type"),
+                        "metadata_file_location": entry.get("location"),
+                    }
+                )
+            )
             if not valid:
                 errors.append(f"{lib_id} metadata_files[{idx}]: {message}")
 

--- a/quickstart.py
+++ b/quickstart.py
@@ -170,6 +170,7 @@ VALIDATION_REASON_LABELS = {
     "invalid_paths": "Invalid paths",
     "missing_library_defaults": "Missing library defaults",
     "missing_placeholder_imdb": "Missing placeholder IMDb ID",
+    "invalid_metadata_files": "Invalid metadata files",
     "invalid_fields": "Invalid fields",
     "no_webhooks": "No webhooks configured",
     "disabled": "Disabled",
@@ -397,6 +398,7 @@ QS_ERROR_REASONS = {
     "validation_error",
     "invalid_paths",
     "invalid_fields",
+    "invalid_metadata_files",
     "missing_library_defaults",
     "missing_placeholder_imdb",
 }
@@ -537,6 +539,63 @@ def _parse_json_array(value):
     except (TypeError, ValueError):
         return []
     return parsed if isinstance(parsed, list) else []
+
+
+def _parse_metadata_file_entries(value):
+    if isinstance(value, list):
+        raw_entries = value
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return []
+        try:
+            raw_entries = json.loads(text)
+        except (TypeError, ValueError):
+            return None
+    else:
+        return []
+
+    if not isinstance(raw_entries, list):
+        return None
+
+    entries = []
+    for entry in raw_entries:
+        if not isinstance(entry, dict):
+            continue
+        entry_type = str(entry.get("type") or "").strip().lower()
+        location = str(entry.get("location") or "").strip()
+        if not entry_type and not location:
+            continue
+        entries.append({"type": entry_type, "location": location})
+    return entries
+
+
+def _validate_library_metadata_files(libraries_data, selected_library_ids):
+    if not isinstance(libraries_data, dict):
+        return []
+
+    errors = []
+    for lib_id in selected_library_ids or []:
+        raw_value = libraries_data.get(f"{lib_id}-metadata_files")
+        if raw_value in [None, "", "[]"]:
+            continue
+
+        entries = _parse_metadata_file_entries(raw_value)
+        if entries is None:
+            errors.append(f"{lib_id}: metadata_files must be a valid list.")
+            continue
+
+        for idx, entry in enumerate(entries, start=1):
+            valid, message = validations.validate_metadata_file_payload(
+                {
+                    "metadata_file_type": entry.get("type"),
+                    "metadata_file_location": entry.get("location"),
+                }
+            )
+            if not valid:
+                errors.append(f"{lib_id} metadata_files[{idx}]: {message}")
+
+    return errors
 
 
 def _library_prefix_from_key(key):
@@ -7941,12 +8000,15 @@ def validate_all_services():
         else:
             libraries_reason = None
             path_errors = path_validation.validate_payload(libraries_data)
+            metadata_file_errors = _validate_library_metadata_files(libraries_data, selected_library_ids)
             if path_errors:
                 libraries_reason = "invalid_paths"
+            elif metadata_file_errors:
+                libraries_reason = "invalid_metadata_files"
             else:
 
                 def has_minimal_library_yaml_selection(lib_id):
-                    allowed_markers = ("-collection_", "-overlay_", "-attribute_", "-top_level_")
+                    allowed_markers = ("-collection_", "-overlay_", "-attribute_", "-top_level_", "-metadata_files")
                     for key, value in libraries_data.items():
                         if not isinstance(key, str) or not key.startswith(f"{lib_id}-"):
                             continue
@@ -16057,6 +16119,12 @@ def purge_test_libraries():
 
     except Exception as e:
         return jsonify(success=False, message=f"Failed to delete folder:\n{str(e)}")
+
+
+@app.route("/validate_metadata_file", methods=["POST"])
+def validate_metadata_file():
+    data = request.get_json(silent=True) or {}
+    return validations.validate_metadata_file_server(data)
 
 
 @app.route("/restart", methods=["POST"])

--- a/quickstart.py
+++ b/quickstart.py
@@ -586,12 +586,12 @@ def _validate_library_metadata_files(libraries_data, selected_library_ids):
             continue
 
         for idx, entry in enumerate(entries, start=1):
-            valid, message = validations.validate_metadata_file_payload(
+            valid, message, _details = validations._normalize_metadata_validation_result(validations.validate_metadata_file_payload(
                 {
                     "metadata_file_type": entry.get("type"),
                     "metadata_file_location": entry.get("location"),
                 }
-            )
+            ))
             if not valid:
                 errors.append(f"{lib_id} metadata_files[{idx}]: {message}")
 

--- a/quickstart.py
+++ b/quickstart.py
@@ -598,6 +598,17 @@ def _validate_library_metadata_files(libraries_data, selected_library_ids):
     return errors
 
 
+def _selected_library_ids_from_libraries_data(libraries_data):
+    if not isinstance(libraries_data, dict):
+        return []
+
+    return [
+        key[: -len("-library")]
+        for key, value in libraries_data.items()
+        if isinstance(key, str) and key.startswith(("mov-library_", "sho-library_")) and key.endswith("-library") and _is_truthy_setting_value(value)
+    ]
+
+
 def _library_prefix_from_key(key):
     if not isinstance(key, str) or not key.startswith(("mov-library_", "sho-library_")):
         return None
@@ -5939,10 +5950,15 @@ def step(name):
         path_errors = path_validation.validate_payload(request.form)
         url_errors = url_validation.validate_payload(request.form)
         validation_errors = path_errors + url_errors
+        save_source, save_source_name = persistence.extract_names(request.referrer or name)
+        if save_source_name == "libraries":
+            clean_payload = persistence.clean_form_data(request.form)
+            incoming_libraries = helpers.build_config_dict("libraries", clean_payload).get("libraries", {})
+            selected_library_ids = _selected_library_ids_from_libraries_data(incoming_libraries)
+            validation_errors += _validate_library_metadata_files(incoming_libraries, selected_library_ids)
         if validation_errors:
             save_error = "Invalid values: " + " ".join(validation_errors)
         else:
-            save_source, save_source_name = persistence.extract_names(request.referrer or name)
             if save_source_name == "imagemaid":
                 request_payload = request.form.to_dict(flat=True)
                 request_payload["config_name"] = session.get("config_name") or request_payload.get("config_name") or request_payload.get("configSelector")
@@ -6799,6 +6815,12 @@ def autosave_library(library_id):
         errors = path_validation.validate_payload(incoming)
         if errors:
             return jsonify({"success": False, "error": "Invalid path values.", "errors": errors}), 400
+        clean_payload = persistence.clean_form_data(MultiDict(incoming))
+        incoming_libraries = helpers.build_config_dict("libraries", clean_payload).get("libraries", {})
+        selected_library_ids = _selected_library_ids_from_libraries_data(incoming_libraries)
+        metadata_errors = _validate_library_metadata_files(incoming_libraries, selected_library_ids)
+        if metadata_errors:
+            return jsonify({"success": False, "error": "Invalid metadata files.", "errors": metadata_errors}), 400
         persistence.save_settings("025-libraries", incoming)
         return jsonify({"success": True})
     except Exception as e:
@@ -7041,6 +7063,7 @@ def copy_library_settings():
 
         source_items = {k: v for k, v in libraries_data.items() if k.startswith(f"{source_prefix}-")}
         source_errors = path_validation.validate_payload(source_items)
+        source_metadata_errors = _validate_library_metadata_files(libraries_data, [source_prefix])
         if source_errors:
             return (
                 jsonify(
@@ -7048,6 +7071,17 @@ def copy_library_settings():
                         "success": False,
                         "error": "Invalid path values found in source library: " + " ".join(source_errors),
                         "errors": source_errors,
+                    }
+                ),
+                400,
+            )
+        if source_metadata_errors:
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "error": "Invalid metadata files found in source library: " + " ".join(source_metadata_errors),
+                        "errors": source_metadata_errors,
                     }
                 ),
                 400,

--- a/quickstart.py
+++ b/quickstart.py
@@ -6055,6 +6055,12 @@ def step(name):
     page_info["header_style"] = header_style
     page_info["save_error"] = save_error
     page_info["template_name"] = name
+    settings_payload = persistence.retrieve_settings("150-settings") or {}
+    settings_section = settings_payload.get("settings", {}) if isinstance(settings_payload, dict) else {}
+    custom_repo_setting = str(settings_section.get("custom_repo") or "").strip()
+    custom_repo_base = validations._normalize_custom_repo_base(custom_repo_setting) or ""
+    page_info["settings_custom_repo"] = custom_repo_setting
+    page_info["settings_custom_repo_base"] = custom_repo_base
     if "shutdown_nonce" not in session:
         session["shutdown_nonce"] = secrets.token_urlsafe(16)
     if "restart_nonce" not in session:

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -145,8 +145,8 @@ document.addEventListener('DOMContentLoaded', function () {
               <input type="text" class="form-control form-control-sm" data-metadata-file-location placeholder="config/metadata.yml or https://example.com/metadata.yml">
             </div>
             <div class="col-md-3 d-flex gap-2 justify-content-md-end">
-              <button type="button" class="btn btn-outline-info btn-sm" data-validate-metadata-file>Validate</button>
-              <button type="button" class="btn btn-outline-danger btn-sm" data-remove-metadata-file>Remove</button>
+              <button type="button" class="btn btn-success btn-sm" data-validate-metadata-file>Validate</button>
+              <button type="button" class="btn btn-danger btn-sm" data-remove-metadata-file>Remove</button>
             </div>
           </div>
           <div class="mt-2 small d-none" data-metadata-file-status></div>
@@ -160,7 +160,18 @@ document.addEventListener('DOMContentLoaded', function () {
       if (locationInput && entry.location) {
         locationInput.value = entry.location
       }
+      updateMetadataFileValidateButton(wrapper, false)
       return wrapper
+    }
+
+    function updateMetadataFileValidateButton (row, isValidated) {
+      if (!row) return
+      const button = row.querySelector('[data-validate-metadata-file]')
+      if (!button) return
+      button.disabled = Boolean(isValidated)
+      button.classList.toggle('btn-success', !isValidated)
+      button.classList.toggle('btn-secondary', isValidated)
+      button.textContent = isValidated ? 'Validated' : 'Validate'
     }
 
     function setMetadataFileStatus (row, kind, message) {
@@ -172,6 +183,7 @@ document.addEventListener('DOMContentLoaded', function () {
       if (!message) {
         target.classList.add('d-none')
         target.textContent = ''
+        updateMetadataFileValidateButton(row, false)
         const editor = row.closest('[data-metadata-files-editor]')
         if (editor) updateMetadataFilesAccordionState(editor)
         return
@@ -185,6 +197,7 @@ document.addEventListener('DOMContentLoaded', function () {
         target.classList.add('text-warning')
       }
       target.textContent = message
+      updateMetadataFileValidateButton(row, kind === 'success')
       const editor = row.closest('[data-metadata-files-editor]')
       if (editor) updateMetadataFilesAccordionState(editor)
     }
@@ -327,7 +340,9 @@ document.addEventListener('DOMContentLoaded', function () {
         } catch (_error) {
           setMetadataFileStatus(row, 'error', 'Validation request failed.')
         } finally {
-          validateButton.disabled = false
+          if (row.dataset.metadataFileState !== 'success') {
+            updateMetadataFileValidateButton(row, false)
+          }
         }
       }
     })

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -1,4 +1,4 @@
-/* global EventHandler, ValidationHandler, OverlayHandler, Sortable, showToast, setupParentChildToggleSync, bootstrap, FontFace, PathValidation, DOMParser, MutationObserver, showNavigationLoadingOverlay, hideNavigationLoadingOverlay */
+/* global EventHandler, ValidationHandler, OverlayHandler, Sortable, showToast, setupParentChildToggleSync, bootstrap, FontFace, PathValidation, DOMParser, MutationObserver, jumpTo, showNavigationLoadingOverlay, hideNavigationLoadingOverlay */
 
 document.addEventListener('DOMContentLoaded', function () {
   console.log('[DEBUG] Initializing Libraries...')
@@ -59,6 +59,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const copyModal = copyModalEl ? new bootstrap.Modal(copyModalEl) : null
     let activeLibraryId = null
     let loadRequestId = 0
+    let allowNextStepNavigation = false
     const dependencyHintConfigs = {
       tautulli: {
         stepKey: '030-tautulli',
@@ -166,19 +167,75 @@ document.addEventListener('DOMContentLoaded', function () {
       if (!row) return
       const target = row.querySelector('[data-metadata-file-status]')
       if (!target) return
+      row.dataset.metadataFileState = kind || ''
       target.className = 'mt-2 small'
       if (!message) {
         target.classList.add('d-none')
         target.textContent = ''
+        const editor = row.closest('[data-metadata-files-editor]')
+        if (editor) updateMetadataFilesAccordionState(editor)
         return
       }
       target.classList.remove('d-none')
       if (kind === 'success') {
         target.classList.add('text-success')
+      } else if (kind === 'error') {
+        target.classList.add('text-danger')
       } else {
         target.classList.add('text-warning')
       }
       target.textContent = message
+      const editor = row.closest('[data-metadata-files-editor]')
+      if (editor) updateMetadataFilesAccordionState(editor)
+    }
+
+    function updateMetadataFilesAccordionState (editor) {
+      if (!editor) return
+      const accordionItem = editor.closest('.accordion-item')
+      const accordionHeader = accordionItem?.querySelector(':scope > .accordion-header')
+      if (!accordionHeader) return
+
+      const rows = Array.from(editor.querySelectorAll('[data-metadata-file-row]'))
+      const hasEntries = rows.some(row => {
+        const type = row.querySelector('[data-metadata-file-type]')?.value || ''
+        const location = row.querySelector('[data-metadata-file-location]')?.value || ''
+        return Boolean(normalizeMetadataFileEntry({ type, location }))
+      })
+      const hasInvalid = rows.some(row => {
+        const state = String(row.dataset.metadataFileState || '').trim().toLowerCase()
+        return state === 'error' || state === 'warning'
+      })
+
+      accordionHeader.classList.remove('invalid')
+      if (hasInvalid) {
+        accordionHeader.classList.add('invalid')
+        return
+      }
+
+      accordionHeader.classList.remove('warning')
+      if (hasEntries) {
+        accordionHeader.classList.add('selected')
+      } else {
+        accordionHeader.classList.remove('selected')
+      }
+    }
+
+    function applyMetadataFileServerErrors (editor, errors) {
+      if (!editor || !Array.isArray(errors) || !errors.length) return false
+      const rows = Array.from(editor.querySelectorAll('[data-metadata-file-row]'))
+      rows.forEach(row => setMetadataFileStatus(row, '', ''))
+      let applied = false
+      errors.forEach(error => {
+        const text = String(error || '').trim()
+        const match = text.match(/metadata_files\[(\d+)\]:\s*(.+)$/i)
+        if (!match) return
+        const index = Number(match[1]) - 1
+        const message = match[2] || 'Validation failed.'
+        if (!Number.isInteger(index) || index < 0 || index >= rows.length) return
+        setMetadataFileStatus(rows[index], 'error', message)
+        applied = true
+      })
+      return applied
     }
 
     function syncMetadataFilesEditor (editor, emitEvents = true) {
@@ -208,6 +265,7 @@ document.addEventListener('DOMContentLoaded', function () {
       list.replaceChildren()
       entries.forEach(entry => list.appendChild(buildMetadataFileRow(entry)))
       syncMetadataFilesEditor(editor, false)
+      updateMetadataFilesAccordionState(editor)
     }
 
     function initMetadataFilesEditors (scope) {
@@ -262,12 +320,12 @@ document.addEventListener('DOMContentLoaded', function () {
           })
           const payload = await response.json().catch(() => ({}))
           if (!response.ok || !payload.valid) {
-            setMetadataFileStatus(row, 'warning', payload.error || 'Validation failed.')
+            setMetadataFileStatus(row, 'error', payload.error || 'Validation failed.')
           } else {
             setMetadataFileStatus(row, 'success', 'Metadata file looks valid.')
           }
         } catch (_error) {
-          setMetadataFileStatus(row, 'warning', 'Validation request failed.')
+          setMetadataFileStatus(row, 'error', 'Validation request failed.')
         } finally {
           validateButton.disabled = false
         }
@@ -1630,6 +1688,7 @@ document.addEventListener('DOMContentLoaded', function () {
       }
 
       const payload = buildPayloadFromCard(card)
+      const metadataEditor = card.querySelector('[data-metadata-files-editor]')
       const option = libraryPicker?.querySelector(`option[value="${activeLibraryId}"]`)
       const friendlyName = option?.dataset.label || option?.textContent?.trim() || activeLibraryId
 
@@ -1640,7 +1699,15 @@ document.addEventListener('DOMContentLoaded', function () {
         body: JSON.stringify(payload)
       })
         .then(res => {
-          if (!res.ok) throw new Error(`Autosave failed: ${res.status}`)
+          if (!res.ok) {
+            return res.json().catch(() => ({})).then(body => {
+              if (metadataEditor) {
+                applyMetadataFileServerErrors(metadataEditor, body && body.errors)
+              }
+              const message = body && body.error ? body.error : `Autosave failed: ${res.status}`
+              throw new Error(message)
+            })
+          }
           return res.json().catch(() => ({}))
         })
         .then(data => {
@@ -1656,7 +1723,7 @@ document.addEventListener('DOMContentLoaded', function () {
         .catch(err => {
           console.error('[Autosave] Failed to save library', activeLibraryId, err)
           if (typeof showToast === 'function') {
-            showToast('error', `Autosave failed for ${friendlyName}.`)
+            showToast('error', err.message || `Autosave failed for ${friendlyName}.`)
           }
           throw err
         })
@@ -1806,6 +1873,7 @@ document.addEventListener('DOMContentLoaded', function () {
     function loadLibrary (libraryId, context = 'switch') {
       if (libraryId === activeLibraryId) return
       const requestId = ++loadRequestId
+      const previousLibraryId = activeLibraryId
       const setLoading = (flag) => {
         if (libraryLoading) {
           libraryLoading.classList.toggle('d-none', !flag)
@@ -1824,7 +1892,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
       setLoading(true)
       autosaveActiveLibrary()
-        .finally(() => {
+        .then(() => {
           if (requestId !== loadRequestId) return
 
           if (!libraryId) {
@@ -1865,6 +1933,13 @@ document.addEventListener('DOMContentLoaded', function () {
               setLoading(false)
             })
         })
+        .catch(() => {
+          if (requestId !== loadRequestId) return
+          if (libraryPicker && previousLibraryId) {
+            libraryPicker.value = previousLibraryId
+          }
+          setLoading(false)
+        })
     }
 
     if (libraryPicker) {
@@ -1886,6 +1961,27 @@ document.addEventListener('DOMContentLoaded', function () {
         libraryPicker.value = ''
       }
     }
+
+    document.addEventListener('qs:before-step-navigation', (event) => {
+      const detail = (event && event.detail) || {}
+      if (allowNextStepNavigation) {
+        allowNextStepNavigation = false
+        return
+      }
+      if (!activeLibraryId || !libraryContainer || !libraryContainer.firstElementChild) return
+      if (!detail.targetPage || detail.targetPage === '025-libraries') return
+
+      event.preventDefault()
+
+      autosaveActiveLibrary()
+        .then(() => {
+          allowNextStepNavigation = true
+          jumpTo(detail.targetPage, detail.targetLabel)
+        })
+        .catch(() => {
+          allowNextStepNavigation = false
+        })
+    })
 
     if (typeof setupParentChildToggleSync === 'function') {
       setupParentChildToggleSync()

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -126,6 +126,19 @@ document.addEventListener('DOMContentLoaded', function () {
       }
     }
 
+    const metadataCustomRepoRaw = String(window.QS_SETTINGS_CUSTOM_REPO || '').trim()
+    const metadataCustomRepoBase = String(window.QS_SETTINGS_CUSTOM_REPO_BASE || '').trim()
+    const metadataRepoDependencyMessage = 'Metadata file repo entries require Custom Repo to be configured and saved first within the Settings page.'
+
+    function appendMetadataSettingsLink (target, className = 'link-light fw-semibold text-decoration-underline') {
+      const link = document.createElement('a')
+      link.href = '/step/150-settings#custom_repo'
+      link.textContent = 'Settings'
+      link.className = className
+      target.appendChild(link)
+      return link
+    }
+
     function buildMetadataFileRow (entry = {}) {
       const wrapper = document.createElement('div')
       wrapper.className = 'card bg-body-tertiary border-secondary'
@@ -137,12 +150,14 @@ document.addEventListener('DOMContentLoaded', function () {
               <label class="form-label small text-muted">Type</label>
               <select class="form-select form-select-sm" data-metadata-file-type>
                 <option value="file">file</option>
+                <option value="git">git</option>
+                <option value="repo">repo</option>
                 <option value="url">url</option>
               </select>
             </div>
             <div class="col-md-7">
-              <label class="form-label small text-muted">Path or URL</label>
-              <input type="text" class="form-control form-control-sm" data-metadata-file-location placeholder="config/metadata.yml or https://example.com/metadata.yml">
+              <label class="form-label small text-muted">Location</label>
+              <input type="text" class="form-control form-control-sm" data-metadata-file-location placeholder="config/metadata.yml, user/file.yml, or https://example.com/metadata.yml">
             </div>
             <div class="col-md-3 d-flex gap-2 justify-content-md-end">
               <button type="button" class="btn btn-success btn-sm" data-validate-metadata-file>Validate</button>
@@ -154,8 +169,8 @@ document.addEventListener('DOMContentLoaded', function () {
       `
       const typeSelect = wrapper.querySelector('[data-metadata-file-type]')
       const locationInput = wrapper.querySelector('[data-metadata-file-location]')
-      if (typeSelect && entry.type === 'url') {
-        typeSelect.value = 'url'
+      if (typeSelect && ['file', 'git', 'repo', 'url'].includes(entry.type)) {
+        typeSelect.value = entry.type
       }
       if (locationInput && entry.location) {
         locationInput.value = entry.location
@@ -168,10 +183,124 @@ document.addEventListener('DOMContentLoaded', function () {
       if (!row) return
       const button = row.querySelector('[data-validate-metadata-file]')
       if (!button) return
-      button.disabled = Boolean(isValidated)
-      button.classList.toggle('btn-success', !isValidated)
-      button.classList.toggle('btn-secondary', isValidated)
-      button.textContent = isValidated ? 'Validated' : 'Validate'
+      const state = String(row.dataset.metadataFileButtonState || '').trim() || (isValidated ? 'success' : 'idle')
+      button.classList.remove('btn-success', 'btn-secondary')
+      if (state === 'success') {
+        button.disabled = true
+        button.classList.add('btn-secondary')
+        button.textContent = 'Validated'
+        return
+      }
+      if (state === 'blocked') {
+        button.disabled = true
+        button.classList.add('btn-secondary')
+        button.textContent = 'Needs Repo'
+        return
+      }
+      if (state === 'loading') {
+        button.disabled = true
+        button.classList.add('btn-secondary')
+        button.textContent = 'Validating...'
+        return
+      }
+      button.disabled = false
+      button.classList.add('btn-success')
+      button.textContent = 'Validate'
+    }
+
+    function setMetadataFileButtonState (row, state) {
+      if (!row) return
+      row.dataset.metadataFileButtonState = state || 'idle'
+      updateMetadataFileValidateButton(row, state === 'success')
+    }
+
+    function updateMetadataCustomRepoStatus (editor) {
+      if (!editor) return
+      const target = editor.querySelector('[data-metadata-custom-repo-status]')
+      if (!target) return
+
+      target.replaceChildren()
+      target.className = 'alert small mb-3'
+      if (!metadataCustomRepoBase) {
+        target.classList.add('alert-warning')
+        target.append('Custom Repo is not configured. ')
+        target.append('Use ')
+        appendMetadataSettingsLink(target, 'alert-link fw-semibold')
+        target.append(' to configure and save it before using ')
+        const code = document.createElement('code')
+        code.textContent = 'repo'
+        target.appendChild(code)
+        target.append(' metadata files.')
+        return
+      }
+
+      target.classList.add('alert-secondary')
+      const label = document.createElement('div')
+      label.className = 'fw-semibold mb-1'
+      label.textContent = 'Custom Repo base used for repo entries'
+      target.appendChild(label)
+
+      const baseValue = document.createElement('code')
+      baseValue.textContent = metadataCustomRepoBase
+      target.appendChild(baseValue)
+
+      if (metadataCustomRepoRaw && metadataCustomRepoRaw !== metadataCustomRepoBase) {
+        const savedValue = document.createElement('div')
+        savedValue.className = 'mt-2'
+        savedValue.append('Saved Custom Repo value: ')
+        const savedCode = document.createElement('code')
+        savedCode.textContent = metadataCustomRepoRaw
+        savedValue.appendChild(savedCode)
+        target.appendChild(savedValue)
+      }
+
+      const hint = document.createElement('div')
+      hint.className = 'mt-2'
+      hint.append('Change it in ')
+      appendMetadataSettingsLink(hint, 'alert-link fw-semibold')
+      hint.append('.')
+      target.appendChild(hint)
+    }
+
+    function applyMetadataFileDependencyState (row, opts = {}) {
+      if (!row) return false
+      const skipStatus = Boolean(opts.skipStatus)
+      const type = row.querySelector('[data-metadata-file-type]')?.value || ''
+      if (type !== 'repo') {
+        if (row.dataset.metadataFileDependency === 'repo-missing') {
+          row.dataset.metadataFileDependency = ''
+        }
+        return false
+      }
+
+      if (metadataCustomRepoBase) {
+        if (row.dataset.metadataFileDependency === 'repo-missing') {
+          row.dataset.metadataFileDependency = ''
+        }
+        return false
+      }
+
+      row.dataset.metadataFileDependency = 'repo-missing'
+      setMetadataFileButtonState(row, 'blocked')
+      if (!skipStatus) {
+        setMetadataFileStatus(row, 'error', metadataRepoDependencyMessage)
+      }
+      return true
+    }
+
+    function renderMetadataFileStatusMessage (target, message) {
+      const text = String(message || '').trim()
+      target.replaceChildren()
+      if (!text) return
+
+      if (text === metadataRepoDependencyMessage) {
+        target.append('Metadata file repo entries require Custom Repo to be configured and saved first within the ')
+        appendMetadataSettingsLink(target)
+        target.append(' page.')
+        return
+      }
+
+      target.textContent = text
     }
 
     function setMetadataFileStatus (row, kind, message) {
@@ -183,7 +312,11 @@ document.addEventListener('DOMContentLoaded', function () {
       if (!message) {
         target.classList.add('d-none')
         target.textContent = ''
-        updateMetadataFileValidateButton(row, false)
+        if (applyMetadataFileDependencyState(row, { skipStatus: true })) {
+          setMetadataFileButtonState(row, 'blocked')
+        } else {
+          setMetadataFileButtonState(row, 'idle')
+        }
         const editor = row.closest('[data-metadata-files-editor]')
         if (editor) updateMetadataFilesAccordionState(editor)
         return
@@ -196,8 +329,14 @@ document.addEventListener('DOMContentLoaded', function () {
       } else {
         target.classList.add('text-warning')
       }
-      target.textContent = message
-      updateMetadataFileValidateButton(row, kind === 'success')
+      renderMetadataFileStatusMessage(target, message)
+      if (kind === 'success') {
+        setMetadataFileButtonState(row, 'success')
+      } else if (row.dataset.metadataFileDependency === 'repo-missing') {
+        setMetadataFileButtonState(row, 'blocked')
+      } else {
+        setMetadataFileButtonState(row, 'idle')
+      }
       const editor = row.closest('[data-metadata-files-editor]')
       if (editor) updateMetadataFilesAccordionState(editor)
     }
@@ -266,6 +405,7 @@ document.addEventListener('DOMContentLoaded', function () {
         hidden.dispatchEvent(new Event('input', { bubbles: true }))
         hidden.dispatchEvent(new Event('change', { bubbles: true }))
       }
+      updateMetadataFilesAccordionState(editor)
       return entries
     }
 
@@ -274,9 +414,14 @@ document.addEventListener('DOMContentLoaded', function () {
       const hidden = editor.querySelector('input[type="hidden"][name$="-metadata_files"]')
       const list = editor.querySelector('[data-metadata-files-list]')
       if (!hidden || !list) return
+      updateMetadataCustomRepoStatus(editor)
       const entries = parseMetadataFilesValue(hidden.value)
       list.replaceChildren()
       entries.forEach(entry => list.appendChild(buildMetadataFileRow(entry)))
+      list.querySelectorAll('[data-metadata-file-row]').forEach(row => {
+        if (applyMetadataFileDependencyState(row)) return
+        setMetadataFileButtonState(row, 'idle')
+      })
       syncMetadataFilesEditor(editor, false)
       updateMetadataFilesAccordionState(editor)
     }
@@ -316,11 +461,12 @@ document.addEventListener('DOMContentLoaded', function () {
         const row = validateButton.closest('[data-metadata-file-row]')
         const editor = validateButton.closest('[data-metadata-files-editor]')
         if (!row || !editor) return
+        if (applyMetadataFileDependencyState(row)) return
         const type = row.querySelector('[data-metadata-file-type]')?.value || ''
         const location = row.querySelector('[data-metadata-file-location]')?.value || ''
         syncMetadataFilesEditor(editor, false)
-        validateButton.disabled = true
         setMetadataFileStatus(row, '', 'Validating...')
+        setMetadataFileButtonState(row, 'loading')
         try {
           const response = await fetch('/validate_metadata_file', {
             method: 'POST',
@@ -340,8 +486,8 @@ document.addEventListener('DOMContentLoaded', function () {
         } catch (_error) {
           setMetadataFileStatus(row, 'error', 'Validation request failed.')
         } finally {
-          if (row.dataset.metadataFileState !== 'success') {
-            updateMetadataFileValidateButton(row, false)
+          if (row.dataset.metadataFileState !== 'success' && row.dataset.metadataFileDependency !== 'repo-missing') {
+            setMetadataFileButtonState(row, 'idle')
           }
         }
       }
@@ -354,6 +500,7 @@ document.addEventListener('DOMContentLoaded', function () {
       const row = target.closest('[data-metadata-file-row]')
       const editor = target.closest('[data-metadata-files-editor]')
       setMetadataFileStatus(row, '', '')
+      applyMetadataFileDependencyState(row)
       syncMetadataFilesEditor(editor)
     })
 
@@ -364,6 +511,7 @@ document.addEventListener('DOMContentLoaded', function () {
       const row = target.closest('[data-metadata-file-row]')
       const editor = target.closest('[data-metadata-files-editor]')
       setMetadataFileStatus(row, '', '')
+      applyMetadataFileDependencyState(row)
       syncMetadataFilesEditor(editor)
     })
 

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -1,4 +1,4 @@
-/* global EventHandler, ValidationHandler, OverlayHandler, Sortable, showToast, setupParentChildToggleSync, bootstrap, FontFace, PathValidation, DOMParser, showNavigationLoadingOverlay, hideNavigationLoadingOverlay */
+/* global EventHandler, ValidationHandler, OverlayHandler, Sortable, showToast, setupParentChildToggleSync, bootstrap, FontFace, PathValidation, DOMParser, MutationObserver, showNavigationLoadingOverlay, hideNavigationLoadingOverlay */
 
 document.addEventListener('DOMContentLoaded', function () {
   console.log('[DEBUG] Initializing Libraries...')
@@ -103,6 +103,202 @@ document.addEventListener('DOMContentLoaded', function () {
     }
     let dependencyHintRefreshTimer = null
     let dependencyHintRequestToken = 0
+
+    function normalizeMetadataFileEntry (entry) {
+      if (!entry || typeof entry !== 'object') return null
+      const type = String(entry.type || '').trim().toLowerCase()
+      const location = String(entry.location || '').trim()
+      if (!type && !location) return null
+      return { type, location }
+    }
+
+    function parseMetadataFilesValue (rawValue) {
+      if (!rawValue) return []
+      try {
+        const parsed = JSON.parse(String(rawValue))
+        if (!Array.isArray(parsed)) return []
+        return parsed
+          .map(normalizeMetadataFileEntry)
+          .filter(Boolean)
+      } catch (_error) {
+        return []
+      }
+    }
+
+    function buildMetadataFileRow (entry = {}) {
+      const wrapper = document.createElement('div')
+      wrapper.className = 'card bg-body-tertiary border-secondary'
+      wrapper.setAttribute('data-metadata-file-row', 'true')
+      wrapper.innerHTML = `
+        <div class="card-body">
+          <div class="row g-3 align-items-end">
+            <div class="col-md-2">
+              <label class="form-label small text-muted">Type</label>
+              <select class="form-select form-select-sm" data-metadata-file-type>
+                <option value="file">file</option>
+                <option value="url">url</option>
+              </select>
+            </div>
+            <div class="col-md-7">
+              <label class="form-label small text-muted">Path or URL</label>
+              <input type="text" class="form-control form-control-sm" data-metadata-file-location placeholder="config/metadata.yml or https://example.com/metadata.yml">
+            </div>
+            <div class="col-md-3 d-flex gap-2 justify-content-md-end">
+              <button type="button" class="btn btn-outline-info btn-sm" data-validate-metadata-file>Validate</button>
+              <button type="button" class="btn btn-outline-danger btn-sm" data-remove-metadata-file>Remove</button>
+            </div>
+          </div>
+          <div class="mt-2 small d-none" data-metadata-file-status></div>
+        </div>
+      `
+      const typeSelect = wrapper.querySelector('[data-metadata-file-type]')
+      const locationInput = wrapper.querySelector('[data-metadata-file-location]')
+      if (typeSelect && entry.type === 'url') {
+        typeSelect.value = 'url'
+      }
+      if (locationInput && entry.location) {
+        locationInput.value = entry.location
+      }
+      return wrapper
+    }
+
+    function setMetadataFileStatus (row, kind, message) {
+      if (!row) return
+      const target = row.querySelector('[data-metadata-file-status]')
+      if (!target) return
+      target.className = 'mt-2 small'
+      if (!message) {
+        target.classList.add('d-none')
+        target.textContent = ''
+        return
+      }
+      target.classList.remove('d-none')
+      if (kind === 'success') {
+        target.classList.add('text-success')
+      } else {
+        target.classList.add('text-warning')
+      }
+      target.textContent = message
+    }
+
+    function syncMetadataFilesEditor (editor, emitEvents = true) {
+      if (!editor) return []
+      const hidden = editor.querySelector('input[type="hidden"][name$="-metadata_files"]')
+      if (!hidden) return []
+      const rows = Array.from(editor.querySelectorAll('[data-metadata-file-row]'))
+      const entries = rows.map(row => {
+        const type = row.querySelector('[data-metadata-file-type]')?.value
+        const location = row.querySelector('[data-metadata-file-location]')?.value
+        return normalizeMetadataFileEntry({ type, location })
+      }).filter(Boolean)
+      hidden.value = JSON.stringify(entries)
+      if (emitEvents) {
+        hidden.dispatchEvent(new Event('input', { bubbles: true }))
+        hidden.dispatchEvent(new Event('change', { bubbles: true }))
+      }
+      return entries
+    }
+
+    function renderMetadataFilesEditor (editor) {
+      if (!editor) return
+      const hidden = editor.querySelector('input[type="hidden"][name$="-metadata_files"]')
+      const list = editor.querySelector('[data-metadata-files-list]')
+      if (!hidden || !list) return
+      const entries = parseMetadataFilesValue(hidden.value)
+      list.replaceChildren()
+      entries.forEach(entry => list.appendChild(buildMetadataFileRow(entry)))
+      syncMetadataFilesEditor(editor, false)
+    }
+
+    function initMetadataFilesEditors (scope) {
+      const root = scope || document
+      root.querySelectorAll('[data-metadata-files-editor]').forEach(editor => {
+        if (editor.dataset.metadataFilesReady === 'true') return
+        renderMetadataFilesEditor(editor)
+        editor.dataset.metadataFilesReady = 'true'
+      })
+    }
+
+    document.addEventListener('click', async function (event) {
+      const addButton = event.target.closest('[data-add-metadata-file]')
+      if (addButton) {
+        const editor = addButton.closest('[data-metadata-files-editor]')
+        const list = editor?.querySelector('[data-metadata-files-list]')
+        if (!editor || !list) return
+        list.appendChild(buildMetadataFileRow({ type: 'file', location: '' }))
+        syncMetadataFilesEditor(editor)
+        return
+      }
+
+      const removeButton = event.target.closest('[data-remove-metadata-file]')
+      if (removeButton) {
+        const row = removeButton.closest('[data-metadata-file-row]')
+        const editor = removeButton.closest('[data-metadata-files-editor]')
+        if (!row || !editor) return
+        row.remove()
+        syncMetadataFilesEditor(editor)
+        return
+      }
+
+      const validateButton = event.target.closest('[data-validate-metadata-file]')
+      if (validateButton) {
+        const row = validateButton.closest('[data-metadata-file-row]')
+        const editor = validateButton.closest('[data-metadata-files-editor]')
+        if (!row || !editor) return
+        const type = row.querySelector('[data-metadata-file-type]')?.value || ''
+        const location = row.querySelector('[data-metadata-file-location]')?.value || ''
+        syncMetadataFilesEditor(editor, false)
+        validateButton.disabled = true
+        setMetadataFileStatus(row, '', 'Validating...')
+        try {
+          const response = await fetch('/validate_metadata_file', {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              metadata_file_type: type,
+              metadata_file_location: location
+            })
+          })
+          const payload = await response.json().catch(() => ({}))
+          if (!response.ok || !payload.valid) {
+            setMetadataFileStatus(row, 'warning', payload.error || 'Validation failed.')
+          } else {
+            setMetadataFileStatus(row, 'success', 'Metadata file looks valid.')
+          }
+        } catch (_error) {
+          setMetadataFileStatus(row, 'warning', 'Validation request failed.')
+        } finally {
+          validateButton.disabled = false
+        }
+      }
+    })
+
+    document.addEventListener('input', function (event) {
+      const target = event.target
+      if (!target || !target.closest('[data-metadata-files-editor]')) return
+      if (!target.matches('[data-metadata-file-type], [data-metadata-file-location]')) return
+      const row = target.closest('[data-metadata-file-row]')
+      const editor = target.closest('[data-metadata-files-editor]')
+      setMetadataFileStatus(row, '', '')
+      syncMetadataFilesEditor(editor)
+    })
+
+    document.addEventListener('change', function (event) {
+      const target = event.target
+      if (!target || !target.closest('[data-metadata-files-editor]')) return
+      if (!target.matches('[data-metadata-file-type], [data-metadata-file-location]')) return
+      const row = target.closest('[data-metadata-file-row]')
+      const editor = target.closest('[data-metadata-files-editor]')
+      setMetadataFileStatus(row, '', '')
+      syncMetadataFilesEditor(editor)
+    })
+
+    initMetadataFilesEditors(document)
+    if (libraryContainer && typeof MutationObserver !== 'undefined') {
+      const metadataObserver = new MutationObserver(() => initMetadataFilesEditors(libraryContainer))
+      metadataObserver.observe(libraryContainer, { childList: true, subtree: true })
+    }
 
     // Ensure hidden "false" inputs don't submit alongside checked checkboxes with the same name
     function syncHiddenCheckboxPairs (scope) {

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -150,6 +150,7 @@ document.addEventListener('DOMContentLoaded', function () {
               <label class="form-label small text-muted">Type</label>
               <select class="form-select form-select-sm" data-metadata-file-type>
                 <option value="file">file</option>
+                <option value="folder">folder</option>
                 <option value="git">git</option>
                 <option value="repo">repo</option>
                 <option value="url">url</option>
@@ -157,7 +158,7 @@ document.addEventListener('DOMContentLoaded', function () {
             </div>
             <div class="col-md-7">
               <label class="form-label small text-muted">Location</label>
-              <input type="text" class="form-control form-control-sm" data-metadata-file-location placeholder="config/metadata.yml, user/file.yml, or https://example.com/metadata.yml">
+              <input type="text" class="form-control form-control-sm" data-metadata-file-location placeholder="config/metadata.yml, config/metadata/, user/file.yml, or https://example.com/metadata.yml">
             </div>
             <div class="col-md-3 d-flex gap-2 justify-content-md-end">
               <button type="button" class="btn btn-success btn-sm" data-validate-metadata-file>Validate</button>
@@ -169,7 +170,7 @@ document.addEventListener('DOMContentLoaded', function () {
       `
       const typeSelect = wrapper.querySelector('[data-metadata-file-type]')
       const locationInput = wrapper.querySelector('[data-metadata-file-location]')
-      if (typeSelect && ['file', 'git', 'repo', 'url'].includes(entry.type)) {
+      if (typeSelect && ['file', 'folder', 'git', 'repo', 'url'].includes(entry.type)) {
         typeSelect.value = entry.type
       }
       if (locationInput && entry.location) {
@@ -289,8 +290,53 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     function renderMetadataFileStatusMessage (target, message) {
-      const text = String(message || '').trim()
       target.replaceChildren()
+      if (!message) return
+
+      if (typeof message === 'object' && message !== null) {
+        const text = String(message.text || message.message || '').trim()
+        const files = Array.isArray(message.files) ? message.files.filter(Boolean) : []
+        if (text) {
+          const summary = document.createElement('div')
+          summary.textContent = text
+          target.appendChild(summary)
+        }
+        if (files.length) {
+          if (files.length <= 5) {
+            const list = document.createElement('ul')
+            list.className = 'mb-0 mt-1 ps-3'
+            files.forEach(file => {
+              const item = document.createElement('li')
+              const code = document.createElement('code')
+              code.textContent = file
+              item.appendChild(code)
+              list.appendChild(item)
+            })
+            target.appendChild(list)
+          } else {
+            const details = document.createElement('details')
+            details.className = 'mt-1'
+            const summary = document.createElement('summary')
+            summary.className = 'cursor-pointer'
+            summary.textContent = 'Show files'
+            details.appendChild(summary)
+            const list = document.createElement('ul')
+            list.className = 'mb-0 mt-1 ps-3'
+            files.forEach(file => {
+              const item = document.createElement('li')
+              const code = document.createElement('code')
+              code.textContent = file
+              item.appendChild(code)
+              list.appendChild(item)
+            })
+            details.appendChild(list)
+            target.appendChild(details)
+          }
+        }
+        return
+      }
+
+      const text = String(message || '').trim()
       if (!text) return
 
       if (text === metadataRepoDependencyMessage) {
@@ -481,7 +527,10 @@ document.addEventListener('DOMContentLoaded', function () {
           if (!response.ok || !payload.valid) {
             setMetadataFileStatus(row, 'error', payload.error || 'Validation failed.')
           } else {
-            setMetadataFileStatus(row, 'success', 'Metadata file looks valid.')
+            setMetadataFileStatus(row, 'success', {
+              text: payload.message || 'Metadata source looks valid.',
+              files: Array.isArray(payload.files) ? payload.files : []
+            })
           }
         } catch (_error) {
           setMetadataFileStatus(row, 'error', 'Validation request failed.')

--- a/static/local-js/150-settings.js
+++ b/static/local-js/150-settings.js
@@ -100,6 +100,21 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   }
 
+  function focusFieldFromHash () {
+    const hash = String(window.location.hash || '').trim()
+    if (!hash || hash.length < 2) return
+    const field = document.getElementById(hash.slice(1))
+    if (!field) return
+
+    showAccordionForField(field)
+    window.setTimeout(() => {
+      field.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      if (typeof field.focus === 'function') {
+        field.focus({ preventScroll: true })
+      }
+    }, 200)
+  }
+
   function validateField (field, regex, errorMessage) {
     const value = field.value.trim()
     console.log(`Validating field: ${field.name}, Value: "${value}"`) // Debug log
@@ -317,4 +332,7 @@ document.addEventListener('DOMContentLoaded', function () {
       setSettingsValidated(true)
     }
   })
+
+  focusFieldFromHash()
+  window.addEventListener('hashchange', focusFieldFromHash)
 })

--- a/templates/000-base.html
+++ b/templates/000-base.html
@@ -60,6 +60,8 @@
     window.QS_FLASK_SESSION_DIR = {{ config.get('QS_FLASK_SESSION_DIR', '') | tojson }};
     window.QS_RESTART_NOTICE = {{ config.get('QS_RESTART_NOTICE') | tojson }};
     window.QS_CURRENT_TEMPLATE = {{ (page_info.get('template_name', '') if page_info else '') | tojson }};
+    window.QS_SETTINGS_CUSTOM_REPO = {{ (page_info.get('settings_custom_repo', '') if page_info else '') | tojson }};
+    window.QS_SETTINGS_CUSTOM_REPO_BASE = {{ (page_info.get('settings_custom_repo_base', '') if page_info else '') | tojson }};
     window.QS_REQUIRED_KEYS = {{ (required_keys if required_keys is defined else []) | tojson }};
     window.QS_OPTIONAL_KEYS = {{ (optional_keys if optional_keys is defined else []) | tojson }};
     window.QS_REVIEW_KEYS = {{ (review_keys if review_keys is defined else []) | tojson }};

--- a/templates/partials/_library_metadata_files.html
+++ b/templates/partials/_library_metadata_files.html
@@ -7,23 +7,26 @@
     </h2>
     <div id="{{ library.id }}-metadata-files" class="accordion-collapse collapse">
         <div class="accordion-body">
-            <div class="alert alert-warning small mb-3" role="alert">
-                <div class="fw-semibold mb-1">Validation is limited.</div>
-                <div>Quickstart can verify that each entry points to a non-empty <code>.yml</code> or <code>.yaml</code> file and that the YAML parses successfully.</div>
-                <div>Quickstart does not fully validate Kometa metadata file schema yet, so a file that passes here may still fail later and cause Kometa to abort during a run.</div>
-            </div>
-            <div class="alert alert-info small mb-3" role="alert">
-                <div>Use one or more <code>file</code> or <code>url</code> entries. These are written to library-level <code>metadata_files</code>.</div>
-            </div>
-            <div class="metadata-files-editor" data-metadata-files-editor data-library-id="{{ library.id }}">
+            <div class="d-flex flex-column gap-3">
+                <div class="alert alert-warning small mb-0" role="alert">
+                    <div class="fw-semibold mb-1">Validation is limited.</div>
+                    <div>Quickstart can verify that each entry points to a non-empty <code>.yml</code> or <code>.yaml</code> file and that the YAML parses successfully.</div>
+                    <div>Quickstart does not fully validate Kometa metadata file schema yet, so a file that passes here may still fail later and cause Kometa to abort during a run.</div>
+                </div>
+                <div class="alert alert-info small mb-0" role="alert">
+                    <div>Use one or more <code>file</code>, <code>url</code>, <code>git</code>, or <code>repo</code> entries. These are written to library-level <code>metadata_files</code>.</div>
+                </div>
+                <div class="metadata-files-editor" data-metadata-files-editor data-library-id="{{ library.id }}">
+                <div class="alert small mb-4" role="alert" data-metadata-custom-repo-status></div>
                 <input type="hidden" name="{{ library.id }}-metadata_files" id="{{ library.id }}-metadata_files"
                     value="{{ data['libraries'].get(library.id ~ '-metadata_files', '[]') }}">
-                <div class="metadata-files-list d-flex flex-column gap-3" data-metadata-files-list></div>
+                <div class="metadata-files-list d-flex flex-column gap-3 mt-1" data-metadata-files-list></div>
                 <div class="d-flex justify-content-between align-items-center mt-3">
                     <button type="button" class="btn btn-outline-secondary btn-sm" data-add-metadata-file>
                         <i class="bi bi-plus-circle me-1"></i>Add Metadata File
                     </button>
-                    <span class="text-muted small">Supports mixed local paths and remote raw YAML URLs.</span>
+                    <span class="text-muted small">Supports mixed local files, raw URLs, Community-Configs git paths, and custom_repo-backed repo paths.</span>
+                </div>
                 </div>
             </div>
         </div>

--- a/templates/partials/_library_metadata_files.html
+++ b/templates/partials/_library_metadata_files.html
@@ -14,7 +14,7 @@
                     <div>Quickstart does not fully validate Kometa metadata file schema yet, so a file that passes here may still fail later and cause Kometa to abort during a run.</div>
                 </div>
                 <div class="alert alert-info small mb-0" role="alert">
-                    <div>Use one or more <code>file</code>, <code>url</code>, <code>git</code>, or <code>repo</code> entries. These are written to library-level <code>metadata_files</code>.</div>
+                    <div>Use one or more <code>file</code>, <code>folder</code>, <code>url</code>, <code>git</code>, or <code>repo</code> entries. These are written to library-level <code>metadata_files</code>.</div>
                 </div>
                 <div class="metadata-files-editor" data-metadata-files-editor data-library-id="{{ library.id }}">
                 <div class="alert small mb-4" role="alert" data-metadata-custom-repo-status></div>
@@ -25,7 +25,7 @@
                     <button type="button" class="btn btn-outline-secondary btn-sm" data-add-metadata-file>
                         <i class="bi bi-plus-circle me-1"></i>Add Metadata File
                     </button>
-                    <span class="text-muted small">Supports mixed local files, raw URLs, Community-Configs git paths, and custom_repo-backed repo paths.</span>
+                    <span class="text-muted small">Supports mixed local files and folders, raw URLs, Community-Configs git paths, and custom_repo-backed repo paths.</span>
                 </div>
                 </div>
             </div>

--- a/templates/partials/_library_metadata_files.html
+++ b/templates/partials/_library_metadata_files.html
@@ -1,0 +1,31 @@
+<div class="accordion-item">
+    <h2 class="accordion-header">
+        <button class="accordion-button" type="button" data-bs-toggle="collapse"
+            data-bs-target="#{{ library.id }}-metadata-files">
+            Metadata Files
+        </button>
+    </h2>
+    <div id="{{ library.id }}-metadata-files" class="accordion-collapse collapse">
+        <div class="accordion-body">
+            <div class="alert alert-warning small mb-3" role="alert">
+                <div class="fw-semibold mb-1">Validation is limited.</div>
+                <div>Quickstart can verify that each entry points to a non-empty <code>.yml</code> or <code>.yaml</code> file and that the YAML parses successfully.</div>
+                <div>Quickstart does not fully validate Kometa metadata file schema yet, so a file that passes here may still fail later and cause Kometa to abort during a run.</div>
+            </div>
+            <div class="alert alert-info small mb-3" role="alert">
+                <div>Use one or more <code>file</code> or <code>url</code> entries. These are written to library-level <code>metadata_files</code>.</div>
+            </div>
+            <div class="metadata-files-editor" data-metadata-files-editor data-library-id="{{ library.id }}">
+                <input type="hidden" name="{{ library.id }}-metadata_files" id="{{ library.id }}-metadata_files"
+                    value="{{ data['libraries'].get(library.id ~ '-metadata_files', '[]') }}">
+                <div class="metadata-files-list d-flex flex-column gap-3" data-metadata-files-list></div>
+                <div class="d-flex justify-content-between align-items-center mt-3">
+                    <button type="button" class="btn btn-outline-secondary btn-sm" data-add-metadata-file>
+                        <i class="bi bi-plus-circle me-1"></i>Add Metadata File
+                    </button>
+                    <span class="text-muted small">Supports mixed local paths and remote raw YAML URLs.</span>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/partials/_movie_library_settings.html
+++ b/templates/partials/_movie_library_settings.html
@@ -47,6 +47,8 @@
             </div>
         </div>
 
+        {% include "partials/_library_metadata_files.html" %}
+
         <!-- Movie Playlists -->
         {% include "partials/_library_playlists.html" %}
     </div>

--- a/templates/partials/_show_library_settings.html
+++ b/templates/partials/_show_library_settings.html
@@ -47,6 +47,8 @@
             </div>
         </div>
 
+        {% include "partials/_library_metadata_files.html" %}
+
         <!-- Show Playlists -->
         {% include "partials/_library_playlists.html" %}
     </div>

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -145,6 +145,79 @@ def test_validate_apprise_rejects_empty_remote_yaml(client, monkeypatch, qs_modu
     assert "must not be empty" in payload["error"]
 
 
+def test_validate_metadata_file_accepts_existing_local_file(client, tmp_path):
+    metadata_file = tmp_path / "metadata.yml"
+    metadata_file.write_text("metadata:\n  test:\n    title: Example\n", encoding="utf-8")
+
+    resp = client.post(
+        "/validate_metadata_file",
+        json={"metadata_file_type": "file", "metadata_file_location": str(metadata_file)},
+    )
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["valid"] is True
+
+
+def test_validate_metadata_file_rejects_invalid_type(client):
+    resp = client.post(
+        "/validate_metadata_file",
+        json={"metadata_file_type": "git", "metadata_file_location": "config/metadata.yml"},
+    )
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert payload["valid"] is False
+    assert "file or url" in payload["error"]
+
+
+def test_validate_metadata_file_rejects_url_in_file_mode(client):
+    resp = client.post(
+        "/validate_metadata_file",
+        json={"metadata_file_type": "file", "metadata_file_location": "https://example.com/metadata.yml"},
+    )
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert payload["valid"] is False
+    assert "local file path" in payload["error"]
+
+
+def test_validate_metadata_file_rejects_invalid_local_yaml(client, tmp_path):
+    metadata_file = tmp_path / "metadata.yml"
+    metadata_file.write_text("metadata: [broken\n", encoding="utf-8")
+
+    resp = client.post(
+        "/validate_metadata_file",
+        json={"metadata_file_type": "file", "metadata_file_location": str(metadata_file)},
+    )
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert payload["valid"] is False
+    assert "valid YAML" in payload["error"]
+
+
+def test_output_metadata_file_entries_are_sorted():
+    import json
+
+    from modules import output
+
+    parsed = output._parse_metadata_file_entries(
+        json.dumps(
+            [
+                {"type": "url", "location": "https://example.com/zeta.yml"},
+                {"type": "file", "location": "config/beta.yml"},
+                {"type": "file", "location": "config/alpha.yml"},
+                {"type": "url", "location": "https://example.com/alpha.yml"},
+            ]
+        )
+    )
+
+    assert parsed == [
+        {"file": "config/alpha.yml"},
+        {"file": "config/beta.yml"},
+        {"url": "https://example.com/alpha.yml"},
+        {"url": "https://example.com/zeta.yml"},
+    ]
+
+
 def test_update_quickstart_settings_supports_independent_imagemaid_log_retention(client, qs_module, isolated_config_dir, monkeypatch):
     from modules import helpers
 
@@ -874,3 +947,76 @@ def test_retrieve_settings_sanitizes_already_persisted_transient_fields(client, 
     assert "configSelector" not in stored["anidb"]
     assert "newConfigName" not in stored["anidb"]
     assert "importMode" not in stored["anidb"]
+
+
+def test_copy_library_settings_mirrors_metadata_files(client, isolated_config_dir, monkeypatch, app, qs_module):
+    import json
+
+    from modules import database
+    from flask import session
+
+    config_name = "pytest_copy_metadata_files"
+    source_metadata_files = json.dumps(
+        [
+            {"type": "file", "location": "config/metadata/movies.yml"},
+            {"type": "url", "location": "https://example.com/movie-metadata.yml"},
+        ]
+    )
+
+    database.save_section_data(
+        section="libraries",
+        validated=False,
+        user_entered=True,
+        name=config_name,
+        data={
+            "libraries": {
+                "mov-library_movies-library": "Movies",
+                "mov-library_movies-metadata_files": source_metadata_files,
+                "mov-library_target-library": "Other Movies",
+                "libraries": "Movies,Other Movies",
+            },
+            "validated": False,
+        },
+    )
+
+    monkeypatch.setattr(
+        qs_module,
+        "_build_library_lists",
+        lambda: (
+            [
+                {"id": "mov-library_movies", "name": "Movies"},
+                {"id": "mov-library_target", "name": "Other Movies"},
+            ],
+            [],
+            {},
+        ),
+    )
+
+    with app.test_request_context("/copy_library_settings"):
+        session["config_name"] = config_name
+
+    with client.session_transaction() as sess:
+        sess["config_name"] = config_name
+
+    resp = client.post(
+        "/copy_library_settings",
+        json={
+            "source_library_id": "mov-library_movies",
+            "target_library_ids": ["mov-library_target"],
+            "source_payload": {
+                "mov-library_movies-library": "Movies",
+                "mov-library_movies-metadata_files": source_metadata_files,
+            },
+        },
+    )
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+
+    validated, user_entered, stored = database.retrieve_section_data(config_name, "libraries")
+    assert validated is False
+    assert user_entered is True
+    libraries = stored["libraries"]
+    assert libraries["mov-library_movies-metadata_files"] == source_metadata_files
+    assert libraries["mov-library_target-metadata_files"] == source_metadata_files

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -194,6 +194,27 @@ def test_validate_metadata_file_rejects_invalid_local_yaml(client, tmp_path):
     assert "valid YAML" in payload["error"]
 
 
+def test_autosave_library_rejects_invalid_metadata_files(client, monkeypatch, qs_module):
+    class _Resp:
+        status_code = 404
+        reason = "Not Found"
+        text = ""
+
+    monkeypatch.setattr(qs_module.validations.requests, "get", lambda *_args, **_kwargs: _Resp())
+
+    resp = client.post(
+        "/autosave_library/mov-library_movies",
+        json={
+            "mov-library_movies-library": "Movies",
+            "mov-library_movies-metadata_files": '[{"type":"url","location":"https://example.com/missing.yml"}]',
+        },
+    )
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert payload["success"] is False
+    assert "Invalid metadata files" in payload["error"]
+
+
 def test_output_metadata_file_entries_are_sorted():
     import json
 
@@ -216,6 +237,195 @@ def test_output_metadata_file_entries_are_sorted():
         {"url": "https://example.com/alpha.yml"},
         {"url": "https://example.com/zeta.yml"},
     ]
+
+
+def test_build_libraries_section_emits_metadata_files(app):
+    import json
+
+    from modules import output
+
+    with app.app_context():
+        libraries_section = output.build_libraries_section(
+            {"mov-library_movies-library": "Movies"},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {
+                "movies": {
+                    "mov-library_movies-metadata_files": json.dumps(
+                        [
+                            {"type": "url", "location": "https://example.com/movies_refresh.yml"},
+                            {"type": "file", "location": "C:\\Users\\bullmoose20\\Community-Configs\\bullmoose20\\godzilla.yml"},
+                        ]
+                    )
+                }
+            },
+            {},
+            {},
+            {},
+            {},
+            {},
+        )
+
+    assert libraries_section["libraries"]["Movies"]["metadata_files"] == [
+        {"file": "C:\\Users\\bullmoose20\\Community-Configs\\bullmoose20\\godzilla.yml"},
+        {"url": "https://example.com/movies_refresh.yml"},
+    ]
+    assert list(libraries_section["libraries"]["Movies"].keys())[:2] == ["template_variables", "metadata_files"]
+
+
+def test_build_config_includes_saved_library_metadata_files(app, isolated_config_dir, monkeypatch):
+    import json
+
+    from flask import session
+    from modules import database, output
+
+    config_name = "pytest_library_metadata_output"
+    metadata_value = json.dumps(
+        [
+            {"type": "file", "location": "C:\\Users\\bullmoose20\\Community-Configs\\bullmoose20\\godzilla.yml"},
+            {"type": "url", "location": "https://example.com/movies_refresh.yml"},
+        ]
+    )
+
+    database.save_section_data(
+        name=config_name,
+        section="libraries",
+        validated=True,
+        user_entered=True,
+        data={
+            "libraries": {
+                "mov-library_movies-library": "Movies",
+                "mov-library_movies-metadata_files": metadata_value,
+                "mov-template_variables": {},
+                "sho-template_variables": {},
+            },
+            "validated_at": "2026-05-19T00:00:00Z",
+        },
+    )
+
+    monkeypatch.setattr(output.helpers, "ensure_json_schema", lambda: None)
+    monkeypatch.setattr(
+        output.helpers,
+        "check_for_update",
+        lambda: {
+            "kometa_branch": "nightly",
+            "branch": "develop",
+            "local_version": "0.10.3-build2",
+            "running_on": "Local-Windows",
+        },
+    )
+    monkeypatch.setattr(output.helpers, "get_plex_summary", lambda: "Plex summary unavailable")
+    monkeypatch.setattr(output.helpers, "get_quickstart_settings_summary", lambda: [])
+    monkeypatch.setattr(output.helpers, "get_library_summaries", lambda _names: "Library summary unavailable")
+    monkeypatch.setattr(output.jsonschema.Draft7Validator, "iter_errors", lambda self, parsed: [])
+    monkeypatch.setitem(app.config, "QS_OPTIMIZE_DEFAULTS", False)
+
+    with app.test_request_context("/step/900-kometa"):
+        session["config_name"] = config_name
+        _validated, _validation_error, _config_data, yaml_content, _validation_errors = output.build_config("single line", config_name=config_name)
+
+    assert "metadata_files:" in yaml_content
+    assert "godzilla.yml" in yaml_content
+    assert "movies_refresh.yml" in yaml_content
+
+
+def test_step_post_from_libraries_persists_metadata_files(client, isolated_config_dir, monkeypatch, qs_module):
+    import json
+
+    from modules import database
+
+    config_name = "pytest_step_save_metadata_files"
+    metadata_value = json.dumps(
+        [
+            {"type": "file", "location": "C:\\Users\\bullmoose20\\Community-Configs\\bullmoose20\\godzilla.yml"},
+            {"type": "url", "location": "https://example.com/movies_refresh.yml"},
+        ]
+    )
+
+    monkeypatch.setattr(qs_module.output, "build_config", lambda *_args, **_kwargs: (True, None, {}, "test: true\n", []))
+    monkeypatch.setattr(qs_module.validations, "validate_metadata_file_payload", lambda _payload: (True, ""))
+    monkeypatch.setattr(
+        qs_module,
+        "_build_final_gate",
+        lambda *_args, **_kwargs: {
+            "stage": "kometa",
+            "todo_count": 0,
+            "todo_blockers": [],
+            "bulk_validation_fresh": True,
+            "bulk_validation_at": qs_module.utc_now_iso(),
+            "validation_ttl_hours": 12,
+            "can_build_config": True,
+            "config_valid": True,
+        },
+    )
+
+    resp = client.post(
+        "/step/900-kometa",
+        data={
+            "configSelector": config_name,
+            "mov-library_movies-library": "Movies",
+            "mov-library_movies-metadata_files": metadata_value,
+        },
+        headers={"Referer": "http://localhost/step/025-libraries"},
+    )
+
+    assert resp.status_code == 200
+
+    validated, user_entered, stored = database.retrieve_section_data(config_name, "libraries")
+    assert validated is False
+    assert user_entered is True
+    assert stored["libraries"]["mov-library_movies-library"] == "Movies"
+    assert stored["libraries"]["mov-library_movies-metadata_files"] == metadata_value
+
+
+def test_step_post_from_libraries_rejects_invalid_metadata_files(client, isolated_config_dir, monkeypatch, qs_module):
+    from modules import database
+
+    class _Resp:
+        status_code = 404
+        reason = "Not Found"
+        text = ""
+
+    monkeypatch.setattr(qs_module.validations.requests, "get", lambda *_args, **_kwargs: _Resp())
+    monkeypatch.setattr(qs_module.output, "build_config", lambda *_args, **_kwargs: (True, None, {}, "test: true\n", []))
+    monkeypatch.setattr(
+        qs_module,
+        "_build_final_gate",
+        lambda *_args, **_kwargs: {
+            "stage": "kometa",
+            "todo_count": 0,
+            "todo_blockers": [],
+            "bulk_validation_fresh": True,
+            "bulk_validation_at": qs_module.utc_now_iso(),
+            "validation_ttl_hours": 12,
+            "can_build_config": True,
+            "config_valid": True,
+        },
+    )
+
+    config_name = "pytest_invalid_step_metadata_files"
+    resp = client.post(
+        "/step/900-kometa",
+        data={
+            "configSelector": config_name,
+            "mov-library_movies-library": "Movies",
+            "mov-library_movies-metadata_files": '[{"type":"url","location":"https://example.com/missing.yml"}]',
+        },
+        headers={"Referer": "http://localhost/step/025-libraries"},
+    )
+
+    assert resp.status_code == 200
+    assert b"Invalid values:" in resp.data
+
+    validated, user_entered, stored = database.retrieve_section_data(config_name, "libraries")
+    assert stored is None
+    assert validated is False
+    assert user_entered is False
 
 
 def test_helpers_extract_library_name_supports_metadata_files():
@@ -985,7 +1195,6 @@ def test_copy_library_settings_mirrors_metadata_files(client, isolated_config_di
             "validated": False,
         },
     )
-
     monkeypatch.setattr(
         qs_module,
         "_build_library_lists",
@@ -996,8 +1205,9 @@ def test_copy_library_settings_mirrors_metadata_files(client, isolated_config_di
             ],
             [],
             {},
-        ),
+            ),
     )
+    monkeypatch.setattr(qs_module.validations, "validate_metadata_file_payload", lambda _payload: (True, ""))
 
     with app.test_request_context("/copy_library_settings"):
         session["config_name"] = config_name

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -161,12 +161,63 @@ def test_validate_metadata_file_accepts_existing_local_file(client, tmp_path):
 def test_validate_metadata_file_rejects_invalid_type(client):
     resp = client.post(
         "/validate_metadata_file",
-        json={"metadata_file_type": "folder", "metadata_file_location": "config/metadata.yml"},
+        json={"metadata_file_type": "default", "metadata_file_location": "config/metadata.yml"},
     )
     assert resp.status_code == 400
     payload = resp.get_json()
     assert payload["valid"] is False
-    assert "file, url, git, or repo" in payload["error"]
+    assert "file, folder, url, git, or repo" in payload["error"]
+
+
+def test_validate_metadata_folder_accepts_top_level_yaml_files(client, tmp_path):
+    metadata_dir = tmp_path / "metadata"
+    metadata_dir.mkdir()
+    (metadata_dir / "godzilla.yml").write_text("metadata:\n  test:\n    title: Godzilla\n", encoding="utf-8")
+    (metadata_dir / "refresh.yaml").write_text("metadata:\n  refresh:\n    title: Refresh\n", encoding="utf-8")
+
+    resp = client.post(
+        "/validate_metadata_file",
+        json={"metadata_file_type": "folder", "metadata_file_location": str(metadata_dir)},
+    )
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["valid"] is True
+    assert payload["validated_files"] == 2
+    assert payload["files"] == ["godzilla.yml", "refresh.yaml"]
+    assert payload["message"] == "Validated 2 YAML files in folder."
+
+
+def test_validate_metadata_folder_rejects_empty_folder(client, tmp_path):
+    metadata_dir = tmp_path / "metadata"
+    metadata_dir.mkdir()
+
+    resp = client.post(
+        "/validate_metadata_file",
+        json={"metadata_file_type": "folder", "metadata_file_location": str(metadata_dir)},
+    )
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert payload["valid"] is False
+    assert "at least one top-level .yml or .yaml file" in payload["error"]
+
+
+def test_validate_metadata_folder_does_not_recurse_into_subfolders(client, tmp_path):
+    metadata_dir = tmp_path / "metadata"
+    metadata_dir.mkdir()
+    (metadata_dir / "godzilla.yml").write_text("metadata:\n  test:\n    title: Godzilla\n", encoding="utf-8")
+    nested_dir = metadata_dir / "nested"
+    nested_dir.mkdir()
+    (nested_dir / "broken.yml").write_text("metadata: [broken\n", encoding="utf-8")
+
+    resp = client.post(
+        "/validate_metadata_file",
+        json={"metadata_file_type": "folder", "metadata_file_location": str(metadata_dir)},
+    )
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["valid"] is True
+    assert payload["validated_files"] == 1
+    assert payload["files"] == ["godzilla.yml"]
 
 
 def test_validate_metadata_file_accepts_git(client, monkeypatch, qs_module):
@@ -288,8 +339,10 @@ def test_output_metadata_file_entries_are_sorted():
                 {"type": "url", "location": "https://example.com/zeta.yml"},
                 {"type": "repo", "location": "custom/movies.yml"},
                 {"type": "file", "location": "config/beta.yml"},
+                {"type": "folder", "location": "config/zeta"},
                 {"type": "git", "location": "community/alpha.yml"},
                 {"type": "file", "location": "config/alpha.yml"},
+                {"type": "folder", "location": "config/alpha"},
                 {"type": "url", "location": "https://example.com/alpha.yml"},
             ]
         )
@@ -298,6 +351,8 @@ def test_output_metadata_file_entries_are_sorted():
     assert parsed == [
         {"file": "config/alpha.yml"},
         {"file": "config/beta.yml"},
+        {"folder": "config/alpha"},
+        {"folder": "config/zeta"},
         {"git": "community/alpha.yml"},
         {"repo": "custom/movies.yml"},
         {"url": "https://example.com/alpha.yml"},
@@ -327,6 +382,7 @@ def test_build_libraries_section_emits_metadata_files(app):
                             {"type": "url", "location": "https://example.com/movies_refresh.yml"},
                             {"type": "repo", "location": "custom/movies_meta.yml"},
                             {"type": "file", "location": "C:\\Users\\bullmoose20\\Community-Configs\\bullmoose20\\godzilla.yml"},
+                            {"type": "folder", "location": "config\\metadata\\movies"},
                             {"type": "git", "location": "bullmoose20/collections/godzilla.yml"},
                         ]
                     )
@@ -341,6 +397,7 @@ def test_build_libraries_section_emits_metadata_files(app):
 
         assert libraries_section["libraries"]["Movies"]["metadata_files"] == [
             {"file": "C:\\Users\\bullmoose20\\Community-Configs\\bullmoose20\\godzilla.yml"},
+            {"folder": "config\\metadata\\movies"},
             {"git": "bullmoose20/collections/godzilla.yml"},
             {"repo": "custom/movies_meta.yml"},
             {"url": "https://example.com/movies_refresh.yml"},
@@ -358,6 +415,7 @@ def test_build_config_includes_saved_library_metadata_files(app, isolated_config
     metadata_value = json.dumps(
         [
             {"type": "file", "location": "C:\\Users\\bullmoose20\\Community-Configs\\bullmoose20\\godzilla.yml"},
+            {"type": "folder", "location": "config\\metadata\\movies"},
             {"type": "url", "location": "https://example.com/movies_refresh.yml"},
         ]
     )
@@ -401,6 +459,7 @@ def test_build_config_includes_saved_library_metadata_files(app, isolated_config
 
     assert "metadata_files:" in yaml_content
     assert "godzilla.yml" in yaml_content
+    assert "config\\metadata\\movies" in yaml_content
     assert "movies_refresh.yml" in yaml_content
 
 

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -1334,7 +1334,7 @@ def test_copy_library_settings_mirrors_metadata_files(client, isolated_config_di
             ],
             [],
             {},
-            ),
+        ),
     )
     monkeypatch.setattr(qs_module.validations, "validate_metadata_file_payload", lambda _payload: (True, ""))
 

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -218,6 +218,13 @@ def test_output_metadata_file_entries_are_sorted():
     ]
 
 
+def test_helpers_extract_library_name_supports_metadata_files():
+    from modules import helpers
+
+    assert helpers.extract_library_name("mov-library_movies-metadata_files") == "movies"
+    assert helpers.extract_library_name("sho-library_tv_shows-metadata_files") == "tv_shows"
+
+
 def test_update_quickstart_settings_supports_independent_imagemaid_log_retention(client, qs_module, isolated_config_dir, monkeypatch):
     from modules import helpers
 

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -161,12 +161,74 @@ def test_validate_metadata_file_accepts_existing_local_file(client, tmp_path):
 def test_validate_metadata_file_rejects_invalid_type(client):
     resp = client.post(
         "/validate_metadata_file",
-        json={"metadata_file_type": "git", "metadata_file_location": "config/metadata.yml"},
+        json={"metadata_file_type": "folder", "metadata_file_location": "config/metadata.yml"},
     )
     assert resp.status_code == 400
     payload = resp.get_json()
     assert payload["valid"] is False
-    assert "file or url" in payload["error"]
+    assert "file, url, git, or repo" in payload["error"]
+
+
+def test_validate_metadata_file_accepts_git(client, monkeypatch, qs_module):
+    class _Resp:
+        status_code = 200
+        reason = "OK"
+        text = "metadata:\n  test:\n    title: Example\n"
+
+    captured = {}
+
+    def _fake_get(url, timeout=10):
+        captured["url"] = url
+        return _Resp()
+
+    monkeypatch.setattr(qs_module.validations.requests, "get", _fake_get)
+
+    resp = client.post(
+        "/validate_metadata_file",
+        json={"metadata_file_type": "git", "metadata_file_location": "bullmoose20/godzilla.yml"},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["valid"] is True
+    assert captured["url"] == "https://raw.githubusercontent.com/Kometa-Team/Community-Configs/master/bullmoose20/godzilla.yml"
+
+
+def test_validate_metadata_file_rejects_repo_without_custom_repo(client):
+    resp = client.post(
+        "/validate_metadata_file",
+        json={"metadata_file_type": "repo", "metadata_file_location": "bullmoose20/godzilla.yml"},
+    )
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert payload["valid"] is False
+    assert payload["error"] == "Metadata file repo entries require Custom Repo to be configured and saved first within the Settings page."
+
+
+def test_validate_metadata_file_accepts_repo_with_saved_custom_repo(client, monkeypatch, qs_module):
+    class _Resp:
+        status_code = 200
+        reason = "OK"
+        text = "metadata:\n  test:\n    title: Example\n"
+
+    captured = {}
+
+    def _fake_get(url, timeout=10):
+        captured["url"] = url
+        return _Resp()
+
+    monkeypatch.setattr(
+        qs_module.validations.persistence,
+        "retrieve_settings",
+        lambda _section: {"settings": {"custom_repo": "https://github.com/example/custom-repo/tree/master"}},
+    )
+    monkeypatch.setattr(qs_module.validations.requests, "get", _fake_get)
+
+    resp = client.post(
+        "/validate_metadata_file",
+        json={"metadata_file_type": "repo", "metadata_file_location": "bullmoose20/godzilla.yml"},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["valid"] is True
+    assert captured["url"] == "https://raw.githubusercontent.com/example/custom-repo/master/bullmoose20/godzilla.yml"
 
 
 def test_validate_metadata_file_rejects_url_in_file_mode(client):
@@ -224,7 +286,9 @@ def test_output_metadata_file_entries_are_sorted():
         json.dumps(
             [
                 {"type": "url", "location": "https://example.com/zeta.yml"},
+                {"type": "repo", "location": "custom/movies.yml"},
                 {"type": "file", "location": "config/beta.yml"},
+                {"type": "git", "location": "community/alpha.yml"},
                 {"type": "file", "location": "config/alpha.yml"},
                 {"type": "url", "location": "https://example.com/alpha.yml"},
             ]
@@ -234,6 +298,8 @@ def test_output_metadata_file_entries_are_sorted():
     assert parsed == [
         {"file": "config/alpha.yml"},
         {"file": "config/beta.yml"},
+        {"git": "community/alpha.yml"},
+        {"repo": "custom/movies.yml"},
         {"url": "https://example.com/alpha.yml"},
         {"url": "https://example.com/zeta.yml"},
     ]
@@ -259,7 +325,9 @@ def test_build_libraries_section_emits_metadata_files(app):
                     "mov-library_movies-metadata_files": json.dumps(
                         [
                             {"type": "url", "location": "https://example.com/movies_refresh.yml"},
+                            {"type": "repo", "location": "custom/movies_meta.yml"},
                             {"type": "file", "location": "C:\\Users\\bullmoose20\\Community-Configs\\bullmoose20\\godzilla.yml"},
+                            {"type": "git", "location": "bullmoose20/collections/godzilla.yml"},
                         ]
                     )
                 }
@@ -271,10 +339,12 @@ def test_build_libraries_section_emits_metadata_files(app):
             {},
         )
 
-    assert libraries_section["libraries"]["Movies"]["metadata_files"] == [
-        {"file": "C:\\Users\\bullmoose20\\Community-Configs\\bullmoose20\\godzilla.yml"},
-        {"url": "https://example.com/movies_refresh.yml"},
-    ]
+        assert libraries_section["libraries"]["Movies"]["metadata_files"] == [
+            {"file": "C:\\Users\\bullmoose20\\Community-Configs\\bullmoose20\\godzilla.yml"},
+            {"git": "bullmoose20/collections/godzilla.yml"},
+            {"repo": "custom/movies_meta.yml"},
+            {"url": "https://example.com/movies_refresh.yml"},
+        ]
     assert list(libraries_section["libraries"]["Movies"].keys())[:2] == ["template_variables", "metadata_files"]
 
 

--- a/tests/test_importer_metadata_files.py
+++ b/tests/test_importer_metadata_files.py
@@ -8,6 +8,8 @@ def test_prepare_import_payload_maps_multiple_metadata_files_per_library():
                 "Movies": {
                     "metadata_files": [
                         {"file": "config/metadata/movies.yml"},
+                        {"git": "bullmoose20/godzilla.yml"},
+                        {"repo": "custom/movies_extra.yml"},
                         {"url": "https://example.com/movie-metadata.yml"},
                     ]
                 }
@@ -21,7 +23,9 @@ def test_prepare_import_payload_maps_multiple_metadata_files_per_library():
     assert "mov-library_movies-metadata_files" in libraries_payload
     assert (
         libraries_payload["mov-library_movies-metadata_files"]
-        == '[{"type": "file", "location": "config/metadata/movies.yml"}, {"type": "url", "location": "https://example.com/movie-metadata.yml"}]'
+        == '[{"type": "file", "location": "config/metadata/movies.yml"}, {"type": "git", "location": "bullmoose20/godzilla.yml"}, {"type": "repo", "location": "custom/movies_extra.yml"}, {"type": "url", "location": "https://example.com/movie-metadata.yml"}]'
     )
     assert any("libraries.Movies.metadata_files[0].file" in line for line in report.lines)
-    assert any("libraries.Movies.metadata_files[1].url" in line for line in report.lines)
+    assert any("libraries.Movies.metadata_files[1].git" in line for line in report.lines)
+    assert any("libraries.Movies.metadata_files[2].repo" in line for line in report.lines)
+    assert any("libraries.Movies.metadata_files[3].url" in line for line in report.lines)

--- a/tests/test_importer_metadata_files.py
+++ b/tests/test_importer_metadata_files.py
@@ -1,0 +1,27 @@
+from modules import importer
+
+
+def test_prepare_import_payload_maps_multiple_metadata_files_per_library():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Movies": {
+                    "metadata_files": [
+                        {"file": "config/metadata/movies.yml"},
+                        {"url": "https://example.com/movie-metadata.yml"},
+                    ]
+                }
+            }
+        },
+        {"Movies"},
+        set(),
+    )
+
+    libraries_payload = payload["libraries"]["libraries"]
+    assert "mov-library_movies-metadata_files" in libraries_payload
+    assert (
+        libraries_payload["mov-library_movies-metadata_files"]
+        == '[{"type": "file", "location": "config/metadata/movies.yml"}, {"type": "url", "location": "https://example.com/movie-metadata.yml"}]'
+    )
+    assert any("libraries.Movies.metadata_files[0].file" in line for line in report.lines)
+    assert any("libraries.Movies.metadata_files[1].url" in line for line in report.lines)

--- a/tests/test_importer_metadata_files.py
+++ b/tests/test_importer_metadata_files.py
@@ -8,6 +8,7 @@ def test_prepare_import_payload_maps_multiple_metadata_files_per_library():
                 "Movies": {
                     "metadata_files": [
                         {"file": "config/metadata/movies.yml"},
+                        {"folder": "config/metadata/movies"},
                         {"git": "bullmoose20/godzilla.yml"},
                         {"repo": "custom/movies_extra.yml"},
                         {"url": "https://example.com/movie-metadata.yml"},
@@ -23,9 +24,10 @@ def test_prepare_import_payload_maps_multiple_metadata_files_per_library():
     assert "mov-library_movies-metadata_files" in libraries_payload
     assert (
         libraries_payload["mov-library_movies-metadata_files"]
-        == '[{"type": "file", "location": "config/metadata/movies.yml"}, {"type": "git", "location": "bullmoose20/godzilla.yml"}, {"type": "repo", "location": "custom/movies_extra.yml"}, {"type": "url", "location": "https://example.com/movie-metadata.yml"}]'
+        == '[{"type": "file", "location": "config/metadata/movies.yml"}, {"type": "folder", "location": "config/metadata/movies"}, {"type": "git", "location": "bullmoose20/godzilla.yml"}, {"type": "repo", "location": "custom/movies_extra.yml"}, {"type": "url", "location": "https://example.com/movie-metadata.yml"}]'
     )
     assert any("libraries.Movies.metadata_files[0].file" in line for line in report.lines)
-    assert any("libraries.Movies.metadata_files[1].git" in line for line in report.lines)
-    assert any("libraries.Movies.metadata_files[2].repo" in line for line in report.lines)
-    assert any("libraries.Movies.metadata_files[3].url" in line for line in report.lines)
+    assert any("libraries.Movies.metadata_files[1].folder" in line for line in report.lines)
+    assert any("libraries.Movies.metadata_files[2].git" in line for line in report.lines)
+    assert any("libraries.Movies.metadata_files[3].repo" in line for line in report.lines)
+    assert any("libraries.Movies.metadata_files[4].url" in line for line in report.lines)


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Adds full metadata_files support to library configuration in Quickstart.

This includes import, persistence, mirroring, YAML output, and validation for mixed file, folder, url, git, and repo entries per library. Validation now checks that each source resolves to non-empty YAML, matches Kometa’s non-recursive folder behavior, and adds dependency-aware handling for repo entries tied to Settings -> Custom Repo. The libraries UI was also updated to surface per-row validation state, clearer dependency guidance, sorted YAML output, and better feedback for validated folders, including file counts and file lists.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
