### PR TITLE
enhance metadata_files yml validation

### DIFF
--- a/modules/validations.py
+++ b/modules/validations.py
@@ -40,9 +40,25 @@ def _validate_yaml_text(raw_text, label):
         return False, f"{label} must not be empty."
     parser = YAML(typ="safe", pure=True)
     try:
-        parser.load(raw_text)
+        parsed = parser.load(raw_text)
     except Exception as exc:
         return False, f"{label} must contain valid YAML. {exc}"
+    return True, None, parsed
+
+
+def _validate_metadata_yaml_text(raw_text, label):
+    result = _validate_yaml_text(raw_text, label)
+    if len(result) == 2:
+        valid, message = result
+        return False, message
+    valid, message, parsed = result
+    if not valid:
+        return False, message
+    if not isinstance(parsed, dict):
+        return False, f"{label} must contain a top-level metadata mapping."
+    metadata = parsed.get("metadata")
+    if not isinstance(metadata, dict) or not metadata:
+        return False, f"{label} must contain a non-empty top-level metadata mapping."
     return True, None
 
 
@@ -71,7 +87,11 @@ def _validate_yaml_location(location, label):
         if response.status_code >= 400:
             return False, f"Failed to fetch {label} ({response.status_code} [{response.reason}])."
 
-        return _validate_yaml_text(response.text, label)
+        result = _validate_yaml_text(response.text, label)
+        if len(result) == 2:
+            return result
+        valid, message, _parsed = result
+        return valid, message
 
     valid, message = path_validation.validate_path(
         location,
@@ -86,7 +106,47 @@ def _validate_yaml_location(location, label):
     except OSError as exc:
         return False, f"{label}: Unable to read file. {exc}"
 
-    return _validate_yaml_text(yaml_text, label)
+    result = _validate_yaml_text(yaml_text, label)
+    if len(result) == 2:
+        return result
+    valid, message, _parsed = result
+    return valid, message
+
+
+def _validate_metadata_yaml_location(location, label):
+    valid, message = _validate_yaml_location_suffix(location, label)
+    if not valid:
+        return False, message
+
+    if str(location).strip().lower().startswith(("http://", "https://")):
+        valid, message = url_validation.validate_url(location, allow_local=True)
+        if not valid:
+            return False, f"{label}: {message}"
+
+        try:
+            response = requests.get(location, timeout=10)
+        except requests.RequestException as exc:
+            return False, f"Connection error: {str(exc)}"
+
+        if response.status_code >= 400:
+            return False, f"Failed to fetch {label} ({response.status_code} [{response.reason}])."
+
+        return _validate_metadata_yaml_text(response.text, label)
+
+    valid, message = path_validation.validate_path(
+        location,
+        {"allow_relative": True, "must_exist": True, "mode": "input_file"},
+    )
+    if not valid:
+        return False, f"{label}: {message}"
+
+    try:
+        with open(location, "r", encoding="utf-8") as handle:
+            yaml_text = handle.read()
+    except OSError as exc:
+        return False, f"{label}: Unable to read file. {exc}"
+
+    return _validate_metadata_yaml_text(yaml_text, label)
 
 
 def _validate_yaml_folder(location, label):
@@ -113,7 +173,7 @@ def _validate_yaml_folder(location, label):
         except OSError as exc:
             return False, f"{label}: Unable to read file {os.path.basename(yaml_file)}. {exc}"
 
-        valid, message = _validate_yaml_text(yaml_text, f"{label} file {os.path.basename(yaml_file)}")
+        valid, message = _validate_metadata_yaml_text(yaml_text, f"{label} file {os.path.basename(yaml_file)}")
         if not valid:
             return False, message
 
@@ -165,7 +225,7 @@ def validate_metadata_file_payload(data):
         if not metadata_file_location.lower().startswith(("http://", "https://")):
             return False, "Metadata file URL must start with http:// or https://.", {}
         label = "Metadata file URL"
-        return _normalize_metadata_validation_result(_validate_yaml_location(metadata_file_location, label))
+        return _normalize_metadata_validation_result(_validate_metadata_yaml_location(metadata_file_location, label))
 
     if metadata_file_type == "folder":
         if metadata_file_location.lower().startswith(("http://", "https://")):
@@ -177,7 +237,7 @@ def validate_metadata_file_payload(data):
         if metadata_file_location.lower().startswith(("http://", "https://")):
             return False, "Metadata file path must be a local file path.", {}
         label = "Metadata file path"
-        return _normalize_metadata_validation_result(_validate_yaml_location(metadata_file_location, label))
+        return _normalize_metadata_validation_result(_validate_metadata_yaml_location(metadata_file_location, label))
 
     if metadata_file_location.lower().startswith(("http://", "https://")):
         return False, f"Metadata file {metadata_file_type} value must not be a full URL.", {}
@@ -187,7 +247,7 @@ def validate_metadata_file_payload(data):
         if not valid:
             return False, message, {}
         return _normalize_metadata_validation_result(
-            _validate_yaml_location(
+            _validate_metadata_yaml_location(
                 f"https://raw.githubusercontent.com/Kometa-Team/Community-Configs/master/{metadata_file_location}",
                 "Metadata file git path",
             )
@@ -200,7 +260,7 @@ def validate_metadata_file_payload(data):
     if not valid:
         return False, message, {}
     resolved_repo_location = f"{custom_repo_base}{metadata_file_location}"
-    return _normalize_metadata_validation_result(_validate_yaml_location(resolved_repo_location, "Metadata file repo path"))
+    return _normalize_metadata_validation_result(_validate_metadata_yaml_location(resolved_repo_location, "Metadata file repo path"))
 
 
 def validate_metadata_file_server(data):

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -158,6 +158,34 @@ def test_validate_metadata_file_accepts_existing_local_file(client, tmp_path):
     assert payload["valid"] is True
 
 
+def test_validate_metadata_file_rejects_missing_top_level_metadata(client, tmp_path):
+    metadata_file = tmp_path / "metadata.yml"
+    metadata_file.write_text("templates:\n  test:\n    default: true\n", encoding="utf-8")
+
+    resp = client.post(
+        "/validate_metadata_file",
+        json={"metadata_file_type": "file", "metadata_file_location": str(metadata_file)},
+    )
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert payload["valid"] is False
+    assert "non-empty top-level metadata mapping" in payload["error"]
+
+
+def test_validate_metadata_file_rejects_empty_top_level_metadata(client, tmp_path):
+    metadata_file = tmp_path / "metadata.yml"
+    metadata_file.write_text("metadata: {}\n", encoding="utf-8")
+
+    resp = client.post(
+        "/validate_metadata_file",
+        json={"metadata_file_type": "file", "metadata_file_location": str(metadata_file)},
+    )
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert payload["valid"] is False
+    assert "non-empty top-level metadata mapping" in payload["error"]
+
+
 def test_validate_metadata_file_rejects_invalid_type(client):
     resp = client.post(
         "/validate_metadata_file",
@@ -218,6 +246,41 @@ def test_validate_metadata_folder_does_not_recurse_into_subfolders(client, tmp_p
     assert payload["valid"] is True
     assert payload["validated_files"] == 1
     assert payload["files"] == ["godzilla.yml"]
+
+
+def test_validate_metadata_folder_rejects_top_level_yaml_without_metadata(client, tmp_path):
+    metadata_dir = tmp_path / "metadata"
+    metadata_dir.mkdir()
+    (metadata_dir / "godzilla.yml").write_text("metadata:\n  test:\n    title: Godzilla\n", encoding="utf-8")
+    (metadata_dir / "broken.yml").write_text("templates:\n  sample:\n    test: true\n", encoding="utf-8")
+
+    resp = client.post(
+        "/validate_metadata_file",
+        json={"metadata_file_type": "folder", "metadata_file_location": str(metadata_dir)},
+    )
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert payload["valid"] is False
+    assert "broken.yml" in payload["error"]
+    assert "non-empty top-level metadata mapping" in payload["error"]
+
+
+def test_validate_metadata_url_rejects_missing_top_level_metadata(client, monkeypatch, qs_module):
+    class _Resp:
+        status_code = 200
+        reason = "OK"
+        text = "templates:\n  sample:\n    default: true\n"
+
+    monkeypatch.setattr(qs_module.validations.requests, "get", lambda *_args, **_kwargs: _Resp())
+
+    resp = client.post(
+        "/validate_metadata_file",
+        json={"metadata_file_type": "url", "metadata_file_location": "https://example.com/metadata.yml"},
+    )
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert payload["valid"] is False
+    assert "non-empty top-level metadata mapping" in payload["error"]
 
 
 def test_validate_metadata_file_accepts_git(client, monkeypatch, qs_module):


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Tightens metadata_files validation to match Kometa’s actual parser behavior.

Quickstart now requires each metadata source to contain a non-empty top-level metadata mapping, which prevents files from validating successfully in Quickstart but failing later when Kometa runs. This applies to file, folder, url, git, and repo metadata entries, with folder validation checking each top-level YAML file individually. Added backend regression tests for missing/empty metadata, invalid folder contents, and remote YAML failures, while keeping Apprise’s generic YAML validation unchanged.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
