### PR TITLE
Add conffig analyser

### DIFF
--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -27,10 +27,13 @@ DEFAULT_EXCLUDED_TOP_LEVEL_DIR_NAMES = {
     "$recycle.bin",
     "program files",
     "program files (x86)",
+    "programdata",
     "windows",
 }
 DEFAULT_EXCLUDED_PATH_SEQUENCES = {
+    ("appdata", "local"),
     ("appdata", "local", "temp"),
+    ("appdata", "roaming", "code", "user", "history"),
 }
 
 yaml = YAML(typ="safe", pure=True)
@@ -110,6 +113,8 @@ def should_exclude_directory(path: Path, root: Path, enabled: bool = True) -> bo
     if not parts:
         return False
     if parts[0] in DEFAULT_EXCLUDED_TOP_LEVEL_DIR_NAMES:
+        return True
+    if any(part.startswith(".") for part in parts):
         return True
     if any(part in DEFAULT_EXCLUDED_DIR_NAMES for part in parts):
         return True
@@ -656,7 +661,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--no-default-excludes",
         action="store_true",
-        help="Disable built-in excludes such as Windows, Program Files, $Recycle.Bin, .git, node_modules, venv, and AppData\\Local\\Temp.",
+        help="Disable built-in excludes such as Windows, Program Files, ProgramData, $Recycle.Bin, dot-prefixed folders, .git, node_modules, venv, AppData\\Local, and VS Code history folders.",
     )
     return parser.parse_args()
 

--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -1,7 +1,10 @@
 import argparse
 import json
+import os
 import re
+import sys
 import tempfile
+import time
 import zipfile
 from collections import defaultdict
 from datetime import datetime
@@ -257,13 +260,23 @@ def normalize_nested_template_key(key: str, value: Any) -> list[tuple[str, Any]]
     return [(key, value)]
 
 
-def collect_yaml_files(inputs: list[Path]) -> tuple[list[Path], list[tempfile.TemporaryDirectory]]:
+def collect_yaml_files(inputs: list[Path], discovery_callback=None) -> tuple[list[Path], list[tempfile.TemporaryDirectory]]:
     yaml_files: list[Path] = []
     temp_dirs: list[tempfile.TemporaryDirectory] = []
     for input_path in inputs:
         if input_path.is_dir():
-            yaml_files.extend(sorted(input_path.rglob("*.yml")))
-            yaml_files.extend(sorted(input_path.rglob("*.yaml")))
+            if discovery_callback:
+                discovery_callback("root", input_path, len(yaml_files))
+            for current_root, _, filenames in os.walk(input_path):
+                current_path = Path(current_root)
+                if discovery_callback:
+                    discovery_callback("dir", current_path, len(yaml_files))
+                for filename in filenames:
+                    lower = filename.lower()
+                    if lower.endswith(".yml") or lower.endswith(".yaml"):
+                        yaml_files.append(current_path / filename)
+            if discovery_callback:
+                discovery_callback("root_done", input_path, len(yaml_files))
         elif input_path.is_file() and input_path.suffix.lower() in {".yml", ".yaml"}:
             yaml_files.append(input_path)
         elif input_path.is_file() and input_path.suffix.lower() == ".zip":
@@ -272,18 +285,50 @@ def collect_yaml_files(inputs: list[Path]) -> tuple[list[Path], list[tempfile.Te
             extract_root = Path(temp_dir.name)
             with zipfile.ZipFile(input_path) as zf:
                 zf.extractall(extract_root)
-            yaml_files.extend(sorted(extract_root.rglob("*.yml")))
-            yaml_files.extend(sorted(extract_root.rglob("*.yaml")))
+            if discovery_callback:
+                discovery_callback("zip", input_path, len(yaml_files))
+            for current_root, _, filenames in os.walk(extract_root):
+                current_path = Path(current_root)
+                if discovery_callback:
+                    discovery_callback("dir", current_path, len(yaml_files))
+                for filename in filenames:
+                    lower = filename.lower()
+                    if lower.endswith(".yml") or lower.endswith(".yaml"):
+                        yaml_files.append(current_path / filename)
         else:
             raise FileNotFoundError(f"Unsupported input path: {input_path}")
-    return yaml_files, temp_dirs
+    return sorted(yaml_files), temp_dirs
 
 
-def scan_uploaded_configs(input_files: list[Path]) -> list[dict[str, Any]]:
+def scan_uploaded_configs(
+    input_files: list[Path],
+    progress_callback=None,
+) -> tuple[list[dict[str, Any]], list[dict[str, str]], list[str]]:
     findings: list[dict[str, Any]] = []
-    for path in input_files:
-        data = load_yaml(path)
+    skipped_files: list[dict[str, str]] = []
+    parsed_file_paths: list[str] = []
+    parsed_count = 0
+    total_files = len(input_files)
+    for idx, path in enumerate(input_files, start=1):
+        try:
+            data = load_yaml(path)
+        except Exception as exc:
+            skipped_files.append(
+                {
+                    "file": str(path),
+                    "error_type": type(exc).__name__,
+                    "reason": str(exc),
+                    "detail": f"{type(exc).__name__}: {exc}",
+                }
+            )
+            if progress_callback:
+                progress_callback(idx, total_files, parsed_count, len(skipped_files), path)
+            continue
+        parsed_file_paths.append(str(path))
         if not isinstance(data, dict):
+            parsed_count += 1
+            if progress_callback:
+                progress_callback(idx, total_files, parsed_count, len(skipped_files), path)
             continue
         libraries = data.get("libraries")
         if isinstance(libraries, dict):
@@ -351,7 +396,10 @@ def scan_uploaded_configs(input_files: list[Path]) -> list[dict[str, Any]]:
                                 "value": raw_value,
                             }
                         )
-    return findings
+        parsed_count += 1
+        if progress_callback:
+            progress_callback(idx, total_files, parsed_count, len(skipped_files), path)
+    return findings, skipped_files, parsed_file_paths
 
 
 def parse_args() -> argparse.Namespace:
@@ -372,7 +420,69 @@ def parse_args() -> argparse.Namespace:
         default=str(ROOT),
         help="Path to the Quickstart repo root. Defaults to the repo containing this script.",
     )
+    parser.add_argument(
+        "--no-progress",
+        action="store_true",
+        help="Disable periodic progress output during long scans.",
+    )
     return parser.parse_args()
+
+
+def build_progress_callbacks(enabled: bool):
+    if not enabled:
+        return None, None
+
+    discovery_state = {"last_time": 0.0, "last_dirs": 0}
+    scan_state = {"last_time": 0.0, "last_index": 0}
+
+    def emit_discovery(event: str, current_path: Path, yaml_found: int) -> None:
+        now = time.monotonic()
+        if event == "root":
+            print(f"[progress] scanning root {current_path}", file=sys.stderr, flush=True)
+            discovery_state["last_time"] = now
+            return
+        if event == "zip":
+            print(f"[progress] extracting and scanning zip {current_path}", file=sys.stderr, flush=True)
+            discovery_state["last_time"] = now
+            return
+        if event == "root_done":
+            print(f"[progress] finished root {current_path} | discovered {yaml_found} YAML files so far", file=sys.stderr, flush=True)
+            discovery_state["last_time"] = now
+            return
+        discovery_state["last_dirs"] += 1
+        should_emit = (
+            discovery_state["last_dirs"] == 1
+            or discovery_state["last_dirs"] % 100 == 0
+            or now - discovery_state["last_time"] >= 5.0
+        )
+        if not should_emit:
+            return
+        print(
+            f"[progress] scanning directory {current_path} | discovered {yaml_found} YAML files",
+            file=sys.stderr,
+            flush=True,
+        )
+        discovery_state["last_time"] = now
+
+    def emit(index: int, total: int, parsed: int, skipped: int, current_path: Path) -> None:
+        now = time.monotonic()
+        should_emit = (
+            index == 1
+            or index == total
+            or index - scan_state["last_index"] >= 100
+            or now - scan_state["last_time"] >= 5.0
+        )
+        if not should_emit:
+            return
+        print(
+            f"[progress] {index}/{total} files | parsed {parsed} | skipped {skipped} | {current_path}",
+            file=sys.stderr,
+            flush=True,
+        )
+        scan_state["last_time"] = now
+        scan_state["last_index"] = index
+
+    return emit_discovery, emit
 
 
 def ensure_json_output_path(root: Path, requested_output: str | None) -> Path:
@@ -433,7 +543,9 @@ def render_summary(report: dict[str, Any], json_output_path: Path) -> str:
 
     lines = [
         "Template Variable Gap Summary",
-        f"  files scanned: {len(report.get('uploaded_files_scanned', []))}",
+        f"  files parsed: {report.get('parsed_file_count', 0)}",
+        f"  files skipped: {report.get('skipped_file_count', 0)}",
+        f"  files with template variables: {report.get('files_with_template_variables_count', 0)}",
         f"  template variable occurrences scanned: {report.get('template_variable_occurrences_scanned', 0)}",
         f"  verified gaps: {report.get('verified_gap_count', 0)}",
         f"  value-shape verified gaps: {report.get('value_shape_verified_gap_count', 0)}",
@@ -450,6 +562,14 @@ def render_summary(report: dict[str, Any], json_output_path: Path) -> str:
         lines.append(render_table("Playlist Gaps", playlists))
     if libraries:
         lines.append(render_table("Library Gaps", libraries))
+    skipped_files = report.get("skipped_files", [])
+    if skipped_files:
+        lines.append("Skipped Files")
+        for item in skipped_files[:10]:
+            lines.append(f"  {item.get('file')}: {item.get('error_type')}")
+        remaining = len(skipped_files) - min(len(skipped_files), 10)
+        if remaining > 0:
+            lines.append(f"  ... plus {remaining} more skipped files")
     lines.append(f"Full JSON report: {json_output_path}")
     return "\n".join(lines)
 
@@ -463,13 +583,20 @@ def main() -> None:
     qs_attributes_path = root / "static" / "json" / "quickstart_attributes.json"
 
     inputs = [Path(p).resolve() for p in args.input] if args.input else [root / "artifacts" / "config_zip_scan"]
-    input_files, temp_dirs = collect_yaml_files(inputs)
+    discovery_callback, progress_callback = build_progress_callbacks(not args.no_progress)
+    input_files, temp_dirs = collect_yaml_files(inputs, discovery_callback=discovery_callback)
 
     try:
         qs_collections = build_qs_collection_map(qs_collections_path)
         qs_overlays = build_qs_overlay_map(qs_overlays_path)
         qs_library_keys = build_qs_library_template_keys(qs_attributes_path)
-        uploaded = scan_uploaded_configs(input_files)
+        if progress_callback:
+            print(
+                f"[progress] discovered {len(input_files)} YAML files across {len(inputs)} input root(s)",
+                file=sys.stderr,
+                flush=True,
+            )
+        uploaded, skipped_files, parsed_file_paths = scan_uploaded_configs(input_files, progress_callback=progress_callback)
 
         gap_rows: list[dict[str, Any]] = []
         all_rows: list[dict[str, Any]] = []
@@ -573,7 +700,12 @@ def main() -> None:
         report = {
             "quickstart_root": str(root),
             "inputs": [str(p) for p in inputs],
+            "parsed_files": sorted(parsed_file_paths),
             "uploaded_files_scanned": sorted({row["file"] for row in uploaded}),
+            "skipped_files": skipped_files,
+            "skipped_file_count": len(skipped_files),
+            "parsed_file_count": len(parsed_file_paths),
+            "files_with_template_variables_count": len(sorted({row["file"] for row in uploaded})),
             "template_variable_occurrences_scanned": len(uploaded),
             "verified_gap_count": len(serializable_ranked),
             "value_shape_verified_gap_count": sum(1 for item in serializable_ranked if item["value_shape_verified_occurrences"] > 0),

--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -1,0 +1,601 @@
+import argparse
+import json
+import re
+import tempfile
+import zipfile
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+yaml = YAML(typ="safe", pure=True)
+
+
+def load_yaml(path: Path) -> Any:
+    return yaml.load(path.read_text(encoding="utf-8"))
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def collect_qs_keys(raw: Any) -> set[str]:
+    keys: set[str] = set()
+    if isinstance(raw, dict):
+        keys.update(str(k) for k in raw.keys())
+    elif isinstance(raw, list):
+        for item in raw:
+            if isinstance(item, dict) and item.get("key"):
+                keys.add(str(item["key"]))
+    return keys
+
+
+def build_qs_collection_map(qs_collections_path: Path) -> dict[str, set[str]]:
+    data = load_json(qs_collections_path)
+    mapping: dict[str, set[str]] = {}
+    for group in data:
+        if not isinstance(group, dict):
+            continue
+        for collection in group.get("collections", []):
+            if not isinstance(collection, dict):
+                continue
+            cid = collection.get("id")
+            if not cid:
+                continue
+            alias = str(cid).replace("collection_", "", 1)
+            mapping[alias] = collect_qs_keys(collection.get("template_variables"))
+    return mapping
+
+
+def build_qs_overlay_map(qs_overlays_path: Path) -> dict[str, set[str]]:
+    data = load_json(qs_overlays_path)
+    mapping: dict[str, set[str]] = {}
+    for group in data:
+        if not isinstance(group, dict):
+            continue
+        for overlay in group.get("overlays", []):
+            if not isinstance(overlay, dict):
+                continue
+            oid = overlay.get("id")
+            if not oid:
+                continue
+            alias = str(oid).replace("overlay_", "", 1)
+            mapping[alias] = collect_qs_keys(overlay.get("template_variables"))
+    return mapping
+
+
+def build_qs_library_template_keys(qs_attributes_path: Path) -> set[str]:
+    data = load_json(qs_attributes_path)
+    keys: set[str] = set()
+    for section in data.get("sections", []):
+        if isinstance(section, dict) and section.get("yml_location") == "template_variables" and section.get("prefix"):
+            keys.add(str(section["prefix"]))
+    return keys
+
+
+def resolve_default_paths(alias: str, kind: str, kometa_defaults: Path) -> list[Path]:
+    if kind == "overlay":
+        path = kometa_defaults / "overlays" / f"{alias}.yml"
+        return [path] if path.exists() else []
+    if kind == "playlist":
+        path = kometa_defaults / "playlist.yml"
+        return [path] if path.exists() else []
+    matches = sorted(kometa_defaults.rglob(f"{alias}.yml"))
+    return [p for p in matches if p.is_file()]
+
+
+KEY_RE = re.compile(r"^\s*([A-Za-z0-9_<>-]+(?:\.[A-Za-z0-9_<>-]+)?)\s*:\s*(?:.*)?$")
+LIST_RE = re.compile(r"^\s*-\s+([A-Za-z0-9_<>-]+(?:\.[A-Za-z0-9_<>-]+)?)\s*$")
+PLACEHOLDER_RE = re.compile(r"<<[^>]+>>")
+
+RESERVED = {
+    "external_templates",
+    "templates",
+    "collections",
+    "overlays",
+    "playlists",
+    "default",
+    "optional",
+    "conditionals",
+    "conditions",
+    "variables",
+    "template",
+    "value",
+    "key",
+    "type",
+    "group",
+    "run_definition",
+    "allowed_libraries",
+    "mapping_name",
+    "mapping_name_encoded",
+    "search",
+    "filters",
+    "plex_search",
+    "plex_all",
+    "ignore_blank_results",
+    "validate",
+    "all",
+    "any",
+    "name",
+    "summary",
+}
+
+
+def patterns_from_default_file(path: Path) -> set[str]:
+    patterns: set[str] = set()
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.rstrip()
+        km = KEY_RE.match(line)
+        lm = LIST_RE.match(line)
+        token = None
+        if km:
+            token = km.group(1)
+        elif lm:
+            token = lm.group(1)
+        if not token:
+            continue
+        if token in RESERVED:
+            continue
+        patterns.add(token)
+        if token.endswith(".exists"):
+            patterns.add(token[: -len(".exists")])
+    return patterns
+
+
+def key_matches_pattern(key: str, pattern: str) -> bool:
+    if key == pattern:
+        return True
+    regex = "^" + PLACEHOLDER_RE.sub(lambda _: r"[^:\s]+", re.escape(pattern)) + "$"
+    return re.match(regex, key) is not None
+
+
+def key_is_valid_for_default(key: str, default_files: list[Path]) -> tuple[bool, list[Path]]:
+    matched: list[Path] = []
+    for path in default_files:
+        for pattern in patterns_from_default_file(path):
+            if key_matches_pattern(key, pattern):
+                matched.append(path)
+                break
+    return bool(matched), matched
+
+
+BOOL_PREFIXES = (
+    "use_",
+    "build_",
+    "remove_",
+    "delete_",
+    "create_",
+    "save_",
+    "show_",
+)
+BOOL_EXACT = {
+    "custom_keys",
+    "sync",
+    "test",
+}
+NUMERIC_HINTS = {
+    "horizontal_offset",
+    "vertical_offset",
+    "back_width",
+    "back_height",
+    "back_padding",
+    "back_radius",
+    "back_line_width",
+    "font_size",
+    "stroke_width",
+    "weight",
+    "overlay_limit",
+    "minimum_items",
+    "data_increment",
+}
+LIST_HINTS = {
+    "libraries",
+    "languages",
+    "exclude",
+    "include",
+    "append_exclude",
+    "append_include",
+    "remove_exclude",
+    "remove_include",
+}
+STRING_HINTS = {
+    "file",
+    "text",
+    "final_name",
+    "horizontal_align",
+    "vertical_align",
+    "horizontal_position",
+    "vertical_position",
+    "style",
+    "collection_mode",
+    "sync_mode",
+    "back_align",
+    "back_color",
+    "back_line_color",
+    "font",
+    "font_color",
+    "stroke_color",
+    "language",
+}
+URLISH_PREFIXES = (
+    "trakt_list_",
+    "imdb_list_",
+    "mdblist_list_",
+    "url_",
+    "git_",
+    "repo_",
+    "file_",
+)
+
+
+def infer_value_shape(value: Any, key: str) -> tuple[bool | None, str]:
+    if key in BOOL_EXACT or key.startswith(BOOL_PREFIXES):
+        return isinstance(value, bool), "bool"
+    if key in NUMERIC_HINTS:
+        return isinstance(value, (int, float)) and not isinstance(value, bool), "number"
+    if key in LIST_HINTS:
+        if isinstance(value, list):
+            return True, "list"
+        if isinstance(value, str):
+            return True, "string_or_list"
+        return False, "string_or_list"
+    if key in STRING_HINTS or key.startswith(URLISH_PREFIXES):
+        return isinstance(value, str), "string"
+    if key.startswith(("data_", "summary_", "name_")):
+        return isinstance(value, (str, int, float, bool, list, dict)), "dynamic"
+    return None, "unknown"
+
+
+def normalize_nested_template_key(key: str, value: Any) -> list[tuple[str, Any]]:
+    if key == "data" and isinstance(value, dict):
+        return [(f"data_{subkey}", subvalue) for subkey, subvalue in value.items()]
+    return [(key, value)]
+
+
+def collect_yaml_files(inputs: list[Path]) -> tuple[list[Path], list[tempfile.TemporaryDirectory]]:
+    yaml_files: list[Path] = []
+    temp_dirs: list[tempfile.TemporaryDirectory] = []
+    for input_path in inputs:
+        if input_path.is_dir():
+            yaml_files.extend(sorted(input_path.rglob("*.yml")))
+            yaml_files.extend(sorted(input_path.rglob("*.yaml")))
+        elif input_path.is_file() and input_path.suffix.lower() in {".yml", ".yaml"}:
+            yaml_files.append(input_path)
+        elif input_path.is_file() and input_path.suffix.lower() == ".zip":
+            temp_dir = tempfile.TemporaryDirectory(prefix="qs_template_gap_")
+            temp_dirs.append(temp_dir)
+            extract_root = Path(temp_dir.name)
+            with zipfile.ZipFile(input_path) as zf:
+                zf.extractall(extract_root)
+            yaml_files.extend(sorted(extract_root.rglob("*.yml")))
+            yaml_files.extend(sorted(extract_root.rglob("*.yaml")))
+        else:
+            raise FileNotFoundError(f"Unsupported input path: {input_path}")
+    return yaml_files, temp_dirs
+
+
+def scan_uploaded_configs(input_files: list[Path]) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    for path in input_files:
+        data = load_yaml(path)
+        if not isinstance(data, dict):
+            continue
+        libraries = data.get("libraries")
+        if isinstance(libraries, dict):
+            for library_name, lib_cfg in libraries.items():
+                if not isinstance(lib_cfg, dict):
+                    continue
+                tv = lib_cfg.get("template_variables")
+                if isinstance(tv, dict):
+                    for raw_key, raw_value in tv.items():
+                        for key, value in normalize_nested_template_key(str(raw_key), raw_value):
+                            findings.append(
+                                {
+                                    "file": str(path),
+                                    "library": str(library_name),
+                                    "section": "library_template_variables",
+                                    "default": None,
+                                    "kind": "library",
+                                    "key": key,
+                                    "value": value,
+                                }
+                            )
+                for section_name, kind in (("collection_files", "collection"), ("overlay_files", "overlay")):
+                    entries = lib_cfg.get(section_name)
+                    if not isinstance(entries, list):
+                        continue
+                    for entry in entries:
+                        if not isinstance(entry, dict):
+                            continue
+                        alias = entry.get("default")
+                        tv = entry.get("template_variables")
+                        if not alias or not isinstance(tv, dict):
+                            continue
+                        for raw_key, raw_value in tv.items():
+                            for key, value in normalize_nested_template_key(str(raw_key), raw_value):
+                                findings.append(
+                                    {
+                                    "file": str(path),
+                                    "library": str(library_name),
+                                    "section": section_name,
+                                        "default": str(alias),
+                                        "kind": kind,
+                                        "key": key,
+                                        "value": value,
+                                    }
+                                )
+        playlist_files = data.get("playlist_files")
+        if isinstance(playlist_files, list):
+            for entry in playlist_files:
+                if not isinstance(entry, dict):
+                    continue
+                alias = entry.get("default")
+                tv = entry.get("template_variables")
+                if not alias or not isinstance(tv, dict):
+                    continue
+                for raw_key, raw_value in tv.items():
+                    for key, value in normalize_nested_template_key(str(raw_key), raw_value):
+                        findings.append(
+                            {
+                                "file": str(path),
+                                "library": None,
+                                "section": "playlist_files",
+                                "default": str(alias),
+                                "kind": "playlist",
+                                "key": key,
+                                "value": raw_value,
+                            }
+                        )
+    return findings
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Find template variables used in uploaded configs that are valid in Kometa but not exposed in Quickstart."
+    )
+    parser.add_argument(
+        "--input",
+        nargs="+",
+        help="YAML file, folder, or ZIP to scan. Can be passed multiple times or with multiple values.",
+    )
+    parser.add_argument(
+        "--output",
+        help="Optional JSON output file path. If omitted, writes to artifacts/template_gap_reports/<timestamp>.json.",
+    )
+    parser.add_argument(
+        "--quickstart-root",
+        default=str(ROOT),
+        help="Path to the Quickstart repo root. Defaults to the repo containing this script.",
+    )
+    return parser.parse_args()
+
+
+def ensure_json_output_path(root: Path, requested_output: str | None) -> Path:
+    if requested_output:
+        return Path(requested_output).resolve()
+    report_dir = root / "artifacts" / "template_gap_reports"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    return report_dir / f"template_gap_report_{timestamp}.json"
+
+
+def compact_path_list(paths: list[str], limit: int = 3) -> str:
+    if not paths:
+        return "-"
+    shown = paths[:limit]
+    text = ", ".join(shown)
+    remaining = len(paths) - len(shown)
+    if remaining > 0:
+        text += f" +{remaining}"
+    return text
+
+
+def render_table(title: str, rows: list[dict[str, Any]]) -> str:
+    if not rows:
+        return f"{title}\n  none\n"
+    headers = ["default", "key", "occ", "shape ok", "shape ?", "files", "libraries", "kometa file"]
+    table_rows = []
+    for row in rows:
+        table_rows.append(
+            [
+                str(row.get("default") or "-"),
+                str(row.get("key") or "-"),
+                str(row.get("occurrences", 0)),
+                str(row.get("value_shape_verified_occurrences", 0)),
+                str(row.get("value_shape_unknown_occurrences", 0)),
+                str(row.get("file_count", 0)),
+                compact_path_list(row.get("libraries", []), limit=2),
+                compact_path_list(row.get("matched_default_files", []), limit=2),
+            ]
+        )
+    widths = []
+    for col_idx, header in enumerate(headers):
+        widths.append(max(len(header), *(len(r[col_idx]) for r in table_rows)))
+
+    def fmt(row: list[str]) -> str:
+        return "  " + " | ".join(cell.ljust(widths[idx]) for idx, cell in enumerate(row))
+
+    lines = [title, fmt(headers), "  " + "-+-".join("-" * width for width in widths)]
+    lines.extend(fmt(row) for row in table_rows)
+    return "\n".join(lines) + "\n"
+
+
+def render_summary(report: dict[str, Any], json_output_path: Path) -> str:
+    overlays = report.get("verified_gaps_by_kind", {}).get("overlay", [])
+    collections = report.get("verified_gaps_by_kind", {}).get("collection", [])
+    playlists = report.get("verified_gaps_by_kind", {}).get("playlist", [])
+    libraries = report.get("verified_gaps_by_kind", {}).get("library", [])
+
+    lines = [
+        "Template Variable Gap Summary",
+        f"  files scanned: {len(report.get('uploaded_files_scanned', []))}",
+        f"  template variable occurrences scanned: {report.get('template_variable_occurrences_scanned', 0)}",
+        f"  verified gaps: {report.get('verified_gap_count', 0)}",
+        f"  value-shape verified gaps: {report.get('value_shape_verified_gap_count', 0)}",
+        f"  overlay gaps: {len(overlays)}",
+        f"  collection gaps: {len(collections)}",
+        f"  playlist gaps: {len(playlists)}",
+        f"  library gaps: {len(libraries)}",
+        "  runtime guaranteed: false",
+        "",
+        render_table("Overlay Gaps", overlays),
+        render_table("Collection Gaps", collections),
+    ]
+    if playlists:
+        lines.append(render_table("Playlist Gaps", playlists))
+    if libraries:
+        lines.append(render_table("Library Gaps", libraries))
+    lines.append(f"Full JSON report: {json_output_path}")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    args = parse_args()
+    root = Path(args.quickstart_root).resolve()
+    kometa_defaults = root / "config" / "kometa" / "defaults"
+    qs_collections_path = root / "static" / "json" / "quickstart_collections.json"
+    qs_overlays_path = root / "static" / "json" / "quickstart_overlays.json"
+    qs_attributes_path = root / "static" / "json" / "quickstart_attributes.json"
+
+    inputs = [Path(p).resolve() for p in args.input] if args.input else [root / "artifacts" / "config_zip_scan"]
+    input_files, temp_dirs = collect_yaml_files(inputs)
+
+    try:
+        qs_collections = build_qs_collection_map(qs_collections_path)
+        qs_overlays = build_qs_overlay_map(qs_overlays_path)
+        qs_library_keys = build_qs_library_template_keys(qs_attributes_path)
+        uploaded = scan_uploaded_configs(input_files)
+
+        gap_rows: list[dict[str, Any]] = []
+        all_rows: list[dict[str, Any]] = []
+        grouped_examples: dict[tuple[str, str | None, str], list[str]] = defaultdict(list)
+
+        for row in uploaded:
+            key = row["key"]
+            kind = row["kind"]
+            alias = row["default"]
+            if kind == "collection":
+                supported = key in qs_collections.get(alias or "", set())
+                default_files = resolve_default_paths(alias or "", kind, kometa_defaults)
+                name_verified, matched_files = key_is_valid_for_default(key, default_files)
+            elif kind == "overlay":
+                supported = key in qs_overlays.get(alias or "", set())
+                default_files = resolve_default_paths(alias or "", kind, kometa_defaults)
+                name_verified, matched_files = key_is_valid_for_default(key, default_files)
+            elif kind == "playlist":
+                supported = False
+                default_files = resolve_default_paths(alias or "", kind, kometa_defaults)
+                name_verified, matched_files = key_is_valid_for_default(key, default_files)
+            else:
+                supported = key in qs_library_keys
+                name_verified = True
+                matched_files = []
+
+            value_shape_verified, value_shape_rule = infer_value_shape(row["value"], key)
+            out = dict(row)
+            out["supported_in_quickstart"] = supported
+            out["name_verified"] = name_verified
+            out["value_shape_verified"] = value_shape_verified
+            out["value_shape_rule"] = value_shape_rule
+            out["runtime_guaranteed"] = False
+            out["valid_for_kometa"] = name_verified
+            out["matched_default_files"] = [str(p.relative_to(kometa_defaults)) for p in matched_files]
+            all_rows.append(out)
+
+            if name_verified and not supported:
+                gap_rows.append(out)
+                grouped_examples[(kind, alias, key)].append(row["file"])
+
+        summary: dict[tuple[str, str | None, str], dict[str, Any]] = {}
+        for row in gap_rows:
+            bucket = summary.setdefault(
+                (row["kind"], row["default"], row["key"]),
+                {
+                    "kind": row["kind"],
+                    "default": row["default"],
+                    "key": row["key"],
+                    "occurrences": 0,
+                    "files": set(),
+                    "libraries": set(),
+                    "matched_default_files": set(),
+                    "value_shape_verified_occurrences": 0,
+                    "value_shape_unknown_occurrences": 0,
+                    "value_shape_rules": set(),
+                },
+            )
+            bucket["occurrences"] += 1
+            bucket["files"].add(row["file"])
+            if row["library"]:
+                bucket["libraries"].add(row["library"])
+            for item in row["matched_default_files"]:
+                bucket["matched_default_files"].add(item)
+            if row["value_shape_verified"] is True:
+                bucket["value_shape_verified_occurrences"] += 1
+            elif row["value_shape_verified"] is None:
+                bucket["value_shape_unknown_occurrences"] += 1
+            bucket["value_shape_rules"].add(row["value_shape_rule"])
+
+        ranked = sorted(
+            summary.values(),
+            key=lambda item: (-item["occurrences"], -len(item["files"]), str(item["default"]), str(item["key"])),
+        )
+
+        serializable_ranked = []
+        for item in ranked:
+            serializable_ranked.append(
+                {
+                    "kind": item["kind"],
+                    "default": item["default"],
+                    "key": item["key"],
+                    "occurrences": item["occurrences"],
+                    "file_count": len(item["files"]),
+                    "files": sorted(item["files"]),
+                    "libraries": sorted(item["libraries"]),
+                    "matched_default_files": sorted(item["matched_default_files"]),
+                    "name_verified": True,
+                    "value_shape_verified_occurrences": item["value_shape_verified_occurrences"],
+                    "value_shape_unknown_occurrences": item["value_shape_unknown_occurrences"],
+                    "value_shape_rules": sorted(item["value_shape_rules"]),
+                    "runtime_guaranteed": False,
+                }
+            )
+
+        by_kind: dict[str, list[dict[str, Any]]] = {"overlay": [], "collection": [], "playlist": [], "library": []}
+        for item in serializable_ranked:
+            kind_key = item["kind"] if item["kind"] in by_kind else "library"
+            by_kind[kind_key].append(item)
+
+        report = {
+            "quickstart_root": str(root),
+            "inputs": [str(p) for p in inputs],
+            "uploaded_files_scanned": sorted({row["file"] for row in uploaded}),
+            "template_variable_occurrences_scanned": len(uploaded),
+            "verified_gap_count": len(serializable_ranked),
+            "value_shape_verified_gap_count": sum(1 for item in serializable_ranked if item["value_shape_verified_occurrences"] > 0),
+            "verification_notes": {
+                "name_verified": "Key name matched a variable declared or referenced in the corresponding built-in Kometa default.",
+                "value_shape_verified": "Best-effort local heuristic that the supplied value looks like the expected basic type. Null means no reliable local rule was inferred.",
+                "runtime_guaranteed": False,
+            },
+            "verified_gaps_ranked": serializable_ranked,
+            "verified_gaps_by_kind": by_kind,
+            "all_rows": all_rows,
+        }
+    finally:
+        for temp_dir in temp_dirs:
+            temp_dir.cleanup()
+
+    json_output_path = ensure_json_output_path(root, args.output)
+    json_output_path.parent.mkdir(parents=True, exist_ok=True)
+    rendered = json.dumps(report, indent=2)
+    json_output_path.write_text(rendered, encoding="utf-8")
+    print(render_summary(report, json_output_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -14,7 +14,6 @@ from typing import Any
 
 from ruamel.yaml import YAML
 
-
 ROOT = Path(__file__).resolve().parents[1]
 CACHE_VERSION = 3
 
@@ -122,12 +121,7 @@ def normalized_parts(path: Path) -> list[str]:
 
 def is_virtualenv_dir_name(name: str) -> bool:
     lowered = name.lower()
-    return (
-        lowered == "venv"
-        or lowered.endswith("-venv")
-        or lowered.endswith("_venv")
-        or lowered.startswith("py_env-python")
-    )
+    return lowered == "venv" or lowered.endswith("-venv") or lowered.endswith("_venv") or lowered.startswith("py_env-python")
 
 
 def has_part_sequence(parts: list[str], sequence: tuple[str, ...]) -> bool:
@@ -518,11 +512,7 @@ def collect_yaml_files(
                 if should_exclude_directory(current_path, input_path, enabled=exclude_defaults):
                     dirnames[:] = []
                     continue
-                dirnames[:] = [
-                    dirname
-                    for dirname in dirnames
-                    if not should_exclude_directory(current_path / dirname, input_path, enabled=exclude_defaults)
-                ]
+                dirnames[:] = [dirname for dirname in dirnames if not should_exclude_directory(current_path / dirname, input_path, enabled=exclude_defaults)]
                 if discovery_callback:
                     discovery_callback("dir", current_path, len(yaml_files))
                 for filename in filenames:
@@ -546,11 +536,7 @@ def collect_yaml_files(
                 if should_exclude_directory(current_path, extract_root, enabled=exclude_defaults):
                     dirnames[:] = []
                     continue
-                dirnames[:] = [
-                    dirname
-                    for dirname in dirnames
-                    if not should_exclude_directory(current_path / dirname, extract_root, enabled=exclude_defaults)
-                ]
+                dirnames[:] = [dirname for dirname in dirnames if not should_exclude_directory(current_path / dirname, extract_root, enabled=exclude_defaults)]
                 if discovery_callback:
                     discovery_callback("dir", current_path, len(yaml_files))
                 for filename in filenames:
@@ -668,9 +654,7 @@ def scan_uploaded_configs(
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Find template variables used in uploaded configs that are valid in Kometa but not exposed in Quickstart."
-    )
+    parser = argparse.ArgumentParser(description="Find template variables used in uploaded configs that are valid in Kometa but not exposed in Quickstart.")
     parser.add_argument(
         "--input",
         nargs="+",
@@ -743,11 +727,7 @@ def build_progress_callbacks(enabled: bool):
             discovery_state["last_time"] = now
             return
         discovery_state["last_dirs"] += 1
-        should_emit = (
-            discovery_state["last_dirs"] == 1
-            or discovery_state["last_dirs"] % 100 == 0
-            or now - discovery_state["last_time"] >= 5.0
-        )
+        should_emit = discovery_state["last_dirs"] == 1 or discovery_state["last_dirs"] % 100 == 0 or now - discovery_state["last_time"] >= 5.0
         if not should_emit:
             return
         print(
@@ -759,12 +739,7 @@ def build_progress_callbacks(enabled: bool):
 
     def emit(index: int, total: int, parsed: int, skipped: int, current_path: Path) -> None:
         now = time.monotonic()
-        should_emit = (
-            index == 1
-            or index == total
-            or index - scan_state["last_index"] >= 100
-            or now - scan_state["last_time"] >= 5.0
-        )
+        should_emit = index == 1 or index == total or index - scan_state["last_index"] >= 100 or now - scan_state["last_time"] >= 5.0
         if not should_emit:
             return
         print(
@@ -783,13 +758,7 @@ def build_progress_callbacks(enabled: bool):
             verify_state["last_stage"] = stage
             verify_state["last_index"] = 0
             return
-        should_emit = (
-            index == 1
-            or index == total
-            or stage != verify_state["last_stage"]
-            or index - verify_state["last_index"] >= 500
-            or now - verify_state["last_time"] >= 5.0
-        )
+        should_emit = index == 1 or index == total or stage != verify_state["last_stage"] or index - verify_state["last_index"] >= 500 or now - verify_state["last_time"] >= 5.0
         if not should_emit:
             return
         print(f"[progress][{elapsed_label()}] {stage} {index}/{total}", file=sys.stderr, flush=True)

--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -16,11 +16,34 @@ from ruamel.yaml import YAML
 
 
 ROOT = Path(__file__).resolve().parents[1]
-CACHE_VERSION = 2
+CACHE_VERSION = 3
 
 DEFAULT_EXCLUDED_DIR_NAMES = {
     ".git",
+    ".venv",
+    "__pycache__",
+    "assets",
+    "bin",
+    "build",
+    "cache",
+    "cache_data",
+    "dist",
+    "downloads",
+    "images",
+    "img",
+    "log",
+    "logs",
     "node_modules",
+    "obj",
+    "output",
+    "packages",
+    "photos",
+    "pictures",
+    "site-packages",
+    "temp",
+    "tmp",
+    "vendor",
+    "videos",
     "venv",
 }
 DEFAULT_EXCLUDED_TOP_LEVEL_DIR_NAMES = {
@@ -34,6 +57,10 @@ DEFAULT_EXCLUDED_PATH_SEQUENCES = {
     ("appdata", "local"),
     ("appdata", "local", "temp"),
     ("appdata", "roaming", "code", "user", "history"),
+    ("defaults-image-creation", "create_people_posters", "config", "chrome-profile"),
+    ("onedrive",),
+    ("users", "default"),
+    ("users", "public"),
 }
 
 yaml = YAML(typ="safe", pure=True)
@@ -675,7 +702,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--no-default-excludes",
         action="store_true",
-        help="Disable built-in excludes such as Windows, Program Files, ProgramData, $Recycle.Bin, dot-prefixed folders, .git, node_modules, common virtualenv folders, all AppData trees, and VS Code history folders.",
+        help="Disable built-in excludes such as Windows, Program Files, ProgramData, $Recycle.Bin, dot-prefixed folders, .git, node_modules, common virtualenv folders, all AppData trees, OneDrive, common media/output/cache/build directories, and VS Code history folders.",
     )
     return parser.parse_args()
 

--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -1,4 +1,5 @@
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -15,6 +16,7 @@ from ruamel.yaml import YAML
 
 
 ROOT = Path(__file__).resolve().parents[1]
+CACHE_VERSION = 2
 
 yaml = YAML(typ="safe", pure=True)
 
@@ -25,6 +27,79 @@ def load_yaml(path: Path) -> Any:
 
 def load_json(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def empty_cache(context: dict[str, Any] | None = None) -> dict[str, Any]:
+    cache: dict[str, Any] = {"version": CACHE_VERSION, "files": {}}
+    if context is not None:
+        cache["context"] = context
+    return cache
+
+
+def load_cache(path: Path, expected_context: dict[str, Any] | None = None) -> dict[str, Any]:
+    if not path.exists():
+        return empty_cache(expected_context)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return empty_cache(expected_context)
+    if not isinstance(data, dict) or data.get("version") != CACHE_VERSION or not isinstance(data.get("files"), dict):
+        return empty_cache(expected_context)
+    if expected_context is not None and data.get("context") != expected_context:
+        return empty_cache(expected_context)
+    return data
+
+
+def save_cache(path: Path, cache_data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(cache_data, indent=2), encoding="utf-8")
+
+
+def get_cache_path(root: Path, requested_path: str | None) -> Path:
+    if requested_path:
+        return Path(requested_path).resolve()
+    return root / "artifacts" / "template_gap_cache.json"
+
+
+def file_signature(path: Path) -> dict[str, int]:
+    stat = path.stat()
+    return {"size": stat.st_size, "mtime_ns": stat.st_mtime_ns}
+
+
+def relative_label(path: Path, base: Path) -> str:
+    try:
+        return str(path.relative_to(base))
+    except ValueError:
+        return str(path.resolve())
+
+
+def fingerprint_paths(paths: list[Path], base: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(paths, key=lambda p: relative_label(p, base)):
+        signature = file_signature(path)
+        digest.update(relative_label(path, base).encode("utf-8"))
+        digest.update(str(signature["size"]).encode("utf-8"))
+        digest.update(str(signature["mtime_ns"]).encode("utf-8"))
+    return digest.hexdigest()
+
+
+def build_cache_context(
+    root: Path,
+    qs_collections_path: Path,
+    qs_overlays_path: Path,
+    qs_attributes_path: Path,
+    kometa_defaults: Path,
+) -> dict[str, Any]:
+    quickstart_support_files = [qs_collections_path, qs_overlays_path, qs_attributes_path]
+    kometa_default_files = [path for path in kometa_defaults.rglob("*.yml") if path.is_file()]
+    analyzer_file = Path(__file__).resolve()
+    return {
+        "quickstart_root": str(root),
+        "analyzer_signature": file_signature(analyzer_file),
+        "quickstart_support_fingerprint": fingerprint_paths(quickstart_support_files, root),
+        "kometa_defaults_fingerprint": fingerprint_paths(kometa_default_files, root),
+        "kometa_default_file_count": len(kometa_default_files),
+    }
 
 
 def collect_qs_keys(raw: Any) -> set[str]:
@@ -260,6 +335,77 @@ def normalize_nested_template_key(key: str, value: Any) -> list[tuple[str, Any]]
     return [(key, value)]
 
 
+def extract_findings_from_data(data: dict[str, Any], path: Path) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    libraries = data.get("libraries")
+    if isinstance(libraries, dict):
+        for library_name, lib_cfg in libraries.items():
+            if not isinstance(lib_cfg, dict):
+                continue
+            tv = lib_cfg.get("template_variables")
+            if isinstance(tv, dict):
+                for raw_key, raw_value in tv.items():
+                    for key, value in normalize_nested_template_key(str(raw_key), raw_value):
+                        findings.append(
+                            {
+                                "file": str(path),
+                                "library": str(library_name),
+                                "section": "library_template_variables",
+                                "default": None,
+                                "kind": "library",
+                                "key": key,
+                                "value": value,
+                            }
+                        )
+            for section_name, kind in (("collection_files", "collection"), ("overlay_files", "overlay")):
+                entries = lib_cfg.get(section_name)
+                if not isinstance(entries, list):
+                    continue
+                for entry in entries:
+                    if not isinstance(entry, dict):
+                        continue
+                    alias = entry.get("default")
+                    tv = entry.get("template_variables")
+                    if not alias or not isinstance(tv, dict):
+                        continue
+                    for raw_key, raw_value in tv.items():
+                        for key, value in normalize_nested_template_key(str(raw_key), raw_value):
+                            findings.append(
+                                {
+                                    "file": str(path),
+                                    "library": str(library_name),
+                                    "section": section_name,
+                                    "default": str(alias),
+                                    "kind": kind,
+                                    "key": key,
+                                    "value": value,
+                                }
+                            )
+    playlist_files = data.get("playlist_files")
+    if isinstance(playlist_files, list):
+        for entry in playlist_files:
+            if not isinstance(entry, dict):
+                continue
+            alias = entry.get("default")
+            tv = entry.get("template_variables")
+            if not alias or not isinstance(tv, dict):
+                continue
+            for raw_key, raw_value in tv.items():
+                for key, value in normalize_nested_template_key(str(raw_key), raw_value):
+                    findings.append(
+                        {
+                            "file": str(path),
+                            "library": None,
+                            "section": "playlist_files",
+                            "default": str(alias),
+                            "kind": "playlist",
+                            "key": key,
+                            "value": raw_value,
+                        }
+                    )
+    return findings
+
+
 def collect_yaml_files(inputs: list[Path], discovery_callback=None) -> tuple[list[Path], list[tempfile.TemporaryDirectory]]:
     yaml_files: list[Path] = []
     temp_dirs: list[tempfile.TemporaryDirectory] = []
@@ -300,106 +446,109 @@ def collect_yaml_files(inputs: list[Path], discovery_callback=None) -> tuple[lis
     return sorted(yaml_files), temp_dirs
 
 
+def prefilter_yaml_files(input_files: list[Path], cache_data: dict[str, Any] | None = None) -> tuple[list[Path], list[dict[str, str]], dict[str, int]]:
+    candidate_files: list[Path] = []
+    skipped_files: list[dict[str, str]] = []
+    stats = {"cache_hits": 0, "cache_misses": 0}
+    files_cache = cache_data.get("files", {}) if isinstance(cache_data, dict) else {}
+    for path in input_files:
+        cache_key = str(path)
+        signature = file_signature(path)
+        cached = files_cache.get(cache_key) if isinstance(files_cache, dict) else None
+        if isinstance(cached, dict) and cached.get("signature") == signature and "contains_template_variables" in cached:
+            stats["cache_hits"] += 1
+            if cached.get("prefilter_skip"):
+                skipped_files.append(dict(cached["prefilter_skip"]))
+                continue
+            if cached.get("contains_template_variables"):
+                candidate_files.append(path)
+            continue
+        stats["cache_misses"] += 1
+        try:
+            raw_text = path.read_text(encoding="utf-8")
+        except Exception as exc:
+            skip_record = {
+                "file": str(path),
+                "error_type": type(exc).__name__,
+                "reason": str(exc),
+                "detail": f"{type(exc).__name__}: {exc}",
+                "stage": "prefilter",
+            }
+            skipped_files.append(skip_record)
+            if isinstance(files_cache, dict):
+                files_cache[cache_key] = {"signature": signature, "prefilter_skip": skip_record, "contains_template_variables": False}
+            continue
+        contains_template_variables = "template_variables" in raw_text
+        if isinstance(files_cache, dict):
+            files_cache[cache_key] = {"signature": signature, "contains_template_variables": contains_template_variables}
+        if contains_template_variables:
+            candidate_files.append(path)
+    return candidate_files, skipped_files, stats
+
+
 def scan_uploaded_configs(
     input_files: list[Path],
     progress_callback=None,
-) -> tuple[list[dict[str, Any]], list[dict[str, str]], list[str]]:
+    cache_data: dict[str, Any] | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, str]], list[str], dict[str, int]]:
     findings: list[dict[str, Any]] = []
     skipped_files: list[dict[str, str]] = []
     parsed_file_paths: list[str] = []
     parsed_count = 0
     total_files = len(input_files)
+    stats = {"cache_hits": 0, "cache_misses": 0}
+    files_cache = cache_data.get("files", {}) if isinstance(cache_data, dict) else {}
     for idx, path in enumerate(input_files, start=1):
+        cache_key = str(path)
+        signature = file_signature(path)
+        cached = files_cache.get(cache_key) if isinstance(files_cache, dict) else None
+        if isinstance(cached, dict) and cached.get("signature") == signature and "scan_result" in cached:
+            stats["cache_hits"] += 1
+            scan_result = cached["scan_result"]
+            if scan_result.get("status") == "skip":
+                skipped_files.append(dict(scan_result["skip_record"]))
+                if progress_callback:
+                    progress_callback(idx, total_files, parsed_count, len(skipped_files), path)
+                continue
+            parsed_file_paths.append(str(path))
+            parsed_count += 1
+            findings.extend(scan_result.get("findings", []))
+            if progress_callback:
+                progress_callback(idx, total_files, parsed_count, len(skipped_files), path)
+            continue
+        stats["cache_misses"] += 1
         try:
             data = load_yaml(path)
         except Exception as exc:
-            skipped_files.append(
-                {
-                    "file": str(path),
-                    "error_type": type(exc).__name__,
-                    "reason": str(exc),
-                    "detail": f"{type(exc).__name__}: {exc}",
-                }
-            )
+            skip_record = {
+                "file": str(path),
+                "error_type": type(exc).__name__,
+                "reason": str(exc),
+                "detail": f"{type(exc).__name__}: {exc}",
+                "stage": "parse",
+            }
+            skipped_files.append(skip_record)
+            if isinstance(files_cache, dict):
+                files_cache[cache_key] = {"signature": signature, "contains_template_variables": True, "scan_result": {"status": "skip", "skip_record": skip_record}}
             if progress_callback:
                 progress_callback(idx, total_files, parsed_count, len(skipped_files), path)
             continue
         parsed_file_paths.append(str(path))
         if not isinstance(data, dict):
             parsed_count += 1
+            if isinstance(files_cache, dict):
+                files_cache[cache_key] = {"signature": signature, "contains_template_variables": True, "scan_result": {"status": "ok", "findings": []}}
             if progress_callback:
                 progress_callback(idx, total_files, parsed_count, len(skipped_files), path)
             continue
-        libraries = data.get("libraries")
-        if isinstance(libraries, dict):
-            for library_name, lib_cfg in libraries.items():
-                if not isinstance(lib_cfg, dict):
-                    continue
-                tv = lib_cfg.get("template_variables")
-                if isinstance(tv, dict):
-                    for raw_key, raw_value in tv.items():
-                        for key, value in normalize_nested_template_key(str(raw_key), raw_value):
-                            findings.append(
-                                {
-                                    "file": str(path),
-                                    "library": str(library_name),
-                                    "section": "library_template_variables",
-                                    "default": None,
-                                    "kind": "library",
-                                    "key": key,
-                                    "value": value,
-                                }
-                            )
-                for section_name, kind in (("collection_files", "collection"), ("overlay_files", "overlay")):
-                    entries = lib_cfg.get(section_name)
-                    if not isinstance(entries, list):
-                        continue
-                    for entry in entries:
-                        if not isinstance(entry, dict):
-                            continue
-                        alias = entry.get("default")
-                        tv = entry.get("template_variables")
-                        if not alias or not isinstance(tv, dict):
-                            continue
-                        for raw_key, raw_value in tv.items():
-                            for key, value in normalize_nested_template_key(str(raw_key), raw_value):
-                                findings.append(
-                                    {
-                                    "file": str(path),
-                                    "library": str(library_name),
-                                    "section": section_name,
-                                        "default": str(alias),
-                                        "kind": kind,
-                                        "key": key,
-                                        "value": value,
-                                    }
-                                )
-        playlist_files = data.get("playlist_files")
-        if isinstance(playlist_files, list):
-            for entry in playlist_files:
-                if not isinstance(entry, dict):
-                    continue
-                alias = entry.get("default")
-                tv = entry.get("template_variables")
-                if not alias or not isinstance(tv, dict):
-                    continue
-                for raw_key, raw_value in tv.items():
-                    for key, value in normalize_nested_template_key(str(raw_key), raw_value):
-                        findings.append(
-                            {
-                                "file": str(path),
-                                "library": None,
-                                "section": "playlist_files",
-                                "default": str(alias),
-                                "kind": "playlist",
-                                "key": key,
-                                "value": raw_value,
-                            }
-                        )
+        file_findings = extract_findings_from_data(data, path)
+        findings.extend(file_findings)
         parsed_count += 1
+        if isinstance(files_cache, dict):
+            files_cache[cache_key] = {"signature": signature, "contains_template_variables": True, "scan_result": {"status": "ok", "findings": file_findings}}
         if progress_callback:
             progress_callback(idx, total_files, parsed_count, len(skipped_files), path)
-    return findings, skipped_files, parsed_file_paths
+    return findings, skipped_files, parsed_file_paths, stats
 
 
 def parse_args() -> argparse.Namespace:
@@ -421,6 +570,15 @@ def parse_args() -> argparse.Namespace:
         help="Path to the Quickstart repo root. Defaults to the repo containing this script.",
     )
     parser.add_argument(
+        "--cache-path",
+        help="Optional cache JSON path. Defaults to artifacts/template_gap_cache.json.",
+    )
+    parser.add_argument(
+        "--no-cache",
+        action="store_true",
+        help="Disable incremental file-result caching for this run.",
+    )
+    parser.add_argument(
         "--no-progress",
         action="store_true",
         help="Disable periodic progress output during long scans.",
@@ -432,21 +590,34 @@ def build_progress_callbacks(enabled: bool):
     if not enabled:
         return None, None
 
+    start_time = time.monotonic()
     discovery_state = {"last_time": 0.0, "last_dirs": 0}
     scan_state = {"last_time": 0.0, "last_index": 0}
+
+    def elapsed_label() -> str:
+        elapsed = int(time.monotonic() - start_time)
+        minutes, seconds = divmod(elapsed, 60)
+        hours, minutes = divmod(minutes, 60)
+        if hours:
+            return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+        return f"{minutes:02d}:{seconds:02d}"
 
     def emit_discovery(event: str, current_path: Path, yaml_found: int) -> None:
         now = time.monotonic()
         if event == "root":
-            print(f"[progress] scanning root {current_path}", file=sys.stderr, flush=True)
+            print(f"[progress][{elapsed_label()}] scanning root {current_path}", file=sys.stderr, flush=True)
             discovery_state["last_time"] = now
             return
         if event == "zip":
-            print(f"[progress] extracting and scanning zip {current_path}", file=sys.stderr, flush=True)
+            print(f"[progress][{elapsed_label()}] extracting and scanning zip {current_path}", file=sys.stderr, flush=True)
             discovery_state["last_time"] = now
             return
         if event == "root_done":
-            print(f"[progress] finished root {current_path} | discovered {yaml_found} YAML files so far", file=sys.stderr, flush=True)
+            print(
+                f"[progress][{elapsed_label()}] finished root {current_path} | discovered {yaml_found} YAML files so far",
+                file=sys.stderr,
+                flush=True,
+            )
             discovery_state["last_time"] = now
             return
         discovery_state["last_dirs"] += 1
@@ -458,7 +629,7 @@ def build_progress_callbacks(enabled: bool):
         if not should_emit:
             return
         print(
-            f"[progress] scanning directory {current_path} | discovered {yaml_found} YAML files",
+            f"[progress][{elapsed_label()}] scanning directory {current_path} | discovered {yaml_found} YAML files",
             file=sys.stderr,
             flush=True,
         )
@@ -475,7 +646,7 @@ def build_progress_callbacks(enabled: bool):
         if not should_emit:
             return
         print(
-            f"[progress] {index}/{total} files | parsed {parsed} | skipped {skipped} | {current_path}",
+            f"[progress][{elapsed_label()}] {index}/{total} files | parsed {parsed} | skipped {skipped} | {current_path}",
             file=sys.stderr,
             flush=True,
         )
@@ -543,9 +714,15 @@ def render_summary(report: dict[str, Any], json_output_path: Path) -> str:
 
     lines = [
         "Template Variable Gap Summary",
+        f"  files discovered: {report.get('discovered_file_count', 0)}",
+        f"  files prefiltered: {report.get('prefiltered_file_count', 0)}",
         f"  files parsed: {report.get('parsed_file_count', 0)}",
         f"  files skipped: {report.get('skipped_file_count', 0)}",
         f"  files with template variables: {report.get('files_with_template_variables_count', 0)}",
+        f"  cache enabled: {report.get('cache_enabled', False)}",
+        f"  cache hits: {report.get('cache_hit_count', 0)}",
+        f"  cache misses: {report.get('cache_miss_count', 0)}",
+        "  cache invalidates on: analyzer, Quickstart support JSON, Kometa defaults, or source file changes",
         f"  template variable occurrences scanned: {report.get('template_variable_occurrences_scanned', 0)}",
         f"  verified gaps: {report.get('verified_gap_count', 0)}",
         f"  value-shape verified gaps: {report.get('value_shape_verified_gap_count', 0)}",
@@ -570,6 +747,8 @@ def render_summary(report: dict[str, Any], json_output_path: Path) -> str:
         remaining = len(skipped_files) - min(len(skipped_files), 10)
         if remaining > 0:
             lines.append(f"  ... plus {remaining} more skipped files")
+    if report.get("cache_enabled", False):
+        lines.append(f"Cache file: {report.get('cache_path')}")
     lines.append(f"Full JSON report: {json_output_path}")
     return "\n".join(lines)
 
@@ -581,10 +760,24 @@ def main() -> None:
     qs_collections_path = root / "static" / "json" / "quickstart_collections.json"
     qs_overlays_path = root / "static" / "json" / "quickstart_overlays.json"
     qs_attributes_path = root / "static" / "json" / "quickstart_attributes.json"
+    cache_context = build_cache_context(
+        root,
+        qs_collections_path,
+        qs_overlays_path,
+        qs_attributes_path,
+        kometa_defaults,
+    )
+    cache_path = get_cache_path(root, args.cache_path)
+    cache_enabled = not args.no_cache
+    cache_data = load_cache(cache_path, expected_context=cache_context) if cache_enabled else empty_cache(cache_context)
 
     inputs = [Path(p).resolve() for p in args.input] if args.input else [root / "artifacts" / "config_zip_scan"]
     discovery_callback, progress_callback = build_progress_callbacks(not args.no_progress)
     input_files, temp_dirs = collect_yaml_files(inputs, discovery_callback=discovery_callback)
+    candidate_files, prefilter_skipped_files, prefilter_cache_stats = prefilter_yaml_files(
+        input_files,
+        cache_data=cache_data if cache_enabled else None,
+    )
 
     try:
         qs_collections = build_qs_collection_map(qs_collections_path)
@@ -592,11 +785,21 @@ def main() -> None:
         qs_library_keys = build_qs_library_template_keys(qs_attributes_path)
         if progress_callback:
             print(
-                f"[progress] discovered {len(input_files)} YAML files across {len(inputs)} input root(s)",
+                f"[progress][discovery] discovered {len(input_files)} YAML files across {len(inputs)} input root(s)",
                 file=sys.stderr,
                 flush=True,
             )
-        uploaded, skipped_files, parsed_file_paths = scan_uploaded_configs(input_files, progress_callback=progress_callback)
+            print(
+                f"[progress][prefilter] selected {len(candidate_files)} YAML files containing template_variables",
+                file=sys.stderr,
+                flush=True,
+            )
+        uploaded, parse_skipped_files, parsed_file_paths, parse_cache_stats = scan_uploaded_configs(
+            candidate_files,
+            progress_callback=progress_callback,
+            cache_data=cache_data if cache_enabled else None,
+        )
+        skipped_files = prefilter_skipped_files + parse_skipped_files
 
         gap_rows: list[dict[str, Any]] = []
         all_rows: list[dict[str, Any]] = []
@@ -700,6 +903,17 @@ def main() -> None:
         report = {
             "quickstart_root": str(root),
             "inputs": [str(p) for p in inputs],
+            "cache_enabled": cache_enabled,
+            "cache_path": str(cache_path),
+            "cache_context": cache_context,
+            "cache_hit_count": prefilter_cache_stats["cache_hits"] + parse_cache_stats["cache_hits"],
+            "cache_miss_count": prefilter_cache_stats["cache_misses"] + parse_cache_stats["cache_misses"],
+            "cache_stats": {
+                "prefilter": prefilter_cache_stats,
+                "parse": parse_cache_stats,
+            },
+            "discovered_file_count": len(input_files),
+            "prefiltered_file_count": len(candidate_files),
             "parsed_files": sorted(parsed_file_paths),
             "uploaded_files_scanned": sorted({row["file"] for row in uploaded}),
             "skipped_files": skipped_files,
@@ -726,6 +940,8 @@ def main() -> None:
     json_output_path.parent.mkdir(parents=True, exist_ok=True)
     rendered = json.dumps(report, indent=2)
     json_output_path.write_text(rendered, encoding="utf-8")
+    if cache_enabled:
+        save_cache(cache_path, cache_data)
     print(render_summary(report, json_output_path))
 
 

--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -18,6 +18,21 @@ from ruamel.yaml import YAML
 ROOT = Path(__file__).resolve().parents[1]
 CACHE_VERSION = 2
 
+DEFAULT_EXCLUDED_DIR_NAMES = {
+    ".git",
+    "node_modules",
+    "venv",
+}
+DEFAULT_EXCLUDED_TOP_LEVEL_DIR_NAMES = {
+    "$recycle.bin",
+    "program files",
+    "program files (x86)",
+    "windows",
+}
+DEFAULT_EXCLUDED_PATH_SEQUENCES = {
+    ("appdata", "local", "temp"),
+}
+
 yaml = YAML(typ="safe", pure=True)
 
 
@@ -64,6 +79,41 @@ def get_cache_path(root: Path, requested_path: str | None) -> Path:
 def file_signature(path: Path) -> dict[str, int]:
     stat = path.stat()
     return {"size": stat.st_size, "mtime_ns": stat.st_mtime_ns}
+
+
+def normalized_parts(path: Path) -> list[str]:
+    parts: list[str] = []
+    for part in path.parts:
+        cleaned = part.rstrip("\\/").lower()
+        if cleaned:
+            parts.append(cleaned)
+    return parts
+
+
+def has_part_sequence(parts: list[str], sequence: tuple[str, ...]) -> bool:
+    if len(parts) < len(sequence):
+        return False
+    for idx in range(len(parts) - len(sequence) + 1):
+        if tuple(parts[idx : idx + len(sequence)]) == sequence:
+            return True
+    return False
+
+
+def should_exclude_directory(path: Path, root: Path, enabled: bool = True) -> bool:
+    if not enabled:
+        return False
+    try:
+        relative = path.relative_to(root)
+        parts = normalized_parts(relative)
+    except ValueError:
+        parts = normalized_parts(path)
+    if not parts:
+        return False
+    if parts[0] in DEFAULT_EXCLUDED_TOP_LEVEL_DIR_NAMES:
+        return True
+    if any(part in DEFAULT_EXCLUDED_DIR_NAMES for part in parts):
+        return True
+    return any(has_part_sequence(parts, sequence) for sequence in DEFAULT_EXCLUDED_PATH_SEQUENCES)
 
 
 def relative_label(path: Path, base: Path) -> str:
@@ -406,15 +456,27 @@ def extract_findings_from_data(data: dict[str, Any], path: Path) -> list[dict[st
     return findings
 
 
-def collect_yaml_files(inputs: list[Path], discovery_callback=None) -> tuple[list[Path], list[tempfile.TemporaryDirectory]]:
+def collect_yaml_files(
+    inputs: list[Path],
+    discovery_callback=None,
+    exclude_defaults: bool = True,
+) -> tuple[list[Path], list[tempfile.TemporaryDirectory]]:
     yaml_files: list[Path] = []
     temp_dirs: list[tempfile.TemporaryDirectory] = []
     for input_path in inputs:
         if input_path.is_dir():
             if discovery_callback:
                 discovery_callback("root", input_path, len(yaml_files))
-            for current_root, _, filenames in os.walk(input_path):
+            for current_root, dirnames, filenames in os.walk(input_path, topdown=True):
                 current_path = Path(current_root)
+                if should_exclude_directory(current_path, input_path, enabled=exclude_defaults):
+                    dirnames[:] = []
+                    continue
+                dirnames[:] = [
+                    dirname
+                    for dirname in dirnames
+                    if not should_exclude_directory(current_path / dirname, input_path, enabled=exclude_defaults)
+                ]
                 if discovery_callback:
                     discovery_callback("dir", current_path, len(yaml_files))
                 for filename in filenames:
@@ -433,8 +495,16 @@ def collect_yaml_files(inputs: list[Path], discovery_callback=None) -> tuple[lis
                 zf.extractall(extract_root)
             if discovery_callback:
                 discovery_callback("zip", input_path, len(yaml_files))
-            for current_root, _, filenames in os.walk(extract_root):
+            for current_root, dirnames, filenames in os.walk(extract_root, topdown=True):
                 current_path = Path(current_root)
+                if should_exclude_directory(current_path, extract_root, enabled=exclude_defaults):
+                    dirnames[:] = []
+                    continue
+                dirnames[:] = [
+                    dirname
+                    for dirname in dirnames
+                    if not should_exclude_directory(current_path / dirname, extract_root, enabled=exclude_defaults)
+                ]
                 if discovery_callback:
                     discovery_callback("dir", current_path, len(yaml_files))
                 for filename in filenames:
@@ -583,16 +653,22 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Disable periodic progress output during long scans.",
     )
+    parser.add_argument(
+        "--no-default-excludes",
+        action="store_true",
+        help="Disable built-in excludes such as Windows, Program Files, $Recycle.Bin, .git, node_modules, venv, and AppData\\Local\\Temp.",
+    )
     return parser.parse_args()
 
 
 def build_progress_callbacks(enabled: bool):
     if not enabled:
-        return None, None
+        return None, None, None
 
     start_time = time.monotonic()
     discovery_state = {"last_time": 0.0, "last_dirs": 0}
     scan_state = {"last_time": 0.0, "last_index": 0}
+    verify_state = {"last_time": 0.0, "last_index": 0, "last_stage": ""}
 
     def elapsed_label() -> str:
         elapsed = int(time.monotonic() - start_time)
@@ -653,7 +729,29 @@ def build_progress_callbacks(enabled: bool):
         scan_state["last_time"] = now
         scan_state["last_index"] = index
 
-    return emit_discovery, emit
+    def emit_verify(stage: str, index: int | None = None, total: int | None = None) -> None:
+        now = time.monotonic()
+        if index is None or total is None:
+            print(f"[progress][{elapsed_label()}] {stage}", file=sys.stderr, flush=True)
+            verify_state["last_time"] = now
+            verify_state["last_stage"] = stage
+            verify_state["last_index"] = 0
+            return
+        should_emit = (
+            index == 1
+            or index == total
+            or stage != verify_state["last_stage"]
+            or index - verify_state["last_index"] >= 500
+            or now - verify_state["last_time"] >= 5.0
+        )
+        if not should_emit:
+            return
+        print(f"[progress][{elapsed_label()}] {stage} {index}/{total}", file=sys.stderr, flush=True)
+        verify_state["last_time"] = now
+        verify_state["last_index"] = index
+        verify_state["last_stage"] = stage
+
+    return emit_discovery, emit, emit_verify
 
 
 def ensure_json_output_path(root: Path, requested_output: str | None) -> Path:
@@ -720,6 +818,7 @@ def render_summary(report: dict[str, Any], json_output_path: Path) -> str:
         f"  files skipped: {report.get('skipped_file_count', 0)}",
         f"  files with template variables: {report.get('files_with_template_variables_count', 0)}",
         f"  cache enabled: {report.get('cache_enabled', False)}",
+        f"  default excludes: {report.get('default_excludes_enabled', True)}",
         f"  cache hits: {report.get('cache_hit_count', 0)}",
         f"  cache misses: {report.get('cache_miss_count', 0)}",
         "  cache invalidates on: analyzer, Quickstart support JSON, Kometa defaults, or source file changes",
@@ -770,10 +869,15 @@ def main() -> None:
     cache_path = get_cache_path(root, args.cache_path)
     cache_enabled = not args.no_cache
     cache_data = load_cache(cache_path, expected_context=cache_context) if cache_enabled else empty_cache(cache_context)
+    default_excludes_enabled = not args.no_default_excludes
 
     inputs = [Path(p).resolve() for p in args.input] if args.input else [root / "artifacts" / "config_zip_scan"]
-    discovery_callback, progress_callback = build_progress_callbacks(not args.no_progress)
-    input_files, temp_dirs = collect_yaml_files(inputs, discovery_callback=discovery_callback)
+    discovery_callback, progress_callback, verify_callback = build_progress_callbacks(not args.no_progress)
+    input_files, temp_dirs = collect_yaml_files(
+        inputs,
+        discovery_callback=discovery_callback,
+        exclude_defaults=default_excludes_enabled,
+    )
     candidate_files, prefilter_skipped_files, prefilter_cache_stats = prefilter_yaml_files(
         input_files,
         cache_data=cache_data if cache_enabled else None,
@@ -805,7 +909,11 @@ def main() -> None:
         all_rows: list[dict[str, Any]] = []
         grouped_examples: dict[tuple[str, str | None, str], list[str]] = defaultdict(list)
 
-        for row in uploaded:
+        if verify_callback:
+            verify_callback(f"verifying {len(uploaded)} findings against Quickstart and Kometa defaults")
+        for idx, row in enumerate(uploaded, start=1):
+            if verify_callback:
+                verify_callback("verifying findings", idx, len(uploaded))
             key = row["key"]
             kind = row["kind"]
             alias = row["default"]
@@ -841,6 +949,8 @@ def main() -> None:
                 gap_rows.append(out)
                 grouped_examples[(kind, alias, key)].append(row["file"])
 
+        if verify_callback:
+            verify_callback("aggregating ranked gaps")
         summary: dict[tuple[str, str | None, str], dict[str, Any]] = {}
         for row in gap_rows:
             bucket = summary.setdefault(
@@ -906,6 +1016,7 @@ def main() -> None:
             "cache_enabled": cache_enabled,
             "cache_path": str(cache_path),
             "cache_context": cache_context,
+            "default_excludes_enabled": default_excludes_enabled,
             "cache_hit_count": prefilter_cache_stats["cache_hits"] + parse_cache_stats["cache_hits"],
             "cache_miss_count": prefilter_cache_stats["cache_misses"] + parse_cache_stats["cache_misses"],
             "cache_stats": {
@@ -938,6 +1049,8 @@ def main() -> None:
 
     json_output_path = ensure_json_output_path(root, args.output)
     json_output_path.parent.mkdir(parents=True, exist_ok=True)
+    if verify_callback:
+        verify_callback(f"writing JSON report to {json_output_path}")
     rendered = json.dumps(report, indent=2)
     json_output_path.write_text(rendered, encoding="utf-8")
     if cache_enabled:

--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -93,6 +93,16 @@ def normalized_parts(path: Path) -> list[str]:
     return parts
 
 
+def is_virtualenv_dir_name(name: str) -> bool:
+    lowered = name.lower()
+    return (
+        lowered == "venv"
+        or lowered.endswith("-venv")
+        or lowered.endswith("_venv")
+        or lowered.startswith("py_env-python")
+    )
+
+
 def has_part_sequence(parts: list[str], sequence: tuple[str, ...]) -> bool:
     if len(parts) < len(sequence):
         return False
@@ -115,6 +125,10 @@ def should_exclude_directory(path: Path, root: Path, enabled: bool = True) -> bo
     if parts[0] in DEFAULT_EXCLUDED_TOP_LEVEL_DIR_NAMES:
         return True
     if any(part.startswith(".") for part in parts):
+        return True
+    if "appdata" in parts:
+        return True
+    if any(is_virtualenv_dir_name(part) for part in parts):
         return True
     if any(part in DEFAULT_EXCLUDED_DIR_NAMES for part in parts):
         return True
@@ -661,7 +675,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--no-default-excludes",
         action="store_true",
-        help="Disable built-in excludes such as Windows, Program Files, ProgramData, $Recycle.Bin, dot-prefixed folders, .git, node_modules, venv, AppData\\Local, and VS Code history folders.",
+        help="Disable built-in excludes such as Windows, Program Files, ProgramData, $Recycle.Bin, dot-prefixed folders, .git, node_modules, common virtualenv folders, all AppData trees, and VS Code history folders.",
     )
     return parser.parse_args()
 

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -12115,6 +12115,17 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "style",
+            "label": "Style",
+            "type": "select",
+            "tooltip": "Controls the visual theme of the collections created.",
+            "default": "color",
+            "options": [
+              "color",
+              "white"
+            ]
+          },
+          {
             "key": "use_favorited",
             "label": "MyAnimeList Favorited",
             "tooltip": "Collection of most Favorited Anime on MyAnimeList.",
@@ -20325,6 +20336,17 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "style",
+            "label": "Style",
+            "type": "select",
+            "tooltip": "Controls the visual theme of the collections created.",
+            "default": "color",
+            "options": [
+              "color",
+              "white"
+            ]
+          },
+          {
             "key": "use_other",
             "label": "Other",
             "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
@@ -20739,6 +20761,17 @@
             "type": "text_input",
             "default": "110",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "style",
+            "label": "Style",
+            "type": "select",
+            "tooltip": "Controls the visual theme of the collections created.",
+            "default": "color",
+            "options": [
+              "color",
+              "white"
+            ]
           },
           {
             "key": "use_other",
@@ -21156,6 +21189,17 @@
             "type": "text_input",
             "default": "081",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "style",
+            "label": "Style",
+            "type": "select",
+            "tooltip": "Controls the visual theme of the collections created.",
+            "default": "color",
+            "options": [
+              "color",
+              "white"
+            ]
           },
           {
             "key": "use_Northern Africa",
@@ -21734,6 +21778,17 @@
             "type": "text_input",
             "default": "082",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "style",
+            "label": "Style",
+            "type": "select",
+            "tooltip": "Controls the visual theme of the collections created.",
+            "default": "color",
+            "options": [
+              "color",
+              "white"
+            ]
           },
           {
             "key": "use_Africa",

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -14414,6 +14414,14 @@
         "tooltip_variant": "danger",
         "template_variables": [
           {
+            "key": "collection_section",
+            "label": "Collection Section",
+            "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
+            "type": "text_input",
+            "tooltip": "Optional override for where this default group appears in the Plex Collections page. Leave blank to keep the Kometa default order.",
+            "placeholder": "Leave blank or enter a value like 040"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
@@ -14835,6 +14843,14 @@
         "tooltip": "Disable Plex's in-built Automatic Collections feature if you use this file",
         "tooltip_variant": "danger",
         "template_variables": [
+          {
+            "key": "collection_section",
+            "label": "Collection Section",
+            "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
+            "type": "text_input",
+            "tooltip": "Optional override for where this default group appears in the Plex Collections page. Leave blank to keep the Kometa default order.",
+            "placeholder": "Leave blank or enter a value like 040"
+          },
           {
             "key": "collection_mode",
             "label": "Collection Mode",

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -4197,6 +4197,157 @@ document.addEventListener('DOMContentLoaded', function () {
       openCopyModal(sourceId, sourceName, sourceType)
     })
 
+    function compareCollectionSectionValues (a, b) {
+      const aTrimmed = String(a || '').trim()
+      const bTrimmed = String(b || '').trim()
+      const aNumeric = /^\d+$/.test(aTrimmed)
+      const bNumeric = /^\d+$/.test(bTrimmed)
+      if (aNumeric && bNumeric) return Number(aTrimmed) - Number(bTrimmed)
+      if (aNumeric) return -1
+      if (bNumeric) return 1
+      if (aTrimmed && bTrimmed) return aTrimmed.localeCompare(bTrimmed)
+      if (aTrimmed) return -1
+      if (bTrimmed) return 1
+      return 0
+    }
+
+    function getCollectionSectionEntries (libraryId) {
+      const container = document.getElementById(`${libraryId}-container`)
+      if (!container) return []
+      const groups = Array.from(container.querySelectorAll('[data-collection-config="true"]'))
+      const entries = []
+      groups.forEach((group, index) => {
+        const collectionId = group.dataset.collectionId || ''
+        const label = group.dataset.collectionLabel || collectionId
+        const toggle = collectionId ? group.querySelector(`input[type="checkbox"]#${libraryId}-${collectionId}`) : null
+        if (!toggle || !toggle.checked) return
+        const input = group.querySelector('input[name$="_collection_section"]')
+        if (!input) return
+        entries.push({
+          collectionId,
+          label,
+          inputId: input.id,
+          currentValue: String(input.value || '').trim(),
+          domIndex: index
+        })
+      })
+      entries.sort((left, right) => {
+        const byValue = compareCollectionSectionValues(left.currentValue, right.currentValue)
+        if (byValue !== 0) return byValue
+        return left.domIndex - right.domIndex
+      })
+      return entries
+    }
+
+    function buildCollectionSectionListItem (entry, position) {
+      const li = document.createElement('li')
+      li.className = 'list-group-item sortable-item d-flex justify-content-between align-items-center gap-3'
+      li.dataset.inputId = entry.inputId
+      li.dataset.collectionId = entry.collectionId
+      li.innerHTML = `
+        <div class="d-flex align-items-center gap-2 flex-grow-1">
+          <i class="bi bi-grip-vertical drag-handle text-muted" role="button" aria-label="Drag to reorder"></i>
+          <div class="d-flex flex-column">
+            <span class="fw-semibold">${entry.label}</span>
+            <span class="small text-muted"><code>${entry.collectionId.replace(/^collection_/, '')}</code></span>
+          </div>
+        </div>
+        <div class="text-end">
+          <div class="small text-muted">Current</div>
+          <span class="badge bg-secondary" data-collection-section-current>${entry.currentValue || 'blank'}</span>
+          <div class="small text-muted mt-1">New: <span data-collection-section-next>${String(position * 10).padStart(3, '0')}</span></div>
+        </div>
+      `
+      return li
+    }
+
+    function refreshCollectionSectionPreviewNumbers (list) {
+      if (!list) return
+      Array.from(list.children).forEach((item, index) => {
+        const next = item.querySelector('[data-collection-section-next]')
+        if (next) next.textContent = String((index + 1) * 10).padStart(3, '0')
+      })
+    }
+
+    function renderCollectionSectionModalList (modalEl) {
+      if (!modalEl) return []
+      const libraryId = modalEl.dataset.libraryId
+      const list = modalEl.querySelector('[data-collection-section-sortable]')
+      const status = modalEl.querySelector('[data-collection-section-modal-status]')
+      const saveButton = modalEl.querySelector('[data-collection-section-save]')
+      const entries = getCollectionSectionEntries(libraryId)
+      list.replaceChildren()
+      if (!entries.length) {
+        if (status) status.textContent = 'No enabled collections with a collection_section field are available to reorder in this library.'
+        if (saveButton) saveButton.disabled = true
+        return entries
+      }
+      entries.forEach((entry, index) => list.appendChild(buildCollectionSectionListItem(entry, index + 1)))
+      if (status) status.textContent = `${entries.length} enabled collection default${entries.length === 1 ? '' : 's'} ready to reorder.`
+      if (saveButton) saveButton.disabled = false
+      refreshCollectionSectionPreviewNumbers(list)
+      if (modalEl._collectionSectionSortable && typeof modalEl._collectionSectionSortable.destroy === 'function') {
+        modalEl._collectionSectionSortable.destroy()
+      }
+      modalEl._collectionSectionSortable = Sortable.create(list, {
+        handle: '.drag-handle',
+        animation: 150,
+        onSort: function () {
+          refreshCollectionSectionPreviewNumbers(list)
+        }
+      })
+      return entries
+    }
+
+    function saveCollectionSectionModalOrder (modalEl) {
+      if (!modalEl) return
+      const list = modalEl.querySelector('[data-collection-section-sortable]')
+      const items = Array.from(list ? list.children : [])
+      if (!items.length) return
+      items.forEach((item, index) => {
+        const inputId = item.dataset.inputId
+        const input = inputId ? document.getElementById(inputId) : null
+        if (!input) return
+        const nextValue = String((index + 1) * 10).padStart(3, '0')
+        input.value = nextValue
+        input.dispatchEvent(new Event('input', { bubbles: true }))
+        input.dispatchEvent(new Event('change', { bubbles: true }))
+        const current = item.querySelector('[data-collection-section-current]')
+        if (current) current.textContent = nextValue
+      })
+      if (typeof showToast === 'function') {
+        showToast('success', 'Collection section order updated.')
+      }
+      refreshCollectionSectionPreviewNumbers(list)
+      const modal = bootstrap && bootstrap.Modal ? bootstrap.Modal.getInstance(modalEl) : null
+      if (modal) modal.hide()
+    }
+
+    document.addEventListener('click', (event) => {
+      const trigger = event.target.closest('[data-collection-section-modal-trigger]')
+      if (trigger) {
+        const libraryId = trigger.dataset.libraryId
+        const modalEl = libraryId ? document.getElementById(`${libraryId}-collection-section-modal`) : null
+        if (!modalEl || !bootstrap || !bootstrap.Modal) return
+        renderCollectionSectionModalList(modalEl)
+        bootstrap.Modal.getOrCreateInstance(modalEl).show()
+        return
+      }
+
+      const resetButton = event.target.closest('[data-collection-section-reset]')
+      if (resetButton) {
+        const modalEl = resetButton.closest('[data-collection-section-modal]')
+        renderCollectionSectionModalList(modalEl)
+        return
+      }
+
+      const saveButton = event.target.closest('[data-collection-section-save]')
+      if (saveButton) {
+        const modalEl = saveButton.closest('[data-collection-section-modal]')
+        saveCollectionSectionModalOrder(modalEl)
+      }
+    })
+
     function initializeSortableList (libraryId, prefix) {
       const list = document.getElementById(`${libraryId}-attribute_${prefix}_sortable`)
       const hiddenInput = document.getElementById(`${libraryId}-attribute_${prefix}_order`)

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -4252,6 +4252,16 @@ document.addEventListener('DOMContentLoaded', function () {
             <span class="small text-muted"><code>${entry.collectionId.replace(/^collection_/, '')}</code></span>
           </div>
         </div>
+        <div class="d-flex align-items-center gap-2">
+          <div class="btn-group btn-group-sm" role="group" aria-label="Move collection section">
+            <button type="button" class="btn btn-outline-secondary" data-collection-section-move="up" aria-label="Move up">
+              <i class="bi bi-chevron-up"></i>
+            </button>
+            <button type="button" class="btn btn-outline-secondary" data-collection-section-move="down" aria-label="Move down">
+              <i class="bi bi-chevron-down"></i>
+            </button>
+          </div>
+        </div>
         <div class="text-end">
           <div class="small text-muted">Current</div>
           <span class="badge bg-secondary" data-collection-section-current>${entry.currentValue || 'blank'}</span>
@@ -4292,6 +4302,9 @@ document.addEventListener('DOMContentLoaded', function () {
       modalEl._collectionSectionSortable = Sortable.create(list, {
         handle: '.drag-handle',
         animation: 150,
+        delayOnTouchOnly: true,
+        delay: 180,
+        touchStartThreshold: 6,
         onSort: function () {
           refreshCollectionSectionPreviewNumbers(list)
         }
@@ -4345,6 +4358,21 @@ document.addEventListener('DOMContentLoaded', function () {
       if (saveButton) {
         const modalEl = saveButton.closest('[data-collection-section-modal]')
         saveCollectionSectionModalOrder(modalEl)
+        return
+      }
+
+      const moveButton = event.target.closest('[data-collection-section-move]')
+      if (moveButton) {
+        const direction = moveButton.dataset.collectionSectionMove
+        const item = moveButton.closest('li')
+        const list = item?.parentElement
+        if (!item || !list) return
+        if (direction === 'up' && item.previousElementSibling) {
+          list.insertBefore(item, item.previousElementSibling)
+        } else if (direction === 'down' && item.nextElementSibling) {
+          list.insertBefore(item.nextElementSibling, item)
+        }
+        refreshCollectionSectionPreviewNumbers(list)
       }
     })
 

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -4279,6 +4279,23 @@ document.addEventListener('DOMContentLoaded', function () {
       })
     }
 
+    function ensureCollectionSectionModalRoot (modalEl) {
+      if (!modalEl || !document.body) return modalEl
+      const modalId = modalEl.id
+      if (modalId) {
+        const bodyModal = Array.from(document.body.querySelectorAll('[data-collection-section-modal]'))
+          .find(el => el.id === modalId && el !== modalEl)
+        if (bodyModal) {
+          if (modalEl.parentElement) modalEl.remove()
+          return bodyModal
+        }
+      }
+      if (modalEl.parentElement !== document.body) {
+        document.body.appendChild(modalEl)
+      }
+      return modalEl
+    }
+
     function renderCollectionSectionModalList (modalEl) {
       if (!modalEl) return []
       const libraryId = modalEl.dataset.libraryId
@@ -4340,8 +4357,9 @@ document.addEventListener('DOMContentLoaded', function () {
       const trigger = event.target.closest('[data-collection-section-modal-trigger]')
       if (trigger) {
         const libraryId = trigger.dataset.libraryId
-        const modalEl = libraryId ? document.getElementById(`${libraryId}-collection-section-modal`) : null
+        let modalEl = libraryId ? document.getElementById(`${libraryId}-collection-section-modal`) : null
         if (!modalEl || !bootstrap || !bootstrap.Modal) return
+        modalEl = ensureCollectionSectionModalRoot(modalEl)
         renderCollectionSectionModalList(modalEl)
         bootstrap.Modal.getOrCreateInstance(modalEl).show()
         return

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -1,4 +1,4 @@
-/* global EventHandler, ValidationHandler, OverlayHandler, Sortable, showToast, setupParentChildToggleSync, bootstrap, FontFace, PathValidation, DOMParser, MutationObserver, jumpTo, showNavigationLoadingOverlay, hideNavigationLoadingOverlay */
+/* global EventHandler, ValidationHandler, OverlayHandler, Sortable, showToast, setupParentChildToggleSync, bootstrap, FontFace, PathValidation, DOMParser, MutationObserver, jumpTo, showNavigationLoadingOverlay, hideNavigationLoadingOverlay, requestAnimationFrame */
 
 document.addEventListener('DOMContentLoaded', function () {
   console.log('[DEBUG] Initializing Libraries...')
@@ -4296,6 +4296,46 @@ document.addEventListener('DOMContentLoaded', function () {
       return modalEl
     }
 
+    function syncCollectionSectionModalBackdrop (modalEl) {
+      if (!modalEl) return
+      modalEl.style.zIndex = '2000'
+      modalEl.style.pointerEvents = 'auto'
+      modalEl.removeAttribute('inert')
+
+      const dialog = modalEl.querySelector('.modal-dialog')
+      if (dialog) dialog.style.pointerEvents = 'auto'
+
+      const content = modalEl.querySelector('.modal-content')
+      if (content) content.style.pointerEvents = 'auto'
+
+      const backdrops = Array.from(document.querySelectorAll('.modal-backdrop'))
+      const latestBackdrop = backdrops.at(-1)
+      if (latestBackdrop) latestBackdrop.style.zIndex = '1990'
+    }
+
+    function cleanupCollectionSectionModalBackdrops () {
+      if (document.querySelector('.modal.show')) return
+      document.querySelectorAll('.modal-backdrop').forEach(backdrop => backdrop.remove())
+    }
+
+    function prepareCollectionSectionModal (modalEl) {
+      if (!modalEl) return modalEl
+      modalEl = ensureCollectionSectionModalRoot(modalEl)
+      if (modalEl.dataset.collectionSectionPrepared === 'true') return modalEl
+      modalEl.dataset.collectionSectionPrepared = 'true'
+      modalEl.addEventListener('show.bs.modal', () => {
+        syncCollectionSectionModalBackdrop(modalEl)
+        requestAnimationFrame(() => syncCollectionSectionModalBackdrop(modalEl))
+      })
+      modalEl.addEventListener('shown.bs.modal', () => {
+        syncCollectionSectionModalBackdrop(modalEl)
+      })
+      modalEl.addEventListener('hidden.bs.modal', () => {
+        cleanupCollectionSectionModalBackdrops()
+      })
+      return modalEl
+    }
+
     function renderCollectionSectionModalList (modalEl) {
       if (!modalEl) return []
       const libraryId = modalEl.dataset.libraryId
@@ -4359,7 +4399,7 @@ document.addEventListener('DOMContentLoaded', function () {
         const libraryId = trigger.dataset.libraryId
         let modalEl = libraryId ? document.getElementById(`${libraryId}-collection-section-modal`) : null
         if (!modalEl || !bootstrap || !bootstrap.Modal) return
-        modalEl = ensureCollectionSectionModalRoot(modalEl)
+        modalEl = prepareCollectionSectionModal(modalEl)
         renderCollectionSectionModalList(modalEl)
         bootstrap.Modal.getOrCreateInstance(modalEl).show()
         return

--- a/templates/partials/_collection_section_modal.html
+++ b/templates/partials/_collection_section_modal.html
@@ -1,7 +1,7 @@
 <div class="modal fade" id="{{ library.id }}-collection-section-modal" tabindex="-1"
   aria-labelledby="{{ library.id }}-collection-section-modal-label" aria-hidden="true"
   data-collection-section-modal data-library-id="{{ library.id }}">
-  <div class="modal-dialog modal-dialog-centered modal-lg">
+  <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-lg modal-fullscreen-sm-down">
     <div class="modal-content border-secondary">
       <div class="modal-header">
         <h5 class="modal-title" id="{{ library.id }}-collection-section-modal-label">Reorder Collection Sections</h5>
@@ -12,9 +12,11 @@
           Drag the enabled collection defaults into the order you want. Saving assigns section values in <code>010</code> steps from top to bottom.
         </div>
         <div class="small text-muted mb-2" data-collection-section-modal-status>
-          Only enabled collections with a <code>collection_section</code> field appear here.
+          Only enabled collections with a <code>collection_section</code> field appear here. Use the grip to drag or the arrow buttons to move rows.
         </div>
-        <ul class="list-group collection-section-sortable" data-collection-section-sortable></ul>
+        <ul class="list-group collection-section-sortable overflow-auto"
+          style="max-height: min(60vh, 32rem); -webkit-overflow-scrolling: touch; touch-action: pan-y;"
+          data-collection-section-sortable></ul>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-outline-secondary btn-sm" data-collection-section-reset>

--- a/templates/partials/_collection_section_modal.html
+++ b/templates/partials/_collection_section_modal.html
@@ -1,0 +1,29 @@
+<div class="modal fade" id="{{ library.id }}-collection-section-modal" tabindex="-1"
+  aria-labelledby="{{ library.id }}-collection-section-modal-label" aria-hidden="true"
+  data-collection-section-modal data-library-id="{{ library.id }}">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
+    <div class="modal-content border-secondary">
+      <div class="modal-header">
+        <h5 class="modal-title" id="{{ library.id }}-collection-section-modal-label">Reorder Collection Sections</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="alert alert-info small mb-3" role="alert">
+          Drag the enabled collection defaults into the order you want. Saving assigns section values in <code>010</code> steps from top to bottom.
+        </div>
+        <div class="small text-muted mb-2" data-collection-section-modal-status>
+          Only enabled collections with a <code>collection_section</code> field appear here.
+        </div>
+        <ul class="list-group collection-section-sortable" data-collection-section-sortable></ul>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary btn-sm" data-collection-section-reset>
+          Reset List
+        </button>
+        <button type="button" class="btn btn-primary btn-sm" data-collection-section-save>
+          Save Order
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -1022,7 +1022,11 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                 {% set disable_toggle = needs_tv_metadata and not valid_tv_metadata %}
 
                 <!-- Rendering Collection: {{ collection.id }} -->
-                <div class="template-toggle-group ms-3 mb-2">
+                <div class="template-toggle-group ms-3 mb-2"
+                    data-collection-config="true"
+                    data-library-id="{{ library.id }}"
+                    data-collection-id="{{ collection.id }}"
+                    data-collection-label="{{ collection.label }}">
 
                     {% if needs_tv_metadata %}
                     {% if disable_toggle %}

--- a/templates/partials/_movie_collections.html
+++ b/templates/partials/_movie_collections.html
@@ -1,7 +1,15 @@
 <p>Select which Collection Files you would like to run against your libraries. You can hover over the magnifying
   glass to see some of the collections that the file will create, or click on the name of the file to be taken
   to it's wiki page.</p>
-  {% import 'partials/_macros.html' as macros %}
+<div class="d-flex flex-wrap align-items-center gap-2 mb-3">
+  <button type="button" class="btn btn-outline-secondary btn-sm"
+    data-collection-section-modal-trigger data-library-id="{{ library.id }}">
+    <i class="bi bi-arrows-move me-1"></i>Reorder Collection Sections
+  </button>
+  <span class="small text-muted">Drag enabled collection defaults into the order you want. Quickstart will rewrite their <code>collection_section</code> values.</span>
+</div>
+{% include "partials/_collection_section_modal.html" %}
+{% import 'partials/_macros.html' as macros %}
 
 {% for group in collection_config %}
 {{ macros.collection_group_section(library, data, version_info, group, telemetry) }}

--- a/templates/partials/_show_collections.html
+++ b/templates/partials/_show_collections.html
@@ -1,7 +1,15 @@
 <p>Select which Collection Files you would like to run against your libraries. You can hover over the magnifying
   glass to see some of the collections that the file will create, or click on the name of the file to be taken
   to it's wiki page.</p>
-  {% import 'partials/_macros.html' as macros %}
+<div class="d-flex flex-wrap align-items-center gap-2 mb-3">
+  <button type="button" class="btn btn-outline-secondary btn-sm"
+    data-collection-section-modal-trigger data-library-id="{{ library.id }}">
+    <i class="bi bi-arrows-move me-1"></i>Reorder Collection Sections
+  </button>
+  <span class="small text-muted">Drag enabled collection defaults into the order you want. Quickstart will rewrite their <code>collection_section</code> values.</span>
+</div>
+{% include "partials/_collection_section_modal.html" %}
+{% import 'partials/_macros.html' as macros %}
 
 {% for group in collection_config %}
 {{ macros.collection_group_section(library, data, version_info, group, telemetry) }}


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Summary
Adds a collection-section reorder workflow for library collections, expands Quickstart support for missing collection template variables, and improves the template-gap analyzer used to compare uploaded configs against Kometa and Quickstart support.

What changed
Added a Reorder Collection Sections modal for collection defaults on the Libraries step.
Added drag/reorder controls plus mobile-safe up/down controls for assigning collection_section values in 010 increments.
Added support for collection_section on franchise collections with a default of blank/null so users can opt in to a custom value.
Added missing style support for several collection defaults that were already valid in Kometa.
Hardened the collection-section modal mounting/stacking logic so it is moved to document.body and can render above the Bootstrap backdrop correctly.
Added an analyzer script to scan folders or zip inputs for Kometa template_variables, verify them against built-in Kometa defaults, compare them to Quickstart support, and rank unsupported gaps by frequency.
Improved the analyzer with recursive scanning, compact summary output, JSON reporting, overlay/collection/playlist/library separation, progress output, caching, and broader default path exclusions.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
