### PR TITLE
update kometa update flow v1

### DIFF
--- a/quickstart.py
+++ b/quickstart.py
@@ -13222,6 +13222,7 @@ def background_job_status(job_id):
         lines=logs[start_idx:],
         next_index=len(logs),
         done=job.get("status") in {"complete", "error"},
+        update_success=bool(job.get("success")),
     )
 
 

--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -2326,7 +2326,8 @@ $(document).ready(function () {
             $('#kometa-update-box').addClass('d-none')
             syncUpdateButtonLabel()
             const elapsed = formatElapsed(Date.now() - startTs)
-            if (progress.update_success) {
+            const updateSucceeded = progress.update_success ?? progress.success
+            if (updateSucceeded) {
               if (progress.up_to_date) {
                 showToast('info', 'Kometa is already up to date.')
                 postUpdateLabel = '<i class="bi bi-check-circle me-1"></i> Up to date'

--- a/tests/test_update_flows.py
+++ b/tests/test_update_flows.py
@@ -358,7 +358,35 @@ def test_background_jobs_active_and_status_routes(client, qs_module):
     assert status_payload["success"] is True
     assert status_payload["job"]["phase"] == "download"
     assert status_payload["job"]["pct"] == 25
+    assert status_payload["update_success"] is False
     qs_module._complete_background_job(job["job_id"])
+
+    completed_status_resp = client.get(f"/background-jobs/{job['job_id']}")
+    assert completed_status_resp.status_code == 200
+    completed_status_payload = completed_status_resp.get_json()
+    assert completed_status_payload["done"] is True
+    assert completed_status_payload["update_success"] is False
+
+
+def test_background_job_status_exposes_success_alias(client, qs_module):
+    job = qs_module._create_background_job(
+        "kometa_update",
+        trigger="manual",
+        phase="running",
+        status="running",
+        success=False,
+        logs=["Starting update..."],
+    )
+
+    qs_module._complete_background_job(job["job_id"], success=True, up_to_date=False)
+
+    status_resp = client.get(f"/background-jobs/{job['job_id']}")
+    assert status_resp.status_code == 200
+    status_payload = status_resp.get_json()
+    assert status_payload["success"] is True
+    assert status_payload["done"] is True
+    assert status_payload["update_success"] is True
+    assert status_payload["job"]["success"] is True
 
 
 def test_clone_test_libraries_routes_use_shared_background_job(client, qs_module):


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

This fixes a UI/backend payload mismatch in the Kometa update flow.

When a Kometa update ran in the background and completed successfully, the frontend was reading update_success from the generic background job status route. That route only exposed the job’s success field, so the page could incorrectly show the update as failed even though the install had completed. A follow-up “Check for Kometa Updates” would then immediately report that Kometa was already up to date.

What changed

Updated the Kometa frontend flow to treat either update_success or success as the completion flag for background update jobs.
Added update_success as a compatibility alias on the shared /background-jobs/<job_id> status response.
Added regression coverage for the shared background job payload and the Kometa update status handling.
User impact

Successful Kometa updates no longer show a false failure state.
The post-update UI now stays consistent with the actual installed version state.


## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
