### PR TITLE
bundles refactor v3

### DIFF
--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -1344,6 +1344,21 @@ def save_to_named_config(yaml_text, config_name, font_refs=None):
         except Exception as exc:
             ts_log(f"Failed to sync fonts to Kometa: {exc}", level="WARNING")
 
+    if kometa_write_ok:
+        try:
+            artifact_result = sync_managed_library_artifacts_to_kometa(name, kometa_root=kometa_root)
+            synced = artifact_result.get("synced", [])
+            removed = artifact_result.get("removed", [])
+            errors = artifact_result.get("errors", [])
+            if synced:
+                ts_log(f"Synced {len(synced)} managed library artifact tree(s) to Kometa config/{name}.")
+            if removed:
+                ts_log(f"Removed {len(removed)} stale managed library artifact tree(s) from Kometa config/{name}.")
+            for err in errors:
+                ts_log(err, level="WARNING")
+        except Exception as exc:
+            ts_log(f"Failed to sync managed library artifacts to Kometa: {exc}", level="WARNING")
+
     ts_log(f"Saved new config to: {latest_path}")
     if kometa_write_ok:
         ts_log(f"Also copied config to: {kometa_path}")
@@ -2634,6 +2649,59 @@ def get_legacy_managed_library_artifact_paths(config_name: str | None) -> list[P
     normalized = normalize_config_name_for_storage(config_name)
     config_dir = Path(CONFIG_DIR)
     return [config_dir / folder / normalized for folder in MANAGED_LIBRARY_FILE_DIRS]
+
+
+def sync_managed_library_artifacts_to_kometa(config_name: str | None, kometa_root: str | Path | None = None) -> dict:
+    normalized = normalize_config_name_for_storage(config_name)
+    source_root = get_managed_config_artifact_root(normalized)
+    destination_root = (Path(kometa_root) if kometa_root is not None else Path(app.config.get("KOMETA_ROOT", "."))) / "config" / normalized
+
+    synced: list[str] = []
+    removed: list[str] = []
+    missing: list[str] = []
+    errors: list[str] = []
+
+    for folder in MANAGED_LIBRARY_FILE_DIRS:
+        source_dir = source_root / folder
+        destination_dir = destination_root / folder
+
+        if source_dir.exists():
+            try:
+                source_resolved = source_dir.resolve()
+                destination_resolved = destination_dir.resolve()
+                if source_resolved == destination_resolved:
+                    synced.append(str(destination_dir))
+                    continue
+            except Exception:
+                pass
+
+            try:
+                destination_dir.parent.mkdir(parents=True, exist_ok=True)
+                if destination_dir.exists():
+                    shutil.rmtree(destination_dir, onerror=handle_remove_readonly)
+                shutil.copytree(source_dir, destination_dir)
+                synced.append(str(destination_dir))
+            except Exception as exc:
+                errors.append(f"Failed to sync {source_dir} -> {destination_dir}: {exc}")
+            continue
+
+        missing.append(folder)
+        if not destination_dir.exists():
+            continue
+        try:
+            shutil.rmtree(destination_dir, onerror=handle_remove_readonly)
+            removed.append(str(destination_dir))
+        except Exception as exc:
+            errors.append(f"Failed to remove stale Kometa artifact directory {destination_dir}: {exc}")
+
+    if destination_root.exists():
+        try:
+            if not any(destination_root.iterdir()):
+                destination_root.rmdir()
+        except Exception:
+            pass
+
+    return {"synced": synced, "removed": removed, "missing": missing, "errors": errors}
 
 
 def delete_config_artifacts(config_name: str | None, kometa_root: str | Path | None = None) -> dict:

--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -2472,6 +2472,46 @@ def list_available_fonts(include_static: bool = True, include_custom: bool = Tru
     return sorted(fonts)
 
 
+def migrate_legacy_custom_fonts_to_config(config_name: str | None, font_names: list[str] | tuple[str, ...] | set[str] | None = None) -> dict:
+    normalized = normalize_config_name_for_storage(config_name)
+    if not normalized:
+        return {"copied": [], "skipped": [], "errors": []}
+
+    source_dir = get_legacy_custom_fonts_dir()
+    destination_dir = get_custom_fonts_dir(normalized)
+    copied: list[str] = []
+    skipped: list[str] = []
+    errors: list[str] = []
+
+    if not source_dir.is_dir():
+        return {"copied": copied, "skipped": skipped, "errors": errors}
+
+    requested: set[str] | None = None
+    if font_names is not None:
+        requested = {str(name or "").strip() for name in font_names if str(name or "").strip()}
+        if not requested:
+            return {"copied": copied, "skipped": skipped, "errors": errors}
+
+    destination_dir.mkdir(parents=True, exist_ok=True)
+
+    for entry in sorted(source_dir.iterdir(), key=lambda p: p.name.lower()):
+        if not entry.is_file() or entry.suffix.lower() not in FONT_EXTENSIONS:
+            continue
+        if requested is not None and entry.name not in requested:
+            continue
+        target = destination_dir / entry.name
+        if target.exists():
+            skipped.append(entry.name)
+            continue
+        try:
+            shutil.copy2(entry, target)
+            copied.append(entry.name)
+        except Exception as exc:
+            errors.append(f"Failed to migrate legacy font {entry} -> {target}: {exc}")
+
+    return {"copied": copied, "skipped": skipped, "errors": errors}
+
+
 def sync_custom_fonts(kometa_root: Path | None = None, config_name: str | None = None) -> list[str]:
     source_dir = get_custom_fonts_dir(config_name)
     if not source_dir.is_dir():
@@ -2518,10 +2558,11 @@ def collect_font_references(config_data) -> list[str]:
 def copy_fonts_to_kometa(font_refs, kometa_root: Path | None = None, config_name: str | None = None) -> dict:
     dest_dir = get_kometa_fonts_dir(kometa_root)
     dest_dir.mkdir(parents=True, exist_ok=True)
+    migration = migrate_legacy_custom_fonts_to_config(config_name, font_refs) if config_name else {"copied": [], "skipped": [], "errors": []}
     sources = get_font_dirs(include_static=True, include_custom=True, config_name=config_name)
     copied: list[str] = []
     missing: list[str] = []
-    errors: list[str] = []
+    errors: list[str] = list(migration.get("errors", []))
 
     for ref in font_refs or []:
         ref_str = str(ref or "").strip()

--- a/quickstart.py
+++ b/quickstart.py
@@ -15047,11 +15047,11 @@ def validate_kometa_root():
         yaml_parser = YAML(typ="safe")
         with src_yaml.open("r", encoding="utf-8") as f:
             parsed_config = yaml_parser.load(f) or {}
+        active_config_name = session.get("config_name") if has_request_context() else None
+        config_scope = active_config_name or _config_name_from_yaml_filename(config_name)
         font_refs = helpers.collect_font_references(parsed_config)
         if font_refs:
-            active_config_name = session.get("config_name") if has_request_context() else None
-            config_font_scope = active_config_name or _config_name_from_yaml_filename(config_name)
-            font_result = helpers.copy_fonts_to_kometa(font_refs, kometa_root=p, config_name=config_font_scope)
+            font_result = helpers.copy_fonts_to_kometa(font_refs, kometa_root=p, config_name=config_scope)
             copied = font_result.get("copied", [])
             missing = font_result.get("missing", [])
             errors = font_result.get("errors", [])
@@ -15061,8 +15061,19 @@ def validate_kometa_root():
                 log(f"⚠️ Fonts referenced in the config not found: {', '.join(missing)}")
             for err in errors:
                 log(f"⚠️ {err}")
+        if config_scope:
+            artifact_result = helpers.sync_managed_library_artifacts_to_kometa(config_scope, kometa_root=p)
+            synced = artifact_result.get("synced", [])
+            removed = artifact_result.get("removed", [])
+            errors = artifact_result.get("errors", [])
+            if synced:
+                log(f"✅ Synced {len(synced)} managed library artifact tree(s) to Kometa config/{config_scope}.")
+            if removed:
+                log(f"ℹ️ Removed {len(removed)} stale managed library artifact tree(s) from Kometa config/{config_scope}.")
+            for err in errors:
+                log(f"⚠️ {err}")
     except Exception as e:
-        log(f"⚠️ Failed to sync fonts referenced in the config: {e}")
+        log(f"⚠️ Failed to sync config-owned assets referenced in the config: {e}")
 
     log("✅ Kometa root is valid and ready.")
 

--- a/quickstart.py
+++ b/quickstart.py
@@ -801,6 +801,27 @@ def _yaml_path_suffix(path_value):
     return str(path_value or "").strip().lower().endswith((".yml", ".yaml"))
 
 
+def _normalize_bundle_member_name(path_value):
+    normalized = str(path_value or "").replace("\\", "/").lstrip("/")
+    return "/".join(part for part in normalized.split("/") if part)
+
+
+def _is_allowed_bundle_member(path_value):
+    normalized = _normalize_bundle_member_name(path_value)
+    if not normalized:
+        return True
+    lowered = normalized.lower()
+    if _is_bundled_library_archive_member(normalized):
+        return _yaml_path_suffix(normalized)
+    if _yaml_path_suffix(normalized):
+        return True
+    if lowered.endswith((".ttf", ".otf")):
+        return True
+    if lowered == "readme.txt":
+        return True
+    return False
+
+
 def _dump_yaml_text(data):
     buffer = io.StringIO()
     YAML().dump(data, buffer)
@@ -3950,7 +3971,12 @@ def _resolve_preview_base_image_path(img_type: str, selected_image: str) -> str:
 
 # Font discovery (TTF/OTF) across common static dirs
 def list_overlay_fonts() -> list[str]:
+    global _FONT_CACHE
     config_name = session.get("config_name") if has_request_context() else None
+    if config_name:
+        migration = helpers.migrate_legacy_custom_fonts_to_config(config_name)
+        if migration.get("copied"):
+            _FONT_CACHE = {}
     cache_key = helpers.normalize_config_name_for_storage(config_name) if config_name else "__default__"
     cached = _FONT_CACHE.get(cache_key)
     if cached:
@@ -5704,8 +5730,31 @@ def import_config_preview():
     if file_name.endswith(".zip"):
         try:
             with zipfile.ZipFile(BytesIO(raw_text)) as archive:
-                bundled_library_files = [n for n in archive.namelist() if _is_bundled_library_archive_member(n)]
-                config_files = [n for n in archive.namelist() if n.lower().endswith((".yml", ".yaml")) and n not in bundled_library_files]
+                archive_members = archive.namelist()
+                unexpected_members = []
+                bundled_library_files = []
+                config_files = []
+                font_files = []
+
+                for member_name in archive_members:
+                    normalized_member = _normalize_bundle_member_name(member_name)
+                    if not normalized_member:
+                        continue
+                    if not _is_allowed_bundle_member(normalized_member):
+                        unexpected_members.append(normalized_member)
+                        continue
+                    if _is_bundled_library_archive_member(normalized_member):
+                        bundled_library_files.append(member_name)
+                    elif _yaml_path_suffix(normalized_member):
+                        config_files.append(member_name)
+                    elif normalized_member.lower().endswith((".ttf", ".otf")):
+                        font_files.append(member_name)
+
+                if unexpected_members:
+                    preview = ", ".join(unexpected_members[:5])
+                    if len(unexpected_members) > 5:
+                        preview += ", ..."
+                    return jsonify(success=False, message=f"Zip file contains unsupported entries: {preview}"), 400
                 if not config_files:
                     return jsonify(success=False, message="No YAML config found in zip file."), 400
                 if len(config_files) > 1:
@@ -5717,7 +5766,6 @@ def import_config_preview():
                 except Exception:
                     return jsonify(success=False, message="Unable to read config from zip."), 400
 
-                font_files = [n for n in archive.namelist() if n.lower().endswith((".ttf", ".otf"))]
                 if font_files or bundled_library_files:
                     cache_dir = Path(helpers.CONFIG_DIR) / "import_cache"
                     cache_dir.mkdir(parents=True, exist_ok=True)
@@ -8252,6 +8300,7 @@ def _get_custom_font_files(config_name: str | None = None) -> list[Path]:
     seen: set[str] = set()
     candidate_dirs: list[Path] = []
     if config_name:
+        helpers.migrate_legacy_custom_fonts_to_config(config_name)
         candidate_dirs.append(helpers.get_custom_fonts_dir(config_name))
     candidate_dirs.append(helpers.get_legacy_custom_fonts_dir())
     for custom_dir in candidate_dirs:
@@ -8297,7 +8346,7 @@ def _build_config_bundle(
         readme_lines.append(f"- {name}/fonts/ (custom fonts uploaded in Quickstart)")
         readme_lines.append(f"- Fonts included: {', '.join(font_names)}")
     if has_artifacts:
-        readme_lines.append(f"- {name}/metadata_files/, {name}/collection_files/, {name}/overlay_files/ (managed library files)")
+        readme_lines.append(f"- {name}/metadata_files/, {name}/collection_files/, {name}/overlay_files/ (config-owned library files)")
     readme_lines += [
         "",
         "Install steps:",
@@ -8309,7 +8358,8 @@ def _build_config_bundle(
         readme_lines.append(f"3) Copy {name}/ into your Kometa config/ folder.")
     readme_lines += [
         "",
-        "Note: The Quickstart Run Now button syncs fonts automatically.",
+        "Note: Validate Kometa and Run Now both sync config-owned library files automatically.",
+        "Note: The Quickstart Run Now button also syncs referenced fonts automatically.",
         "This bundle is for manual installs.",
     ]
     if redacted:

--- a/templates/partials/_config_workspace_modal.html
+++ b/templates/partials/_config_workspace_modal.html
@@ -246,7 +246,7 @@
         <div class="mb-3">
           <label class="form-label" for="importConfigFile">Config File (.yml, .yaml, or .zip)</label>
           <input class="form-control" type="file" id="importConfigFile" accept=".yml,.yaml,.zip">
-          <div class="form-text">Zip files must contain exactly one YAML config; .ttf/.otf fonts will be imported.</div>
+          <div class="form-text">Zip files must contain exactly one YAML config. Optional extras are limited to <code>.ttf</code>/<code>.otf</code> fonts, <code>README.txt</code>, and managed <code>metadata_files</code>, <code>collection_files</code>, or <code>overlay_files</code> YAML content.</div>
         </div>
         <div class="form-floating mb-2">
           <input type="text" class="form-control" id="importConfigName" placeholder="Config name">

--- a/templates/partials/_library_collection_files.html
+++ b/templates/partials/_library_collection_files.html
@@ -7,6 +7,7 @@
     </div>
     <div class="alert alert-info small mb-0" role="alert">
         <div>Use one or more <code>file</code>, <code>folder</code>, <code>url</code>, <code>git</code>, or <code>repo</code> entries. These are appended into library-level <code>collection_files</code>.</div>
+        <div class="mt-1">Local <code>file</code> and <code>folder</code> entries are copied into Quickstart-managed config storage after validation, so the saved path may normalize to <code>config/&lt;config_name&gt;/collection_files/...</code>.</div>
     </div>
     <div class="collection-files-editor" data-collection-files-editor data-library-id="{{ library.id }}">
         <div class="alert small mb-4" role="alert" data-collection-custom-repo-status></div>

--- a/templates/partials/_library_metadata_files.html
+++ b/templates/partials/_library_metadata_files.html
@@ -16,6 +16,7 @@
                 </div>
                 <div class="alert alert-info small mb-0" role="alert">
                     <div>Use one or more <code>file</code>, <code>folder</code>, <code>url</code>, <code>git</code>, or <code>repo</code> entries. These are written to library-level <code>metadata_files</code>.</div>
+                    <div class="mt-1">Local <code>file</code> and <code>folder</code> entries are copied into Quickstart-managed config storage after validation, so the saved path may normalize to <code>config/&lt;config_name&gt;/metadata_files/...</code>.</div>
                 </div>
                 <div class="metadata-files-editor" data-metadata-files-editor data-library-id="{{ library.id }}">
                 <div class="alert small mb-4" role="alert" data-metadata-custom-repo-status></div>

--- a/templates/partials/_library_overlay_files.html
+++ b/templates/partials/_library_overlay_files.html
@@ -16,6 +16,7 @@
                 </div>
                 <div class="alert alert-info small mb-0" role="alert">
                     <div>Use one or more <code>file</code>, <code>folder</code>, <code>url</code>, <code>git</code>, or <code>repo</code> entries. These are written to library-level <code>overlay_files</code>.</div>
+                    <div class="mt-1">Local <code>file</code> and <code>folder</code> entries are copied into Quickstart-managed config storage after validation, so the saved path may normalize to <code>config/&lt;config_name&gt;/overlay_files/...</code>.</div>
                 </div>
                 <div class="overlay-files-editor" data-overlay-files-editor data-library-id="{{ library.id }}">
                 <div class="alert small mb-4" role="alert" data-overlay-custom-repo-status></div>

--- a/templates/partials/_movie_overlays.html
+++ b/templates/partials/_movie_overlays.html
@@ -261,7 +261,7 @@
     <div class="d-flex flex-wrap gap-2 align-items-center justify-content-between">
       <div>
         <h6 class="fw-bold mb-1">Custom Fonts</h6>
-        <p class="small text-muted mb-0">Upload .ttf or .otf files. Saved to the active config’s <code>config/&lt;config_name&gt;/fonts</code> folder and copied to Kometa on final save.</p>
+        <p class="small text-muted mb-0">Upload .ttf or .otf files. Quickstart stores them in the active config’s <code>config/&lt;config_name&gt;/fonts</code> folder, adopts matching legacy shared fonts automatically, and syncs referenced fonts to Kometa during Validate Kometa and Run Now.</p>
       </div>
       <div class="d-flex flex-wrap gap-2 align-items-center">
         <input type="file" class="form-control form-control-sm" data-font-upload-input accept=".ttf,.otf" multiple>

--- a/templates/partials/_show_overlays.html
+++ b/templates/partials/_show_overlays.html
@@ -265,7 +265,7 @@
     <div class="d-flex flex-wrap gap-2 align-items-center justify-content-between">
       <div>
         <h6 class="fw-bold mb-1">Custom Fonts</h6>
-        <p class="small text-muted mb-0">Upload .ttf or .otf files. Saved to the active config’s <code>config/&lt;config_name&gt;/fonts</code> folder and copied to Kometa on final save.</p>
+        <p class="small text-muted mb-0">Upload .ttf or .otf files. Quickstart stores them in the active config’s <code>config/&lt;config_name&gt;/fonts</code> folder, adopts matching legacy shared fonts automatically, and syncs referenced fonts to Kometa during Validate Kometa and Run Now.</p>
       </div>
       <div class="d-flex flex-wrap gap-2 align-items-center">
         <input type="file" class="form-control form-control-sm" data-font-upload-input accept=".ttf,.otf" multiple>

--- a/tests/e2e/test_final_page_e2e.py
+++ b/tests/e2e/test_final_page_e2e.py
@@ -1,4 +1,5 @@
 import re
+from pathlib import Path
 
 import pytest
 from playwright.sync_api import expect
@@ -307,3 +308,74 @@ def test_queued_run_auto_start_toast(page, live_server, monkeypatch, qs_module):
 
     toast = page.locator(".toast .toast-body").filter(has_text="Kometa started from queued request")
     expect(toast).to_be_visible()
+
+
+@pytest.mark.e2e
+def test_validate_kometa_root_syncs_managed_assets_to_kometa(page, live_server, monkeypatch, qs_module):
+    config_name = "pytest_e2e_kometa_copy"
+    config_dir = Path(qs_module.helpers.CONFIG_DIR)
+    kometa_root = Path(qs_module.app.config["KOMETA_ROOT"])
+    source_yaml = Path("config") / f"{config_name}_config.yml"
+
+    managed_dir = config_dir / config_name / "collection_files" / "mov-library_movies"
+    managed_dir.mkdir(parents=True, exist_ok=True)
+    (managed_dir / "collections.yml").write_text(
+        "collections:\n  test:\n    plex_search:\n      any:\n        title: Example\n",
+        encoding="utf-8",
+    )
+    source_yaml.write_text(
+        f"libraries:\n  Movies:\n    collection_files:\n      - file: config/{config_name}/collection_files/mov-library_movies/collections.yml\n",
+        encoding="utf-8",
+    )
+
+    (kometa_root / "kometa.py").write_text("print('kometa')\n", encoding="utf-8")
+    (kometa_root / "requirements.txt").write_text("requests\n", encoding="utf-8")
+    (kometa_root / "VERSION").write_text("0.0.0\n", encoding="utf-8")
+    venv_scripts = kometa_root / "kometa-venv" / "Scripts"
+    venv_scripts.mkdir(parents=True, exist_ok=True)
+    (venv_scripts / "python.exe").write_text("", encoding="utf-8")
+    (venv_scripts / "pip.exe").write_text("", encoding="utf-8")
+
+    stale_dir = kometa_root / "config" / config_name / "overlay_files" / "mov-library_movies"
+    stale_dir.mkdir(parents=True, exist_ok=True)
+    (stale_dir / "stale.yml").write_text("overlays:\n  stale:\n    template:\n      - name: ribbon\n", encoding="utf-8")
+
+    monkeypatch.setattr(qs_module.shutil, "which", lambda _cmd: "C:/Python/python.exe")
+    monkeypatch.setattr(
+        qs_module.subprocess,
+        "check_output",
+        lambda cmd, **_kwargs: "Python 3.12.0" if "--version" in cmd else "git version 2.45.0",
+    )
+
+    class _RunResult:
+        def __init__(self, stdout):
+            self.stdout = stdout
+
+    monkeypatch.setattr(qs_module.subprocess, "run", lambda *args, **kwargs: _RunResult("Requirement already satisfied"))
+
+    page.goto(f"{live_server}/static/favicon.png", wait_until="load")
+
+    payload = page.evaluate(
+        """async ({ path, configName }) => {
+          const res = await fetch('/validate-kometa-root', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ path, config_name: configName })
+          })
+          return { status: res.status, body: await res.json() }
+        }""",
+        {"path": str(kometa_root), "configName": source_yaml.name},
+    )
+
+    assert payload["status"] == 200, payload
+    assert payload["body"]["success"] is True
+    assert any("YAML copied to Kometa config folder" in line for line in payload["body"]["log"])
+    assert any("managed library artifact tree" in line for line in payload["body"]["log"])
+
+    copied_yaml = kometa_root / "config" / source_yaml.name
+    copied_collection = kometa_root / "config" / config_name / "collection_files" / "mov-library_movies" / "collections.yml"
+    assert copied_yaml.exists()
+    assert copied_collection.exists()
+    assert copied_collection.read_text(encoding="utf-8") == (managed_dir / "collections.yml").read_text(encoding="utf-8")
+    assert not stale_dir.exists()
+    source_yaml.unlink(missing_ok=True)

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -2480,6 +2480,35 @@ def test_copy_library_settings_mirrors_metadata_files(client, isolated_config_di
     assert target_file.read_text(encoding="utf-8") == managed_file.read_text(encoding="utf-8")
 
 
+def test_sync_managed_library_artifacts_to_kometa_copies_and_prunes(isolated_config_dir, app):
+    from pathlib import Path
+
+    from modules import helpers
+
+    config_name = "pytest_kometa_artifacts"
+    metadata_dir = isolated_config_dir / config_name / "metadata_files" / "mov-library_movies"
+    overlay_dir = isolated_config_dir / config_name / "overlay_files" / "mov-library_movies"
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+    overlay_dir.mkdir(parents=True, exist_ok=True)
+    (metadata_dir / "movies.yml").write_text("metadata:\n  test:\n    title: Example\n", encoding="utf-8")
+    (overlay_dir / "awards.yml").write_text("overlays:\n  test:\n    template:\n      - name: ribbon\n", encoding="utf-8")
+
+    kometa_root = Path(app.config["KOMETA_ROOT"])
+    stale_dir = kometa_root / "config" / config_name / "collection_files" / "mov-library_movies"
+    stale_dir.mkdir(parents=True, exist_ok=True)
+    (stale_dir / "stale.yml").write_text("collections:\n  stale:\n    plex_search:\n      any:\n        title: Stale\n", encoding="utf-8")
+
+    result = helpers.sync_managed_library_artifacts_to_kometa(config_name, kometa_root=kometa_root)
+
+    assert (kometa_root / "config" / config_name / "metadata_files" / "mov-library_movies" / "movies.yml").exists()
+    assert (kometa_root / "config" / config_name / "overlay_files" / "mov-library_movies" / "awards.yml").exists()
+    assert not stale_dir.exists()
+    assert any(path.endswith(f"{config_name}\\metadata_files") or path.endswith(f"{config_name}/metadata_files") for path in result["synced"])
+    assert any(path.endswith(f"{config_name}\\overlay_files") or path.endswith(f"{config_name}/overlay_files") for path in result["synced"])
+    assert any(path.endswith(f"{config_name}\\collection_files") or path.endswith(f"{config_name}/collection_files") for path in result["removed"])
+    assert result["errors"] == []
+
+
 def test_copy_fonts_to_kometa_prefers_config_scoped_fonts(isolated_config_dir, app):
     from pathlib import Path
 
@@ -2499,6 +2528,28 @@ def test_copy_fonts_to_kometa_prefers_config_scoped_fonts(isolated_config_dir, a
     copied_font = Path(app.config["KOMETA_ROOT"]) / "config" / "fonts" / "Poster.ttf"
     assert copied_font.exists()
     assert copied_font.read_bytes() == b"config-font"
+
+
+def test_save_to_named_config_syncs_managed_library_artifacts_to_kometa(isolated_config_dir, app):
+    from pathlib import Path
+
+    from modules import helpers
+
+    config_name = "pytest_save_sync"
+    collection_dir = isolated_config_dir / config_name / "collection_files" / "mov-library_movies"
+    collection_dir.mkdir(parents=True, exist_ok=True)
+    collection_file = collection_dir / "collections.yml"
+    collection_file.write_text("collections:\n  test:\n    plex_search:\n      any:\n        title: Example\n", encoding="utf-8")
+
+    with app.app_context():
+        latest_filename = helpers.save_to_named_config("settings:\n  cache: true\n", config_name)
+
+    kometa_root = Path(app.config["KOMETA_ROOT"])
+    assert latest_filename == f"{config_name}_config.yml"
+    assert (kometa_root / "config" / latest_filename).exists()
+    synced_file = kometa_root / "config" / config_name / "collection_files" / "mov-library_movies" / "collections.yml"
+    assert synced_file.exists()
+    assert synced_file.read_text(encoding="utf-8") == collection_file.read_text(encoding="utf-8")
 
 
 def test_import_config_confirm_rehomes_bundled_library_files(client, isolated_config_dir, monkeypatch, qs_module):

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -1863,6 +1863,32 @@ def test_upload_fonts_store_in_active_config_directory(client, isolated_config_d
     assert not (isolated_config_dir / "fonts" / "Poster.ttf").exists()
 
 
+def test_download_bundle_adopts_legacy_fonts_into_active_config(client, isolated_config_dir):
+    import io
+    import zipfile
+
+    config_name = "pytest_font_migration"
+    legacy_font_dir = isolated_config_dir / "fonts"
+    legacy_font_dir.mkdir(parents=True, exist_ok=True)
+    (legacy_font_dir / "Poster.ttf").write_bytes(b"legacy-font")
+
+    with client.session_transaction() as sess:
+        sess["config_name"] = config_name
+        sess["yaml_content"] = "settings:\n  cache: true\n"
+
+    resp = client.get("/download")
+    assert resp.status_code == 200
+    assert resp.mimetype == "application/zip"
+
+    with zipfile.ZipFile(io.BytesIO(resp.data)) as archive:
+        names = set(archive.namelist())
+        assert f"{config_name}/fonts/Poster.ttf" in names
+
+    migrated_font = isolated_config_dir / config_name / "fonts" / "Poster.ttf"
+    assert migrated_font.exists()
+    assert migrated_font.read_bytes() == b"legacy-font"
+
+
 def test_download_bundle_places_fonts_under_config_name(client, isolated_config_dir):
     import io
     import zipfile
@@ -1884,6 +1910,29 @@ def test_download_bundle_places_fonts_under_config_name(client, isolated_config_
         names = set(archive.namelist())
         assert "config.yml" in names
         assert f"{config_name}/fonts/Poster.ttf" in names
+
+
+def test_import_config_preview_rejects_zip_with_unsupported_entries(client):
+    import io
+    import zipfile
+
+    bundle = io.BytesIO()
+    with zipfile.ZipFile(bundle, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("config.yml", "settings:\n  cache: true\n")
+        archive.writestr("unexpected.exe", b"nope")
+    bundle.seek(0)
+
+    resp = client.post(
+        "/import-config/preview",
+        data={"config_name": "pytest_bad_bundle", "file": (bundle, "bundle.zip")},
+        content_type="multipart/form-data",
+    )
+
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert payload["success"] is False
+    assert "unsupported entries" in payload["message"].lower()
+    assert "unexpected.exe" in payload["message"]
 
 
 def test_yaml_generation_missing_sections_shows_error(client, isolated_config_dir, monkeypatch, qs_module):
@@ -2528,6 +2577,27 @@ def test_copy_fonts_to_kometa_prefers_config_scoped_fonts(isolated_config_dir, a
     copied_font = Path(app.config["KOMETA_ROOT"]) / "config" / "fonts" / "Poster.ttf"
     assert copied_font.exists()
     assert copied_font.read_bytes() == b"config-font"
+
+
+def test_copy_fonts_to_kometa_adopts_legacy_font_into_config_scope(isolated_config_dir, app):
+    from pathlib import Path
+
+    from modules import helpers
+
+    config_name = "pytest_font_adopt"
+    legacy_font_dir = isolated_config_dir / "fonts"
+    legacy_font_dir.mkdir(parents=True, exist_ok=True)
+    (legacy_font_dir / "Poster.ttf").write_bytes(b"legacy-font")
+
+    result = helpers.copy_fonts_to_kometa(["Poster.ttf"], kometa_root=app.config["KOMETA_ROOT"], config_name=config_name)
+
+    assert result["copied"] == ["Poster.ttf"]
+    adopted_font = isolated_config_dir / config_name / "fonts" / "Poster.ttf"
+    assert adopted_font.exists()
+    assert adopted_font.read_bytes() == b"legacy-font"
+    copied_font = Path(app.config["KOMETA_ROOT"]) / "config" / "fonts" / "Poster.ttf"
+    assert copied_font.exists()
+    assert copied_font.read_bytes() == b"legacy-font"
 
 
 def test_save_to_named_config_syncs_managed_library_artifacts_to_kometa(isolated_config_dir, app):


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Summary
This PR completes the config-owned bundle and Kometa-sync workflow for external library assets and fonts, then hardens and polishes the experience around it.

Quickstart now:

syncs managed library metadata_files, collection_files, and overlay_files into Kometa during direct save/copy flows
automatically adopts legacy shared fonts into the active config’s font folder
enforces a stricter ZIP import contract for config bundles
adds end-to-end coverage for the real Kometa validate/copy path
updates UI copy so managed-path normalization is less surprising

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
