### PR TITLE
add overlay_files: v1

### DIFF
--- a/modules/importer.py
+++ b/modules/importer.py
@@ -1251,19 +1251,33 @@ def prepare_import_payload(
             # Overlays
             overlay_files = lib_cfg.get("overlay_files")
             if isinstance(overlay_files, list):
+                imported_overlay_files = []
                 for idx, entry in enumerate(overlay_files):
                     default_value = None
                     template_values = None
                     builder_level = builder_default
+                    raw_entry_type = None
+                    raw_entry_location = None
                     if isinstance(entry, dict):
                         default_value = entry.get("default")
                         template_values = entry.get("template_variables")
+                        for candidate in ("file", "folder", "url", "git", "repo"):
+                            location = entry.get(candidate)
+                            if location:
+                                raw_entry_type = candidate
+                                raw_entry_location = str(location)
+                                break
                         if isinstance(template_values, dict) and "builder_level" in template_values:
                             level = template_values.get("builder_level")
                             if level in {"show", "season", "episode"}:
                                 builder_level = level
                     elif isinstance(entry, str):
                         default_value = entry
+
+                    if raw_entry_type and raw_entry_location:
+                        imported_overlay_files.append({"type": raw_entry_type, "location": raw_entry_location})
+                        report.add("imported", f"libraries.{lib_name}.overlay_files[{idx}].{raw_entry_type}")
+                        continue
 
                     if not default_value:
                         report.add("unmapped", f"libraries.{lib_name}.overlay_files[{idx}]", "Missing default.")
@@ -1331,6 +1345,10 @@ def prepare_import_payload(
                                 "imported",
                                 f"libraries.{lib_name}.overlay_files[{idx}].template_variables.{key}",
                             )
+
+                if imported_overlay_files:
+                    libraries_data[f"{lib_id}-overlay_files"] = json.dumps(imported_overlay_files, ensure_ascii=True)
+                    report.add("imported", f"libraries.{lib_name}.overlay_files")
 
             elif overlay_files is not None:
                 report.add("unmapped", f"libraries.{lib_name}.overlay_files", "Unsupported overlay_files format.")

--- a/modules/output.py
+++ b/modules/output.py
@@ -1052,6 +1052,37 @@ def _parse_collection_file_block_entries(raw_value):
     return normalized
 
 
+def _parse_overlay_file_block_entries(raw_value):
+    if isinstance(raw_value, list):
+        entries = raw_value
+    elif isinstance(raw_value, str):
+        text = raw_value.strip()
+        if not text:
+            return []
+        try:
+            entries = json.loads(text)
+        except Exception:
+            return []
+    else:
+        return []
+
+    if not isinstance(entries, list):
+        return []
+
+    normalized = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        entry_type = str(entry.get("type") or "").strip().lower()
+        location = str(entry.get("location") or "").strip()
+        if entry_type not in {"file", "folder", "url", "git", "repo"} or not location:
+            continue
+        normalized.append({entry_type: location})
+
+    normalized.sort(key=lambda item: (next(iter(item.keys())), next(iter(item.values())).casefold()))
+    return normalized
+
+
 def build_libraries_section(
     movie_libraries,
     show_libraries,
@@ -1372,10 +1403,10 @@ def build_libraries_section(
             helpers.ts_log(f"collections keys for {collection_key}: {list(collections.get(collection_key, {}).keys())}", level="DEBUG")
             helpers.ts_log(f"templates keys for {collection_key}: {list(templates.get(collection_key, {}).keys())}", level="DEBUG")
 
-        if collection_key and collection_key in collections:
+        if collection_key:
             collection_files = []
 
-            for key, selected in collections[collection_key].items():
+            for key, selected in collections.get(collection_key, {}).items():
                 if "template_collection_" in key:
                     if app.config["QS_DEBUG"]:
                         helpers.ts_log(f"Skipping invalid collection key (template child): {key}", level="DEBUG")
@@ -1945,6 +1976,12 @@ def build_libraries_section(
 
                         overlay_entries.sort(key=overlay_sort_key)
 
+                overlay_library_prefix = library_key[: -len("-library")] if isinstance(library_key, str) and library_key.endswith("-library") else library_key
+                raw_overlay_file_entries = _parse_overlay_file_block_entries(overlays.get(overlay_key, {}).get(f"{overlay_library_prefix}-overlay_files"))
+                if raw_overlay_file_entries:
+                    overlay_entries.extend(raw_overlay_file_entries)
+
+                if overlay_entries:
                     entry["overlay_files"] = overlay_entries
 
         metadata_group = (
@@ -2534,10 +2571,16 @@ def build_config(header_style="standard", config_name=None):
         show_collections = group_by_library("collection_", show_library_names)
         movie_collection_files = group_by_library("collection_files", movie_library_names)
         show_collection_files = group_by_library("collection_files", show_library_names)
+        movie_overlay_file_blocks = group_by_library("overlay_files", movie_library_names)
+        show_overlay_file_blocks = group_by_library("overlay_files", show_library_names)
         # movie_overlays = group_by_library("overlay_", movie_library_names)
         # show_overlays = group_by_library("overlay_", show_library_names)
         movie_overlays = group_by_library("overlay_", movie_library_names, normalize_overlays=True)
         show_overlays = group_by_library("overlay_", show_library_names, normalize_overlays=True)
+        for lib_name, payload in movie_overlay_file_blocks.items():
+            movie_overlays.setdefault(lib_name, {}).update(payload)
+        for lib_name, payload in show_overlay_file_blocks.items():
+            show_overlays.setdefault(lib_name, {}).update(payload)
         movie_attributes = group_by_library("attribute_", movie_library_names)
         show_attributes = group_by_library("attribute_", show_library_names)
         movie_metadata_files = group_by_library("metadata_files", movie_library_names)
@@ -2555,6 +2598,8 @@ def build_config(header_style="standard", config_name=None):
             helpers.ts_log(f"Extracted Show Collections: {show_collections}", level="DEBUG")
             helpers.ts_log(f"Extracted Movie Collection Files: {movie_collection_files}", level="DEBUG")
             helpers.ts_log(f"Extracted Show Collection Files: {show_collection_files}", level="DEBUG")
+            helpers.ts_log(f"Extracted Movie Overlay File Blocks: {movie_overlay_file_blocks}", level="DEBUG")
+            helpers.ts_log(f"Extracted Show Overlay File Blocks: {show_overlay_file_blocks}", level="DEBUG")
             helpers.ts_log(f"Extracted Movie Overlays: {movie_overlays}", level="DEBUG")
             helpers.ts_log(f"Extracted Show Overlays: {show_overlays}", level="DEBUG")
             helpers.ts_log(f"Extracted Movie Attributes: {movie_attributes}", level="DEBUG")

--- a/modules/validations.py
+++ b/modules/validations.py
@@ -85,6 +85,10 @@ def _validate_collection_yaml_text(raw_text, label, source_name=None):
     return _validate_required_top_level_mapping(raw_text, label, source_name, "collections")
 
 
+def _validate_overlay_yaml_text(raw_text, label, source_name=None):
+    return _validate_required_top_level_mapping(raw_text, label, source_name, "overlays")
+
+
 def _validate_yaml_location_suffix(location, label):
     lowered = str(location or "").strip().lower()
     if not lowered.endswith((".yml", ".yaml")):
@@ -212,6 +216,42 @@ def _validate_collection_yaml_location(location, label):
     return _validate_collection_yaml_text(yaml_text, label, source_name)
 
 
+def _validate_overlay_yaml_location(location, label):
+    valid, message = _validate_yaml_location_suffix(location, label)
+    if not valid:
+        return False, message
+
+    source_name = os.path.basename(urllib.parse.urlparse(str(location)).path) or os.path.basename(str(location)) or label
+
+    if str(location).strip().lower().startswith(("http://", "https://")):
+        valid, message = url_validation.validate_url(location, allow_local=True)
+        if not valid:
+            return False, f"{label}: {message}"
+
+        try:
+            response = requests.get(location, timeout=15)
+        except requests.RequestException as exc:
+            return False, f"{label}: Unable to fetch URL. {exc}"
+        if response.status_code >= 400:
+            return False, f"{label}: URL returned HTTP {response.status_code} {response.reason}."
+        yaml_text = response.text
+    else:
+        valid, message = path_validation.validate_path(
+            location,
+            {"allow_relative": True, "must_exist": True, "mode": "input_file"},
+        )
+        if not valid:
+            return False, f"{label}: {message}"
+
+        try:
+            with open(location, "r", encoding="utf-8") as handle:
+                yaml_text = handle.read()
+        except OSError as exc:
+            return False, f"{label}: Unable to read file. {exc}"
+
+    return _validate_overlay_yaml_text(yaml_text, label, source_name)
+
+
 def _summarize_folder_validation_failures(label, yaml_files, failures):
     scanned_files = len(yaml_files)
     invalid_files = len(failures)
@@ -287,6 +327,45 @@ def _validate_collection_yaml_folder(location, label):
             continue
 
         valid, message = _validate_collection_yaml_text(yaml_text, label, os.path.basename(yaml_file))
+        if not valid:
+            failures.append(message)
+
+    if failures:
+        return _summarize_folder_validation_failures(label, yaml_files, failures)
+
+    validated_files = len(yaml_files)
+    file_names = [os.path.basename(yaml_file) for yaml_file in yaml_files]
+    suffix = "" if validated_files == 1 else "s"
+    return True, None, {"validated_files": validated_files, "files": file_names, "message": f"Validated {validated_files} YAML file{suffix} in folder."}
+
+
+def _validate_overlay_yaml_folder(location, label):
+    valid, message = path_validation.validate_path(
+        location,
+        {"allow_relative": True, "must_exist": True, "mode": "input_dir"},
+    )
+    if not valid:
+        return False, f"{label}: {message}"
+
+    try:
+        entries = sorted(os.listdir(location), key=str.casefold)
+    except OSError as exc:
+        return False, f"{label}: Unable to read folder. {exc}"
+
+    yaml_files = [os.path.join(location, entry) for entry in entries if os.path.isfile(os.path.join(location, entry)) and entry.lower().endswith((".yml", ".yaml"))]
+    if not yaml_files:
+        return False, f"{label}: Folder must contain at least one top-level .yml or .yaml file."
+
+    failures = []
+    for yaml_file in yaml_files:
+        try:
+            with open(yaml_file, "r", encoding="utf-8") as handle:
+                yaml_text = handle.read()
+        except OSError as exc:
+            failures.append(f"Unable to read `{os.path.basename(yaml_file)}`. {exc}")
+            continue
+
+        valid, message = _validate_overlay_yaml_text(yaml_text, label, os.path.basename(yaml_file))
         if not valid:
             failures.append(message)
 
@@ -431,6 +510,58 @@ def validate_collection_file_payload(data):
     return _normalize_metadata_validation_result(_validate_collection_yaml_location(resolved_repo_location, "Collection file repo path"))
 
 
+def validate_overlay_file_payload(data):
+    overlay_file_type = str(data.get("overlay_file_type") or "").strip().lower()
+    overlay_file_location = str(data.get("overlay_file_location") or "").strip()
+
+    if overlay_file_type not in {"file", "folder", "url", "git", "repo"}:
+        return False, "Overlay file type must be file, folder, url, git, or repo.", {}
+
+    if not overlay_file_location:
+        return False, "Overlay file location is required.", {}
+
+    if overlay_file_type == "url":
+        if not overlay_file_location.lower().startswith(("http://", "https://")):
+            return False, "Overlay file URL must start with http:// or https://.", {}
+        label = "Overlay file URL"
+        return _normalize_metadata_validation_result(_validate_overlay_yaml_location(overlay_file_location, label))
+
+    if overlay_file_type == "folder":
+        if overlay_file_location.lower().startswith(("http://", "https://")):
+            return False, "Overlay folder path must be a local folder path.", {}
+        label = "Overlay folder path"
+        return _normalize_metadata_validation_result(_validate_overlay_yaml_folder(overlay_file_location, label))
+
+    if overlay_file_type == "file":
+        if overlay_file_location.lower().startswith(("http://", "https://")):
+            return False, "Overlay file path must be a local file path.", {}
+        label = "Overlay file path"
+        return _normalize_metadata_validation_result(_validate_overlay_yaml_location(overlay_file_location, label))
+
+    if overlay_file_location.lower().startswith(("http://", "https://")):
+        return False, f"Overlay file {overlay_file_type} value must not be a full URL.", {}
+
+    if overlay_file_type == "git":
+        valid, message = _validate_yaml_location_suffix(overlay_file_location, "Overlay file git path")
+        if not valid:
+            return False, message, {}
+        return _normalize_metadata_validation_result(
+            _validate_overlay_yaml_location(
+                f"https://raw.githubusercontent.com/Kometa-Team/Community-Configs/master/{overlay_file_location}",
+                "Overlay file git path",
+            )
+        )
+
+    custom_repo_base = _saved_custom_repo_base()
+    if not custom_repo_base:
+        return False, "Overlay file repo entries require Custom Repo to be configured and saved first within the Settings page.", {}
+    valid, message = _validate_yaml_location_suffix(overlay_file_location, "Overlay file repo path")
+    if not valid:
+        return False, message, {}
+    resolved_repo_location = f"{custom_repo_base}{overlay_file_location}"
+    return _normalize_metadata_validation_result(_validate_overlay_yaml_location(resolved_repo_location, "Overlay file repo path"))
+
+
 def validate_metadata_file_server(data):
     valid, message, details = validate_metadata_file_payload(data)
     if not valid:
@@ -452,6 +583,25 @@ def validate_metadata_file_server(data):
 
 def validate_collection_file_server(data):
     valid, message, details = validate_collection_file_payload(data)
+    if not valid:
+        payload = {"valid": False, "error": message}
+        if details.get("message") or isinstance(details.get("files"), list):
+            payload["error_details"] = {"text": details.get("message") or message, "files": details.get("files") if isinstance(details.get("files"), list) else []}
+        if isinstance(details.get("files"), list):
+            payload["files"] = details["files"]
+        return jsonify(payload), 400
+    payload = {"valid": True}
+    if details.get("message"):
+        payload["message"] = details["message"]
+    if "validated_files" in details:
+        payload["validated_files"] = details["validated_files"]
+    if isinstance(details.get("files"), list):
+        payload["files"] = details["files"]
+    return jsonify(payload)
+
+
+def validate_overlay_file_server(data):
+    valid, message, details = validate_overlay_file_payload(data)
     if not valid:
         payload = {"valid": False, "error": message}
         if details.get("message") or isinstance(details.get("files"), list):

--- a/quickstart.py
+++ b/quickstart.py
@@ -173,6 +173,7 @@ VALIDATION_REASON_LABELS = {
     "missing_placeholder_imdb": "Missing placeholder IMDb ID",
     "invalid_metadata_files": "Invalid metadata files",
     "invalid_collection_files": "Invalid collection files",
+    "invalid_overlay_files": "Invalid overlay files",
     "invalid_fields": "Invalid fields",
     "no_webhooks": "No webhooks configured",
     "disabled": "Disabled",
@@ -401,6 +402,7 @@ QS_ERROR_REASONS = {
     "invalid_paths",
     "invalid_arr_overrides",
     "invalid_collection_files",
+    "invalid_overlay_files",
     "invalid_fields",
     "invalid_metadata_files",
     "missing_library_defaults",
@@ -662,6 +664,35 @@ def _parse_collection_file_entries(value):
     return entries
 
 
+def _parse_overlay_file_entries(value):
+    if isinstance(value, list):
+        raw_entries = value
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return []
+        try:
+            raw_entries = json.loads(text)
+        except (TypeError, ValueError):
+            return None
+    else:
+        return []
+
+    if not isinstance(raw_entries, list):
+        return None
+
+    entries = []
+    for entry in raw_entries:
+        if not isinstance(entry, dict):
+            continue
+        entry_type = str(entry.get("type") or "").strip().lower()
+        location = str(entry.get("location") or "").strip()
+        if not entry_type and not location:
+            continue
+        entries.append({"type": entry_type, "location": location})
+    return entries
+
+
 def _is_blank_override_value(value):
     if value is None:
         return True
@@ -870,6 +901,36 @@ def _validate_library_collection_files(libraries_data, selected_library_ids):
             )
             if not valid:
                 errors.append(f"{lib_id} collection_files[{idx}]: {message}")
+
+    return errors
+
+
+def _validate_library_overlay_files(libraries_data, selected_library_ids):
+    if not isinstance(libraries_data, dict):
+        return []
+
+    errors = []
+    for lib_id in selected_library_ids or []:
+        raw_value = libraries_data.get(f"{lib_id}-overlay_files")
+        if raw_value in [None, "", "[]"]:
+            continue
+
+        entries = _parse_overlay_file_entries(raw_value)
+        if entries is None:
+            errors.append(f"{lib_id}: overlay_files must be a valid list.")
+            continue
+
+        for idx, entry in enumerate(entries, start=1):
+            valid, message, _details = validations._normalize_metadata_validation_result(
+                validations.validate_overlay_file_payload(
+                    {
+                        "overlay_file_type": entry.get("type"),
+                        "overlay_file_location": entry.get("location"),
+                    }
+                )
+            )
+            if not valid:
+                errors.append(f"{lib_id} overlay_files[{idx}]: {message}")
 
     return errors
 
@@ -6233,6 +6294,7 @@ def step(name):
             selected_library_ids = _selected_library_ids_from_libraries_data(incoming_libraries)
             validation_errors += _validate_library_collection_files(incoming_libraries, selected_library_ids)
             validation_errors += _validate_library_metadata_files(incoming_libraries, selected_library_ids)
+            validation_errors += _validate_library_overlay_files(incoming_libraries, selected_library_ids)
             for lib_id in selected_library_ids:
                 override_result = _validate_library_service_overrides(lib_id, incoming_libraries)
                 if not override_result.get("valid") and not override_result.get("skipped"):
@@ -7107,10 +7169,13 @@ def autosave_library(library_id):
         selected_library_ids = _selected_library_ids_from_libraries_data(incoming_libraries)
         collection_errors = _validate_library_collection_files(incoming_libraries, selected_library_ids)
         metadata_errors = _validate_library_metadata_files(incoming_libraries, selected_library_ids)
+        overlay_errors = _validate_library_overlay_files(incoming_libraries, selected_library_ids)
         if collection_errors:
             return jsonify({"success": False, "error": "Invalid collection files.", "errors": collection_errors}), 400
         if metadata_errors:
             return jsonify({"success": False, "error": "Invalid metadata files.", "errors": metadata_errors}), 400
+        if overlay_errors:
+            return jsonify({"success": False, "error": "Invalid overlay files.", "errors": overlay_errors}), 400
         persistence.save_settings("025-libraries", incoming)
         return jsonify({"success": True})
     except Exception as e:
@@ -7355,6 +7420,7 @@ def copy_library_settings():
         source_errors = path_validation.validate_payload(source_items)
         source_collection_errors = _validate_library_collection_files(libraries_data, [source_prefix])
         source_metadata_errors = _validate_library_metadata_files(libraries_data, [source_prefix])
+        source_overlay_errors = _validate_library_overlay_files(libraries_data, [source_prefix])
         if source_errors:
             return (
                 jsonify(
@@ -7384,6 +7450,17 @@ def copy_library_settings():
                         "success": False,
                         "error": "Invalid metadata files found in source library: " + " ".join(source_metadata_errors),
                         "errors": source_metadata_errors,
+                    }
+                ),
+                400,
+            )
+        if source_overlay_errors:
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "error": "Invalid overlay files found in source library: " + " ".join(source_overlay_errors),
+                        "errors": source_overlay_errors,
                     }
                 ),
                 400,
@@ -8356,17 +8433,20 @@ def validate_all_services():
             path_errors = path_validation.validate_payload(libraries_data)
             collection_file_errors = _validate_library_collection_files(libraries_data, selected_library_ids)
             metadata_file_errors = _validate_library_metadata_files(libraries_data, selected_library_ids)
+            overlay_file_errors = _validate_library_overlay_files(libraries_data, selected_library_ids)
             arr_override_errors = []
             if path_errors:
                 libraries_reason = "invalid_paths"
             elif collection_file_errors:
                 libraries_reason = "invalid_collection_files"
+            elif overlay_file_errors:
+                libraries_reason = "invalid_overlay_files"
             elif metadata_file_errors:
                 libraries_reason = "invalid_metadata_files"
             else:
 
                 def has_minimal_library_yaml_selection(lib_id):
-                    allowed_markers = ("-collection_", "-overlay_", "-attribute_", "-top_level_", "-metadata_files", "-collection_files")
+                    allowed_markers = ("-collection_", "-overlay_", "-attribute_", "-top_level_", "-metadata_files", "-collection_files", "-overlay_files")
                     for key, value in libraries_data.items():
                         if not isinstance(key, str) or not key.startswith(f"{lib_id}-"):
                             continue
@@ -16499,6 +16579,12 @@ def validate_metadata_file():
 def validate_collection_file():
     data = request.get_json(silent=True) or {}
     return validations.validate_collection_file_server(data)
+
+
+@app.route("/validate_overlay_file", methods=["POST"])
+def validate_overlay_file():
+    data = request.get_json(silent=True) or {}
+    return validations.validate_overlay_file_server(data)
 
 
 @app.route("/restart", methods=["POST"])

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -131,6 +131,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const metadataCustomRepoBase = String(window.QS_SETTINGS_CUSTOM_REPO_BASE || '').trim()
     const metadataRepoDependencyMessage = 'Metadata file repo entries require Custom Repo to be configured and saved first within the Settings page.'
     const collectionRepoDependencyMessage = 'Collection file repo entries require Custom Repo to be configured and saved first within the Settings page.'
+    const overlayRepoDependencyMessage = 'Overlay file repo entries require Custom Repo to be configured and saved first within the Settings page.'
 
     function appendMetadataSettingsLink (target, className = 'link-light fw-semibold text-decoration-underline') {
       const link = document.createElement('a')
@@ -1017,6 +1018,429 @@ document.addEventListener('DOMContentLoaded', function () {
     if (libraryContainer && typeof MutationObserver !== 'undefined') {
       const collectionObserver = new MutationObserver(() => initCollectionFilesEditors(libraryContainer))
       collectionObserver.observe(libraryContainer, { childList: true, subtree: true })
+    }
+
+    function buildOverlayFileRow (entry = {}) {
+      const wrapper = document.createElement('div')
+      wrapper.className = 'card bg-body-tertiary border-secondary'
+      wrapper.setAttribute('data-overlay-file-row', 'true')
+      wrapper.innerHTML = `
+        <div class="card-body">
+          <div class="row g-3 align-items-end">
+            <div class="col-md-2">
+              <label class="form-label small text-muted">Type</label>
+              <select class="form-select form-select-sm" data-overlay-file-type>
+                <option value="file">file</option>
+                <option value="folder">folder</option>
+                <option value="git">git</option>
+                <option value="repo">repo</option>
+                <option value="url">url</option>
+              </select>
+            </div>
+            <div class="col-md-7">
+              <label class="form-label small text-muted">Location</label>
+              <input type="text" class="form-control form-control-sm" data-overlay-file-location placeholder="config/overlays.yml, config/overlays/, user/file.yml, or https://example.com/overlays.yml">
+            </div>
+            <div class="col-md-3 d-flex gap-2 justify-content-md-end">
+              <button type="button" class="btn btn-success btn-sm" data-validate-overlay-file>Validate</button>
+              <button type="button" class="btn btn-danger btn-sm" data-remove-overlay-file>Remove</button>
+            </div>
+          </div>
+          <div class="mt-2 small d-none" data-overlay-file-status></div>
+        </div>
+      `
+      const typeSelect = wrapper.querySelector('[data-overlay-file-type]')
+      const locationInput = wrapper.querySelector('[data-overlay-file-location]')
+      if (typeSelect && ['file', 'folder', 'git', 'repo', 'url'].includes(entry.type)) {
+        typeSelect.value = entry.type
+      }
+      if (locationInput && entry.location) {
+        locationInput.value = entry.location
+      }
+      updateOverlayFileValidateButton(wrapper, false)
+      return wrapper
+    }
+
+    function updateOverlayFileValidateButton (row, isValidated) {
+      if (!row) return
+      const button = row.querySelector('[data-validate-overlay-file]')
+      if (!button) return
+      const state = String(row.dataset.overlayFileButtonState || '').trim() || (isValidated ? 'success' : 'idle')
+      button.classList.remove('btn-success', 'btn-secondary')
+      if (state === 'success') {
+        button.disabled = true
+        button.classList.add('btn-secondary')
+        button.textContent = 'Validated'
+        return
+      }
+      if (state === 'blocked') {
+        button.disabled = true
+        button.classList.add('btn-secondary')
+        button.textContent = 'Needs Repo'
+        return
+      }
+      if (state === 'loading') {
+        button.disabled = true
+        button.classList.add('btn-secondary')
+        button.textContent = 'Validating...'
+        return
+      }
+      button.disabled = false
+      button.classList.add('btn-success')
+      button.textContent = 'Validate'
+    }
+
+    function setOverlayFileButtonState (row, state) {
+      if (!row) return
+      row.dataset.overlayFileButtonState = state || 'idle'
+      updateOverlayFileValidateButton(row, state === 'success')
+    }
+
+    function updateOverlayCustomRepoStatus (editor) {
+      if (!editor) return
+      const target = editor.querySelector('[data-overlay-custom-repo-status]')
+      if (!target) return
+
+      target.replaceChildren()
+      target.className = 'alert small mb-3'
+      if (!metadataCustomRepoBase) {
+        target.classList.add('alert-warning')
+        target.append('Custom Repo is not configured. ')
+        target.append('Use ')
+        appendMetadataSettingsLink(target, 'alert-link fw-semibold')
+        target.append(' to configure and save it before using ')
+        const code = document.createElement('code')
+        code.textContent = 'repo'
+        target.appendChild(code)
+        target.append(' overlay files.')
+        return
+      }
+
+      target.classList.add('alert-secondary')
+      const label = document.createElement('div')
+      label.className = 'fw-semibold mb-1'
+      label.textContent = 'Custom Repo base used for repo entries'
+      target.appendChild(label)
+
+      const baseValue = document.createElement('code')
+      baseValue.textContent = metadataCustomRepoBase
+      target.appendChild(baseValue)
+
+      if (metadataCustomRepoRaw && metadataCustomRepoRaw !== metadataCustomRepoBase) {
+        const savedValue = document.createElement('div')
+        savedValue.className = 'mt-2'
+        savedValue.append('Saved Custom Repo value: ')
+        const savedCode = document.createElement('code')
+        savedCode.textContent = metadataCustomRepoRaw
+        savedValue.appendChild(savedCode)
+        target.appendChild(savedValue)
+      }
+
+      const hint = document.createElement('div')
+      hint.className = 'mt-2'
+      hint.append('Change it in ')
+      appendMetadataSettingsLink(hint, 'alert-link fw-semibold')
+      hint.append('.')
+      target.appendChild(hint)
+    }
+
+    function applyOverlayFileDependencyState (row, opts = {}) {
+      if (!row) return false
+      const skipStatus = Boolean(opts.skipStatus)
+      const type = row.querySelector('[data-overlay-file-type]')?.value || ''
+      if (type !== 'repo') {
+        if (row.dataset.overlayFileDependency === 'repo-missing') {
+          row.dataset.overlayFileDependency = ''
+        }
+        return false
+      }
+
+      if (metadataCustomRepoBase) {
+        if (row.dataset.overlayFileDependency === 'repo-missing') {
+          row.dataset.overlayFileDependency = ''
+        }
+        return false
+      }
+
+      row.dataset.overlayFileDependency = 'repo-missing'
+      setOverlayFileButtonState(row, 'blocked')
+      if (!skipStatus) {
+        setOverlayFileStatus(row, 'error', overlayRepoDependencyMessage)
+      }
+      return true
+    }
+
+    function renderOverlayFileStatusMessage (target, message) {
+      target.replaceChildren()
+      if (!message) return
+
+      if (typeof message === 'object' && message !== null) {
+        const text = String(message.text || message.message || '').trim()
+        const files = Array.isArray(message.files) ? message.files.filter(Boolean) : []
+        if (text) {
+          const summary = document.createElement('div')
+          appendInlineCodeText(summary, text)
+          target.appendChild(summary)
+        }
+        if (files.length) {
+          if (files.length <= 5) {
+            const list = document.createElement('ul')
+            list.className = 'mb-0 mt-1 ps-3'
+            files.forEach(file => {
+              const item = document.createElement('li')
+              appendInlineCodeText(item, file, { wrapPlainInCode: true })
+              list.appendChild(item)
+            })
+            target.appendChild(list)
+          } else {
+            const details = document.createElement('details')
+            details.className = 'mt-1'
+            const summary = document.createElement('summary')
+            summary.className = 'cursor-pointer'
+            summary.textContent = 'Show files'
+            details.appendChild(summary)
+            const list = document.createElement('ul')
+            list.className = 'mb-0 mt-1 ps-3'
+            files.forEach(file => {
+              const item = document.createElement('li')
+              appendInlineCodeText(item, file, { wrapPlainInCode: true })
+              list.appendChild(item)
+            })
+            details.appendChild(list)
+            target.appendChild(details)
+          }
+        }
+        return
+      }
+
+      const text = String(message || '').trim()
+      if (!text) return
+
+      if (text === overlayRepoDependencyMessage) {
+        target.append('Overlay file repo entries require Custom Repo to be configured and saved first within the ')
+        appendMetadataSettingsLink(target)
+        target.append(' page.')
+        return
+      }
+
+      appendInlineCodeText(target, text)
+    }
+
+    function setOverlayFileStatus (row, kind, message) {
+      if (!row) return
+      const target = row.querySelector('[data-overlay-file-status]')
+      if (!target) return
+      row.dataset.overlayFileState = kind || ''
+      target.className = 'mt-2 small'
+      if (!message) {
+        target.classList.add('d-none')
+        target.textContent = ''
+        if (applyOverlayFileDependencyState(row, { skipStatus: true })) {
+          setOverlayFileButtonState(row, 'blocked')
+        } else {
+          setOverlayFileButtonState(row, 'idle')
+        }
+        const editor = row.closest('[data-overlay-files-editor]')
+        if (editor) updateOverlayFilesAccordionState(editor)
+        return
+      }
+      target.classList.remove('d-none')
+      if (kind === 'success') {
+        target.classList.add('text-success')
+      } else if (kind === 'error') {
+        target.classList.add('text-danger')
+      } else {
+        target.classList.add('text-warning')
+      }
+      renderOverlayFileStatusMessage(target, message)
+      if (kind === 'success') {
+        setOverlayFileButtonState(row, 'success')
+      } else if (row.dataset.overlayFileDependency === 'repo-missing') {
+        setOverlayFileButtonState(row, 'blocked')
+      } else {
+        setOverlayFileButtonState(row, 'idle')
+      }
+      const editor = row.closest('[data-overlay-files-editor]')
+      if (editor) updateOverlayFilesAccordionState(editor)
+    }
+
+    function updateOverlayFilesAccordionState (editor) {
+      if (!editor) return
+      const accordionItem = editor.closest('.accordion-item')
+      const accordionHeader = accordionItem?.querySelector(':scope > .accordion-header')
+      if (!accordionHeader) return
+
+      const rows = Array.from(editor.querySelectorAll('[data-overlay-file-row]'))
+      const hasEntries = rows.some(row => normalizeMetadataFileEntry({
+        type: row.querySelector('[data-overlay-file-type]')?.value || '',
+        location: row.querySelector('[data-overlay-file-location]')?.value || ''
+      }))
+      const hasInvalid = rows.some(row => {
+        const state = String(row.dataset.overlayFileState || '').trim().toLowerCase()
+        return state === 'error' || state === 'warning'
+      })
+
+      accordionHeader.classList.toggle('invalid', hasInvalid)
+      if (!hasInvalid && hasEntries) {
+        accordionHeader.classList.add('selected')
+      } else if (!hasEntries && !hasInvalid && typeof EventHandler !== 'undefined' && typeof EventHandler.updateAccordionHighlights === 'function') {
+        EventHandler.updateAccordionHighlights()
+      }
+    }
+
+    function applyOverlayFileServerErrors (editor, errors) {
+      if (!editor || !Array.isArray(errors) || !errors.length) return false
+      const rows = Array.from(editor.querySelectorAll('[data-overlay-file-row]'))
+      rows.forEach(row => setOverlayFileStatus(row, '', ''))
+      let applied = false
+      errors.forEach(error => {
+        const text = String(error || '').trim()
+        const match = text.match(/overlay_files\[(\d+)\]:\s*(.+)$/i)
+        if (!match) return
+        const index = Number(match[1]) - 1
+        const message = match[2] || 'Validation failed.'
+        if (!Number.isInteger(index) || index < 0 || index >= rows.length) return
+        setOverlayFileStatus(rows[index], 'error', message)
+        applied = true
+      })
+      return applied
+    }
+
+    function syncOverlayFilesEditor (editor, emitEvents = true) {
+      if (!editor) return []
+      const hidden = editor.querySelector('input[type="hidden"][name$="-overlay_files"]')
+      if (!hidden) return []
+      const rows = Array.from(editor.querySelectorAll('[data-overlay-file-row]'))
+      const entries = rows.map(row => {
+        const type = row.querySelector('[data-overlay-file-type]')?.value
+        const location = row.querySelector('[data-overlay-file-location]')?.value
+        return normalizeMetadataFileEntry({ type, location })
+      }).filter(Boolean)
+      hidden.value = JSON.stringify(entries)
+      if (emitEvents) {
+        hidden.dispatchEvent(new Event('input', { bubbles: true }))
+        hidden.dispatchEvent(new Event('change', { bubbles: true }))
+      }
+      updateOverlayFilesAccordionState(editor)
+      return entries
+    }
+
+    function renderOverlayFilesEditor (editor) {
+      if (!editor) return
+      const hidden = editor.querySelector('input[type="hidden"][name$="-overlay_files"]')
+      const list = editor.querySelector('[data-overlay-files-list]')
+      if (!hidden || !list) return
+      updateOverlayCustomRepoStatus(editor)
+      const entries = parseMetadataFilesValue(hidden.value)
+      list.replaceChildren()
+      entries.forEach(entry => list.appendChild(buildOverlayFileRow(entry)))
+      list.querySelectorAll('[data-overlay-file-row]').forEach(row => {
+        if (applyOverlayFileDependencyState(row)) return
+        setOverlayFileButtonState(row, 'idle')
+      })
+      syncOverlayFilesEditor(editor, false)
+      updateOverlayFilesAccordionState(editor)
+    }
+
+    function initOverlayFilesEditors (scope) {
+      const root = scope || document
+      root.querySelectorAll('[data-overlay-files-editor]').forEach(editor => {
+        if (editor.dataset.overlayFilesReady === 'true') return
+        renderOverlayFilesEditor(editor)
+        editor.dataset.overlayFilesReady = 'true'
+      })
+    }
+
+    document.addEventListener('click', async function (event) {
+      const addButton = event.target.closest('[data-add-overlay-file]')
+      if (addButton) {
+        const editor = addButton.closest('[data-overlay-files-editor]')
+        const list = editor?.querySelector('[data-overlay-files-list]')
+        if (!editor || !list) return
+        list.appendChild(buildOverlayFileRow({ type: 'file', location: '' }))
+        syncOverlayFilesEditor(editor)
+        return
+      }
+
+      const removeButton = event.target.closest('[data-remove-overlay-file]')
+      if (removeButton) {
+        const row = removeButton.closest('[data-overlay-file-row]')
+        const editor = removeButton.closest('[data-overlay-files-editor]')
+        if (!row || !editor) return
+        row.remove()
+        syncOverlayFilesEditor(editor)
+        return
+      }
+
+      const validateButton = event.target.closest('[data-validate-overlay-file]')
+      if (validateButton) {
+        const row = validateButton.closest('[data-overlay-file-row]')
+        const editor = validateButton.closest('[data-overlay-files-editor]')
+        if (!row || !editor) return
+        if (applyOverlayFileDependencyState(row)) return
+        const type = row.querySelector('[data-overlay-file-type]')?.value || ''
+        const location = row.querySelector('[data-overlay-file-location]')?.value || ''
+        syncOverlayFilesEditor(editor, false)
+        setOverlayFileStatus(row, '', 'Validating...')
+        setOverlayFileButtonState(row, 'loading')
+        try {
+          const response = await fetch('/validate_overlay_file', {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              overlay_file_type: type,
+              overlay_file_location: location
+            })
+          })
+          const payload = await response.json().catch(() => ({}))
+          if (!response.ok || !payload.valid) {
+            setOverlayFileStatus(row, 'error', payload.error_details || {
+              text: payload.error || 'Validation failed.',
+              files: Array.isArray(payload.files) ? payload.files : []
+            })
+          } else {
+            setOverlayFileStatus(row, 'success', {
+              text: payload.message || 'Overlay source looks valid.',
+              files: Array.isArray(payload.files) ? payload.files : []
+            })
+          }
+        } catch (_error) {
+          setOverlayFileStatus(row, 'error', 'Validation request failed.')
+        } finally {
+          if (row.dataset.overlayFileState !== 'success' && row.dataset.overlayFileDependency !== 'repo-missing') {
+            setOverlayFileButtonState(row, 'idle')
+          }
+        }
+      }
+    })
+
+    document.addEventListener('input', function (event) {
+      const target = event.target
+      if (!target || !target.closest('[data-overlay-files-editor]')) return
+      if (!target.matches('[data-overlay-file-type], [data-overlay-file-location]')) return
+      const row = target.closest('[data-overlay-file-row]')
+      const editor = target.closest('[data-overlay-files-editor]')
+      setOverlayFileStatus(row, '', '')
+      applyOverlayFileDependencyState(row)
+      syncOverlayFilesEditor(editor)
+    })
+
+    document.addEventListener('change', function (event) {
+      const target = event.target
+      if (!target || !target.closest('[data-overlay-files-editor]')) return
+      if (!target.matches('[data-overlay-file-type], [data-overlay-file-location]')) return
+      const row = target.closest('[data-overlay-file-row]')
+      const editor = target.closest('[data-overlay-files-editor]')
+      setOverlayFileStatus(row, '', '')
+      applyOverlayFileDependencyState(row)
+      syncOverlayFilesEditor(editor)
+    })
+
+    initOverlayFilesEditors(document)
+    if (libraryContainer && typeof MutationObserver !== 'undefined') {
+      const overlayObserver = new MutationObserver(() => initOverlayFilesEditors(libraryContainer))
+      overlayObserver.observe(libraryContainer, { childList: true, subtree: true })
     }
 
     // Ensure hidden "false" inputs don't submit alongside checked checkboxes with the same name
@@ -2167,7 +2591,7 @@ document.addEventListener('DOMContentLoaded', function () {
         if (field.type === 'checkbox' || field.type === 'radio') return field.checked
         const value = String(field.value ?? '').trim()
         if (!value) return false
-        if (field.name.endsWith('-metadata_files') || field.name.endsWith('-collection_files')) {
+        if (field.name.endsWith('-metadata_files') || field.name.endsWith('-collection_files') || field.name.endsWith('-overlay_files')) {
           return value !== '[]'
         }
         return true
@@ -2608,6 +3032,7 @@ document.addEventListener('DOMContentLoaded', function () {
       const payload = buildPayloadFromCard(card)
       const collectionEditor = card.querySelector('[data-collection-files-editor]')
       const metadataEditor = card.querySelector('[data-metadata-files-editor]')
+      const overlayEditor = card.querySelector('[data-overlay-files-editor]')
       const option = libraryPicker?.querySelector(`option[value="${activeLibraryId}"]`)
       const friendlyName = option?.dataset.label || option?.textContent?.trim() || activeLibraryId
 
@@ -2625,6 +3050,9 @@ document.addEventListener('DOMContentLoaded', function () {
               }
               if (metadataEditor) {
                 applyMetadataFileServerErrors(metadataEditor, body && body.errors)
+              }
+              if (overlayEditor) {
+                applyOverlayFileServerErrors(overlayEditor, body && body.errors)
               }
               const message = body && body.error ? body.error : `Autosave failed: ${res.status}`
               throw new Error(message)

--- a/templates/partials/_library_overlay_files.html
+++ b/templates/partials/_library_overlay_files.html
@@ -1,0 +1,35 @@
+<div class="accordion-item library-advanced-section d-none" data-advanced-section>
+    <h2 class="accordion-header">
+        <button class="accordion-button" type="button" data-bs-toggle="collapse"
+            data-bs-target="#{{ library.id }}-overlay-files">
+            Overlay Files
+        </button>
+    </h2>
+    <div id="{{ library.id }}-overlay-files" class="accordion-collapse collapse">
+        <div class="accordion-body">
+            <div class="d-flex flex-column gap-3">
+                <div class="alert alert-warning small mb-0" role="alert">
+                    <div class="fw-semibold mb-1">Validation is limited.</div>
+                    <div>Quickstart can verify that each entry points to a non-empty <code>.yml</code> or <code>.yaml</code> file and that the YAML parses successfully.</div>
+                    <div>Quickstart also verifies that each overlay file contains a non-empty top-level <code>overlays:</code> mapping.</div>
+                    <div>Quickstart does not fully validate Kometa overlay file schema yet, so a file that passes here may still fail later and cause Kometa to abort during a run.</div>
+                </div>
+                <div class="alert alert-info small mb-0" role="alert">
+                    <div>Use one or more <code>file</code>, <code>folder</code>, <code>url</code>, <code>git</code>, or <code>repo</code> entries. These are written to library-level <code>overlay_files</code>.</div>
+                </div>
+                <div class="overlay-files-editor" data-overlay-files-editor data-library-id="{{ library.id }}">
+                <div class="alert small mb-4" role="alert" data-overlay-custom-repo-status></div>
+                <input type="hidden" name="{{ library.id }}-overlay_files" id="{{ library.id }}-overlay_files"
+                    value="{{ data['libraries'].get(library.id ~ '-overlay_files', '[]') }}">
+                <div class="overlay-files-list d-flex flex-column gap-3 mt-1" data-overlay-files-list></div>
+                <div class="d-flex justify-content-between align-items-center mt-3">
+                    <button type="button" class="btn btn-outline-secondary btn-sm" data-add-overlay-file>
+                        <i class="bi bi-plus-circle me-1"></i>Add Overlay File
+                    </button>
+                    <span class="text-muted small">Supports mixed local files and folders, raw URLs, Community-Configs git paths, and custom_repo-backed repo paths.</span>
+                </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/partials/_movie_library_settings.html
+++ b/templates/partials/_movie_library_settings.html
@@ -49,6 +49,7 @@
 
         {% include "partials/_library_collection_files_accordion.html" %}
         {% include "partials/_library_metadata_files.html" %}
+        {% include "partials/_library_overlay_files.html" %}
         {% include "partials/_library_radarr_overrides.html" %}
 
         <!-- Movie Playlists -->

--- a/templates/partials/_show_library_settings.html
+++ b/templates/partials/_show_library_settings.html
@@ -49,6 +49,7 @@
 
         {% include "partials/_library_collection_files_accordion.html" %}
         {% include "partials/_library_metadata_files.html" %}
+        {% include "partials/_library_overlay_files.html" %}
         {% include "partials/_library_sonarr_overrides.html" %}
 
         <!-- Show Playlists -->

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -171,6 +171,19 @@ def test_validate_collection_file_accepts_existing_local_file(client, tmp_path):
     assert payload["valid"] is True
 
 
+def test_validate_overlay_file_accepts_existing_local_file(client, tmp_path):
+    overlay_file = tmp_path / "overlays.yml"
+    overlay_file.write_text("overlays:\n  test:\n    template:\n      - name: ribbon\n", encoding="utf-8")
+
+    resp = client.post(
+        "/validate_overlay_file",
+        json={"overlay_file_type": "file", "overlay_file_location": str(overlay_file)},
+    )
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["valid"] is True
+
+
 def test_validate_collection_file_rejects_missing_top_level_collections(client, tmp_path):
     collection_file = tmp_path / "collections.yml"
     collection_file.write_text("templates:\n  test:\n    default: true\n", encoding="utf-8")
@@ -198,6 +211,21 @@ def test_validate_collection_file_rejects_empty_top_level_collections(client, tm
     payload = resp.get_json()
     assert payload["valid"] is False
     assert "Top-level `collections:` in `collections.yml` must be a non-empty mapping." == payload["error"]
+
+
+def test_validate_overlay_file_rejects_missing_top_level_overlays(client, tmp_path):
+    overlay_file = tmp_path / "overlays.yml"
+    overlay_file.write_text("templates:\n  test:\n    default: true\n", encoding="utf-8")
+
+    resp = client.post(
+        "/validate_overlay_file",
+        json={"overlay_file_type": "file", "overlay_file_location": str(overlay_file)},
+    )
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert payload["valid"] is False
+    assert "Top-level `overlays:` was not found" in payload["error"]
+    assert "`overlays.yml`" in payload["error"]
 
 
 def test_validate_metadata_file_rejects_missing_top_level_metadata(client, tmp_path):
@@ -505,6 +533,27 @@ def test_autosave_library_rejects_invalid_collection_files(client, monkeypatch, 
     assert "Invalid collection files" in payload["error"]
 
 
+def test_autosave_library_rejects_invalid_overlay_files(client, monkeypatch, qs_module):
+    class _Resp:
+        status_code = 404
+        reason = "Not Found"
+        text = ""
+
+    monkeypatch.setattr(qs_module.validations.requests, "get", lambda *_args, **_kwargs: _Resp())
+
+    resp = client.post(
+        "/autosave_library/mov-library_movies",
+        json={
+            "mov-library_movies-library": "Movies",
+            "mov-library_movies-overlay_files": '[{"type":"url","location":"https://example.com/missing.yml"}]',
+        },
+    )
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert payload["success"] is False
+    assert "Invalid overlay files" in payload["error"]
+
+
 def test_output_metadata_file_entries_are_sorted():
     import json
 
@@ -543,6 +592,38 @@ def test_output_collection_file_entries_are_sorted():
     from modules import output
 
     parsed = output._parse_collection_file_block_entries(
+        json.dumps(
+            [
+                {"type": "url", "location": "https://example.com/zeta.yml"},
+                {"type": "repo", "location": "custom/movies.yml"},
+                {"type": "file", "location": "config/beta.yml"},
+                {"type": "folder", "location": "config/zeta"},
+                {"type": "git", "location": "community/alpha.yml"},
+                {"type": "file", "location": "config/alpha.yml"},
+                {"type": "folder", "location": "config/alpha"},
+                {"type": "url", "location": "https://example.com/alpha.yml"},
+            ]
+        )
+    )
+
+    assert parsed == [
+        {"file": "config/alpha.yml"},
+        {"file": "config/beta.yml"},
+        {"folder": "config/alpha"},
+        {"folder": "config/zeta"},
+        {"git": "community/alpha.yml"},
+        {"repo": "custom/movies.yml"},
+        {"url": "https://example.com/alpha.yml"},
+        {"url": "https://example.com/zeta.yml"},
+    ]
+
+
+def test_output_overlay_file_entries_are_sorted():
+    import json
+
+    from modules import output
+
+    parsed = output._parse_overlay_file_block_entries(
         json.dumps(
             [
                 {"type": "url", "location": "https://example.com/zeta.yml"},
@@ -614,6 +695,53 @@ def test_build_libraries_section_emits_metadata_files(app):
             {"url": "https://example.com/movies_refresh.yml"},
         ]
     assert list(libraries_section["libraries"]["Movies"].keys())[:2] == ["template_variables", "metadata_files"]
+
+
+def test_build_libraries_section_emits_raw_overlay_files(app):
+    import json
+
+    from modules import output
+
+    with app.app_context():
+        libraries_section = output.build_libraries_section(
+            {"mov-library_movies-library": "Movies"},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {
+                "movies": {
+                    "mov-library_movies-overlay_files": json.dumps(
+                        [
+                            {"type": "url", "location": "https://example.com/movies_refresh.yml"},
+                            {"type": "repo", "location": "custom/movies_overlay.yml"},
+                            {"type": "file", "location": "C:\\Users\\bullmoose20\\Community-Configs\\bullmoose20\\overlays.yml"},
+                            {"type": "folder", "location": "config\\overlays\\movies"},
+                            {"type": "git", "location": "bullmoose20/overlays.yml"},
+                        ]
+                    )
+                }
+            },
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+        )
+
+        assert libraries_section["libraries"]["Movies"]["overlay_files"] == [
+            {"file": "C:\\Users\\bullmoose20\\Community-Configs\\bullmoose20\\overlays.yml"},
+            {"folder": "config\\overlays\\movies"},
+            {"git": "bullmoose20/overlays.yml"},
+            {"repo": "custom/movies_overlay.yml"},
+            {"url": "https://example.com/movies_refresh.yml"},
+        ]
+    assert list(libraries_section["libraries"]["Movies"].keys())[:2] == ["template_variables", "overlay_files"]
 
 
 def test_build_libraries_section_emits_collection_files(app):

--- a/tests/test_importer_overlay_files.py
+++ b/tests/test_importer_overlay_files.py
@@ -1,0 +1,34 @@
+from modules import importer
+
+
+def test_prepare_import_payload_maps_multiple_overlay_files_per_library():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Movies": {
+                    "overlay_files": [
+                        {"file": "config/overlays/movies.yml"},
+                        {"folder": "config/overlays/movies"},
+                        {"git": "bullmoose20/overlays.yml"},
+                        {"repo": "custom/movies_overlays.yml"},
+                        {"url": "https://example.com/movie-overlays.yml"},
+                    ]
+                }
+            }
+        },
+        {"Movies"},
+        set(),
+        set(),
+    )
+
+    libraries_payload = payload["libraries"]["libraries"]
+    assert "mov-library_movies-overlay_files" in libraries_payload
+    assert (
+        libraries_payload["mov-library_movies-overlay_files"]
+        == '[{"type": "file", "location": "config/overlays/movies.yml"}, {"type": "folder", "location": "config/overlays/movies"}, {"type": "git", "location": "bullmoose20/overlays.yml"}, {"type": "repo", "location": "custom/movies_overlays.yml"}, {"type": "url", "location": "https://example.com/movie-overlays.yml"}]'
+    )
+    assert any("libraries.Movies.overlay_files[0].file" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[1].folder" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[2].git" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[3].repo" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[4].url" in line for line in report.lines)


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

This PR adds library-level advanced overlay_files support to Quickstart so users can import, validate, edit, autosave, and emit raw overlay file blocks the same way they already can for metadata_files and collection_files.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
