### PR TITLE
Per library arr settings

### DIFF
--- a/modules/importer.py
+++ b/modules/importer.py
@@ -27,6 +27,44 @@ SIMPLE_SECTIONS = {
     "playlist_files",
 }
 
+LIBRARY_RADARR_IMPORT_FIELDS = {
+    "url": "string",
+    "token": "string",
+    "root_folder_path": "string",
+    "quality_profile": "string",
+    "availability": "string",
+    "tag": "string",
+    "monitor": "bool",
+    "search": "bool",
+    "add_missing": "bool",
+    "add_existing": "bool",
+    "upgrade_existing": "bool",
+    "monitor_existing": "bool",
+    "ignore_cache": "bool",
+    "radarr_path": "string",
+    "plex_path": "string",
+}
+LIBRARY_SONARR_IMPORT_FIELDS = {
+    "url": "string",
+    "token": "string",
+    "root_folder_path": "string",
+    "quality_profile": "string",
+    "language_profile": "string",
+    "series_type": "string",
+    "season_folder": "bool",
+    "monitor": "string",
+    "tag": "string",
+    "search": "bool",
+    "cutoff_search": "bool",
+    "add_missing": "bool",
+    "add_existing": "bool",
+    "upgrade_existing": "bool",
+    "monitor_existing": "bool",
+    "ignore_cache": "bool",
+    "sonarr_path": "string",
+    "plex_path": "string",
+}
+
 
 def sanitize_config_name(raw_name: str | None) -> str:
     if not isinstance(raw_name, str):
@@ -660,6 +698,18 @@ def _flatten_dict(base: str, payload: Any, report: ImportReport, max_depth: int 
             report.add("imported", base)
     else:
         report.add("imported", base)
+
+
+def _coerce_import_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "yes", "1", "on"}:
+            return True
+        if lowered in {"false", "no", "0", "off"}:
+            return False
+    return None
 
 
 def prepare_import_payload(
@@ -1390,6 +1440,53 @@ def prepare_import_payload(
             elif settings_section is not None:
                 report.add("unmapped", f"libraries.{lib_name}.settings", "Unsupported settings format.")
 
+            for service_name, field_map in (
+                ("radarr", LIBRARY_RADARR_IMPORT_FIELDS),
+                ("sonarr", LIBRARY_SONARR_IMPORT_FIELDS),
+            ):
+                service_section = lib_cfg.get(service_name)
+                if not isinstance(service_section, dict):
+                    if service_section is not None:
+                        report.add("unmapped", f"libraries.{lib_name}.{service_name}", "Unsupported service override format.")
+                    continue
+
+                imported_service = False
+                if service_name == "radarr" and not str(lib_id).startswith("mov-library_"):
+                    report.add("unmapped", f"libraries.{lib_name}.radarr", "Radarr overrides are only supported on movie libraries.")
+                    continue
+                if service_name == "sonarr" and not str(lib_id).startswith("sho-library_"):
+                    report.add("unmapped", f"libraries.{lib_name}.sonarr", "Sonarr overrides are only supported on show libraries.")
+                    continue
+
+                for key, value in service_section.items():
+                    field_type = field_map.get(str(key))
+                    if not field_type:
+                        report.add("unmapped", f"libraries.{lib_name}.{service_name}.{key}", "Library service override not supported for import.")
+                        continue
+
+                    target_key = f"{lib_id}-attribute_{service_name}_{key}"
+                    if field_type == "bool":
+                        bool_value = _coerce_import_bool(value)
+                        if bool_value is None:
+                            report.add("unmapped", f"libraries.{lib_name}.{service_name}.{key}", "Invalid boolean value.")
+                            continue
+                        libraries_data[target_key] = "true" if bool_value else "false"
+                    else:
+                        if isinstance(value, (dict, list)):
+                            report.add("unmapped", f"libraries.{lib_name}.{service_name}.{key}", "Unsupported override value format.")
+                            continue
+                        text_value = str(value).strip()
+                        if not text_value:
+                            report.add("unmapped", f"libraries.{lib_name}.{service_name}.{key}", "Override value is empty.")
+                            continue
+                        libraries_data[target_key] = text_value
+
+                    report.add("imported", f"libraries.{lib_name}.{service_name}.{key}")
+                    imported_service = True
+
+                if imported_service:
+                    report.add("imported", f"libraries.{lib_name}.{service_name}")
+
             # Operations
             operations = lib_cfg.get("operations")
             if isinstance(operations, dict):
@@ -1425,7 +1522,7 @@ def prepare_import_payload(
             elif operations is not None:
                 report.add("unmapped", f"libraries.{lib_name}.operations", "Unsupported operations format.")
 
-            handled_keys = {"collection_files", "overlay_files", "metadata_files", "template_variables", "settings", "operations"}
+            handled_keys = {"collection_files", "overlay_files", "metadata_files", "template_variables", "settings", "operations", "radarr", "sonarr"}
             handled_keys.update(top_level_map.keys())
             for key in lib_cfg.keys():
                 if key in handled_keys:

--- a/modules/output.py
+++ b/modules/output.py
@@ -19,6 +19,44 @@ from ruamel.yaml.comments import CommentedSeq
 
 from modules import helpers, persistence, database
 
+LIBRARY_RADARR_FIELDS = {
+    "url": "string",
+    "token": "string",
+    "root_folder_path": "string",
+    "quality_profile": "string",
+    "availability": "string",
+    "tag": "string",
+    "monitor": "bool",
+    "search": "bool",
+    "add_missing": "bool",
+    "add_existing": "bool",
+    "upgrade_existing": "bool",
+    "monitor_existing": "bool",
+    "ignore_cache": "bool",
+    "radarr_path": "string",
+    "plex_path": "string",
+}
+LIBRARY_SONARR_FIELDS = {
+    "url": "string",
+    "token": "string",
+    "root_folder_path": "string",
+    "quality_profile": "string",
+    "language_profile": "string",
+    "series_type": "string",
+    "season_folder": "bool",
+    "monitor": "string",
+    "tag": "string",
+    "search": "bool",
+    "cutoff_search": "bool",
+    "add_missing": "bool",
+    "add_existing": "bool",
+    "upgrade_existing": "bool",
+    "monitor_existing": "bool",
+    "ignore_cache": "bool",
+    "sonarr_path": "string",
+    "plex_path": "string",
+}
+
 
 def add_border_to_ascii_art(art):
     lines = art.split("\n")
@@ -1078,6 +1116,7 @@ def build_libraries_section(
             "sonarr_add_all",
         ]
         library_settings = {}
+        service_overrides = {}
         operations = {}
         attr_group = attributes.get(lib_id, {})
         # Begin: Mass Genre Update Section
@@ -1266,6 +1305,19 @@ def build_libraries_section(
             if value not in [None, "", False]:
                 operations[field] = value
 
+        service_field_map = LIBRARY_RADARR_FIELDS if library_type == "mov" else LIBRARY_SONARR_FIELDS
+        service_name = "radarr" if library_type == "mov" else "sonarr"
+        for field, field_type in service_field_map.items():
+            attr_key = f"{library_type}-library_{lib_id}-attribute_{service_name}_{field}"
+            value = attr_group.get(attr_key, None)
+            if field_type == "bool":
+                bool_value = _coerce_bool(value)
+                if bool_value is not None:
+                    service_overrides[field] = bool_value
+                continue
+            if value not in [None, "", False]:
+                service_overrides[field] = value
+
         # Handle nested delete_collections block
         delete_collections = {}
         configured_key = f"{library_type}-library_{lib_id}-attribute_delete_collections_configured"
@@ -1306,6 +1358,9 @@ def build_libraries_section(
 
         if library_settings:
             entry["settings"] = library_settings
+
+        if service_overrides:
+            entry[service_name] = service_overrides
 
         if operations:
             entry["operations"] = operations
@@ -2174,7 +2229,7 @@ def reorder_library_section(library_data):
     - `template_variables` next.
     - `metadata_files` appears before `collection_files`.
     - `collection_files` appears before `overlay_files`.
-    - `settings` appears before `operations`.
+    - `settings` appears before `radarr` / `sonarr` / `operations`.
     - Keys inside `operations` are ordered as per Kometa Wiki.
     - Other keys retain their natural order.
     """
@@ -2206,7 +2261,13 @@ def reorder_library_section(library_data):
     if "settings" in library_data:
         reordered_data["settings"] = library_data["settings"]
 
-    # 6. Reorder operations
+    # 6. Then per-library Arr overrides
+    if "radarr" in library_data:
+        reordered_data["radarr"] = library_data["radarr"]
+    if "sonarr" in library_data:
+        reordered_data["sonarr"] = library_data["sonarr"]
+
+    # 7. Reorder operations
     operations_order = [
         "assets_for_all",
         "assets_for_all_collections",

--- a/modules/url_validation.py
+++ b/modules/url_validation.py
@@ -47,6 +47,8 @@ def validate_url(value, allow_local=True):
     text = str(value).strip()
     if text == "":
         return True, None
+    if text.lower() == "none":
+        return True, None
     if is_placeholder(text):
         return False, "URL is incomplete."
     parsed = urlparse(text)

--- a/modules/validations.py
+++ b/modules/validations.py
@@ -783,60 +783,70 @@ def validate_webhook_server(data):
 
 
 def validate_radarr_server(data):
-    radarr_url = data.get("radarr_url")
-    radarr_apikey = data.get("radarr_token")
+    result, status_code = validate_radarr_payload(data)
+    if not result.get("valid"):
+        error = result.get("error")
+        if error:
+            flash(f"Invalid Radarr URL or API Key: {error}", "error")
+    return (jsonify(result), status_code) if status_code != 200 else jsonify(result)
+
+
+def validate_sonarr_server(data):
+    result, status_code = validate_sonarr_payload(data)
+    if not result.get("valid"):
+        error = result.get("error")
+        if error:
+            flash(f"Invalid Sonarr URL or API Key: {error}", "error")
+    return (jsonify(result), status_code) if status_code != 200 else jsonify(result)
+
+
+def validate_radarr_payload(data):
+    radarr_url = data.get("radarr_url") or data.get("url")
+    radarr_apikey = data.get("radarr_token") or data.get("token")
 
     ok, msg = _validate_service_url(radarr_url, "Radarr", allow_local=True)
     if not ok:
-        return jsonify({"valid": False, "error": msg}), 400
+        return {"valid": False, "error": msg}, 400
 
     status_api_url = f"{radarr_url}/api/v3/system/status?apikey={radarr_apikey}"
     root_folder_api_url = f"{radarr_url}/api/v3/rootfolder?apikey={radarr_apikey}"
     quality_profile_api_url = f"{radarr_url}/api/v3/qualityprofile?apikey={radarr_apikey}"
 
     try:
-        # Validate API key by checking system status
         response = requests.get(status_api_url, timeout=10)
         response.raise_for_status()
         status_data = response.json()
 
         if "version" not in status_data:
             helpers.ts_log("Radarr connection failed. Invalid response data.")
-            return jsonify({"valid": False, "error": "Invalid Radarr URL or Apikey"})
+            return {"valid": False, "error": "Invalid Radarr URL or Apikey"}, 200
 
-        # Fetch root folders
         response = requests.get(root_folder_api_url, timeout=10)
         response.raise_for_status()
         root_folders = response.json()
 
-        # Fetch quality profiles
         response = requests.get(quality_profile_api_url, timeout=10)
         response.raise_for_status()
         quality_profiles = response.json()
 
         helpers.ts_log("Radarr connection successful.")
-
-        return jsonify(
-            {
-                "valid": True,
-                "root_folders": root_folders,
-                "quality_profiles": quality_profiles,
-            }
-        )
-
+        return {
+            "valid": True,
+            "root_folders": root_folders,
+            "quality_profiles": quality_profiles,
+        }, 200
     except requests.exceptions.RequestException as e:
-        helpers.ts_log("Error validating Radarr connection: {e}", level="ERROR")
-        flash(f"Invalid Radarr URL or API Key: {str(e)}", "error")
-        return jsonify({"valid": False, "error": f"Invalid Radarr URL or Apikey: {str(e)}"})
+        helpers.ts_log(f"Error validating Radarr connection: {e}", level="ERROR")
+        return {"valid": False, "error": f"Invalid Radarr URL or Apikey: {str(e)}"}, 200
 
 
-def validate_sonarr_server(data):
-    sonarr_url = data.get("sonarr_url")
-    sonarr_apikey = data.get("sonarr_token")
+def validate_sonarr_payload(data):
+    sonarr_url = data.get("sonarr_url") or data.get("url")
+    sonarr_apikey = data.get("sonarr_token") or data.get("token")
 
     ok, msg = _validate_service_url(sonarr_url, "Sonarr", allow_local=True)
     if not ok:
-        return jsonify({"valid": False, "error": msg}), 400
+        return {"valid": False, "error": msg}, 400
 
     status_api_url = f"{sonarr_url}/api/v3/system/status?apikey={sonarr_apikey}"
     root_folder_api_url = f"{sonarr_url}/api/v3/rootfolder?apikey={sonarr_apikey}"
@@ -844,45 +854,36 @@ def validate_sonarr_server(data):
     language_profile_api_url = f"{sonarr_url}/api/v3/language?apikey={sonarr_apikey}"
 
     try:
-        # Validate API key by checking system status
         response = requests.get(status_api_url, timeout=10)
         response.raise_for_status()
         status_data = response.json()
 
         if "version" not in status_data:
             helpers.ts_log("Sonarr connection failed. Invalid response data.")
-            return jsonify({"valid": False, "error": "Invalid Sonarr URL or Apikey"})
+            return {"valid": False, "error": "Invalid Sonarr URL or Apikey"}, 200
 
-        # Fetch root folders
         response = requests.get(root_folder_api_url, timeout=10)
         response.raise_for_status()
         root_folders = response.json()
 
-        # Fetch quality profiles
         response = requests.get(quality_profile_api_url, timeout=10)
         response.raise_for_status()
         quality_profiles = response.json()
 
-        # Fetch quality profiles
         response = requests.get(language_profile_api_url, timeout=10)
         response.raise_for_status()
         language_profiles = response.json()
 
         helpers.ts_log("Sonarr connection successful.")
-
-        return jsonify(
-            {
-                "valid": True,
-                "root_folders": root_folders,
-                "quality_profiles": quality_profiles,
-                "language_profiles": language_profiles,
-            }
-        )
-
+        return {
+            "valid": True,
+            "root_folders": root_folders,
+            "quality_profiles": quality_profiles,
+            "language_profiles": language_profiles,
+        }, 200
     except requests.exceptions.RequestException as e:
         helpers.ts_log(f"Error validating Sonarr connection: {e}", level="ERROR")
-        flash(f"Invalid Sonarr URL or API Key: {str(e)}", "error")
-        return jsonify({"valid": False, "error": f"Invalid Sonarr URL or Apikey: {str(e)}"})
+        return {"valid": False, "error": f"Invalid Sonarr URL or Apikey: {str(e)}"}, 200
 
 
 def validate_omdb_server(data):

--- a/quickstart.py
+++ b/quickstart.py
@@ -8426,13 +8426,7 @@ def validate_all_services():
                 "libraries",
                 libraries_reason is None,
                 reason=libraries_reason,
-                details=(
-                    missing_placeholders
-                    if libraries_reason == "missing_placeholder_imdb"
-                    else arr_override_errors
-                    if libraries_reason == "invalid_arr_overrides"
-                    else None
-                ),
+                details=(missing_placeholders if libraries_reason == "missing_placeholder_imdb" else arr_override_errors if libraries_reason == "invalid_arr_overrides" else None),
             )
 
     # Bulk validation for settings

--- a/quickstart.py
+++ b/quickstart.py
@@ -168,6 +168,7 @@ VALIDATION_REASON_LABELS = {
     "missing_plex_validation": "Plex not validated",
     "no_libraries": "No libraries selected",
     "invalid_paths": "Invalid paths",
+    "invalid_arr_overrides": "Invalid Arr overrides",
     "missing_library_defaults": "Missing library defaults",
     "missing_placeholder_imdb": "Missing placeholder IMDb ID",
     "invalid_metadata_files": "Invalid metadata files",
@@ -398,12 +399,72 @@ QS_ERROR_REASONS = {
     "account_locked",
     "validation_error",
     "invalid_paths",
+    "invalid_arr_overrides",
     "invalid_collection_files",
     "invalid_fields",
     "invalid_metadata_files",
     "missing_library_defaults",
     "missing_placeholder_imdb",
 }
+LIBRARY_RADARR_FIELDS = [
+    "url",
+    "token",
+    "root_folder_path",
+    "quality_profile",
+    "availability",
+    "tag",
+    "monitor",
+    "search",
+    "add_missing",
+    "add_existing",
+    "upgrade_existing",
+    "monitor_existing",
+    "ignore_cache",
+    "radarr_path",
+    "plex_path",
+]
+LIBRARY_RADARR_BOOL_FIELDS = {
+    "monitor",
+    "search",
+    "add_missing",
+    "add_existing",
+    "upgrade_existing",
+    "monitor_existing",
+    "ignore_cache",
+}
+LIBRARY_RADARR_AVAILABILITY_VALUES = {"announced", "cinemas", "released", "db"}
+LIBRARY_SONARR_FIELDS = [
+    "url",
+    "token",
+    "root_folder_path",
+    "quality_profile",
+    "language_profile",
+    "series_type",
+    "season_folder",
+    "monitor",
+    "tag",
+    "search",
+    "cutoff_search",
+    "add_missing",
+    "add_existing",
+    "upgrade_existing",
+    "monitor_existing",
+    "ignore_cache",
+    "sonarr_path",
+    "plex_path",
+]
+LIBRARY_SONARR_BOOL_FIELDS = {
+    "season_folder",
+    "search",
+    "cutoff_search",
+    "add_missing",
+    "add_existing",
+    "upgrade_existing",
+    "monitor_existing",
+    "ignore_cache",
+}
+LIBRARY_SONARR_MONITOR_VALUES = {"all", "none", "future", "missing", "existing", "pilot", "first", "latest"}
+LIBRARY_SONARR_SERIES_TYPE_VALUES = {"standard", "daily", "anime"}
 QS_TAUTULLI_REQUIRED_STEP_KEY = "030-tautulli"
 QS_OMDB_REQUIRED_STEP_KEY = "050-omdb"
 QS_MDBLIST_REQUIRED_STEP_KEY = "060-mdblist"
@@ -599,6 +660,158 @@ def _parse_collection_file_entries(value):
             continue
         entries.append({"type": entry_type, "location": location})
     return entries
+
+
+def _is_blank_override_value(value):
+    if value is None:
+        return True
+    if isinstance(value, str):
+        text = value.strip()
+        return text == "" or text.lower() == "none"
+    return False
+
+
+def _coerce_override_bool(value):
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "yes", "1", "on"}:
+            return True
+        if lowered in {"false", "no", "0", "off"}:
+            return False
+    return None
+
+
+def _library_service_definition(service_name):
+    if service_name == "radarr":
+        return {
+            "template_key": "110-radarr",
+            "section_name": "radarr",
+            "fields": LIBRARY_RADARR_FIELDS,
+            "bool_fields": LIBRARY_RADARR_BOOL_FIELDS,
+            "label": "Radarr",
+        }
+    if service_name == "sonarr":
+        return {
+            "template_key": "120-sonarr",
+            "section_name": "sonarr",
+            "fields": LIBRARY_SONARR_FIELDS,
+            "bool_fields": LIBRARY_SONARR_BOOL_FIELDS,
+            "label": "Sonarr",
+        }
+    return None
+
+
+def _extract_library_service_overrides(libraries_data, library_id, service_name):
+    definition = _library_service_definition(service_name)
+    if not definition or not isinstance(libraries_data, dict):
+        return {}
+    overrides = {}
+    for field in definition["fields"]:
+        value = libraries_data.get(f"{library_id}-attribute_{service_name}_{field}")
+        if field in definition["bool_fields"]:
+            bool_value = _coerce_override_bool(value)
+            if bool_value is not None:
+                overrides[field] = bool_value
+            continue
+        if not _is_blank_override_value(value):
+            overrides[field] = str(value).strip() if isinstance(value, str) else value
+    return overrides
+
+
+def _validate_library_service_overrides(library_id, libraries_data, force_validate=False):
+    service_name = "radarr" if str(library_id or "").startswith("mov-library_") else "sonarr" if str(library_id or "").startswith("sho-library_") else None
+    definition = _library_service_definition(service_name)
+    if not definition:
+        return {"valid": True, "skipped": True, "service": None, "errors": []}
+
+    overrides = _extract_library_service_overrides(libraries_data, library_id, service_name)
+    if not overrides and not force_validate:
+        return {"valid": True, "skipped": True, "service": service_name, "overrides": {}, "errors": []}
+
+    settings = persistence.retrieve_settings(definition["template_key"]) or {}
+    global_section = settings.get(definition["section_name"], {}) if isinstance(settings, dict) else {}
+    if not isinstance(global_section, dict):
+        global_section = {}
+
+    effective_url = overrides.get("url") or global_section.get("url")
+    effective_token = overrides.get("token") or global_section.get("token")
+    library_name = libraries_data.get(f"{library_id}-library") if isinstance(libraries_data, dict) else None
+    display_name = str(library_name or library_id or "").strip() or str(library_id or "")
+    scoped_label = f"{display_name} {definition['label']}"
+
+    if _is_blank_override_value(effective_url) or _is_blank_override_value(effective_token):
+        return {
+            "valid": False,
+            "skipped": False,
+            "service": service_name,
+            "overrides": overrides,
+            "errors": [f"{scoped_label}: URL and token are required after applying overrides."],
+        }
+
+    if service_name == "radarr":
+        response_data, _status = validations.validate_radarr_payload({"url": effective_url, "token": effective_token})
+    else:
+        response_data, _status = validations.validate_sonarr_payload({"url": effective_url, "token": effective_token})
+
+    if not response_data.get("valid"):
+        return {
+            "valid": False,
+            "skipped": False,
+            "service": service_name,
+            "overrides": overrides,
+            "errors": [f"{scoped_label}: {response_data.get('error') or 'Validation failed.'}"],
+        }
+
+    errors = []
+    root_folders = response_data.get("root_folders", []) if isinstance(response_data, dict) else []
+    quality_profiles = response_data.get("quality_profiles", []) if isinstance(response_data, dict) else []
+    language_profiles = response_data.get("language_profiles", []) if isinstance(response_data, dict) else []
+
+    root_folder_names = {str(item.get("path") or "").strip() for item in root_folders if isinstance(item, dict)}
+    quality_profile_names = {str(item.get("name") or "").strip() for item in quality_profiles if isinstance(item, dict)}
+    language_profile_names = {str(item.get("name") or "").strip() for item in language_profiles if isinstance(item, dict)}
+
+    root_folder_path = overrides.get("root_folder_path")
+    if root_folder_path and root_folder_path not in root_folder_names:
+        errors.append(f"{scoped_label}: unknown root folder path '{root_folder_path}'.")
+
+    quality_profile = overrides.get("quality_profile")
+    if quality_profile and quality_profile not in quality_profile_names:
+        errors.append(f"{scoped_label}: unknown quality profile '{quality_profile}'.")
+
+    if service_name == "radarr":
+        availability = overrides.get("availability")
+        if availability and availability not in LIBRARY_RADARR_AVAILABILITY_VALUES:
+            errors.append(f"{scoped_label}: unsupported availability '{availability}'.")
+    else:
+        language_profile = overrides.get("language_profile")
+        if language_profile and language_profile not in language_profile_names:
+            errors.append(f"{scoped_label}: unknown language profile '{language_profile}'.")
+
+        series_type = overrides.get("series_type")
+        if series_type and series_type not in LIBRARY_SONARR_SERIES_TYPE_VALUES:
+            errors.append(f"{scoped_label}: unsupported series_type '{series_type}'.")
+
+        monitor_value = overrides.get("monitor")
+        if monitor_value and monitor_value not in LIBRARY_SONARR_MONITOR_VALUES:
+            errors.append(f"{scoped_label}: unsupported monitor value '{monitor_value}'.")
+
+    return {
+        "valid": not errors,
+        "skipped": False,
+        "service": service_name,
+        "overrides": overrides,
+        "errors": errors,
+        "root_folders": root_folders,
+        "quality_profiles": quality_profiles,
+        "language_profiles": language_profiles,
+    }
 
 
 def _validate_library_metadata_files(libraries_data, selected_library_ids):
@@ -6020,6 +6233,10 @@ def step(name):
             selected_library_ids = _selected_library_ids_from_libraries_data(incoming_libraries)
             validation_errors += _validate_library_collection_files(incoming_libraries, selected_library_ids)
             validation_errors += _validate_library_metadata_files(incoming_libraries, selected_library_ids)
+            for lib_id in selected_library_ids:
+                override_result = _validate_library_service_overrides(lib_id, incoming_libraries)
+                if not override_result.get("valid") and not override_result.get("skipped"):
+                    validation_errors += list(override_result.get("errors") or [])
         if validation_errors:
             save_error = "Invalid values: " + " ".join(validation_errors)
         else:
@@ -7778,22 +7995,40 @@ def validate_webhook():
 def validate_radarr():
     data = request.json
     result = validations.validate_radarr_server(data)
+    status_code = 200
+    if isinstance(result, tuple):
+        result, status_code = result
 
     if result.get_json().get("valid"):
         return jsonify(result.get_json())
     else:
-        return jsonify(result.get_json()), 400
+        return jsonify(result.get_json()), status_code or 400
 
 
 @app.route("/validate_sonarr", methods=["POST"])
 def validate_sonarr():
     data = request.json
     result = validations.validate_sonarr_server(data)
+    status_code = 200
+    if isinstance(result, tuple):
+        result, status_code = result
 
     if result.get_json().get("valid"):
         return jsonify(result.get_json())
     else:
-        return jsonify(result.get_json()), 400
+        return jsonify(result.get_json()), status_code or 400
+
+
+@app.route("/validate_library_service_overrides/<library_id>", methods=["POST"])
+def validate_library_service_overrides(library_id):
+    payload = request.get_json(silent=True) or request.form or {}
+    clean_payload = persistence.clean_form_data(MultiDict(payload))
+    libraries_data = helpers.build_config_dict("libraries", clean_payload).get("libraries", {})
+    if not isinstance(libraries_data, dict):
+        libraries_data = {}
+    result = _validate_library_service_overrides(library_id, libraries_data, force_validate=True)
+    status_code = 200 if result.get("valid") else 400
+    return jsonify(result), status_code
 
 
 @app.route("/validate_omdb", methods=["POST"])
@@ -8121,6 +8356,7 @@ def validate_all_services():
             path_errors = path_validation.validate_payload(libraries_data)
             collection_file_errors = _validate_library_collection_files(libraries_data, selected_library_ids)
             metadata_file_errors = _validate_library_metadata_files(libraries_data, selected_library_ids)
+            arr_override_errors = []
             if path_errors:
                 libraries_reason = "invalid_paths"
             elif collection_file_errors:
@@ -8177,12 +8413,26 @@ def validate_all_services():
                 if libraries_reason is None and missing_placeholders:
                     libraries_reason = "missing_placeholder_imdb"
 
+                if libraries_reason is None:
+                    for lib_id in selected_library_ids:
+                        override_result = _validate_library_service_overrides(lib_id, libraries_data)
+                        if not override_result.get("valid") and not override_result.get("skipped"):
+                            arr_override_errors.extend(list(override_result.get("errors") or []))
+                if libraries_reason is None and arr_override_errors:
+                    libraries_reason = "invalid_arr_overrides"
+
             update_section_validation(
                 "025-libraries",
                 "libraries",
                 libraries_reason is None,
                 reason=libraries_reason,
-                details=missing_placeholders if libraries_reason == "missing_placeholder_imdb" else None,
+                details=(
+                    missing_placeholders
+                    if libraries_reason == "missing_placeholder_imdb"
+                    else arr_override_errors
+                    if libraries_reason == "invalid_arr_overrides"
+                    else None
+                ),
             )
 
     # Bulk validation for settings
@@ -8322,6 +8572,7 @@ def validate_all_services():
         "missing_plex_validation": "Plex not validated",
         "no_libraries": "No libraries selected",
         "invalid_paths": "Invalid paths",
+        "invalid_arr_overrides": "Invalid Arr overrides",
         "missing_library_defaults": "Missing library defaults",
         "missing_placeholder_imdb": "Missing placeholder IMDb ID",
         "invalid_fields": "Invalid fields",

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -2225,6 +2225,68 @@ document.addEventListener('DOMContentLoaded', function () {
       statusEl.classList.add(kind === 'success' ? 'alert-success' : kind === 'error' ? 'alert-danger' : 'alert-info')
     }
 
+    function getLibraryServiceValidationFields (card, serviceName) {
+      if (!card || !serviceName) return {}
+      return {
+        validatedInput: card.querySelector(`[data-library-service-validated="${serviceName}"]`),
+        validatedAtInput: card.querySelector(`[data-library-service-validated-at="${serviceName}"]`),
+        button: card.querySelector(`[data-validate-library-service="${serviceName}"]`)
+      }
+    }
+
+    function isLibraryServiceValidated (card, serviceName) {
+      const { validatedInput } = getLibraryServiceValidationFields(card, serviceName)
+      return String(validatedInput?.value || '').trim().toLowerCase() === 'true'
+    }
+
+    function updateLibraryServiceValidateButton (card, serviceName, state = null) {
+      const { button } = getLibraryServiceValidationFields(card, serviceName)
+      if (!button) return
+      const effectiveState = String(state || button.dataset.validationState || '').trim() || (isLibraryServiceValidated(card, serviceName) ? 'success' : 'idle')
+      button.dataset.validationState = effectiveState
+      button.classList.remove('btn-success', 'btn-secondary')
+
+      if (effectiveState === 'loading') {
+        button.disabled = true
+        button.classList.add('btn-secondary')
+        button.textContent = `Validating ${serviceName === 'radarr' ? 'Radarr' : 'Sonarr'} Overrides...`
+        return
+      }
+
+      if (effectiveState === 'success') {
+        button.disabled = true
+        button.classList.add('btn-secondary')
+        button.textContent = 'Validated'
+        return
+      }
+
+      button.disabled = false
+      button.classList.add('btn-success')
+      button.textContent = `Validate ${serviceName === 'radarr' ? 'Radarr' : 'Sonarr'} Overrides`
+    }
+
+    function setLibraryServiceValidatedState (card, serviceName, isValidated) {
+      const { validatedInput, validatedAtInput, button } = getLibraryServiceValidationFields(card, serviceName)
+      if (validatedInput) validatedInput.value = isValidated ? 'true' : 'false'
+      if (validatedAtInput) validatedAtInput.value = isValidated ? new Date().toISOString() : ''
+      if (button) {
+        button.dataset.validationState = isValidated ? 'success' : 'idle'
+      }
+      updateLibraryServiceValidateButton(card, serviceName, isValidated ? 'success' : 'idle')
+    }
+
+    function resetLibraryServiceValidatedState (card, serviceName, opts = {}) {
+      const clearStatus = opts.clearStatus !== false
+      setLibraryServiceValidatedState(card, serviceName, false)
+      if (clearStatus) {
+        setLibraryServiceStatus(card, serviceName, '', '')
+      }
+    }
+
+    function libraryServiceOverrideFieldSelector (serviceName) {
+      return `[name*="-attribute_${serviceName}_"]`
+    }
+
     function populateOverrideDatalist (card, listId, items, valueField) {
       const list = card ? card.querySelector(`#${listId}`) : null
       if (!list) return
@@ -2246,7 +2308,7 @@ document.addEventListener('DOMContentLoaded', function () {
       if (!button || !serviceName || !libraryId || !card) return
 
       const payload = buildPayloadFromCard(card)
-      button.disabled = true
+      updateLibraryServiceValidateButton(card, serviceName, 'loading')
       setLibraryServiceStatus(card, serviceName, 'info', `Validating ${serviceName} overrides...`)
 
       fetch(`/validate_library_service_overrides/${encodeURIComponent(libraryId)}`, {
@@ -2273,21 +2335,36 @@ document.addEventListener('DOMContentLoaded', function () {
             populateOverrideDatalist(card, `${libraryId}-sonarr-language-profiles`, data.language_profiles, 'name')
           }
           setAdvancedVisibility(card, true)
+          setLibraryServiceValidatedState(card, serviceName, true)
           setLibraryServiceStatus(card, serviceName, 'success', `${serviceName === 'radarr' ? 'Radarr' : 'Sonarr'} overrides validated.`)
         })
         .catch((error) => {
           setAdvancedVisibility(card, true)
+          resetLibraryServiceValidatedState(card, serviceName, { clearStatus: false })
           setLibraryServiceStatus(card, serviceName, 'error', error.message || 'Validation failed.')
         })
         .finally(() => {
-          button.disabled = false
+          if (!isLibraryServiceValidated(card, serviceName)) {
+            updateLibraryServiceValidateButton(card, serviceName, 'idle')
+          }
         })
     }
 
     function wireLibraryServiceValidationButtons (card) {
       if (!card || card.dataset.libraryServiceValidationBound === 'true') return
       card.querySelectorAll('[data-validate-library-service]').forEach(button => {
+        const serviceName = button.dataset.validateLibraryService
+        updateLibraryServiceValidateButton(card, serviceName)
         button.addEventListener('click', () => validateLibraryServiceOverrides(button))
+      })
+      card.querySelectorAll(`${libraryServiceOverrideFieldSelector('radarr')}, ${libraryServiceOverrideFieldSelector('sonarr')}`).forEach(field => {
+        const fieldName = String(field.name || '')
+        const serviceName = fieldName.includes('-attribute_sonarr_') ? 'sonarr' : fieldName.includes('-attribute_radarr_') ? 'radarr' : ''
+        if (!serviceName || field.dataset.libraryServiceWatcherBound === 'true') return
+        const onChange = () => resetLibraryServiceValidatedState(card, serviceName)
+        field.addEventListener('input', onChange)
+        field.addEventListener('change', onChange)
+        field.dataset.libraryServiceWatcherBound = 'true'
       })
       card.dataset.libraryServiceValidationBound = 'true'
     }

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -104,6 +104,7 @@ document.addEventListener('DOMContentLoaded', function () {
     }
     let dependencyHintRefreshTimer = null
     let dependencyHintRequestToken = 0
+    const advancedVisibilityStorageKey = 'qsLibrariesAdvancedVisible'
 
     function normalizeMetadataFileEntry (entry) {
       if (!entry || typeof entry !== 'object') return null
@@ -2158,6 +2159,139 @@ document.addEventListener('DOMContentLoaded', function () {
       toggle.dataset.listenerAdded = 'true'
     }
 
+    function hasConfiguredAdvancedValues (card) {
+      if (!card) return false
+      const fields = card.querySelectorAll('.library-advanced-section [name]')
+      return Array.from(fields).some((field) => {
+        if (!field || field.disabled) return false
+        if (field.type === 'checkbox' || field.type === 'radio') return field.checked
+        const value = String(field.value ?? '').trim()
+        if (!value) return false
+        if (field.name.endsWith('-metadata_files') || field.name.endsWith('-collection_files')) {
+          return value !== '[]'
+        }
+        return true
+      })
+    }
+
+    function setAdvancedVisibility (card, visible) {
+      if (!card) return
+      card.querySelectorAll('.library-advanced-section').forEach(section => {
+        section.classList.toggle('d-none', !visible)
+      })
+      const toggle = card.querySelector('.library-advanced-toggle')
+      if (toggle) {
+        toggle.textContent = visible ? 'Hide Advanced' : 'Show Advanced'
+        toggle.setAttribute('aria-expanded', visible ? 'true' : 'false')
+      }
+      card.dataset.advancedVisible = visible ? 'true' : 'false'
+    }
+
+    function wireAdvancedToggle (card) {
+      if (!card || card.dataset.advancedToggleBound === 'true') return
+      const toggle = card.querySelector('.library-advanced-toggle')
+      if (!toggle) return
+
+      let persisted = null
+      try {
+        persisted = window.localStorage ? window.localStorage.getItem(advancedVisibilityStorageKey) : null
+      } catch (_error) {}
+      const initialVisible = persisted === 'true' || (persisted !== 'false' && hasConfiguredAdvancedValues(card))
+      setAdvancedVisibility(card, initialVisible)
+
+      toggle.addEventListener('click', () => {
+        const nextVisible = card.dataset.advancedVisible !== 'true'
+        setAdvancedVisibility(card, nextVisible)
+        try {
+          if (window.localStorage) window.localStorage.setItem(advancedVisibilityStorageKey, nextVisible ? 'true' : 'false')
+        } catch (_error) {}
+      })
+
+      card.dataset.advancedToggleBound = 'true'
+    }
+
+    function setLibraryServiceStatus (card, serviceName, kind, message) {
+      const statusEl = card ? card.querySelector(`[data-library-service-status="${serviceName}"]`) : null
+      if (!statusEl) return
+      const text = String(message || '').trim()
+      if (!text) {
+        statusEl.classList.add('d-none')
+        statusEl.textContent = ''
+        statusEl.classList.remove('alert-success', 'alert-danger', 'alert-info')
+        return
+      }
+      statusEl.textContent = text
+      statusEl.classList.remove('d-none', 'alert-success', 'alert-danger', 'alert-info')
+      statusEl.classList.add(kind === 'success' ? 'alert-success' : kind === 'error' ? 'alert-danger' : 'alert-info')
+    }
+
+    function populateOverrideDatalist (card, listId, items, valueField) {
+      const list = card ? card.querySelector(`#${listId}`) : null
+      if (!list) return
+      list.replaceChildren()
+      const normalizedItems = Array.isArray(items) ? items : []
+      normalizedItems.forEach(item => {
+        const value = item && typeof item === 'object' ? item[valueField] : ''
+        if (!value) return
+        const option = document.createElement('option')
+        option.value = value
+        list.appendChild(option)
+      })
+    }
+
+    function validateLibraryServiceOverrides (button) {
+      const serviceName = button?.dataset?.validateLibraryService
+      const libraryId = button?.dataset?.libraryId || activeLibraryId
+      const card = libraryContainer?.firstElementChild
+      if (!button || !serviceName || !libraryId || !card) return
+
+      const payload = buildPayloadFromCard(card)
+      button.disabled = true
+      setLibraryServiceStatus(card, serviceName, 'info', `Validating ${serviceName} overrides...`)
+
+      fetch(`/validate_library_service_overrides/${encodeURIComponent(libraryId)}`, {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      })
+        .then(async (res) => {
+          const data = await res.json().catch(() => ({}))
+          if (!res.ok) {
+            const errors = Array.isArray(data.errors) ? data.errors : [data.error || `Validation failed (${res.status})`]
+            throw new Error(errors.filter(Boolean).join(' '))
+          }
+          return data
+        })
+        .then((data) => {
+          if (serviceName === 'radarr') {
+            populateOverrideDatalist(card, `${libraryId}-radarr-root-folders`, data.root_folders, 'path')
+            populateOverrideDatalist(card, `${libraryId}-radarr-quality-profiles`, data.quality_profiles, 'name')
+          } else {
+            populateOverrideDatalist(card, `${libraryId}-sonarr-root-folders`, data.root_folders, 'path')
+            populateOverrideDatalist(card, `${libraryId}-sonarr-quality-profiles`, data.quality_profiles, 'name')
+            populateOverrideDatalist(card, `${libraryId}-sonarr-language-profiles`, data.language_profiles, 'name')
+          }
+          setAdvancedVisibility(card, true)
+          setLibraryServiceStatus(card, serviceName, 'success', `${serviceName === 'radarr' ? 'Radarr' : 'Sonarr'} overrides validated.`)
+        })
+        .catch((error) => {
+          setAdvancedVisibility(card, true)
+          setLibraryServiceStatus(card, serviceName, 'error', error.message || 'Validation failed.')
+        })
+        .finally(() => {
+          button.disabled = false
+        })
+    }
+
+    function wireLibraryServiceValidationButtons (card) {
+      if (!card || card.dataset.libraryServiceValidationBound === 'true') return
+      card.querySelectorAll('[data-validate-library-service]').forEach(button => {
+        button.addEventListener('click', () => validateLibraryServiceOverrides(button))
+      })
+      card.dataset.libraryServiceValidationBound = 'true'
+    }
+
     function moveCurrentToCache () {
       const current = libraryContainer.firstElementChild
       if (current) {
@@ -2173,6 +2307,8 @@ document.addEventListener('DOMContentLoaded', function () {
       activeLibraryId = libraryId
       syncHiddenCheckboxPairs(card)
       wireIncludeToggle(card, libraryId)
+      wireAdvancedToggle(card)
+      wireLibraryServiceValidationButtons(card)
       refreshPickerLabels()
       initTooltips(card)
       sortLanguageSelects(card)

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -2287,6 +2287,51 @@ document.addEventListener('DOMContentLoaded', function () {
       return `[name*="-attribute_${serviceName}_"]`
     }
 
+    function setSecretToggleButtonIcon (button, showPlainText) {
+      if (!button) return
+      const icon = document.createElement('i')
+      icon.className = showPlainText ? 'fas fa-eye-slash' : 'fas fa-eye'
+      button.replaceChildren(icon)
+    }
+
+    function initSecretVisibilityToggles (scope) {
+      const root = scope || document
+      root.querySelectorAll('[data-toggle-secret-visibility]').forEach(button => {
+        if (button.dataset.secretToggleBound === 'true') return
+        const targetId = button.dataset.targetInput
+        const input = targetId ? root.querySelector(`#${targetId}`) : null
+        if (!input) return
+
+        const syncState = () => {
+          const hasValue = String(input.value || '').trim() !== ''
+          input.setAttribute('type', hasValue ? 'password' : 'text')
+          setSecretToggleButtonIcon(button, !hasValue)
+        }
+
+        syncState()
+
+        button.addEventListener('click', () => {
+          const currentType = input.getAttribute('type')
+          const nextType = currentType === 'password' ? 'text' : 'password'
+          input.setAttribute('type', nextType)
+          setSecretToggleButtonIcon(button, nextType === 'text')
+        })
+
+        input.addEventListener('input', () => {
+          const currentType = input.getAttribute('type')
+          if (String(input.value || '').trim() === '') {
+            input.setAttribute('type', 'text')
+            setSecretToggleButtonIcon(button, true)
+          } else if (currentType !== 'password' && currentType !== 'text') {
+            input.setAttribute('type', 'password')
+            setSecretToggleButtonIcon(button, false)
+          }
+        })
+
+        button.dataset.secretToggleBound = 'true'
+      })
+    }
+
     function populateOverrideDatalist (card, listId, items, valueField) {
       const list = card ? card.querySelector(`#${listId}`) : null
       if (!list) return
@@ -2382,6 +2427,7 @@ document.addEventListener('DOMContentLoaded', function () {
       card.style.display = ''
       libraryContainer.appendChild(card)
       activeLibraryId = libraryId
+      initSecretVisibilityToggles(card)
       syncHiddenCheckboxPairs(card)
       wireIncludeToggle(card, libraryId)
       wireAdvancedToggle(card)

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -2304,28 +2304,27 @@ document.addEventListener('DOMContentLoaded', function () {
 
         const syncState = () => {
           const hasValue = String(input.value || '').trim() !== ''
-          input.setAttribute('type', hasValue ? 'password' : 'text')
-          setSecretToggleButtonIcon(button, !hasValue)
+          const forceVisible = button.dataset.secretVisible === 'true'
+          const showPlainText = !hasValue || forceVisible
+          input.setAttribute('type', showPlainText ? 'text' : 'password')
+          setSecretToggleButtonIcon(button, showPlainText)
         }
 
+        button.dataset.secretVisible = 'false'
         syncState()
 
         button.addEventListener('click', () => {
           const currentType = input.getAttribute('type')
-          const nextType = currentType === 'password' ? 'text' : 'password'
-          input.setAttribute('type', nextType)
-          setSecretToggleButtonIcon(button, nextType === 'text')
+          const nextVisible = currentType === 'password'
+          button.dataset.secretVisible = nextVisible ? 'true' : 'false'
+          syncState()
         })
 
         input.addEventListener('input', () => {
-          const currentType = input.getAttribute('type')
           if (String(input.value || '').trim() === '') {
-            input.setAttribute('type', 'text')
-            setSecretToggleButtonIcon(button, true)
-          } else if (currentType !== 'password' && currentType !== 'text') {
-            input.setAttribute('type', 'password')
-            setSecretToggleButtonIcon(button, false)
+            button.dataset.secretVisible = 'false'
           }
+          syncState()
         })
 
         button.dataset.secretToggleBound = 'true'

--- a/templates/partials/_library_card.html
+++ b/templates/partials/_library_card.html
@@ -29,6 +29,14 @@
     <i class="bi bi-chevron-down text-white rotate-icon"></i>
   </div>
   <div class="card-body">
+    <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+      <div class="small text-muted">
+        Advanced reveals library-level file imports and per-library Arr overrides.
+      </div>
+      <button type="button" class="btn btn-outline-secondary btn-sm library-advanced-toggle">
+        Show Advanced
+      </button>
+    </div>
     {% include "partials/_movie_library_settings.html" %}
   </div>
 </div>
@@ -62,6 +70,14 @@
     <i class="bi bi-chevron-down text-white rotate-icon"></i>
   </div>
   <div class="card-body">
+    <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+      <div class="small text-muted">
+        Advanced reveals library-level file imports and per-library Arr overrides.
+      </div>
+      <button type="button" class="btn btn-outline-secondary btn-sm library-advanced-toggle">
+        Show Advanced
+      </button>
+    </div>
     {% include "partials/_show_library_settings.html" %}
   </div>
 </div>

--- a/templates/partials/_library_collection_files_accordion.html
+++ b/templates/partials/_library_collection_files_accordion.html
@@ -1,0 +1,16 @@
+<div class="accordion-item library-advanced-section d-none" data-advanced-section>
+    <h2 class="accordion-header">
+        <button class="accordion-button" type="button" data-bs-toggle="collapse"
+            data-bs-target="#{{ library.id }}-collection-files">
+            Collection Files
+        </button>
+    </h2>
+    <div id="{{ library.id }}-collection-files" class="accordion-collapse collapse">
+        <div class="accordion-body">
+            <div class="alert alert-info small mb-3" role="alert">
+                Leave these entries blank unless you want explicit library-level <code>collection_files</code>.
+            </div>
+            {% include "partials/_library_collection_files.html" %}
+        </div>
+    </div>
+</div>

--- a/templates/partials/_library_metadata_files.html
+++ b/templates/partials/_library_metadata_files.html
@@ -1,4 +1,4 @@
-<div class="accordion-item">
+<div class="accordion-item library-advanced-section d-none" data-advanced-section>
     <h2 class="accordion-header">
         <button class="accordion-button" type="button" data-bs-toggle="collapse"
             data-bs-target="#{{ library.id }}-metadata-files">

--- a/templates/partials/_library_radarr_overrides.html
+++ b/templates/partials/_library_radarr_overrides.html
@@ -62,6 +62,12 @@
                     value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_token', '') | default('', true) }}"
                     placeholder="Leave blank to use global Radarr token"
                     aria-describedby="{{ library.id }}-attribute_radarr_token_text">
+                <button class="btn btn-outline-secondary" type="button"
+                    data-toggle-secret-visibility
+                    data-target-input="{{ library.id }}-attribute_radarr_token"
+                    aria-label="Toggle Radarr API key visibility">
+                    <i class="fas fa-eye"></i>
+                </button>
             </div>
 
             <div class="input-group mb-2">

--- a/templates/partials/_library_radarr_overrides.html
+++ b/templates/partials/_library_radarr_overrides.html
@@ -7,109 +7,192 @@
     </h2>
     <div id="{{ library.id }}-radarr-overrides" class="accordion-collapse collapse">
         <div class="accordion-body">
+            <div class="alert alert-success small mb-3" role="alert">
+                Enter your Radarr URL and token override only if this library should use a different Radarr instance than the global
+                Radarr page. Then validate the override and complete the rest of the form. The token can be found in
+                Radarr &gt; Settings &gt; General &gt; Security &gt; API Key.
+                <div class="mt-2">
+                    <a href="https://kometa.wiki/en/nightly/config/radarr/" target="_blank" rel="noopener noreferrer">
+                        Click Here
+                    </a>
+                    to go to the Kometa wiki for this connector.
+                </div>
+            </div>
             <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
                 <div class="small text-muted">Blank values inherit the global Radarr page setting.</div>
-                <button type="button" class="btn btn-outline-info btn-sm" data-validate-library-service="radarr"
+                <button type="button" class="btn btn-success btn-sm" data-validate-library-service="radarr"
                     data-library-id="{{ library.id }}">
                     Validate Radarr Overrides
                 </button>
             </div>
+            <input type="hidden" name="{{ library.id }}-library_service_radarr_validated"
+                value="{{ data['libraries'].get(library.id ~ '-library_service_radarr_validated', '') }}"
+                data-library-service-validated="radarr">
+            <input type="hidden" name="{{ library.id }}-library_service_radarr_validated_at"
+                value="{{ data['libraries'].get(library.id ~ '-library_service_radarr_validated_at', '') }}"
+                data-library-service-validated-at="radarr">
             <div class="alert d-none small mb-3" role="alert" data-library-service-status="radarr"></div>
-            <div class="row g-3">
-                <div class="col-md-6">
-                    <label class="form-label" for="{{ library.id }}-attribute_radarr_url">Radarr URL Override</label>
-                    <input type="text" class="form-control" id="{{ library.id }}-attribute_radarr_url"
-                        name="{{ library.id }}-attribute_radarr_url"
-                        value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_url', '') }}"
-                        placeholder="Leave blank to use global Radarr URL">
-                </div>
-                <div class="col-md-6">
-                    <label class="form-label" for="{{ library.id }}-attribute_radarr_token">Radarr Token Override</label>
-                    <input type="password" class="form-control" id="{{ library.id }}-attribute_radarr_token"
-                        name="{{ library.id }}-attribute_radarr_token"
-                        value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_token', '') }}"
-                        placeholder="Leave blank to use global Radarr token">
-                </div>
-                <div class="col-md-6">
-                    <label class="form-label" for="{{ library.id }}-attribute_radarr_root_folder_path">Root Folder Path</label>
-                    <input type="text" class="form-control" list="{{ library.id }}-radarr-root-folders"
-                        id="{{ library.id }}-attribute_radarr_root_folder_path"
-                        name="{{ library.id }}-attribute_radarr_root_folder_path"
-                        value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_root_folder_path', '') }}">
-                    <datalist id="{{ library.id }}-radarr-root-folders"></datalist>
-                </div>
-                <div class="col-md-6">
-                    <label class="form-label" for="{{ library.id }}-attribute_radarr_quality_profile">Quality Profile</label>
-                    <input type="text" class="form-control" list="{{ library.id }}-radarr-quality-profiles"
-                        id="{{ library.id }}-attribute_radarr_quality_profile"
-                        name="{{ library.id }}-attribute_radarr_quality_profile"
-                        value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_quality_profile', '') }}">
-                    <datalist id="{{ library.id }}-radarr-quality-profiles"></datalist>
-                </div>
-                <div class="col-md-4">
-                    <label class="form-label" for="{{ library.id }}-attribute_radarr_availability">Availability</label>
-                    {% set radarr_availability = data['libraries'].get(library.id ~ '-attribute_radarr_availability', '') %}
-                    <select class="form-select" id="{{ library.id }}-attribute_radarr_availability"
-                        name="{{ library.id }}-attribute_radarr_availability">
-                        <option value="" {% if not radarr_availability %}selected{% endif %}>Inherit</option>
-                        <option value="announced" {% if radarr_availability == 'announced' %}selected{% endif %}>announced</option>
-                        <option value="cinemas" {% if radarr_availability == 'cinemas' %}selected{% endif %}>cinemas</option>
-                        <option value="released" {% if radarr_availability == 'released' %}selected{% endif %}>released</option>
-                        <option value="db" {% if radarr_availability == 'db' %}selected{% endif %}>db</option>
-                    </select>
-                </div>
-                <div class="col-md-4">
-                    <label class="form-label" for="{{ library.id }}-attribute_radarr_tag">Tag</label>
-                    <input type="text" class="form-control" id="{{ library.id }}-attribute_radarr_tag"
-                        name="{{ library.id }}-attribute_radarr_tag"
-                        value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_tag', '') }}">
-                </div>
-                <div class="col-md-4">
-                    <label class="form-label" for="{{ library.id }}-attribute_radarr_monitor">Monitor When Added</label>
-                    {% set radarr_monitor = data['libraries'].get(library.id ~ '-attribute_radarr_monitor', '') %}
-                    <select class="form-select" id="{{ library.id }}-attribute_radarr_monitor"
-                        name="{{ library.id }}-attribute_radarr_monitor">
-                        <option value="" {% if radarr_monitor == '' %}selected{% endif %}>Inherit</option>
-                        <option value="true" {% if radarr_monitor|string|lower == 'true' %}selected{% endif %}>True</option>
-                        <option value="false" {% if radarr_monitor|string|lower == 'false' %}selected{% endif %}>False</option>
-                    </select>
-                </div>
-                <div class="col-md-6">
-                    <label class="form-label" for="{{ library.id }}-attribute_radarr_radarr_path">Radarr Path</label>
-                    <input type="text" class="form-control" data-path-rule="radarr_path"
-                        id="{{ library.id }}-attribute_radarr_radarr_path"
-                        name="{{ library.id }}-attribute_radarr_radarr_path"
-                        value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_radarr_path', '') }}">
-                </div>
-                <div class="col-md-6">
-                    <label class="form-label" for="{{ library.id }}-attribute_radarr_plex_path">Plex Path</label>
-                    <input type="text" class="form-control" data-path-rule="plex_path"
-                        id="{{ library.id }}-attribute_radarr_plex_path"
-                        name="{{ library.id }}-attribute_radarr_plex_path"
-                        value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_plex_path', '') }}">
-                </div>
+            <div class="input-group mb-2">
+                <span class="input-group-text" id="{{ library.id }}-attribute_radarr_url_text"
+                    style="width: 560px; justify-content: space-between;">
+                    Radarr URL Override
+                    <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true"
+                        title="Enter your Radarr URL including the port. If Radarr is running in Docker, ensure it&#39;s on the same network as Kometa.">
+                        <i class="bi bi-info-circle-fill"></i>
+                    </span>
+                </span>
+                <input type="text" class="form-control" id="{{ library.id }}-attribute_radarr_url"
+                    name="{{ library.id }}-attribute_radarr_url"
+                    value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_url', '') | default('', true) }}"
+                    placeholder="Leave blank to use global Radarr URL"
+                    aria-describedby="{{ library.id }}-attribute_radarr_url_text">
             </div>
-            <div class="row g-3 mt-1">
-                {% for field, label in [
-                    ('search', 'Search'),
-                    ('add_missing', 'Add Missing'),
-                    ('add_existing', 'Add Existing'),
-                    ('upgrade_existing', 'Upgrade Existing'),
-                    ('monitor_existing', 'Monitor Existing'),
-                    ('ignore_cache', 'Ignore Cache')
-                ] %}
-                {% set field_value = data['libraries'].get(library.id ~ '-attribute_radarr_' ~ field, '') %}
-                <div class="col-md-4">
-                    <label class="form-label" for="{{ library.id }}-attribute_radarr_{{ field }}">{{ label }}</label>
-                    <select class="form-select" id="{{ library.id }}-attribute_radarr_{{ field }}"
-                        name="{{ library.id }}-attribute_radarr_{{ field }}">
-                        <option value="" {% if field_value == '' %}selected{% endif %}>Inherit</option>
-                        <option value="true" {% if field_value|string|lower == 'true' %}selected{% endif %}>True</option>
-                        <option value="false" {% if field_value|string|lower == 'false' %}selected{% endif %}>False</option>
-                    </select>
-                </div>
-                {% endfor %}
+
+            <div class="input-group mb-2">
+                <span class="input-group-text" id="{{ library.id }}-attribute_radarr_token_text"
+                    style="width: 560px; justify-content: space-between;">
+                    Radarr API Key Override
+                    <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true"
+                        title="Enter your Radarr API Key to allow Quickstart to authenticate with Radarr.">
+                        <i class="bi bi-info-circle-fill"></i>
+                    </span>
+                </span>
+                <input type="password" class="form-control" id="{{ library.id }}-attribute_radarr_token"
+                    name="{{ library.id }}-attribute_radarr_token"
+                    value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_token', '') | default('', true) }}"
+                    placeholder="Leave blank to use global Radarr token"
+                    aria-describedby="{{ library.id }}-attribute_radarr_token_text">
             </div>
+
+            <div class="input-group mb-2">
+                <span class="input-group-text" id="{{ library.id }}-attribute_radarr_root_folder_path_text"
+                    style="width: 560px; justify-content: space-between;">
+                    Root Folder Path
+                    <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true"
+                        title="Select the root folder where Radarr should store movies.">
+                        <i class="bi bi-info-circle-fill"></i>
+                    </span>
+                </span>
+                <input type="text" class="form-control" list="{{ library.id }}-radarr-root-folders"
+                    id="{{ library.id }}-attribute_radarr_root_folder_path"
+                    name="{{ library.id }}-attribute_radarr_root_folder_path"
+                    value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_root_folder_path', '') | default('', true) }}"
+                    aria-describedby="{{ library.id }}-attribute_radarr_root_folder_path_text">
+                <datalist id="{{ library.id }}-radarr-root-folders"></datalist>
+            </div>
+
+            <div class="input-group mb-2">
+                <span class="input-group-text" id="{{ library.id }}-attribute_radarr_quality_profile_text"
+                    style="width: 560px; justify-content: space-between;">
+                    Quality Profile
+                    <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true"
+                        title="Choose the quality profile that determines the preferred resolution and format for movies.">
+                        <i class="bi bi-info-circle-fill"></i>
+                    </span>
+                </span>
+                <input type="text" class="form-control" list="{{ library.id }}-radarr-quality-profiles"
+                    id="{{ library.id }}-attribute_radarr_quality_profile"
+                    name="{{ library.id }}-attribute_radarr_quality_profile"
+                    value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_quality_profile', '') | default('', true) }}"
+                    aria-describedby="{{ library.id }}-attribute_radarr_quality_profile_text">
+                <datalist id="{{ library.id }}-radarr-quality-profiles"></datalist>
+            </div>
+
+            <div class="input-group mb-2">
+                <span class="input-group-text" id="{{ library.id }}-attribute_radarr_availability_text"
+                    style="width: 560px; justify-content: space-between;">
+                    Availability
+                    <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true"
+                        title="Select when Radarr should consider a movie available for downloading.">
+                        <i class="bi bi-info-circle-fill"></i>
+                    </span>
+                </span>
+                {% set radarr_availability = data['libraries'].get(library.id ~ '-attribute_radarr_availability', '') %}
+                <select class="form-select" id="{{ library.id }}-attribute_radarr_availability"
+                    name="{{ library.id }}-attribute_radarr_availability"
+                    aria-describedby="{{ library.id }}-attribute_radarr_availability_text">
+                    <option value="" {% if not radarr_availability %}selected{% endif %}>Inherit</option>
+                    <option value="announced" {% if radarr_availability == 'announced' %}selected{% endif %}>Announced (default)</option>
+                    <option value="cinemas" {% if radarr_availability == 'cinemas' %}selected{% endif %}>Cinemas</option>
+                    <option value="released" {% if radarr_availability == 'released' %}selected{% endif %}>Released</option>
+                    <option value="db" {% if radarr_availability == 'db' %}selected{% endif %}>DB</option>
+                </select>
+            </div>
+
+            <div class="input-group mb-2">
+                <span class="input-group-text" id="{{ library.id }}-attribute_radarr_tag_text"
+                    style="width: 560px; justify-content: space-between;">
+                    Tag
+                    <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true"
+                        title="Enter a tag that will be applied to all movies added through Radarr.">
+                        <i class="bi bi-info-circle-fill"></i>
+                    </span>
+                </span>
+                <input type="text" class="form-control" id="{{ library.id }}-attribute_radarr_tag"
+                    name="{{ library.id }}-attribute_radarr_tag"
+                    value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_tag', '') | default('', true) }}"
+                    aria-describedby="{{ library.id }}-attribute_radarr_tag_text">
+            </div>
+
+            <div class="input-group mb-3">
+                <span class="input-group-text" id="{{ library.id }}-attribute_radarr_radarr_path_text"
+                    style="width: 560px; justify-content: space-between;">
+                    Radarr Path
+                    <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true"
+                        title="Specify the path Radarr should use when adding movies.">
+                        <i class="bi bi-info-circle-fill"></i>
+                    </span>
+                </span>
+                <input type="text" class="form-control" data-path-rule="radarr_path"
+                    id="{{ library.id }}-attribute_radarr_radarr_path"
+                    name="{{ library.id }}-attribute_radarr_radarr_path"
+                    value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_radarr_path', '') | default('', true) }}"
+                    aria-describedby="{{ library.id }}-attribute_radarr_radarr_path_text">
+            </div>
+
+            <div class="input-group mb-3">
+                <span class="input-group-text" id="{{ library.id }}-attribute_radarr_plex_path_text"
+                    style="width: 560px; justify-content: space-between;">
+                    Plex Path
+                    <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true"
+                        title="Set the path where Plex will find the movies added through Radarr.">
+                        <i class="bi bi-info-circle-fill"></i>
+                    </span>
+                </span>
+                <input type="text" class="form-control" data-path-rule="plex_path"
+                    id="{{ library.id }}-attribute_radarr_plex_path"
+                    name="{{ library.id }}-attribute_radarr_plex_path"
+                    value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_plex_path', '') | default('', true) }}"
+                    aria-describedby="{{ library.id }}-attribute_radarr_plex_path_text">
+            </div>
+
+            {% for field, label, tooltip in [
+                ('monitor', 'Monitor media when added', 'Enables monitoring of newly added media in Radarr.'),
+                ('search', 'Search media when added', 'Automatically searches for media when added.'),
+                ('add_missing', 'Add missing media from collections', 'Adds missing movies from collections to Radarr.'),
+                ('add_existing', 'Add existing media from collections', 'Adds already available movies from collections to Radarr.'),
+                ('upgrade_existing', 'Upgrade existing media from collections to the Quality Profile', 'Attempts to upgrade existing media to match the assigned quality profile.'),
+                ('monitor_existing', 'Set existing media from collections to monitored', 'Changes all existing media from collections to monitored in Radarr.'),
+                ('ignore_cache', "Ignore Kometa's cache when adding media", "Forces Radarr to ignore Kometa's cache when adding media, ensuring the latest data is fetched.")
+            ] %}
+            {% set field_name = library.id ~ '-attribute_radarr_' ~ field %}
+            {% set field_value = data['libraries'].get(field_name, '') %}
+            <div class="input-group mb-2">
+                <span class="input-group-text" id="{{ field_name }}_text"
+                    style="width: 560px; justify-content: space-between;">
+                    {{ label }}
+                    <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true" title="{{ tooltip }}">
+                        <i class="bi bi-info-circle-fill"></i>
+                    </span>
+                </span>
+                <select class="form-select" id="{{ field_name }}" name="{{ field_name }}"
+                    aria-describedby="{{ field_name }}_text">
+                    <option value="" {% if field_value == '' %}selected{% endif %}>Inherit</option>
+                    <option value="true" {% if field_value|string|lower == 'true' %}selected{% endif %}>True</option>
+                    <option value="false" {% if field_value|string|lower == 'false' %}selected{% endif %}>False</option>
+                </select>
+            </div>
+            {% endfor %}
         </div>
     </div>
 </div>

--- a/templates/partials/_library_radarr_overrides.html
+++ b/templates/partials/_library_radarr_overrides.html
@@ -1,0 +1,115 @@
+<div class="accordion-item library-advanced-section d-none" data-advanced-section>
+    <h2 class="accordion-header">
+        <button class="accordion-button" type="button" data-bs-toggle="collapse"
+            data-bs-target="#{{ library.id }}-radarr-overrides">
+            Radarr Overrides
+        </button>
+    </h2>
+    <div id="{{ library.id }}-radarr-overrides" class="accordion-collapse collapse">
+        <div class="accordion-body">
+            <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+                <div class="small text-muted">Blank values inherit the global Radarr page setting.</div>
+                <button type="button" class="btn btn-outline-info btn-sm" data-validate-library-service="radarr"
+                    data-library-id="{{ library.id }}">
+                    Validate Radarr Overrides
+                </button>
+            </div>
+            <div class="alert d-none small mb-3" role="alert" data-library-service-status="radarr"></div>
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <label class="form-label" for="{{ library.id }}-attribute_radarr_url">Radarr URL Override</label>
+                    <input type="text" class="form-control" id="{{ library.id }}-attribute_radarr_url"
+                        name="{{ library.id }}-attribute_radarr_url"
+                        value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_url', '') }}"
+                        placeholder="Leave blank to use global Radarr URL">
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label" for="{{ library.id }}-attribute_radarr_token">Radarr Token Override</label>
+                    <input type="password" class="form-control" id="{{ library.id }}-attribute_radarr_token"
+                        name="{{ library.id }}-attribute_radarr_token"
+                        value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_token', '') }}"
+                        placeholder="Leave blank to use global Radarr token">
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label" for="{{ library.id }}-attribute_radarr_root_folder_path">Root Folder Path</label>
+                    <input type="text" class="form-control" list="{{ library.id }}-radarr-root-folders"
+                        id="{{ library.id }}-attribute_radarr_root_folder_path"
+                        name="{{ library.id }}-attribute_radarr_root_folder_path"
+                        value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_root_folder_path', '') }}">
+                    <datalist id="{{ library.id }}-radarr-root-folders"></datalist>
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label" for="{{ library.id }}-attribute_radarr_quality_profile">Quality Profile</label>
+                    <input type="text" class="form-control" list="{{ library.id }}-radarr-quality-profiles"
+                        id="{{ library.id }}-attribute_radarr_quality_profile"
+                        name="{{ library.id }}-attribute_radarr_quality_profile"
+                        value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_quality_profile', '') }}">
+                    <datalist id="{{ library.id }}-radarr-quality-profiles"></datalist>
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label" for="{{ library.id }}-attribute_radarr_availability">Availability</label>
+                    {% set radarr_availability = data['libraries'].get(library.id ~ '-attribute_radarr_availability', '') %}
+                    <select class="form-select" id="{{ library.id }}-attribute_radarr_availability"
+                        name="{{ library.id }}-attribute_radarr_availability">
+                        <option value="" {% if not radarr_availability %}selected{% endif %}>Inherit</option>
+                        <option value="announced" {% if radarr_availability == 'announced' %}selected{% endif %}>announced</option>
+                        <option value="cinemas" {% if radarr_availability == 'cinemas' %}selected{% endif %}>cinemas</option>
+                        <option value="released" {% if radarr_availability == 'released' %}selected{% endif %}>released</option>
+                        <option value="db" {% if radarr_availability == 'db' %}selected{% endif %}>db</option>
+                    </select>
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label" for="{{ library.id }}-attribute_radarr_tag">Tag</label>
+                    <input type="text" class="form-control" id="{{ library.id }}-attribute_radarr_tag"
+                        name="{{ library.id }}-attribute_radarr_tag"
+                        value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_tag', '') }}">
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label" for="{{ library.id }}-attribute_radarr_monitor">Monitor When Added</label>
+                    {% set radarr_monitor = data['libraries'].get(library.id ~ '-attribute_radarr_monitor', '') %}
+                    <select class="form-select" id="{{ library.id }}-attribute_radarr_monitor"
+                        name="{{ library.id }}-attribute_radarr_monitor">
+                        <option value="" {% if radarr_monitor == '' %}selected{% endif %}>Inherit</option>
+                        <option value="true" {% if radarr_monitor|string|lower == 'true' %}selected{% endif %}>True</option>
+                        <option value="false" {% if radarr_monitor|string|lower == 'false' %}selected{% endif %}>False</option>
+                    </select>
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label" for="{{ library.id }}-attribute_radarr_radarr_path">Radarr Path</label>
+                    <input type="text" class="form-control" data-path-rule="radarr_path"
+                        id="{{ library.id }}-attribute_radarr_radarr_path"
+                        name="{{ library.id }}-attribute_radarr_radarr_path"
+                        value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_radarr_path', '') }}">
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label" for="{{ library.id }}-attribute_radarr_plex_path">Plex Path</label>
+                    <input type="text" class="form-control" data-path-rule="plex_path"
+                        id="{{ library.id }}-attribute_radarr_plex_path"
+                        name="{{ library.id }}-attribute_radarr_plex_path"
+                        value="{{ data['libraries'].get(library.id ~ '-attribute_radarr_plex_path', '') }}">
+                </div>
+            </div>
+            <div class="row g-3 mt-1">
+                {% for field, label in [
+                    ('search', 'Search'),
+                    ('add_missing', 'Add Missing'),
+                    ('add_existing', 'Add Existing'),
+                    ('upgrade_existing', 'Upgrade Existing'),
+                    ('monitor_existing', 'Monitor Existing'),
+                    ('ignore_cache', 'Ignore Cache')
+                ] %}
+                {% set field_value = data['libraries'].get(library.id ~ '-attribute_radarr_' ~ field, '') %}
+                <div class="col-md-4">
+                    <label class="form-label" for="{{ library.id }}-attribute_radarr_{{ field }}">{{ label }}</label>
+                    <select class="form-select" id="{{ library.id }}-attribute_radarr_{{ field }}"
+                        name="{{ library.id }}-attribute_radarr_{{ field }}">
+                        <option value="" {% if field_value == '' %}selected{% endif %}>Inherit</option>
+                        <option value="true" {% if field_value|string|lower == 'true' %}selected{% endif %}>True</option>
+                        <option value="false" {% if field_value|string|lower == 'false' %}selected{% endif %}>False</option>
+                    </select>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/partials/_library_sonarr_overrides.html
+++ b/templates/partials/_library_sonarr_overrides.html
@@ -62,6 +62,12 @@
                     value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_token', '') | default('', true) }}"
                     placeholder="Leave blank to use global Sonarr token"
                     aria-describedby="{{ library.id }}-attribute_sonarr_token_text">
+                <button class="btn btn-outline-secondary" type="button"
+                    data-toggle-secret-visibility
+                    data-target-input="{{ library.id }}-attribute_sonarr_token"
+                    aria-label="Toggle Sonarr API key visibility">
+                    <i class="fas fa-eye"></i>
+                </button>
             </div>
 
             <div class="input-group mb-2">

--- a/templates/partials/_library_sonarr_overrides.html
+++ b/templates/partials/_library_sonarr_overrides.html
@@ -1,0 +1,130 @@
+<div class="accordion-item library-advanced-section d-none" data-advanced-section>
+    <h2 class="accordion-header">
+        <button class="accordion-button" type="button" data-bs-toggle="collapse"
+            data-bs-target="#{{ library.id }}-sonarr-overrides">
+            Sonarr Overrides
+        </button>
+    </h2>
+    <div id="{{ library.id }}-sonarr-overrides" class="accordion-collapse collapse">
+        <div class="accordion-body">
+            <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+                <div class="small text-muted">Blank values inherit the global Sonarr page setting.</div>
+                <button type="button" class="btn btn-outline-info btn-sm" data-validate-library-service="sonarr"
+                    data-library-id="{{ library.id }}">
+                    Validate Sonarr Overrides
+                </button>
+            </div>
+            <div class="alert d-none small mb-3" role="alert" data-library-service-status="sonarr"></div>
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <label class="form-label" for="{{ library.id }}-attribute_sonarr_url">Sonarr URL Override</label>
+                    <input type="text" class="form-control" id="{{ library.id }}-attribute_sonarr_url"
+                        name="{{ library.id }}-attribute_sonarr_url"
+                        value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_url', '') }}"
+                        placeholder="Leave blank to use global Sonarr URL">
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label" for="{{ library.id }}-attribute_sonarr_token">Sonarr Token Override</label>
+                    <input type="password" class="form-control" id="{{ library.id }}-attribute_sonarr_token"
+                        name="{{ library.id }}-attribute_sonarr_token"
+                        value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_token', '') }}"
+                        placeholder="Leave blank to use global Sonarr token">
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label" for="{{ library.id }}-attribute_sonarr_root_folder_path">Root Folder Path</label>
+                    <input type="text" class="form-control" list="{{ library.id }}-sonarr-root-folders"
+                        id="{{ library.id }}-attribute_sonarr_root_folder_path"
+                        name="{{ library.id }}-attribute_sonarr_root_folder_path"
+                        value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_root_folder_path', '') }}">
+                    <datalist id="{{ library.id }}-sonarr-root-folders"></datalist>
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label" for="{{ library.id }}-attribute_sonarr_quality_profile">Quality Profile</label>
+                    <input type="text" class="form-control" list="{{ library.id }}-sonarr-quality-profiles"
+                        id="{{ library.id }}-attribute_sonarr_quality_profile"
+                        name="{{ library.id }}-attribute_sonarr_quality_profile"
+                        value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_quality_profile', '') }}">
+                    <datalist id="{{ library.id }}-sonarr-quality-profiles"></datalist>
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label" for="{{ library.id }}-attribute_sonarr_language_profile">Language Profile</label>
+                    <input type="text" class="form-control" list="{{ library.id }}-sonarr-language-profiles"
+                        id="{{ library.id }}-attribute_sonarr_language_profile"
+                        name="{{ library.id }}-attribute_sonarr_language_profile"
+                        value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_language_profile', '') }}">
+                    <datalist id="{{ library.id }}-sonarr-language-profiles"></datalist>
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label" for="{{ library.id }}-attribute_sonarr_series_type">Series Type</label>
+                    {% set sonarr_series_type = data['libraries'].get(library.id ~ '-attribute_sonarr_series_type', '') %}
+                    <select class="form-select" id="{{ library.id }}-attribute_sonarr_series_type"
+                        name="{{ library.id }}-attribute_sonarr_series_type">
+                        <option value="" {% if not sonarr_series_type %}selected{% endif %}>Inherit</option>
+                        <option value="standard" {% if sonarr_series_type == 'standard' %}selected{% endif %}>standard</option>
+                        <option value="daily" {% if sonarr_series_type == 'daily' %}selected{% endif %}>daily</option>
+                        <option value="anime" {% if sonarr_series_type == 'anime' %}selected{% endif %}>anime</option>
+                    </select>
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label" for="{{ library.id }}-attribute_sonarr_monitor">Monitor</label>
+                    {% set sonarr_monitor = data['libraries'].get(library.id ~ '-attribute_sonarr_monitor', '') %}
+                    <select class="form-select" id="{{ library.id }}-attribute_sonarr_monitor"
+                        name="{{ library.id }}-attribute_sonarr_monitor">
+                        <option value="" {% if not sonarr_monitor %}selected{% endif %}>Inherit</option>
+                        <option value="all" {% if sonarr_monitor == 'all' %}selected{% endif %}>all</option>
+                        <option value="none" {% if sonarr_monitor == 'none' %}selected{% endif %}>none</option>
+                        <option value="future" {% if sonarr_monitor == 'future' %}selected{% endif %}>future</option>
+                        <option value="missing" {% if sonarr_monitor == 'missing' %}selected{% endif %}>missing</option>
+                        <option value="existing" {% if sonarr_monitor == 'existing' %}selected{% endif %}>existing</option>
+                        <option value="pilot" {% if sonarr_monitor == 'pilot' %}selected{% endif %}>pilot</option>
+                        <option value="first" {% if sonarr_monitor == 'first' %}selected{% endif %}>first</option>
+                        <option value="latest" {% if sonarr_monitor == 'latest' %}selected{% endif %}>latest</option>
+                    </select>
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label" for="{{ library.id }}-attribute_sonarr_tag">Tag</label>
+                    <input type="text" class="form-control" id="{{ library.id }}-attribute_sonarr_tag"
+                        name="{{ library.id }}-attribute_sonarr_tag"
+                        value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_tag', '') }}">
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label" for="{{ library.id }}-attribute_sonarr_sonarr_path">Sonarr Path</label>
+                    <input type="text" class="form-control" data-path-rule="sonarr_path"
+                        id="{{ library.id }}-attribute_sonarr_sonarr_path"
+                        name="{{ library.id }}-attribute_sonarr_sonarr_path"
+                        value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_sonarr_path', '') }}">
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label" for="{{ library.id }}-attribute_sonarr_plex_path">Plex Path</label>
+                    <input type="text" class="form-control" data-path-rule="plex_path"
+                        id="{{ library.id }}-attribute_sonarr_plex_path"
+                        name="{{ library.id }}-attribute_sonarr_plex_path"
+                        value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_plex_path', '') }}">
+                </div>
+            </div>
+            <div class="row g-3 mt-1">
+                {% for field, label in [
+                    ('season_folder', 'Season Folder'),
+                    ('search', 'Search'),
+                    ('cutoff_search', 'Cutoff Search'),
+                    ('add_missing', 'Add Missing'),
+                    ('add_existing', 'Add Existing'),
+                    ('upgrade_existing', 'Upgrade Existing'),
+                    ('monitor_existing', 'Monitor Existing'),
+                    ('ignore_cache', 'Ignore Cache')
+                ] %}
+                {% set field_value = data['libraries'].get(library.id ~ '-attribute_sonarr_' ~ field, '') %}
+                <div class="col-md-3">
+                    <label class="form-label" for="{{ library.id }}-attribute_sonarr_{{ field }}">{{ label }}</label>
+                    <select class="form-select" id="{{ library.id }}-attribute_sonarr_{{ field }}"
+                        name="{{ library.id }}-attribute_sonarr_{{ field }}">
+                        <option value="" {% if field_value == '' %}selected{% endif %}>Inherit</option>
+                        <option value="true" {% if field_value|string|lower == 'true' %}selected{% endif %}>True</option>
+                        <option value="false" {% if field_value|string|lower == 'false' %}selected{% endif %}>False</option>
+                    </select>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/partials/_library_sonarr_overrides.html
+++ b/templates/partials/_library_sonarr_overrides.html
@@ -7,124 +7,234 @@
     </h2>
     <div id="{{ library.id }}-sonarr-overrides" class="accordion-collapse collapse">
         <div class="accordion-body">
+            <div class="alert alert-success small mb-3" role="alert">
+                Enter your Sonarr URL and token override only if this library should use a different Sonarr instance than the global
+                Sonarr page. Then validate the override and complete the rest of the form. The token can be found in
+                Sonarr &gt; Settings &gt; General &gt; Security &gt; API Key.
+                <div class="mt-2">
+                    <a href="https://kometa.wiki/en/nightly/config/sonarr/" target="_blank" rel="noopener noreferrer">
+                        Click Here
+                    </a>
+                    to go to the Kometa wiki for this connector.
+                </div>
+            </div>
             <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
                 <div class="small text-muted">Blank values inherit the global Sonarr page setting.</div>
-                <button type="button" class="btn btn-outline-info btn-sm" data-validate-library-service="sonarr"
+                <button type="button" class="btn btn-success btn-sm" data-validate-library-service="sonarr"
                     data-library-id="{{ library.id }}">
                     Validate Sonarr Overrides
                 </button>
             </div>
+            <input type="hidden" name="{{ library.id }}-library_service_sonarr_validated"
+                value="{{ data['libraries'].get(library.id ~ '-library_service_sonarr_validated', '') }}"
+                data-library-service-validated="sonarr">
+            <input type="hidden" name="{{ library.id }}-library_service_sonarr_validated_at"
+                value="{{ data['libraries'].get(library.id ~ '-library_service_sonarr_validated_at', '') }}"
+                data-library-service-validated-at="sonarr">
             <div class="alert d-none small mb-3" role="alert" data-library-service-status="sonarr"></div>
-            <div class="row g-3">
-                <div class="col-md-6">
-                    <label class="form-label" for="{{ library.id }}-attribute_sonarr_url">Sonarr URL Override</label>
-                    <input type="text" class="form-control" id="{{ library.id }}-attribute_sonarr_url"
-                        name="{{ library.id }}-attribute_sonarr_url"
-                        value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_url', '') }}"
-                        placeholder="Leave blank to use global Sonarr URL">
-                </div>
-                <div class="col-md-6">
-                    <label class="form-label" for="{{ library.id }}-attribute_sonarr_token">Sonarr Token Override</label>
-                    <input type="password" class="form-control" id="{{ library.id }}-attribute_sonarr_token"
-                        name="{{ library.id }}-attribute_sonarr_token"
-                        value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_token', '') }}"
-                        placeholder="Leave blank to use global Sonarr token">
-                </div>
-                <div class="col-md-4">
-                    <label class="form-label" for="{{ library.id }}-attribute_sonarr_root_folder_path">Root Folder Path</label>
-                    <input type="text" class="form-control" list="{{ library.id }}-sonarr-root-folders"
-                        id="{{ library.id }}-attribute_sonarr_root_folder_path"
-                        name="{{ library.id }}-attribute_sonarr_root_folder_path"
-                        value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_root_folder_path', '') }}">
-                    <datalist id="{{ library.id }}-sonarr-root-folders"></datalist>
-                </div>
-                <div class="col-md-4">
-                    <label class="form-label" for="{{ library.id }}-attribute_sonarr_quality_profile">Quality Profile</label>
-                    <input type="text" class="form-control" list="{{ library.id }}-sonarr-quality-profiles"
-                        id="{{ library.id }}-attribute_sonarr_quality_profile"
-                        name="{{ library.id }}-attribute_sonarr_quality_profile"
-                        value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_quality_profile', '') }}">
-                    <datalist id="{{ library.id }}-sonarr-quality-profiles"></datalist>
-                </div>
-                <div class="col-md-4">
-                    <label class="form-label" for="{{ library.id }}-attribute_sonarr_language_profile">Language Profile</label>
-                    <input type="text" class="form-control" list="{{ library.id }}-sonarr-language-profiles"
-                        id="{{ library.id }}-attribute_sonarr_language_profile"
-                        name="{{ library.id }}-attribute_sonarr_language_profile"
-                        value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_language_profile', '') }}">
-                    <datalist id="{{ library.id }}-sonarr-language-profiles"></datalist>
-                </div>
-                <div class="col-md-4">
-                    <label class="form-label" for="{{ library.id }}-attribute_sonarr_series_type">Series Type</label>
-                    {% set sonarr_series_type = data['libraries'].get(library.id ~ '-attribute_sonarr_series_type', '') %}
-                    <select class="form-select" id="{{ library.id }}-attribute_sonarr_series_type"
-                        name="{{ library.id }}-attribute_sonarr_series_type">
-                        <option value="" {% if not sonarr_series_type %}selected{% endif %}>Inherit</option>
-                        <option value="standard" {% if sonarr_series_type == 'standard' %}selected{% endif %}>standard</option>
-                        <option value="daily" {% if sonarr_series_type == 'daily' %}selected{% endif %}>daily</option>
-                        <option value="anime" {% if sonarr_series_type == 'anime' %}selected{% endif %}>anime</option>
-                    </select>
-                </div>
-                <div class="col-md-4">
-                    <label class="form-label" for="{{ library.id }}-attribute_sonarr_monitor">Monitor</label>
-                    {% set sonarr_monitor = data['libraries'].get(library.id ~ '-attribute_sonarr_monitor', '') %}
-                    <select class="form-select" id="{{ library.id }}-attribute_sonarr_monitor"
-                        name="{{ library.id }}-attribute_sonarr_monitor">
-                        <option value="" {% if not sonarr_monitor %}selected{% endif %}>Inherit</option>
-                        <option value="all" {% if sonarr_monitor == 'all' %}selected{% endif %}>all</option>
-                        <option value="none" {% if sonarr_monitor == 'none' %}selected{% endif %}>none</option>
-                        <option value="future" {% if sonarr_monitor == 'future' %}selected{% endif %}>future</option>
-                        <option value="missing" {% if sonarr_monitor == 'missing' %}selected{% endif %}>missing</option>
-                        <option value="existing" {% if sonarr_monitor == 'existing' %}selected{% endif %}>existing</option>
-                        <option value="pilot" {% if sonarr_monitor == 'pilot' %}selected{% endif %}>pilot</option>
-                        <option value="first" {% if sonarr_monitor == 'first' %}selected{% endif %}>first</option>
-                        <option value="latest" {% if sonarr_monitor == 'latest' %}selected{% endif %}>latest</option>
-                    </select>
-                </div>
-                <div class="col-md-4">
-                    <label class="form-label" for="{{ library.id }}-attribute_sonarr_tag">Tag</label>
-                    <input type="text" class="form-control" id="{{ library.id }}-attribute_sonarr_tag"
-                        name="{{ library.id }}-attribute_sonarr_tag"
-                        value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_tag', '') }}">
-                </div>
-                <div class="col-md-6">
-                    <label class="form-label" for="{{ library.id }}-attribute_sonarr_sonarr_path">Sonarr Path</label>
-                    <input type="text" class="form-control" data-path-rule="sonarr_path"
-                        id="{{ library.id }}-attribute_sonarr_sonarr_path"
-                        name="{{ library.id }}-attribute_sonarr_sonarr_path"
-                        value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_sonarr_path', '') }}">
-                </div>
-                <div class="col-md-6">
-                    <label class="form-label" for="{{ library.id }}-attribute_sonarr_plex_path">Plex Path</label>
-                    <input type="text" class="form-control" data-path-rule="plex_path"
-                        id="{{ library.id }}-attribute_sonarr_plex_path"
-                        name="{{ library.id }}-attribute_sonarr_plex_path"
-                        value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_plex_path', '') }}">
-                </div>
+            <div class="input-group mb-2">
+                <span class="input-group-text" id="{{ library.id }}-attribute_sonarr_url_text"
+                    style="width: 560px; justify-content: space-between;">
+                    Sonarr URL Override
+                    <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true"
+                        title="You must provide the direct address you use to access your Sonarr server, including the port.">
+                        <i class="bi bi-info-circle-fill"></i>
+                    </span>
+                </span>
+                <input type="text" class="form-control" id="{{ library.id }}-attribute_sonarr_url"
+                    name="{{ library.id }}-attribute_sonarr_url"
+                    value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_url', '') | default('', true) }}"
+                    placeholder="Leave blank to use global Sonarr URL"
+                    aria-describedby="{{ library.id }}-attribute_sonarr_url_text">
             </div>
-            <div class="row g-3 mt-1">
-                {% for field, label in [
-                    ('season_folder', 'Season Folder'),
-                    ('search', 'Search'),
-                    ('cutoff_search', 'Cutoff Search'),
-                    ('add_missing', 'Add Missing'),
-                    ('add_existing', 'Add Existing'),
-                    ('upgrade_existing', 'Upgrade Existing'),
-                    ('monitor_existing', 'Monitor Existing'),
-                    ('ignore_cache', 'Ignore Cache')
-                ] %}
-                {% set field_value = data['libraries'].get(library.id ~ '-attribute_sonarr_' ~ field, '') %}
-                <div class="col-md-3">
-                    <label class="form-label" for="{{ library.id }}-attribute_sonarr_{{ field }}">{{ label }}</label>
-                    <select class="form-select" id="{{ library.id }}-attribute_sonarr_{{ field }}"
-                        name="{{ library.id }}-attribute_sonarr_{{ field }}">
-                        <option value="" {% if field_value == '' %}selected{% endif %}>Inherit</option>
-                        <option value="true" {% if field_value|string|lower == 'true' %}selected{% endif %}>True</option>
-                        <option value="false" {% if field_value|string|lower == 'false' %}selected{% endif %}>False</option>
-                    </select>
-                </div>
-                {% endfor %}
+
+            <div class="input-group mb-2">
+                <span class="input-group-text" id="{{ library.id }}-attribute_sonarr_token_text"
+                    style="width: 560px; justify-content: space-between;">
+                    Sonarr API Key Override
+                    <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true"
+                        title="Enter your Sonarr API Key to allow Quickstart to authenticate with Sonarr.">
+                        <i class="bi bi-info-circle-fill"></i>
+                    </span>
+                </span>
+                <input type="password" class="form-control" id="{{ library.id }}-attribute_sonarr_token"
+                    name="{{ library.id }}-attribute_sonarr_token"
+                    value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_token', '') | default('', true) }}"
+                    placeholder="Leave blank to use global Sonarr token"
+                    aria-describedby="{{ library.id }}-attribute_sonarr_token_text">
             </div>
+
+            <div class="input-group mb-2">
+                <span class="input-group-text" id="{{ library.id }}-attribute_sonarr_root_folder_path_text"
+                    style="width: 560px; justify-content: space-between;">
+                    Root Folder Path
+                    <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true"
+                        title="Select the root folder where Sonarr should store TV shows.">
+                        <i class="bi bi-info-circle-fill"></i>
+                    </span>
+                </span>
+                <input type="text" class="form-control" list="{{ library.id }}-sonarr-root-folders"
+                    id="{{ library.id }}-attribute_sonarr_root_folder_path"
+                    name="{{ library.id }}-attribute_sonarr_root_folder_path"
+                    value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_root_folder_path', '') | default('', true) }}"
+                    aria-describedby="{{ library.id }}-attribute_sonarr_root_folder_path_text">
+                <datalist id="{{ library.id }}-sonarr-root-folders"></datalist>
+            </div>
+
+            <div class="input-group mb-2">
+                <span class="input-group-text" id="{{ library.id }}-attribute_sonarr_quality_profile_text"
+                    style="width: 560px; justify-content: space-between;">
+                    Quality Profile
+                    <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true"
+                        title="Choose the quality profile that determines the preferred resolution and format for TV shows.">
+                        <i class="bi bi-info-circle-fill"></i>
+                    </span>
+                </span>
+                <input type="text" class="form-control" list="{{ library.id }}-sonarr-quality-profiles"
+                    id="{{ library.id }}-attribute_sonarr_quality_profile"
+                    name="{{ library.id }}-attribute_sonarr_quality_profile"
+                    value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_quality_profile', '') | default('', true) }}"
+                    aria-describedby="{{ library.id }}-attribute_sonarr_quality_profile_text">
+                <datalist id="{{ library.id }}-sonarr-quality-profiles"></datalist>
+            </div>
+
+            <div class="input-group mb-2">
+                <span class="input-group-text" id="{{ library.id }}-attribute_sonarr_language_profile_text"
+                    style="width: 560px; justify-content: space-between;">
+                    Language Profile
+                    <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true"
+                        title="Select the preferred language for downloaded TV shows.">
+                        <i class="bi bi-info-circle-fill"></i>
+                    </span>
+                </span>
+                <input type="text" class="form-control" list="{{ library.id }}-sonarr-language-profiles"
+                    id="{{ library.id }}-attribute_sonarr_language_profile"
+                    name="{{ library.id }}-attribute_sonarr_language_profile"
+                    value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_language_profile', '') | default('', true) }}"
+                    aria-describedby="{{ library.id }}-attribute_sonarr_language_profile_text">
+                <datalist id="{{ library.id }}-sonarr-language-profiles"></datalist>
+            </div>
+
+            <div class="input-group mb-2">
+                <span class="input-group-text" id="{{ library.id }}-attribute_sonarr_series_type_text"
+                    style="width: 560px; justify-content: space-between;">
+                    Series Type
+                    <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true"
+                        title="Choose the type of TV series (Standard, Daily, or Anime).">
+                        <i class="bi bi-info-circle-fill"></i>
+                    </span>
+                </span>
+                {% set sonarr_series_type = data['libraries'].get(library.id ~ '-attribute_sonarr_series_type', '') %}
+                <select class="form-select" id="{{ library.id }}-attribute_sonarr_series_type"
+                    name="{{ library.id }}-attribute_sonarr_series_type"
+                    aria-describedby="{{ library.id }}-attribute_sonarr_series_type_text">
+                    <option value="" {% if not sonarr_series_type %}selected{% endif %}>Inherit</option>
+                    <option value="standard" {% if sonarr_series_type == 'standard' %}selected{% endif %}>Standard (default)</option>
+                    <option value="daily" {% if sonarr_series_type == 'daily' %}selected{% endif %}>Daily</option>
+                    <option value="anime" {% if sonarr_series_type == 'anime' %}selected{% endif %}>Anime</option>
+                </select>
+            </div>
+
+            <div class="input-group mb-2">
+                <span class="input-group-text" id="{{ library.id }}-attribute_sonarr_monitor_text"
+                    style="width: 560px; justify-content: space-between;">
+                    Monitor
+                    <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true"
+                        title="Choose how Sonarr monitors episodes when adding a show.">
+                        <i class="bi bi-info-circle-fill"></i>
+                    </span>
+                </span>
+                {% set sonarr_monitor = data['libraries'].get(library.id ~ '-attribute_sonarr_monitor', '') %}
+                <select class="form-select" id="{{ library.id }}-attribute_sonarr_monitor"
+                    name="{{ library.id }}-attribute_sonarr_monitor"
+                    aria-describedby="{{ library.id }}-attribute_sonarr_monitor_text">
+                    <option value="" {% if not sonarr_monitor %}selected{% endif %}>Inherit</option>
+                    <option value="all" {% if sonarr_monitor == 'all' %}selected{% endif %}>all (default) - monitor all episodes except specials</option>
+                    <option value="none" {% if sonarr_monitor == 'none' %}selected{% endif %}>none - Do not monitor any episodes</option>
+                    <option value="future" {% if sonarr_monitor == 'future' %}selected{% endif %}>future - monitor episodes that have not aired yet</option>
+                    <option value="missing" {% if sonarr_monitor == 'missing' %}selected{% endif %}>missing - monitor episodes that do not have files or have not aired yet</option>
+                    <option value="existing" {% if sonarr_monitor == 'existing' %}selected{% endif %}>existing - monitor episodes that have files or have not aired yet</option>
+                    <option value="pilot" {% if sonarr_monitor == 'pilot' %}selected{% endif %}>pilot - monitor the first episode, all others will be ignored</option>
+                    <option value="first" {% if sonarr_monitor == 'first' %}selected{% endif %}>first - monitor all episodes of the first season only</option>
+                    <option value="latest" {% if sonarr_monitor == 'latest' %}selected{% endif %}>latest - monitor all episodes of the latest season and future seasons</option>
+                </select>
+            </div>
+
+            <div class="input-group mb-2">
+                <span class="input-group-text" id="{{ library.id }}-attribute_sonarr_tag_text"
+                    style="width: 560px; justify-content: space-between;">
+                    Tag
+                    <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true"
+                        title="Enter a tag that will be applied to all shows added through Sonarr.">
+                        <i class="bi bi-info-circle-fill"></i>
+                    </span>
+                </span>
+                <input type="text" class="form-control" id="{{ library.id }}-attribute_sonarr_tag"
+                    name="{{ library.id }}-attribute_sonarr_tag"
+                    value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_tag', '') | default('', true) }}"
+                    aria-describedby="{{ library.id }}-attribute_sonarr_tag_text">
+            </div>
+
+            <div class="input-group mb-3">
+                <span class="input-group-text" id="{{ library.id }}-attribute_sonarr_sonarr_path_text"
+                    style="width: 560px; justify-content: space-between;">
+                    Sonarr Path
+                    <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true"
+                        title="Specify the path Sonarr should use when adding shows.">
+                        <i class="bi bi-info-circle-fill"></i>
+                    </span>
+                </span>
+                <input type="text" class="form-control" data-path-rule="sonarr_path"
+                    id="{{ library.id }}-attribute_sonarr_sonarr_path"
+                    name="{{ library.id }}-attribute_sonarr_sonarr_path"
+                    value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_sonarr_path', '') | default('', true) }}"
+                    aria-describedby="{{ library.id }}-attribute_sonarr_sonarr_path_text">
+            </div>
+
+            <div class="input-group mb-3">
+                <span class="input-group-text" id="{{ library.id }}-attribute_sonarr_plex_path_text"
+                    style="width: 560px; justify-content: space-between;">
+                    Plex Path
+                    <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true"
+                        title="Set the path where Plex will find the shows added through Sonarr.">
+                        <i class="bi bi-info-circle-fill"></i>
+                    </span>
+                </span>
+                <input type="text" class="form-control" data-path-rule="plex_path"
+                    id="{{ library.id }}-attribute_sonarr_plex_path"
+                    name="{{ library.id }}-attribute_sonarr_plex_path"
+                    value="{{ data['libraries'].get(library.id ~ '-attribute_sonarr_plex_path', '') | default('', true) }}"
+                    aria-describedby="{{ library.id }}-attribute_sonarr_plex_path_text">
+            </div>
+
+            {% for field, label, tooltip in [
+                ('search', 'Search for media when added', 'Automatically searches for episodes when added.'),
+                ('season_folder', 'Use the Season Folder option when adding new media', 'Enables the Season Folder setting when adding new media.'),
+                ('add_missing', 'Add missing media from collections', 'Adds missing TV shows from collections to Sonarr.'),
+                ('add_existing', 'Add existing media from collections', 'Adds already available TV shows from collections to Sonarr.'),
+                ('upgrade_existing', 'Upgrade existing media from collections to the Quality Profile', 'Upgrades existing TV shows to match the assigned quality profile.'),
+                ('monitor_existing', 'Set existing media from collections to monitored', 'Marks all existing media from collections as monitored in Sonarr.'),
+                ('cutoff_search', 'Start search for cutoff unmet episodes when adding new media', "Searches for better quality versions if the current episode doesn't meet the cutoff."),
+                ('ignore_cache', "Ignore Kometa's cache when adding media", "Forces Sonarr to ignore Kometa's cache when adding media, ensuring the latest data is fetched.")
+            ] %}
+            {% set field_name = library.id ~ '-attribute_sonarr_' ~ field %}
+            {% set field_value = data['libraries'].get(field_name, '') %}
+            <div class="input-group mb-2">
+                <span class="input-group-text" id="{{ field_name }}_text"
+                    style="width: 560px; justify-content: space-between;">
+                    {{ label }}
+                    <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true" title="{{ tooltip }}">
+                        <i class="bi bi-info-circle-fill"></i>
+                    </span>
+                </span>
+                <select class="form-select" id="{{ field_name }}" name="{{ field_name }}"
+                    aria-describedby="{{ field_name }}_text">
+                    <option value="" {% if field_value == '' %}selected{% endif %}>Inherit</option>
+                    <option value="true" {% if field_value|string|lower == 'true' %}selected{% endif %}>True</option>
+                    <option value="false" {% if field_value|string|lower == 'false' %}selected{% endif %}>False</option>
+                </select>
+            </div>
+            {% endfor %}
         </div>
     </div>
 </div>

--- a/templates/partials/_movie_collections.html
+++ b/templates/partials/_movie_collections.html
@@ -3,8 +3,6 @@
   to it's wiki page.</p>
   {% import 'partials/_macros.html' as macros %}
 
-  {% for group in collection_config %}
-  {{ macros.collection_group_section(library, data, version_info, group, telemetry) }}
-  {% endfor %}
-
-{% include "partials/_library_collection_files.html" %}
+{% for group in collection_config %}
+{{ macros.collection_group_section(library, data, version_info, group, telemetry) }}
+{% endfor %}

--- a/templates/partials/_movie_library_settings.html
+++ b/templates/partials/_movie_library_settings.html
@@ -47,7 +47,9 @@
             </div>
         </div>
 
+        {% include "partials/_library_collection_files_accordion.html" %}
         {% include "partials/_library_metadata_files.html" %}
+        {% include "partials/_library_radarr_overrides.html" %}
 
         <!-- Movie Playlists -->
         {% include "partials/_library_playlists.html" %}

--- a/templates/partials/_show_collections.html
+++ b/templates/partials/_show_collections.html
@@ -3,8 +3,6 @@
   to it's wiki page.</p>
   {% import 'partials/_macros.html' as macros %}
 
-  {% for group in collection_config %}
-  {{ macros.collection_group_section(library, data, version_info, group, telemetry) }}
-  {% endfor %}
-
-{% include "partials/_library_collection_files.html" %}
+{% for group in collection_config %}
+{{ macros.collection_group_section(library, data, version_info, group, telemetry) }}
+{% endfor %}

--- a/templates/partials/_show_library_settings.html
+++ b/templates/partials/_show_library_settings.html
@@ -47,7 +47,9 @@
             </div>
         </div>
 
+        {% include "partials/_library_collection_files_accordion.html" %}
         {% include "partials/_library_metadata_files.html" %}
+        {% include "partials/_library_sonarr_overrides.html" %}
 
         <!-- Show Playlists -->
         {% include "partials/_library_playlists.html" %}

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -663,6 +663,55 @@ def test_build_libraries_section_emits_collection_files(app):
         ]
 
 
+def test_build_libraries_section_emits_library_arr_overrides(app):
+    from modules import output
+
+    with app.app_context():
+        libraries_section = output.build_libraries_section(
+            {"mov-library_movies-library": "Movies"},
+            {"sho-library_shows-library": "Shows"},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {
+                "movies": {
+                    "mov-library_movies-attribute_radarr_url": "http://radarr.local:7878",
+                    "mov-library_movies-attribute_radarr_quality_profile": "HD-1080p",
+                    "mov-library_movies-attribute_radarr_search": "true",
+                    "mov-library_movies-attribute_radarr_add_existing": "false",
+                }
+            },
+            {
+                "shows": {
+                    "sho-library_shows-attribute_sonarr_url": "http://sonarr.local:8989",
+                    "sho-library_shows-attribute_sonarr_language_profile": "English",
+                    "sho-library_shows-attribute_sonarr_monitor": "future",
+                    "sho-library_shows-attribute_sonarr_season_folder": "true",
+                }
+            },
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+        )
+
+    movies = libraries_section["libraries"]["Movies"]["radarr"]
+    shows = libraries_section["libraries"]["Shows"]["sonarr"]
+    assert movies["url"] == "http://radarr.local:7878"
+    assert movies["quality_profile"] == "HD-1080p"
+    assert movies["search"] is True
+    assert movies["add_existing"] is False
+    assert shows["url"] == "http://sonarr.local:8989"
+    assert shows["language_profile"] == "English"
+    assert shows["monitor"] == "future"
+    assert shows["season_folder"] is True
+
+
 def test_build_config_includes_saved_library_metadata_files(app, isolated_config_dir, monkeypatch):
     import json
 
@@ -819,6 +868,65 @@ def test_step_post_from_libraries_persists_collection_files(client, isolated_con
     assert stored["libraries"]["mov-library_movies-collection_files"] == collection_value
 
 
+def test_step_post_from_libraries_persists_library_arr_overrides(client, isolated_config_dir, monkeypatch, qs_module):
+    from modules import database
+
+    config_name = "pytest_step_save_library_arr_overrides"
+
+    monkeypatch.setattr(qs_module.output, "build_config", lambda *_args, **_kwargs: (True, None, {}, "test: true\n", []))
+    monkeypatch.setattr(
+        qs_module.validations,
+        "validate_radarr_payload",
+        lambda _payload: ({"valid": True, "root_folders": [{"path": "/movies"}], "quality_profiles": [{"name": "HD-1080p"}]}, 200),
+    )
+    monkeypatch.setattr(
+        qs_module,
+        "_build_final_gate",
+        lambda *_args, **_kwargs: {
+            "stage": "kometa",
+            "todo_count": 0,
+            "todo_blockers": [],
+            "bulk_validation_fresh": True,
+            "bulk_validation_at": qs_module.utc_now_iso(),
+            "validation_ttl_hours": 12,
+            "can_build_config": True,
+            "config_valid": True,
+        },
+    )
+    original_retrieve_settings = qs_module.persistence.retrieve_settings
+
+    def fake_retrieve_settings(target):
+        if target == "110-radarr":
+            return {"radarr": {"url": "http://global-radarr:7878", "token": "global-token"}}
+        return original_retrieve_settings(target)
+
+    monkeypatch.setattr(qs_module.persistence, "retrieve_settings", fake_retrieve_settings)
+
+    resp = client.post(
+        "/step/900-kometa",
+        data={
+            "configSelector": config_name,
+            "mov-library_movies-library": "Movies",
+            "mov-library_movies-attribute_assets_for_all": "true",
+            "mov-library_movies-attribute_radarr_root_folder_path": "/movies",
+            "mov-library_movies-attribute_radarr_quality_profile": "HD-1080p",
+            "mov-library_movies-attribute_radarr_search": "true",
+            "mov-library_movies-attribute_radarr_add_existing": "false",
+        },
+        headers={"Referer": "http://localhost/step/025-libraries"},
+    )
+
+    assert resp.status_code == 200
+
+    validated, user_entered, stored = database.retrieve_section_data(config_name, "libraries")
+    assert validated is False
+    assert user_entered is True
+    assert stored["libraries"]["mov-library_movies-attribute_radarr_root_folder_path"] == "/movies"
+    assert stored["libraries"]["mov-library_movies-attribute_radarr_quality_profile"] == "HD-1080p"
+    assert stored["libraries"]["mov-library_movies-attribute_radarr_search"] is True
+    assert stored["libraries"]["mov-library_movies-attribute_radarr_add_existing"] is False
+
+
 def test_step_post_from_libraries_rejects_invalid_metadata_files(client, isolated_config_dir, monkeypatch, qs_module):
     from modules import database
 
@@ -862,6 +970,123 @@ def test_step_post_from_libraries_rejects_invalid_metadata_files(client, isolate
     assert stored is None
     assert validated is False
     assert user_entered is False
+
+
+def test_validate_library_service_overrides_endpoint_returns_options(client, monkeypatch, qs_module):
+    original_retrieve_settings = qs_module.persistence.retrieve_settings
+
+    def fake_retrieve_settings(target):
+        if target == "110-radarr":
+            return {"radarr": {"url": "http://global-radarr:7878", "token": "global-token"}}
+        return original_retrieve_settings(target)
+
+    monkeypatch.setattr(qs_module.persistence, "retrieve_settings", fake_retrieve_settings)
+    monkeypatch.setattr(
+        qs_module.validations,
+        "validate_radarr_payload",
+        lambda _payload: (
+            {
+                "valid": True,
+                "root_folders": [{"path": "/movies"}],
+                "quality_profiles": [{"name": "HD-1080p"}],
+            },
+            200,
+        ),
+    )
+
+    resp = client.post(
+        "/validate_library_service_overrides/mov-library_movies",
+        json={
+            "mov-library_movies-library": "Movies",
+            "mov-library_movies-attribute_radarr_root_folder_path": "/movies",
+            "mov-library_movies-attribute_radarr_quality_profile": "HD-1080p",
+        },
+    )
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["valid"] is True
+    assert payload["root_folders"][0]["path"] == "/movies"
+    assert payload["quality_profiles"][0]["name"] == "HD-1080p"
+
+
+def test_validate_library_service_overrides_endpoint_rejects_unknown_profile(client, monkeypatch, qs_module):
+    original_retrieve_settings = qs_module.persistence.retrieve_settings
+
+    def fake_retrieve_settings(target):
+        if target == "120-sonarr":
+            return {"sonarr": {"url": "http://global-sonarr:8989", "token": "global-token"}}
+        return original_retrieve_settings(target)
+
+    monkeypatch.setattr(qs_module.persistence, "retrieve_settings", fake_retrieve_settings)
+    monkeypatch.setattr(
+        qs_module.validations,
+        "validate_sonarr_payload",
+        lambda _payload: (
+            {
+                "valid": True,
+                "root_folders": [{"path": "/shows"}],
+                "quality_profiles": [{"name": "HD-TV"}],
+                "language_profiles": [{"name": "English"}],
+            },
+            200,
+        ),
+    )
+
+    resp = client.post(
+        "/validate_library_service_overrides/sho-library_shows",
+        json={
+            "sho-library_shows-library": "Shows",
+            "sho-library_shows-attribute_sonarr_quality_profile": "4K-UHD",
+        },
+    )
+
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert payload["valid"] is False
+    assert any("unknown quality profile" in error for error in payload["errors"])
+
+
+def test_validate_all_services_flags_invalid_library_arr_overrides(client, monkeypatch, qs_module):
+    import copy
+
+    settings_map = {
+        "010-plex": {"validated": True, "plex": {}},
+        "025-libraries": {
+            "libraries": {
+                "mov-library_movies-library": "Movies",
+                "mov-library_movies-attribute_assets_for_all": "true",
+                "mov-library_movies-attribute_radarr_url": "http://alt-radarr:7878",
+                "mov-library_movies-attribute_radarr_token": "alt-token",
+                "mov-library_movies-attribute_radarr_root_folder_path": "/bad-root",
+            }
+        },
+    }
+
+    monkeypatch.setattr(qs_module.persistence, "retrieve_settings", lambda target: copy.deepcopy(settings_map.get(target, {})))
+    monkeypatch.setattr(
+        qs_module.validations,
+        "validate_radarr_payload",
+        lambda _payload: (
+            {
+                "valid": True,
+                "root_folders": [{"path": "/movies"}],
+                "quality_profiles": [{"name": "HD-1080p"}],
+            },
+            200,
+        ),
+    )
+
+    with client.session_transaction() as sess:
+        sess["config_name"] = "pytest_bulk_invalid_arr"
+
+    resp = client.post("/validate_all_services")
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    libraries_result = payload["results"]["025-libraries"]
+    assert libraries_result["status"] == "failed"
+    assert libraries_result["reason"] == "invalid_arr_overrides"
+    assert any("/bad-root" in detail for detail in libraries_result["details"])
 
 
 def test_step_post_from_libraries_rejects_invalid_collection_files(client, isolated_config_dir, monkeypatch, qs_module):

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -927,6 +927,39 @@ def test_step_post_from_libraries_persists_library_arr_overrides(client, isolate
     assert stored["libraries"]["mov-library_movies-attribute_radarr_add_existing"] is False
 
 
+def test_step_post_from_libraries_accepts_literal_none_arr_url_override(client, isolated_config_dir, monkeypatch, qs_module):
+    config_name = "pytest_step_save_library_arr_none_url"
+
+    monkeypatch.setattr(qs_module.output, "build_config", lambda *_args, **_kwargs: (True, None, {}, "test: true\n", []))
+    monkeypatch.setattr(
+        qs_module,
+        "_build_final_gate",
+        lambda *_args, **_kwargs: {
+            "stage": "kometa",
+            "todo_count": 0,
+            "todo_blockers": [],
+            "bulk_validation_fresh": True,
+            "bulk_validation_at": qs_module.utc_now_iso(),
+            "validation_ttl_hours": 12,
+            "can_build_config": True,
+            "config_valid": True,
+        },
+    )
+
+    resp = client.post(
+        "/step/900-kometa",
+        data={
+            "configSelector": config_name,
+            "mov-library_movies-library": "Movies",
+            "mov-library_movies-attribute_radarr_url": "None",
+        },
+        headers={"Referer": "http://localhost/step/025-libraries"},
+    )
+
+    assert resp.status_code == 200
+    assert b"Invalid values:" not in resp.data
+
+
 def test_step_post_from_libraries_rejects_invalid_metadata_files(client, isolated_config_dir, monkeypatch, qs_module):
     from modules import database
 

--- a/tests/test_importer_library_services.py
+++ b/tests/test_importer_library_services.py
@@ -1,0 +1,55 @@
+from modules import importer
+
+
+def test_prepare_import_payload_maps_library_radarr_overrides():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Movies": {
+                    "radarr": {
+                        "url": "http://radarr.local:7878",
+                        "quality_profile": "HD-1080p",
+                        "search": True,
+                        "add_existing": False,
+                    }
+                }
+            }
+        },
+        {"Movies"},
+        set(),
+    )
+
+    libraries = payload["libraries"]["libraries"]
+    assert libraries["mov-library_movies-library"] == "Movies"
+    assert libraries["mov-library_movies-attribute_radarr_url"] == "http://radarr.local:7878"
+    assert libraries["mov-library_movies-attribute_radarr_quality_profile"] == "HD-1080p"
+    assert libraries["mov-library_movies-attribute_radarr_search"] == "true"
+    assert libraries["mov-library_movies-attribute_radarr_add_existing"] == "false"
+    assert any("libraries.Movies.radarr.url" in line for line in report.lines)
+
+
+def test_prepare_import_payload_maps_library_sonarr_overrides():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Shows": {
+                    "sonarr": {
+                        "url": "http://sonarr.local:8989",
+                        "language_profile": "English",
+                        "monitor": "future",
+                        "season_folder": True,
+                    }
+                }
+            }
+        },
+        set(),
+        {"Shows"},
+    )
+
+    libraries = payload["libraries"]["libraries"]
+    assert libraries["sho-library_shows-library"] == "Shows"
+    assert libraries["sho-library_shows-attribute_sonarr_url"] == "http://sonarr.local:8989"
+    assert libraries["sho-library_shows-attribute_sonarr_language_profile"] == "English"
+    assert libraries["sho-library_shows-attribute_sonarr_monitor"] == "future"
+    assert libraries["sho-library_shows-attribute_sonarr_season_folder"] == "true"
+    assert any("libraries.Shows.sonarr.language_profile" in line for line in report.lines)


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Title
Add per-library Radarr and Sonarr override settings

Description
This adds support for configuring radarr and sonarr at the individual library level, instead of only using the global Arr settings pages.

Quickstart can now store, import, validate, and emit library-specific Arr overrides in generated Kometa YAML. That allows one library to inherit the global Arr config while another library can override values such as URL, token, root folder, quality profile, path mappings, and Arr behavior flags.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #1210 

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
