### PR TITLE
added test and fix for persistence

### DIFF
--- a/static/local-js/overlayHandler.js
+++ b/static/local-js/overlayHandler.js
@@ -1237,6 +1237,14 @@ const OverlayHandler = {
       return (label.textContent || '').trim()
     }
 
+    const getCurrentMassToggleValue = (libraryId, group) => {
+      if (!libraryId || !group) return null
+      const inputPrefix = `${libraryId}-attribute_${group}_`
+      const toggles = Array.from(document.querySelectorAll(`input.form-check-input[id^="${inputPrefix}"]`))
+      const checked = toggles.find(input => input.checked)
+      return checked ? checked.id.replace(inputPrefix, '') : null
+    }
+
     const setStatusTooltip = (el, message) => {
       if (!el) return
       el.setAttribute('title', message)
@@ -1865,14 +1873,22 @@ const OverlayHandler = {
           ? RATING_SOURCE_MAP_EPISODE[imageKey]
           : RATING_SOURCE_MAP[imageKey]
         const source = sourceMap ? (sourceMap[ratingValRaw] || sourceMap.any || null) : null
-        if (!source) {
+        const currentSource = getCurrentMassToggleValue(libraryId, group)
+        const effectiveSource = currentSource || source
+        if (!effectiveSource) {
           setStatusIcon(statusEl, 'neutral', `${slot.label} (${ratingLabel} + ${imageLabel}) has no matching rating source.`)
           return
         }
         const groupLabel = RATING_GROUP_LABEL_MAP[group] || group
-        const toggleLabel = getMassToggleLabel(libraryId, group, source) || RATING_SOURCE_LABEL_MAP[source] || source
+        const toggleLabel = currentSource
+          ? (getCurrentMassToggleLabel(libraryId, group) || getMassToggleLabel(libraryId, group, currentSource) || RATING_SOURCE_LABEL_MAP[currentSource] || currentSource)
+          : (getMassToggleLabel(libraryId, group, source) || RATING_SOURCE_LABEL_MAP[source] || source)
         let message = `${slot.label} (${ratingLabel} + ${imageLabel}) → ${groupLabel}: ${toggleLabel}`
-        const service = RATING_SOURCE_SERVICE_MAP[source] || null
+        if (currentSource && source && currentSource !== source) {
+          const defaultLabel = getMassToggleLabel(libraryId, group, source) || RATING_SOURCE_LABEL_MAP[source] || source
+          message = `${slot.label} (${ratingLabel} + ${imageLabel}) preserves ${groupLabel}: ${toggleLabel}. Default for this badge would be ${defaultLabel}.`
+        }
+        const service = RATING_SOURCE_SERVICE_MAP[effectiveSource] || null
         if (!service) {
           message += '. No service required.'
           setStatusIcon(statusEl, 'neutral', message)
@@ -1936,8 +1952,12 @@ const OverlayHandler = {
       }
     }
 
-    const setMassRatingSource = (libraryId, prefix, source) => {
+    const setMassRatingSource = (libraryId, prefix, source, opts = {}) => {
       if (!libraryId || !prefix) return
+      const preserveExisting = Boolean(opts.preserveExisting)
+      const current = getCurrentMassToggleValue(libraryId, prefix)
+      if (preserveExisting && current) return current
+      if (current && current === source) return current
       const inputPrefix = `${libraryId}-attribute_${prefix}_`
       const toggles = document.querySelectorAll(`input.form-check-input[id^="${inputPrefix}"]`)
       toggles.forEach(input => {
@@ -1952,9 +1972,10 @@ const OverlayHandler = {
         target.checked = true
         target.dispatchEvent(new Event('change', { bubbles: true }))
       }
+      return source
     }
 
-    const syncRatingSources = (cfg, slot) => {
+    const syncRatingSources = (cfg, slot, opts = {}) => {
       if (!cfg?.container) return
       const overlayType = cfg.container.dataset.overlayType || ''
       if (!['movie', 'show', 'episode'].includes(overlayType)) return
@@ -1973,7 +1994,13 @@ const OverlayHandler = {
         ? RATING_SOURCE_MAP_EPISODE[imageKey]
         : RATING_SOURCE_MAP[imageKey]
       const source = sourceMap ? (sourceMap[ratingVal] || sourceMap.any || null) : null
-      setMassRatingSource(libraryId, group, source)
+      setMassRatingSource(libraryId, group, source, opts)
+    }
+
+    if (typeof window !== 'undefined') {
+      window.__qsOverlayTestHooks = window.__qsOverlayTestHooks || {}
+      window.__qsOverlayTestHooks.syncRatingSources = syncRatingSources
+      window.__qsOverlayTestHooks.getCurrentMassToggleValue = getCurrentMassToggleValue
     }
 
     const sortRatingImageOptions = (input) => {
@@ -4291,7 +4318,7 @@ const OverlayHandler = {
         }
 
         if (cfg.id === 'overlay_ratings' && layer && cfg.container) {
-          const runRatingsUpdate = (event, forceSync = false) => {
+          const runRatingsUpdate = (event, forceSync = false, preserveExistingSources = false) => {
             if (cfg.container?.dataset?.resetting === 'true') return
             enforceUniqueRatingTypes(cfg)
             if (event && event.target && cfg.container) {
@@ -4313,7 +4340,7 @@ const OverlayHandler = {
                 { ratingKey: 'rating2', imageKey: 'rating2_image' },
                 { ratingKey: 'rating3', imageKey: 'rating3_image' }
               ]
-              slots.forEach(slot => syncRatingSources(cfg, slot))
+              slots.forEach(slot => syncRatingSources(cfg, slot, { preserveExisting: preserveExistingSources }))
             }
             const positionInput = cfg.container.querySelector(`[name="${templateName}[horizontal_position]"]`)
             const verticalInput = cfg.container.querySelector(`[name="${templateName}[vertical_position]"]`)
@@ -4347,21 +4374,25 @@ const OverlayHandler = {
               applyPosition(cfg)
             })
           }
-          const scheduleRatingsUpdate = (event, forceSync = false) => {
+          const scheduleRatingsUpdate = (event, forceSync = false, preserveExistingSources = false) => {
             if (!cfg.container) return
             if (cfg.container.dataset.ratingRefreshScheduled === 'true') {
               if (forceSync) cfg.container.dataset.ratingRefreshForce = 'true'
+              if (preserveExistingSources) cfg.container.dataset.ratingRefreshPreserve = 'true'
               return
             }
             cfg.container.dataset.ratingRefreshScheduled = 'true'
             if (forceSync) cfg.container.dataset.ratingRefreshForce = 'true'
+            if (preserveExistingSources) cfg.container.dataset.ratingRefreshPreserve = 'true'
             requestAnimationFrame(() => {
               const doForce = cfg.container?.dataset?.ratingRefreshForce === 'true'
+              const doPreserve = cfg.container?.dataset?.ratingRefreshPreserve === 'true'
               if (cfg.container) {
                 delete cfg.container.dataset.ratingRefreshScheduled
                 delete cfg.container.dataset.ratingRefreshForce
+                delete cfg.container.dataset.ratingRefreshPreserve
               }
-              runRatingsUpdate(null, doForce)
+              runRatingsUpdate(null, doForce, doPreserve)
             })
           }
           const templateName = cfg.container.dataset.overlayTemplate
@@ -4420,12 +4451,12 @@ const OverlayHandler = {
             cfg.toggle.dataset.ratingSyncBound = 'true'
             cfg.toggle.addEventListener('change', () => {
               if (cfg.toggle.checked) {
-                scheduleRatingsUpdate(null, true)
+                scheduleRatingsUpdate(null, true, true)
               }
             })
           }
           if (cfg.toggle && cfg.toggle.checked) {
-            scheduleRatingsUpdate(null, true)
+            scheduleRatingsUpdate(null, true, true)
           } else {
             scheduleRatingsUpdate()
           }

--- a/tests/e2e/test_ratings_overlay_e2e.py
+++ b/tests/e2e/test_ratings_overlay_e2e.py
@@ -233,8 +233,7 @@ def _enable_overlay_group(page, template):
 
 
 def _ensure_overlay_test_hooks(page):
-    page.evaluate(
-        """() => {
+    page.evaluate("""() => {
           const handler = typeof OverlayHandler !== 'undefined'
             ? OverlayHandler
             : window.OverlayHandler
@@ -243,8 +242,7 @@ def _ensure_overlay_test_hooks(page):
               typeof handler.initializeOverlayBoards === 'function') {
             handler.initializeOverlayBoards(document)
           }
-        }"""
-    )
+        }""")
     page.wait_for_function(
         """() => !!window.__qsOverlayTestHooks &&
           typeof window.__qsOverlayTestHooks.syncRatingSources === 'function'""",

--- a/tests/e2e/test_ratings_overlay_e2e.py
+++ b/tests/e2e/test_ratings_overlay_e2e.py
@@ -232,6 +232,108 @@ def _enable_overlay_group(page, template):
     )
 
 
+def _ensure_overlay_test_hooks(page):
+    page.evaluate(
+        """() => {
+          const handler = typeof OverlayHandler !== 'undefined'
+            ? OverlayHandler
+            : window.OverlayHandler
+          if (!window.__qsOverlayTestHooks &&
+              handler &&
+              typeof handler.initializeOverlayBoards === 'function') {
+            handler.initializeOverlayBoards(document)
+          }
+        }"""
+    )
+    page.wait_for_function(
+        """() => !!window.__qsOverlayTestHooks &&
+          typeof window.__qsOverlayTestHooks.syncRatingSources === 'function'""",
+        timeout=10000,
+    )
+
+
+def _ensure_rating_source_harness(page):
+    return page.evaluate("""() => {
+      const existing = document.querySelector('[data-test-ratings-source-harness="true"]')
+      if (existing) {
+        return {
+          templateName: existing.dataset.templateName,
+          libraryId: existing.dataset.libraryId
+        }
+      }
+
+      const templateName = 'test_ratings_source_overlay'
+      const libraryId = 'test_library'
+      const host = document.createElement('div')
+      host.setAttribute('data-test-ratings-source-harness', 'true')
+      host.dataset.templateName = templateName
+      host.dataset.libraryId = libraryId
+      host.style.display = 'none'
+
+      const container = document.createElement('div')
+      container.className = 'template-toggle-group'
+      container.dataset.overlayTemplate = templateName
+      container.dataset.overlayType = 'show'
+      container.dataset.libraryId = libraryId
+      host.appendChild(container)
+
+      const addSelect = (name, value, options) => {
+        const select = document.createElement('select')
+        select.name = `${templateName}[${name}]`
+        options.forEach(opt => {
+          const option = document.createElement('option')
+          option.value = opt
+          option.textContent = opt || 'None'
+          if (opt === value) option.selected = true
+          select.appendChild(option)
+        })
+        select.dataset.default = String(value)
+        container.appendChild(select)
+        return select
+      }
+
+      const addToggle = (group, value, checked = false) => {
+        const input = document.createElement('input')
+        input.type = 'checkbox'
+        input.className = 'form-check-input'
+        input.id = `${libraryId}-attribute_${group}_${value}`
+        input.checked = checked
+        host.appendChild(input)
+        const label = document.createElement('label')
+        label.setAttribute('for', input.id)
+        label.textContent = value
+        host.appendChild(label)
+        return input
+      }
+
+      addSelect('rating1', 'user', ['', 'user', 'critic', 'audience'])
+      addSelect('rating1_image', 'imdb', ['', 'rt_tomato', 'rt_popcorn', 'imdb'])
+      addSelect('rating2', 'critic', ['', 'user', 'critic', 'audience'])
+      addSelect('rating2_image', 'rt_tomato', ['', 'rt_tomato', 'rt_popcorn', 'imdb'])
+      addSelect('rating3', 'audience', ['', 'user', 'critic', 'audience'])
+      addSelect('rating3_image', 'rt_popcorn', ['', 'rt_tomato', 'rt_popcorn', 'imdb'])
+
+      addToggle('mass_critic_rating_update', 'plex_tomatoes', true)
+      addToggle('mass_critic_rating_update', 'mdb_tomatoes', false)
+      addToggle('mass_audience_rating_update', 'plex_tomatoesaudience', true)
+      addToggle('mass_audience_rating_update', 'mdb_tomatoesaudience', false)
+      addToggle('mass_user_rating_update', 'imdb', true)
+
+      document.body.appendChild(host)
+      return { templateName, libraryId }
+    }""")
+
+
+def _rating_toggle_map(page):
+    return page.evaluate("""() => {
+      return Array.from(document.querySelectorAll('[data-test-ratings-source-harness="true"] input.form-check-input'))
+        .reduce((acc, el) => {
+          acc[el.id] = !!el.checked
+          return acc
+        }, {})
+    }""")
+
+
 def _slot_offsets(page, template):
     return {
         "rating1": {
@@ -458,3 +560,53 @@ def test_ratings_slot_order_across_position_combos(page, live_server, enabled_sl
                     else:
                         assert single["h"] == expected_h
                         assert single["v"] == expected_v
+
+
+@pytest.mark.e2e
+def test_ratings_toggle_preserves_existing_rt_mass_sources(page, live_server):
+    page.goto(f"{live_server}/step/025-libraries", wait_until="domcontentloaded")
+    page.wait_for_selector("#libraryPicker", timeout=10000)
+    _ensure_overlay_test_hooks(page)
+    ctx = _ensure_rating_source_harness(page)
+    library_id = ctx["libraryId"]
+
+    page.evaluate(
+        """(libraryId) => {
+          const container = document.querySelector('[data-test-ratings-source-harness="true"] [data-overlay-template]')
+          const sync = window.__qsOverlayTestHooks.syncRatingSources
+          sync({ container }, { ratingKey: 'rating2', imageKey: 'rating2_image' }, { preserveExisting: true })
+          sync({ container }, { ratingKey: 'rating3', imageKey: 'rating3_image' }, { preserveExisting: true })
+          return {
+            critic: window.__qsOverlayTestHooks.getCurrentMassToggleValue(libraryId, 'mass_critic_rating_update'),
+            audience: window.__qsOverlayTestHooks.getCurrentMassToggleValue(libraryId, 'mass_audience_rating_update')
+          }
+        }""",
+        library_id,
+    )
+
+    checked = _rating_toggle_map(page)
+    assert checked[f"{library_id}-attribute_mass_critic_rating_update_plex_tomatoes"] is True
+    assert checked.get(f"{library_id}-attribute_mass_critic_rating_update_mdb_tomatoes", False) is False
+    assert checked[f"{library_id}-attribute_mass_audience_rating_update_plex_tomatoesaudience"] is True
+    assert checked.get(f"{library_id}-attribute_mass_audience_rating_update_mdb_tomatoesaudience", False) is False
+    assert checked[f"{library_id}-attribute_mass_user_rating_update_imdb"] is True
+
+    page.evaluate(
+        """(libraryId) => {
+          const container = document.querySelector('[data-test-ratings-source-harness="true"] [data-overlay-template]')
+          document.getElementById(`${libraryId}-attribute_mass_critic_rating_update_plex_tomatoes`).checked = false
+          document.getElementById(`${libraryId}-attribute_mass_critic_rating_update_mdb_tomatoes`).checked = false
+          document.getElementById(`${libraryId}-attribute_mass_audience_rating_update_plex_tomatoesaudience`).checked = false
+          document.getElementById(`${libraryId}-attribute_mass_audience_rating_update_mdb_tomatoesaudience`).checked = false
+          const sync = window.__qsOverlayTestHooks.syncRatingSources
+          sync({ container }, { ratingKey: 'rating2', imageKey: 'rating2_image' }, { preserveExisting: true })
+          sync({ container }, { ratingKey: 'rating3', imageKey: 'rating3_image' }, { preserveExisting: true })
+        }""",
+        library_id,
+    )
+
+    checked = _rating_toggle_map(page)
+    assert checked[f"{library_id}-attribute_mass_critic_rating_update_mdb_tomatoes"] is True
+    assert checked.get(f"{library_id}-attribute_mass_critic_rating_update_plex_tomatoes", False) is False
+    assert checked[f"{library_id}-attribute_mass_audience_rating_update_mdb_tomatoesaudience"] is True
+    assert checked.get(f"{library_id}-attribute_mass_audience_rating_update_plex_tomatoesaudience", False) is False


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Fixes a ratings overlay persistence bug where Quickstart could overwrite already-saved Rotten Tomatoes mass rating sources with badge-derived defaults when revisiting the Libraries page.

The overlay sync logic now defaults sources only when they are unset, while preserving existing valid selections such as `plex_tomatoes` and `plex_tomatoesaudience`. This PR also adds an e2e regression test covering both behaviors: preserve on existing values, default on empty values.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #1235 

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
