### PR TITLE
Extend exclude feature

### DIFF
--- a/quickstart.py
+++ b/quickstart.py
@@ -8921,6 +8921,63 @@ def validate_tmdb():
         return jsonify(result.get_json()), 400
 
 
+def _get_active_tmdb_api_key():
+    config_name = session.get("config_name")
+    if not config_name:
+        return ""
+    try:
+        _validated, _user_entered, stored = database.retrieve_section_data(config_name, "tmdb")
+    except Exception:
+        return ""
+    if not isinstance(stored, dict):
+        return ""
+    tmdb_block = stored.get("tmdb", stored)
+    if not isinstance(tmdb_block, dict):
+        return ""
+    api_key = tmdb_block.get("apikey") or tmdb_block.get("api_key") or tmdb_block.get("tmdb_apikey") or tmdb_block.get("token") or ""
+    return str(api_key).strip()
+
+
+@app.route("/lookup_template_string_value", methods=["POST"])
+def lookup_template_string_value():
+    data = request.get_json(silent=True) or {}
+    preset = str(data.get("preset") or "").strip()
+    value = str(data.get("value") or "").strip()
+
+    if not preset or not value:
+        return jsonify({"error": "Lookup preset and value are required."}), 400
+
+    if preset == "tmdb_collection_id":
+        api_key = _get_active_tmdb_api_key()
+        if not api_key:
+            return jsonify({"valid": False, "verified": False, "message": "TMDb is not configured for the active config."})
+        try:
+            response = requests.get(
+                f"https://api.themoviedb.org/3/collection/{value}",
+                params={"api_key": api_key},
+                timeout=10,
+            )
+        except requests.RequestException as exc:
+            return jsonify({"valid": False, "verified": False, "message": f"TMDb lookup failed: {exc}."})
+
+        if response.status_code == 200:
+            payload = response.json() if response.content else {}
+            label = str(payload.get("name") or "").strip()
+            if label:
+                return jsonify({"valid": True, "verified": True, "label": label, "message": f"TMDb: {label}"})
+            return jsonify({"valid": False, "verified": True, "message": "TMDb collection found, but no collection name was returned."})
+
+        if response.status_code == 404:
+            return jsonify({"valid": False, "verified": True, "message": "TMDb collection ID not found."})
+
+        if response.status_code in {401, 403}:
+            return jsonify({"valid": False, "verified": False, "message": "TMDb lookup could not be verified with the configured API key."})
+
+        return jsonify({"valid": False, "verified": False, "message": f"TMDb lookup failed with status {response.status_code}."})
+
+    return jsonify({"error": f"Unsupported lookup preset: {preset}"}), 400
+
+
 @app.route("/validate_mdblist", methods=["POST"])
 def validate_mdblist():
     data = request.json

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -14406,6 +14406,7 @@
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
+            "validation_preset": "tmdb_collection_id",
             "tooltip": "Exclude specific TMDb collections from these collections.",
             "placeholder": "Add TMDb collection ID (e.g. 131292)"
           },

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -123,6 +123,13 @@
             "step": 1
           },
           {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific years from these collections.",
+            "placeholder": "Add year (e.g. 2022)"
+          },
+          {
             "key": "use_best_picture",
             "label": "Oscars Best Picture Winners",
             "tooltip": "Collection of Oscars Best Picture Award Winners.",
@@ -676,6 +683,13 @@
             "step": 1
           },
           {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific years from these collections.",
+            "placeholder": "Add year (e.g. 2022)"
+          },
+          {
             "key": "use_golden",
             "label": "Berlinale Golden Bears",
             "tooltip": "Collection of Berlin International Film Festival Golden Bear Award Winners.",
@@ -1210,6 +1224,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific years from these collections.",
+            "placeholder": "Add year (e.g. 2022)"
           },
           {
             "key": "use_best",
@@ -1748,6 +1769,13 @@
             "step": 1
           },
           {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific years from these collections.",
+            "placeholder": "Add year (e.g. 2022)"
+          },
+          {
             "key": "use_palm",
             "label": "Cannes Golden Palm Winners",
             "tooltip": "Collection of Cannes Golden Palm Award Winners.",
@@ -2282,6 +2310,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific years from these collections.",
+            "placeholder": "Add year (e.g. 2022)"
           },
           {
             "key": "use_best",
@@ -2819,6 +2854,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific years from these collections.",
+            "placeholder": "Add year (e.g. 2022)"
           },
           {
             "key": "use_best",
@@ -3359,6 +3401,13 @@
             "step": 1
           },
           {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific years from these collections.",
+            "placeholder": "Add year (e.g. 2022)"
+          },
+          {
             "key": "use_best",
             "label": "Emmys Best in Category Winners",
             "tooltip": "Collection of Emmys Best in Category Award Winners.",
@@ -3895,6 +3944,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific years from these collections.",
+            "placeholder": "Add year (e.g. 2022)"
           },
           {
             "key": "use_best_picture",
@@ -4461,6 +4517,13 @@
             "step": 1
           },
           {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific years from these collections.",
+            "placeholder": "Add year (e.g. 2022)"
+          },
+          {
             "key": "use_best",
             "label": "Independent Spirit Best Feature Winners",
             "tooltip": "Collection of Independent Spirit Best Feature Award Winners.",
@@ -4995,6 +5058,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific years from these collections.",
+            "placeholder": "Add year (e.g. 2022)"
           },
           {
             "key": "use_all_time",
@@ -5534,6 +5604,13 @@
             "step": 1
           },
           {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific years from these collections.",
+            "placeholder": "Add year (e.g. 2022)"
+          },
+          {
             "key": "use_pca",
             "label": "People's Choice Award Winners",
             "tooltip": "Collection of People's Choice Award Winners.",
@@ -6069,6 +6146,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific years from these collections.",
+            "placeholder": "Add year (e.g. 2022)"
           },
           {
             "key": "use_golden",
@@ -6607,6 +6691,13 @@
             "step": 1
           },
           {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific years from these collections.",
+            "placeholder": "Add year (e.g. 2022)"
+          },
+          {
             "key": "use_golden",
             "label": "Screen Actors Guild Award Winners",
             "tooltip": "Collection of Screen Actors Guild Award Winners.",
@@ -7141,6 +7232,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific years from these collections.",
+            "placeholder": "Add year (e.g. 2022)"
           },
           {
             "key": "use_grand",
@@ -7679,6 +7777,13 @@
             "step": 1
           },
           {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific years from these collections.",
+            "placeholder": "Add year (e.g. 2022)"
+          },
+          {
             "key": "use_best",
             "label": "Toronto People's Choice Award Winners",
             "tooltip": "Collection of Toronto International Film Festival People's Choice Award Winners.",
@@ -8213,6 +8318,13 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific years from these collections.",
+            "placeholder": "Add year (e.g. 2022)"
           },
           {
             "key": "use_golden",
@@ -13888,6 +14000,13 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific Genres from these collections.",
+            "placeholder": "Add genre name (e.g. Politics)"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -14283,6 +14402,13 @@
         "tooltip": "Disable Plex's in-built Automatic Collections feature if you use this file. Click the name of this file to go to the wiki page to learn more.",
         "tooltip_variant": "danger",
         "template_variables": [
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific TMDb collections from these collections.",
+            "placeholder": "Add TMDb collection ID (e.g. 131292)"
+          },
           {
             "key": "collection_mode",
             "label": "Collection Mode",
@@ -15119,6 +15245,13 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific Universes from these collections.",
+            "placeholder": "Add universe key (e.g. mcu)"
+          },
+          {
             "key": "use_avp",
             "label": "Alien / Predator",
             "tooltip": "Collection of Movies in the Alien / Predator Universe",
@@ -15943,6 +16076,13 @@
             "type": "text_input",
             "default": "085",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific media outlets from these collections.",
+            "placeholder": "Add media outlet key (e.g. books)"
           },
           {
             "key": "use_books",
@@ -16803,6 +16943,20 @@
                 ]
               }
             ]
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific collections from being considered for collectionless.",
+            "placeholder": "Add collection name (e.g. Marvel Cinematic Universe)"
+          },
+          {
+            "key": "exclude_prefix",
+            "label": "Exclude Prefix",
+            "type": "string_list",
+            "tooltip": "Exclude collections with these prefixes from being considered for collectionless.",
+            "placeholder": "Add prefix (e.g. ~)"
           }
         ]
       }
@@ -16835,6 +16989,13 @@
             "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
             "type": "toggle",
             "default": true
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific content ratings from these collections.",
+            "placeholder": "Add content rating (e.g. PG-13)"
           },
           {
             "key": "collection_mode",
@@ -17244,6 +17405,13 @@
             "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
             "type": "toggle",
             "default": true
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific content ratings from these collections.",
+            "placeholder": "Add content rating (e.g. TV-14)"
           },
           {
             "key": "collection_mode",
@@ -17656,6 +17824,13 @@
             "default": true
           },
           {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific content ratings from these collections.",
+            "placeholder": "Add content rating (e.g. 15)"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -18064,6 +18239,13 @@
             "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
             "type": "toggle",
             "default": true
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific content ratings from these collections.",
+            "placeholder": "Add content rating (e.g. 12)"
           },
           {
             "key": "collection_mode",
@@ -18476,6 +18658,13 @@
             "default": true
           },
           {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific content ratings from these collections.",
+            "placeholder": "Add content rating (e.g. M)"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -18884,6 +19073,13 @@
             "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
             "type": "toggle",
             "default": true
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific content ratings from these collections.",
+            "placeholder": "Add content rating (e.g. PG)"
           },
           {
             "key": "collection_mode",
@@ -19296,6 +19492,13 @@
             "default": true
           },
           {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific content ratings from these collections.",
+            "placeholder": "Add content rating (e.g. PG-13)"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -19704,6 +19907,13 @@
             "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
             "type": "toggle",
             "default": true
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific content ratings from these collections.",
+            "placeholder": "Add content rating (e.g. 13)"
           },
           {
             "key": "collection_mode",
@@ -20121,6 +20331,13 @@
             "default": true
           },
           {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific countries from these collections.",
+            "placeholder": "Add country name (e.g. France)"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -20528,6 +20745,13 @@
             "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
             "type": "toggle",
             "default": true
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific countries from these collections.",
+            "placeholder": "Add country name (e.g. France)"
           },
           {
             "key": "collection_mode",
@@ -21101,6 +21325,13 @@
             "default": true
           },
           {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific regions from these collections.",
+            "placeholder": "Add region name (e.g. Melanesia)"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -21551,6 +21782,13 @@
             "tooltip": "Collection of Movies that are in other uncommon Continents.",
             "type": "toggle",
             "default": true
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific continents from these collections.",
+            "placeholder": "Add continent name (e.g. Europe)"
           },
           {
             "key": "collection_mode",
@@ -22018,6 +22256,13 @@
             "default": true
           },
           {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific aspect ratios from these collections.",
+            "placeholder": "Add aspect ratio key (e.g. 1.65)"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -22439,6 +22684,13 @@
             ]
           },
           {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific resolutions from these collections.",
+            "placeholder": "Add resolution key (e.g. 4k)"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -22849,6 +23101,13 @@
             "default": true
           },
           {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific audio languages from these collections.",
+            "placeholder": "Add language code (e.g. fr)"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -23257,6 +23516,13 @@
             "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
             "type": "toggle",
             "default": true
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific subtitle languages from these collections.",
+            "placeholder": "Add language code (e.g. fr)"
           },
           {
             "key": "collection_mode",
@@ -26081,6 +26347,13 @@
             ]
           },
           {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific streaming services from these collections.",
+            "placeholder": "Add service key (e.g. netflix)"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -26482,6 +26755,13 @@
             "type": "text_input",
             "default": "070",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific studios from these collections.",
+            "placeholder": "Add studio name (e.g. Marvel Studios)"
           },
           {
             "key": "collection_mode",
@@ -26897,6 +27177,13 @@
               "color",
               "white"
             ]
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific networks from these collections.",
+            "placeholder": "Add network name (e.g. HBO)"
           },
           {
             "key": "collection_mode",
@@ -27782,6 +28069,13 @@
             "label_width": 240
           },
           {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific seasonal collections from these collections.",
+            "placeholder": "Add seasonal key (e.g. halloween)"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -28260,6 +28554,13 @@
             "tooltip": "Controls the increment (i.e. every 5th year). Allowed values: number greater than 0."
           },
           {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific years from these collections.",
+            "placeholder": "Add year (e.g. 2022)"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -28662,6 +28963,13 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific decades from these collections.",
+            "placeholder": "Add decade key (e.g. 2020)"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -29062,6 +29370,13 @@
             "type": "text_input",
             "default": "100",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific decades from these collections.",
+            "placeholder": "Add decade key (e.g. 2020)"
           },
           {
             "key": "collection_mode",

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -2228,7 +2228,226 @@ document.addEventListener('DOMContentLoaded', function () {
       })
     }
 
+    const templateStringListPresetConfigs = {
+      generic_text: {
+        duplicateInsensitive: false,
+        normalize: value => value,
+        validate: value => {
+          if (!value) return { valid: false, message: 'Enter a value before adding it.' }
+          return { valid: true }
+        }
+      },
+      name_like: {
+        duplicateInsensitive: true,
+        normalize: value => value.replace(/\s+/g, ' '),
+        validate: value => {
+          const normalized = String(value || '').trim()
+          if (!normalized) return { valid: false, message: 'Enter a text value before adding it.' }
+          try {
+            if (!/[\p{L}\p{N}]/u.test(normalized)) {
+              return { valid: false, message: 'Enter a text value with letters or numbers.' }
+            }
+            if (!/^[\p{L}\p{N} .,&'’:+\-/()!]+$/u.test(normalized)) {
+              return { valid: false, message: 'Use letters, numbers, spaces, or common punctuation only.' }
+            }
+          } catch (_error) {
+            if (!/[A-Za-z0-9]/.test(normalized)) {
+              return { valid: false, message: 'Enter a text value with letters or numbers.' }
+            }
+            if (!/^[A-Za-z0-9 .,&':+\-/()!]+$/.test(normalized)) {
+              return { valid: false, message: 'Use letters, numbers, spaces, or common punctuation only.' }
+            }
+          }
+          return { valid: true }
+        }
+      },
+      tmdb_collection_id: {
+        duplicateInsensitive: true,
+        normalize: value => value,
+        lookupService: 'tmdb',
+        validate: value => /^\d+$/.test(value)
+          ? { valid: true }
+          : { valid: false, message: 'Enter a numeric TMDb collection ID like 131292.' }
+      },
+      year: {
+        duplicateInsensitive: true,
+        normalize: value => value,
+        validate: value => /^\d{4}$/.test(value)
+          ? { valid: true }
+          : { valid: false, message: 'Enter a 4-digit year like 2022.' }
+      },
+      decade: {
+        duplicateInsensitive: true,
+        normalize: value => value,
+        validate: value => /^\d{3,4}0$/.test(value)
+          ? { valid: true }
+          : { valid: false, message: 'Enter a decade key ending in 0 like 2020.' }
+      },
+      language_code: {
+        duplicateInsensitive: true,
+        normalize: value => value.toLowerCase(),
+        suggestions: [
+          'en', 'fr', 'es', 'de', 'it', 'pt', 'ja', 'ko', 'zh', 'ru', 'ar', 'hi',
+          'fil', 'myn', 'rom', 'tai'
+        ],
+        validate: value => /^[a-z]{2,3}$/.test(value)
+          ? { valid: true }
+          : { valid: false, message: 'Enter a 2 or 3 letter language code like fr or fil.' }
+      },
+      aspect_key: {
+        duplicateInsensitive: true,
+        normalize: value => value,
+        suggestions: ['1.33', '1.65', '1.66', '1.78', '1.85', '2.2', '2.35', '2.77'],
+        allowedValues: new Set(['1.33', '1.65', '1.66', '1.78', '1.85', '2.2', '2.35', '2.77']),
+        validate: value => templateStringListPresetConfigs.aspect_key.allowedValues.has(value)
+          ? { valid: true }
+          : { valid: false, message: 'Enter a supported aspect ratio key like 1.78 or 2.35.' }
+      },
+      resolution_key: {
+        duplicateInsensitive: true,
+        normalize: value => value.toLowerCase(),
+        suggestions: ['4k', '1080', '720', '480', '8k', '2k', '576', 'sd'],
+        allowedValues: new Set(['4k', '1080', '720', '480', '8k', '2k', '144', '240', '360', '576', 'sd']),
+        validate: value => templateStringListPresetConfigs.resolution_key.allowedValues.has(value)
+          ? { valid: true }
+          : { valid: false, message: 'Enter a supported resolution key like 4k, 1080, 720, 480, or sd.' }
+      },
+      streaming_key: {
+        duplicateInsensitive: true,
+        normalize: value => value.toLowerCase(),
+        suggestions: ['netflix', 'disney', 'amazon', 'hulu', 'hbomax', 'paramount', 'peacock'],
+        allowedValues: new Set(['channel4', 'appletv', 'bet', 'crave', 'crunchyroll', 'discovery', 'disney', 'itvx', 'hbomax', 'hayu', 'hulu', 'movistar', 'atresplayer', 'netflix', 'now', 'paramount', 'peacock', 'amazon', 'amc', 'filmin', 'youtube', 'tubi']),
+        validate: value => templateStringListPresetConfigs.streaming_key.allowedValues.has(value)
+          ? { valid: true }
+          : { valid: false, message: 'Enter a supported streaming service key like netflix, disney, or amazon.' }
+      },
+      universe_key: {
+        duplicateInsensitive: true,
+        normalize: value => value.toLowerCase(),
+        suggestions: ['mcu', 'star', 'trek', 'wizard', 'fast'],
+        allowedValues: new Set(['avp', 'arrow', 'askew', 'conjuring', 'dca', 'dcu', 'fast', 'marvel', 'mcu', 'middle', 'rocky', 'trek', 'star', 'mummy', 'wizard', 'xmen']),
+        validate: value => templateStringListPresetConfigs.universe_key.allowedValues.has(value)
+          ? { valid: true }
+          : { valid: false, message: 'Enter a supported universe key like mcu, star, trek, or wizard.' }
+      },
+      based_key: {
+        duplicateInsensitive: true,
+        normalize: value => value.toLowerCase(),
+        suggestions: ['books', 'comics', 'true_story', 'video_games'],
+        allowedValues: new Set(['books', 'comics', 'true_story', 'video_games']),
+        validate: value => templateStringListPresetConfigs.based_key.allowedValues.has(value)
+          ? { valid: true }
+          : { valid: false, message: 'Enter a supported media outlet key like books or video_games.' }
+      },
+      seasonal_key: {
+        duplicateInsensitive: true,
+        normalize: value => value.toLowerCase(),
+        suggestions: ['christmas', 'halloween', 'valentine', 'years', 'women'],
+        allowedValues: new Set(['years', 'valentine', 'patrick', 'easter', 'mother', 'memorial', 'father', 'independence', 'labor', 'halloween', 'veteran', 'thanksgiving', 'christmas', 'aapi', 'disabilities', 'black_history', 'lgbtq', 'latinx', 'women']),
+        validate: value => templateStringListPresetConfigs.seasonal_key.allowedValues.has(value)
+          ? { valid: true }
+          : { valid: false, message: 'Enter a supported seasonal key like halloween, christmas, or women.' }
+      },
+      content_rating: {
+        duplicateInsensitive: true,
+        normalize: value => value.replace(/\s+/g, ' '),
+        validate: value => /^[A-Za-z0-9][A-Za-z0-9 +\-./()]*$/.test(value)
+          ? { valid: true }
+          : { valid: false, message: 'Enter a content rating like PG-13, TV-14, 15, or M.' }
+      }
+    }
+
+    function inferTemplateStringListPreset (wrapper, input) {
+      const explicitPreset = String(wrapper.dataset.validationPreset || input.dataset.validationPreset || '').trim()
+      if (explicitPreset && templateStringListPresetConfigs[explicitPreset]) return explicitPreset
+
+      const placeholder = String(input.getAttribute('placeholder') || '').trim().toLowerCase()
+      if (placeholder.includes('tmdb collection id')) return 'tmdb_collection_id'
+      if (placeholder.includes('year (e.g. 2022)')) return 'year'
+      if (placeholder.includes('decade key')) return 'decade'
+      if (placeholder.includes('language code')) return 'language_code'
+      if (placeholder.includes('aspect ratio key')) return 'aspect_key'
+      if (placeholder.includes('resolution key')) return 'resolution_key'
+      if (placeholder.includes('service key')) return 'streaming_key'
+      if (placeholder.includes('universe key')) return 'universe_key'
+      if (placeholder.includes('media outlet key')) return 'based_key'
+      if (placeholder.includes('seasonal key')) return 'seasonal_key'
+      if (placeholder.includes('content rating')) return 'content_rating'
+      if (
+        placeholder.includes('genre name') ||
+        placeholder.includes('person name') ||
+        placeholder.includes('studio name') ||
+        placeholder.includes('network name') ||
+        placeholder.includes('country name') ||
+        placeholder.includes('region name') ||
+        placeholder.includes('continent name')
+      ) {
+        return 'name_like'
+      }
+      return 'generic_text'
+    }
+
+    function ensureTemplateStringListDatalist (wrapper, input, presetConfig, presetName) {
+      if (!wrapper || !input || !presetConfig || !Array.isArray(presetConfig.suggestions) || !presetConfig.suggestions.length) return
+      if (presetConfig.suggestions.length > 50) return
+      const existingListId = input.getAttribute('list')
+      if (existingListId && document.getElementById(existingListId)) return
+      const hiddenId = String(wrapper.dataset.hiddenInput || input.id || 'template-string-list').replace(/[^A-Za-z0-9_-]+/g, '_')
+      const datalistId = `${hiddenId}_${presetName}_options`
+      let datalist = document.getElementById(datalistId)
+      if (!datalist) {
+        datalist = document.createElement('datalist')
+        datalist.id = datalistId
+        presetConfig.suggestions.forEach(value => {
+          const option = document.createElement('option')
+          option.value = value
+          datalist.appendChild(option)
+        })
+        wrapper.appendChild(datalist)
+      }
+      input.setAttribute('list', datalistId)
+    }
+
     function setupTemplateStringListHandlers (scope) {
+      const templateStringLookupCache = window.__qsTemplateStringLookupCache || new Map()
+      window.__qsTemplateStringLookupCache = templateStringLookupCache
+
+      function getServiceValidationState (serviceName) {
+        const el = document.getElementById(`qs-validate-${serviceName}`)
+        return String(el?.value || '').trim().toLowerCase() === 'true'
+      }
+
+      async function lookupTemplateStringValue (presetName, value) {
+        const cacheKey = `${presetName}:${value}`
+        if (templateStringLookupCache.has(cacheKey)) {
+          return templateStringLookupCache.get(cacheKey)
+        }
+        const request = fetch('/lookup_template_string_value', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ preset: presetName, value })
+        })
+          .then(async (response) => {
+            const data = await response.json().catch(() => ({}))
+            if (!response.ok) {
+              return {
+                valid: false,
+                verified: false,
+                message: data.error || data.message || `Lookup failed (${response.status})`
+              }
+            }
+            return data
+          })
+          .catch(() => ({
+            valid: false,
+            verified: false,
+            message: 'Lookup unavailable right now.'
+          }))
+        templateStringLookupCache.set(cacheKey, request)
+        return request
+      }
+
       const root = scope || document
       root.querySelectorAll('[data-template-string-list]').forEach(wrapper => {
         if (wrapper.dataset.listenerAdded) return
@@ -2237,8 +2456,46 @@ document.addEventListener('DOMContentLoaded', function () {
         const input = wrapper.querySelector('input[type="text"]')
         const addBtn = wrapper.querySelector('[data-template-string-add]')
         const list = wrapper.querySelector('[data-template-string-items]')
+        const feedback = wrapper.querySelector('[data-template-string-feedback]')
 
         if (!hidden || !input || !addBtn || !list) return
+
+        const presetName = inferTemplateStringListPreset(wrapper, input)
+        const presetConfig = templateStringListPresetConfigs[presetName] || templateStringListPresetConfigs.generic_text
+        ensureTemplateStringListDatalist(wrapper, input, presetConfig, presetName)
+
+        function setLookupState (target, state) {
+          if (!target) return
+          target.textContent = state?.message || ''
+          target.className = 'small mt-1'
+          if (!state?.message) {
+            target.classList.add('d-none')
+            return
+          }
+          target.classList.remove('d-none')
+          if (state.valid && state.verified) {
+            target.classList.add('text-success')
+          } else if (state.verified) {
+            target.classList.add('text-danger')
+          } else {
+            target.classList.add('text-warning')
+          }
+        }
+
+        function setFeedback (message, persistent = false) {
+          if (feedback) {
+            feedback.textContent = message || ''
+            feedback.classList.toggle('d-none', !message)
+            feedback.classList.toggle('d-block', Boolean(message))
+          }
+          input.classList.toggle('is-invalid', Boolean(message))
+          input.setCustomValidity(persistent && message ? message : '')
+        }
+
+        function clearTransientFeedback () {
+          if (input.validationMessage) return
+          setFeedback('')
+        }
 
         function parseValues () {
           const raw = String(hidden.value || '').trim()
@@ -2254,13 +2511,66 @@ document.addEventListener('DOMContentLoaded', function () {
           return [raw]
         }
 
-        function renderList (values) {
+        function validateValue (rawValue) {
+          const normalizedRaw = String(rawValue || '').trim()
+          const normalized = presetConfig.normalize ? presetConfig.normalize(normalizedRaw) : normalizedRaw
+          const result = presetConfig.validate ? presetConfig.validate(normalized) : { valid: Boolean(normalized) }
+          return {
+            value: normalized,
+            valid: Boolean(result.valid),
+            message: result.message || 'Enter a valid value.'
+          }
+        }
+
+        function duplicateKeyForValue (value) {
+          return presetConfig.duplicateInsensitive ? String(value || '').toLowerCase() : String(value || '')
+        }
+
+        function analyzeValues (values) {
+          const seen = new Set()
+          const analyzed = []
+          values.forEach(rawValue => {
+            const checked = validateValue(rawValue)
+            if (!checked.value) return
+            const duplicateKey = duplicateKeyForValue(checked.value)
+            if (seen.has(duplicateKey)) return
+            seen.add(duplicateKey)
+            analyzed.push(checked)
+          })
+          return analyzed
+        }
+
+        function renderList (items) {
           list.replaceChildren()
-          values.forEach(value => {
+          items.forEach((item, index) => {
             const li = document.createElement('li')
             li.className = 'list-group-item d-flex justify-content-between align-items-center'
+            if (!item.valid) li.classList.add('list-group-item-danger')
+
+            const textWrap = document.createElement('div')
+            textWrap.className = 'd-flex flex-column'
+
+            const titleRow = document.createElement('div')
+            titleRow.className = 'd-flex align-items-center gap-2'
+
             const textSpan = document.createElement('span')
-            textSpan.textContent = value
+            textSpan.textContent = item.value
+            titleRow.appendChild(textSpan)
+
+            if (!item.valid) {
+              const badge = document.createElement('span')
+              badge.className = 'badge text-bg-danger'
+              badge.textContent = 'Invalid'
+              badge.title = item.message
+              titleRow.appendChild(badge)
+            }
+
+            textWrap.appendChild(titleRow)
+
+            const lookupMeta = document.createElement('div')
+            lookupMeta.className = 'small mt-1 d-none'
+            textWrap.appendChild(lookupMeta)
+
             const button = document.createElement('button')
             button.type = 'button'
             button.className = 'btn btn-sm btn-danger'
@@ -2268,33 +2578,93 @@ document.addEventListener('DOMContentLoaded', function () {
             const icon = document.createElement('i')
             icon.className = 'bi bi-x-lg'
             button.appendChild(icon)
-            li.append(textSpan, button)
+            li.append(textWrap, button)
             list.appendChild(li)
 
             button.addEventListener('click', () => {
-              const updated = values.filter(item => item !== value)
-              hidden.value = JSON.stringify(updated)
-              renderList(updated)
+              const updated = items
+                .filter((_, itemIndex) => itemIndex !== index)
+                .map(entry => entry.value)
+              syncState(updated)
             })
+
+            if (item.valid && presetConfig.lookupService === 'tmdb') {
+              if (!getServiceValidationState('tmdb')) {
+                setLookupState(lookupMeta, {
+                  valid: false,
+                  verified: false,
+                  message: 'TMDb not validated, so the collection title could not be checked.'
+                })
+              } else {
+                setLookupState(lookupMeta, {
+                  valid: false,
+                  verified: false,
+                  message: 'Checking TMDb collection title...'
+                })
+                lookupTemplateStringValue(presetName, item.value).then(result => {
+                  if (!lookupMeta.isConnected) return
+                  if (result.valid && result.verified && result.label) {
+                    setLookupState(lookupMeta, {
+                      valid: true,
+                      verified: true,
+                      message: `TMDb: ${result.label}`
+                    })
+                    return
+                  }
+                  setLookupState(lookupMeta, {
+                    valid: Boolean(result.valid),
+                    verified: Boolean(result.verified),
+                    message: result.message || 'TMDb lookup failed.'
+                  })
+                })
+              }
+            }
           })
         }
 
-        function addValue () {
-          const value = input.value.trim()
-          if (!value) return
-          const current = parseValues()
-          if (current.includes(value)) return
-          current.push(value)
-          hidden.value = JSON.stringify(current)
-          renderList(current)
-          input.value = ''
+        function syncState (values, transientMessage = '') {
+          const analyzed = analyzeValues(values)
+          hidden.value = JSON.stringify(analyzed.map(item => item.value))
+          renderList(analyzed)
+
+          const invalidItems = analyzed.filter(item => !item.valid)
+          if (invalidItems.length) {
+            const message = invalidItems.length === 1
+              ? `${invalidItems[0].message} Remove or fix the invalid entry.`
+              : `${invalidItems[0].message} Remove or fix the invalid entries.`
+            setFeedback(message, true)
+            return analyzed
+          }
+
+          setFeedback(transientMessage || '', false)
+          return analyzed
         }
 
-        const initial = parseValues()
-        hidden.value = JSON.stringify(initial)
-        renderList(initial)
+        function addValue () {
+          const checked = validateValue(input.value)
+          if (!checked.value) {
+            setFeedback('Enter a value before adding it.', false)
+            return
+          }
+          if (!checked.valid) {
+            setFeedback(checked.message, false)
+            return
+          }
+          const current = analyzeValues(parseValues())
+          if (current.some(item => duplicateKeyForValue(item.value) === duplicateKeyForValue(checked.value))) {
+            setFeedback('That value is already in the list.', false)
+            return
+          }
+          current.push(checked)
+          syncState(current.map(item => item.value))
+          input.value = ''
+          clearTransientFeedback()
+        }
+
+        syncState(parseValues())
 
         addBtn.addEventListener('click', addValue)
+        input.addEventListener('input', clearTransientFeedback)
         input.addEventListener('keydown', (event) => {
           if (event.key === 'Enter') {
             event.preventDefault()

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -1183,7 +1183,10 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                         {% else %}
                         {% set list_json = '[]' %}
                         {% endif %}
-                        <div class="mb-2" data-template-string-list data-hidden-input="{{ input_name }}">
+                        <div class="mb-2" data-template-string-list data-hidden-input="{{ input_name }}"
+                            {% if item.validation_preset %}data-validation-preset="{{ item.validation_preset }}"{% endif %}
+                            {% if item.validation_mode %}data-validation-mode="{{ item.validation_mode }}"{% endif %}
+                            {% if item.validation_normalize %}data-validation-normalize="{{ item.validation_normalize }}"{% endif %}>
                             <div class="input-group">
                                 <span class="input-group-text" id="{{ input_name }}_text" style="width: 170px;">
                                     {{ item.label }}
@@ -1198,10 +1201,12 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                 <input type="text" class="form-control" id="{{ input_name }}_input"
                                     aria-describedby="{{ input_name }}_text"
                                     placeholder="{{ item.placeholder | default('Add value') }}"
+                                    {% if item.validation_preset %}data-validation-preset="{{ item.validation_preset }}"{% endif %}
                                     {% if disable_toggle %}disabled{% endif %}>
                                 <button class="btn nav-button" type="button" data-template-string-add
                                     {% if disable_toggle %}disabled{% endif %}>Add</button>
                             </div>
+                            <div class="invalid-feedback d-none" data-template-string-feedback></div>
                             <ul class="list-group mt-2" data-template-string-items></ul>
                             <input type="hidden" id="{{ input_name }}" name="{{ input_name }}" value="{{ list_json }}">
                         </div>


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Summary
Adds schema-driven validation for string_list template variables on the Libraries page and introduces UI-only lookup metadata for service-backed IDs.

This change expands the newly added exclude support so users get immediate feedback when entered values do not match the expected format or key type. Validation is now driven by per-field presets instead of treating every list as generic free text. For TMDb collection IDs, the UI now resolves the collection name after validation and shows it as helper metadata without changing the generated YAML.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
