### PR TITLE
Update analyzer

### DIFF
--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -14,7 +14,6 @@ from typing import Any
 
 from ruamel.yaml import YAML
 
-
 ROOT = Path(__file__).resolve().parents[1]
 CACHE_VERSION = 3
 QS_SPECIAL_LIBRARY_TEMPLATE_KEYS = {
@@ -120,12 +119,7 @@ def normalized_parts(path: Path) -> list[str]:
 
 def is_virtualenv_dir_name(name: str) -> bool:
     lowered = name.lower()
-    return (
-        lowered == "venv"
-        or lowered.endswith("-venv")
-        or lowered.endswith("_venv")
-        or lowered.startswith("py_env-python")
-    )
+    return lowered == "venv" or lowered.endswith("-venv") or lowered.endswith("_venv") or lowered.startswith("py_env-python")
 
 
 def has_part_sequence(parts: list[str], sequence: tuple[str, ...]) -> bool:
@@ -596,11 +590,7 @@ def collect_yaml_files(
                 if should_exclude_directory(current_path, input_path, enabled=exclude_defaults):
                     dirnames[:] = []
                     continue
-                dirnames[:] = [
-                    dirname
-                    for dirname in dirnames
-                    if not should_exclude_directory(current_path / dirname, input_path, enabled=exclude_defaults)
-                ]
+                dirnames[:] = [dirname for dirname in dirnames if not should_exclude_directory(current_path / dirname, input_path, enabled=exclude_defaults)]
                 if discovery_callback:
                     discovery_callback("dir", current_path, len(yaml_files))
                 for filename in filenames:
@@ -624,11 +614,7 @@ def collect_yaml_files(
                 if should_exclude_directory(current_path, extract_root, enabled=exclude_defaults):
                     dirnames[:] = []
                     continue
-                dirnames[:] = [
-                    dirname
-                    for dirname in dirnames
-                    if not should_exclude_directory(current_path / dirname, extract_root, enabled=exclude_defaults)
-                ]
+                dirnames[:] = [dirname for dirname in dirnames if not should_exclude_directory(current_path / dirname, extract_root, enabled=exclude_defaults)]
                 if discovery_callback:
                     discovery_callback("dir", current_path, len(yaml_files))
                 for filename in filenames:
@@ -746,9 +732,7 @@ def scan_uploaded_configs(
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Find template variables used in uploaded configs that are valid in Kometa but not exposed in Quickstart."
-    )
+    parser = argparse.ArgumentParser(description="Find template variables used in uploaded configs that are valid in Kometa but not exposed in Quickstart.")
     parser.add_argument(
         "--input",
         nargs="+",
@@ -821,11 +805,7 @@ def build_progress_callbacks(enabled: bool):
             discovery_state["last_time"] = now
             return
         discovery_state["last_dirs"] += 1
-        should_emit = (
-            discovery_state["last_dirs"] == 1
-            or discovery_state["last_dirs"] % 100 == 0
-            or now - discovery_state["last_time"] >= 5.0
-        )
+        should_emit = discovery_state["last_dirs"] == 1 or discovery_state["last_dirs"] % 100 == 0 or now - discovery_state["last_time"] >= 5.0
         if not should_emit:
             return
         print(
@@ -837,12 +817,7 @@ def build_progress_callbacks(enabled: bool):
 
     def emit(index: int, total: int, parsed: int, skipped: int, current_path: Path) -> None:
         now = time.monotonic()
-        should_emit = (
-            index == 1
-            or index == total
-            or index - scan_state["last_index"] >= 100
-            or now - scan_state["last_time"] >= 5.0
-        )
+        should_emit = index == 1 or index == total or index - scan_state["last_index"] >= 100 or now - scan_state["last_time"] >= 5.0
         if not should_emit:
             return
         print(
@@ -861,13 +836,7 @@ def build_progress_callbacks(enabled: bool):
             verify_state["last_stage"] = stage
             verify_state["last_index"] = 0
             return
-        should_emit = (
-            index == 1
-            or index == total
-            or stage != verify_state["last_stage"]
-            or index - verify_state["last_index"] >= 500
-            or now - verify_state["last_time"] >= 5.0
-        )
+        should_emit = index == 1 or index == total or stage != verify_state["last_stage"] or index - verify_state["last_index"] >= 500 or now - verify_state["last_time"] >= 5.0
         if not should_emit:
             return
         print(f"[progress][{elapsed_label()}] {stage} {index}/{total}", file=sys.stderr, flush=True)

--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from ruamel.yaml import YAML
 
+
 ROOT = Path(__file__).resolve().parents[1]
 CACHE_VERSION = 3
 
@@ -27,7 +28,6 @@ DEFAULT_EXCLUDED_DIR_NAMES = {
     "cache",
     "cache_data",
     "dist",
-    "downloads",
     "images",
     "img",
     "log",
@@ -39,8 +39,6 @@ DEFAULT_EXCLUDED_DIR_NAMES = {
     "photos",
     "pictures",
     "site-packages",
-    "temp",
-    "tmp",
     "vendor",
     "videos",
     "venv",
@@ -53,9 +51,6 @@ DEFAULT_EXCLUDED_TOP_LEVEL_DIR_NAMES = {
     "windows",
 }
 DEFAULT_EXCLUDED_PATH_SEQUENCES = {
-    ("appdata", "local"),
-    ("appdata", "local", "temp"),
-    ("appdata", "roaming", "code", "user", "history"),
     ("defaults-image-creation", "create_people_posters", "config", "chrome-profile"),
     ("onedrive",),
     ("users", "default"),
@@ -121,7 +116,12 @@ def normalized_parts(path: Path) -> list[str]:
 
 def is_virtualenv_dir_name(name: str) -> bool:
     lowered = name.lower()
-    return lowered == "venv" or lowered.endswith("-venv") or lowered.endswith("_venv") or lowered.startswith("py_env-python")
+    return (
+        lowered == "venv"
+        or lowered.endswith("-venv")
+        or lowered.endswith("_venv")
+        or lowered.startswith("py_env-python")
+    )
 
 
 def has_part_sequence(parts: list[str], sequence: tuple[str, ...]) -> bool:
@@ -154,6 +154,28 @@ def should_exclude_directory(path: Path, root: Path, enabled: bool = True) -> bo
     if any(part in DEFAULT_EXCLUDED_DIR_NAMES for part in parts):
         return True
     return any(has_part_sequence(parts, sequence) for sequence in DEFAULT_EXCLUDED_PATH_SEQUENCES)
+
+
+def describe_default_excludes(enabled: bool) -> dict[str, Any]:
+    if not enabled:
+        return {
+            "enabled": False,
+            "top_level_dir_names": [],
+            "dir_names_anywhere": [],
+            "path_sequences": [],
+            "logic_rules": [],
+        }
+    return {
+        "enabled": True,
+        "top_level_dir_names": sorted(DEFAULT_EXCLUDED_TOP_LEVEL_DIR_NAMES),
+        "dir_names_anywhere": sorted(DEFAULT_EXCLUDED_DIR_NAMES),
+        "path_sequences": ["\\".join(sequence) for sequence in sorted(DEFAULT_EXCLUDED_PATH_SEQUENCES)],
+        "logic_rules": [
+            "dot-prefixed folders",
+            "any path containing AppData",
+            "virtualenv-style folders: venv, *-venv, *_venv, py_env-python*",
+        ],
+    }
 
 
 def relative_label(path: Path, base: Path) -> str:
@@ -512,7 +534,11 @@ def collect_yaml_files(
                 if should_exclude_directory(current_path, input_path, enabled=exclude_defaults):
                     dirnames[:] = []
                     continue
-                dirnames[:] = [dirname for dirname in dirnames if not should_exclude_directory(current_path / dirname, input_path, enabled=exclude_defaults)]
+                dirnames[:] = [
+                    dirname
+                    for dirname in dirnames
+                    if not should_exclude_directory(current_path / dirname, input_path, enabled=exclude_defaults)
+                ]
                 if discovery_callback:
                     discovery_callback("dir", current_path, len(yaml_files))
                 for filename in filenames:
@@ -536,7 +562,11 @@ def collect_yaml_files(
                 if should_exclude_directory(current_path, extract_root, enabled=exclude_defaults):
                     dirnames[:] = []
                     continue
-                dirnames[:] = [dirname for dirname in dirnames if not should_exclude_directory(current_path / dirname, extract_root, enabled=exclude_defaults)]
+                dirnames[:] = [
+                    dirname
+                    for dirname in dirnames
+                    if not should_exclude_directory(current_path / dirname, extract_root, enabled=exclude_defaults)
+                ]
                 if discovery_callback:
                     discovery_callback("dir", current_path, len(yaml_files))
                 for filename in filenames:
@@ -654,7 +684,9 @@ def scan_uploaded_configs(
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Find template variables used in uploaded configs that are valid in Kometa but not exposed in Quickstart.")
+    parser = argparse.ArgumentParser(
+        description="Find template variables used in uploaded configs that are valid in Kometa but not exposed in Quickstart."
+    )
     parser.add_argument(
         "--input",
         nargs="+",
@@ -727,7 +759,11 @@ def build_progress_callbacks(enabled: bool):
             discovery_state["last_time"] = now
             return
         discovery_state["last_dirs"] += 1
-        should_emit = discovery_state["last_dirs"] == 1 or discovery_state["last_dirs"] % 100 == 0 or now - discovery_state["last_time"] >= 5.0
+        should_emit = (
+            discovery_state["last_dirs"] == 1
+            or discovery_state["last_dirs"] % 100 == 0
+            or now - discovery_state["last_time"] >= 5.0
+        )
         if not should_emit:
             return
         print(
@@ -739,7 +775,12 @@ def build_progress_callbacks(enabled: bool):
 
     def emit(index: int, total: int, parsed: int, skipped: int, current_path: Path) -> None:
         now = time.monotonic()
-        should_emit = index == 1 or index == total or index - scan_state["last_index"] >= 100 or now - scan_state["last_time"] >= 5.0
+        should_emit = (
+            index == 1
+            or index == total
+            or index - scan_state["last_index"] >= 100
+            or now - scan_state["last_time"] >= 5.0
+        )
         if not should_emit:
             return
         print(
@@ -758,7 +799,13 @@ def build_progress_callbacks(enabled: bool):
             verify_state["last_stage"] = stage
             verify_state["last_index"] = 0
             return
-        should_emit = index == 1 or index == total or stage != verify_state["last_stage"] or index - verify_state["last_index"] >= 500 or now - verify_state["last_time"] >= 5.0
+        should_emit = (
+            index == 1
+            or index == total
+            or stage != verify_state["last_stage"]
+            or index - verify_state["last_index"] >= 500
+            or now - verify_state["last_time"] >= 5.0
+        )
         if not should_emit:
             return
         print(f"[progress][{elapsed_label()}] {stage} {index}/{total}", file=sys.stderr, flush=True)
@@ -846,9 +893,24 @@ def render_summary(report: dict[str, Any], json_output_path: Path) -> str:
         f"  library gaps: {len(libraries)}",
         "  runtime guaranteed: false",
         "",
-        render_table("Overlay Gaps", overlays),
-        render_table("Collection Gaps", collections),
     ]
+    exclude_details = report.get("default_excludes")
+    if isinstance(exclude_details, dict):
+        lines.append("Default Excludes Active")
+        if exclude_details.get("enabled"):
+            lines.append(f"  top-level dir names: {', '.join(exclude_details.get('top_level_dir_names', [])) or 'none'}")
+            lines.append(f"  dir names anywhere: {', '.join(exclude_details.get('dir_names_anywhere', [])) or 'none'}")
+            lines.append(f"  path sequences: {', '.join(exclude_details.get('path_sequences', [])) or 'none'}")
+            lines.append(f"  logic rules: {', '.join(exclude_details.get('logic_rules', [])) or 'none'}")
+        else:
+            lines.append("  none")
+        lines.append("")
+    lines.extend(
+        [
+            render_table("Overlay Gaps", overlays),
+            render_table("Collection Gaps", collections),
+        ]
+    )
     if playlists:
         lines.append(render_table("Playlist Gaps", playlists))
     if libraries:
@@ -885,6 +947,7 @@ def main() -> None:
     cache_enabled = not args.no_cache
     cache_data = load_cache(cache_path, expected_context=cache_context) if cache_enabled else empty_cache(cache_context)
     default_excludes_enabled = not args.no_default_excludes
+    default_excludes = describe_default_excludes(default_excludes_enabled)
 
     inputs = [Path(p).resolve() for p in args.input] if args.input else [root / "artifacts" / "config_zip_scan"]
     discovery_callback, progress_callback, verify_callback = build_progress_callbacks(not args.no_progress)
@@ -1032,6 +1095,7 @@ def main() -> None:
             "cache_path": str(cache_path),
             "cache_context": cache_context,
             "default_excludes_enabled": default_excludes_enabled,
+            "default_excludes": default_excludes,
             "cache_hit_count": prefilter_cache_stats["cache_hits"] + parse_cache_stats["cache_hits"],
             "cache_miss_count": prefilter_cache_stats["cache_misses"] + parse_cache_stats["cache_misses"],
             "cache_stats": {

--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -17,6 +17,10 @@ from ruamel.yaml import YAML
 
 ROOT = Path(__file__).resolve().parents[1]
 CACHE_VERSION = 3
+QS_SPECIAL_LIBRARY_TEMPLATE_KEYS = {
+    "placeholder_imdb_id",
+    "sep_style",
+}
 
 DEFAULT_EXCLUDED_DIR_NAMES = {
     ".git",
@@ -261,22 +265,64 @@ def build_qs_overlay_map(qs_overlays_path: Path) -> dict[str, set[str]]:
 
 def build_qs_library_template_keys(qs_attributes_path: Path) -> set[str]:
     data = load_json(qs_attributes_path)
-    keys: set[str] = set()
+    keys: set[str] = set(QS_SPECIAL_LIBRARY_TEMPLATE_KEYS)
     for section in data.get("sections", []):
         if isinstance(section, dict) and section.get("yml_location") == "template_variables" and section.get("prefix"):
             keys.add(str(section["prefix"]))
     return keys
 
 
+def build_schema_key_set(schema_path: Path) -> set[str]:
+    data = load_json(schema_path)
+    keys: set[str] = set()
+
+    def walk(node: Any) -> None:
+        if isinstance(node, dict):
+            properties = node.get("properties")
+            if isinstance(properties, dict):
+                for key, value in properties.items():
+                    keys.add(str(key))
+                    walk(value)
+            pattern_properties = node.get("patternProperties")
+            if isinstance(pattern_properties, dict):
+                for key, value in pattern_properties.items():
+                    keys.add(str(key))
+                    walk(value)
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(data)
+    return keys
+
+
 def resolve_default_paths(alias: str, kind: str, kometa_defaults: Path) -> list[Path]:
+    support_files: list[Path] = []
+    shared_templates = kometa_defaults / "templates.yml"
+    if shared_templates.exists():
+        support_files.append(shared_templates)
     if kind == "overlay":
         path = kometa_defaults / "overlays" / f"{alias}.yml"
-        return [path] if path.exists() else []
+        if path.exists():
+            support_files.append(path)
+        return support_files
     if kind == "playlist":
         path = kometa_defaults / "playlist.yml"
-        return [path] if path.exists() else []
+        if path.exists():
+            support_files.append(path)
+        return support_files
     matches = sorted(kometa_defaults.rglob(f"{alias}.yml"))
-    return [p for p in matches if p.is_file()]
+    support_files.extend([p for p in matches if p.is_file()])
+    deduped: list[Path] = []
+    seen: set[Path] = set()
+    for path in support_files:
+        if path in seen:
+            continue
+        deduped.append(path)
+        seen.add(path)
+    return deduped
 
 
 KEY_RE = re.compile(r"^\s*([A-Za-z0-9_<>-]+(?:\.[A-Za-z0-9_<>-]+)?)\s*:\s*(?:.*)?$")
@@ -352,6 +398,22 @@ def key_is_valid_for_default(key: str, default_files: list[Path]) -> tuple[bool,
                 matched.append(path)
                 break
     return bool(matched), matched
+
+
+def classify_validation_level(
+    quickstart_supported: bool,
+    schema_declared: bool,
+    kometa_declared: bool,
+) -> str:
+    if quickstart_supported:
+        return "supported_in_quickstart"
+    if kometa_declared and schema_declared:
+        return "works_in_kometa_missing_from_quickstart"
+    if kometa_declared and not schema_declared:
+        return "works_in_kometa_missing_from_quickstart_and_schema"
+    if schema_declared and not kometa_declared:
+        return "schema_declared_not_confirmed_in_kometa_defaults"
+    return "unverified"
 
 
 BOOL_PREFIXES = (
@@ -839,7 +901,7 @@ def compact_path_list(paths: list[str], limit: int = 3) -> str:
 def render_table(title: str, rows: list[dict[str, Any]]) -> str:
     if not rows:
         return f"{title}\n  none\n"
-    headers = ["default", "key", "occ", "shape ok", "shape ?", "files", "libraries", "kometa file"]
+    headers = ["default", "key", "occ", "qs", "schema", "kometa", "status", "files", "libraries", "kometa file"]
     table_rows = []
     for row in rows:
         table_rows.append(
@@ -847,11 +909,40 @@ def render_table(title: str, rows: list[dict[str, Any]]) -> str:
                 str(row.get("default") or "-"),
                 str(row.get("key") or "-"),
                 str(row.get("occurrences", 0)),
-                str(row.get("value_shape_verified_occurrences", 0)),
-                str(row.get("value_shape_unknown_occurrences", 0)),
+                "yes" if row.get("supported_in_quickstart") else "no",
+                "yes" if row.get("schema_declared") else "no",
+                "yes" if row.get("kometa_declared") else "no",
+                str(row.get("validation_level") or "-"),
                 str(row.get("file_count", 0)),
                 compact_path_list(row.get("libraries", []), limit=2),
                 compact_path_list(row.get("matched_default_files", []), limit=2),
+            ]
+        )
+    widths = []
+    for col_idx, header in enumerate(headers):
+        widths.append(max(len(header), *(len(r[col_idx]) for r in table_rows)))
+
+    def fmt(row: list[str]) -> str:
+        return "  " + " | ".join(cell.ljust(widths[idx]) for idx, cell in enumerate(row))
+
+    lines = [title, fmt(headers), "  " + "-+-".join("-" * width for width in widths)]
+    lines.extend(fmt(row) for row in table_rows)
+    return "\n".join(lines) + "\n"
+
+
+def render_grouped_default_table(title: str, rows: list[dict[str, Any]]) -> str:
+    if not rows:
+        return f"{title}\n  none\n"
+    headers = ["kind", "default", "gaps", "occ", "keys"]
+    table_rows = []
+    for row in rows:
+        table_rows.append(
+            [
+                str(row.get("kind") or "-"),
+                str(row.get("default") or "-"),
+                str(row.get("gap_count", 0)),
+                str(row.get("occurrences", 0)),
+                compact_path_list(row.get("keys", []), limit=4),
             ]
         )
     widths = []
@@ -871,6 +962,7 @@ def render_summary(report: dict[str, Any], json_output_path: Path) -> str:
     collections = report.get("verified_gaps_by_kind", {}).get("collection", [])
     playlists = report.get("verified_gaps_by_kind", {}).get("playlist", [])
     libraries = report.get("verified_gaps_by_kind", {}).get("library", [])
+    schema_backlog = report.get("schema_backlog_by_default", [])
 
     lines = [
         "Template Variable Gap Summary",
@@ -886,6 +978,9 @@ def render_summary(report: dict[str, Any], json_output_path: Path) -> str:
         "  cache invalidates on: analyzer, Quickstart support JSON, Kometa defaults, or source file changes",
         f"  template variable occurrences scanned: {report.get('template_variable_occurrences_scanned', 0)}",
         f"  verified gaps: {report.get('verified_gap_count', 0)}",
+        f"  schema-declared verified gaps: {report.get('schema_declared_gap_count', 0)}",
+        f"  kometa-declared verified gaps: {report.get('kometa_declared_gap_count', 0)}",
+        f"  verified gaps missing from schema but supported by Kometa: {report.get('kometa_missing_schema_gap_count', 0)}",
         f"  value-shape verified gaps: {report.get('value_shape_verified_gap_count', 0)}",
         f"  overlay gaps: {len(overlays)}",
         f"  collection gaps: {len(collections)}",
@@ -911,6 +1006,8 @@ def render_summary(report: dict[str, Any], json_output_path: Path) -> str:
             render_table("Collection Gaps", collections),
         ]
     )
+    if schema_backlog:
+        lines.append(render_grouped_default_table("Schema Backlog By Default", schema_backlog))
     if playlists:
         lines.append(render_table("Playlist Gaps", playlists))
     if libraries:
@@ -933,6 +1030,7 @@ def main() -> None:
     args = parse_args()
     root = Path(args.quickstart_root).resolve()
     kometa_defaults = root / "config" / "kometa" / "defaults"
+    kometa_schema_path = root / "config" / "kometa" / "json-schema" / "config-schema.json"
     qs_collections_path = root / "static" / "json" / "quickstart_collections.json"
     qs_overlays_path = root / "static" / "json" / "quickstart_overlays.json"
     qs_attributes_path = root / "static" / "json" / "quickstart_attributes.json"
@@ -965,6 +1063,7 @@ def main() -> None:
         qs_collections = build_qs_collection_map(qs_collections_path)
         qs_overlays = build_qs_overlay_map(qs_overlays_path)
         qs_library_keys = build_qs_library_template_keys(qs_attributes_path)
+        schema_keys = build_schema_key_set(kometa_schema_path)
         if progress_callback:
             print(
                 f"[progress][discovery] discovered {len(input_files)} YAML files across {len(inputs)} input root(s)",
@@ -1013,8 +1112,13 @@ def main() -> None:
                 matched_files = []
 
             value_shape_verified, value_shape_rule = infer_value_shape(row["value"], key)
+            schema_declared = key in schema_keys
+            validation_level = classify_validation_level(supported, schema_declared, name_verified)
             out = dict(row)
             out["supported_in_quickstart"] = supported
+            out["schema_declared"] = schema_declared
+            out["kometa_declared"] = name_verified
+            out["validation_level"] = validation_level
             out["name_verified"] = name_verified
             out["value_shape_verified"] = value_shape_verified
             out["value_shape_rule"] = value_shape_rule
@@ -1041,6 +1145,10 @@ def main() -> None:
                     "files": set(),
                     "libraries": set(),
                     "matched_default_files": set(),
+                    "supported_in_quickstart": False,
+                    "schema_declared": False,
+                    "kometa_declared": False,
+                    "validation_level": "",
                     "value_shape_verified_occurrences": 0,
                     "value_shape_unknown_occurrences": 0,
                     "value_shape_rules": set(),
@@ -1052,6 +1160,10 @@ def main() -> None:
                 bucket["libraries"].add(row["library"])
             for item in row["matched_default_files"]:
                 bucket["matched_default_files"].add(item)
+            bucket["supported_in_quickstart"] = bucket["supported_in_quickstart"] or bool(row.get("supported_in_quickstart"))
+            bucket["schema_declared"] = bucket["schema_declared"] or bool(row.get("schema_declared"))
+            bucket["kometa_declared"] = bucket["kometa_declared"] or bool(row.get("kometa_declared"))
+            bucket["validation_level"] = str(row.get("validation_level") or bucket["validation_level"])
             if row["value_shape_verified"] is True:
                 bucket["value_shape_verified_occurrences"] += 1
             elif row["value_shape_verified"] is None:
@@ -1075,6 +1187,10 @@ def main() -> None:
                     "files": sorted(item["files"]),
                     "libraries": sorted(item["libraries"]),
                     "matched_default_files": sorted(item["matched_default_files"]),
+                    "supported_in_quickstart": item["supported_in_quickstart"],
+                    "schema_declared": item["schema_declared"],
+                    "kometa_declared": item["kometa_declared"],
+                    "validation_level": item["validation_level"],
                     "name_verified": True,
                     "value_shape_verified_occurrences": item["value_shape_verified_occurrences"],
                     "value_shape_unknown_occurrences": item["value_shape_unknown_occurrences"],
@@ -1087,6 +1203,36 @@ def main() -> None:
         for item in serializable_ranked:
             kind_key = item["kind"] if item["kind"] in by_kind else "library"
             by_kind[kind_key].append(item)
+
+        schema_backlog_summary: dict[tuple[str, str | None], dict[str, Any]] = {}
+        for item in serializable_ranked:
+            if not item["kometa_declared"] or item["schema_declared"]:
+                continue
+            bucket = schema_backlog_summary.setdefault(
+                (item["kind"], item["default"]),
+                {
+                    "kind": item["kind"],
+                    "default": item["default"],
+                    "occurrences": 0,
+                    "keys": set(),
+                },
+            )
+            bucket["occurrences"] += item["occurrences"]
+            bucket["keys"].add(item["key"])
+
+        schema_backlog_by_default = sorted(
+            [
+                {
+                    "kind": item["kind"],
+                    "default": item["default"],
+                    "occurrences": item["occurrences"],
+                    "gap_count": len(item["keys"]),
+                    "keys": sorted(item["keys"]),
+                }
+                for item in schema_backlog_summary.values()
+            ],
+            key=lambda item: (-item["occurrences"], -item["gap_count"], str(item["default"]), str(item["kind"])),
+        )
 
         report = {
             "quickstart_root": str(root),
@@ -1112,14 +1258,21 @@ def main() -> None:
             "files_with_template_variables_count": len(sorted({row["file"] for row in uploaded})),
             "template_variable_occurrences_scanned": len(uploaded),
             "verified_gap_count": len(serializable_ranked),
+            "schema_declared_gap_count": sum(1 for item in serializable_ranked if item["schema_declared"]),
+            "kometa_declared_gap_count": sum(1 for item in serializable_ranked if item["kometa_declared"]),
+            "kometa_missing_schema_gap_count": sum(1 for item in serializable_ranked if item["kometa_declared"] and not item["schema_declared"]),
             "value_shape_verified_gap_count": sum(1 for item in serializable_ranked if item["value_shape_verified_occurrences"] > 0),
             "verification_notes": {
-                "name_verified": "Key name matched a variable declared or referenced in the corresponding built-in Kometa default.",
+                "name_verified": "Key name matched a variable declared or referenced in the corresponding built-in Kometa default or shared built-in templates.yml.",
+                "schema_declared": "Key name was found in Kometa's bundled config-schema.json. This is a secondary signal because the schema is not fully exhaustive.",
+                "kometa_declared": "Key name was found in Kometa's bundled built-in defaults/templates, which is treated as the stronger local source of truth.",
+                "validation_level": "works_in_kometa_missing_from_quickstart_and_schema means the key was not found in Quickstart or schema, but was found in Kometa built-in defaults/templates.",
                 "value_shape_verified": "Best-effort local heuristic that the supplied value looks like the expected basic type. Null means no reliable local rule was inferred.",
                 "runtime_guaranteed": False,
             },
             "verified_gaps_ranked": serializable_ranked,
             "verified_gaps_by_kind": by_kind,
+            "schema_backlog_by_default": schema_backlog_by_default,
             "all_rows": all_rows,
         }
     finally:

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -14014,7 +14014,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "exclude",
@@ -15282,7 +15283,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "exclude",
@@ -16121,7 +16123,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "exclude",
@@ -17033,7 +17036,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "use_other",
@@ -17455,7 +17459,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "use_other",
@@ -17878,7 +17883,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "use_other",
@@ -18301,7 +18307,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "use_other",
@@ -18724,7 +18731,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "use_other",
@@ -19147,7 +19155,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "use_other",
@@ -19570,7 +19579,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "use_other",
@@ -19993,7 +20003,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "use_other",
@@ -20421,7 +20432,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "style",
@@ -20854,7 +20866,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "style",
@@ -21288,7 +21301,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "style",
@@ -21883,7 +21897,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "style",
@@ -22365,7 +22380,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "use_1.33",
@@ -22837,7 +22853,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "style",
@@ -23280,7 +23297,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "use_other",
@@ -23712,7 +23730,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "use_other",
@@ -24152,7 +24171,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "style",
@@ -24637,7 +24657,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "style",
@@ -25131,7 +25152,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "style",
@@ -25625,7 +25647,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "style",
@@ -26126,7 +26149,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "use_appletv",
@@ -27039,7 +27063,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "include",
@@ -27465,7 +27490,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "style",
@@ -27906,7 +27932,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections. Kometa defaults Seasonal to off unless you enable it.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": false
           },
           {
             "key": "use_aapi",
@@ -28806,7 +28833,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "data_starting",
@@ -29287,7 +29315,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "exclude",
@@ -29702,7 +29731,8 @@
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle"
+            "type": "toggle",
+            "default": true
           },
           {
             "key": "exclude",

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -14011,6 +14011,12 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
@@ -15273,6 +15279,12 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
@@ -16104,6 +16116,12 @@
             "type": "text_input",
             "default": "085",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
           },
           {
             "key": "exclude",
@@ -17012,6 +17030,12 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
+          },
+          {
             "key": "use_other",
             "label": "Other",
             "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
@@ -17426,6 +17450,12 @@
             "type": "text_input",
             "default": "110",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
           },
           {
             "key": "use_other",
@@ -17845,6 +17875,12 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
+          },
+          {
             "key": "use_other",
             "label": "Other",
             "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
@@ -18260,6 +18296,12 @@
             "type": "text_input",
             "default": "110",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
           },
           {
             "key": "use_other",
@@ -18679,6 +18721,12 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
+          },
+          {
             "key": "use_other",
             "label": "Other",
             "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
@@ -19094,6 +19142,12 @@
             "type": "text_input",
             "default": "110",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
           },
           {
             "key": "use_other",
@@ -19513,6 +19567,12 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
+          },
+          {
             "key": "use_other",
             "label": "Other",
             "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
@@ -19928,6 +19988,12 @@
             "type": "text_input",
             "default": "110",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
           },
           {
             "key": "use_other",
@@ -20350,6 +20416,12 @@
             "type": "text_input",
             "default": "080",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
           },
           {
             "key": "style",
@@ -20779,6 +20851,12 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
+          },
+          {
             "key": "style",
             "label": "Style",
             "type": "select",
@@ -21205,6 +21283,12 @@
             "type": "text_input",
             "default": "081",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
           },
           {
             "key": "style",
@@ -21796,6 +21880,12 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
+          },
+          {
             "key": "style",
             "label": "Style",
             "type": "select",
@@ -22272,6 +22362,12 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
+          },
+          {
             "key": "use_1.33",
             "label": "1.33 - Academy Aperture",
             "tooltip": "Collection of Movies/Shows with a 1.33 aspect ratio.",
@@ -22738,6 +22834,12 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
+          },
+          {
             "key": "style",
             "label": "Style",
             "url": "https://kometa.wiki/en/nightly/defaults/both/resolution/#standards-style",
@@ -23175,6 +23277,12 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
+          },
+          {
             "key": "use_other",
             "label": "Other",
             "tooltip": "Include an \"Other\" collection for items that do not match the listed values.",
@@ -23599,6 +23707,12 @@
             "type": "text_input",
             "default": "095",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
           },
           {
             "key": "use_other",
@@ -24033,6 +24147,12 @@
             "type": "text_input",
             "default": "140",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
           },
           {
             "key": "style",
@@ -24512,6 +24632,12 @@
             "type": "text_input",
             "default": "150",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
           },
           {
             "key": "style",
@@ -25002,6 +25128,12 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
+          },
+          {
             "key": "style",
             "label": "Style",
             "type": "select",
@@ -25488,6 +25620,12 @@
             "type": "text_input",
             "default": "170",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
           },
           {
             "key": "style",
@@ -25983,6 +26121,12 @@
             "type": "text_input",
             "default": "030",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
           },
           {
             "key": "use_appletv",
@@ -26892,6 +27036,12 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
+          },
+          {
             "key": "include",
             "label": "Include",
             "type": "string_list",
@@ -27310,6 +27460,12 @@
             "type": "text_input",
             "default": "050",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
           },
           {
             "key": "style",
@@ -27745,6 +27901,12 @@
             "type": "text_input",
             "default": "000",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections. Kometa defaults Seasonal to off unless you enable it.",
+            "type": "toggle"
           },
           {
             "key": "use_aapi",
@@ -28641,6 +28803,12 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
+          },
+          {
             "key": "data_starting",
             "label": "Data Starting",
             "type": "relative_year",
@@ -29116,6 +29284,12 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
@@ -29523,6 +29697,12 @@
             "type": "text_input",
             "default": "100",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle"
           },
           {
             "key": "exclude",

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -5012,10 +5012,14 @@ function setupParentChildToggleVisibility (scope) {
         const id = child.id || ''
         return id.includes('_visible_')
       }
+      const isCollectionBehaviorToggle = (child) => {
+        const id = child.id || ''
+        return id.endsWith('_use_separator') || id.endsWith('_use_other')
+      }
       const isRequiredChild = (child) => {
         const id = child.id || ''
         if (!id.includes('-template_collection_')) return false
-        if (isAddMissingToggle(child) || isVisibleToggle(child)) return false
+        if (isAddMissingToggle(child) || isVisibleToggle(child) || isCollectionBehaviorToggle(child)) return false
         return id.includes('_use_')
       }
       const requiredChildren = Array.from(childrenToggles).filter(isRequiredChild)


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Title

Add collection-level use_separator support and fix libraries-page toggle regression

Description

This updates Quickstart to support Kometa’s collection-level use_separator template variable anywhere the upstream default actually uses the shared separator template.

It also fixes a UI regression on the Libraries page where adding use_separator caused some enabled collection defaults, especially the People collections, to appear unchecked on reload before saving.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
