### PR TITLE
Add collection files

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ Kometa Quickstart is more than just a YAML generator - it's a full interactive e
 - **Dependency-Aware Optional Pages:** Optional pages such as Tautulli, OMDb, MDBList, AniDB, Radarr, Sonarr, Trakt, and MyAnimeList become required when selected library features need them
 - **TODO Sidebar:** Outstanding dependency and validation tasks are grouped into clickable cards that save the current page and open the affected setup page
 - **Library-Scoped Playlists:** Playlist file selection now lives on the Libraries page so playlists stay tied to the libraries included in the generated YAML
+- **Library Collection Files:** Add multiple raw `collection_files` entries per library with mixed `file`, `folder`, `url`, `git`, and `repo` sources, import them from existing configs, and validate that each entry resolves to non-empty YAML with a top-level `collections` mapping before output
 - **Library Metadata Files:** Add multiple `metadata_files` entries per library with mixed `file`, `folder`, `url`, `git`, and `repo` sources, import them from existing configs, and validate that each entry resolves to non-empty YAML before output
-- **Custom Repo Awareness:** `repo` metadata files are dependency-aware and point back to `Settings -> Custom Repo` when that base path is missing
+- **Custom Repo Awareness:** `repo` collection and metadata files are dependency-aware and point back to `Settings -> Custom Repo` when that base path is missing
 - **Filtered Page Search:** Find matches on Libraries and Settings pages and auto-expand matching sections
 - **Settings Cog:** Quick access to runtime controls like debug mode and port changes from anywhere
 
@@ -138,6 +139,7 @@ How it works:
 - **Plex credentials prompt:** If the import contains libraries, Plex validation is required for mapping. Quickstart will prompt for Plex URL/token if none are present; if the credentials in the file fail validation, you’ll be prompted to correct them and re‑run Preview.
 - **Library mapping:** Imported library names must be mapped to Plex libraries (or ignored) before confirming the import; you can re‑preview after mapping.
 - **Metadata file import:** Library `metadata_files` import supports `file`, `folder`, `url`, `git`, and `repo` entries. Quickstart currently validates file or folder resolution and YAML parsing, but it does not fully validate Kometa metadata schema yet.
+- **Collection file import:** Library `collection_files` import supports `file`, `folder`, `url`, `git`, and `repo` entries. Quickstart currently validates file or folder resolution, YAML parsing, and a non-empty top-level `collections` mapping, but it does not fully validate Kometa collection file schema yet.
 - **After import:** Quickstart stays on the Welcome page, runs bulk validation automatically, then refreshes the workspace status for the imported config.
 
 #### What happens after import?

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Kometa Quickstart is more than just a YAML generator - it's a full interactive e
 - **Dependency-Aware Optional Pages:** Optional pages such as Tautulli, OMDb, MDBList, AniDB, Radarr, Sonarr, Trakt, and MyAnimeList become required when selected library features need them
 - **TODO Sidebar:** Outstanding dependency and validation tasks are grouped into clickable cards that save the current page and open the affected setup page
 - **Library-Scoped Playlists:** Playlist file selection now lives on the Libraries page so playlists stay tied to the libraries included in the generated YAML
-- **Library Collection Files:** Add multiple raw `collection_files` entries per library with mixed `file`, `folder`, `url`, `git`, and `repo` sources, import them from existing configs, and validate that each entry resolves to non-empty YAML with a top-level `collections` mapping before output
-- **Library Metadata Files:** Add multiple `metadata_files` entries per library with mixed `file`, `folder`, `url`, `git`, and `repo` sources, import them from existing configs, and validate that each entry resolves to non-empty YAML before output
+- **Library Collection Files:** Add multiple raw `collection_files` entries per library with mixed `file`, `folder`, `url`, `git`, and `repo` sources, import them from existing configs, and validate that each entry resolves to non-empty YAML with a non-empty top-level `collections:` mapping before output
+- **Library Metadata Files:** Add multiple `metadata_files` entries per library with mixed `file`, `folder`, `url`, `git`, and `repo` sources, import them from existing configs, and validate that each entry resolves to non-empty YAML with a non-empty top-level `metadata:` mapping before output
 - **Custom Repo Awareness:** `repo` collection and metadata files are dependency-aware and point back to `Settings -> Custom Repo` when that base path is missing
 - **Filtered Page Search:** Find matches on Libraries and Settings pages and auto-expand matching sections
 - **Settings Cog:** Quick access to runtime controls like debug mode and port changes from anywhere
@@ -138,8 +138,8 @@ How it works:
 - **Preview required:** Quickstart always runs a preview before import and shows a line‑by‑line report (`imported / not imported`) with filters (All/Imported/Not Imported/Comments) and a downloadable report.
 - **Plex credentials prompt:** If the import contains libraries, Plex validation is required for mapping. Quickstart will prompt for Plex URL/token if none are present; if the credentials in the file fail validation, you’ll be prompted to correct them and re‑run Preview.
 - **Library mapping:** Imported library names must be mapped to Plex libraries (or ignored) before confirming the import; you can re‑preview after mapping.
-- **Metadata file import:** Library `metadata_files` import supports `file`, `folder`, `url`, `git`, and `repo` entries. Quickstart currently validates file or folder resolution and YAML parsing, but it does not fully validate Kometa metadata schema yet.
-- **Collection file import:** Library `collection_files` import supports `file`, `folder`, `url`, `git`, and `repo` entries. Quickstart currently validates file or folder resolution, YAML parsing, and a non-empty top-level `collections` mapping, but it does not fully validate Kometa collection file schema yet.
+- **Metadata file import:** Library `metadata_files` import supports `file`, `folder`, `url`, `git`, and `repo` entries. Quickstart currently validates file or folder resolution, YAML parsing, and a non-empty top-level `metadata:` mapping, but it does not fully validate Kometa metadata schema yet.
+- **Collection file import:** Library `collection_files` import supports `file`, `folder`, `url`, `git`, and `repo` entries. Quickstart currently validates file or folder resolution, YAML parsing, and a non-empty top-level `collections:` mapping, but it does not fully validate Kometa collection file schema yet.
 - **After import:** Quickstart stays on the Welcome page, runs bulk validation automatically, then refreshes the workspace status for the imported config.
 
 #### What happens after import?

--- a/modules/importer.py
+++ b/modules/importer.py
@@ -1111,14 +1111,27 @@ def prepare_import_payload(
             # Collections
             collection_files = lib_cfg.get("collection_files")
             if isinstance(collection_files, list):
+                imported_collection_files = []
                 for idx, entry in enumerate(collection_files):
                     default_value = None
                     template_values = None
+                    raw_entry_type = None
+                    raw_entry_location = None
                     if isinstance(entry, dict):
                         default_value = entry.get("default")
                         template_values = entry.get("template_variables")
+                        for candidate in ("file", "folder", "url", "git", "repo"):
+                            location = entry.get(candidate)
+                            if location:
+                                raw_entry_type = candidate
+                                raw_entry_location = str(location)
+                                break
                     elif isinstance(entry, str):
                         default_value = entry
+                    if raw_entry_type and raw_entry_location:
+                        imported_collection_files.append({"type": raw_entry_type, "location": raw_entry_location})
+                        report.add("imported", f"libraries.{lib_name}.collection_files[{idx}].{raw_entry_type}")
+                        continue
                     if not default_value:
                         report.add("unmapped", f"libraries.{lib_name}.collection_files[{idx}]", "Missing default.")
                         continue
@@ -1177,6 +1190,10 @@ def prepare_import_payload(
                                     f"libraries.{lib_name}.collection_files[{idx}].template_variables.{key}",
                                     "Template variable not available in Quickstart.",
                                 )
+
+                if imported_collection_files:
+                    libraries_data[f"{lib_id}-collection_files"] = json.dumps(imported_collection_files, ensure_ascii=True)
+                    report.add("imported", f"libraries.{lib_name}.collection_files")
 
             elif collection_files is not None:
                 report.add("unmapped", f"libraries.{lib_name}.collection_files", "Unsupported collection_files format.")

--- a/modules/output.py
+++ b/modules/output.py
@@ -983,11 +983,44 @@ def _parse_metadata_file_entries(raw_value):
     return normalized
 
 
+def _parse_collection_file_block_entries(raw_value):
+    if isinstance(raw_value, list):
+        entries = raw_value
+    elif isinstance(raw_value, str):
+        text = raw_value.strip()
+        if not text:
+            return []
+        try:
+            entries = json.loads(text)
+        except Exception:
+            return []
+    else:
+        return []
+
+    if not isinstance(entries, list):
+        return []
+
+    normalized = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        entry_type = str(entry.get("type") or "").strip().lower()
+        location = str(entry.get("location") or "").strip()
+        if entry_type not in {"file", "folder", "url", "git", "repo"} or not location:
+            continue
+        normalized.append({entry_type: location})
+
+    normalized.sort(key=lambda item: (next(iter(item.keys())), next(iter(item.values())).casefold()))
+    return normalized
+
+
 def build_libraries_section(
     movie_libraries,
     show_libraries,
     movie_collections,
     show_collections,
+    movie_collection_files,
+    show_collection_files,
     movie_overlays,
     show_overlays,
     movie_attributes,
@@ -1349,6 +1382,14 @@ def build_libraries_section(
 
                 collection_files.append(file_entry)
 
+            raw_collection_group = (
+                movie_collection_files.get(collection_key, {})
+                if library_type == "mov"
+                else show_collection_files.get(collection_key, {})
+            )
+            library_prefix = library_key[: -len("-library")] if isinstance(library_key, str) and library_key.endswith("-library") else library_key
+            raw_collection_entries = _parse_collection_file_block_entries(raw_collection_group.get(f"{library_prefix}-collection_files"))
+
             if collection_files:
 
                 def is_collectionless(item):
@@ -1356,6 +1397,11 @@ def build_libraries_section(
                     return default_name in {"collectionless", "collection_collectionless"} or default_name.endswith("collectionless")
 
                 collection_files.sort(key=lambda item: (is_collectionless(item)))
+
+            if raw_collection_entries:
+                collection_files.extend(raw_collection_entries)
+
+            if collection_files:
                 entry["collection_files"] = collection_files
 
             # Process Overlays
@@ -2412,6 +2458,8 @@ def build_config(header_style="standard", config_name=None):
         # Group collections, overlays, attributes, and templates only for selected libraries
         movie_collections = group_by_library("collection_", movie_library_names)
         show_collections = group_by_library("collection_", show_library_names)
+        movie_collection_files = group_by_library("collection_files", movie_library_names)
+        show_collection_files = group_by_library("collection_files", show_library_names)
         # movie_overlays = group_by_library("overlay_", movie_library_names)
         # show_overlays = group_by_library("overlay_", show_library_names)
         movie_overlays = group_by_library("overlay_", movie_library_names, normalize_overlays=True)
@@ -2431,6 +2479,8 @@ def build_config(header_style="standard", config_name=None):
             helpers.ts_log(f"Extracted Show Libraries: {show_libraries}", level="DEBUG")
             helpers.ts_log(f"Extracted Movie Collections: {movie_collections}", level="DEBUG")
             helpers.ts_log(f"Extracted Show Collections: {show_collections}", level="DEBUG")
+            helpers.ts_log(f"Extracted Movie Collection Files: {movie_collection_files}", level="DEBUG")
+            helpers.ts_log(f"Extracted Show Collection Files: {show_collection_files}", level="DEBUG")
             helpers.ts_log(f"Extracted Movie Overlays: {movie_overlays}", level="DEBUG")
             helpers.ts_log(f"Extracted Show Overlays: {show_overlays}", level="DEBUG")
             helpers.ts_log(f"Extracted Movie Attributes: {movie_attributes}", level="DEBUG")
@@ -2448,6 +2498,8 @@ def build_config(header_style="standard", config_name=None):
             show_libraries,
             movie_collections,
             show_collections,
+            movie_collection_files,
+            show_collection_files,
             movie_overlays,
             show_overlays,
             movie_attributes,

--- a/modules/output.py
+++ b/modules/output.py
@@ -1382,11 +1382,7 @@ def build_libraries_section(
 
                 collection_files.append(file_entry)
 
-            raw_collection_group = (
-                movie_collection_files.get(collection_key, {})
-                if library_type == "mov"
-                else show_collection_files.get(collection_key, {})
-            )
+            raw_collection_group = movie_collection_files.get(collection_key, {}) if library_type == "mov" else show_collection_files.get(collection_key, {})
             library_prefix = library_key[: -len("-library")] if isinstance(library_key, str) and library_key.endswith("-library") else library_key
             raw_collection_entries = _parse_collection_file_block_entries(raw_collection_group.get(f"{library_prefix}-collection_files"))
 

--- a/modules/validations.py
+++ b/modules/validations.py
@@ -46,36 +46,43 @@ def _validate_yaml_text(raw_text, label):
     return True, None, parsed
 
 
-def _validate_metadata_yaml_text(raw_text, label):
-    result = _validate_yaml_text(raw_text, label)
-    if len(result) == 2:
-        valid, message = result
-        return False, message
-    valid, message, parsed = result
-    if not valid:
-        return False, message
+def _display_yaml_source_name(source_name, label):
+    source = str(source_name or "").strip()
+    if source:
+        return f"`{source}`"
+    return label
+
+
+def _validate_required_top_level_mapping(raw_text, label, source_name, mapping_name):
+    subject = _display_yaml_source_name(source_name, label)
+    if not isinstance(raw_text, str) or not raw_text.strip():
+        return False, f"{subject} must not be empty."
+
+    parser = YAML(typ="safe", pure=True)
+    try:
+        parsed = parser.load(raw_text)
+    except Exception as exc:
+        return False, f"Invalid YAML in {subject}. {exc}"
+
     if not isinstance(parsed, dict):
-        return False, f"{label} must contain a top-level metadata mapping."
-    metadata = parsed.get("metadata")
-    if not isinstance(metadata, dict) or not metadata:
-        return False, f"{label} must contain a non-empty top-level metadata mapping."
+        return False, f"Top-level `{mapping_name}:` was not found in {subject}."
+
+    if mapping_name not in parsed:
+        return False, f"Top-level `{mapping_name}:` was not found in {subject}."
+
+    mapping = parsed.get(mapping_name)
+    if not isinstance(mapping, dict) or not mapping:
+        return False, f"Top-level `{mapping_name}:` in {subject} must be a non-empty mapping."
+
     return True, None
 
 
-def _validate_collection_yaml_text(raw_text, label):
-    result = _validate_yaml_text(raw_text, label)
-    if len(result) == 2:
-        valid, message = result
-        return False, message
-    valid, message, parsed = result
-    if not valid:
-        return False, message
-    if not isinstance(parsed, dict):
-        return False, f"{label} must contain a top-level collections mapping."
-    collections = parsed.get("collections")
-    if not isinstance(collections, dict) or not collections:
-        return False, f"{label} must contain a non-empty top-level collections mapping."
-    return True, None
+def _validate_metadata_yaml_text(raw_text, label, source_name=None):
+    return _validate_required_top_level_mapping(raw_text, label, source_name, "metadata")
+
+
+def _validate_collection_yaml_text(raw_text, label, source_name=None):
+    return _validate_required_top_level_mapping(raw_text, label, source_name, "collections")
 
 
 def _validate_yaml_location_suffix(location, label):
@@ -134,6 +141,8 @@ def _validate_metadata_yaml_location(location, label):
     if not valid:
         return False, message
 
+    source_name = os.path.basename(urllib.parse.urlparse(str(location)).path) or os.path.basename(str(location)) or label
+
     if str(location).strip().lower().startswith(("http://", "https://")):
         valid, message = url_validation.validate_url(location, allow_local=True)
         if not valid:
@@ -147,7 +156,7 @@ def _validate_metadata_yaml_location(location, label):
         if response.status_code >= 400:
             return False, f"Failed to fetch {label} ({response.status_code} [{response.reason}])."
 
-        return _validate_metadata_yaml_text(response.text, label)
+        return _validate_metadata_yaml_text(response.text, label, source_name)
 
     valid, message = path_validation.validate_path(
         location,
@@ -162,7 +171,7 @@ def _validate_metadata_yaml_location(location, label):
     except OSError as exc:
         return False, f"{label}: Unable to read file. {exc}"
 
-    return _validate_metadata_yaml_text(yaml_text, label)
+    return _validate_metadata_yaml_text(yaml_text, label, source_name)
 
 
 def _validate_collection_yaml_location(location, label):
@@ -170,6 +179,8 @@ def _validate_collection_yaml_location(location, label):
     if not valid:
         return False, message
 
+    source_name = os.path.basename(urllib.parse.urlparse(str(location)).path) or os.path.basename(str(location)) or label
+
     if str(location).strip().lower().startswith(("http://", "https://")):
         valid, message = url_validation.validate_url(location, allow_local=True)
         if not valid:
@@ -183,7 +194,7 @@ def _validate_collection_yaml_location(location, label):
         if response.status_code >= 400:
             return False, f"Failed to fetch {label} ({response.status_code} [{response.reason}])."
 
-        return _validate_collection_yaml_text(response.text, label)
+        return _validate_collection_yaml_text(response.text, label, source_name)
 
     valid, message = path_validation.validate_path(
         location,
@@ -198,7 +209,16 @@ def _validate_collection_yaml_location(location, label):
     except OSError as exc:
         return False, f"{label}: Unable to read file. {exc}"
 
-    return _validate_collection_yaml_text(yaml_text, label)
+    return _validate_collection_yaml_text(yaml_text, label, source_name)
+
+
+def _summarize_folder_validation_failures(label, yaml_files, failures):
+    scanned_files = len(yaml_files)
+    invalid_files = len(failures)
+    suffix = "" if scanned_files == 1 else "s"
+    invalid_suffix = "" if invalid_files == 1 else "s"
+    summary = f"{label}: Scanned {scanned_files} top-level YAML file{suffix} and found {invalid_files} invalid file{invalid_suffix}."
+    return False, summary, {"message": summary, "files": failures}
 
 
 def _validate_yaml_folder(location, label):
@@ -218,16 +238,21 @@ def _validate_yaml_folder(location, label):
     if not yaml_files:
         return False, f"{label}: Folder must contain at least one top-level .yml or .yaml file."
 
+    failures = []
     for yaml_file in yaml_files:
         try:
             with open(yaml_file, "r", encoding="utf-8") as handle:
                 yaml_text = handle.read()
         except OSError as exc:
-            return False, f"{label}: Unable to read file {os.path.basename(yaml_file)}. {exc}"
+            failures.append(f"Unable to read `{os.path.basename(yaml_file)}`. {exc}")
+            continue
 
-        valid, message = _validate_metadata_yaml_text(yaml_text, f"{label} file {os.path.basename(yaml_file)}")
+        valid, message = _validate_metadata_yaml_text(yaml_text, label, os.path.basename(yaml_file))
         if not valid:
-            return False, message
+            failures.append(message)
+
+    if failures:
+        return _summarize_folder_validation_failures(label, yaml_files, failures)
 
     validated_files = len(yaml_files)
     file_names = [os.path.basename(yaml_file) for yaml_file in yaml_files]
@@ -252,16 +277,21 @@ def _validate_collection_yaml_folder(location, label):
     if not yaml_files:
         return False, f"{label}: Folder must contain at least one top-level .yml or .yaml file."
 
+    failures = []
     for yaml_file in yaml_files:
         try:
             with open(yaml_file, "r", encoding="utf-8") as handle:
                 yaml_text = handle.read()
         except OSError as exc:
-            return False, f"{label}: Unable to read file {os.path.basename(yaml_file)}. {exc}"
+            failures.append(f"Unable to read `{os.path.basename(yaml_file)}`. {exc}")
+            continue
 
-        valid, message = _validate_collection_yaml_text(yaml_text, f"{label} file {os.path.basename(yaml_file)}")
+        valid, message = _validate_collection_yaml_text(yaml_text, label, os.path.basename(yaml_file))
         if not valid:
-            return False, message
+            failures.append(message)
+
+    if failures:
+        return _summarize_folder_validation_failures(label, yaml_files, failures)
 
     validated_files = len(yaml_files)
     file_names = [os.path.basename(yaml_file) for yaml_file in yaml_files]
@@ -404,7 +434,15 @@ def validate_collection_file_payload(data):
 def validate_metadata_file_server(data):
     valid, message, details = validate_metadata_file_payload(data)
     if not valid:
-        return jsonify({"valid": False, "error": message}), 400
+        payload = {"valid": False, "error": message}
+        if details.get("message") or isinstance(details.get("files"), list):
+            payload["error_details"] = {
+                "text": details.get("message") or message,
+                "files": details.get("files") if isinstance(details.get("files"), list) else []
+            }
+        if isinstance(details.get("files"), list):
+            payload["files"] = details["files"]
+        return jsonify(payload), 400
     payload = {"valid": True}
     if details.get("message"):
         payload["message"] = details["message"]
@@ -418,7 +456,15 @@ def validate_metadata_file_server(data):
 def validate_collection_file_server(data):
     valid, message, details = validate_collection_file_payload(data)
     if not valid:
-        return jsonify({"valid": False, "error": message}), 400
+        payload = {"valid": False, "error": message}
+        if details.get("message") or isinstance(details.get("files"), list):
+            payload["error_details"] = {
+                "text": details.get("message") or message,
+                "files": details.get("files") if isinstance(details.get("files"), list) else []
+            }
+        if isinstance(details.get("files"), list):
+            payload["files"] = details["files"]
+        return jsonify(payload), 400
     payload = {"valid": True}
     if details.get("message"):
         payload["message"] = details["message"]

--- a/modules/validations.py
+++ b/modules/validations.py
@@ -436,10 +436,7 @@ def validate_metadata_file_server(data):
     if not valid:
         payload = {"valid": False, "error": message}
         if details.get("message") or isinstance(details.get("files"), list):
-            payload["error_details"] = {
-                "text": details.get("message") or message,
-                "files": details.get("files") if isinstance(details.get("files"), list) else []
-            }
+            payload["error_details"] = {"text": details.get("message") or message, "files": details.get("files") if isinstance(details.get("files"), list) else []}
         if isinstance(details.get("files"), list):
             payload["files"] = details["files"]
         return jsonify(payload), 400
@@ -458,10 +455,7 @@ def validate_collection_file_server(data):
     if not valid:
         payload = {"valid": False, "error": message}
         if details.get("message") or isinstance(details.get("files"), list):
-            payload["error_details"] = {
-                "text": details.get("message") or message,
-                "files": details.get("files") if isinstance(details.get("files"), list) else []
-            }
+            payload["error_details"] = {"text": details.get("message") or message, "files": details.get("files") if isinstance(details.get("files"), list) else []}
         if isinstance(details.get("files"), list):
             payload["files"] = details["files"]
         return jsonify(payload), 400

--- a/modules/validations.py
+++ b/modules/validations.py
@@ -62,6 +62,22 @@ def _validate_metadata_yaml_text(raw_text, label):
     return True, None
 
 
+def _validate_collection_yaml_text(raw_text, label):
+    result = _validate_yaml_text(raw_text, label)
+    if len(result) == 2:
+        valid, message = result
+        return False, message
+    valid, message, parsed = result
+    if not valid:
+        return False, message
+    if not isinstance(parsed, dict):
+        return False, f"{label} must contain a top-level collections mapping."
+    collections = parsed.get("collections")
+    if not isinstance(collections, dict) or not collections:
+        return False, f"{label} must contain a non-empty top-level collections mapping."
+    return True, None
+
+
 def _validate_yaml_location_suffix(location, label):
     lowered = str(location or "").strip().lower()
     if not lowered.endswith((".yml", ".yaml")):
@@ -149,6 +165,42 @@ def _validate_metadata_yaml_location(location, label):
     return _validate_metadata_yaml_text(yaml_text, label)
 
 
+def _validate_collection_yaml_location(location, label):
+    valid, message = _validate_yaml_location_suffix(location, label)
+    if not valid:
+        return False, message
+
+    if str(location).strip().lower().startswith(("http://", "https://")):
+        valid, message = url_validation.validate_url(location, allow_local=True)
+        if not valid:
+            return False, f"{label}: {message}"
+
+        try:
+            response = requests.get(location, timeout=10)
+        except requests.RequestException as exc:
+            return False, f"Connection error: {str(exc)}"
+
+        if response.status_code >= 400:
+            return False, f"Failed to fetch {label} ({response.status_code} [{response.reason}])."
+
+        return _validate_collection_yaml_text(response.text, label)
+
+    valid, message = path_validation.validate_path(
+        location,
+        {"allow_relative": True, "must_exist": True, "mode": "input_file"},
+    )
+    if not valid:
+        return False, f"{label}: {message}"
+
+    try:
+        with open(location, "r", encoding="utf-8") as handle:
+            yaml_text = handle.read()
+    except OSError as exc:
+        return False, f"{label}: Unable to read file. {exc}"
+
+    return _validate_collection_yaml_text(yaml_text, label)
+
+
 def _validate_yaml_folder(location, label):
     valid, message = path_validation.validate_path(
         location,
@@ -174,6 +226,40 @@ def _validate_yaml_folder(location, label):
             return False, f"{label}: Unable to read file {os.path.basename(yaml_file)}. {exc}"
 
         valid, message = _validate_metadata_yaml_text(yaml_text, f"{label} file {os.path.basename(yaml_file)}")
+        if not valid:
+            return False, message
+
+    validated_files = len(yaml_files)
+    file_names = [os.path.basename(yaml_file) for yaml_file in yaml_files]
+    suffix = "" if validated_files == 1 else "s"
+    return True, None, {"validated_files": validated_files, "files": file_names, "message": f"Validated {validated_files} YAML file{suffix} in folder."}
+
+
+def _validate_collection_yaml_folder(location, label):
+    valid, message = path_validation.validate_path(
+        location,
+        {"allow_relative": True, "must_exist": True, "mode": "input_dir"},
+    )
+    if not valid:
+        return False, f"{label}: {message}"
+
+    try:
+        entries = sorted(os.listdir(location), key=str.casefold)
+    except OSError as exc:
+        return False, f"{label}: Unable to read folder. {exc}"
+
+    yaml_files = [os.path.join(location, entry) for entry in entries if os.path.isfile(os.path.join(location, entry)) and entry.lower().endswith((".yml", ".yaml"))]
+    if not yaml_files:
+        return False, f"{label}: Folder must contain at least one top-level .yml or .yaml file."
+
+    for yaml_file in yaml_files:
+        try:
+            with open(yaml_file, "r", encoding="utf-8") as handle:
+                yaml_text = handle.read()
+        except OSError as exc:
+            return False, f"{label}: Unable to read file {os.path.basename(yaml_file)}. {exc}"
+
+        valid, message = _validate_collection_yaml_text(yaml_text, f"{label} file {os.path.basename(yaml_file)}")
         if not valid:
             return False, message
 
@@ -263,8 +349,74 @@ def validate_metadata_file_payload(data):
     return _normalize_metadata_validation_result(_validate_metadata_yaml_location(resolved_repo_location, "Metadata file repo path"))
 
 
+def validate_collection_file_payload(data):
+    collection_file_type = str(data.get("collection_file_type") or "").strip().lower()
+    collection_file_location = str(data.get("collection_file_location") or "").strip()
+
+    if collection_file_type not in {"file", "folder", "url", "git", "repo"}:
+        return False, "Collection file type must be file, folder, url, git, or repo.", {}
+
+    if not collection_file_location:
+        return False, "Collection file location is required.", {}
+
+    if collection_file_type == "url":
+        if not collection_file_location.lower().startswith(("http://", "https://")):
+            return False, "Collection file URL must start with http:// or https://.", {}
+        label = "Collection file URL"
+        return _normalize_metadata_validation_result(_validate_collection_yaml_location(collection_file_location, label))
+
+    if collection_file_type == "folder":
+        if collection_file_location.lower().startswith(("http://", "https://")):
+            return False, "Collection folder path must be a local folder path.", {}
+        label = "Collection folder path"
+        return _normalize_metadata_validation_result(_validate_collection_yaml_folder(collection_file_location, label))
+
+    if collection_file_type == "file":
+        if collection_file_location.lower().startswith(("http://", "https://")):
+            return False, "Collection file path must be a local file path.", {}
+        label = "Collection file path"
+        return _normalize_metadata_validation_result(_validate_collection_yaml_location(collection_file_location, label))
+
+    if collection_file_location.lower().startswith(("http://", "https://")):
+        return False, f"Collection file {collection_file_type} value must not be a full URL.", {}
+
+    if collection_file_type == "git":
+        valid, message = _validate_yaml_location_suffix(collection_file_location, "Collection file git path")
+        if not valid:
+            return False, message, {}
+        return _normalize_metadata_validation_result(
+            _validate_collection_yaml_location(
+                f"https://raw.githubusercontent.com/Kometa-Team/Community-Configs/master/{collection_file_location}",
+                "Collection file git path",
+            )
+        )
+
+    custom_repo_base = _saved_custom_repo_base()
+    if not custom_repo_base:
+        return False, "Collection file repo entries require Custom Repo to be configured and saved first within the Settings page.", {}
+    valid, message = _validate_yaml_location_suffix(collection_file_location, "Collection file repo path")
+    if not valid:
+        return False, message, {}
+    resolved_repo_location = f"{custom_repo_base}{collection_file_location}"
+    return _normalize_metadata_validation_result(_validate_collection_yaml_location(resolved_repo_location, "Collection file repo path"))
+
+
 def validate_metadata_file_server(data):
     valid, message, details = validate_metadata_file_payload(data)
+    if not valid:
+        return jsonify({"valid": False, "error": message}), 400
+    payload = {"valid": True}
+    if details.get("message"):
+        payload["message"] = details["message"]
+    if "validated_files" in details:
+        payload["validated_files"] = details["validated_files"]
+    if isinstance(details.get("files"), list):
+        payload["files"] = details["files"]
+    return jsonify(payload)
+
+
+def validate_collection_file_server(data):
+    valid, message, details = validate_collection_file_payload(data)
     if not valid:
         return jsonify({"valid": False, "error": message}), 400
     payload = {"valid": True}

--- a/quickstart.py
+++ b/quickstart.py
@@ -171,6 +171,7 @@ VALIDATION_REASON_LABELS = {
     "missing_library_defaults": "Missing library defaults",
     "missing_placeholder_imdb": "Missing placeholder IMDb ID",
     "invalid_metadata_files": "Invalid metadata files",
+    "invalid_collection_files": "Invalid collection files",
     "invalid_fields": "Invalid fields",
     "no_webhooks": "No webhooks configured",
     "disabled": "Disabled",
@@ -397,6 +398,7 @@ QS_ERROR_REASONS = {
     "account_locked",
     "validation_error",
     "invalid_paths",
+    "invalid_collection_files",
     "invalid_fields",
     "invalid_metadata_files",
     "missing_library_defaults",
@@ -570,6 +572,35 @@ def _parse_metadata_file_entries(value):
     return entries
 
 
+def _parse_collection_file_entries(value):
+    if isinstance(value, list):
+        raw_entries = value
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return []
+        try:
+            raw_entries = json.loads(text)
+        except (TypeError, ValueError):
+            return None
+    else:
+        return []
+
+    if not isinstance(raw_entries, list):
+        return None
+
+    entries = []
+    for entry in raw_entries:
+        if not isinstance(entry, dict):
+            continue
+        entry_type = str(entry.get("type") or "").strip().lower()
+        location = str(entry.get("location") or "").strip()
+        if not entry_type and not location:
+            continue
+        entries.append({"type": entry_type, "location": location})
+    return entries
+
+
 def _validate_library_metadata_files(libraries_data, selected_library_ids):
     if not isinstance(libraries_data, dict):
         return []
@@ -596,6 +627,36 @@ def _validate_library_metadata_files(libraries_data, selected_library_ids):
             )
             if not valid:
                 errors.append(f"{lib_id} metadata_files[{idx}]: {message}")
+
+    return errors
+
+
+def _validate_library_collection_files(libraries_data, selected_library_ids):
+    if not isinstance(libraries_data, dict):
+        return []
+
+    errors = []
+    for lib_id in selected_library_ids or []:
+        raw_value = libraries_data.get(f"{lib_id}-collection_files")
+        if raw_value in [None, "", "[]"]:
+            continue
+
+        entries = _parse_collection_file_entries(raw_value)
+        if entries is None:
+            errors.append(f"{lib_id}: collection_files must be a valid list.")
+            continue
+
+        for idx, entry in enumerate(entries, start=1):
+            valid, message, _details = validations._normalize_metadata_validation_result(
+                validations.validate_collection_file_payload(
+                    {
+                        "collection_file_type": entry.get("type"),
+                        "collection_file_location": entry.get("location"),
+                    }
+                )
+            )
+            if not valid:
+                errors.append(f"{lib_id} collection_files[{idx}]: {message}")
 
     return errors
 
@@ -5957,6 +6018,7 @@ def step(name):
             clean_payload = persistence.clean_form_data(request.form)
             incoming_libraries = helpers.build_config_dict("libraries", clean_payload).get("libraries", {})
             selected_library_ids = _selected_library_ids_from_libraries_data(incoming_libraries)
+            validation_errors += _validate_library_collection_files(incoming_libraries, selected_library_ids)
             validation_errors += _validate_library_metadata_files(incoming_libraries, selected_library_ids)
         if validation_errors:
             save_error = "Invalid values: " + " ".join(validation_errors)
@@ -6826,7 +6888,10 @@ def autosave_library(library_id):
         clean_payload = persistence.clean_form_data(MultiDict(incoming))
         incoming_libraries = helpers.build_config_dict("libraries", clean_payload).get("libraries", {})
         selected_library_ids = _selected_library_ids_from_libraries_data(incoming_libraries)
+        collection_errors = _validate_library_collection_files(incoming_libraries, selected_library_ids)
         metadata_errors = _validate_library_metadata_files(incoming_libraries, selected_library_ids)
+        if collection_errors:
+            return jsonify({"success": False, "error": "Invalid collection files.", "errors": collection_errors}), 400
         if metadata_errors:
             return jsonify({"success": False, "error": "Invalid metadata files.", "errors": metadata_errors}), 400
         persistence.save_settings("025-libraries", incoming)
@@ -7071,6 +7136,7 @@ def copy_library_settings():
 
         source_items = {k: v for k, v in libraries_data.items() if k.startswith(f"{source_prefix}-")}
         source_errors = path_validation.validate_payload(source_items)
+        source_collection_errors = _validate_library_collection_files(libraries_data, [source_prefix])
         source_metadata_errors = _validate_library_metadata_files(libraries_data, [source_prefix])
         if source_errors:
             return (
@@ -7079,6 +7145,17 @@ def copy_library_settings():
                         "success": False,
                         "error": "Invalid path values found in source library: " + " ".join(source_errors),
                         "errors": source_errors,
+                    }
+                ),
+                400,
+            )
+        if source_collection_errors:
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "error": "Invalid collection files found in source library: " + " ".join(source_collection_errors),
+                        "errors": source_collection_errors,
                     }
                 ),
                 400,
@@ -8042,15 +8119,18 @@ def validate_all_services():
         else:
             libraries_reason = None
             path_errors = path_validation.validate_payload(libraries_data)
+            collection_file_errors = _validate_library_collection_files(libraries_data, selected_library_ids)
             metadata_file_errors = _validate_library_metadata_files(libraries_data, selected_library_ids)
             if path_errors:
                 libraries_reason = "invalid_paths"
+            elif collection_file_errors:
+                libraries_reason = "invalid_collection_files"
             elif metadata_file_errors:
                 libraries_reason = "invalid_metadata_files"
             else:
 
                 def has_minimal_library_yaml_selection(lib_id):
-                    allowed_markers = ("-collection_", "-overlay_", "-attribute_", "-top_level_", "-metadata_files")
+                    allowed_markers = ("-collection_", "-overlay_", "-attribute_", "-top_level_", "-metadata_files", "-collection_files")
                     for key, value in libraries_data.items():
                         if not isinstance(key, str) or not key.startswith(f"{lib_id}-"):
                             continue
@@ -16167,6 +16247,12 @@ def purge_test_libraries():
 def validate_metadata_file():
     data = request.get_json(silent=True) or {}
     return validations.validate_metadata_file_server(data)
+
+
+@app.route("/validate_collection_file", methods=["POST"])
+def validate_collection_file():
+    data = request.get_json(silent=True) or {}
+    return validations.validate_collection_file_server(data)
 
 
 @app.route("/restart", methods=["POST"])

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -140,6 +140,31 @@ document.addEventListener('DOMContentLoaded', function () {
       return link
     }
 
+    function appendInlineCodeText (target, text, options = {}) {
+      const value = String(text || '')
+      const wrapPlainInCode = Boolean(options.wrapPlainInCode)
+      const parts = value.split(/(`[^`]+`)/g)
+      const hasInlineCode = parts.some(part => part.startsWith('`') && part.endsWith('`'))
+
+      if (!hasInlineCode && wrapPlainInCode) {
+        const code = document.createElement('code')
+        code.textContent = value
+        target.appendChild(code)
+        return
+      }
+
+      parts.forEach(part => {
+        if (!part) return
+        if (part.startsWith('`') && part.endsWith('`')) {
+          const code = document.createElement('code')
+          code.textContent = part.slice(1, -1)
+          target.appendChild(code)
+        } else {
+          target.appendChild(document.createTextNode(part))
+        }
+      })
+    }
+
     function buildMetadataFileRow (entry = {}) {
       const wrapper = document.createElement('div')
       wrapper.className = 'card bg-body-tertiary border-secondary'
@@ -299,7 +324,7 @@ document.addEventListener('DOMContentLoaded', function () {
         const files = Array.isArray(message.files) ? message.files.filter(Boolean) : []
         if (text) {
           const summary = document.createElement('div')
-          summary.textContent = text
+          appendInlineCodeText(summary, text)
           target.appendChild(summary)
         }
         if (files.length) {
@@ -308,9 +333,7 @@ document.addEventListener('DOMContentLoaded', function () {
             list.className = 'mb-0 mt-1 ps-3'
             files.forEach(file => {
               const item = document.createElement('li')
-              const code = document.createElement('code')
-              code.textContent = file
-              item.appendChild(code)
+              appendInlineCodeText(item, file, { wrapPlainInCode: true })
               list.appendChild(item)
             })
             target.appendChild(list)
@@ -325,9 +348,7 @@ document.addEventListener('DOMContentLoaded', function () {
             list.className = 'mb-0 mt-1 ps-3'
             files.forEach(file => {
               const item = document.createElement('li')
-              const code = document.createElement('code')
-              code.textContent = file
-              item.appendChild(code)
+              appendInlineCodeText(item, file, { wrapPlainInCode: true })
               list.appendChild(item)
             })
             details.appendChild(list)
@@ -347,7 +368,7 @@ document.addEventListener('DOMContentLoaded', function () {
         return
       }
 
-      target.textContent = text
+      appendInlineCodeText(target, text)
     }
 
     function setMetadataFileStatus (row, kind, message) {
@@ -641,7 +662,7 @@ document.addEventListener('DOMContentLoaded', function () {
         const files = Array.isArray(message.files) ? message.files.filter(Boolean) : []
         if (text) {
           const summary = document.createElement('div')
-          summary.textContent = text
+          appendInlineCodeText(summary, text)
           target.appendChild(summary)
         }
         if (files.length) {
@@ -650,9 +671,7 @@ document.addEventListener('DOMContentLoaded', function () {
             list.className = 'mb-0 mt-1 ps-3'
             files.forEach(file => {
               const item = document.createElement('li')
-              const code = document.createElement('code')
-              code.textContent = file
-              item.appendChild(code)
+              appendInlineCodeText(item, file, { wrapPlainInCode: true })
               list.appendChild(item)
             })
             target.appendChild(list)
@@ -667,9 +686,7 @@ document.addEventListener('DOMContentLoaded', function () {
             list.className = 'mb-0 mt-1 ps-3'
             files.forEach(file => {
               const item = document.createElement('li')
-              const code = document.createElement('code')
-              code.textContent = file
-              item.appendChild(code)
+              appendInlineCodeText(item, file, { wrapPlainInCode: true })
               list.appendChild(item)
             })
             details.appendChild(list)
@@ -689,7 +706,7 @@ document.addEventListener('DOMContentLoaded', function () {
         return
       }
 
-      target.textContent = text
+      appendInlineCodeText(target, text)
     }
 
     function setCollectionFileStatus (row, kind, message) {
@@ -861,7 +878,10 @@ document.addEventListener('DOMContentLoaded', function () {
           })
           const payload = await response.json().catch(() => ({}))
           if (!response.ok || !payload.valid) {
-            setMetadataFileStatus(row, 'error', payload.error || 'Validation failed.')
+            setMetadataFileStatus(row, 'error', payload.error_details || {
+              text: payload.error || 'Validation failed.',
+              files: Array.isArray(payload.files) ? payload.files : []
+            })
           } else {
             setMetadataFileStatus(row, 'success', {
               text: payload.message || 'Metadata source looks valid.',
@@ -950,7 +970,10 @@ document.addEventListener('DOMContentLoaded', function () {
           })
           const payload = await response.json().catch(() => ({}))
           if (!response.ok || !payload.valid) {
-            setCollectionFileStatus(row, 'error', payload.error || 'Validation failed.')
+            setCollectionFileStatus(row, 'error', payload.error_details || {
+              text: payload.error || 'Validation failed.',
+              files: Array.isArray(payload.files) ? payload.files : []
+            })
           } else {
             setCollectionFileStatus(row, 'success', {
               text: payload.message || 'Collection source looks valid.',

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -129,6 +129,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const metadataCustomRepoRaw = String(window.QS_SETTINGS_CUSTOM_REPO || '').trim()
     const metadataCustomRepoBase = String(window.QS_SETTINGS_CUSTOM_REPO_BASE || '').trim()
     const metadataRepoDependencyMessage = 'Metadata file repo entries require Custom Repo to be configured and saved first within the Settings page.'
+    const collectionRepoDependencyMessage = 'Collection file repo entries require Custom Repo to be configured and saved first within the Settings page.'
 
     function appendMetadataSettingsLink (target, className = 'link-light fw-semibold text-decoration-underline') {
       const link = document.createElement('a')
@@ -481,6 +482,338 @@ document.addEventListener('DOMContentLoaded', function () {
       })
     }
 
+    function buildCollectionFileRow (entry = {}) {
+      const wrapper = document.createElement('div')
+      wrapper.className = 'card bg-body-tertiary border-secondary'
+      wrapper.setAttribute('data-collection-file-row', 'true')
+      wrapper.innerHTML = `
+        <div class="card-body">
+          <div class="row g-3 align-items-end">
+            <div class="col-md-2">
+              <label class="form-label small text-muted">Type</label>
+              <select class="form-select form-select-sm" data-collection-file-type>
+                <option value="file">file</option>
+                <option value="folder">folder</option>
+                <option value="git">git</option>
+                <option value="repo">repo</option>
+                <option value="url">url</option>
+              </select>
+            </div>
+            <div class="col-md-7">
+              <label class="form-label small text-muted">Location</label>
+              <input type="text" class="form-control form-control-sm" data-collection-file-location placeholder="config/collections.yml, config/collections/, user/file.yml, or https://example.com/collections.yml">
+            </div>
+            <div class="col-md-3 d-flex gap-2 justify-content-md-end">
+              <button type="button" class="btn btn-success btn-sm" data-validate-collection-file>Validate</button>
+              <button type="button" class="btn btn-danger btn-sm" data-remove-collection-file>Remove</button>
+            </div>
+          </div>
+          <div class="mt-2 small d-none" data-collection-file-status></div>
+        </div>
+      `
+      const typeSelect = wrapper.querySelector('[data-collection-file-type]')
+      const locationInput = wrapper.querySelector('[data-collection-file-location]')
+      if (typeSelect && ['file', 'folder', 'git', 'repo', 'url'].includes(entry.type)) {
+        typeSelect.value = entry.type
+      }
+      if (locationInput && entry.location) {
+        locationInput.value = entry.location
+      }
+      updateCollectionFileValidateButton(wrapper, false)
+      return wrapper
+    }
+
+    function updateCollectionFileValidateButton (row, isValidated) {
+      if (!row) return
+      const button = row.querySelector('[data-validate-collection-file]')
+      if (!button) return
+      const state = String(row.dataset.collectionFileButtonState || '').trim() || (isValidated ? 'success' : 'idle')
+      button.classList.remove('btn-success', 'btn-secondary')
+      if (state === 'success') {
+        button.disabled = true
+        button.classList.add('btn-secondary')
+        button.textContent = 'Validated'
+        return
+      }
+      if (state === 'blocked') {
+        button.disabled = true
+        button.classList.add('btn-secondary')
+        button.textContent = 'Needs Repo'
+        return
+      }
+      if (state === 'loading') {
+        button.disabled = true
+        button.classList.add('btn-secondary')
+        button.textContent = 'Validating...'
+        return
+      }
+      button.disabled = false
+      button.classList.add('btn-success')
+      button.textContent = 'Validate'
+    }
+
+    function setCollectionFileButtonState (row, state) {
+      if (!row) return
+      row.dataset.collectionFileButtonState = state || 'idle'
+      updateCollectionFileValidateButton(row, state === 'success')
+    }
+
+    function updateCollectionCustomRepoStatus (editor) {
+      if (!editor) return
+      const target = editor.querySelector('[data-collection-custom-repo-status]')
+      if (!target) return
+
+      target.replaceChildren()
+      target.className = 'alert small mb-3'
+      if (!metadataCustomRepoBase) {
+        target.classList.add('alert-warning')
+        target.append('Custom Repo is not configured. ')
+        target.append('Use ')
+        appendMetadataSettingsLink(target, 'alert-link fw-semibold')
+        target.append(' to configure and save it before using ')
+        const code = document.createElement('code')
+        code.textContent = 'repo'
+        target.appendChild(code)
+        target.append(' collection files.')
+        return
+      }
+
+      target.classList.add('alert-secondary')
+      const label = document.createElement('div')
+      label.className = 'fw-semibold mb-1'
+      label.textContent = 'Custom Repo base used for repo entries'
+      target.appendChild(label)
+
+      const baseValue = document.createElement('code')
+      baseValue.textContent = metadataCustomRepoBase
+      target.appendChild(baseValue)
+
+      if (metadataCustomRepoRaw && metadataCustomRepoRaw !== metadataCustomRepoBase) {
+        const savedValue = document.createElement('div')
+        savedValue.className = 'mt-2'
+        savedValue.append('Saved Custom Repo value: ')
+        const savedCode = document.createElement('code')
+        savedCode.textContent = metadataCustomRepoRaw
+        savedValue.appendChild(savedCode)
+        target.appendChild(savedValue)
+      }
+
+      const hint = document.createElement('div')
+      hint.className = 'mt-2'
+      hint.append('Change it in ')
+      appendMetadataSettingsLink(hint, 'alert-link fw-semibold')
+      hint.append('.')
+      target.appendChild(hint)
+    }
+
+    function applyCollectionFileDependencyState (row, opts = {}) {
+      if (!row) return false
+      const skipStatus = Boolean(opts.skipStatus)
+      const type = row.querySelector('[data-collection-file-type]')?.value || ''
+      if (type !== 'repo') {
+        if (row.dataset.collectionFileDependency === 'repo-missing') {
+          row.dataset.collectionFileDependency = ''
+        }
+        return false
+      }
+
+      if (metadataCustomRepoBase) {
+        if (row.dataset.collectionFileDependency === 'repo-missing') {
+          row.dataset.collectionFileDependency = ''
+        }
+        return false
+      }
+
+      row.dataset.collectionFileDependency = 'repo-missing'
+      setCollectionFileButtonState(row, 'blocked')
+      if (!skipStatus) {
+        setCollectionFileStatus(row, 'error', collectionRepoDependencyMessage)
+      }
+      return true
+    }
+
+    function renderCollectionFileStatusMessage (target, message) {
+      target.replaceChildren()
+      if (!message) return
+
+      if (typeof message === 'object' && message !== null) {
+        const text = String(message.text || message.message || '').trim()
+        const files = Array.isArray(message.files) ? message.files.filter(Boolean) : []
+        if (text) {
+          const summary = document.createElement('div')
+          summary.textContent = text
+          target.appendChild(summary)
+        }
+        if (files.length) {
+          if (files.length <= 5) {
+            const list = document.createElement('ul')
+            list.className = 'mb-0 mt-1 ps-3'
+            files.forEach(file => {
+              const item = document.createElement('li')
+              const code = document.createElement('code')
+              code.textContent = file
+              item.appendChild(code)
+              list.appendChild(item)
+            })
+            target.appendChild(list)
+          } else {
+            const details = document.createElement('details')
+            details.className = 'mt-1'
+            const summary = document.createElement('summary')
+            summary.className = 'cursor-pointer'
+            summary.textContent = 'Show files'
+            details.appendChild(summary)
+            const list = document.createElement('ul')
+            list.className = 'mb-0 mt-1 ps-3'
+            files.forEach(file => {
+              const item = document.createElement('li')
+              const code = document.createElement('code')
+              code.textContent = file
+              item.appendChild(code)
+              list.appendChild(item)
+            })
+            details.appendChild(list)
+            target.appendChild(details)
+          }
+        }
+        return
+      }
+
+      const text = String(message || '').trim()
+      if (!text) return
+
+      if (text === collectionRepoDependencyMessage) {
+        target.append('Collection file repo entries require Custom Repo to be configured and saved first within the ')
+        appendMetadataSettingsLink(target)
+        target.append(' page.')
+        return
+      }
+
+      target.textContent = text
+    }
+
+    function setCollectionFileStatus (row, kind, message) {
+      if (!row) return
+      const target = row.querySelector('[data-collection-file-status]')
+      if (!target) return
+      row.dataset.collectionFileState = kind || ''
+      target.className = 'mt-2 small'
+      if (!message) {
+        target.classList.add('d-none')
+        target.textContent = ''
+        if (applyCollectionFileDependencyState(row, { skipStatus: true })) {
+          setCollectionFileButtonState(row, 'blocked')
+        } else {
+          setCollectionFileButtonState(row, 'idle')
+        }
+        const editor = row.closest('[data-collection-files-editor]')
+        if (editor) updateCollectionFilesAccordionState(editor)
+        return
+      }
+      target.classList.remove('d-none')
+      if (kind === 'success') {
+        target.classList.add('text-success')
+      } else if (kind === 'error') {
+        target.classList.add('text-danger')
+      } else {
+        target.classList.add('text-warning')
+      }
+      renderCollectionFileStatusMessage(target, message)
+      if (kind === 'success') {
+        setCollectionFileButtonState(row, 'success')
+      } else if (row.dataset.collectionFileDependency === 'repo-missing') {
+        setCollectionFileButtonState(row, 'blocked')
+      } else {
+        setCollectionFileButtonState(row, 'idle')
+      }
+      const editor = row.closest('[data-collection-files-editor]')
+      if (editor) updateCollectionFilesAccordionState(editor)
+    }
+
+    function updateCollectionFilesAccordionState (editor) {
+      if (!editor) return
+      const accordionItem = editor.closest('.accordion-item')
+      const accordionHeader = accordionItem?.querySelector(':scope > .accordion-header')
+      if (!accordionHeader) return
+
+      const rows = Array.from(editor.querySelectorAll('[data-collection-file-row]'))
+      const hasInvalid = rows.some(row => {
+        const state = String(row.dataset.collectionFileState || '').trim().toLowerCase()
+        return state === 'error' || state === 'warning'
+      })
+
+      accordionHeader.classList.toggle('invalid', hasInvalid)
+      if (!hasInvalid && rows.some(row => normalizeMetadataFileEntry({
+        type: row.querySelector('[data-collection-file-type]')?.value || '',
+        location: row.querySelector('[data-collection-file-location]')?.value || ''
+      }))) {
+        accordionHeader.classList.add('selected')
+      }
+    }
+
+    function applyCollectionFileServerErrors (editor, errors) {
+      if (!editor || !Array.isArray(errors) || !errors.length) return false
+      const rows = Array.from(editor.querySelectorAll('[data-collection-file-row]'))
+      rows.forEach(row => setCollectionFileStatus(row, '', ''))
+      let applied = false
+      errors.forEach(error => {
+        const text = String(error || '').trim()
+        const match = text.match(/collection_files\[(\d+)\]:\s*(.+)$/i)
+        if (!match) return
+        const index = Number(match[1]) - 1
+        const message = match[2] || 'Validation failed.'
+        if (!Number.isInteger(index) || index < 0 || index >= rows.length) return
+        setCollectionFileStatus(rows[index], 'error', message)
+        applied = true
+      })
+      return applied
+    }
+
+    function syncCollectionFilesEditor (editor, emitEvents = true) {
+      if (!editor) return []
+      const hidden = editor.querySelector('input[type="hidden"][name$="-collection_files"]')
+      if (!hidden) return []
+      const rows = Array.from(editor.querySelectorAll('[data-collection-file-row]'))
+      const entries = rows.map(row => {
+        const type = row.querySelector('[data-collection-file-type]')?.value
+        const location = row.querySelector('[data-collection-file-location]')?.value
+        return normalizeMetadataFileEntry({ type, location })
+      }).filter(Boolean)
+      hidden.value = JSON.stringify(entries)
+      if (emitEvents) {
+        hidden.dispatchEvent(new Event('input', { bubbles: true }))
+        hidden.dispatchEvent(new Event('change', { bubbles: true }))
+      }
+      updateCollectionFilesAccordionState(editor)
+      return entries
+    }
+
+    function renderCollectionFilesEditor (editor) {
+      if (!editor) return
+      const hidden = editor.querySelector('input[type="hidden"][name$="-collection_files"]')
+      const list = editor.querySelector('[data-collection-files-list]')
+      if (!hidden || !list) return
+      updateCollectionCustomRepoStatus(editor)
+      const entries = parseMetadataFilesValue(hidden.value)
+      list.replaceChildren()
+      entries.forEach(entry => list.appendChild(buildCollectionFileRow(entry)))
+      list.querySelectorAll('[data-collection-file-row]').forEach(row => {
+        if (applyCollectionFileDependencyState(row)) return
+        setCollectionFileButtonState(row, 'idle')
+      })
+      syncCollectionFilesEditor(editor, false)
+      updateCollectionFilesAccordionState(editor)
+    }
+
+    function initCollectionFilesEditors (scope) {
+      const root = scope || document
+      root.querySelectorAll('[data-collection-files-editor]').forEach(editor => {
+        if (editor.dataset.collectionFilesReady === 'true') return
+        renderCollectionFilesEditor(editor)
+        editor.dataset.collectionFilesReady = 'true'
+      })
+    }
+
     document.addEventListener('click', async function (event) {
       const addButton = event.target.closest('[data-add-metadata-file]')
       if (addButton) {
@@ -568,6 +901,95 @@ document.addEventListener('DOMContentLoaded', function () {
     if (libraryContainer && typeof MutationObserver !== 'undefined') {
       const metadataObserver = new MutationObserver(() => initMetadataFilesEditors(libraryContainer))
       metadataObserver.observe(libraryContainer, { childList: true, subtree: true })
+    }
+
+    document.addEventListener('click', async function (event) {
+      const addButton = event.target.closest('[data-add-collection-file]')
+      if (addButton) {
+        const editor = addButton.closest('[data-collection-files-editor]')
+        const list = editor?.querySelector('[data-collection-files-list]')
+        if (!editor || !list) return
+        list.appendChild(buildCollectionFileRow({ type: 'file', location: '' }))
+        syncCollectionFilesEditor(editor)
+        return
+      }
+
+      const removeButton = event.target.closest('[data-remove-collection-file]')
+      if (removeButton) {
+        const row = removeButton.closest('[data-collection-file-row]')
+        const editor = removeButton.closest('[data-collection-files-editor]')
+        if (!row || !editor) return
+        row.remove()
+        syncCollectionFilesEditor(editor)
+        return
+      }
+
+      const validateButton = event.target.closest('[data-validate-collection-file]')
+      if (validateButton) {
+        const row = validateButton.closest('[data-collection-file-row]')
+        const editor = validateButton.closest('[data-collection-files-editor]')
+        if (!row || !editor) return
+        if (applyCollectionFileDependencyState(row)) return
+        const type = row.querySelector('[data-collection-file-type]')?.value || ''
+        const location = row.querySelector('[data-collection-file-location]')?.value || ''
+        syncCollectionFilesEditor(editor, false)
+        setCollectionFileStatus(row, '', 'Validating...')
+        setCollectionFileButtonState(row, 'loading')
+        try {
+          const response = await fetch('/validate_collection_file', {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              collection_file_type: type,
+              collection_file_location: location
+            })
+          })
+          const payload = await response.json().catch(() => ({}))
+          if (!response.ok || !payload.valid) {
+            setCollectionFileStatus(row, 'error', payload.error || 'Validation failed.')
+          } else {
+            setCollectionFileStatus(row, 'success', {
+              text: payload.message || 'Collection source looks valid.',
+              files: Array.isArray(payload.files) ? payload.files : []
+            })
+          }
+        } catch (_error) {
+          setCollectionFileStatus(row, 'error', 'Validation request failed.')
+        } finally {
+          if (row.dataset.collectionFileState !== 'success' && row.dataset.collectionFileDependency !== 'repo-missing') {
+            setCollectionFileButtonState(row, 'idle')
+          }
+        }
+      }
+    })
+
+    document.addEventListener('input', function (event) {
+      const target = event.target
+      if (!target || !target.closest('[data-collection-files-editor]')) return
+      if (!target.matches('[data-collection-file-type], [data-collection-file-location]')) return
+      const row = target.closest('[data-collection-file-row]')
+      const editor = target.closest('[data-collection-files-editor]')
+      setCollectionFileStatus(row, '', '')
+      applyCollectionFileDependencyState(row)
+      syncCollectionFilesEditor(editor)
+    })
+
+    document.addEventListener('change', function (event) {
+      const target = event.target
+      if (!target || !target.closest('[data-collection-files-editor]')) return
+      if (!target.matches('[data-collection-file-type], [data-collection-file-location]')) return
+      const row = target.closest('[data-collection-file-row]')
+      const editor = target.closest('[data-collection-files-editor]')
+      setCollectionFileStatus(row, '', '')
+      applyCollectionFileDependencyState(row)
+      syncCollectionFilesEditor(editor)
+    })
+
+    initCollectionFilesEditors(document)
+    if (libraryContainer && typeof MutationObserver !== 'undefined') {
+      const collectionObserver = new MutationObserver(() => initCollectionFilesEditors(libraryContainer))
+      collectionObserver.observe(libraryContainer, { childList: true, subtree: true })
     }
 
     // Ensure hidden "false" inputs don't submit alongside checked checkboxes with the same name
@@ -1900,6 +2322,7 @@ document.addEventListener('DOMContentLoaded', function () {
       }
 
       const payload = buildPayloadFromCard(card)
+      const collectionEditor = card.querySelector('[data-collection-files-editor]')
       const metadataEditor = card.querySelector('[data-metadata-files-editor]')
       const option = libraryPicker?.querySelector(`option[value="${activeLibraryId}"]`)
       const friendlyName = option?.dataset.label || option?.textContent?.trim() || activeLibraryId
@@ -1913,6 +2336,9 @@ document.addEventListener('DOMContentLoaded', function () {
         .then(res => {
           if (!res.ok) {
             return res.json().catch(() => ({})).then(body => {
+              if (collectionEditor) {
+                applyCollectionFileServerErrors(collectionEditor, body && body.errors)
+              }
               if (metadataEditor) {
                 applyMetadataFileServerErrors(metadataEditor, body && body.errors)
               }

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -737,17 +737,20 @@ document.addEventListener('DOMContentLoaded', function () {
       if (!accordionHeader) return
 
       const rows = Array.from(editor.querySelectorAll('[data-collection-file-row]'))
+      const hasEntries = rows.some(row => normalizeMetadataFileEntry({
+        type: row.querySelector('[data-collection-file-type]')?.value || '',
+        location: row.querySelector('[data-collection-file-location]')?.value || ''
+      }))
       const hasInvalid = rows.some(row => {
         const state = String(row.dataset.collectionFileState || '').trim().toLowerCase()
         return state === 'error' || state === 'warning'
       })
 
       accordionHeader.classList.toggle('invalid', hasInvalid)
-      if (!hasInvalid && rows.some(row => normalizeMetadataFileEntry({
-        type: row.querySelector('[data-collection-file-type]')?.value || '',
-        location: row.querySelector('[data-collection-file-location]')?.value || ''
-      }))) {
+      if (!hasInvalid && hasEntries) {
         accordionHeader.classList.add('selected')
+      } else if (!hasEntries && !hasInvalid && typeof EventHandler !== 'undefined' && typeof EventHandler.updateAccordionHighlights === 'function') {
+        EventHandler.updateAccordionHighlights()
       }
     }
 

--- a/templates/partials/_library_collection_files.html
+++ b/templates/partials/_library_collection_files.html
@@ -1,0 +1,23 @@
+<div class="d-flex flex-column gap-3 mt-3">
+    <div class="alert alert-warning small mb-0" role="alert">
+        <div class="fw-semibold mb-1">Validation is limited.</div>
+        <div>Quickstart can verify that each entry points to a non-empty <code>.yml</code> or <code>.yaml</code> file and that the YAML parses successfully.</div>
+        <div>Quickstart also verifies that each collection file contains a non-empty top-level <code>collections</code> mapping.</div>
+        <div>Quickstart does not fully validate Kometa collection file schema yet, so a file that passes here may still fail later and cause Kometa to abort during a run.</div>
+    </div>
+    <div class="alert alert-info small mb-0" role="alert">
+        <div>Use one or more <code>file</code>, <code>folder</code>, <code>url</code>, <code>git</code>, or <code>repo</code> entries. These are appended into library-level <code>collection_files</code>.</div>
+    </div>
+    <div class="collection-files-editor" data-collection-files-editor data-library-id="{{ library.id }}">
+        <div class="alert small mb-4" role="alert" data-collection-custom-repo-status></div>
+        <input type="hidden" name="{{ library.id }}-collection_files" id="{{ library.id }}-collection_files"
+            value="{{ data['libraries'].get(library.id ~ '-collection_files', '[]') }}">
+        <div class="collection-files-list d-flex flex-column gap-3 mt-1" data-collection-files-list></div>
+        <div class="d-flex justify-content-between align-items-center mt-3">
+            <button type="button" class="btn btn-outline-secondary btn-sm" data-add-collection-file>
+                <i class="bi bi-plus-circle me-1"></i>Add Collection File
+            </button>
+            <span class="text-muted small">Supports mixed local files and folders, raw URLs, Community-Configs git paths, and custom_repo-backed repo paths.</span>
+        </div>
+    </div>
+</div>

--- a/templates/partials/_library_collection_files.html
+++ b/templates/partials/_library_collection_files.html
@@ -1,23 +1,35 @@
-<div class="d-flex flex-column gap-3 mt-3">
-    <div class="alert alert-warning small mb-0" role="alert">
-        <div class="fw-semibold mb-1">Validation is limited.</div>
-        <div>Quickstart can verify that each entry points to a non-empty <code>.yml</code> or <code>.yaml</code> file and that the YAML parses successfully.</div>
-        <div>Quickstart also verifies that each collection file contains a non-empty top-level <code>collections</code> mapping.</div>
-        <div>Quickstart does not fully validate Kometa collection file schema yet, so a file that passes here may still fail later and cause Kometa to abort during a run.</div>
-    </div>
-    <div class="alert alert-info small mb-0" role="alert">
-        <div>Use one or more <code>file</code>, <code>folder</code>, <code>url</code>, <code>git</code>, or <code>repo</code> entries. These are appended into library-level <code>collection_files</code>.</div>
-    </div>
-    <div class="collection-files-editor" data-collection-files-editor data-library-id="{{ library.id }}">
-        <div class="alert small mb-4" role="alert" data-collection-custom-repo-status></div>
-        <input type="hidden" name="{{ library.id }}-collection_files" id="{{ library.id }}-collection_files"
-            value="{{ data['libraries'].get(library.id ~ '-collection_files', '[]') }}">
-        <div class="collection-files-list d-flex flex-column gap-3 mt-1" data-collection-files-list></div>
-        <div class="d-flex justify-content-between align-items-center mt-3">
-            <button type="button" class="btn btn-outline-secondary btn-sm" data-add-collection-file>
-                <i class="bi bi-plus-circle me-1"></i>Add Collection File
-            </button>
-            <span class="text-muted small">Supports mixed local files and folders, raw URLs, Community-Configs git paths, and custom_repo-backed repo paths.</span>
+<div class="accordion-item mt-3">
+    <h2 class="accordion-header">
+        <button class="accordion-button" type="button" data-bs-toggle="collapse"
+            data-bs-target="#{{ library.id }}-collection-files">
+            Collection Files
+        </button>
+    </h2>
+    <div id="{{ library.id }}-collection-files" class="accordion-collapse collapse">
+        <div class="accordion-body">
+            <div class="d-flex flex-column gap-3">
+                <div class="alert alert-warning small mb-0" role="alert">
+                    <div class="fw-semibold mb-1">Validation is limited.</div>
+                    <div>Quickstart can verify that each entry points to a non-empty <code>.yml</code> or <code>.yaml</code> file and that the YAML parses successfully.</div>
+                    <div>Quickstart also verifies that each collection file contains a non-empty top-level <code>collections:</code> mapping.</div>
+                    <div>Quickstart does not fully validate Kometa collection file schema yet, so a file that passes here may still fail later and cause Kometa to abort during a run.</div>
+                </div>
+                <div class="alert alert-info small mb-0" role="alert">
+                    <div>Use one or more <code>file</code>, <code>folder</code>, <code>url</code>, <code>git</code>, or <code>repo</code> entries. These are appended into library-level <code>collection_files</code>.</div>
+                </div>
+                <div class="collection-files-editor" data-collection-files-editor data-library-id="{{ library.id }}">
+                    <div class="alert small mb-4" role="alert" data-collection-custom-repo-status></div>
+                    <input type="hidden" name="{{ library.id }}-collection_files" id="{{ library.id }}-collection_files"
+                        value="{{ data['libraries'].get(library.id ~ '-collection_files', '[]') }}">
+                    <div class="collection-files-list d-flex flex-column gap-3 mt-1" data-collection-files-list></div>
+                    <div class="d-flex justify-content-between align-items-center mt-3">
+                        <button type="button" class="btn btn-outline-secondary btn-sm" data-add-collection-file>
+                            <i class="bi bi-plus-circle me-1"></i>Add Collection File
+                        </button>
+                        <span class="text-muted small">Supports mixed local files and folders, raw URLs, Community-Configs git paths, and custom_repo-backed repo paths.</span>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 </div>

--- a/templates/partials/_library_metadata_files.html
+++ b/templates/partials/_library_metadata_files.html
@@ -11,6 +11,7 @@
                 <div class="alert alert-warning small mb-0" role="alert">
                     <div class="fw-semibold mb-1">Validation is limited.</div>
                     <div>Quickstart can verify that each entry points to a non-empty <code>.yml</code> or <code>.yaml</code> file and that the YAML parses successfully.</div>
+                    <div>Quickstart also verifies that each metadata file contains a non-empty top-level <code>metadata:</code> mapping.</div>
                     <div>Quickstart does not fully validate Kometa metadata file schema yet, so a file that passes here may still fail later and cause Kometa to abort during a run.</div>
                 </div>
                 <div class="alert alert-info small mb-0" role="alert">

--- a/templates/partials/_movie_collections.html
+++ b/templates/partials/_movie_collections.html
@@ -6,3 +6,5 @@
   {% for group in collection_config %}
   {{ macros.collection_group_section(library, data, version_info, group, telemetry) }}
   {% endfor %}
+
+{% include "partials/_library_collection_files.html" %}

--- a/templates/partials/_show_collections.html
+++ b/templates/partials/_show_collections.html
@@ -6,3 +6,5 @@
   {% for group in collection_config %}
   {{ macros.collection_group_section(library, data, version_info, group, telemetry) }}
   {% endfor %}
+
+{% include "partials/_library_collection_files.html" %}

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -182,7 +182,8 @@ def test_validate_collection_file_rejects_missing_top_level_collections(client, 
     assert resp.status_code == 400
     payload = resp.get_json()
     assert payload["valid"] is False
-    assert "non-empty top-level collections mapping" in payload["error"]
+    assert "Top-level `collections:` was not found" in payload["error"]
+    assert "`collections.yml`" in payload["error"]
 
 
 def test_validate_collection_file_rejects_empty_top_level_collections(client, tmp_path):
@@ -196,7 +197,7 @@ def test_validate_collection_file_rejects_empty_top_level_collections(client, tm
     assert resp.status_code == 400
     payload = resp.get_json()
     assert payload["valid"] is False
-    assert "non-empty top-level collections mapping" in payload["error"]
+    assert "Top-level `collections:` in `collections.yml` must be a non-empty mapping." == payload["error"]
 
 
 def test_validate_metadata_file_rejects_missing_top_level_metadata(client, tmp_path):
@@ -210,7 +211,8 @@ def test_validate_metadata_file_rejects_missing_top_level_metadata(client, tmp_p
     assert resp.status_code == 400
     payload = resp.get_json()
     assert payload["valid"] is False
-    assert "non-empty top-level metadata mapping" in payload["error"]
+    assert "Top-level `metadata:` was not found" in payload["error"]
+    assert "`metadata.yml`" in payload["error"]
 
 
 def test_validate_metadata_file_rejects_empty_top_level_metadata(client, tmp_path):
@@ -224,7 +226,7 @@ def test_validate_metadata_file_rejects_empty_top_level_metadata(client, tmp_pat
     assert resp.status_code == 400
     payload = resp.get_json()
     assert payload["valid"] is False
-    assert "non-empty top-level metadata mapping" in payload["error"]
+    assert "Top-level `metadata:` in `metadata.yml` must be a non-empty mapping." == payload["error"]
 
 
 def test_validate_metadata_file_rejects_invalid_type(client):
@@ -312,6 +314,7 @@ def test_validate_metadata_folder_rejects_top_level_yaml_without_metadata(client
     metadata_dir.mkdir()
     (metadata_dir / "godzilla.yml").write_text("metadata:\n  test:\n    title: Godzilla\n", encoding="utf-8")
     (metadata_dir / "broken.yml").write_text("templates:\n  sample:\n    test: true\n", encoding="utf-8")
+    (metadata_dir / "empty.yml").write_text("metadata: {}\n", encoding="utf-8")
 
     resp = client.post(
         "/validate_metadata_file",
@@ -320,8 +323,12 @@ def test_validate_metadata_folder_rejects_top_level_yaml_without_metadata(client
     assert resp.status_code == 400
     payload = resp.get_json()
     assert payload["valid"] is False
-    assert "broken.yml" in payload["error"]
-    assert "non-empty top-level metadata mapping" in payload["error"]
+    assert payload["error"] == "Metadata folder path: Scanned 3 top-level YAML files and found 2 invalid files."
+    assert payload["error_details"]["text"] == payload["error"]
+    assert payload["files"] == [
+        "Top-level `metadata:` was not found in `broken.yml`.",
+        "Top-level `metadata:` in `empty.yml` must be a non-empty mapping."
+    ]
 
 
 def test_validate_collection_folder_rejects_top_level_yaml_without_collections(client, tmp_path):
@@ -329,6 +336,7 @@ def test_validate_collection_folder_rejects_top_level_yaml_without_collections(c
     collection_dir.mkdir()
     (collection_dir / "godzilla.yml").write_text("collections:\n  test:\n    title: Godzilla\n", encoding="utf-8")
     (collection_dir / "broken.yml").write_text("templates:\n  sample:\n    test: true\n", encoding="utf-8")
+    (collection_dir / "empty.yml").write_text("collections: {}\n", encoding="utf-8")
 
     resp = client.post(
         "/validate_collection_file",
@@ -337,8 +345,12 @@ def test_validate_collection_folder_rejects_top_level_yaml_without_collections(c
     assert resp.status_code == 400
     payload = resp.get_json()
     assert payload["valid"] is False
-    assert "broken.yml" in payload["error"]
-    assert "non-empty top-level collections mapping" in payload["error"]
+    assert payload["error"] == "Collection folder path: Scanned 3 top-level YAML files and found 2 invalid files."
+    assert payload["error_details"]["text"] == payload["error"]
+    assert payload["files"] == [
+        "Top-level `collections:` was not found in `broken.yml`.",
+        "Top-level `collections:` in `empty.yml` must be a non-empty mapping."
+    ]
 
 
 def test_validate_metadata_url_rejects_missing_top_level_metadata(client, monkeypatch, qs_module):
@@ -356,7 +368,7 @@ def test_validate_metadata_url_rejects_missing_top_level_metadata(client, monkey
     assert resp.status_code == 400
     payload = resp.get_json()
     assert payload["valid"] is False
-    assert "non-empty top-level metadata mapping" in payload["error"]
+    assert payload["error"] == "Top-level `metadata:` was not found in `metadata.yml`."
 
 
 def test_validate_metadata_file_accepts_git(client, monkeypatch, qs_module):

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -642,10 +642,11 @@ def test_build_libraries_section_emits_collection_files(app):
             {},
             {},
             {},
+            {},
         )
 
         assert libraries_section["libraries"]["Movies"]["collection_files"] == [
-            {"default": "collection_collectionless"},
+            {"default": "collectionless"},
             {"file": "C:\\Users\\bullmoose20\\Community-Configs\\bullmoose20\\godzilla.yml"},
             {"folder": "config\\metadata\\movies"},
             {"git": "bullmoose20/collections/godzilla.yml"},

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -158,6 +158,47 @@ def test_validate_metadata_file_accepts_existing_local_file(client, tmp_path):
     assert payload["valid"] is True
 
 
+def test_validate_collection_file_accepts_existing_local_file(client, tmp_path):
+    collection_file = tmp_path / "collections.yml"
+    collection_file.write_text("collections:\n  test:\n    plex_search:\n      any:\n        title: Example\n", encoding="utf-8")
+
+    resp = client.post(
+        "/validate_collection_file",
+        json={"collection_file_type": "file", "collection_file_location": str(collection_file)},
+    )
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["valid"] is True
+
+
+def test_validate_collection_file_rejects_missing_top_level_collections(client, tmp_path):
+    collection_file = tmp_path / "collections.yml"
+    collection_file.write_text("templates:\n  test:\n    default: true\n", encoding="utf-8")
+
+    resp = client.post(
+        "/validate_collection_file",
+        json={"collection_file_type": "file", "collection_file_location": str(collection_file)},
+    )
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert payload["valid"] is False
+    assert "non-empty top-level collections mapping" in payload["error"]
+
+
+def test_validate_collection_file_rejects_empty_top_level_collections(client, tmp_path):
+    collection_file = tmp_path / "collections.yml"
+    collection_file.write_text("collections: {}\n", encoding="utf-8")
+
+    resp = client.post(
+        "/validate_collection_file",
+        json={"collection_file_type": "file", "collection_file_location": str(collection_file)},
+    )
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert payload["valid"] is False
+    assert "non-empty top-level collections mapping" in payload["error"]
+
+
 def test_validate_metadata_file_rejects_missing_top_level_metadata(client, tmp_path):
     metadata_file = tmp_path / "metadata.yml"
     metadata_file.write_text("templates:\n  test:\n    default: true\n", encoding="utf-8")
@@ -206,6 +247,24 @@ def test_validate_metadata_folder_accepts_top_level_yaml_files(client, tmp_path)
     resp = client.post(
         "/validate_metadata_file",
         json={"metadata_file_type": "folder", "metadata_file_location": str(metadata_dir)},
+    )
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["valid"] is True
+    assert payload["validated_files"] == 2
+    assert payload["files"] == ["godzilla.yml", "refresh.yaml"]
+    assert payload["message"] == "Validated 2 YAML files in folder."
+
+
+def test_validate_collection_folder_accepts_top_level_yaml_files(client, tmp_path):
+    collection_dir = tmp_path / "collections"
+    collection_dir.mkdir()
+    (collection_dir / "godzilla.yml").write_text("collections:\n  test:\n    title: Godzilla\n", encoding="utf-8")
+    (collection_dir / "refresh.yaml").write_text("collections:\n  refresh:\n    title: Refresh\n", encoding="utf-8")
+
+    resp = client.post(
+        "/validate_collection_file",
+        json={"collection_file_type": "folder", "collection_file_location": str(collection_dir)},
     )
     assert resp.status_code == 200
     payload = resp.get_json()
@@ -265,6 +324,23 @@ def test_validate_metadata_folder_rejects_top_level_yaml_without_metadata(client
     assert "non-empty top-level metadata mapping" in payload["error"]
 
 
+def test_validate_collection_folder_rejects_top_level_yaml_without_collections(client, tmp_path):
+    collection_dir = tmp_path / "collections"
+    collection_dir.mkdir()
+    (collection_dir / "godzilla.yml").write_text("collections:\n  test:\n    title: Godzilla\n", encoding="utf-8")
+    (collection_dir / "broken.yml").write_text("templates:\n  sample:\n    test: true\n", encoding="utf-8")
+
+    resp = client.post(
+        "/validate_collection_file",
+        json={"collection_file_type": "folder", "collection_file_location": str(collection_dir)},
+    )
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert payload["valid"] is False
+    assert "broken.yml" in payload["error"]
+    assert "non-empty top-level collections mapping" in payload["error"]
+
+
 def test_validate_metadata_url_rejects_missing_top_level_metadata(client, monkeypatch, qs_module):
     class _Resp:
         status_code = 200
@@ -304,6 +380,17 @@ def test_validate_metadata_file_accepts_git(client, monkeypatch, qs_module):
     assert resp.status_code == 200
     assert resp.get_json()["valid"] is True
     assert captured["url"] == "https://raw.githubusercontent.com/Kometa-Team/Community-Configs/master/bullmoose20/godzilla.yml"
+
+
+def test_validate_collection_file_rejects_repo_without_custom_repo(client):
+    resp = client.post(
+        "/validate_collection_file",
+        json={"collection_file_type": "repo", "collection_file_location": "bullmoose20/collections.yml"},
+    )
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert payload["valid"] is False
+    assert payload["error"] == "Collection file repo entries require Custom Repo to be configured and saved first within the Settings page."
 
 
 def test_validate_metadata_file_rejects_repo_without_custom_repo(client):
@@ -391,12 +478,65 @@ def test_autosave_library_rejects_invalid_metadata_files(client, monkeypatch, qs
     assert "Invalid metadata files" in payload["error"]
 
 
+def test_autosave_library_rejects_invalid_collection_files(client, monkeypatch, qs_module):
+    class _Resp:
+        status_code = 404
+        reason = "Not Found"
+        text = ""
+
+    monkeypatch.setattr(qs_module.validations.requests, "get", lambda *_args, **_kwargs: _Resp())
+
+    resp = client.post(
+        "/autosave_library/mov-library_movies",
+        json={
+            "mov-library_movies-library": "Movies",
+            "mov-library_movies-collection_files": '[{"type":"url","location":"https://example.com/missing.yml"}]',
+        },
+    )
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert payload["success"] is False
+    assert "Invalid collection files" in payload["error"]
+
+
 def test_output_metadata_file_entries_are_sorted():
     import json
 
     from modules import output
 
     parsed = output._parse_metadata_file_entries(
+        json.dumps(
+            [
+                {"type": "url", "location": "https://example.com/zeta.yml"},
+                {"type": "repo", "location": "custom/movies.yml"},
+                {"type": "file", "location": "config/beta.yml"},
+                {"type": "folder", "location": "config/zeta"},
+                {"type": "git", "location": "community/alpha.yml"},
+                {"type": "file", "location": "config/alpha.yml"},
+                {"type": "folder", "location": "config/alpha"},
+                {"type": "url", "location": "https://example.com/alpha.yml"},
+            ]
+        )
+    )
+
+    assert parsed == [
+        {"file": "config/alpha.yml"},
+        {"file": "config/beta.yml"},
+        {"folder": "config/alpha"},
+        {"folder": "config/zeta"},
+        {"git": "community/alpha.yml"},
+        {"repo": "custom/movies.yml"},
+        {"url": "https://example.com/alpha.yml"},
+        {"url": "https://example.com/zeta.yml"},
+    ]
+
+
+def test_output_collection_file_entries_are_sorted():
+    import json
+
+    from modules import output
+
+    parsed = output._parse_collection_file_block_entries(
         json.dumps(
             [
                 {"type": "url", "location": "https://example.com/zeta.yml"},
@@ -438,6 +578,8 @@ def test_build_libraries_section_emits_metadata_files(app):
             {},
             {},
             {},
+            {},
+            {},
             {
                 "movies": {
                     "mov-library_movies-metadata_files": json.dumps(
@@ -466,6 +608,50 @@ def test_build_libraries_section_emits_metadata_files(app):
             {"url": "https://example.com/movies_refresh.yml"},
         ]
     assert list(libraries_section["libraries"]["Movies"].keys())[:2] == ["template_variables", "metadata_files"]
+
+
+def test_build_libraries_section_emits_collection_files(app):
+    import json
+
+    from modules import output
+
+    with app.app_context():
+        libraries_section = output.build_libraries_section(
+            {"mov-library_movies-library": "Movies"},
+            {},
+            {"movies": {"mov-library_movies-collection_collectionless": True}},
+            {},
+            {"movies": {
+                "mov-library_movies-collection_files": json.dumps(
+                    [
+                        {"type": "url", "location": "https://example.com/movies_refresh.yml"},
+                        {"type": "repo", "location": "custom/movies_meta.yml"},
+                        {"type": "file", "location": "C:\\Users\\bullmoose20\\Community-Configs\\bullmoose20\\godzilla.yml"},
+                        {"type": "folder", "location": "config\\metadata\\movies"},
+                        {"type": "git", "location": "bullmoose20/collections/godzilla.yml"},
+                    ]
+                )
+            }},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+        )
+
+        assert libraries_section["libraries"]["Movies"]["collection_files"] == [
+            {"default": "collection_collectionless"},
+            {"file": "C:\\Users\\bullmoose20\\Community-Configs\\bullmoose20\\godzilla.yml"},
+            {"folder": "config\\metadata\\movies"},
+            {"git": "bullmoose20/collections/godzilla.yml"},
+            {"repo": "custom/movies_meta.yml"},
+            {"url": "https://example.com/movies_refresh.yml"},
+        ]
 
 
 def test_build_config_includes_saved_library_metadata_files(app, isolated_config_dir, monkeypatch):
@@ -575,6 +761,55 @@ def test_step_post_from_libraries_persists_metadata_files(client, isolated_confi
     assert stored["libraries"]["mov-library_movies-metadata_files"] == metadata_value
 
 
+def test_step_post_from_libraries_persists_collection_files(client, isolated_config_dir, monkeypatch, qs_module):
+    import json
+
+    from modules import database
+
+    config_name = "pytest_step_save_collection_files"
+    collection_value = json.dumps(
+        [
+            {"type": "file", "location": "C:\\Users\\bullmoose20\\Community-Configs\\bullmoose20\\godzilla.yml"},
+            {"type": "url", "location": "https://example.com/movies_refresh.yml"},
+        ]
+    )
+
+    monkeypatch.setattr(qs_module.output, "build_config", lambda *_args, **_kwargs: (True, None, {}, "test: true\n", []))
+    monkeypatch.setattr(qs_module.validations, "validate_collection_file_payload", lambda _payload: (True, "", {}))
+    monkeypatch.setattr(
+        qs_module,
+        "_build_final_gate",
+        lambda *_args, **_kwargs: {
+            "stage": "kometa",
+            "todo_count": 0,
+            "todo_blockers": [],
+            "bulk_validation_fresh": True,
+            "bulk_validation_at": qs_module.utc_now_iso(),
+            "validation_ttl_hours": 12,
+            "can_build_config": True,
+            "config_valid": True,
+        },
+    )
+
+    resp = client.post(
+        "/step/900-kometa",
+        data={
+            "configSelector": config_name,
+            "mov-library_movies-library": "Movies",
+            "mov-library_movies-collection_files": collection_value,
+        },
+        headers={"Referer": "http://localhost/step/025-libraries"},
+    )
+
+    assert resp.status_code == 200
+
+    validated, user_entered, stored = database.retrieve_section_data(config_name, "libraries")
+    assert validated is False
+    assert user_entered is True
+    assert stored["libraries"]["mov-library_movies-library"] == "Movies"
+    assert stored["libraries"]["mov-library_movies-collection_files"] == collection_value
+
+
 def test_step_post_from_libraries_rejects_invalid_metadata_files(client, isolated_config_dir, monkeypatch, qs_module):
     from modules import database
 
@@ -607,6 +842,51 @@ def test_step_post_from_libraries_rejects_invalid_metadata_files(client, isolate
             "configSelector": config_name,
             "mov-library_movies-library": "Movies",
             "mov-library_movies-metadata_files": '[{"type":"url","location":"https://example.com/missing.yml"}]',
+        },
+        headers={"Referer": "http://localhost/step/025-libraries"},
+    )
+
+    assert resp.status_code == 200
+    assert b"Invalid values:" in resp.data
+
+    validated, user_entered, stored = database.retrieve_section_data(config_name, "libraries")
+    assert stored is None
+    assert validated is False
+    assert user_entered is False
+
+
+def test_step_post_from_libraries_rejects_invalid_collection_files(client, isolated_config_dir, monkeypatch, qs_module):
+    from modules import database
+
+    class _Resp:
+        status_code = 404
+        reason = "Not Found"
+        text = ""
+
+    monkeypatch.setattr(qs_module.validations.requests, "get", lambda *_args, **_kwargs: _Resp())
+    monkeypatch.setattr(qs_module.output, "build_config", lambda *_args, **_kwargs: (True, None, {}, "test: true\n", []))
+    monkeypatch.setattr(
+        qs_module,
+        "_build_final_gate",
+        lambda *_args, **_kwargs: {
+            "stage": "kometa",
+            "todo_count": 0,
+            "todo_blockers": [],
+            "bulk_validation_fresh": True,
+            "bulk_validation_at": qs_module.utc_now_iso(),
+            "validation_ttl_hours": 12,
+            "can_build_config": True,
+            "config_valid": True,
+        },
+    )
+
+    config_name = "pytest_invalid_step_collection_files"
+    resp = client.post(
+        "/step/900-kometa",
+        data={
+            "configSelector": config_name,
+            "mov-library_movies-library": "Movies",
+            "mov-library_movies-collection_files": '[{"type":"url","location":"https://example.com/missing.yml"}]',
         },
         headers={"Referer": "http://localhost/step/025-libraries"},
     )

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -325,10 +325,7 @@ def test_validate_metadata_folder_rejects_top_level_yaml_without_metadata(client
     assert payload["valid"] is False
     assert payload["error"] == "Metadata folder path: Scanned 3 top-level YAML files and found 2 invalid files."
     assert payload["error_details"]["text"] == payload["error"]
-    assert payload["files"] == [
-        "Top-level `metadata:` was not found in `broken.yml`.",
-        "Top-level `metadata:` in `empty.yml` must be a non-empty mapping."
-    ]
+    assert payload["files"] == ["Top-level `metadata:` was not found in `broken.yml`.", "Top-level `metadata:` in `empty.yml` must be a non-empty mapping."]
 
 
 def test_validate_collection_folder_rejects_top_level_yaml_without_collections(client, tmp_path):
@@ -347,10 +344,7 @@ def test_validate_collection_folder_rejects_top_level_yaml_without_collections(c
     assert payload["valid"] is False
     assert payload["error"] == "Collection folder path: Scanned 3 top-level YAML files and found 2 invalid files."
     assert payload["error_details"]["text"] == payload["error"]
-    assert payload["files"] == [
-        "Top-level `collections:` was not found in `broken.yml`.",
-        "Top-level `collections:` in `empty.yml` must be a non-empty mapping."
-    ]
+    assert payload["files"] == ["Top-level `collections:` was not found in `broken.yml`.", "Top-level `collections:` in `empty.yml` must be a non-empty mapping."]
 
 
 def test_validate_metadata_url_rejects_missing_top_level_metadata(client, monkeypatch, qs_module):
@@ -633,17 +627,19 @@ def test_build_libraries_section_emits_collection_files(app):
             {},
             {"movies": {"mov-library_movies-collection_collectionless": True}},
             {},
-            {"movies": {
-                "mov-library_movies-collection_files": json.dumps(
-                    [
-                        {"type": "url", "location": "https://example.com/movies_refresh.yml"},
-                        {"type": "repo", "location": "custom/movies_meta.yml"},
-                        {"type": "file", "location": "C:\\Users\\bullmoose20\\Community-Configs\\bullmoose20\\godzilla.yml"},
-                        {"type": "folder", "location": "config\\metadata\\movies"},
-                        {"type": "git", "location": "bullmoose20/collections/godzilla.yml"},
-                    ]
-                )
-            }},
+            {
+                "movies": {
+                    "mov-library_movies-collection_files": json.dumps(
+                        [
+                            {"type": "url", "location": "https://example.com/movies_refresh.yml"},
+                            {"type": "repo", "location": "custom/movies_meta.yml"},
+                            {"type": "file", "location": "C:\\Users\\bullmoose20\\Community-Configs\\bullmoose20\\godzilla.yml"},
+                            {"type": "folder", "location": "config\\metadata\\movies"},
+                            {"type": "git", "location": "bullmoose20/collections/godzilla.yml"},
+                        ]
+                    )
+                }
+            },
             {},
             {},
             {},

--- a/tests/test_importer_collection_files.py
+++ b/tests/test_importer_collection_files.py
@@ -1,0 +1,33 @@
+from modules import importer
+
+
+def test_prepare_import_payload_maps_multiple_collection_files_per_library():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Movies": {
+                    "collection_files": [
+                        {"file": "config/collections/movies.yml"},
+                        {"folder": "config/collections/movies"},
+                        {"git": "bullmoose20/godzilla.yml"},
+                        {"repo": "custom/movies_extra.yml"},
+                        {"url": "https://example.com/movie-collections.yml"},
+                    ]
+                }
+            }
+        },
+        {"Movies"},
+        set(),
+    )
+
+    libraries_payload = payload["libraries"]["libraries"]
+    assert "mov-library_movies-collection_files" in libraries_payload
+    assert (
+        libraries_payload["mov-library_movies-collection_files"]
+        == '[{"type": "file", "location": "config/collections/movies.yml"}, {"type": "folder", "location": "config/collections/movies"}, {"type": "git", "location": "bullmoose20/godzilla.yml"}, {"type": "repo", "location": "custom/movies_extra.yml"}, {"type": "url", "location": "https://example.com/movie-collections.yml"}]'
+    )
+    assert any("libraries.Movies.collection_files[0].file" in line for line in report.lines)
+    assert any("libraries.Movies.collection_files[1].folder" in line for line in report.lines)
+    assert any("libraries.Movies.collection_files[2].git" in line for line in report.lines)
+    assert any("libraries.Movies.collection_files[3].repo" in line for line in report.lines)
+    assert any("libraries.Movies.collection_files[4].url" in line for line in report.lines)


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Adds full library-level collection_files support to Quickstart.

This includes import, persistence, mirroring, YAML output, and validation for mixed file, folder, url, git, and repo entries per library. Validation now checks that each source resolves to non-empty YAML with a non-empty top-level collections: mapping, matches Kometa’s non-recursive folder behavior, and reports all folder validation failures with clearer per-file feedback. The Libraries UI now includes a dedicated Collection Files accordion with green/red validation state, repo dependency guidance tied to Settings -> Custom Repo, and updated README documentation for the new support and current validation limits.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
