### PR TITLE
fix order of accordions and nested ui issue

### DIFF
--- a/templates/partials/_library_collection_files.html
+++ b/templates/partials/_library_collection_files.html
@@ -1,35 +1,23 @@
-<div class="accordion-item mt-3">
-    <h2 class="accordion-header">
-        <button class="accordion-button" type="button" data-bs-toggle="collapse"
-            data-bs-target="#{{ library.id }}-collection-files">
-            Collection Files
-        </button>
-    </h2>
-    <div id="{{ library.id }}-collection-files" class="accordion-collapse collapse">
-        <div class="accordion-body">
-            <div class="d-flex flex-column gap-3">
-                <div class="alert alert-warning small mb-0" role="alert">
-                    <div class="fw-semibold mb-1">Validation is limited.</div>
-                    <div>Quickstart can verify that each entry points to a non-empty <code>.yml</code> or <code>.yaml</code> file and that the YAML parses successfully.</div>
-                    <div>Quickstart also verifies that each collection file contains a non-empty top-level <code>collections:</code> mapping.</div>
-                    <div>Quickstart does not fully validate Kometa collection file schema yet, so a file that passes here may still fail later and cause Kometa to abort during a run.</div>
-                </div>
-                <div class="alert alert-info small mb-0" role="alert">
-                    <div>Use one or more <code>file</code>, <code>folder</code>, <code>url</code>, <code>git</code>, or <code>repo</code> entries. These are appended into library-level <code>collection_files</code>.</div>
-                </div>
-                <div class="collection-files-editor" data-collection-files-editor data-library-id="{{ library.id }}">
-                    <div class="alert small mb-4" role="alert" data-collection-custom-repo-status></div>
-                    <input type="hidden" name="{{ library.id }}-collection_files" id="{{ library.id }}-collection_files"
-                        value="{{ data['libraries'].get(library.id ~ '-collection_files', '[]') }}">
-                    <div class="collection-files-list d-flex flex-column gap-3 mt-1" data-collection-files-list></div>
-                    <div class="d-flex justify-content-between align-items-center mt-3">
-                        <button type="button" class="btn btn-outline-secondary btn-sm" data-add-collection-file>
-                            <i class="bi bi-plus-circle me-1"></i>Add Collection File
-                        </button>
-                        <span class="text-muted small">Supports mixed local files and folders, raw URLs, Community-Configs git paths, and custom_repo-backed repo paths.</span>
-                    </div>
-                </div>
-            </div>
+<div class="d-flex flex-column gap-3">
+    <div class="alert alert-warning small mb-0" role="alert">
+        <div class="fw-semibold mb-1">Validation is limited.</div>
+        <div>Quickstart can verify that each entry points to a non-empty <code>.yml</code> or <code>.yaml</code> file and that the YAML parses successfully.</div>
+        <div>Quickstart also verifies that each collection file contains a non-empty top-level <code>collections:</code> mapping.</div>
+        <div>Quickstart does not fully validate Kometa collection file schema yet, so a file that passes here may still fail later and cause Kometa to abort during a run.</div>
+    </div>
+    <div class="alert alert-info small mb-0" role="alert">
+        <div>Use one or more <code>file</code>, <code>folder</code>, <code>url</code>, <code>git</code>, or <code>repo</code> entries. These are appended into library-level <code>collection_files</code>.</div>
+    </div>
+    <div class="collection-files-editor" data-collection-files-editor data-library-id="{{ library.id }}">
+        <div class="alert small mb-4" role="alert" data-collection-custom-repo-status></div>
+        <input type="hidden" name="{{ library.id }}-collection_files" id="{{ library.id }}-collection_files"
+            value="{{ data['libraries'].get(library.id ~ '-collection_files', '[]') }}">
+        <div class="collection-files-list d-flex flex-column gap-3 mt-1" data-collection-files-list></div>
+        <div class="d-flex justify-content-between align-items-center mt-3">
+            <button type="button" class="btn btn-outline-secondary btn-sm" data-add-collection-file>
+                <i class="bi bi-plus-circle me-1"></i>Add Collection File
+            </button>
+            <span class="text-muted small">Supports mixed local files and folders, raw URLs, Community-Configs git paths, and custom_repo-backed repo paths.</span>
         </div>
     </div>
 </div>

--- a/templates/partials/_movie_library_settings.html
+++ b/templates/partials/_movie_library_settings.html
@@ -47,11 +47,11 @@
             </div>
         </div>
 
+        <!-- Movie Playlists -->
+        {% include "partials/_library_playlists.html" %}
+
         {% include "partials/_library_collection_files_accordion.html" %}
         {% include "partials/_library_metadata_files.html" %}
         {% include "partials/_library_radarr_overrides.html" %}
-
-        <!-- Movie Playlists -->
-        {% include "partials/_library_playlists.html" %}
     </div>
 </div>

--- a/templates/partials/_show_library_settings.html
+++ b/templates/partials/_show_library_settings.html
@@ -47,11 +47,11 @@
             </div>
         </div>
 
+        <!-- Show Playlists -->
+        {% include "partials/_library_playlists.html" %}
+
         {% include "partials/_library_collection_files_accordion.html" %}
         {% include "partials/_library_metadata_files.html" %}
         {% include "partials/_library_sonarr_overrides.html" %}
-
-        <!-- Show Playlists -->
-        {% include "partials/_library_playlists.html" %}
     </div>
 </div>


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Title
Fix nested advanced library accordions and polish library Arr override UX

Description
This branch fixes a set of Libraries page UI issues introduced around the advanced library sections, especially the new per-library Arr override and file-import accordions.

The main fix is removing the nested Collection Files accordion structure so advanced sections render as a clean, single accordion list. The branch also improves ordering and interaction consistency for advanced library sections and aligns library Arr override fields more closely with existing Quickstart UI behavior.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
