### PR TITLE
add include to collections v1

### DIFF
--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -3139,14 +3139,14 @@ def list_orphaned_config_artifacts(
 
     if active_kometa_config_dir and active_kometa_config_dir.exists():
         for path in active_kometa_config_dir.iterdir():
-                if not path.is_file() or not path.name.lower().endswith("_config.yml"):
-                    continue
-                match = current_pattern.match(path.name)
-                if not match:
-                    continue
-                bundle = ensure_bundle(match.group("name"))
-                bundle["has_kometa_copy"] = True
-                bundle["paths"].append(str(path))
+            if not path.is_file() or not path.name.lower().endswith("_config.yml"):
+                continue
+            match = current_pattern.match(path.name)
+            if not match:
+                continue
+            bundle = ensure_bundle(match.group("name"))
+            bundle["has_kometa_copy"] = True
+            bundle["paths"].append(str(path))
 
     for bundle in bundles.values():
         name = bundle.get("name")

--- a/modules/importer.py
+++ b/modules/importer.py
@@ -363,6 +363,25 @@ def _collect_template_keys(template_vars: Any) -> set[str]:
     return keys
 
 
+def _has_template_string_list_values(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, list):
+        return any(str(item).strip() for item in value if item is not None)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return False
+        try:
+            parsed = json.loads(stripped)
+        except Exception:
+            parsed = None
+        if isinstance(parsed, list):
+            return any(str(item).strip() for item in parsed if item is not None)
+        return True
+    return bool(value)
+
+
 def _build_collection_index(collection_config: list[dict]) -> tuple[dict[str, dict], dict[str, str]]:
     by_id: dict[str, dict] = {}
     by_alias: dict[str, str] = {}
@@ -1309,6 +1328,15 @@ def prepare_import_payload(
                                     "imported",
                                     f"libraries.{lib_name}.collection_files[{idx}].template_variables.data",
                                 )
+                        if (
+                            _has_template_string_list_values(expanded_template_values.get("include"))
+                            and _has_template_string_list_values(expanded_template_values.get("exclude"))
+                        ):
+                            report.add(
+                                "skipped",
+                                f"libraries.{lib_name}.collection_files[{idx}].template_variables.include_exclude_warning",
+                                "Warning - include and exclude were both imported. Kometa code allows this, but the wiki says not to combine them.",
+                            )
                         for key, value in expanded_template_values.items():
                             if key in allowed:
                                 child_name = f"{lib_id}-template_collection_{clean_id}_{key}"

--- a/modules/importer.py
+++ b/modules/importer.py
@@ -1328,10 +1328,7 @@ def prepare_import_payload(
                                     "imported",
                                     f"libraries.{lib_name}.collection_files[{idx}].template_variables.data",
                                 )
-                        if (
-                            _has_template_string_list_values(expanded_template_values.get("include"))
-                            and _has_template_string_list_values(expanded_template_values.get("exclude"))
-                        ):
+                        if _has_template_string_list_values(expanded_template_values.get("include")) and _has_template_string_list_values(expanded_template_values.get("exclude")):
                             report.add(
                                 "skipped",
                                 f"libraries.{lib_name}.collection_files[{idx}].template_variables.include_exclude_warning",

--- a/modules/output.py
+++ b/modules/output.py
@@ -1469,7 +1469,7 @@ def build_libraries_section(
                         if new_key not in template_vars:
                             template_vars[new_key] = template_vars[old_key]
                         template_vars.pop(old_key, None)
-                    for list_key in ("exclude", "exclude_prefix"):
+                    for list_key in ("include", "exclude", "exclude_prefix"):
                         if list_key not in template_vars:
                             continue
                         list_values = _parse_string_list(template_vars.get(list_key))

--- a/quickstart.py
+++ b/quickstart.py
@@ -4215,7 +4215,9 @@ def _resolve_kometa_selection(section_data=None):
 
     if mode == KOMETA_INSTALL_MODE_EXISTING:
         selection_valid = False
-        status_message = "Quickstart will use an existing Kometa install visible from this environment. Quickstart will not update that install; update it manually outside Quickstart."
+        status_message = (
+            "Quickstart will use an existing Kometa install visible from this environment. Quickstart will not update that install; update it manually outside Quickstart."
+        )
         mode_label = "Existing direct install"
         can_update = False
         if existing_root_raw:
@@ -4229,7 +4231,9 @@ def _resolve_kometa_selection(section_data=None):
                 if not resolved_existing.exists():
                     status_message = "The selected existing Kometa path is saved, but it is not currently visible from this Quickstart environment."
                 else:
-                    status_message = "Quickstart will use the selected existing Kometa install. Quickstart can validate and launch it, but updates must be done manually outside Quickstart."
+                    status_message = (
+                        "Quickstart will use the selected existing Kometa install. Quickstart can validate and launch it, but updates must be done manually outside Quickstart."
+                    )
             else:
                 selected_root = None
                 primary_path = None
@@ -15637,10 +15641,13 @@ def save_kometa_install_mode():
         missing = _validate_existing_kometa_root(resolved_existing)
         if missing:
             if "kometa.py" in missing or "requirements.txt" in missing or "config" in missing:
-                return jsonify(
-                    success=False,
-                    error="Choose the Kometa root folder that contains kometa.py, requirements.txt, and config/.",
-                ), 400
+                return (
+                    jsonify(
+                        success=False,
+                        error="Choose the Kometa root folder that contains kometa.py, requirements.txt, and config/.",
+                    ),
+                    400,
+                )
         section_payload_update = {
             "install_mode": install_mode,
             "existing_root": existing_root,
@@ -15798,11 +15805,14 @@ def validate_kometa_root():
         if missing:
             log("❌ The selected existing Kometa path does not look like a Kometa root.")
             log("ℹ️ Choose the folder that contains kometa.py, requirements.txt, and config/.")
-            return jsonify(
-                success=False,
-                error="Choose the Kometa root folder that contains kometa.py, requirements.txt, and config/.",
-                log=logs,
-            ), 400
+            return (
+                jsonify(
+                    success=False,
+                    error="Choose the Kometa root folder that contains kometa.py, requirements.txt, and config/.",
+                    log=logs,
+                ),
+                400,
+            )
 
     try:
         if install_mode == KOMETA_INSTALL_MODE_MANAGED:
@@ -16029,11 +16039,14 @@ def probe_kometa_root():
         if missing:
             log("❌ The selected existing Kometa path does not look like a Kometa root.")
             log("ℹ️ Choose the folder that contains kometa.py, requirements.txt, and config/.")
-            return jsonify(
-                success=False,
-                error="Choose the Kometa root folder that contains kometa.py, requirements.txt, and config/.",
-                log=logs,
-            ), 400
+            return (
+                jsonify(
+                    success=False,
+                    error="Choose the Kometa root folder that contains kometa.py, requirements.txt, and config/.",
+                    log=logs,
+                ),
+                400,
+            )
     p = target["path_obj"]
 
     state = _probe_kometa_root_state(p)
@@ -16105,11 +16118,14 @@ def check_kometa_update():
         if missing:
             log("❌ The selected existing Kometa path does not look like a Kometa root.")
             log("ℹ️ Choose the folder that contains kometa.py, requirements.txt, and config/.")
-            return jsonify(
-                success=False,
-                error="Choose the Kometa root folder that contains kometa.py, requirements.txt, and config/.",
-                log=logs,
-            ), 400
+            return (
+                jsonify(
+                    success=False,
+                    error="Choose the Kometa root folder that contains kometa.py, requirements.txt, and config/.",
+                    log=logs,
+                ),
+                400,
+            )
     p = target["path_obj"]
 
     state = _probe_kometa_root_state(p)

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -22685,11 +22685,20 @@
             ]
           },
           {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these resolutions. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add resolution key (e.g. 4k)",
+            "mutually_exclusive_with": "exclude"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
-            "tooltip": "Exclude specific resolutions from these collections.",
-            "placeholder": "Add resolution key (e.g. 4k)"
+            "tooltip": "Exclude specific resolutions from these collections. Kometa code allows this with Include, but the wiki says not to combine them.",
+            "placeholder": "Add resolution key (e.g. 4k)",
+            "mutually_exclusive_with": "include"
           },
           {
             "key": "collection_mode",
@@ -23102,11 +23111,20 @@
             "default": true
           },
           {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these audio languages. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add language code (e.g. fr)",
+            "mutually_exclusive_with": "exclude"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
-            "tooltip": "Exclude specific audio languages from these collections.",
-            "placeholder": "Add language code (e.g. fr)"
+            "tooltip": "Exclude specific audio languages from these collections. Kometa code allows this with Include, but the wiki says not to combine them.",
+            "placeholder": "Add language code (e.g. fr)",
+            "mutually_exclusive_with": "include"
           },
           {
             "key": "collection_mode",
@@ -23519,11 +23537,20 @@
             "default": true
           },
           {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these subtitle languages. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add language code (e.g. fr)",
+            "mutually_exclusive_with": "exclude"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
-            "tooltip": "Exclude specific subtitle languages from these collections.",
-            "placeholder": "Add language code (e.g. fr)"
+            "tooltip": "Exclude specific subtitle languages from these collections. Kometa code allows this with Include, but the wiki says not to combine them.",
+            "placeholder": "Add language code (e.g. fr)",
+            "mutually_exclusive_with": "include"
           },
           {
             "key": "collection_mode",
@@ -23996,11 +24023,20 @@
             "tooltip": "Replaces the data dynamic collection value. Controls the maximum number of collections to create."
           },
           {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these people. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add person name (e.g. Jeremy Kleiner)",
+            "mutually_exclusive_with": "exclude"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
-            "tooltip": "Exclude specific people from these collections.",
-            "placeholder": "Add person name (e.g. Jeremy Kleiner)"
+            "tooltip": "Exclude specific people from these collections. Kometa code allows this with Include, but the wiki says not to combine them.",
+            "placeholder": "Add person name (e.g. Jeremy Kleiner)",
+            "mutually_exclusive_with": "include"
           },
           {
             "key": "collection_mode",
@@ -24466,11 +24502,20 @@
             "tooltip": "Replaces the data dynamic collection value. Controls the maximum number of collections to create."
           },
           {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these people. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add person name (e.g. Jeremy Kleiner)",
+            "mutually_exclusive_with": "exclude"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
-            "tooltip": "Exclude specific people from these collections.",
-            "placeholder": "Add person name (e.g. Jeremy Kleiner)"
+            "tooltip": "Exclude specific people from these collections. Kometa code allows this with Include, but the wiki says not to combine them.",
+            "placeholder": "Add person name (e.g. Jeremy Kleiner)",
+            "mutually_exclusive_with": "include"
           },
           {
             "key": "collection_mode",
@@ -24945,11 +24990,20 @@
             "tooltip": "Replaces the data dynamic collection value. Controls the maximum number of collections to create."
           },
           {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these people. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add person name (e.g. Jeremy Kleiner)",
+            "mutually_exclusive_with": "exclude"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
-            "tooltip": "Exclude specific people from these collections.",
-            "placeholder": "Add person name (e.g. Jeremy Kleiner)"
+            "tooltip": "Exclude specific people from these collections. Kometa code allows this with Include, but the wiki says not to combine them.",
+            "placeholder": "Add person name (e.g. Jeremy Kleiner)",
+            "mutually_exclusive_with": "include"
           },
           {
             "key": "collection_mode",
@@ -25424,11 +25478,20 @@
             "tooltip": "Replaces the data dynamic collection value. Controls the maximum number of collections to create."
           },
           {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these people. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add person name (e.g. Jeremy Kleiner)",
+            "mutually_exclusive_with": "exclude"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
-            "tooltip": "Exclude specific people from these collections.",
-            "placeholder": "Add person name (e.g. Jeremy Kleiner)"
+            "tooltip": "Exclude specific people from these collections. Kometa code allows this with Include, but the wiki says not to combine them.",
+            "placeholder": "Add person name (e.g. Jeremy Kleiner)",
+            "mutually_exclusive_with": "include"
           },
           {
             "key": "collection_mode",
@@ -26758,11 +26821,20 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these studios. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add studio name (e.g. Marvel Studios)",
+            "mutually_exclusive_with": "exclude"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
-            "tooltip": "Exclude specific studios from these collections.",
-            "placeholder": "Add studio name (e.g. Marvel Studios)"
+            "tooltip": "Exclude specific studios from these collections. Kometa code allows this with Include, but the wiki says not to combine them.",
+            "placeholder": "Add studio name (e.g. Marvel Studios)",
+            "mutually_exclusive_with": "include"
           },
           {
             "key": "collection_mode",
@@ -27180,11 +27252,20 @@
             ]
           },
           {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these networks. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add network name (e.g. HBO)",
+            "mutually_exclusive_with": "exclude"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
-            "tooltip": "Exclude specific networks from these collections.",
-            "placeholder": "Add network name (e.g. HBO)"
+            "tooltip": "Exclude specific networks from these collections. Kometa code allows this with Include, but the wiki says not to combine them.",
+            "placeholder": "Add network name (e.g. HBO)",
+            "mutually_exclusive_with": "include"
           },
           {
             "key": "collection_mode",

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -2783,12 +2783,51 @@ document.addEventListener('DOMContentLoaded', function () {
         const addBtn = wrapper.querySelector('[data-template-string-add]')
         const list = wrapper.querySelector('[data-template-string-items]')
         const feedback = wrapper.querySelector('[data-template-string-feedback]')
+        const templateVariableKey = String(wrapper.dataset.templateVariableKey || '').trim()
+        const mutuallyExclusiveWith = String(wrapper.dataset.mutuallyExclusiveWith || '').trim()
 
         if (!hidden || !input || !addBtn || !list) return
 
         const presetName = inferTemplateStringListPreset(wrapper, input)
         const presetConfig = templateStringListPresetConfigs[presetName] || templateStringListPresetConfigs.generic_text
         ensureTemplateStringListDatalist(wrapper, input, presetConfig, presetName)
+
+        function parseStoredStringList (rawValue) {
+          const raw = String(rawValue || '').trim()
+          if (!raw) return []
+          try {
+            const parsed = JSON.parse(raw)
+            if (Array.isArray(parsed)) {
+              return parsed.map(item => String(item).trim()).filter(Boolean)
+            }
+          } catch (e) {
+            // fall through to treat as single value
+          }
+          return [raw]
+        }
+
+        function getCounterpartHiddenId () {
+          if (!hiddenId || !templateVariableKey || !mutuallyExclusiveWith) return ''
+          const suffix = `_${templateVariableKey}`
+          if (!hiddenId.endsWith(suffix)) return ''
+          return `${hiddenId.slice(0, -suffix.length)}_${mutuallyExclusiveWith}`
+        }
+
+        function getCounterpartWrapper () {
+          const counterpartHiddenId = getCounterpartHiddenId()
+          if (!counterpartHiddenId) return null
+          return document.querySelector(`[data-template-string-list][data-hidden-input="${counterpartHiddenId}"]`)
+        }
+
+        function getCounterpartValues () {
+          const counterpartWrapper = getCounterpartWrapper()
+          if (counterpartWrapper && typeof counterpartWrapper.__qsTemplateStringListGetValues === 'function') {
+            return counterpartWrapper.__qsTemplateStringListGetValues()
+          }
+          const counterpartHiddenId = getCounterpartHiddenId()
+          const counterpartHidden = counterpartHiddenId ? document.getElementById(counterpartHiddenId) : null
+          return parseStoredStringList(counterpartHidden?.value)
+        }
 
         function setLookupState (target, state) {
           if (!target) return
@@ -2808,14 +2847,18 @@ document.addEventListener('DOMContentLoaded', function () {
           }
         }
 
-        function setFeedback (message, persistent = false) {
+        function setFeedback (message, persistent = false, level = 'error') {
+          const isError = Boolean(message) && level === 'error'
           if (feedback) {
             feedback.textContent = message || ''
             feedback.classList.toggle('d-none', !message)
             feedback.classList.toggle('d-block', Boolean(message))
+            feedback.classList.toggle('invalid-feedback', isError)
+            feedback.classList.toggle('text-warning', Boolean(message) && level === 'warning')
+            feedback.classList.toggle('small', Boolean(message) && level === 'warning')
           }
-          input.classList.toggle('is-invalid', Boolean(message))
-          input.setCustomValidity(persistent && message ? message : '')
+          input.classList.toggle('is-invalid', isError)
+          input.setCustomValidity(persistent && isError && message ? message : '')
         }
 
         function clearTransientFeedback () {
@@ -2824,17 +2867,7 @@ document.addEventListener('DOMContentLoaded', function () {
         }
 
         function parseValues () {
-          const raw = String(hidden.value || '').trim()
-          if (!raw) return []
-          try {
-            const parsed = JSON.parse(raw)
-            if (Array.isArray(parsed)) {
-              return parsed.map(item => String(item).trim()).filter(Boolean)
-            }
-          } catch (e) {
-            // fall through to treat as single value
-          }
-          return [raw]
+          return parseStoredStringList(hidden.value)
         }
 
         function validateValue (rawValue) {
@@ -2948,9 +2981,23 @@ document.addEventListener('DOMContentLoaded', function () {
           })
         }
 
-        function syncState (values, transientMessage = '') {
+        function syncState (values, transientMessage = '', options = {}) {
           const analyzed = analyzeValues(values)
-          hidden.value = JSON.stringify(analyzed.map(item => item.value))
+          const normalizedValues = analyzed.map(item => item.value)
+          let feedbackMessage = transientMessage || ''
+          let feedbackLevel = 'error'
+
+          if (!options.skipMutualExclusion && mutuallyExclusiveWith && normalizedValues.length) {
+            const counterpartValues = getCounterpartValues()
+            if (counterpartValues.length) {
+              if (!feedbackMessage) {
+                feedbackMessage = 'Include and Exclude are both set. Kometa code allows this, but the wiki says not to combine them.'
+                feedbackLevel = 'warning'
+              }
+            }
+          }
+
+          hidden.value = JSON.stringify(normalizedValues)
           renderList(analyzed)
 
           const invalidItems = analyzed.filter(item => !item.valid)
@@ -2962,7 +3009,7 @@ document.addEventListener('DOMContentLoaded', function () {
             return analyzed
           }
 
-          setFeedback(transientMessage || '', false)
+          setFeedback(feedbackMessage || '', false, feedbackLevel)
           return analyzed
         }
 
@@ -2987,6 +3034,8 @@ document.addEventListener('DOMContentLoaded', function () {
           clearTransientFeedback()
         }
 
+        wrapper.__qsTemplateStringListGetValues = () => parseValues()
+        wrapper.__qsTemplateStringListSync = syncState
         syncState(parseValues())
 
         addBtn.addEventListener('click', addValue)

--- a/templates/001-start.html
+++ b/templates/001-start.html
@@ -51,7 +51,7 @@
                   </span>
                 </div>
                 {% if kometa_ready %}
-                <p class="small text-muted mb-3">This config is valid for the Kometa workflow. Open the final Kometa page when you want to validate, review, download, or generate output.  You can also launch Kometa.</p>
+                <p class="small text-muted mb-3">This config is valid for Kometa. Open the final Kometa page when you want to validate, review, download, or generate output.  You can also launch Kometa depending on the mode selected below.</p>
                 {% else %}
                 <p class="small text-muted mb-3">Plex, TMDb, libraries, or final validation still need attention before this config is fully ready for Kometa.</p>
                 {% endif %}

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -1184,6 +1184,8 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                         {% set list_json = '[]' %}
                         {% endif %}
                         <div class="mb-2" data-template-string-list data-hidden-input="{{ input_name }}"
+                            {% if item.key is defined %}data-template-variable-key="{{ item.key }}"{% endif %}
+                            {% if item.mutually_exclusive_with %}data-mutually-exclusive-with="{{ item.mutually_exclusive_with }}"{% endif %}
                             {% if item.validation_preset %}data-validation-preset="{{ item.validation_preset }}"{% endif %}
                             {% if item.validation_mode %}data-validation-mode="{{ item.validation_mode }}"{% endif %}
                             {% if item.validation_normalize %}data-validation-normalize="{{ item.validation_normalize }}"{% endif %}>

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -3366,12 +3366,9 @@ def test_prepare_import_payload_accepts_collection_include_and_exclude_with_warn
 
     libraries_payload = payload["libraries"]["libraries"]
     assert libraries_payload["mov-library_movies-collection_actor"] is True
-    assert libraries_payload["mov-library_movies-template_collection_actor_include"] == "[\"Tom Hanks\"]"
-    assert libraries_payload["mov-library_movies-template_collection_actor_exclude"] == "[\"Morgan Freeman\"]"
-    assert any(
-        "template_variables.include_exclude_warning" in line and "include and exclude were both imported" in line
-        for line in report.lines
-    )
+    assert libraries_payload["mov-library_movies-template_collection_actor_include"] == '["Tom Hanks"]'
+    assert libraries_payload["mov-library_movies-template_collection_actor_exclude"] == '["Morgan Freeman"]'
+    assert any("template_variables.include_exclude_warning" in line and "include and exclude were both imported" in line for line in report.lines)
 
 
 def test_build_libraries_section_includes_separator_placeholder_imdb_id(app):
@@ -3906,17 +3903,7 @@ def test_validate_library_metadata_files_includes_failing_path(qs_module):
 
 
 def test_normalize_generated_config_library_files_includes_failing_path(qs_module):
-    config_data = {
-        "libraries": {
-            "Movies": {
-                "metadata_files": [
-                    {
-                        "folder": r"C:\does-not-exist\metadata"
-                    }
-                ]
-            }
-        }
-    }
+    config_data = {"libraries": {"Movies": {"metadata_files": [{"folder": r"C:\does-not-exist\metadata"}]}}}
 
     _config_data, _changed, errors = qs_module._normalize_generated_config_library_files(config_data, "pytest_config")
 

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -950,6 +950,44 @@ def test_build_libraries_section_emits_collection_files(app):
         ]
 
 
+def test_build_libraries_section_preserves_collection_include_and_exclude(app):
+    from modules import output
+
+    with app.app_context():
+        libraries_section = output.build_libraries_section(
+            {"mov-library_movies-library": "Movies"},
+            {},
+            {
+                "movies": {
+                    "mov-library_movies-collection_actor": True,
+                    "mov-library_movies-template_collection_actor_include": ["Tom Hanks"],
+                    "mov-library_movies-template_collection_actor_exclude": ["Morgan Freeman"],
+                }
+            },
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+        )
+
+    actor_entry = next(
+        (entry for entry in libraries_section["libraries"]["Movies"]["collection_files"] if entry.get("default") == "actor"),
+        None,
+    )
+    assert actor_entry is not None
+    assert actor_entry["template_variables"]["include"] == ["Tom Hanks"]
+    assert actor_entry["template_variables"]["exclude"] == ["Morgan Freeman"]
+
+
 def test_build_libraries_section_emits_library_arr_overrides(app):
     from modules import output
 
@@ -3299,6 +3337,41 @@ def test_prepare_import_payload_accepts_language_weight_override():
     assert libraries_payload["mov-library_movies-movie-template_overlay_languages_subtitles[languages]"] == ["en", "ja"]
     assert libraries_payload["mov-library_movies-movie-template_overlay_languages_subtitles[weight_ja]"] == 700
     assert report.summary()["imported"] > 0
+
+
+def test_prepare_import_payload_accepts_collection_include_and_exclude_with_warning():
+    from modules import importer
+
+    config_data = {
+        "libraries": {
+            "Movies": {
+                "collection_files": [
+                    {
+                        "default": "actor",
+                        "template_variables": {
+                            "include": ["Tom Hanks"],
+                            "exclude": ["Morgan Freeman"],
+                        },
+                    }
+                ]
+            }
+        }
+    }
+
+    payload, report = importer.prepare_import_payload(
+        config_data,
+        plex_movie_names={"Movies"},
+        plex_show_names=set(),
+    )
+
+    libraries_payload = payload["libraries"]["libraries"]
+    assert libraries_payload["mov-library_movies-collection_actor"] is True
+    assert libraries_payload["mov-library_movies-template_collection_actor_include"] == "[\"Tom Hanks\"]"
+    assert libraries_payload["mov-library_movies-template_collection_actor_exclude"] == "[\"Morgan Freeman\"]"
+    assert any(
+        "template_variables.include_exclude_warning" in line and "include and exclude were both imported" in line
+        for line in report.lines
+    )
 
 
 def test_build_libraries_section_includes_separator_placeholder_imdb_id(app):


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Summary

Adds missing include support to collection defaults that already supported exclude, and aligns Quickstart’s behavior with actual Kometa code when both are present.

Quickstart now exposes include for the relevant dynamic collection defaults, preserves both include and exclude during import/export, and warns users when they combine them instead of silently dropping one side. This matches Kometa’s current parser behavior more closely while still acknowledging the wiki guidance that the combination is discouraged.

What changed

Added missing include template variables for supported collection defaults

actor
audio_language
resolution
studio
subtitle_language
director
producer
writer
network

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
