### PR TITLE
Scheduke overlays

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -2157,10 +2157,12 @@ def build_libraries_section(
 
         remove_key = f"{library_type}-library_{lib_id}-top_level_remove_overlays"
         reset_key = f"{library_type}-library_{lib_id}-top_level_reset_overlays"
+        schedule_overlays_key = f"{library_type}-library_{lib_id}-top_level_schedule_overlays"
         report_path_key = f"{library_type}-library_{lib_id}-top_level_report_path"
 
         remove_overlays = top_group.get(remove_key)
         reset_overlays = top_group.get(reset_key)
+        schedule_overlays = top_group.get(schedule_overlays_key)
         report_path = top_group.get(report_path_key)
 
         if report_path not in [None, ""]:
@@ -2169,12 +2171,15 @@ def build_libraries_section(
             entry["remove_overlays"] = True
         if reset_overlays not in [None, "None", ""]:
             entry["reset_overlays"] = reset_overlays
+        if schedule_overlays not in [None, ""]:
+            entry["schedule_overlays"] = schedule_overlays
 
         if app.config["QS_DEBUG"]:
             helpers.ts_log(f"Top Level for {lib_id}: {top_group}", level="DEBUG")
             helpers.ts_log(f"{report_path_key} = {report_path}", level="DEBUG")
             helpers.ts_log(f"{remove_key} = {remove_overlays}", level="DEBUG")
             helpers.ts_log(f"{reset_key} = {reset_overlays}", level="DEBUG")
+            helpers.ts_log(f"{schedule_overlays_key} = {schedule_overlays}", level="DEBUG")
 
         if operations:
             entry["operations"] = operations
@@ -2225,7 +2230,7 @@ def reorder_library_section(library_data):
     """
     Reorders library data so that:
     - `report_path` appears first.
-    - `remove_overlays` and `reset_overlays` come next.
+    - `remove_overlays`, `reset_overlays`, and `schedule_overlays` come next.
     - `template_variables` next.
     - `metadata_files` appears before `collection_files`.
     - `collection_files` appears before `overlay_files`.
@@ -2244,6 +2249,8 @@ def reorder_library_section(library_data):
         reordered_data["remove_overlays"] = library_data["remove_overlays"]
     if "reset_overlays" in library_data:
         reordered_data["reset_overlays"] = library_data["reset_overlays"]
+    if "schedule_overlays" in library_data:
+        reordered_data["schedule_overlays"] = library_data["schedule_overlays"]
 
     # 3. Then template_variables
     if "template_variables" in library_data:

--- a/modules/output.py
+++ b/modules/output.py
@@ -2157,16 +2157,20 @@ def build_libraries_section(
 
         remove_key = f"{library_type}-library_{lib_id}-top_level_remove_overlays"
         reset_key = f"{library_type}-library_{lib_id}-top_level_reset_overlays"
+        schedule_key = f"{library_type}-library_{lib_id}-top_level_schedule"
         schedule_overlays_key = f"{library_type}-library_{lib_id}-top_level_schedule_overlays"
         report_path_key = f"{library_type}-library_{lib_id}-top_level_report_path"
 
         remove_overlays = top_group.get(remove_key)
         reset_overlays = top_group.get(reset_key)
+        schedule = top_group.get(schedule_key)
         schedule_overlays = top_group.get(schedule_overlays_key)
         report_path = top_group.get(report_path_key)
 
         if report_path not in [None, ""]:
             entry["report_path"] = report_path
+        if schedule not in [None, ""]:
+            entry["schedule"] = schedule
         if remove_overlays:
             entry["remove_overlays"] = True
         if reset_overlays not in [None, "None", ""]:
@@ -2177,6 +2181,7 @@ def build_libraries_section(
         if app.config["QS_DEBUG"]:
             helpers.ts_log(f"Top Level for {lib_id}: {top_group}", level="DEBUG")
             helpers.ts_log(f"{report_path_key} = {report_path}", level="DEBUG")
+            helpers.ts_log(f"{schedule_key} = {schedule}", level="DEBUG")
             helpers.ts_log(f"{remove_key} = {remove_overlays}", level="DEBUG")
             helpers.ts_log(f"{reset_key} = {reset_overlays}", level="DEBUG")
             helpers.ts_log(f"{schedule_overlays_key} = {schedule_overlays}", level="DEBUG")
@@ -2230,7 +2235,8 @@ def reorder_library_section(library_data):
     """
     Reorders library data so that:
     - `report_path` appears first.
-    - `remove_overlays`, `reset_overlays`, and `schedule_overlays` come next.
+    - `schedule` comes next.
+    - `remove_overlays`, `reset_overlays`, and `schedule_overlays` come after that.
     - `template_variables` next.
     - `metadata_files` appears before `collection_files`.
     - `collection_files` appears before `overlay_files`.
@@ -2244,7 +2250,11 @@ def reorder_library_section(library_data):
     if "report_path" in library_data:
         reordered_data["report_path"] = library_data["report_path"]
 
-    # 2. Then remove/reset overlays
+    # 2. Then library schedule
+    if "schedule" in library_data:
+        reordered_data["schedule"] = library_data["schedule"]
+
+    # 3. Then remove/reset overlays
     if "remove_overlays" in library_data:
         reordered_data["remove_overlays"] = library_data["remove_overlays"]
     if "reset_overlays" in library_data:
@@ -2252,11 +2262,11 @@ def reorder_library_section(library_data):
     if "schedule_overlays" in library_data:
         reordered_data["schedule_overlays"] = library_data["schedule_overlays"]
 
-    # 3. Then template_variables
+    # 4. Then template_variables
     if "template_variables" in library_data:
         reordered_data["template_variables"] = library_data["template_variables"]
 
-    # 4. Then library-level metadata/collections/overlays in explicit YAML order
+    # 5. Then library-level metadata/collections/overlays in explicit YAML order
     if "metadata_files" in library_data:
         reordered_data["metadata_files"] = library_data["metadata_files"]
     if "collection_files" in library_data:

--- a/static/json/quickstart_attributes.json
+++ b/static/json/quickstart_attributes.json
@@ -219,6 +219,23 @@
       "yml_location": "top_level"
     },
     {
+      "prefix": "top_level_schedule_overlays",
+      "type": "text_input",
+      "input_mode": "schedule",
+      "accordion": "overlays",
+      "media_types": [
+        "movie",
+        "show"
+      ],
+      "title": "Overlay Schedule",
+      "wiki": "https://kometa.wiki/en/nightly/config/schedule/#scheduling-overlays",
+      "description": "Define when overlays run for this library using Kometa schedule syntax such as <code>weekly(saturday)</code>.<br><br><b>Warning:</b> Overlay files cannot be scheduled individually. Use <code>schedule_overlays</code> at the library level to control all overlay files for this library.",
+      "tooltip_variant": "info",
+      "container_class": "",
+      "placeholder": "e.g. weekly(saturday)",
+      "yml_location": "top_level"
+    },
+    {
       "prefix": "top_level_reset_overlays",
       "type": "select",
       "accordion": "overlays",

--- a/static/json/quickstart_attributes.json
+++ b/static/json/quickstart_attributes.json
@@ -204,6 +204,23 @@
       "yml_location": "top_level"
     },
     {
+      "prefix": "top_level_schedule",
+      "type": "text_input",
+      "input_mode": "schedule",
+      "accordion": "miscellaneous",
+      "media_types": [
+        "movie",
+        "show"
+      ],
+      "title": "Library Schedule",
+      "wiki": "https://kometa.wiki/en/nightly/config/libraries/#attributes",
+      "description": "Define when this library runs using Kometa schedule syntax such as <code>weekly(saturday)</code>.",
+      "tooltip_variant": "info",
+      "container_class": "",
+      "placeholder": "e.g. weekly(saturday)",
+      "yml_location": "top_level"
+    },
+    {
       "prefix": "top_level_remove_overlays",
       "type": "boolean_toggle",
       "accordion": "overlays",

--- a/templates/partials/_library_collection_files.html
+++ b/templates/partials/_library_collection_files.html
@@ -1,35 +1,23 @@
-<div class="accordion-item mt-3">
-    <h2 class="accordion-header">
-        <button class="accordion-button" type="button" data-bs-toggle="collapse"
-            data-bs-target="#{{ library.id }}-collection-files">
-            Collection Files
-        </button>
-    </h2>
-    <div id="{{ library.id }}-collection-files" class="accordion-collapse collapse">
-        <div class="accordion-body">
-            <div class="d-flex flex-column gap-3">
-                <div class="alert alert-warning small mb-0" role="alert">
-                    <div class="fw-semibold mb-1">Validation is limited.</div>
-                    <div>Quickstart can verify that each entry points to a non-empty <code>.yml</code> or <code>.yaml</code> file and that the YAML parses successfully.</div>
-                    <div>Quickstart also verifies that each collection file contains a non-empty top-level <code>collections:</code> mapping.</div>
-                    <div>Quickstart does not fully validate Kometa collection file schema yet, so a file that passes here may still fail later and cause Kometa to abort during a run.</div>
-                </div>
-                <div class="alert alert-info small mb-0" role="alert">
-                    <div>Use one or more <code>file</code>, <code>folder</code>, <code>url</code>, <code>git</code>, or <code>repo</code> entries. These are appended into library-level <code>collection_files</code>.</div>
-                </div>
-                <div class="collection-files-editor" data-collection-files-editor data-library-id="{{ library.id }}">
-                    <div class="alert small mb-4" role="alert" data-collection-custom-repo-status></div>
-                    <input type="hidden" name="{{ library.id }}-collection_files" id="{{ library.id }}-collection_files"
-                        value="{{ data['libraries'].get(library.id ~ '-collection_files', '[]') }}">
-                    <div class="collection-files-list d-flex flex-column gap-3 mt-1" data-collection-files-list></div>
-                    <div class="d-flex justify-content-between align-items-center mt-3">
-                        <button type="button" class="btn btn-outline-secondary btn-sm" data-add-collection-file>
-                            <i class="bi bi-plus-circle me-1"></i>Add Collection File
-                        </button>
-                        <span class="text-muted small">Supports mixed local files and folders, raw URLs, Community-Configs git paths, and custom_repo-backed repo paths.</span>
-                    </div>
-                </div>
-            </div>
+<div class="d-flex flex-column gap-3">
+    <div class="alert alert-warning small mb-0" role="alert">
+        <div class="fw-semibold mb-1">Validation is limited.</div>
+        <div>Quickstart can verify that each entry points to a non-empty <code>.yml</code> or <code>.yaml</code> file and that the YAML parses successfully.</div>
+        <div>Quickstart also verifies that each collection file contains a non-empty top-level <code>collections:</code> mapping.</div>
+        <div>Quickstart does not fully validate Kometa collection file schema yet, so a file that passes here may still fail later and cause Kometa to abort during a run.</div>
+    </div>
+    <div class="alert alert-info small mb-0" role="alert">
+        <div>Use one or more <code>file</code>, <code>folder</code>, <code>url</code>, <code>git</code>, or <code>repo</code> entries. These are appended into library-level <code>collection_files</code>.</div>
+    </div>
+    <div class="collection-files-editor" data-collection-files-editor data-library-id="{{ library.id }}">
+        <div class="alert small mb-4" role="alert" data-collection-custom-repo-status></div>
+        <input type="hidden" name="{{ library.id }}-collection_files" id="{{ library.id }}-collection_files"
+            value="{{ data['libraries'].get(library.id ~ '-collection_files', '[]') }}">
+        <div class="collection-files-list d-flex flex-column gap-3 mt-1" data-collection-files-list></div>
+        <div class="d-flex justify-content-between align-items-center mt-3">
+            <button type="button" class="btn btn-outline-secondary btn-sm" data-add-collection-file>
+                <i class="bi bi-plus-circle me-1"></i>Add Collection File
+            </button>
+            <span class="text-muted small">Supports mixed local files and folders, raw URLs, Community-Configs git paths, and custom_repo-backed repo paths.</span>
         </div>
     </div>
 </div>

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -826,7 +826,7 @@ select_input.key if yml_location == "top_level" else
 {% endmacro %}
 
 {% macro text_input_section(library, data, prefix, title, description, wiki, placeholder="", tooltip_variant="info",
-container_class="border rounded p-3 mb-2", yml_location="attribute", multiline=false, rows=3) %}
+container_class="border rounded p-3 mb-2", yml_location="attribute", multiline=false, rows=3, input_mode="") %}
 {% set field_prefix = "template_variables" if yml_location == "template_variables" else "" if yml_location ==
 "top_level" else "attribute" %}
 {% set full_id = library.id ~ "-" ~ (field_prefix ~ "_" if field_prefix) ~ prefix %}
@@ -834,6 +834,102 @@ container_class="border rounded p-3 mb-2", yml_location="attribute", multiline=f
 field_prefix ~ "_" ~ prefix if field_prefix else prefix) %}
 {% set legacy_name = library.id ~ "-" ~ prefix %}
 {% set field_value = data.libraries.get(full_name, data.libraries.get(legacy_name, '')) %}
+{% if input_mode == "schedule" %}
+<div class="{{ container_class }}">
+    <div class="schedule-builder mb-2" data-schedule-builder data-hidden-input="{{ full_name }}"
+        data-default-value="{{ field_value | default('', true) }}">
+        <div class="input-group mb-2 schedule-builder-header">
+            <span class="input-group-text" id="{{ full_id }}_text">
+                <a href="{{ wiki }}" target="_blank" rel="noopener noreferrer">{{ title }}</a>
+                <span class="text-{{ tooltip_variant }} ms-3" data-bs-toggle="tooltip" data-bs-html="true"
+                    title="{{ description }}">
+                    <i
+                        class="bi {% if tooltip_variant == 'danger' %}bi-exclamation-circle-fill{% else %}bi-info-circle-fill{% endif %}"></i>
+                </span>
+            </span>
+            <select class="form-select" id="{{ full_id }}_schedule_mode" data-schedule-mode-select>
+                <option value="range">Range</option>
+                <option value="weekly">Weekly</option>
+                <option value="monthly">Monthly</option>
+                <option value="yearly">Yearly</option>
+                <option value="date">Date</option>
+                <option value="hourly">Hourly</option>
+                <option value="daily">Daily</option>
+                <option value="never">Never</option>
+                <option value="non_existing">Only If Missing</option>
+                <option value="custom">Custom (Advanced)</option>
+            </select>
+        </div>
+        <div class="schedule-builder-body">
+            <div class="schedule-mode" data-schedule-mode="range">
+                <div class="schedule-grid">
+                    <input type="date" class="form-control" id="{{ full_id }}_schedule_range_start"
+                        data-schedule-range-start aria-label="Range start">
+                    <span class="schedule-range-sep">to</span>
+                    <input type="date" class="form-control" id="{{ full_id }}_schedule_range_end"
+                        data-schedule-range-end aria-label="Range end">
+                </div>
+                <div class="form-text">Month/day are used; year is ignored.</div>
+            </div>
+            <div class="schedule-mode" data-schedule-mode="weekly">
+                <div class="schedule-weekly">
+                    {% for day in ['sun','mon','tue','wed','thu','fri','sat'] %}
+                    <label class="schedule-day">
+                        <input type="checkbox" id="{{ full_id }}_schedule_week_{{ day }}" value="{{ day }}"
+                            data-schedule-week-day>
+                        <span>{{ day|capitalize }}</span>
+                    </label>
+                    {% endfor %}
+                </div>
+            </div>
+            <div class="schedule-mode" data-schedule-mode="monthly">
+                <input type="number" class="form-control" id="{{ full_id }}_schedule_month_day" min="1" max="31"
+                    step="1" data-schedule-month-day placeholder="Day of month">
+            </div>
+            <div class="schedule-mode" data-schedule-mode="yearly">
+                <input type="date" class="form-control" id="{{ full_id }}_schedule_yearly" data-schedule-yearly
+                    aria-label="Yearly date">
+                <div class="form-text">Month/day are used; year is ignored.</div>
+            </div>
+            <div class="schedule-mode" data-schedule-mode="date">
+                <input type="date" class="form-control" id="{{ full_id }}_schedule_date" data-schedule-date
+                    aria-label="Exact date">
+            </div>
+            <div class="schedule-mode" data-schedule-mode="hourly">
+                <div class="schedule-grid">
+                    <input type="number" class="form-control" id="{{ full_id }}_schedule_hour_start" min="0" max="23"
+                        step="1" data-schedule-hour-start placeholder="Start hour">
+                    <span class="schedule-range-sep">to</span>
+                    <input type="number" class="form-control" id="{{ full_id }}_schedule_hour_end" min="0" max="23"
+                        step="1" data-schedule-hour-end placeholder="End hour (optional)">
+                </div>
+            </div>
+            <div class="schedule-mode" data-schedule-mode="daily">
+                <div class="form-text">Runs once per day.</div>
+            </div>
+            <div class="schedule-mode" data-schedule-mode="never">
+                <div class="form-text">Skips overlay processing for this library.</div>
+            </div>
+            <div class="schedule-mode" data-schedule-mode="non_existing">
+                <div class="form-text">Runs only when the target does not already exist.</div>
+            </div>
+            <div class="schedule-mode" data-schedule-mode="custom">
+                <div class="form-text">Use Advanced to enter a raw schedule string.</div>
+            </div>
+        </div>
+        <div class="schedule-preview small text-muted mt-2">
+            Preview: <code data-schedule-preview></code>
+        </div>
+        <details class="schedule-advanced mt-2">
+            <summary>Advanced (use with caution)</summary>
+            <div class="form-text mb-2">Only use this if you know Kometa schedule syntax.</div>
+            <input type="text" class="form-control" id="{{ full_id }}_schedule_raw" data-schedule-raw
+                placeholder="{{ placeholder }}" value="{{ field_value }}">
+        </details>
+        <input type="hidden" id="{{ full_id }}" name="{{ full_name }}" value="{{ field_value }}">
+    </div>
+</div>
+{% else %}
 <div class="{{ container_class }}">
     <div class="input-group mb-2">
         <span class="input-group-text" id="{{ full_id }}_text">
@@ -853,6 +949,7 @@ field_prefix ~ "_" ~ prefix if field_prefix else prefix) %}
         {% endif %}
     </div>
 </div>
+{% endif %}
 {% endmacro %}
 
 {% macro asset_directory_list_section(library, data, prefix, title, description, wiki, placeholder="Add Asset Directory",

--- a/templates/partials/_movie_attributes.html
+++ b/templates/partials/_movie_attributes.html
@@ -76,6 +76,22 @@
         container_class=section.container_class,
         yml_location=section.yml_location
         ) }}
+        {% elif section.type == 'text_input' %}
+        {{ macros.text_input_section(
+        library,
+        data,
+        section.prefix,
+        section.title,
+        section.description,
+        section.wiki,
+        tooltip_variant=section.tooltip_variant,
+        container_class=section.container_class,
+        yml_location=section.yml_location,
+        placeholder=section.placeholder,
+        multiline=section.multiline | default(false),
+        rows=section.rows | default(3),
+        input_mode=section.input_mode | default('')
+        ) }}
         {% endif %}
         {% endfor %}
         <p class="text-white mt-3">
@@ -222,7 +238,8 @@
         yml_location=section.yml_location,
         placeholder=section.placeholder,
         multiline=section.multiline | default(false),
-        rows=section.rows | default(3)
+        rows=section.rows | default(3),
+        input_mode=section.input_mode | default('')
         ) }}
 
         {% elif section.type == "mapping_list" %}
@@ -286,7 +303,8 @@
               yml_location=section.yml_location,
               placeholder=section.placeholder,
               multiline=section.multiline | default(false),
-              rows=section.rows | default(3)
+              rows=section.rows | default(3),
+              input_mode=section.input_mode | default('')
             ) }}
           {% endif %}
         {% endfor %}

--- a/templates/partials/_show_attributes.html
+++ b/templates/partials/_show_attributes.html
@@ -76,6 +76,22 @@
         container_class=section.container_class,
         yml_location=section.yml_location
         ) }}
+        {% elif section.type == 'text_input' %}
+        {{ macros.text_input_section(
+        library,
+        data,
+        section.prefix,
+        section.title,
+        section.description,
+        section.wiki,
+        tooltip_variant=section.tooltip_variant,
+        container_class=section.container_class,
+        yml_location=section.yml_location,
+        placeholder=section.placeholder,
+        multiline=section.multiline | default(false),
+        rows=section.rows | default(3),
+        input_mode=section.input_mode | default('')
+        ) }}
         {% endif %}
         {% endfor %}
         <p class="text-white mt-3">
@@ -222,7 +238,8 @@
         yml_location=section.yml_location,
         placeholder=section.placeholder,
         multiline=section.multiline | default(false),
-        rows=section.rows | default(3)
+        rows=section.rows | default(3),
+        input_mode=section.input_mode | default('')
         ) }}
 
         {% elif section.type == "mapping_list" %}
@@ -286,7 +303,8 @@
               yml_location=section.yml_location,
               placeholder=section.placeholder,
               multiline=section.multiline | default(false),
-              rows=section.rows | default(3)
+              rows=section.rows | default(3),
+              input_mode=section.input_mode | default('')
             ) }}
           {% endif %}
         {% endfor %}

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -1976,3 +1976,35 @@ def test_copy_library_settings_mirrors_metadata_files(client, isolated_config_di
     libraries = stored["libraries"]
     assert libraries["mov-library_movies-metadata_files"] == source_metadata_files
     assert libraries["mov-library_target-metadata_files"] == source_metadata_files
+
+
+def test_build_libraries_section_emits_schedule_overlays(app):
+    from modules import output
+
+    with app.app_context():
+        libraries_section = output.build_libraries_section(
+            {"mov-library_movies-library": "Movies"},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {
+                "movies": {
+                    "mov-library_movies-top_level_schedule_overlays": "weekly(saturday)"
+                }
+            },
+            {},
+        )
+
+    movies = libraries_section["libraries"]["Movies"]
+    assert movies["schedule_overlays"] == "weekly(saturday)"
+    assert list(movies.keys())[:2] == ["schedule_overlays", "template_variables"]

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -1997,11 +1997,7 @@ def test_build_libraries_section_emits_schedule_overlays(app):
             {},
             {},
             {},
-            {
-                "movies": {
-                    "mov-library_movies-top_level_schedule_overlays": "weekly(saturday)"
-                }
-            },
+            {"movies": {"mov-library_movies-top_level_schedule_overlays": "weekly(saturday)"}},
             {},
         )
 
@@ -2029,11 +2025,7 @@ def test_build_libraries_section_emits_schedule(app):
             {},
             {},
             {},
-            {
-                "movies": {
-                    "mov-library_movies-top_level_schedule": "weekly(saturday)"
-                }
-            },
+            {"movies": {"mov-library_movies-top_level_schedule": "weekly(saturday)"}},
             {},
         )
 

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -2008,3 +2008,35 @@ def test_build_libraries_section_emits_schedule_overlays(app):
     movies = libraries_section["libraries"]["Movies"]
     assert movies["schedule_overlays"] == "weekly(saturday)"
     assert list(movies.keys())[:2] == ["schedule_overlays", "template_variables"]
+
+
+def test_build_libraries_section_emits_schedule(app):
+    from modules import output
+
+    with app.app_context():
+        libraries_section = output.build_libraries_section(
+            {"mov-library_movies-library": "Movies"},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {
+                "movies": {
+                    "mov-library_movies-top_level_schedule": "weekly(saturday)"
+                }
+            },
+            {},
+        )
+
+    movies = libraries_section["libraries"]["Movies"]
+    assert movies["schedule"] == "weekly(saturday)"
+    assert list(movies.keys())[:2] == ["schedule", "template_variables"]

--- a/tests/test_importer_library_services.py
+++ b/tests/test_importer_library_services.py
@@ -57,13 +57,7 @@ def test_prepare_import_payload_maps_library_sonarr_overrides():
 
 def test_prepare_import_payload_maps_library_schedule_overlays():
     payload, report = importer.prepare_import_payload(
-        {
-            "libraries": {
-                "Movies": {
-                    "schedule_overlays": "weekly(saturday)"
-                }
-            }
-        },
+        {"libraries": {"Movies": {"schedule_overlays": "weekly(saturday)"}}},
         {"Movies"},
         set(),
     )
@@ -75,13 +69,7 @@ def test_prepare_import_payload_maps_library_schedule_overlays():
 
 def test_prepare_import_payload_maps_library_schedule():
     payload, report = importer.prepare_import_payload(
-        {
-            "libraries": {
-                "Movies": {
-                    "schedule": "weekly(saturday)"
-                }
-            }
-        },
+        {"libraries": {"Movies": {"schedule": "weekly(saturday)"}}},
         {"Movies"},
         set(),
         set(),

--- a/tests/test_importer_library_services.py
+++ b/tests/test_importer_library_services.py
@@ -71,3 +71,22 @@ def test_prepare_import_payload_maps_library_schedule_overlays():
     libraries = payload["libraries"]["libraries"]
     assert libraries["mov-library_movies-top_level_schedule_overlays"] == "weekly(saturday)"
     assert any("libraries.Movies.schedule_overlays" in line for line in report.lines)
+
+
+def test_prepare_import_payload_maps_library_schedule():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Movies": {
+                    "schedule": "weekly(saturday)"
+                }
+            }
+        },
+        {"Movies"},
+        set(),
+        set(),
+    )
+
+    libraries = payload["libraries"]["libraries"]
+    assert libraries["mov-library_movies-top_level_schedule"] == "weekly(saturday)"
+    assert any("libraries.Movies.schedule" in line for line in report.lines)

--- a/tests/test_importer_library_services.py
+++ b/tests/test_importer_library_services.py
@@ -53,3 +53,21 @@ def test_prepare_import_payload_maps_library_sonarr_overrides():
     assert libraries["sho-library_shows-attribute_sonarr_monitor"] == "future"
     assert libraries["sho-library_shows-attribute_sonarr_season_folder"] == "true"
     assert any("libraries.Shows.sonarr.language_profile" in line for line in report.lines)
+
+
+def test_prepare_import_payload_maps_library_schedule_overlays():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Movies": {
+                    "schedule_overlays": "weekly(saturday)"
+                }
+            }
+        },
+        {"Movies"},
+        set(),
+    )
+
+    libraries = payload["libraries"]["libraries"]
+    assert libraries["mov-library_movies-top_level_schedule_overlays"] == "weekly(saturday)"
+    assert any("libraries.Movies.schedule_overlays" in line for line in report.lines)


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

This PR fixes a Libraries page UI regression where Collection Files rendered as a nested accordion inside itself, and expands library-level scheduling support by adding both standard schedule and schedule_overlays handling to Quickstart.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
