### PR TITLE
Order of accordions fix

### DIFF
--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -1334,7 +1334,7 @@ def save_to_named_config(yaml_text, config_name, font_refs=None):
 
     if font_refs and kometa_write_ok:
         try:
-            font_result = copy_fonts_to_kometa(font_refs, kometa_root=kometa_root)
+            font_result = copy_fonts_to_kometa(font_refs, kometa_root=kometa_root, config_name=name)
             missing = font_result.get("missing", [])
             errors = font_result.get("errors", [])
             if missing:
@@ -2391,8 +2391,14 @@ def is_imagemaid_running():
         return False
 
 
-def get_custom_fonts_dir() -> Path:
+def get_legacy_custom_fonts_dir() -> Path:
     return Path(CONFIG_DIR) / "fonts"
+
+
+def get_custom_fonts_dir(config_name: str | None = None) -> Path:
+    if config_name:
+        return get_managed_config_artifact_root(config_name) / "fonts"
+    return get_legacy_custom_fonts_dir()
 
 
 def get_kometa_fonts_dir(kometa_root: Path | None = None) -> Path:
@@ -2400,12 +2406,16 @@ def get_kometa_fonts_dir(kometa_root: Path | None = None) -> Path:
     return root / "config" / "fonts"
 
 
-def get_font_dirs(include_static: bool = True, include_custom: bool = True) -> list[Path]:
+def get_font_dirs(include_static: bool = True, include_custom: bool = True, config_name: str | None = None) -> list[Path]:
     dirs: list[Path] = []
     seen: set[str] = set()
 
     if include_custom:
-        for path in (get_custom_fonts_dir(), get_kometa_fonts_dir()):
+        custom_paths = []
+        if config_name:
+            custom_paths.append(get_custom_fonts_dir(config_name))
+        custom_paths.extend((get_legacy_custom_fonts_dir(), get_kometa_fonts_dir()))
+        for path in custom_paths:
             key = str(path)
             if key not in seen:
                 dirs.append(path)
@@ -2422,9 +2432,12 @@ def get_font_dirs(include_static: bool = True, include_custom: bool = True) -> l
     return dirs
 
 
-def list_custom_fonts() -> list[str]:
+def list_custom_fonts(config_name: str | None = None) -> list[str]:
     fonts: set[str] = set()
-    for folder in (get_custom_fonts_dir(), get_kometa_fonts_dir()):
+    folders = [get_kometa_fonts_dir(), get_legacy_custom_fonts_dir()]
+    if config_name:
+        folders.insert(0, get_custom_fonts_dir(config_name))
+    for folder in folders:
         if not folder.is_dir():
             continue
         for entry in folder.iterdir():
@@ -2433,9 +2446,9 @@ def list_custom_fonts() -> list[str]:
     return sorted(fonts)
 
 
-def list_available_fonts(include_static: bool = True, include_custom: bool = True) -> list[str]:
+def list_available_fonts(include_static: bool = True, include_custom: bool = True, config_name: str | None = None) -> list[str]:
     fonts: set[str] = set()
-    for folder in get_font_dirs(include_static=include_static, include_custom=include_custom):
+    for folder in get_font_dirs(include_static=include_static, include_custom=include_custom, config_name=config_name):
         if not folder.is_dir():
             continue
         for entry in folder.iterdir():
@@ -2444,8 +2457,8 @@ def list_available_fonts(include_static: bool = True, include_custom: bool = Tru
     return sorted(fonts)
 
 
-def sync_custom_fonts(kometa_root: Path | None = None) -> list[str]:
-    source_dir = get_custom_fonts_dir()
+def sync_custom_fonts(kometa_root: Path | None = None, config_name: str | None = None) -> list[str]:
+    source_dir = get_custom_fonts_dir(config_name)
     if not source_dir.is_dir():
         return []
     dest_dir = get_kometa_fonts_dir(kometa_root)
@@ -2487,10 +2500,10 @@ def collect_font_references(config_data) -> list[str]:
     return sorted(fonts)
 
 
-def copy_fonts_to_kometa(font_refs, kometa_root: Path | None = None) -> dict:
+def copy_fonts_to_kometa(font_refs, kometa_root: Path | None = None, config_name: str | None = None) -> dict:
     dest_dir = get_kometa_fonts_dir(kometa_root)
     dest_dir.mkdir(parents=True, exist_ok=True)
-    sources = get_font_dirs(include_static=True, include_custom=True)
+    sources = get_font_dirs(include_static=True, include_custom=True, config_name=config_name)
     copied: list[str] = []
     missing: list[str] = []
     errors: list[str] = []
@@ -2607,7 +2620,17 @@ def normalize_config_name_for_storage(config_name: str | None) -> str:
 MANAGED_LIBRARY_FILE_DIRS = ("metadata_files", "collection_files", "overlay_files")
 
 
+def get_managed_config_artifact_root(config_name: str | None) -> Path:
+    normalized = normalize_config_name_for_storage(config_name)
+    return Path(CONFIG_DIR) / normalized
+
+
 def get_managed_library_artifact_paths(config_name: str | None) -> list[Path]:
+    config_root = get_managed_config_artifact_root(config_name)
+    return [config_root / folder for folder in MANAGED_LIBRARY_FILE_DIRS]
+
+
+def get_legacy_managed_library_artifact_paths(config_name: str | None) -> list[Path]:
     normalized = normalize_config_name_for_storage(config_name)
     config_dir = Path(CONFIG_DIR)
     return [config_dir / folder / normalized for folder in MANAGED_LIBRARY_FILE_DIRS]
@@ -2623,8 +2646,10 @@ def delete_config_artifacts(config_name: str | None, kometa_root: str | Path | N
     targets = [
         config_dir / f"{normalized}_config.yml",
         archive_root / normalized,
+        get_managed_config_artifact_root(normalized),
     ]
     targets.extend(get_managed_library_artifact_paths(normalized))
+    targets.extend(get_legacy_managed_library_artifact_paths(normalized))
 
     if kometa_root:
         targets.append(Path(kometa_root) / "config" / f"{normalized}_config.yml")
@@ -2727,6 +2752,15 @@ def list_orphaned_config_artifacts(active_config_names: list[str] | None = None,
         bundle["has_current_file"] = True
         bundle["paths"].append(str(path))
 
+    for path in config_dir.iterdir():
+        if not path.is_dir():
+            continue
+        if any((path / folder_name).exists() and (path / folder_name).is_dir() for folder_name in MANAGED_LIBRARY_FILE_DIRS):
+            bundle = ensure_bundle(path.name)
+            path_text = str(path)
+            if path_text not in bundle["paths"]:
+                bundle["paths"].append(path_text)
+
     for folder_name in MANAGED_LIBRARY_FILE_DIRS:
         managed_root = config_dir / folder_name
         if not managed_root.exists() or not managed_root.is_dir():
@@ -2735,7 +2769,9 @@ def list_orphaned_config_artifacts(active_config_names: list[str] | None = None,
             if not path.is_dir():
                 continue
             bundle = ensure_bundle(path.name)
-            bundle["paths"].append(str(path))
+            path_text = str(path)
+            if path_text not in bundle["paths"]:
+                bundle["paths"].append(path_text)
 
     if archive_root.exists():
         for path in archive_root.iterdir():
@@ -2790,6 +2826,16 @@ def list_orphaned_config_artifacts(active_config_names: list[str] | None = None,
         for managed_path in get_managed_library_artifact_paths(name):
             if managed_path.exists() and managed_path.is_dir():
                 path_text = str(managed_path)
+                if path_text not in bundle["paths"]:
+                    bundle["paths"].append(path_text)
+        managed_root = get_managed_config_artifact_root(name)
+        if managed_root.exists() and managed_root.is_dir():
+            path_text = str(managed_root)
+            if path_text not in bundle["paths"]:
+                bundle["paths"].append(path_text)
+        for legacy_path in get_legacy_managed_library_artifact_paths(name):
+            if legacy_path.exists() and legacy_path.is_dir():
+                path_text = str(legacy_path)
                 if path_text not in bundle["paths"]:
                     bundle["paths"].append(path_text)
 

--- a/modules/validations.py
+++ b/modules/validations.py
@@ -105,6 +105,8 @@ def _resolve_managed_library_path(location):
     if expanded.is_absolute():
         return str(expanded)
     normalized_parts = [part for part in str(expanded).replace("\\", "/").split("/") if part]
+    if len(normalized_parts) >= 3 and normalized_parts[1] in helpers.MANAGED_LIBRARY_FILE_DIRS:
+        return str(Path(helpers.CONFIG_DIR) / Path(*normalized_parts))
     if normalized_parts and normalized_parts[0] in helpers.MANAGED_LIBRARY_FILE_DIRS:
         return str(Path(helpers.CONFIG_DIR) / expanded)
     return raw

--- a/modules/validations.py
+++ b/modules/validations.py
@@ -2,6 +2,7 @@ import os
 import re
 import urllib.parse
 from json import JSONDecodeError
+from pathlib import Path
 
 import requests
 from ruamel.yaml import YAML
@@ -96,7 +97,21 @@ def _validate_yaml_location_suffix(location, label):
     return True, None
 
 
+def _resolve_managed_library_path(location):
+    raw = str(location or "").strip()
+    if not raw:
+        return raw
+    expanded = Path(os.path.expandvars(os.path.expanduser(raw)))
+    if expanded.is_absolute():
+        return str(expanded)
+    normalized_parts = [part for part in str(expanded).replace("\\", "/").split("/") if part]
+    if normalized_parts and normalized_parts[0] in helpers.MANAGED_LIBRARY_FILE_DIRS:
+        return str(Path(helpers.CONFIG_DIR) / expanded)
+    return raw
+
+
 def _validate_yaml_location(location, label):
+    resolved_location = _resolve_managed_library_path(location)
     valid, message = _validate_yaml_location_suffix(location, label)
     if not valid:
         return False, message
@@ -121,14 +136,14 @@ def _validate_yaml_location(location, label):
         return valid, message
 
     valid, message = path_validation.validate_path(
-        location,
+        resolved_location,
         {"allow_relative": True, "must_exist": True, "mode": "input_file"},
     )
     if not valid:
         return False, f"{label}: {message}"
 
     try:
-        with open(location, "r", encoding="utf-8") as handle:
+        with open(resolved_location, "r", encoding="utf-8") as handle:
             yaml_text = handle.read()
     except OSError as exc:
         return False, f"{label}: Unable to read file. {exc}"
@@ -141,6 +156,7 @@ def _validate_yaml_location(location, label):
 
 
 def _validate_metadata_yaml_location(location, label):
+    resolved_location = _resolve_managed_library_path(location)
     valid, message = _validate_yaml_location_suffix(location, label)
     if not valid:
         return False, message
@@ -163,14 +179,14 @@ def _validate_metadata_yaml_location(location, label):
         return _validate_metadata_yaml_text(response.text, label, source_name)
 
     valid, message = path_validation.validate_path(
-        location,
+        resolved_location,
         {"allow_relative": True, "must_exist": True, "mode": "input_file"},
     )
     if not valid:
         return False, f"{label}: {message}"
 
     try:
-        with open(location, "r", encoding="utf-8") as handle:
+        with open(resolved_location, "r", encoding="utf-8") as handle:
             yaml_text = handle.read()
     except OSError as exc:
         return False, f"{label}: Unable to read file. {exc}"
@@ -179,6 +195,7 @@ def _validate_metadata_yaml_location(location, label):
 
 
 def _validate_collection_yaml_location(location, label):
+    resolved_location = _resolve_managed_library_path(location)
     valid, message = _validate_yaml_location_suffix(location, label)
     if not valid:
         return False, message
@@ -201,14 +218,14 @@ def _validate_collection_yaml_location(location, label):
         return _validate_collection_yaml_text(response.text, label, source_name)
 
     valid, message = path_validation.validate_path(
-        location,
+        resolved_location,
         {"allow_relative": True, "must_exist": True, "mode": "input_file"},
     )
     if not valid:
         return False, f"{label}: {message}"
 
     try:
-        with open(location, "r", encoding="utf-8") as handle:
+        with open(resolved_location, "r", encoding="utf-8") as handle:
             yaml_text = handle.read()
     except OSError as exc:
         return False, f"{label}: Unable to read file. {exc}"
@@ -217,6 +234,7 @@ def _validate_collection_yaml_location(location, label):
 
 
 def _validate_overlay_yaml_location(location, label):
+    resolved_location = _resolve_managed_library_path(location)
     valid, message = _validate_yaml_location_suffix(location, label)
     if not valid:
         return False, message
@@ -237,14 +255,14 @@ def _validate_overlay_yaml_location(location, label):
         yaml_text = response.text
     else:
         valid, message = path_validation.validate_path(
-            location,
+            resolved_location,
             {"allow_relative": True, "must_exist": True, "mode": "input_file"},
         )
         if not valid:
             return False, f"{label}: {message}"
 
         try:
-            with open(location, "r", encoding="utf-8") as handle:
+            with open(resolved_location, "r", encoding="utf-8") as handle:
                 yaml_text = handle.read()
         except OSError as exc:
             return False, f"{label}: Unable to read file. {exc}"
@@ -262,19 +280,20 @@ def _summarize_folder_validation_failures(label, yaml_files, failures):
 
 
 def _validate_yaml_folder(location, label):
+    resolved_location = _resolve_managed_library_path(location)
     valid, message = path_validation.validate_path(
-        location,
+        resolved_location,
         {"allow_relative": True, "must_exist": True, "mode": "input_dir"},
     )
     if not valid:
         return False, f"{label}: {message}"
 
     try:
-        entries = sorted(os.listdir(location), key=str.casefold)
+        entries = sorted(os.listdir(resolved_location), key=str.casefold)
     except OSError as exc:
         return False, f"{label}: Unable to read folder. {exc}"
 
-    yaml_files = [os.path.join(location, entry) for entry in entries if os.path.isfile(os.path.join(location, entry)) and entry.lower().endswith((".yml", ".yaml"))]
+    yaml_files = [os.path.join(resolved_location, entry) for entry in entries if os.path.isfile(os.path.join(resolved_location, entry)) and entry.lower().endswith((".yml", ".yaml"))]
     if not yaml_files:
         return False, f"{label}: Folder must contain at least one top-level .yml or .yaml file."
 
@@ -301,19 +320,20 @@ def _validate_yaml_folder(location, label):
 
 
 def _validate_collection_yaml_folder(location, label):
+    resolved_location = _resolve_managed_library_path(location)
     valid, message = path_validation.validate_path(
-        location,
+        resolved_location,
         {"allow_relative": True, "must_exist": True, "mode": "input_dir"},
     )
     if not valid:
         return False, f"{label}: {message}"
 
     try:
-        entries = sorted(os.listdir(location), key=str.casefold)
+        entries = sorted(os.listdir(resolved_location), key=str.casefold)
     except OSError as exc:
         return False, f"{label}: Unable to read folder. {exc}"
 
-    yaml_files = [os.path.join(location, entry) for entry in entries if os.path.isfile(os.path.join(location, entry)) and entry.lower().endswith((".yml", ".yaml"))]
+    yaml_files = [os.path.join(resolved_location, entry) for entry in entries if os.path.isfile(os.path.join(resolved_location, entry)) and entry.lower().endswith((".yml", ".yaml"))]
     if not yaml_files:
         return False, f"{label}: Folder must contain at least one top-level .yml or .yaml file."
 
@@ -340,19 +360,20 @@ def _validate_collection_yaml_folder(location, label):
 
 
 def _validate_overlay_yaml_folder(location, label):
+    resolved_location = _resolve_managed_library_path(location)
     valid, message = path_validation.validate_path(
-        location,
+        resolved_location,
         {"allow_relative": True, "must_exist": True, "mode": "input_dir"},
     )
     if not valid:
         return False, f"{label}: {message}"
 
     try:
-        entries = sorted(os.listdir(location), key=str.casefold)
+        entries = sorted(os.listdir(resolved_location), key=str.casefold)
     except OSError as exc:
         return False, f"{label}: Unable to read folder. {exc}"
 
-    yaml_files = [os.path.join(location, entry) for entry in entries if os.path.isfile(os.path.join(location, entry)) and entry.lower().endswith((".yml", ".yaml"))]
+    yaml_files = [os.path.join(resolved_location, entry) for entry in entries if os.path.isfile(os.path.join(resolved_location, entry)) and entry.lower().endswith((".yml", ".yaml"))]
     if not yaml_files:
         return False, f"{label}: Folder must contain at least one top-level .yml or .yaml file."
 

--- a/modules/validations.py
+++ b/modules/validations.py
@@ -295,7 +295,9 @@ def _validate_yaml_folder(location, label):
     except OSError as exc:
         return False, f"{label}: Unable to read folder. {exc}"
 
-    yaml_files = [os.path.join(resolved_location, entry) for entry in entries if os.path.isfile(os.path.join(resolved_location, entry)) and entry.lower().endswith((".yml", ".yaml"))]
+    yaml_files = [
+        os.path.join(resolved_location, entry) for entry in entries if os.path.isfile(os.path.join(resolved_location, entry)) and entry.lower().endswith((".yml", ".yaml"))
+    ]
     if not yaml_files:
         return False, f"{label}: Folder must contain at least one top-level .yml or .yaml file."
 
@@ -335,7 +337,9 @@ def _validate_collection_yaml_folder(location, label):
     except OSError as exc:
         return False, f"{label}: Unable to read folder. {exc}"
 
-    yaml_files = [os.path.join(resolved_location, entry) for entry in entries if os.path.isfile(os.path.join(resolved_location, entry)) and entry.lower().endswith((".yml", ".yaml"))]
+    yaml_files = [
+        os.path.join(resolved_location, entry) for entry in entries if os.path.isfile(os.path.join(resolved_location, entry)) and entry.lower().endswith((".yml", ".yaml"))
+    ]
     if not yaml_files:
         return False, f"{label}: Folder must contain at least one top-level .yml or .yaml file."
 
@@ -375,7 +379,9 @@ def _validate_overlay_yaml_folder(location, label):
     except OSError as exc:
         return False, f"{label}: Unable to read folder. {exc}"
 
-    yaml_files = [os.path.join(resolved_location, entry) for entry in entries if os.path.isfile(os.path.join(resolved_location, entry)) and entry.lower().endswith((".yml", ".yaml"))]
+    yaml_files = [
+        os.path.join(resolved_location, entry) for entry in entries if os.path.isfile(os.path.join(resolved_location, entry)) and entry.lower().endswith((".yml", ".yaml"))
+    ]
     if not yaml_files:
         return False, f"{label}: Folder must contain at least one top-level .yml or .yaml file."
 

--- a/quickstart.py
+++ b/quickstart.py
@@ -746,8 +746,55 @@ def _managed_library_folder_slug(source_path, kind):
     return folder_name
 
 
-def _managed_library_file_root(kind):
-    return (Path(helpers.CONFIG_DIR) / kind).resolve()
+def _managed_library_config_root(config_name):
+    config_slug = helpers.normalize_config_name_for_storage(config_name)
+    return (Path(helpers.CONFIG_DIR) / config_slug).resolve()
+
+
+def _managed_library_file_root(kind, config_name):
+    return (_managed_library_config_root(config_name) / kind).resolve()
+
+
+def _parse_managed_library_relative_path(path_value):
+    raw = str(path_value or "").strip().replace("\\", "/")
+    if not raw:
+        return None
+    parts = [part for part in raw.split("/") if part]
+    if not parts:
+        return None
+    has_config_prefix = parts[0] == "config"
+    if has_config_prefix:
+        parts = parts[1:]
+    if len(parts) >= 3 and parts[1] in LIBRARY_FILE_KINDS:
+        return {
+            "layout": "config_first",
+            "config_name": parts[0],
+            "kind": parts[1],
+            "remainder": parts[2:],
+            "has_config_prefix": has_config_prefix,
+            "parts": parts,
+        }
+    if len(parts) >= 3 and parts[0] in LIBRARY_FILE_KINDS:
+        return {
+            "layout": "type_first",
+            "config_name": parts[1],
+            "kind": parts[0],
+            "remainder": parts[2:],
+            "has_config_prefix": has_config_prefix,
+            "parts": parts,
+        }
+    return None
+
+
+def _normalized_managed_library_relative_path(path_value):
+    info = _parse_managed_library_relative_path(path_value)
+    if not info:
+        return None
+    return Path(info["config_name"], info["kind"], *info["remainder"]).as_posix()
+
+
+def _is_bundled_library_archive_member(path_value):
+    return _normalized_managed_library_relative_path(str(path_value or "").replace("\\", "/").lstrip("/")) is not None
 
 
 def _yaml_path_suffix(path_value):
@@ -770,6 +817,16 @@ def _resolve_local_library_source(location):
             return expanded.resolve()
         except OSError:
             return expanded
+    managed_info = _parse_managed_library_relative_path(expanded)
+    if managed_info:
+        if managed_info["layout"] == "config_first":
+            managed_relative = Path(managed_info["config_name"], managed_info["kind"], *managed_info["remainder"])
+        else:
+            managed_relative = Path(*managed_info["parts"])
+        try:
+            return (Path(helpers.CONFIG_DIR) / managed_relative).resolve()
+        except OSError:
+            return Path(helpers.CONFIG_DIR) / managed_relative
     normalized_parts = [part for part in str(expanded).replace("\\", "/").split("/") if part]
     if normalized_parts and normalized_parts[0] in LIBRARY_FILE_KINDS:
         try:
@@ -788,19 +845,22 @@ def _managed_bundle_location_for_path(path):
         relative = Path(path).resolve().relative_to(config_root)
     except Exception:
         return None
-    relative_parts = list(relative.parts)
-    if not relative_parts or relative_parts[0] not in LIBRARY_FILE_KINDS:
+    normalized_relative = _normalized_managed_library_relative_path(Path(*relative.parts).as_posix())
+    if not normalized_relative:
         return None
-    return Path(*relative_parts).as_posix()
+    info = _parse_managed_library_relative_path(normalized_relative)
+    if not info or info["layout"] != "config_first":
+        return None
+    return normalized_relative
 
 
 def _display_library_managed_location(location):
     raw = str(location or "").strip().replace("\\", "/")
     if not raw:
         return raw
-    normalized_parts = [part for part in raw.split("/") if part]
-    if normalized_parts and normalized_parts[0] in LIBRARY_FILE_KINDS:
-        return Path("config", *normalized_parts).as_posix()
+    normalized_relative = _normalized_managed_library_relative_path(raw)
+    if normalized_relative:
+        return Path("config", *normalized_relative.split("/")).as_posix()
     return raw
 
 
@@ -838,12 +898,11 @@ def _copy_library_artifact_to_managed_store(kind, entry_type, location, config_n
     if managed_location:
         return managed_location
 
-    managed_root = _managed_library_file_root(kind)
-    config_slug = helpers.normalize_config_name_for_storage(config_name)
+    managed_root = _managed_library_file_root(kind, config_name)
     library_slug = _safe_external_artifact_slug(library_scope, "library")
     source_token = str(source_path).replace("\\", "/").lower()
     digest = hashlib.sha1(source_token.encode("utf-8", errors="ignore")).hexdigest()[:10]
-    target_dir = managed_root / config_slug / library_slug
+    target_dir = managed_root / library_slug
     target_dir.mkdir(parents=True, exist_ok=True)
 
     if entry_type == "file":
@@ -976,6 +1035,10 @@ def _rewrite_bundle_library_paths(config_data, bundle_root):
                     raw_location = str(location).strip()
                     candidate = root / Path(raw_location)
                     if not candidate.exists():
+                        normalized_relative = _normalized_managed_library_relative_path(raw_location)
+                        if normalized_relative:
+                            candidate = root / Path(normalized_relative)
+                    if not candidate.exists():
                         continue
                     entry[entry_type] = str(candidate.resolve())
                     break
@@ -1037,7 +1100,6 @@ def _iter_bundle_artifacts(config_data):
     if not isinstance(libraries, dict):
         return []
     artifacts = []
-    config_root = Path(helpers.CONFIG_DIR).resolve()
     for lib_cfg in libraries.values():
         if not isinstance(lib_cfg, dict):
             continue
@@ -1055,16 +1117,14 @@ def _iter_bundle_artifacts(config_data):
                     raw_location = str(location).strip()
                     if not raw_location:
                         continue
-                    source_path = Path(raw_location)
-                    if not source_path.is_absolute():
-                        source_path = (config_root / Path(raw_location)).resolve()
-                    else:
-                        source_path = source_path.resolve()
+                    source_path = _resolve_local_library_source(raw_location)
+                    if source_path is None:
+                        continue
                     if not source_path.exists():
                         continue
                     archive_path = _managed_bundle_location_for_path(source_path)
                     if not archive_path:
-                        archive_path = Path(raw_location).as_posix()
+                        archive_path = _normalized_managed_library_relative_path(raw_location) or Path(raw_location).as_posix()
                     dedupe_key = (str(source_path), archive_path)
                     if dedupe_key in seen:
                         break
@@ -3688,8 +3748,12 @@ def _rename_config_files(old_name: str, new_name: str, dry_run: bool = False) ->
     archive_root = config_dir / "archives"
     old_archive = archive_root / old_norm
     new_archive = archive_root / new_norm
+    old_managed_root = helpers.get_managed_config_artifact_root(old_norm)
+    new_managed_root = helpers.get_managed_config_artifact_root(new_norm)
     old_managed_dirs = helpers.get_managed_library_artifact_paths(old_norm)
     new_managed_dirs = helpers.get_managed_library_artifact_paths(new_norm)
+    old_legacy_managed_dirs = helpers.get_legacy_managed_library_artifact_paths(old_norm)
+    new_legacy_managed_dirs = helpers.get_legacy_managed_library_artifact_paths(new_norm)
     if old_archive.exists():
         if new_archive.exists():
             result["errors"].append("Target archive directory already exists.")
@@ -3701,9 +3765,21 @@ def _rename_config_files(old_name: str, new_name: str, dry_run: bool = False) ->
                 result["errors"].append(f"Archive file already exists: {target_name}")
                 return result
 
+    if old_managed_root.exists() and new_managed_root.exists():
+        result["errors"].append(f"Target managed config directory already exists: {new_managed_root}")
+        return result
+
     for old_managed, new_managed in zip(old_managed_dirs, new_managed_dirs):
         if old_managed.exists() and new_managed.exists():
             result["errors"].append(f"Target managed library directory already exists: {new_managed}")
+            return result
+    for old_managed, new_managed in zip(old_legacy_managed_dirs, new_managed_dirs):
+        if old_managed.exists() and new_managed.exists():
+            result["errors"].append(f"Target managed library directory already exists: {new_managed}")
+            return result
+    for old_managed, new_managed in zip(old_legacy_managed_dirs, new_legacy_managed_dirs):
+        if old_managed.exists() and new_managed.exists():
+            result["errors"].append(f"Target legacy managed library directory already exists: {new_managed}")
             return result
 
     if dry_run:
@@ -3720,7 +3796,18 @@ def _rename_config_files(old_name: str, new_name: str, dry_run: bool = False) ->
             kometa_file.rename(new_kometa_file)
             completed.append((kometa_file, new_kometa_file))
             result["renamed"].append(str(new_kometa_file))
+        if old_managed_root.exists():
+            new_managed_root.parent.mkdir(parents=True, exist_ok=True)
+            old_managed_root.rename(new_managed_root)
+            completed.append((old_managed_root, new_managed_root))
+            result["renamed"].append(str(new_managed_root))
         for old_managed, new_managed in zip(old_managed_dirs, new_managed_dirs):
+            if old_managed.exists():
+                new_managed.parent.mkdir(parents=True, exist_ok=True)
+                old_managed.rename(new_managed)
+                completed.append((old_managed, new_managed))
+                result["renamed"].append(str(new_managed))
+        for old_managed, new_managed in zip(old_legacy_managed_dirs, new_managed_dirs):
             if old_managed.exists():
                 new_managed.parent.mkdir(parents=True, exist_ok=True)
                 old_managed.rename(new_managed)
@@ -3771,7 +3858,6 @@ for folder in UPLOAD_FOLDERS.values():
 IMAGES_FOLDER = os.path.join(helpers.MEIPASS_DIR, "static", "images")
 OVERLAY_FOLDER = os.path.join(IMAGES_FOLDER, "overlays")
 FONTS_FOLDER = os.path.join(helpers.MEIPASS_DIR, "static", "fonts")
-CUSTOM_FONTS_FOLDER = os.path.join(helpers.CONFIG_DIR, "fonts")
 DEFAULT_IMAGE_MAP = {
     "movie": os.path.join(IMAGES_FOLDER, "default.png"),
     "show": os.path.join(IMAGES_FOLDER, "default-sho_preview.png"),
@@ -3793,7 +3879,7 @@ os.makedirs(PREVIEW_FOLDER, exist_ok=True)
 OVERLAY_CACHE_FOLDER = os.path.join(helpers.CONFIG_DIR, "cache", "overlays")
 os.makedirs(OVERLAY_CACHE_FOLDER, exist_ok=True)
 OVERLAY_CACHE_TTL_SECONDS = 60 * 60 * 24 * 30
-_FONT_CACHE: list[str] = []
+_FONT_CACHE: dict[str, list[str]] = {}
 
 
 def _list_preview_images_for_type(image_type: str) -> list[str]:
@@ -3834,11 +3920,13 @@ def _resolve_preview_base_image_path(img_type: str, selected_image: str) -> str:
 
 # Font discovery (TTF/OTF) across common static dirs
 def list_overlay_fonts() -> list[str]:
-    global _FONT_CACHE
-    if _FONT_CACHE:
-        return _FONT_CACHE
+    config_name = session.get("config_name") if session else None
+    cache_key = helpers.normalize_config_name_for_storage(config_name) if config_name else "__default__"
+    cached = _FONT_CACHE.get(cache_key)
+    if cached:
+        return cached
     fonts: list[str] = []
-    font_dirs = helpers.get_font_dirs(include_static=True, include_custom=True)
+    font_dirs = helpers.get_font_dirs(include_static=True, include_custom=True, config_name=config_name)
     for fdir in font_dirs:
         try:
             if os.path.isdir(fdir):
@@ -3847,7 +3935,7 @@ def list_overlay_fonts() -> list[str]:
                         fonts.append(fname)
         except Exception:
             continue
-    _FONT_CACHE = fonts
+    _FONT_CACHE[cache_key] = fonts
     return fonts
 
 
@@ -4205,7 +4293,10 @@ def upload_fonts():
     if not files:
         return jsonify({"status": "error", "message": "No fonts uploaded"}), 400
 
-    os.makedirs(CUSTOM_FONTS_FOLDER, exist_ok=True)
+    config_name = (request.form.get("config_name") or session.get("config_name") or "").strip()
+    fonts_dir = helpers.get_custom_fonts_dir(config_name or None)
+
+    os.makedirs(fonts_dir, exist_ok=True)
     saved = []
     errors = []
 
@@ -4217,13 +4308,13 @@ def upload_fonts():
         if ext not in helpers.FONT_EXTENSIONS:
             errors.append(f"Invalid font type: {filename}")
             continue
-        save_path = os.path.join(CUSTOM_FONTS_FOLDER, filename)
+        save_path = os.path.join(str(fonts_dir), filename)
         font_file.save(save_path)
         saved.append(filename)
 
     if saved:
         global _FONT_CACHE
-        _FONT_CACHE = []
+        _FONT_CACHE = {}
 
     if not saved:
         return jsonify({"status": "error", "message": "No valid fonts uploaded.", "errors": errors}), 400
@@ -4247,7 +4338,8 @@ def custom_fonts(filename):
     if not safe_name.lower().endswith((".ttf", ".otf")):
         abort(404)
 
-    for fdir in helpers.get_font_dirs(include_static=True, include_custom=True):
+    current_config = session.get("config_name") if session else None
+    for fdir in helpers.get_font_dirs(include_static=True, include_custom=True, config_name=current_config):
         candidate = os.path.join(str(fdir), safe_name)
         if os.path.exists(candidate):
             return send_from_directory(str(fdir), safe_name)
@@ -5570,7 +5662,7 @@ def import_config_preview():
         try:
             with zipfile.ZipFile(BytesIO(raw_text)) as archive:
                 bundled_library_files = [
-                    n for n in archive.namelist() if str(n).replace("\\", "/").lstrip("/").startswith(("metadata_files/", "collection_files/", "overlay_files/"))
+                    n for n in archive.namelist() if _is_bundled_library_archive_member(n)
                 ]
                 config_files = [n for n in archive.namelist() if n.lower().endswith((".yml", ".yaml")) and n not in bundled_library_files]
                 if not config_files:
@@ -6703,10 +6795,11 @@ def import_config_confirm():
     fonts_skipped_existing = []
     fonts_skipped_failed = []
     if fonts_dir and fonts:
-        os.makedirs(CUSTOM_FONTS_FOLDER, exist_ok=True)
+        config_fonts_dir = helpers.get_custom_fonts_dir(config_name)
+        os.makedirs(config_fonts_dir, exist_ok=True)
         for font_name in fonts:
             src_path = os.path.join(fonts_dir, font_name)
-            dest_path = os.path.join(CUSTOM_FONTS_FOLDER, font_name)
+            dest_path = os.path.join(str(config_fonts_dir), font_name)
             if os.path.exists(dest_path):
                 fonts_skipped.append(font_name)
                 fonts_skipped_existing.append(font_name)
@@ -6719,7 +6812,7 @@ def import_config_confirm():
                 fonts_skipped_failed.append(font_name)
         if fonts_copied:
             global _FONT_CACHE
-            _FONT_CACHE = []
+            _FONT_CACHE = {}
 
     try:
         os.remove(cache_path)
@@ -8106,8 +8199,8 @@ def _safe_bundle_name(raw_name: str | None) -> str:
     return safe or "default"
 
 
-def _get_custom_font_files() -> list[Path]:
-    custom_dir = helpers.get_custom_fonts_dir()
+def _get_custom_font_files(config_name: str | None = None) -> list[Path]:
+    custom_dir = helpers.get_custom_fonts_dir(config_name)
     if not custom_dir.is_dir():
         return []
     fonts = [entry for entry in custom_dir.iterdir() if entry.is_file() and entry.suffix.lower() in helpers.FONT_EXTENSIONS]
@@ -8144,7 +8237,7 @@ def _build_config_bundle(
         readme_lines.append("- fonts/ (custom fonts uploaded in Quickstart)")
         readme_lines.append(f"- Fonts included: {', '.join(font_names)}")
     if has_artifacts:
-        readme_lines.append("- metadata_files/ collection_files/ overlay_files/ (managed library files)")
+        readme_lines.append(f"- {name}/metadata_files/, {name}/collection_files/, {name}/overlay_files/ (managed library files)")
     readme_lines += [
         "",
         "Install steps:",
@@ -8153,7 +8246,7 @@ def _build_config_bundle(
     if font_names:
         readme_lines.append("2) Copy the font files from fonts/ into your Kometa config/fonts/ folder.")
     if has_artifacts:
-        readme_lines.append("3) Copy metadata_files/, collection_files/, and overlay_files/ into your Kometa config/ folder.")
+        readme_lines.append(f"3) Copy {name}/ into your Kometa config/ folder.")
     readme_lines += [
         "",
         "Note: The Quickstart Run Now button syncs fonts automatically.",
@@ -8182,9 +8275,9 @@ def _build_config_bundle(
 def download():
     yaml_content = session.get("yaml_content", "")
     if yaml_content:
-        custom_fonts = _get_custom_font_files()
-        artifact_files = _bundle_artifacts_from_yaml(yaml_content)
         config_name = session.get("config_name")
+        custom_fonts = _get_custom_font_files(config_name)
+        artifact_files = _bundle_artifacts_from_yaml(yaml_content)
         if custom_fonts or artifact_files:
             bundle = _build_config_bundle(
                 yaml_content,
@@ -8219,9 +8312,9 @@ def download_redacted():
         redacted_content = helpers.redact_sensitive_data(yaml_content)
 
         # Serve the redacted YAML as a file download
-        custom_fonts = _get_custom_font_files()
-        artifact_files = _bundle_artifacts_from_yaml(yaml_content)
         config_name = session.get("config_name")
+        custom_fonts = _get_custom_font_files(config_name)
+        artifact_files = _bundle_artifacts_from_yaml(yaml_content)
         if custom_fonts or artifact_files:
             bundle = _build_config_bundle(
                 redacted_content,

--- a/quickstart.py
+++ b/quickstart.py
@@ -889,13 +889,13 @@ def _remove_managed_path(path, root):
         resolved_path.unlink()
 
 
-def _copy_library_artifact_to_managed_store(kind, entry_type, location, config_name, library_scope):
+def _copy_library_artifact_to_managed_store(kind, entry_type, location, config_name, library_scope, force_clone_managed=False):
     source_path = _resolve_local_library_source(location)
     if source_path is None:
         raise RuntimeError("Path is required.")
 
     managed_location = _managed_bundle_location_for_path(source_path)
-    if managed_location:
+    if managed_location and not force_clone_managed:
         return managed_location
 
     managed_root = _managed_library_file_root(kind, config_name)
@@ -926,7 +926,7 @@ def _copy_library_artifact_to_managed_store(kind, entry_type, location, config_n
     return Path(*relative.parts).as_posix()
 
 
-def _normalize_library_external_entry(kind, entry, config_name, library_scope, validate_local=True):
+def _normalize_library_external_entry(kind, entry, config_name, library_scope, validate_local=True, force_clone_managed=False):
     parsed_entry = dict(entry) if isinstance(entry, dict) else {}
     entry_type = str(parsed_entry.get("type") or "").strip().lower()
     location = str(parsed_entry.get("location") or "").strip()
@@ -945,7 +945,14 @@ def _normalize_library_external_entry(kind, entry, config_name, library_scope, v
             return None, False, message
 
     try:
-        normalized_location = _copy_library_artifact_to_managed_store(kind, entry_type, location, config_name, library_scope)
+        normalized_location = _copy_library_artifact_to_managed_store(
+            kind,
+            entry_type,
+            location,
+            config_name,
+            library_scope,
+            force_clone_managed=force_clone_managed,
+        )
     except Exception as exc:
         return None, False, f"Unable to organize {kind}: {exc}"
 
@@ -955,6 +962,29 @@ def _normalize_library_external_entry(kind, entry, config_name, library_scope, v
     if is_validated:
         normalized_entry["validated"] = True
     return normalized_entry, changed, None
+
+
+def _clone_library_file_entries_for_target(kind, raw_value, config_name, target_library_id):
+    parser = LIBRARY_FILE_PARSE_FUNCTIONS.get(kind)
+    if not parser:
+        return raw_value
+    entries = parser(raw_value)
+    if entries is None:
+        return raw_value
+    cloned_entries = []
+    for idx, entry in enumerate(entries, start=1):
+        normalized_entry, _changed, entry_error = _normalize_library_external_entry(
+            kind,
+            entry,
+            config_name,
+            target_library_id,
+            validate_local=False,
+            force_clone_managed=True,
+        )
+        if entry_error:
+            raise RuntimeError(f"{target_library_id} {kind}[{idx}]: {entry_error}")
+        cloned_entries.append(normalized_entry if normalized_entry is not None else entry)
+    return json.dumps(cloned_entries, ensure_ascii=True)
 
 
 def _normalize_library_file_entries_payload(libraries_data, config_name, validate_local=True):
@@ -3920,7 +3950,7 @@ def _resolve_preview_base_image_path(img_type: str, selected_image: str) -> str:
 
 # Font discovery (TTF/OTF) across common static dirs
 def list_overlay_fonts() -> list[str]:
-    config_name = session.get("config_name") if session else None
+    config_name = session.get("config_name") if has_request_context() else None
     cache_key = helpers.normalize_config_name_for_storage(config_name) if config_name else "__default__"
     cached = _FONT_CACHE.get(cache_key)
     if cached:
@@ -3937,6 +3967,19 @@ def list_overlay_fonts() -> list[str]:
             continue
     _FONT_CACHE[cache_key] = fonts
     return fonts
+
+
+def _config_name_from_yaml_filename(filename: str | None) -> str | None:
+    text = str(filename or "").strip()
+    if not text:
+        return None
+    base = Path(text).name
+    lowered = base.lower()
+    if lowered.endswith("_config.yml"):
+        return base[:-11]
+    if lowered.endswith("_config.yaml"):
+        return base[:-12]
+    return None
 
 
 # Initialize logging
@@ -4338,7 +4381,7 @@ def custom_fonts(filename):
     if not safe_name.lower().endswith((".ttf", ".otf")):
         abort(404)
 
-    current_config = session.get("config_name") if session else None
+    current_config = session.get("config_name") if has_request_context() else None
     for fdir in helpers.get_font_dirs(include_static=True, include_custom=True, config_name=current_config):
         candidate = os.path.join(str(fdir), safe_name)
         if os.path.exists(candidate):
@@ -8141,6 +8184,7 @@ def copy_library_settings():
 
         merged = libraries_data.copy()
         targets_to_process = [source_prefix] + [tid for tid in filtered_targets if tid != source_prefix]
+        config_name = session.get("config_name") or source_payload.get("config_name") or namesgenerator.get_random_name()
 
         for target_id in targets_to_process:
             target_name = name_map.get(target_id, "")
@@ -8158,6 +8202,13 @@ def copy_library_settings():
                 new_value = value
                 if key.endswith("-library"):
                     new_value = target_name or value
+                elif target_id != source_prefix:
+                    if key.endswith("-metadata_files"):
+                        new_value = _clone_library_file_entries_for_target("metadata_files", value, config_name, target_id)
+                    elif key.endswith("-collection_files"):
+                        new_value = _clone_library_file_entries_for_target("collection_files", value, config_name, target_id)
+                    elif key.endswith("-overlay_files"):
+                        new_value = _clone_library_file_entries_for_target("overlay_files", value, config_name, target_id)
                 merged[new_key] = new_value
 
         # Update the aggregated libraries list to include all configured library names
@@ -8168,7 +8219,6 @@ def copy_library_settings():
         merged["libraries"] = ",".join(sorted(set(configured_names)))
 
         # Persist directly to the DB to avoid any loss of data during merge
-        config_name = session.get("config_name") or namesgenerator.get_random_name()
         database.save_section_data(
             name=config_name,
             section="libraries",
@@ -8200,11 +8250,23 @@ def _safe_bundle_name(raw_name: str | None) -> str:
 
 
 def _get_custom_font_files(config_name: str | None = None) -> list[Path]:
-    custom_dir = helpers.get_custom_fonts_dir(config_name)
-    if not custom_dir.is_dir():
-        return []
-    fonts = [entry for entry in custom_dir.iterdir() if entry.is_file() and entry.suffix.lower() in helpers.FONT_EXTENSIONS]
-    return sorted(fonts, key=lambda p: p.name.lower())
+    font_files: list[Path] = []
+    seen: set[str] = set()
+    candidate_dirs: list[Path] = []
+    if config_name:
+        candidate_dirs.append(helpers.get_custom_fonts_dir(config_name))
+    candidate_dirs.append(helpers.get_legacy_custom_fonts_dir())
+    for custom_dir in candidate_dirs:
+        if not custom_dir.is_dir():
+            continue
+        for entry in sorted(custom_dir.iterdir(), key=lambda p: p.name.lower()):
+            if not entry.is_file() or entry.suffix.lower() not in helpers.FONT_EXTENSIONS:
+                continue
+            if entry.name in seen:
+                continue
+            font_files.append(entry)
+            seen.add(entry.name)
+    return font_files
 
 
 def _bundle_artifacts_from_yaml(yaml_text):
@@ -8234,7 +8296,7 @@ def _build_config_bundle(
         f"- {config_filename}",
     ]
     if font_names:
-        readme_lines.append("- fonts/ (custom fonts uploaded in Quickstart)")
+        readme_lines.append(f"- {name}/fonts/ (custom fonts uploaded in Quickstart)")
         readme_lines.append(f"- Fonts included: {', '.join(font_names)}")
     if has_artifacts:
         readme_lines.append(f"- {name}/metadata_files/, {name}/collection_files/, {name}/overlay_files/ (managed library files)")
@@ -8244,7 +8306,7 @@ def _build_config_bundle(
         "1) Copy the config file into your Kometa config folder (config/).",
     ]
     if font_names:
-        readme_lines.append("2) Copy the font files from fonts/ into your Kometa config/fonts/ folder.")
+        readme_lines.append(f"2) Copy the font files from {name}/fonts/ into your Kometa config/fonts/ folder.")
     if has_artifacts:
         readme_lines.append(f"3) Copy {name}/ into your Kometa config/ folder.")
     readme_lines += [
@@ -8263,7 +8325,7 @@ def _build_config_bundle(
     with zipfile.ZipFile(bundle, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         zf.writestr(config_filename, config_text)
         for font_path in font_files:
-            zf.write(font_path, f"fonts/{font_path.name}")
+            zf.write(font_path, f"{name}/fonts/{font_path.name}")
         for artifact in artifact_files:
             _bundle_write_artifact(zf, artifact, redacted=redacted)
         zf.writestr("README.txt", "\n".join(readme_lines))
@@ -14989,7 +15051,9 @@ def validate_kometa_root():
             parsed_config = yaml_parser.load(f) or {}
         font_refs = helpers.collect_font_references(parsed_config)
         if font_refs:
-            font_result = helpers.copy_fonts_to_kometa(font_refs, kometa_root=p)
+            active_config_name = session.get("config_name") if has_request_context() else None
+            config_font_scope = active_config_name or _config_name_from_yaml_filename(config_name)
+            font_result = helpers.copy_fonts_to_kometa(font_refs, kometa_root=p, config_name=config_font_scope)
             copied = font_result.get("copied", [])
             missing = font_result.get("missing", [])
             errors = font_result.get("errors", [])

--- a/quickstart.py
+++ b/quickstart.py
@@ -629,9 +629,13 @@ def _parse_metadata_file_entries(value):
             continue
         entry_type = str(entry.get("type") or "").strip().lower()
         location = str(entry.get("location") or "").strip()
+        validated = helpers.booler(entry.get("validated"))
         if not entry_type and not location:
             continue
-        entries.append({"type": entry_type, "location": location})
+        parsed_entry = {"type": entry_type, "location": location}
+        if validated:
+            parsed_entry["validated"] = True
+        entries.append(parsed_entry)
     return entries
 
 
@@ -658,9 +662,13 @@ def _parse_collection_file_entries(value):
             continue
         entry_type = str(entry.get("type") or "").strip().lower()
         location = str(entry.get("location") or "").strip()
+        validated = helpers.booler(entry.get("validated"))
         if not entry_type and not location:
             continue
-        entries.append({"type": entry_type, "location": location})
+        parsed_entry = {"type": entry_type, "location": location}
+        if validated:
+            parsed_entry["validated"] = True
+        entries.append(parsed_entry)
     return entries
 
 
@@ -687,9 +695,13 @@ def _parse_overlay_file_entries(value):
             continue
         entry_type = str(entry.get("type") or "").strip().lower()
         location = str(entry.get("location") or "").strip()
+        validated = helpers.booler(entry.get("validated"))
         if not entry_type and not location:
             continue
-        entries.append({"type": entry_type, "location": location})
+        parsed_entry = {"type": entry_type, "location": location}
+        if validated:
+            parsed_entry["validated"] = True
+        entries.append(parsed_entry)
     return entries
 
 
@@ -782,6 +794,16 @@ def _managed_bundle_location_for_path(path):
     return Path(*relative_parts).as_posix()
 
 
+def _display_library_managed_location(location):
+    raw = str(location or "").strip().replace("\\", "/")
+    if not raw:
+        return raw
+    normalized_parts = [part for part in raw.split("/") if part]
+    if normalized_parts and normalized_parts[0] in LIBRARY_FILE_KINDS:
+        return Path("config", *normalized_parts).as_posix()
+    return raw
+
+
 def _validate_library_file_entry(kind, entry):
     validator_info = LIBRARY_FILE_VALIDATORS.get(kind)
     if not validator_info:
@@ -849,10 +871,14 @@ def _normalize_library_external_entry(kind, entry, config_name, library_scope, v
     parsed_entry = dict(entry) if isinstance(entry, dict) else {}
     entry_type = str(parsed_entry.get("type") or "").strip().lower()
     location = str(parsed_entry.get("location") or "").strip()
+    is_validated = helpers.booler(parsed_entry.get("validated"))
     if entry_type not in {"file", "folder", "url", "git", "repo"} or not location:
         return parsed_entry, False, None
     if entry_type not in LOCAL_LIBRARY_FILE_TYPES or not config_name or not library_scope:
-        return {"type": entry_type, "location": location}, False, None
+        normalized_entry = {"type": entry_type, "location": location}
+        if is_validated:
+            normalized_entry["validated"] = True
+        return normalized_entry, False, None
 
     if validate_local:
         valid, message, _details = _validate_library_file_entry(kind, {"type": entry_type, "location": location})
@@ -864,8 +890,12 @@ def _normalize_library_external_entry(kind, entry, config_name, library_scope, v
     except Exception as exc:
         return None, False, f"Unable to organize {kind}: {exc}"
 
-    changed = normalized_location != location
-    return {"type": entry_type, "location": normalized_location}, changed, None
+    display_location = _display_library_managed_location(normalized_location)
+    changed = display_location != location
+    normalized_entry = {"type": entry_type, "location": display_location}
+    if is_validated:
+        normalized_entry["validated"] = True
+    return normalized_entry, changed, None
 
 
 def _normalize_library_file_entries_payload(libraries_data, config_name, validate_local=True):

--- a/quickstart.py
+++ b/quickstart.py
@@ -5704,9 +5704,7 @@ def import_config_preview():
     if file_name.endswith(".zip"):
         try:
             with zipfile.ZipFile(BytesIO(raw_text)) as archive:
-                bundled_library_files = [
-                    n for n in archive.namelist() if _is_bundled_library_archive_member(n)
-                ]
+                bundled_library_files = [n for n in archive.namelist() if _is_bundled_library_archive_member(n)]
                 config_files = [n for n in archive.namelist() if n.lower().endswith((".yml", ".yaml")) and n not in bundled_library_files]
                 if not config_files:
                     return jsonify(success=False, message="No YAML config found in zip file."), 400

--- a/quickstart.py
+++ b/quickstart.py
@@ -724,6 +724,16 @@ def _safe_external_artifact_slug(value, fallback="artifact"):
     return safe or fallback
 
 
+def _managed_library_folder_slug(source_path, kind):
+    raw_name = str(getattr(source_path, "name", "") or "").strip().lower()
+    folder_name = _safe_external_artifact_slug(getattr(source_path, "name", ""), "folder")
+    if raw_name in set(LIBRARY_FILE_KINDS):
+        parent_name = _safe_external_artifact_slug(getattr(source_path.parent, "name", ""), "")
+        if parent_name:
+            return f"{parent_name}_{folder_name}"
+    return folder_name
+
+
 def _managed_library_file_root(kind):
     return (Path(helpers.CONFIG_DIR) / kind).resolve()
 
@@ -821,7 +831,7 @@ def _copy_library_artifact_to_managed_store(kind, entry_type, location, config_n
         if source_path != target_path:
             shutil.copy2(source_path, target_path)
     else:
-        folder_name = _safe_external_artifact_slug(source_path.name, "folder")
+        folder_name = _managed_library_folder_slug(source_path, kind)
         target_path = (target_dir / f"{folder_name}_{digest}").resolve()
         if source_path != target_path:
             if target_path.exists():

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -110,8 +110,11 @@ document.addEventListener('DOMContentLoaded', function () {
       if (!entry || typeof entry !== 'object') return null
       const type = String(entry.type || '').trim().toLowerCase()
       const location = String(entry.location || '').trim()
+      const validated = entry.validated === true || String(entry.validated || '').trim().toLowerCase() === 'true'
       if (!type && !location) return null
-      return { type, location }
+      const normalized = { type, location }
+      if (validated) normalized.validated = true
+      return normalized
     }
 
     function parseMetadataFilesValue (rawValue) {
@@ -221,7 +224,11 @@ document.addEventListener('DOMContentLoaded', function () {
       if (locationInput && entry.location) {
         locationInput.value = entry.location
       }
-      updateMetadataFileValidateButton(wrapper, false)
+      if (entry.validated) {
+        wrapper.dataset.metadataFileState = 'success'
+        wrapper.dataset.metadataFileButtonState = 'success'
+      }
+      updateMetadataFileValidateButton(wrapper, Boolean(entry.validated))
       return wrapper
     }
 
@@ -485,7 +492,8 @@ document.addEventListener('DOMContentLoaded', function () {
       const entries = rows.map(row => {
         const type = row.querySelector('[data-metadata-file-type]')?.value
         const location = row.querySelector('[data-metadata-file-location]')?.value
-        return normalizeMetadataFileEntry({ type, location })
+        const validated = String(row.dataset.metadataFileState || '').trim().toLowerCase() === 'success'
+        return normalizeMetadataFileEntry({ type, location, validated })
       }).filter(Boolean)
       hidden.value = JSON.stringify(entries)
       if (emitEvents) {
@@ -507,7 +515,11 @@ document.addEventListener('DOMContentLoaded', function () {
       entries.forEach(entry => list.appendChild(buildMetadataFileRow(entry)))
       list.querySelectorAll('[data-metadata-file-row]').forEach(row => {
         if (applyMetadataFileDependencyState(row)) return
-        setMetadataFileButtonState(row, 'idle')
+        if (String(row.dataset.metadataFileState || '').trim().toLowerCase() === 'success') {
+          setMetadataFileButtonState(row, 'success')
+        } else {
+          setMetadataFileButtonState(row, 'idle')
+        }
       })
       syncMetadataFilesEditor(editor, false)
       updateMetadataFilesAccordionState(editor)
@@ -559,7 +571,11 @@ document.addEventListener('DOMContentLoaded', function () {
       if (locationInput && entry.location) {
         locationInput.value = entry.location
       }
-      updateCollectionFileValidateButton(wrapper, false)
+      if (entry.validated) {
+        wrapper.dataset.collectionFileState = 'success'
+        wrapper.dataset.collectionFileButtonState = 'success'
+      }
+      updateCollectionFileValidateButton(wrapper, Boolean(entry.validated))
       return wrapper
     }
 
@@ -782,11 +798,15 @@ document.addEventListener('DOMContentLoaded', function () {
         return state === 'error' || state === 'warning'
       })
 
+      accordionHeader.classList.remove('warning')
       accordionHeader.classList.toggle('invalid', hasInvalid)
       if (!hasInvalid && hasEntries) {
         accordionHeader.classList.add('selected')
-      } else if (!hasEntries && !hasInvalid && typeof EventHandler !== 'undefined' && typeof EventHandler.updateAccordionHighlights === 'function') {
-        EventHandler.updateAccordionHighlights()
+      } else {
+        accordionHeader.classList.remove('selected')
+        if (!hasEntries && !hasInvalid && typeof EventHandler !== 'undefined' && typeof EventHandler.updateAccordionHighlights === 'function') {
+          EventHandler.updateAccordionHighlights()
+        }
       }
     }
 
@@ -816,7 +836,8 @@ document.addEventListener('DOMContentLoaded', function () {
       const entries = rows.map(row => {
         const type = row.querySelector('[data-collection-file-type]')?.value
         const location = row.querySelector('[data-collection-file-location]')?.value
-        return normalizeMetadataFileEntry({ type, location })
+        const validated = String(row.dataset.collectionFileState || '').trim().toLowerCase() === 'success'
+        return normalizeMetadataFileEntry({ type, location, validated })
       }).filter(Boolean)
       hidden.value = JSON.stringify(entries)
       if (emitEvents) {
@@ -838,7 +859,11 @@ document.addEventListener('DOMContentLoaded', function () {
       entries.forEach(entry => list.appendChild(buildCollectionFileRow(entry)))
       list.querySelectorAll('[data-collection-file-row]').forEach(row => {
         if (applyCollectionFileDependencyState(row)) return
-        setCollectionFileButtonState(row, 'idle')
+        if (String(row.dataset.collectionFileState || '').trim().toLowerCase() === 'success') {
+          setCollectionFileButtonState(row, 'success')
+        } else {
+          setCollectionFileButtonState(row, 'idle')
+        }
       })
       syncCollectionFilesEditor(editor, false)
       updateCollectionFilesAccordionState(editor)
@@ -910,6 +935,7 @@ document.addEventListener('DOMContentLoaded', function () {
               text: payload.message || 'Metadata source looks valid.',
               files: Array.isArray(payload.files) ? payload.files : []
             })
+            syncMetadataFilesEditor(editor, false)
           }
         } catch (_error) {
           setMetadataFileStatus(row, 'error', 'Validation request failed.')
@@ -1006,6 +1032,7 @@ document.addEventListener('DOMContentLoaded', function () {
               text: payload.message || 'Collection source looks valid.',
               files: Array.isArray(payload.files) ? payload.files : []
             })
+            syncCollectionFilesEditor(editor, false)
           }
         } catch (_error) {
           setCollectionFileStatus(row, 'error', 'Validation request failed.')
@@ -1082,7 +1109,11 @@ document.addEventListener('DOMContentLoaded', function () {
       if (locationInput && entry.location) {
         locationInput.value = entry.location
       }
-      updateOverlayFileValidateButton(wrapper, false)
+      if (entry.validated) {
+        wrapper.dataset.overlayFileState = 'success'
+        wrapper.dataset.overlayFileButtonState = 'success'
+      }
+      updateOverlayFileValidateButton(wrapper, Boolean(entry.validated))
       return wrapper
     }
 
@@ -1305,11 +1336,15 @@ document.addEventListener('DOMContentLoaded', function () {
         return state === 'error' || state === 'warning'
       })
 
+      accordionHeader.classList.remove('warning')
       accordionHeader.classList.toggle('invalid', hasInvalid)
       if (!hasInvalid && hasEntries) {
         accordionHeader.classList.add('selected')
-      } else if (!hasEntries && !hasInvalid && typeof EventHandler !== 'undefined' && typeof EventHandler.updateAccordionHighlights === 'function') {
-        EventHandler.updateAccordionHighlights()
+      } else {
+        accordionHeader.classList.remove('selected')
+        if (!hasEntries && !hasInvalid && typeof EventHandler !== 'undefined' && typeof EventHandler.updateAccordionHighlights === 'function') {
+          EventHandler.updateAccordionHighlights()
+        }
       }
     }
 
@@ -1339,7 +1374,8 @@ document.addEventListener('DOMContentLoaded', function () {
       const entries = rows.map(row => {
         const type = row.querySelector('[data-overlay-file-type]')?.value
         const location = row.querySelector('[data-overlay-file-location]')?.value
-        return normalizeMetadataFileEntry({ type, location })
+        const validated = String(row.dataset.overlayFileState || '').trim().toLowerCase() === 'success'
+        return normalizeMetadataFileEntry({ type, location, validated })
       }).filter(Boolean)
       hidden.value = JSON.stringify(entries)
       if (emitEvents) {
@@ -1361,7 +1397,11 @@ document.addEventListener('DOMContentLoaded', function () {
       entries.forEach(entry => list.appendChild(buildOverlayFileRow(entry)))
       list.querySelectorAll('[data-overlay-file-row]').forEach(row => {
         if (applyOverlayFileDependencyState(row)) return
-        setOverlayFileButtonState(row, 'idle')
+        if (String(row.dataset.overlayFileState || '').trim().toLowerCase() === 'success') {
+          setOverlayFileButtonState(row, 'success')
+        } else {
+          setOverlayFileButtonState(row, 'idle')
+        }
       })
       syncOverlayFilesEditor(editor, false)
       updateOverlayFilesAccordionState(editor)
@@ -1433,6 +1473,7 @@ document.addEventListener('DOMContentLoaded', function () {
               text: payload.message || 'Overlay source looks valid.',
               files: Array.isArray(payload.files) ? payload.files : []
             })
+            syncOverlayFilesEditor(editor, false)
           }
         } catch (_error) {
           setOverlayFileStatus(row, 'error', 'Validation request failed.')

--- a/static/local-js/eventHandler.js
+++ b/static/local-js/eventHandler.js
@@ -397,6 +397,16 @@ const EventHandler = {
     return toggles.some(toggle => toggle.checked)
   },
 
+  hasLibraryFileEntries: function (accordionBody) {
+    if (!accordionBody) return false
+    const hidden = accordionBody.querySelector(
+      'input[type="hidden"][name$="-metadata_files"], input[type="hidden"][name$="-collection_files"], input[type="hidden"][name$="-overlay_files"]'
+    )
+    if (!hidden) return false
+    const raw = String(hidden.value || '').trim()
+    return Boolean(raw && raw !== '[]')
+  },
+
   /**
    * Update accordion highlights when selections change
    */
@@ -432,10 +442,16 @@ const EventHandler = {
         // Suppress value-based highlighting for true Collection/Overlay sections,
         // but allow it for "Delete Collections" (so its numeric field bubbles up).
         const headerLower = headerText.toLowerCase()
+        const isLibraryFileSection = EventHandler.hasLibraryFileEntries(accordionBody)
         const suppressValueCheck =
-          headerLower.includes('overlay') ||
-          (headerLower.includes('collection') && !headerLower.includes('delete collections'))
-        if (!suppressValueCheck) {
+          !isLibraryFileSection &&
+          (
+            headerLower.includes('overlay') ||
+            (headerLower.includes('collection') && !headerLower.includes('delete collections'))
+          )
+        if (isLibraryFileSection) {
+          hasValue = true
+        } else if (!suppressValueCheck) {
           const textInputs = Array.from(
             accordionBody.querySelectorAll("input[type='text'], input[type='number'], input[type='date']")
           )
@@ -587,10 +603,11 @@ const EventHandler = {
       "select[data-user-modified='true'] option:checked:not([value='']):not([value='none']), " +
       '.list-group li'
     ) !== null
+    const hasLibraryFileEntries = EventHandler.hasLibraryFileEntries(accordionBody)
 
     // If this accordion has collection toggles and none are enabled, force no highlight.
     const anyTemplateGroupChecked = EventHandler.hasCheckedTemplateGroupToggle(accordionBody)
-    const effectiveSelections = (anyTemplateGroupChecked === false) ? false : hasSelections
+    const effectiveSelections = (anyTemplateGroupChecked === false) ? false : (hasSelections || hasLibraryFileEntries)
 
     if (!effectiveSelections) {
       element.classList.remove('selected')

--- a/templates/partials/_library_advanced_separator.html
+++ b/templates/partials/_library_advanced_separator.html
@@ -1,0 +1,7 @@
+<div class="library-advanced-section d-none px-2 pt-3 pb-1" data-advanced-section>
+    <div class="d-flex align-items-center gap-3 small fw-semibold text-muted">
+        <span class="flex-grow-1 border-top border-secondary-subtle"></span>
+        <span>Advanced Library Options</span>
+        <span class="flex-grow-1 border-top border-secondary-subtle"></span>
+    </div>
+</div>

--- a/templates/partials/_movie_library_settings.html
+++ b/templates/partials/_movie_library_settings.html
@@ -47,12 +47,13 @@
             </div>
         </div>
 
+        <!-- Movie Playlists -->
+        {% include "partials/_library_playlists.html" %}
+
+        {% include "partials/_library_advanced_separator.html" %}
         {% include "partials/_library_collection_files_accordion.html" %}
         {% include "partials/_library_metadata_files.html" %}
         {% include "partials/_library_overlay_files.html" %}
         {% include "partials/_library_radarr_overrides.html" %}
-
-        <!-- Movie Playlists -->
-        {% include "partials/_library_playlists.html" %}
     </div>
 </div>

--- a/templates/partials/_movie_overlays.html
+++ b/templates/partials/_movie_overlays.html
@@ -261,7 +261,7 @@
     <div class="d-flex flex-wrap gap-2 align-items-center justify-content-between">
       <div>
         <h6 class="fw-bold mb-1">Custom Fonts</h6>
-        <p class="small text-muted mb-0">Upload .ttf or .otf files. Saved to <code>config/fonts</code> and copied to Kometa on final save.</p>
+        <p class="small text-muted mb-0">Upload .ttf or .otf files. Saved to the active config’s <code>config/&lt;config_name&gt;/fonts</code> folder and copied to Kometa on final save.</p>
       </div>
       <div class="d-flex flex-wrap gap-2 align-items-center">
         <input type="file" class="form-control form-control-sm" data-font-upload-input accept=".ttf,.otf" multiple>

--- a/templates/partials/_show_library_settings.html
+++ b/templates/partials/_show_library_settings.html
@@ -47,12 +47,13 @@
             </div>
         </div>
 
+        <!-- Show Playlists -->
+        {% include "partials/_library_playlists.html" %}
+
+        {% include "partials/_library_advanced_separator.html" %}
         {% include "partials/_library_collection_files_accordion.html" %}
         {% include "partials/_library_metadata_files.html" %}
         {% include "partials/_library_overlay_files.html" %}
         {% include "partials/_library_sonarr_overrides.html" %}
-
-        <!-- Show Playlists -->
-        {% include "partials/_library_playlists.html" %}
     </div>
 </div>

--- a/templates/partials/_show_overlays.html
+++ b/templates/partials/_show_overlays.html
@@ -265,7 +265,7 @@
     <div class="d-flex flex-wrap gap-2 align-items-center justify-content-between">
       <div>
         <h6 class="fw-bold mb-1">Custom Fonts</h6>
-        <p class="small text-muted mb-0">Upload .ttf or .otf files. Saved to <code>config/fonts</code> and copied to Kometa on final save.</p>
+        <p class="small text-muted mb-0">Upload .ttf or .otf files. Saved to the active config’s <code>config/&lt;config_name&gt;/fonts</code> folder and copied to Kometa on final save.</p>
       </div>
       <div class="d-flex flex-wrap gap-2 align-items-center">
         <input type="file" class="form-control form-control-sm" data-font-upload-input accept=".ttf,.otf" multiple>

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -205,8 +205,8 @@ def test_validate_metadata_file_organizes_local_file_into_managed_store(client, 
     assert payload["valid"] is True
     assert payload["organized"] is True
     normalized_location = payload["normalized_location"]
-    assert normalized_location.startswith(f"metadata_files/{config_name}/mov-library_movies/")
-    managed_file = isolated_config_dir / Path(normalized_location)
+    assert normalized_location.startswith(f"config/{config_name}/metadata_files/mov-library_movies/")
+    managed_file = isolated_config_dir.parent / Path(normalized_location)
     assert managed_file.exists()
     assert managed_file.read_text(encoding="utf-8") == metadata_file.read_text(encoding="utf-8")
 
@@ -333,7 +333,7 @@ def test_validate_metadata_folder_organizes_generic_folder_name_into_descriptive
     payload = resp.get_json()
     assert payload["valid"] is True
     normalized_location = str(payload["normalized_location"]).replace("\\", "/")
-    assert normalized_location.startswith(f"config/metadata_files/{config_name}/mov-library_movies/")
+    assert normalized_location.startswith(f"config/{config_name}/metadata_files/mov-library_movies/")
     assert "/movies_metadata_files_" in normalized_location
     assert (isolated_config_dir.parent / normalized_location).exists()
 
@@ -374,7 +374,7 @@ def test_validate_collection_folder_accepts_managed_relative_folder_path(client,
     assert resp.status_code == 200
     payload = resp.get_json()
     assert payload["valid"] is True
-    assert payload["normalized_location"] == "config/collection_files"
+    assert payload["normalized_location"].startswith("config/pytest_managed_collection_folder/collection_files/mov-library_movies/")
     assert payload["organized"] is True
 
 
@@ -628,7 +628,10 @@ def test_autosave_library_accepts_managed_relative_collection_folder_path(client
     payload = resp.get_json()
     assert payload["success"] is True
     saved_entries = json.loads(payload["libraries"]["mov-library_movies-collection_files"])
-    assert saved_entries == [{"type": "folder", "location": "config/collection_files", "validated": True}]
+    assert len(saved_entries) == 1
+    assert saved_entries[0]["type"] == "folder"
+    assert saved_entries[0]["validated"] is True
+    assert saved_entries[0]["location"].startswith("config/pytest_autosave_managed_collection_folder/collection_files/mov-library_movies/")
 
 
 def test_autosave_library_rejects_invalid_overlay_files(client, monkeypatch, qs_module):
@@ -682,7 +685,7 @@ def test_autosave_library_organizes_overlay_folder(client, isolated_config_dir, 
     assert len(overlay_entries) == 1
     assert overlay_entries[0]["type"] == "folder"
     managed_location = overlay_entries[0]["location"]
-    assert managed_location.startswith(f"config/overlay_files/{config_name}/mov-library_movies/")
+    assert managed_location.startswith(f"config/{config_name}/overlay_files/mov-library_movies/")
     managed_dir = isolated_config_dir.parent / managed_location
     assert managed_dir.is_dir()
     assert (managed_dir / "movies.yml").exists()
@@ -1152,7 +1155,7 @@ def test_step_post_from_libraries_persists_metadata_files(client, isolated_confi
     assert stored["libraries"]["mov-library_movies-library"] == "Movies"
     saved_entries = json.loads(stored["libraries"]["mov-library_movies-metadata_files"])
     assert saved_entries[0]["type"] == "file"
-    assert saved_entries[0]["location"].startswith(f"config/metadata_files/{config_name}/mov-library_movies/")
+    assert saved_entries[0]["location"].startswith(f"config/{config_name}/metadata_files/mov-library_movies/")
     assert saved_entries[0]["validated"] is True
     assert saved_entries[1] == {"type": "url", "location": "https://example.com/movies_refresh.yml", "validated": True}
     managed_file = isolated_config_dir.parent / Path(saved_entries[0]["location"])
@@ -1211,7 +1214,7 @@ def test_step_post_from_libraries_persists_collection_files(client, isolated_con
     assert stored["libraries"]["mov-library_movies-library"] == "Movies"
     saved_entries = json.loads(stored["libraries"]["mov-library_movies-collection_files"])
     assert saved_entries[0]["type"] == "file"
-    assert saved_entries[0]["location"].startswith(f"config/collection_files/{config_name}/mov-library_movies/")
+    assert saved_entries[0]["location"].startswith(f"config/{config_name}/collection_files/mov-library_movies/")
     assert saved_entries[0]["validated"] is True
     assert saved_entries[1] == {"type": "url", "location": "https://example.com/movies_refresh.yml", "validated": True}
     managed_file = isolated_config_dir.parent / Path(saved_entries[0]["location"])
@@ -1812,7 +1815,7 @@ def test_download_redacted_bundles_managed_overlay_folder(client, isolated_confi
     import zipfile
 
     config_name = "pytest_redacted_bundle"
-    managed_dir = isolated_config_dir / "overlay_files" / config_name / "mov-library_movies" / "seasonal"
+    managed_dir = isolated_config_dir / config_name / "overlay_files" / "mov-library_movies" / "seasonal"
     managed_dir.mkdir(parents=True, exist_ok=True)
     managed_file = managed_dir / "awards.yml"
     managed_file.write_text(
@@ -1822,7 +1825,7 @@ def test_download_redacted_bundles_managed_overlay_folder(client, isolated_confi
 
     with client.session_transaction() as sess:
         sess["config_name"] = config_name
-        sess["yaml_content"] = "libraries:\n" "  Movies:\n" "    overlay_files:\n" f"      - folder: overlay_files/{config_name}/mov-library_movies/seasonal\n"
+        sess["yaml_content"] = "libraries:\n" "  Movies:\n" "    overlay_files:\n" f"      - folder: {config_name}/overlay_files/mov-library_movies/seasonal\n"
 
     resp = client.get("/download_redacted")
     assert resp.status_code == 200
@@ -1831,7 +1834,7 @@ def test_download_redacted_bundles_managed_overlay_folder(client, isolated_confi
     with zipfile.ZipFile(io.BytesIO(resp.data)) as archive:
         names = set(archive.namelist())
         assert "config_redacted.yml" in names
-        bundled_name = f"overlay_files/{config_name}/mov-library_movies/seasonal/awards.yml"
+        bundled_name = f"{config_name}/overlay_files/mov-library_movies/seasonal/awards.yml"
         assert bundled_name in names
         bundled_text = archive.read(bundled_name).decode("utf-8")
         assert "(redacted)" in bundled_text
@@ -2006,8 +2009,8 @@ def test_bulk_delete_configs_removes_config_artifacts(client, isolated_config_di
         archive_dir = isolated_config_dir / "archives" / name
         archive_dir.mkdir(parents=True, exist_ok=True)
         (archive_dir / f"{name}_config_1.yml").write_text("archived: true\n", encoding="utf-8")
-        (isolated_config_dir / "metadata_files" / name / "mov-library_movies").mkdir(parents=True, exist_ok=True)
-        (isolated_config_dir / "overlay_files" / name / "mov-library_movies").mkdir(parents=True, exist_ok=True)
+        (isolated_config_dir / name / "metadata_files" / "mov-library_movies").mkdir(parents=True, exist_ok=True)
+        (isolated_config_dir / name / "overlay_files" / "mov-library_movies").mkdir(parents=True, exist_ok=True)
         (kometa_path / f"{name}_config.yml").write_text("test: true\n", encoding="utf-8")
         database.save_section_data(
             name=name,
@@ -2030,8 +2033,8 @@ def test_bulk_delete_configs_removes_config_artifacts(client, isolated_config_di
     for name in (first, second):
         assert not (isolated_config_dir / f"{name}_config.yml").exists()
         assert not (isolated_config_dir / "archives" / name).exists()
-        assert not (isolated_config_dir / "metadata_files" / name).exists()
-        assert not (isolated_config_dir / "overlay_files" / name).exists()
+        assert not (isolated_config_dir / name / "metadata_files").exists()
+        assert not (isolated_config_dir / name / "overlay_files").exists()
         assert not (kometa_path / f"{name}_config.yml").exists()
 
 
@@ -2045,7 +2048,7 @@ def test_orphaned_config_artifacts_route_lists_disk_only_bundles(client, isolate
     archive_dir.mkdir(parents=True, exist_ok=True)
     (archive_dir / f"{orphan_name}_config_1.yml").write_text("archive: true\n", encoding="utf-8")
     (isolated_config_dir / f"{orphan_name}_config.yml").write_text("current: true\n", encoding="utf-8")
-    managed_dir = isolated_config_dir / "metadata_files" / orphan_name / "mov-library_movies"
+    managed_dir = isolated_config_dir / orphan_name / "metadata_files" / "mov-library_movies"
     managed_dir.mkdir(parents=True, exist_ok=True)
     (managed_dir / "movies.yml").write_text("metadata:\n  test:\n    title: Example\n", encoding="utf-8")
 
@@ -2083,7 +2086,7 @@ def test_delete_orphaned_config_artifacts_route_removes_selected_bundle(client, 
     archive_dir.mkdir(parents=True, exist_ok=True)
     (archive_dir / f"{orphan_name}_config_1.yml").write_text("archive: true\n", encoding="utf-8")
     (isolated_config_dir / f"{orphan_name}_config.yml").write_text("current: true\n", encoding="utf-8")
-    managed_dir = isolated_config_dir / "collection_files" / orphan_name / "mov-library_movies"
+    managed_dir = isolated_config_dir / orphan_name / "collection_files" / "mov-library_movies"
     managed_dir.mkdir(parents=True, exist_ok=True)
     (managed_dir / "collections.yml").write_text("collections:\n  test:\n    plex_search:\n      any:\n        title: Example\n", encoding="utf-8")
 
@@ -2098,7 +2101,7 @@ def test_delete_orphaned_config_artifacts_route_removes_selected_bundle(client, 
     assert payload["deleted"] == [orphan_name]
     assert not (isolated_config_dir / f"{orphan_name}_config.yml").exists(), payload
     assert not archive_dir.exists()
-    assert not (isolated_config_dir / "collection_files" / orphan_name).exists()
+    assert not (isolated_config_dir / orphan_name / "collection_files").exists()
     assert not (kometa_path / f"{orphan_name}_config.yml").exists()
 
 
@@ -2184,8 +2187,8 @@ def test_rename_config_moves_managed_library_file_directories(client, isolated_c
 
     (isolated_config_dir / f"{old_name}_config.yml").write_text("test: true\n", encoding="utf-8")
     (kometa_path / f"{old_name}_config.yml").write_text("test: true\n", encoding="utf-8")
-    metadata_dir = isolated_config_dir / "metadata_files" / old_name / "mov-library_movies"
-    overlay_dir = isolated_config_dir / "overlay_files" / old_name / "mov-library_movies"
+    metadata_dir = isolated_config_dir / old_name / "metadata_files" / "mov-library_movies"
+    overlay_dir = isolated_config_dir / old_name / "overlay_files" / "mov-library_movies"
     metadata_dir.mkdir(parents=True, exist_ok=True)
     overlay_dir.mkdir(parents=True, exist_ok=True)
     (metadata_dir / "movies.yml").write_text("metadata:\n  test:\n    title: Example\n", encoding="utf-8")
@@ -2206,10 +2209,10 @@ def test_rename_config_moves_managed_library_file_directories(client, isolated_c
     payload = resp.get_json()
     assert payload["success"] is True
 
-    assert not (isolated_config_dir / "metadata_files" / old_name).exists()
-    assert not (isolated_config_dir / "overlay_files" / old_name).exists()
-    assert (isolated_config_dir / "metadata_files" / new_name / "mov-library_movies" / "movies.yml").exists()
-    assert (isolated_config_dir / "overlay_files" / new_name / "mov-library_movies" / "awards.yml").exists()
+    assert not (isolated_config_dir / old_name / "metadata_files").exists()
+    assert not (isolated_config_dir / old_name / "overlay_files").exists()
+    assert (isolated_config_dir / new_name / "metadata_files" / "mov-library_movies" / "movies.yml").exists()
+    assert (isolated_config_dir / new_name / "overlay_files" / "mov-library_movies" / "awards.yml").exists()
     assert f"{new_name}_config.yml" in "".join(payload["files"]["renamed"])
 
     with client.session_transaction() as sess:
@@ -2353,7 +2356,7 @@ def test_copy_library_settings_mirrors_metadata_files(client, isolated_config_di
     from flask import session
 
     config_name = "pytest_copy_metadata_files"
-    managed_dir = isolated_config_dir / "metadata_files" / config_name / "mov-library_movies"
+    managed_dir = isolated_config_dir / config_name / "metadata_files" / "mov-library_movies"
     managed_dir.mkdir(parents=True, exist_ok=True)
     managed_file = managed_dir / "movies.yml"
     managed_file.write_text("metadata:\n  test:\n    title: Example\n", encoding="utf-8")
@@ -2420,8 +2423,12 @@ def test_copy_library_settings_mirrors_metadata_files(client, isolated_config_di
     assert validated is False
     assert user_entered is True
     libraries = stored["libraries"]
-    assert libraries["mov-library_movies-metadata_files"] == source_metadata_files
-    assert libraries["mov-library_target-metadata_files"] == source_metadata_files
+    source_entries = json.loads(libraries["mov-library_movies-metadata_files"])
+    target_entries = json.loads(libraries["mov-library_target-metadata_files"])
+    assert source_entries[0]["location"] == f"config/{managed_location}"
+    assert target_entries[0]["location"] == f"config/{managed_location}"
+    assert source_entries[1] == {"type": "url", "location": "https://example.com/movie-metadata.yml"}
+    assert target_entries[1] == {"type": "url", "location": "https://example.com/movie-metadata.yml"}
 
 
 def test_import_config_confirm_rehomes_bundled_library_files(client, isolated_config_dir, monkeypatch, qs_module):
@@ -2469,10 +2476,10 @@ def test_import_config_confirm_rehomes_bundled_library_files(client, isolated_co
     with zipfile.ZipFile(bundle, "w", compression=zipfile.ZIP_DEFLATED) as archive:
         archive.writestr(
             "config.yml",
-            "plex:\n  url: http://plex.local\n  token: test-token\ntmdb:\n  apikey: test-key\nlibraries:\n  Movies:\n    metadata_files:\n      - file: metadata_files/original/movies/source.yml\n",
+            "plex:\n  url: http://plex.local\n  token: test-token\ntmdb:\n  apikey: test-key\nlibraries:\n  Movies:\n    metadata_files:\n      - file: original/metadata_files/movies/source.yml\n",
         )
         archive.writestr(
-            "metadata_files/original/movies/source.yml",
+            "original/metadata_files/movies/source.yml",
             "metadata:\n  imported:\n    title: Imported Example\n",
         )
     bundle.seek(0)
@@ -2497,8 +2504,8 @@ def test_import_config_confirm_rehomes_bundled_library_files(client, isolated_co
     metadata_entries = json.loads(stored["libraries"]["mov-library_movies-metadata_files"])
     assert len(metadata_entries) == 1
     normalized_location = metadata_entries[0]["location"]
-    assert normalized_location.startswith(f"metadata_files/{config_name}/mov-library_movies/")
-    managed_file = isolated_config_dir / normalized_location
+    assert normalized_location.startswith(f"config/{config_name}/metadata_files/mov-library_movies/")
+    managed_file = isolated_config_dir.parent / normalized_location
     assert managed_file.exists()
     assert "Imported Example" in managed_file.read_text(encoding="utf-8")
 

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -1842,6 +1842,50 @@ def test_download_redacted_bundles_managed_overlay_folder(client, isolated_confi
         assert "internal.example" not in bundled_text
 
 
+def test_upload_fonts_store_in_active_config_directory(client, isolated_config_dir):
+    import io
+
+    config_name = "pytest_font_upload"
+    with client.session_transaction() as sess:
+        sess["config_name"] = config_name
+
+    resp = client.post(
+        "/upload-fonts",
+        data={"fonts": (io.BytesIO(b"font-bytes"), "Poster.ttf")},
+        content_type="multipart/form-data",
+    )
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["status"] == "success"
+    assert "Poster.ttf" in payload["fonts"]
+    assert (isolated_config_dir / config_name / "fonts" / "Poster.ttf").exists()
+    assert not (isolated_config_dir / "fonts" / "Poster.ttf").exists()
+
+
+def test_download_bundle_places_fonts_under_config_name(client, isolated_config_dir):
+    import io
+    import zipfile
+
+    config_name = "pytest_font_bundle"
+    font_dir = isolated_config_dir / config_name / "fonts"
+    font_dir.mkdir(parents=True, exist_ok=True)
+    (font_dir / "Poster.ttf").write_bytes(b"font-bytes")
+
+    with client.session_transaction() as sess:
+        sess["config_name"] = config_name
+        sess["yaml_content"] = "settings:\n  cache: true\n"
+
+    resp = client.get("/download")
+    assert resp.status_code == 200
+    assert resp.mimetype == "application/zip"
+
+    with zipfile.ZipFile(io.BytesIO(resp.data)) as archive:
+        names = set(archive.namelist())
+        assert "config.yml" in names
+        assert f"{config_name}/fonts/Poster.ttf" in names
+
+
 def test_yaml_generation_missing_sections_shows_error(client, isolated_config_dir, monkeypatch, qs_module):
     monkeypatch.setattr(
         qs_module,
@@ -2351,6 +2395,7 @@ def test_retrieve_settings_sanitizes_already_persisted_transient_fields(client, 
 
 def test_copy_library_settings_mirrors_metadata_files(client, isolated_config_dir, monkeypatch, app, qs_module):
     import json
+    from pathlib import Path
 
     from modules import database
     from flask import session
@@ -2426,9 +2471,34 @@ def test_copy_library_settings_mirrors_metadata_files(client, isolated_config_di
     source_entries = json.loads(libraries["mov-library_movies-metadata_files"])
     target_entries = json.loads(libraries["mov-library_target-metadata_files"])
     assert source_entries[0]["location"] == f"config/{managed_location}"
-    assert target_entries[0]["location"] == f"config/{managed_location}"
+    assert target_entries[0]["location"].startswith(f"config/{config_name}/metadata_files/mov-library_target/")
+    assert target_entries[0]["location"] != source_entries[0]["location"]
     assert source_entries[1] == {"type": "url", "location": "https://example.com/movie-metadata.yml"}
     assert target_entries[1] == {"type": "url", "location": "https://example.com/movie-metadata.yml"}
+    target_file = isolated_config_dir.parent / Path(target_entries[0]["location"])
+    assert target_file.exists()
+    assert target_file.read_text(encoding="utf-8") == managed_file.read_text(encoding="utf-8")
+
+
+def test_copy_fonts_to_kometa_prefers_config_scoped_fonts(isolated_config_dir, app):
+    from pathlib import Path
+
+    from modules import helpers
+
+    config_name = "pytest_font_sync"
+    config_font_dir = isolated_config_dir / config_name / "fonts"
+    legacy_font_dir = isolated_config_dir / "fonts"
+    config_font_dir.mkdir(parents=True, exist_ok=True)
+    legacy_font_dir.mkdir(parents=True, exist_ok=True)
+    (config_font_dir / "Poster.ttf").write_bytes(b"config-font")
+    (legacy_font_dir / "Poster.ttf").write_bytes(b"legacy-font")
+
+    result = helpers.copy_fonts_to_kometa(["Poster.ttf"], kometa_root=app.config["KOMETA_ROOT"], config_name=config_name)
+
+    assert result["copied"] == ["Poster.ttf"]
+    copied_font = Path(app.config["KOMETA_ROOT"]) / "config" / "fonts" / "Poster.ttf"
+    assert copied_font.exists()
+    assert copied_font.read_bytes() == b"config-font"
 
 
 def test_import_config_confirm_rehomes_bundled_library_files(client, isolated_config_dir, monkeypatch, qs_module):
@@ -2482,6 +2552,10 @@ def test_import_config_confirm_rehomes_bundled_library_files(client, isolated_co
             "original/metadata_files/movies/source.yml",
             "metadata:\n  imported:\n    title: Imported Example\n",
         )
+        archive.writestr(
+            f"{config_name}/fonts/Poster.ttf",
+            b"font-bytes",
+        )
     bundle.seek(0)
 
     preview = client.post(
@@ -2508,6 +2582,9 @@ def test_import_config_confirm_rehomes_bundled_library_files(client, isolated_co
     managed_file = isolated_config_dir.parent / normalized_location
     assert managed_file.exists()
     assert "Imported Example" in managed_file.read_text(encoding="utf-8")
+    bundled_font = isolated_config_dir / config_name / "fonts" / "Poster.ttf"
+    assert bundled_font.exists()
+    assert bundled_font.read_bytes() == b"font-bytes"
 
 
 def test_build_libraries_section_emits_schedule_overlays(app):

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -313,6 +313,31 @@ def test_validate_metadata_folder_accepts_top_level_yaml_files(client, tmp_path)
     assert payload["message"] == "Validated 2 YAML files in folder."
 
 
+def test_validate_metadata_folder_organizes_generic_folder_name_into_descriptive_managed_store(client, isolated_config_dir, tmp_path):
+    source_dir = tmp_path / "movies" / "metadata_files"
+    source_dir.mkdir(parents=True)
+    (source_dir / "godzilla.yml").write_text("metadata:\n  test:\n    title: Godzilla\n", encoding="utf-8")
+
+    config_name = "pytest_metadata_folder_name"
+    resp = client.post(
+        "/validate_metadata_file",
+        json={
+            "metadata_file_type": "folder",
+            "metadata_file_location": str(source_dir),
+            "library_id": "mov-library_movies",
+            "config_name": config_name,
+        },
+    )
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["valid"] is True
+    normalized_location = str(payload["normalized_location"]).replace("\\", "/")
+    assert normalized_location.startswith(f"metadata_files/{config_name}/mov-library_movies/")
+    assert "/movies_metadata_files_" in normalized_location
+    assert (isolated_config_dir / normalized_location).exists()
+
+
 def test_validate_collection_folder_accepts_top_level_yaml_files(client, tmp_path):
     collection_dir = tmp_path / "collections"
     collection_dir.mkdir()

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -333,9 +333,9 @@ def test_validate_metadata_folder_organizes_generic_folder_name_into_descriptive
     payload = resp.get_json()
     assert payload["valid"] is True
     normalized_location = str(payload["normalized_location"]).replace("\\", "/")
-    assert normalized_location.startswith(f"metadata_files/{config_name}/mov-library_movies/")
+    assert normalized_location.startswith(f"config/metadata_files/{config_name}/mov-library_movies/")
     assert "/movies_metadata_files_" in normalized_location
-    assert (isolated_config_dir / normalized_location).exists()
+    assert (isolated_config_dir.parent / normalized_location).exists()
 
 
 def test_validate_collection_folder_accepts_top_level_yaml_files(client, tmp_path):
@@ -354,6 +354,28 @@ def test_validate_collection_folder_accepts_top_level_yaml_files(client, tmp_pat
     assert payload["validated_files"] == 2
     assert payload["files"] == ["godzilla.yml", "refresh.yaml"]
     assert payload["message"] == "Validated 2 YAML files in folder."
+
+
+def test_validate_collection_folder_accepts_managed_relative_folder_path(client, isolated_config_dir):
+    managed_dir = isolated_config_dir / "collection_files"
+    managed_dir.mkdir(parents=True, exist_ok=True)
+    (managed_dir / "godzilla.yml").write_text("collections:\n  test:\n    title: Godzilla\n", encoding="utf-8")
+
+    resp = client.post(
+        "/validate_collection_file",
+        json={
+            "config_name": "pytest_managed_collection_folder",
+            "library_id": "mov-library_movies",
+            "collection_file_type": "folder",
+            "collection_file_location": "collection_files",
+        },
+    )
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["valid"] is True
+    assert payload["normalized_location"] == "config/collection_files"
+    assert payload["organized"] is True
 
 
 def test_validate_metadata_folder_rejects_empty_folder(client, tmp_path):
@@ -585,6 +607,30 @@ def test_autosave_library_rejects_invalid_collection_files(client, monkeypatch, 
     assert "Invalid collection files" in payload["error"]
 
 
+def test_autosave_library_accepts_managed_relative_collection_folder_path(client, isolated_config_dir, monkeypatch, qs_module):
+    import json
+
+    managed_dir = isolated_config_dir / "collection_files"
+    managed_dir.mkdir(parents=True, exist_ok=True)
+    (managed_dir / "godzilla.yml").write_text("collections:\n  test:\n    title: Godzilla\n", encoding="utf-8")
+
+    monkeypatch.setattr(qs_module.output, "build_config", lambda *_args, **_kwargs: (True, None, {}, "test: true\n", []))
+
+    resp = client.post(
+        "/autosave_library/mov-library_movies",
+        json={
+            "config_name": "pytest_autosave_managed_collection_folder",
+            "mov-library_movies-library": "Movies",
+            "mov-library_movies-collection_files": '[{"type":"folder","location":"collection_files","validated":true}]',
+        },
+    )
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    saved_entries = json.loads(payload["libraries"]["mov-library_movies-collection_files"])
+    assert saved_entries == [{"type": "folder", "location": "config/collection_files", "validated": True}]
+
+
 def test_autosave_library_rejects_invalid_overlay_files(client, monkeypatch, qs_module):
     class _Resp:
         status_code = 404
@@ -636,8 +682,8 @@ def test_autosave_library_organizes_overlay_folder(client, isolated_config_dir, 
     assert len(overlay_entries) == 1
     assert overlay_entries[0]["type"] == "folder"
     managed_location = overlay_entries[0]["location"]
-    assert managed_location.startswith(f"overlay_files/{config_name}/mov-library_movies/")
-    managed_dir = isolated_config_dir / managed_location
+    assert managed_location.startswith(f"config/overlay_files/{config_name}/mov-library_movies/")
+    managed_dir = isolated_config_dir.parent / managed_location
     assert managed_dir.is_dir()
     assert (managed_dir / "movies.yml").exists()
 
@@ -1066,8 +1112,8 @@ def test_step_post_from_libraries_persists_metadata_files(client, isolated_confi
     metadata_file.write_text("metadata:\n  test:\n    title: Example\n", encoding="utf-8")
     metadata_value = json.dumps(
         [
-            {"type": "file", "location": str(metadata_file)},
-            {"type": "url", "location": "https://example.com/movies_refresh.yml"},
+            {"type": "file", "location": str(metadata_file), "validated": True},
+            {"type": "url", "location": "https://example.com/movies_refresh.yml", "validated": True},
         ]
     )
 
@@ -1106,9 +1152,10 @@ def test_step_post_from_libraries_persists_metadata_files(client, isolated_confi
     assert stored["libraries"]["mov-library_movies-library"] == "Movies"
     saved_entries = json.loads(stored["libraries"]["mov-library_movies-metadata_files"])
     assert saved_entries[0]["type"] == "file"
-    assert saved_entries[0]["location"].startswith(f"metadata_files/{config_name}/mov-library_movies/")
-    assert saved_entries[1] == {"type": "url", "location": "https://example.com/movies_refresh.yml"}
-    managed_file = isolated_config_dir / Path(saved_entries[0]["location"])
+    assert saved_entries[0]["location"].startswith(f"config/metadata_files/{config_name}/mov-library_movies/")
+    assert saved_entries[0]["validated"] is True
+    assert saved_entries[1] == {"type": "url", "location": "https://example.com/movies_refresh.yml", "validated": True}
+    managed_file = isolated_config_dir.parent / Path(saved_entries[0]["location"])
     assert managed_file.exists()
     assert managed_file.read_text(encoding="utf-8") == metadata_file.read_text(encoding="utf-8")
 
@@ -1124,8 +1171,8 @@ def test_step_post_from_libraries_persists_collection_files(client, isolated_con
     collection_file.write_text("collections:\n  test:\n    plex_search:\n      any:\n        title: Example\n", encoding="utf-8")
     collection_value = json.dumps(
         [
-            {"type": "file", "location": str(collection_file)},
-            {"type": "url", "location": "https://example.com/movies_refresh.yml"},
+            {"type": "file", "location": str(collection_file), "validated": True},
+            {"type": "url", "location": "https://example.com/movies_refresh.yml", "validated": True},
         ]
     )
 
@@ -1164,9 +1211,10 @@ def test_step_post_from_libraries_persists_collection_files(client, isolated_con
     assert stored["libraries"]["mov-library_movies-library"] == "Movies"
     saved_entries = json.loads(stored["libraries"]["mov-library_movies-collection_files"])
     assert saved_entries[0]["type"] == "file"
-    assert saved_entries[0]["location"].startswith(f"collection_files/{config_name}/mov-library_movies/")
-    assert saved_entries[1] == {"type": "url", "location": "https://example.com/movies_refresh.yml"}
-    managed_file = isolated_config_dir / Path(saved_entries[0]["location"])
+    assert saved_entries[0]["location"].startswith(f"config/collection_files/{config_name}/mov-library_movies/")
+    assert saved_entries[0]["validated"] is True
+    assert saved_entries[1] == {"type": "url", "location": "https://example.com/movies_refresh.yml", "validated": True}
+    managed_file = isolated_config_dir.parent / Path(saved_entries[0]["location"])
     assert managed_file.exists()
     assert managed_file.read_text(encoding="utf-8") == collection_file.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Summary
This PR completes Quickstart’s config-owned bundle model for external library assets and custom fonts.

Quickstart now stores managed library files and uploaded fonts under the active config, includes them in config bundle downloads, restores them on bundle import, and cleans them up with the rest of the config lifecycle. It also fixes Mirror to... so local managed library file entries are cloned into each target library’s own managed subtree instead of silently sharing the source library path.

What Changed
Moved managed library file storage to a config-first layout:
config/<config_name>/metadata_files/<library_id>/...
config/<config_name>/collection_files/<library_id>/...
config/<config_name>/overlay_files/<library_id>/...
Moved uploaded custom font storage to a config-owned layout:
config/<config_name>/fonts/...
Updated library file validation/save/autosave flows to normalize local file and folder entries into those config-owned managed paths.
Updated bundle export so downloaded config bundles include:
config-owned managed library files
config-owned custom fonts
Updated bundle import so bundled library files and fonts are restored into the receiving config’s managed directories.
Updated redacted bundle generation so bundled YAML file contents are redacted alongside the main config.
Updated config rename/delete/orphan cleanup so managed library asset trees move and clean up with the owning config.
Updated Mirror to... behavior:
local managed file / folder entries are now cloned into the target library’s own managed subtree
url / git / repo entries remain shared plain references
Updated Kometa font sync so config-scoped fonts are preferred when copying referenced fonts into Kometa config/fonts.
Why
Before this change, Quickstart could bundle some external assets, but ownership was inconsistent:

managed library file paths were type-first instead of config-first
custom fonts were stored in a global pool
mirrored local library file entries could leave multiple libraries pointing at a source library’s managed path
bundle lifecycle behavior was not fully aligned with config ownership
This PR makes the bundle model coherent. Each config now owns its managed external assets directly, which makes sharing, import/export, rename, cleanup, and library mirroring much more predictable.

Result
Quickstart-managed assets now behave like config-owned bundle artifacts rather than loose references:

local library metadata_files, collection_files, and overlay_files are copied into config-owned storage
uploaded fonts are stored per config
bundle downloads are more complete
bundle imports restore config assets cleanly
mirrored libraries get their own local managed file copies
config cleanup has a clear ownership boundary


## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
