### PR TITLE
Fix regression on output

### DIFF
--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -1279,8 +1279,7 @@ def save_to_named_config(yaml_text, config_name, font_refs=None):
     config_dir = Path(CONFIG_DIR)
     kometa_root = Path(app.config.get("KOMETA_ROOT", "."))
     kometa_config_dir = kometa_root / "config"
-    # Normalize config name
-    name = config_name.strip().lower().replace(" ", "_") or "default"
+    name = require_config_name_for_storage(config_name, context="Saving a named config")
     latest_filename = f"{name}_config.yml"
     latest_path = config_dir / latest_filename
     kometa_path = kometa_config_dir / latest_filename
@@ -2473,9 +2472,10 @@ def list_available_fonts(include_static: bool = True, include_custom: bool = Tru
 
 
 def migrate_legacy_custom_fonts_to_config(config_name: str | None, font_names: list[str] | tuple[str, ...] | set[str] | None = None) -> dict:
-    normalized = normalize_config_name_for_storage(config_name)
-    if not normalized:
-        return {"copied": [], "skipped": [], "errors": []}
+    try:
+        normalized = require_config_name_for_storage(config_name, context="Config-scoped font migration")
+    except ValueError as exc:
+        return {"copied": [], "skipped": [], "errors": [str(exc)]}
 
     source_dir = get_legacy_custom_fonts_dir()
     destination_dir = get_custom_fonts_dir(normalized)
@@ -2673,11 +2673,22 @@ def normalize_config_name_for_storage(config_name: str | None) -> str:
     return name or "default"
 
 
+def require_config_name_for_storage(config_name: str | None, context: str = "Artifact operation") -> str:
+    raw = str(config_name or "").strip()
+    if not raw:
+        raise ValueError(f"{context} requires an explicit config name.")
+    normalized = normalize_config_name_for_storage(raw)
+    if not normalized:
+        raise ValueError(f"{context} requires an explicit config name.")
+    return normalized
+
+
 MANAGED_LIBRARY_FILE_DIRS = ("metadata_files", "collection_files", "overlay_files")
+MANAGED_CONFIG_ARTIFACT_DIRS = ("fonts",) + MANAGED_LIBRARY_FILE_DIRS
 
 
 def get_managed_config_artifact_root(config_name: str | None) -> Path:
-    normalized = normalize_config_name_for_storage(config_name)
+    normalized = require_config_name_for_storage(config_name, context="Managed config artifact paths")
     return Path(CONFIG_DIR) / normalized
 
 
@@ -2687,13 +2698,13 @@ def get_managed_library_artifact_paths(config_name: str | None) -> list[Path]:
 
 
 def get_legacy_managed_library_artifact_paths(config_name: str | None) -> list[Path]:
-    normalized = normalize_config_name_for_storage(config_name)
+    normalized = require_config_name_for_storage(config_name, context="Legacy managed library artifact paths")
     config_dir = Path(CONFIG_DIR)
     return [config_dir / folder / normalized for folder in MANAGED_LIBRARY_FILE_DIRS]
 
 
 def sync_managed_library_artifacts_to_kometa(config_name: str | None, kometa_root: str | Path | None = None) -> dict:
-    normalized = normalize_config_name_for_storage(config_name)
+    normalized = require_config_name_for_storage(config_name, context="Managed library artifact sync")
     source_root = get_managed_config_artifact_root(normalized)
     destination_root = (Path(kometa_root) if kometa_root is not None else Path(app.config.get("KOMETA_ROOT", "."))) / "config" / normalized
 
@@ -2746,7 +2757,7 @@ def sync_managed_library_artifacts_to_kometa(config_name: str | None, kometa_roo
 
 
 def delete_config_artifacts(config_name: str | None, kometa_root: str | Path | None = None) -> dict:
-    normalized = normalize_config_name_for_storage(config_name)
+    normalized = require_config_name_for_storage(config_name, context="Config artifact cleanup")
     config_dir = Path(CONFIG_DIR)
     archive_root = config_dir / "archives"
     removed: list[str] = []
@@ -2864,7 +2875,7 @@ def list_orphaned_config_artifacts(active_config_names: list[str] | None = None,
     for path in config_dir.iterdir():
         if not path.is_dir():
             continue
-        if any((path / folder_name).exists() and (path / folder_name).is_dir() for folder_name in MANAGED_LIBRARY_FILE_DIRS):
+        if any((path / folder_name).exists() and (path / folder_name).is_dir() for folder_name in MANAGED_CONFIG_ARTIFACT_DIRS):
             bundle = ensure_bundle(path.name)
             path_text = str(path)
             if path_text not in bundle["paths"]:

--- a/modules/output.py
+++ b/modules/output.py
@@ -952,7 +952,13 @@ def _collapse_collection_data_template_vars(config_data):
     if not isinstance(config_data, dict):
         return config_data
     libraries_section = config_data.get("libraries", {})
-    libraries = libraries_section.get("libraries")
+    libraries = None
+    if isinstance(libraries_section, dict):
+        nested = libraries_section.get("libraries")
+        if isinstance(nested, dict):
+            libraries = nested
+        else:
+            libraries = libraries_section
     if not isinstance(libraries, dict):
         return config_data
     for library_data in libraries.values():

--- a/modules/output.py
+++ b/modules/output.py
@@ -2570,7 +2570,7 @@ def build_config(header_style="standard", config_name=None):
                 if prefix == "attribute_":
                     return "-attribute_" in key
                 if prefix == "template_variables":
-                    return "-template_variables" in key
+                    return "-template_variables" in key or "-attribute_template_variables" in key
                 if prefix == "top_level_":
                     return "-top_level_" in key
                 if prefix in {"collection_files", "overlay_files", "metadata_files"}:

--- a/modules/output.py
+++ b/modules/output.py
@@ -1469,13 +1469,16 @@ def build_libraries_section(
                         if new_key not in template_vars:
                             template_vars[new_key] = template_vars[old_key]
                         template_vars.pop(old_key, None)
-                    if "exclude" in template_vars:
-                        exclude_values = _parse_string_list(template_vars.get("exclude"))
-                        if exclude_values:
-                            template_vars["exclude"] = exclude_values
+                    for list_key in ("exclude", "exclude_prefix"):
+                        if list_key not in template_vars:
+                            continue
+                        list_values = _parse_string_list(template_vars.get(list_key))
+                        if list_values:
+                            template_vars[list_key] = list_values
                         else:
-                            template_vars.pop("exclude", None)
-                    file_entry["template_variables"] = template_vars
+                            template_vars.pop(list_key, None)
+                    if template_vars:
+                        file_entry["template_variables"] = template_vars
 
                 collection_files.append(file_entry)
 
@@ -2286,9 +2289,10 @@ def reorder_library_section(library_data):
     - `schedule` comes next.
     - `remove_overlays`, `reset_overlays`, and `schedule_overlays` come after that.
     - `template_variables` next.
+    - `settings` appears before `radarr` / `sonarr` / `operations`.
+    - `metadata_files` appears after library settings and operations.
     - `metadata_files` appears before `collection_files`.
     - `collection_files` appears before `overlay_files`.
-    - `settings` appears before `radarr` / `sonarr` / `operations`.
     - Keys inside `operations` are ordered as per Kometa Wiki.
     - Other keys retain their natural order.
     """
@@ -2313,14 +2317,6 @@ def reorder_library_section(library_data):
     # 4. Then template_variables
     if "template_variables" in library_data:
         reordered_data["template_variables"] = library_data["template_variables"]
-
-    # 5. Then library-level metadata/collections/overlays in explicit YAML order
-    if "metadata_files" in library_data:
-        reordered_data["metadata_files"] = library_data["metadata_files"]
-    if "collection_files" in library_data:
-        reordered_data["collection_files"] = library_data["collection_files"]
-    if "overlay_files" in library_data:
-        reordered_data["overlay_files"] = library_data["overlay_files"]
 
     # 5. Then library settings
     if "settings" in library_data:
@@ -2377,7 +2373,15 @@ def reorder_library_section(library_data):
                 ordered_ops[k] = v
         reordered_data["operations"] = ordered_ops
 
-    # 7. Finally add any other keys that weren't handled
+    # 8. Then library-level metadata/collections/overlays in explicit YAML order
+    if "metadata_files" in library_data:
+        reordered_data["metadata_files"] = library_data["metadata_files"]
+    if "collection_files" in library_data:
+        reordered_data["collection_files"] = library_data["collection_files"]
+    if "overlay_files" in library_data:
+        reordered_data["overlay_files"] = library_data["overlay_files"]
+
+    # 9. Finally add any other keys that weren't handled
     for key, value in library_data.items():
         if key not in reordered_data:
             reordered_data[key] = value

--- a/quickstart.py
+++ b/quickstart.py
@@ -747,7 +747,7 @@ def _managed_library_folder_slug(source_path, kind):
 
 
 def _managed_library_config_root(config_name):
-    config_slug = helpers.normalize_config_name_for_storage(config_name)
+    config_slug = helpers.require_config_name_for_storage(config_name, context="Managed library artifact paths")
     return (Path(helpers.CONFIG_DIR) / config_slug).resolve()
 
 
@@ -947,13 +947,18 @@ def _copy_library_artifact_to_managed_store(kind, entry_type, location, config_n
     return Path(*relative.parts).as_posix()
 
 
-def _normalize_library_external_entry(kind, entry, config_name, library_scope, validate_local=True, force_clone_managed=False):
+def _normalize_library_external_entry(kind, entry, config_name, library_scope, validate_local=True, force_clone_managed=False, require_managed_context=False):
     parsed_entry = dict(entry) if isinstance(entry, dict) else {}
     entry_type = str(parsed_entry.get("type") or "").strip().lower()
     location = str(parsed_entry.get("location") or "").strip()
     is_validated = helpers.booler(parsed_entry.get("validated"))
     if entry_type not in {"file", "folder", "url", "git", "repo"} or not location:
         return parsed_entry, False, None
+    if entry_type in LOCAL_LIBRARY_FILE_TYPES and require_managed_context:
+        if not str(config_name or "").strip():
+            return None, False, "Managed library files require an explicit config name."
+        if not str(library_scope or "").strip():
+            return None, False, "Managed library files require a library scope."
     if entry_type not in LOCAL_LIBRARY_FILE_TYPES or not config_name or not library_scope:
         normalized_entry = {"type": entry_type, "location": location}
         if is_validated:
@@ -1001,6 +1006,7 @@ def _clone_library_file_entries_for_target(kind, raw_value, config_name, target_
             target_library_id,
             validate_local=False,
             force_clone_managed=True,
+            require_managed_context=True,
         )
         if entry_error:
             raise RuntimeError(f"{target_library_id} {kind}[{idx}]: {entry_error}")
@@ -1034,6 +1040,7 @@ def _normalize_library_file_entries_payload(libraries_data, config_name, validat
                     config_name,
                     library_scope,
                     validate_local=validate_local,
+                    require_managed_context=True,
                 )
                 if entry_error:
                     errors.append(f"{library_scope} {kind}[{idx}]: {entry_error}")
@@ -1128,6 +1135,7 @@ def _normalize_generated_config_library_files(config_data, config_name):
                         config_name,
                         library_name,
                         validate_local=True,
+                        require_managed_context=True,
                     )
                     if entry_error:
                         errors.append(f"{library_name} {kind}[{idx}]: {entry_error}")
@@ -15628,7 +15636,8 @@ def _imagemaid_settings_to_form_payload(payload):
         "overlays_only",
     ]
     form_payload = {}
-    config_name = helpers.normalize_config_name_for_storage(payload.get("config_name"))
+    raw_config_name = str(payload.get("config_name") or "").strip()
+    config_name = helpers.normalize_config_name_for_storage(raw_config_name) if raw_config_name else ""
     if config_name:
         form_payload["config_name"] = config_name
     for key in keys:
@@ -15638,7 +15647,8 @@ def _imagemaid_settings_to_form_payload(payload):
 
 
 def _resolve_request_config_name(payload=None):
-    normalized = helpers.normalize_config_name_for_storage((payload or {}).get("config_name")) if isinstance(payload, dict) else ""
+    raw_config_name = str((payload or {}).get("config_name") or "").strip() if isinstance(payload, dict) else ""
+    normalized = helpers.normalize_config_name_for_storage(raw_config_name) if raw_config_name else ""
     if normalized:
         if has_request_context():
             session["config_name"] = normalized

--- a/quickstart.py
+++ b/quickstart.py
@@ -7522,7 +7522,8 @@ def step(name):
                 if normalization_errors:
                     validation_errors = list(validation_errors or []) + normalization_errors
                     validated = False
-                yaml_content = _dump_yaml_text(config_data)
+                if not isinstance(yaml_content, str) or not yaml_content.strip():
+                    yaml_content = _dump_yaml_text(config_data)
             validation_summary = build_validation_summary(validation_errors)
             used_fonts = helpers.collect_font_references(config_data)
             saved_filename = helpers.save_to_named_config(yaml_content, config_name, used_fonts)

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -3351,6 +3351,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     function buildPayloadFromCard (card) {
       const payload = {}
+      const libraryId = activeLibraryId || String(card?.querySelector('[name]')?.name || '').split('-')[0]
       const checkboxNames = new Set(
         Array.from(card.querySelectorAll('input[type="checkbox"][name]'))
           .map(el => String(el.name || '').trim())
@@ -3390,6 +3391,14 @@ document.addEventListener('DOMContentLoaded', function () {
 
         payload[el.name] = el.value ?? ''
       })
+      if (libraryId) {
+        document.querySelectorAll(`input[type="hidden"][name^="${libraryId}-"]`).forEach(el => {
+          if (!el.name || el.disabled) return
+          if (card.contains(el)) return
+          if (checkboxNames.has(String(el.name || '').trim())) return
+          payload[el.name] = el.value ?? ''
+        })
+      }
       card.querySelectorAll('input.playlist-library-toggle[type="checkbox"][name]:disabled').forEach(el => {
         payload[el.name] = 'false'
       })

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -3038,6 +3038,72 @@ def test_build_libraries_section_includes_separator_placeholder_imdb_id(app):
     assert template_variables["collection_mode"] == "hide"
 
 
+def test_reorder_library_section_keeps_settings_and_operations_before_library_files():
+    from modules import output
+
+    reordered = output.reorder_library_section(
+        {
+            "report_path": "config/Movies_Report.yml",
+            "schedule": "weekly(mon)",
+            "schedule_overlays": "weekly(wed)",
+            "template_variables": {"sep_style": "gray"},
+            "metadata_files": [{"folder": "config/example/metadata"}],
+            "collection_files": [{"folder": "config/example/collections"}],
+            "overlay_files": [{"folder": "config/example/overlays"}],
+            "settings": {"asset_directory": ["C:\\Assets\\Movies"]},
+            "radarr": {"url": "http://radarr.local"},
+            "operations": {"assets_for_all": True},
+        }
+    )
+
+    assert list(reordered.keys()) == [
+        "report_path",
+        "schedule",
+        "schedule_overlays",
+        "template_variables",
+        "settings",
+        "radarr",
+        "operations",
+        "metadata_files",
+        "collection_files",
+        "overlay_files",
+    ]
+
+
+def test_build_libraries_section_omits_empty_collectionless_exclude_prefix(app):
+    from modules import output
+
+    libraries_section = output.build_libraries_section(
+        {"mov-library_movies-library": "Movies"},
+        {},
+        {
+            "movies": {
+                "mov-library_movies-collection_collectionless": True,
+                "mov-library_movies-template_collection_collectionless_exclude_prefix": "[]",
+            }
+        },
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+    )
+
+    collection_entries = libraries_section["libraries"]["Movies"]["collection_files"]
+    collectionless_entry = next((entry for entry in collection_entries if entry.get("default") == "collectionless"), None)
+
+    assert collectionless_entry is not None
+    assert "template_variables" not in collectionless_entry
+
+
 def test_build_libraries_section_emits_schedule(app):
     from modules import output
 

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -3002,6 +3002,42 @@ def test_build_libraries_section_keeps_default_ratings_overlay_when_overlay_file
     assert ratings_entry["template_variables"]["rating1_image"] == "imdb"
 
 
+def test_build_libraries_section_includes_separator_placeholder_imdb_id(app):
+    from modules import output
+
+    libraries_section = output.build_libraries_section(
+        {"mov-library_movies-library": "Movies"},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {
+            "movies": {
+                "mov-library_movies-template_variables[use_separator]": "gray",
+                "mov-library_movies-attribute_template_variables[placeholder_imdb_id]": "tt0108052",
+                "mov-library_movies-template_variables[language]": "en",
+                "mov-library_movies-template_variables[collection_mode]": "hide",
+            }
+        },
+        {},
+        {},
+        {},
+    )
+
+    template_variables = libraries_section["libraries"]["Movies"]["template_variables"]
+    assert template_variables["sep_style"] == "gray"
+    assert template_variables["placeholder_imdb_id"] == "tt0108052"
+    assert template_variables["language"] == "en"
+    assert template_variables["collection_mode"] == "hide"
+
+
 def test_build_libraries_section_emits_schedule(app):
     from modules import output
 

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -1155,10 +1155,7 @@ def test_collapse_collection_data_template_vars_removes_flat_data_keys_from_all_
 
     for entry in entries:
         template_variables = entry.get("template_variables", {})
-        flat_data_keys = [
-            key for key in template_variables.keys()
-            if isinstance(key, str) and key.startswith("data_")
-        ]
+        flat_data_keys = [key for key in template_variables.keys() if isinstance(key, str) and key.startswith("data_")]
         assert flat_data_keys == []
         if "data" in template_variables:
             assert isinstance(template_variables["data"], dict)
@@ -2148,10 +2145,7 @@ def test_final_page_stale_bulk_gate_skips_config_generation(client, isolated_con
 
 def test_final_page_preserves_annotated_yaml_content(client, isolated_config_dir, monkeypatch, qs_module):
     annotated_yaml = (
-        "# yaml-language-server: $schema=https://example.invalid/config-schema.json\n\n"
-        "#==================== KOMETA ====================#\n\n"
-        "plex:\n"
-        "  token: secret\n"
+        "# yaml-language-server: $schema=https://example.invalid/config-schema.json\n\n" "#==================== KOMETA ====================#\n\n" "plex:\n" "  token: secret\n"
     )
     captured = {}
 

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -2018,6 +2018,62 @@ def test_final_page_stale_bulk_gate_skips_config_generation(client, isolated_con
     assert b'data-auto-validate="true"' in resp.data
 
 
+def test_final_page_preserves_annotated_yaml_content(client, isolated_config_dir, monkeypatch, qs_module):
+    annotated_yaml = (
+        "# yaml-language-server: $schema=https://example.invalid/config-schema.json\n\n"
+        "#==================== KOMETA ====================#\n\n"
+        "plex:\n"
+        "  token: secret\n"
+    )
+    captured = {}
+
+    monkeypatch.setattr(
+        qs_module,
+        "_build_final_gate",
+        lambda *_args, **_kwargs: {
+            "stage": "kometa",
+            "todo_count": 0,
+            "todo_blockers": [],
+            "bulk_validation_fresh": True,
+            "bulk_validation_at": qs_module.utc_now_iso(),
+            "validation_ttl_hours": 12,
+            "can_build_config": True,
+            "config_valid": False,
+        },
+    )
+    monkeypatch.setattr(
+        qs_module.output,
+        "build_config",
+        lambda *_args, **_kwargs: (True, "", {"plex": {"token": "secret"}}, annotated_yaml, []),
+    )
+    monkeypatch.setattr(
+        qs_module,
+        "_normalize_generated_config_library_files",
+        lambda config_data, _config_name: (config_data, False, []),
+    )
+
+    def fake_save_to_named_config(yaml_text, config_name, used_fonts):
+        captured["yaml_text"] = yaml_text
+        captured["config_name"] = config_name
+        captured["used_fonts"] = used_fonts
+        return f"{config_name}.yml"
+
+    monkeypatch.setattr(qs_module.helpers, "save_to_named_config", fake_save_to_named_config)
+
+    with client.session_transaction() as sess:
+        sess["config_name"] = "pytest_final_annotated_yaml"
+
+    resp = client.get("/step/900-kometa")
+    assert resp.status_code == 200
+    assert b"yaml-language-server" in resp.data
+
+    with client.session_transaction() as sess:
+        assert sess.get("yaml_content") == annotated_yaml
+
+    assert captured["yaml_text"] == annotated_yaml
+    assert captured["config_name"] == "pytest_final_annotated_yaml"
+
+
 def test_switch_config_returns_new_workspace_status(client, isolated_config_dir, app, qs_module):
     from modules import database
 

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def _contains_dummy_field(value, expected):
     if isinstance(value, dict):
         for key, item in value.items():
@@ -1034,6 +1037,131 @@ def test_build_config_includes_saved_library_metadata_files(app, isolated_config
     assert "godzilla.yml" in yaml_content
     assert "config\\metadata\\movies" in yaml_content
     assert "movies_refresh.yml" in yaml_content
+
+
+def test_collapse_collection_data_template_vars_handles_direct_libraries_dict():
+    from modules import output
+
+    config_data = {
+        "libraries": {
+            "Movies": {
+                "collection_files": [
+                    {
+                        "default": "oscars",
+                        "template_variables": {
+                            "data_starting": "first",
+                        },
+                    },
+                    {
+                        "default": "year",
+                        "template_variables": {
+                            "data_starting": "1880",
+                            "data_ending": "current_year",
+                        },
+                    },
+                ]
+            }
+        }
+    }
+
+    collapsed = output._collapse_collection_data_template_vars(config_data)
+    entries = collapsed["libraries"]["Movies"]["collection_files"]
+
+    assert entries[0]["template_variables"] == {"data": {"starting": "first"}}
+    assert entries[1]["template_variables"] == {"data": {"starting": 1880, "ending": "current_year"}}
+
+
+def test_collapse_collection_data_template_vars_handles_actor_style_data_blocks():
+    from modules import output
+
+    config_data = {
+        "libraries": {
+            "Movies": {
+                "collection_files": [
+                    {
+                        "default": "actor",
+                        "template_variables": {
+                            "collection_section": "001",
+                            "style": "signature",
+                            "data_depth": 1,
+                            "data_limit": 15,
+                            "sort_by": "audience_rating.desc",
+                        },
+                    },
+                    {
+                        "default": "director",
+                        "template_variables": {
+                            "style": "signature",
+                            "data_depth": 1,
+                            "data_limit": 15,
+                        },
+                    },
+                ]
+            }
+        }
+    }
+
+    collapsed = output._collapse_collection_data_template_vars(config_data)
+    actor_tv = collapsed["libraries"]["Movies"]["collection_files"][0]["template_variables"]
+    director_tv = collapsed["libraries"]["Movies"]["collection_files"][1]["template_variables"]
+
+    assert actor_tv == {
+        "collection_section": "001",
+        "style": "signature",
+        "sort_by": "audience_rating.desc",
+        "data": {"depth": 1, "limit": 15},
+    }
+    assert director_tv == {
+        "style": "signature",
+        "data": {"depth": 1, "limit": 15},
+    }
+
+
+def test_collapse_collection_data_template_vars_removes_flat_data_keys_from_all_collection_entries():
+    from modules import output
+
+    config_data = {
+        "libraries": {
+            "Movies": {
+                "collection_files": [
+                    {
+                        "default": "oscars",
+                        "template_variables": {
+                            "data_starting": "first",
+                        },
+                    },
+                    {
+                        "default": "actor",
+                        "template_variables": {
+                            "style": "signature",
+                            "data_depth": 1,
+                            "data_limit": 15,
+                        },
+                    },
+                    {
+                        "default": "year",
+                        "template_variables": {
+                            "data_starting": "1880",
+                            "data_ending": "current_year",
+                        },
+                    },
+                ]
+            }
+        }
+    }
+
+    collapsed = output._collapse_collection_data_template_vars(config_data)
+    entries = collapsed["libraries"]["Movies"]["collection_files"]
+
+    for entry in entries:
+        template_variables = entry.get("template_variables", {})
+        flat_data_keys = [
+            key for key in template_variables.keys()
+            if isinstance(key, str) and key.startswith("data_")
+        ]
+        assert flat_data_keys == []
+        if "data" in template_variables:
+            assert isinstance(template_variables["data"], dict)
 
 
 def test_build_config_prunes_default_horizontal_ratings_offsets(app, monkeypatch):
@@ -2227,6 +2355,21 @@ def test_orphaned_config_artifacts_route_lists_disk_only_bundles(client, isolate
     assert any("metadata_files" in path for path in orphan["paths"])
 
 
+def test_orphaned_config_artifacts_route_lists_font_only_default_bundle(client, isolated_config_dir):
+    default_font_dir = isolated_config_dir / "default" / "fonts"
+    default_font_dir.mkdir(parents=True, exist_ok=True)
+    (default_font_dir / "Poster.ttf").write_bytes(b"default-font")
+
+    resp = client.get("/orphaned-config-artifacts")
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+
+    orphan = next((item for item in payload["orphans"] if item["name"] == "default"), None)
+    assert orphan is not None
+    assert any(path.endswith("\\default") or path.endswith("/default") for path in orphan["paths"])
+
+
 def test_delete_orphaned_config_artifacts_route_removes_selected_bundle(client, isolated_config_dir, app):
     from pathlib import Path
 
@@ -2252,6 +2395,19 @@ def test_delete_orphaned_config_artifacts_route_removes_selected_bundle(client, 
     assert not archive_dir.exists()
     assert not (isolated_config_dir / orphan_name / "collection_files").exists()
     assert not (kometa_path / f"{orphan_name}_config.yml").exists()
+
+
+def test_delete_orphaned_config_artifacts_route_removes_font_only_default_bundle(client, isolated_config_dir):
+    default_font_dir = isolated_config_dir / "default" / "fonts"
+    default_font_dir.mkdir(parents=True, exist_ok=True)
+    (default_font_dir / "Poster.ttf").write_bytes(b"default-font")
+
+    resp = client.post("/orphaned-config-artifacts/delete", json={"names": ["default"]})
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert payload["deleted"] == ["default"]
+    assert not (isolated_config_dir / "default").exists()
 
 
 def test_delete_orphaned_config_artifacts_route_removes_copy_named_yaml(client, isolated_config_dir):
@@ -2676,6 +2832,24 @@ def test_save_to_named_config_syncs_managed_library_artifacts_to_kometa(isolated
     synced_file = kometa_root / "config" / config_name / "collection_files" / "mov-library_movies" / "collections.yml"
     assert synced_file.exists()
     assert synced_file.read_text(encoding="utf-8") == collection_file.read_text(encoding="utf-8")
+
+
+def test_save_to_named_config_rejects_blank_config_name(isolated_config_dir, app):
+    from modules import helpers
+
+    with app.app_context():
+        with pytest.raises(ValueError, match="requires an explicit config name"):
+            helpers.save_to_named_config("settings:\n  cache: true\n", "   ")
+
+    assert not (isolated_config_dir / "default_config.yml").exists()
+    assert not (isolated_config_dir / "default").exists()
+
+
+def test_sync_managed_library_artifacts_to_kometa_rejects_blank_config_name(isolated_config_dir, app):
+    from modules import helpers
+
+    with pytest.raises(ValueError, match="requires an explicit config name"):
+        helpers.sync_managed_library_artifacts_to_kometa("   ", kometa_root=app.config["KOMETA_ROOT"])
 
 
 def test_import_config_confirm_rehomes_bundled_library_files(client, isolated_config_dir, monkeypatch, qs_module):


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Summary

Fixes a set of final YAML regressions introduced across recent Quickstart builds. The changes restore the annotated final output, preserve historical library ordering, prevent blank config names from silently creating config/default artifacts, and correctly re-nest flattened collection data_* template variables.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
