### PR TITLE
improved ui guidance

### DIFF
--- a/quickstart.py
+++ b/quickstart.py
@@ -2262,6 +2262,180 @@ def _build_final_gate(workspace_status, template_list, validation_bulk_rollup_at
     }
 
 
+def _step_href(step_key):
+    target = str(step_key or "").strip()
+    if not target:
+        target = "001-start"
+    if has_request_context():
+        try:
+            return url_for("step", name=target)
+        except Exception:
+            return f"/step/{target}"
+    return f"/step/{target}"
+
+
+def _latest_bulk_validation_timestamp(config_name):
+    if not config_name:
+        return ""
+    try:
+        stored_validation = database.retrieve_section_data(config_name, "validation_summary")
+        stored_payload = stored_validation[2] if stored_validation else None
+        if isinstance(stored_payload, dict):
+            return str(stored_payload.get("updated_at") or "").strip()
+    except Exception:
+        return ""
+    return ""
+
+
+def _workspace_step_status_from_app_readiness(state):
+    normalized = str(state or "").strip().lower()
+    if normalized in {"ready", "review", "running", "queued"}:
+        return "ok"
+    if normalized == "needs_validation":
+        return "warn"
+    if normalized in {"needs_prepare", "needs_setup", "blocked", "error"}:
+        return "error"
+    return "unknown"
+
+
+def _build_workspace_app_readiness_from_status(config_name, workspace_status, template_list=None):
+    template_list = template_list or helpers.get_menu_list()
+    final_gate = _build_final_gate(
+        workspace_status,
+        template_list,
+        _latest_bulk_validation_timestamp(config_name),
+    )
+    install_context = _build_kometa_install_context(config_name)
+
+    first_blocker = {}
+    todo_blockers = final_gate.get("todo_blockers") or []
+    if todo_blockers:
+        first_blocker = todo_blockers[0] if isinstance(todo_blockers[0], dict) else {}
+    blocker_key = first_blocker.get("key") or "001-start"
+    blocker_label = first_blocker.get("label") or "setup"
+    todo_count = int(final_gate.get("todo_count") or 0)
+
+    kometa = {
+        "name": "Kometa",
+        "href": _step_href("900-kometa"),
+        "action_label": "Open Kometa",
+        "state": "review",
+        "summary": "Open Kometa",
+        "detail": "Use the Kometa page to review build status, prepare the runtime, and run this config.",
+        "target_step": "900-kometa",
+        "final_gate_stage": final_gate.get("stage") or "todo",
+        "todo_count": todo_count,
+        "install_mode": install_context.get("kometa_install_mode") or "",
+        "mode_label": install_context.get("kometa_mode_label") or "",
+        "can_launch": bool(install_context.get("kometa_can_launch")),
+        "can_sync_config": bool(install_context.get("kometa_can_sync_config")),
+    }
+
+    if final_gate.get("stage") == "todo":
+        noun = "item" if todo_count == 1 else "items"
+        kometa.update(
+            state="needs_setup",
+            summary=f"{todo_count} setup {noun} left" if todo_count else "Finish setup first",
+            detail=f"Finish {blocker_label} before Kometa is ready to review in Quickstart.",
+            action_label="Finish setup",
+            href=_step_href(blocker_key),
+            target_step=blocker_key,
+        )
+    elif final_gate.get("stage") == "freshness":
+        kometa.update(
+            state="review",
+            summary="Validation refresh recommended",
+            detail=f"Open Kometa to refresh bulk validation before running. Quickstart expects validation within the last {QS_FINAL_VALIDATION_TTL_HOURS} hours, but the app itself is still available.",
+            action_label="Open Kometa",
+            href=_step_href("900-kometa"),
+            target_step="900-kometa",
+        )
+    elif install_context.get("kometa_can_launch"):
+        kometa.update(
+            state="ready",
+            summary="Ready in Quickstart",
+            detail="Open Kometa to prepare the runtime if needed, then review or run this config.",
+        )
+    elif install_context.get("kometa_can_sync_config"):
+        detail = "Open Kometa to review and sync this config."
+        if install_context.get("kometa_is_external_install"):
+            detail = "Open Kometa to review and sync this config for your external Kometa install."
+        kometa.update(
+            state="review",
+            summary="Config ready",
+            detail=detail,
+        )
+
+    imagemaid_settings, imagemaid_section = _get_imagemaid_settings_section(config_name)
+    imagemaid_state = _probe_imagemaid_root_state(helpers.get_imagemaid_root_path())
+    imagemaid_row = database.retrieve_section_data(config_name, "imagemaid") if config_name else None
+    imagemaid_validated = helpers.booler(imagemaid_row[0]) if imagemaid_row else helpers.booler(imagemaid_settings.get("validated", False))
+    imagemaid_is_valid, imagemaid_reason, imagemaid_details = _validate_imagemaid_settings(imagemaid_section, config_name=config_name)
+
+    imagemaid = {
+        "name": "ImageMaid",
+        "href": _step_href("915-imagemaid"),
+        "action_label": "Open ImageMaid",
+        "state": "needs_prepare",
+        "summary": "Prepare ImageMaid",
+        "detail": "Install or prepare ImageMaid before validating and running it in Quickstart.",
+        "target_step": "915-imagemaid",
+        "validated": bool(imagemaid_validated),
+        "settings_valid": bool(imagemaid_is_valid),
+        "installed": bool(imagemaid_state.get("imagemaid_installed")),
+        "venv_ready": bool(imagemaid_state.get("venv_python_exists")),
+    }
+
+    if imagemaid_state.get("imagemaid_installed") and imagemaid_state.get("venv_python_exists"):
+        if imagemaid_is_valid and imagemaid_validated:
+            imagemaid.update(
+                state="ready",
+                summary="Ready to run",
+                detail="Open ImageMaid to review the command preview and run it.",
+            )
+        elif imagemaid_is_valid:
+            imagemaid.update(
+                state="needs_validation",
+                summary="Ready to validate",
+                detail="Open ImageMaid and validate the saved settings to unlock run controls.",
+            )
+        else:
+            summary_map = {
+                "missing_plex_validation": "Plex validation required",
+                "missing_credentials": "Saved Plex credentials required",
+                "invalid_path": "Plex path needs attention",
+            }
+            imagemaid.update(
+                state="needs_setup",
+                summary=summary_map.get(imagemaid_reason, "ImageMaid needs attention"),
+                detail=str(imagemaid_details or "Open ImageMaid to finish setup.").strip(),
+            )
+            if imagemaid_reason == "missing_plex_validation":
+                imagemaid.update(
+                    href=_step_href("010-plex"),
+                    action_label="Open Plex",
+                    target_step="010-plex",
+                )
+
+    return {
+        "generated_at": utc_now_iso(),
+        "kometa": kometa,
+        "imagemaid": imagemaid,
+    }
+
+
+def _build_workspace_app_readiness(config_name, template_list=None, available_configs=None):
+    template_list = template_list or helpers.get_menu_list()
+    available_configs = available_configs or database.get_unique_config_names() or []
+    workspace_status = _build_workspace_status_context(
+        config_name,
+        template_list,
+        available_configs=available_configs,
+        include_app_readiness_overrides=False,
+    )
+    return _build_workspace_app_readiness_from_status(config_name, workspace_status, template_list=template_list)
+
+
 def _is_nonblank_setting(value):
     if value is None:
         return False
@@ -2465,7 +2639,7 @@ def _derive_step_status(template_key, group, section_rows, config_exists):
     return "ok"
 
 
-def _build_workspace_status_context(config_name, template_list, available_configs=None):
+def _build_workspace_status_context(config_name, template_list, available_configs=None, include_app_readiness_overrides=True):
     template_keys = []
     for file_entry, _ in template_list or []:
         template_key = file_entry.rsplit(".", 1)[0]
@@ -2528,6 +2702,29 @@ def _build_workspace_status_context(config_name, template_list, available_config
         step_statuses[template_key] = _derive_step_status(template_key, group, section_rows, config_exists)
     if "900-kometa" in template_keys:
         step_statuses["900-kometa"] = _derive_live_final_validation_status(step_statuses, template_keys)
+
+    if include_app_readiness_overrides and config_name:
+        provisional_status = {
+            "step_statuses": dict(step_statuses),
+            "required_keys": list(required_keys),
+            "optional_keys": list(optional_keys),
+            "review_keys": list(review_keys),
+            "tautulli_requirement_reasons": tautulli_requirement_reasons,
+            "omdb_requirement_reasons": omdb_requirement_reasons,
+            "mdblist_requirement_reasons": mdblist_requirement_reasons,
+            "anidb_requirement_reasons": anidb_requirement_reasons,
+            "radarr_requirement_reasons": radarr_requirement_reasons,
+            "sonarr_requirement_reasons": sonarr_requirement_reasons,
+            "trakt_requirement_reasons": trakt_requirement_reasons,
+            "mal_requirement_reasons": mal_requirement_reasons,
+        }
+        app_readiness = _build_workspace_app_readiness_from_status(config_name, provisional_status, template_list=template_list)
+        kometa_readiness = app_readiness.get("kometa") if isinstance(app_readiness, dict) else None
+        imagemaid_readiness = app_readiness.get("imagemaid") if isinstance(app_readiness, dict) else None
+        if "900-kometa" in step_statuses and isinstance(kometa_readiness, dict):
+            step_statuses["900-kometa"] = _workspace_step_status_from_app_readiness(kometa_readiness.get("state"))
+        if "915-imagemaid" in step_statuses and isinstance(imagemaid_readiness, dict):
+            step_statuses["915-imagemaid"] = _workspace_step_status_from_app_readiness(imagemaid_readiness.get("state"))
 
     required_rollup = _worst_status(step_statuses.get(key, "warn") for key in required_keys) if required_keys else "ok"
     review_rollup = _worst_status(step_statuses.get(key, "ok") for key in review_keys) if review_keys else "ok"
@@ -8298,6 +8495,14 @@ def workspace_status():
         mal_requirement_reasons=status.get("mal_requirement_reasons", []),
         readiness=status.get("readiness", {}),
     )
+
+
+@app.route("/workspace_app_readiness", methods=["GET"])
+def workspace_app_readiness():
+    persistence.ensure_session_config_name()
+    config_name = request.args.get("config_name") or session.get("config_name")
+    payload = _build_workspace_app_readiness(config_name)
+    return jsonify(success=True, config_name=config_name, apps=payload)
 
 
 @app.route("/get_top_imdb_items/<library_name>")

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -4815,6 +4815,26 @@ body {
     font-weight: 500;
 }
 
+.qs-readiness-apps-line {
+    color: var(--theme-text-muted);
+}
+
+.qs-readiness-apps-line.qs-readiness-apps-line--ok {
+    color: #7ee8bf;
+}
+
+.qs-readiness-apps-line.qs-readiness-apps-line--warn {
+    color: #ffd793;
+}
+
+.qs-readiness-apps-line.qs-readiness-apps-line--error {
+    color: #ffb6be;
+}
+
+.qs-readiness-apps-line.qs-readiness-apps-line--unknown {
+    color: #9ee8ff;
+}
+
 .qs-readiness-freshness-fresh {
     color: #7ee8bf;
 }
@@ -5106,6 +5126,47 @@ body {
     display: inline-flex;
     align-items: center;
     gap: 0.32rem;
+}
+
+.qs-step-group-summary-meta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 1.35rem;
+    padding: 0.08rem 0.42rem;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--theme-text);
+    font-size: 0.58rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+
+.qs-step-group-summary-meta--ok {
+    border-color: rgba(22, 163, 101, 0.75);
+    background: rgba(22, 163, 101, 0.16);
+    color: #79f3c8;
+}
+
+.qs-step-group-summary-meta--warn {
+    border-color: rgba(245, 158, 11, 0.72);
+    background: rgba(245, 158, 11, 0.16);
+    color: #ffd793;
+}
+
+.qs-step-group-summary-meta--error {
+    border-color: rgba(220, 53, 69, 0.72);
+    background: rgba(220, 53, 69, 0.16);
+    color: #ffb6be;
+}
+
+.qs-step-group-summary-meta--unknown {
+    border-color: rgba(56, 189, 248, 0.72);
+    background: rgba(56, 189, 248, 0.16);
+    color: #9ee8ff;
 }
 
 .qs-step-group summary::-webkit-details-marker {
@@ -6077,6 +6138,10 @@ body {
     .qs-workspace-section[data-qs-sidebar="collapsed"] .qs-step-group-summary-right {
         width: 100%;
         justify-content: center;
+    }
+
+    .qs-workspace-section[data-qs-sidebar="collapsed"] .qs-step-group-summary-meta {
+        display: none !important;
     }
 
     .qs-workspace-section[data-qs-sidebar="collapsed"] .qs-sidebar-utility-group .qs-step-group-summary-right {

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -555,13 +555,16 @@ const qsCurrentTemplate = String(window.QS_CURRENT_TEMPLATE || document.document
 const qsSkipMaintenancePoll = qsCurrentTemplate === '900-kometa'
 const qsSkipImageMaidPoll = qsCurrentTemplate === '915-imagemaid'
 const qsSkipLogscanReingestPoll = qsCurrentTemplate === '905-analytics'
+const QS_APP_READINESS_POLL_INTERVAL_MS = 12000
 let qsLatestKometaStatus = null
 let qsLatestImageMaidStatus = null
+let qsLatestAppReadiness = null
 let qsActiveBackgroundJobs = []
 let qsMaintenancePollInFlight = false
 let qsLogscanReingestPollInFlight = false
 let qsImageMaidPollInFlight = false
 let qsBackgroundJobsPollInFlight = false
+let qsAppReadinessPollInFlight = false
 
 function qsShouldPollBackgroundState () {
   return !document.hidden
@@ -982,6 +985,7 @@ function qsHandleMaintenanceStatus (data) {
 
   qsLastMaintenancePaused = paused
   qsRenderActiveWorkCard()
+  qsRenderAppReadiness()
   document.dispatchEvent(new CustomEvent('qs:maintenance-status', { detail: data }))
 }
 
@@ -1004,6 +1008,7 @@ function qsHandleImageMaidStatus (data) {
     }
   }
   qsRenderActiveWorkCard()
+  qsRenderAppReadiness()
 }
 
 window.QS_handleImageMaidStatus = qsHandleImageMaidStatus
@@ -1017,6 +1022,202 @@ function qsHandleLogscanReingestStatus (data) {
 }
 
 window.QS_handleLogscanReingestStatus = qsHandleLogscanReingestStatus
+
+function qsGetAppReadinessState (entry) {
+  return String((entry && entry.state) || '').trim().toLowerCase()
+}
+
+function qsIsAppReadinessAvailable (entry) {
+  return ['ready', 'review', 'running', 'queued'].includes(qsGetAppReadinessState(entry))
+}
+
+function qsHydrateKometaReadiness (entry) {
+  const hydrated = { ...(entry || {}) }
+  const data = qsLatestKometaStatus
+  if (!data || typeof data !== 'object') return hydrated
+
+  const status = String(data.status || '').trim().toLowerCase()
+  const elapsed = typeof data.elapsed_seconds === 'number' ? qsFormatElapsedLabel(data.elapsed_seconds) : ''
+  const windowLabel = String(data.maintenance_window || '').trim()
+  const windowSuffix = windowLabel ? ` (${windowLabel})` : ''
+  const unavailableBlocksWork = Boolean(data.window_unavailable) && (Boolean(data.pending_start) || Boolean(data.maintenance_paused) || status !== 'running')
+
+  if (status === 'running') {
+    hydrated.state = 'running'
+    hydrated.summary = 'Running now'
+    hydrated.detail = `Kometa is currently running${elapsed ? ` (${elapsed})` : ''}.`
+    return hydrated
+  }
+  if (data.pending_start) {
+    hydrated.state = 'queued'
+    hydrated.summary = 'Start queued'
+    hydrated.detail = `Kometa will start when the Plex maintenance window allows it${windowSuffix}.`
+    return hydrated
+  }
+  if (data.maintenance_paused) {
+    hydrated.state = 'blocked'
+    hydrated.summary = 'Paused for maintenance'
+    hydrated.detail = `Kometa is paused for Plex maintenance${windowSuffix}.`
+    return hydrated
+  }
+  if (unavailableBlocksWork) {
+    hydrated.state = 'blocked'
+    hydrated.summary = 'Window data unavailable'
+    hydrated.detail = 'Quickstart cannot confirm the Plex maintenance window right now.'
+  }
+  return hydrated
+}
+
+function qsHydrateImageMaidReadiness (entry) {
+  const hydrated = { ...(entry || {}) }
+  const data = qsLatestImageMaidStatus
+  if (!data || typeof data !== 'object') return hydrated
+
+  if (String(data.status || '').trim().toLowerCase() === 'running') {
+    const elapsed = typeof data.elapsed_seconds === 'number' ? qsFormatElapsedLabel(data.elapsed_seconds) : ''
+    hydrated.state = 'running'
+    hydrated.summary = 'Running now'
+    hydrated.detail = `ImageMaid is currently running${elapsed ? ` (${elapsed})` : ''}.`
+  }
+  return hydrated
+}
+
+function qsFormatAppReadinessSnippet (entry) {
+  const state = qsGetAppReadinessState(entry)
+  const name = String((entry && entry.name) || 'App').trim()
+  switch (state) {
+    case 'ready':
+    case 'review':
+      return `${name} ready`
+    case 'running':
+      return `${name} running`
+    case 'queued':
+      return `${name} queued`
+    case 'needs_validation':
+      return `${name} needs validation`
+    case 'needs_prepare':
+      return `${name} needs preparation`
+    case 'blocked':
+    case 'needs_setup':
+    case 'error':
+      return `${name}: ${String((entry && entry.summary) || 'needs attention').trim()}`
+    default:
+      return `${name}: ${String((entry && entry.summary) || 'checking status').trim()}`
+  }
+}
+
+function qsSetStepGroupIndicatorState (group, state) {
+  if (!group) return
+  const normalized = ['ok', 'warn', 'error', 'unknown'].includes(String(state || '').trim().toLowerCase())
+    ? String(state || '').trim().toLowerCase()
+    : 'unknown'
+  const indicator = group.querySelector('.qs-step-group-state')
+  if (!indicator) return
+  indicator.classList.remove('qs-step-group-state--ok', 'qs-step-group-state--warn', 'qs-step-group-state--error', 'qs-step-group-state--unknown')
+  indicator.classList.add(`qs-step-group-state--${normalized}`)
+}
+
+function qsRenderAppReadiness () {
+  const appsLineEl = document.querySelector('[data-qs-readiness-apps]')
+  const appsGroup = document.querySelector('[data-step-group="apps"]')
+  const appsGroupSummaryEl = appsGroup ? appsGroup.querySelector('[data-qs-app-group-summary]') : null
+  const payload = qsLatestAppReadiness && typeof qsLatestAppReadiness === 'object'
+    ? (qsLatestAppReadiness.apps || qsLatestAppReadiness)
+    : null
+
+  if (!appsLineEl && !appsGroupSummaryEl) return
+
+  if (!payload || typeof payload !== 'object') {
+    if (appsLineEl) {
+      appsLineEl.textContent = 'Apps: checking status...'
+      appsLineEl.classList.remove('qs-readiness-apps-line--ok', 'qs-readiness-apps-line--warn', 'qs-readiness-apps-line--error', 'qs-readiness-apps-line--unknown')
+      appsLineEl.classList.add('qs-readiness-apps-line--unknown')
+    }
+    if (appsGroupSummaryEl) {
+      appsGroupSummaryEl.classList.add('d-none')
+      appsGroupSummaryEl.textContent = ''
+      appsGroupSummaryEl.removeAttribute('title')
+    }
+    qsSetStepGroupIndicatorState(appsGroup, 'unknown')
+    return
+  }
+
+  const entries = []
+  if (payload.kometa) entries.push(qsHydrateKometaReadiness(payload.kometa))
+  if (payload.imagemaid) entries.push(qsHydrateImageMaidReadiness(payload.imagemaid))
+
+  if (!entries.length) {
+    if (appsLineEl) {
+      appsLineEl.textContent = 'Apps: status unavailable.'
+      appsLineEl.classList.remove('qs-readiness-apps-line--ok', 'qs-readiness-apps-line--warn', 'qs-readiness-apps-line--error', 'qs-readiness-apps-line--unknown')
+      appsLineEl.classList.add('qs-readiness-apps-line--unknown')
+    }
+    if (appsGroupSummaryEl) {
+      appsGroupSummaryEl.classList.add('d-none')
+      appsGroupSummaryEl.textContent = ''
+      appsGroupSummaryEl.removeAttribute('title')
+    }
+    qsSetStepGroupIndicatorState(appsGroup, 'unknown')
+    return
+  }
+
+  const availableEntries = entries.filter(entry => qsIsAppReadinessAvailable(entry))
+  const runningEntries = entries.filter(entry => qsGetAppReadinessState(entry) === 'running')
+  const validationEntries = entries.filter(entry => qsGetAppReadinessState(entry) === 'needs_validation')
+  const setupEntries = entries.filter((entry) => ['needs_setup', 'needs_prepare', 'blocked', 'error'].includes(qsGetAppReadinessState(entry)))
+
+  let lineState = 'unknown'
+  let lineText = 'Apps: checking status...'
+  let groupMetaText = ''
+
+  if (availableEntries.length === entries.length) {
+    lineState = 'ok'
+    if (entries.length === 1) {
+      lineText = `Apps: ${entries[0].name} is ready.`
+    } else {
+      lineText = `Apps: ${entries.map(entry => entry.name).join(' and ')} are ready.`
+    }
+    groupMetaText = runningEntries.length > 0 ? `${runningEntries.length} Running` : `${availableEntries.length} Ready`
+  } else if (availableEntries.length > 0) {
+    lineState = 'warn'
+    lineText = `Apps: ${entries.map(qsFormatAppReadinessSnippet).join('; ')}.`
+    groupMetaText = `${availableEntries.length} Ready`
+  } else if (validationEntries.length > 0) {
+    lineState = 'warn'
+    lineText = `Apps: ${entries.map(qsFormatAppReadinessSnippet).join('; ')}.`
+    groupMetaText = 'Validate'
+  } else if (setupEntries.length > 0) {
+    lineState = 'error'
+    lineText = `Apps: ${entries.map(qsFormatAppReadinessSnippet).join('; ')}.`
+    groupMetaText = 'Needs Setup'
+  } else {
+    lineState = 'unknown'
+    lineText = `Apps: ${entries.map(qsFormatAppReadinessSnippet).join('; ')}.`
+    groupMetaText = 'Checking'
+  }
+
+  if (appsLineEl) {
+    appsLineEl.textContent = lineText
+    appsLineEl.classList.remove('qs-readiness-apps-line--ok', 'qs-readiness-apps-line--warn', 'qs-readiness-apps-line--error', 'qs-readiness-apps-line--unknown')
+    appsLineEl.classList.add(`qs-readiness-apps-line--${lineState}`)
+    appsLineEl.title = entries.map((entry) => `${entry.name}: ${entry.summary}`).join(' | ')
+  }
+
+  if (appsGroupSummaryEl) {
+    appsGroupSummaryEl.classList.remove('d-none', 'qs-step-group-summary-meta--ok', 'qs-step-group-summary-meta--warn', 'qs-step-group-summary-meta--error', 'qs-step-group-summary-meta--unknown')
+    appsGroupSummaryEl.classList.add(`qs-step-group-summary-meta--${lineState}`)
+    appsGroupSummaryEl.textContent = groupMetaText
+    appsGroupSummaryEl.title = entries.map((entry) => `${entry.name}: ${entry.summary}`).join(' | ')
+  }
+
+  qsSetStepGroupIndicatorState(appsGroup, lineState)
+}
+
+function qsRefreshAppReadiness () {
+  qsRenderAppReadiness()
+}
+
+window.QS_refreshAppReadiness = qsRefreshAppReadiness
 
 ;(function qsMaintenancePoll () {
   if (qsSkipMaintenancePoll) return
@@ -1068,6 +1269,25 @@ window.QS_handleLogscanReingestStatus = qsHandleLogscanReingestStatus
   }
   setTimeout(poll, 1600)
   setInterval(poll, QS_MAINTENANCE_TOAST_INTERVAL_MS)
+})()
+
+;(function qsAppReadinessPoll () {
+  const poll = () => {
+    if (!qsShouldPollBackgroundState() || qsAppReadinessPollInFlight) return
+    qsAppReadinessPollInFlight = true
+    fetch('/workspace_app_readiness')
+      .then(res => res.json())
+      .then((data) => {
+        qsLatestAppReadiness = data
+        qsRenderAppReadiness()
+      })
+      .catch(() => {})
+      .finally(() => {
+        qsAppReadinessPollInFlight = false
+      })
+  }
+  setTimeout(poll, 900)
+  setInterval(poll, QS_APP_READINESS_POLL_INTERVAL_MS)
 })()
 
 ;(function qsBackgroundJobsPoll () {

--- a/templates/001-navigation.html
+++ b/templates/001-navigation.html
@@ -186,6 +186,9 @@
               <div class="small qs-readiness-subline qs-readiness-freshness-{{ readiness.get('validation_freshness', 'never') }}">
                 Last validated: {{ readiness.get('validation_age_label', 'Never') }}
               </div>
+              <div class="small qs-readiness-subline qs-readiness-apps-line" data-qs-readiness-apps>
+                Apps: checking status...
+              </div>
               <div class="qs-readiness-compact" data-qs-readiness-compact>
                 <div class="qs-readiness-compact-row" data-qs-readiness-required-row title="Required progress">
                   <span class="qs-readiness-compact-label">R</span>

--- a/templates/partials/_workspace_macros.html
+++ b/templates/partials/_workspace_macros.html
@@ -122,6 +122,9 @@ Sponsor
   <summary class="qs-step-group-summary" title="{{ title }}">
     <span>{{ title }}</span>
     <span class="qs-step-group-summary-right">
+      {% if group_key == 'apps' %}
+      <span class="qs-step-group-summary-meta d-none" data-qs-app-group-summary></span>
+      {% endif %}
       {{ status_icon(group_state, 'qs-step-group-state') }}
       <i class="bi bi-chevron-down" aria-hidden="true"></i>
     </span>

--- a/tests/test_workspace_dependency_logic.py
+++ b/tests/test_workspace_dependency_logic.py
@@ -523,6 +523,141 @@ def test_workspace_status_route_returns_all_dependency_reasons(client, monkeypat
     assert "120-sonarr" in payload["required_keys"]
 
 
+def test_workspace_app_readiness_kometa_points_to_first_blocker(monkeypatch, qs_module):
+    monkeypatch.setattr(qs_module.helpers, "get_menu_list", _template_list)
+    monkeypatch.setattr(qs_module.database, "get_unique_config_names", lambda: ["cfg"])
+    monkeypatch.setattr(qs_module, "_build_workspace_status_context", lambda *_args, **_kwargs: {"readiness": {}})
+    monkeypatch.setattr(
+        qs_module,
+        "_build_final_gate",
+        lambda *_args, **_kwargs: {
+            "stage": "todo",
+            "todo_count": 2,
+            "todo_blockers": [{"key": "020-tmdb", "label": "TMDb"}],
+        },
+    )
+    monkeypatch.setattr(qs_module, "_build_kometa_install_context", lambda _name: {})
+    monkeypatch.setattr(qs_module, "_get_imagemaid_settings_section", lambda _name: ({}, {}))
+    monkeypatch.setattr(qs_module.helpers, "get_imagemaid_root_path", lambda: "")
+    monkeypatch.setattr(qs_module, "_probe_imagemaid_root_state", lambda _path: {})
+    monkeypatch.setattr(qs_module.database, "retrieve_section_data", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(qs_module, "_validate_imagemaid_settings", lambda *_args, **_kwargs: (False, "", ""))
+
+    payload = qs_module._build_workspace_app_readiness("cfg")
+
+    assert payload["kometa"]["state"] == "needs_setup"
+    assert payload["kometa"]["href"] == "/step/020-tmdb"
+    assert payload["kometa"]["action_label"] == "Finish setup"
+    assert payload["kometa"]["target_step"] == "020-tmdb"
+
+
+def test_workspace_app_readiness_imagemaid_missing_plex_points_to_plex(monkeypatch, qs_module):
+    monkeypatch.setattr(qs_module.helpers, "get_menu_list", _template_list)
+    monkeypatch.setattr(qs_module.database, "get_unique_config_names", lambda: ["cfg"])
+    monkeypatch.setattr(qs_module, "_build_workspace_status_context", lambda *_args, **_kwargs: {"readiness": {}})
+    monkeypatch.setattr(
+        qs_module,
+        "_build_final_gate",
+        lambda *_args, **_kwargs: {
+            "stage": "config",
+            "todo_count": 0,
+            "todo_blockers": [],
+        },
+    )
+    monkeypatch.setattr(qs_module, "_build_kometa_install_context", lambda _name: {})
+    monkeypatch.setattr(qs_module, "_get_imagemaid_settings_section", lambda _name: ({"validated": False}, {"imagemaid": {}}))
+    monkeypatch.setattr(qs_module.helpers, "get_imagemaid_root_path", lambda: "C:\\ImageMaid")
+    monkeypatch.setattr(
+        qs_module,
+        "_probe_imagemaid_root_state",
+        lambda _path: {"imagemaid_installed": True, "venv_python_exists": True},
+    )
+    monkeypatch.setattr(qs_module.database, "retrieve_section_data", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        qs_module,
+        "_validate_imagemaid_settings",
+        lambda *_args, **_kwargs: (False, "missing_plex_validation", "Validate Plex first."),
+    )
+
+    payload = qs_module._build_workspace_app_readiness("cfg")
+
+    assert payload["imagemaid"]["state"] == "needs_setup"
+    assert payload["imagemaid"]["summary"] == "Plex validation required"
+    assert payload["imagemaid"]["href"] == "/step/010-plex"
+    assert payload["imagemaid"]["action_label"] == "Open Plex"
+    assert payload["imagemaid"]["target_step"] == "010-plex"
+
+
+def test_workspace_app_readiness_kometa_freshness_keeps_app_available(monkeypatch, qs_module):
+    monkeypatch.setattr(qs_module.helpers, "get_menu_list", _template_list)
+    monkeypatch.setattr(qs_module.database, "get_unique_config_names", lambda: ["cfg"])
+    monkeypatch.setattr(qs_module, "_build_workspace_status_context", lambda *_args, **_kwargs: {"readiness": {}})
+    monkeypatch.setattr(
+        qs_module,
+        "_build_final_gate",
+        lambda *_args, **_kwargs: {
+            "stage": "freshness",
+            "todo_count": 0,
+            "todo_blockers": [],
+        },
+    )
+    monkeypatch.setattr(qs_module, "_build_kometa_install_context", lambda _name: {})
+    monkeypatch.setattr(qs_module, "_get_imagemaid_settings_section", lambda _name: ({}, {}))
+    monkeypatch.setattr(qs_module.helpers, "get_imagemaid_root_path", lambda: "")
+    monkeypatch.setattr(qs_module, "_probe_imagemaid_root_state", lambda _path: {})
+    monkeypatch.setattr(qs_module.database, "retrieve_section_data", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(qs_module, "_validate_imagemaid_settings", lambda *_args, **_kwargs: (False, "", ""))
+
+    payload = qs_module._build_workspace_app_readiness("cfg")
+
+    assert payload["kometa"]["state"] == "review"
+    assert payload["kometa"]["summary"] == "Validation refresh recommended"
+    assert payload["kometa"]["action_label"] == "Open Kometa"
+
+
+def test_workspace_status_context_aligns_app_steps_with_app_readiness(monkeypatch, qs_module):
+    monkeypatch.setattr(qs_module.database, "retrieve_config_sections", lambda _name: [])
+    monkeypatch.setattr(qs_module.database, "get_unique_config_names", lambda: ["cfg"])
+    template_list = _template_list() + [("915-imagemaid.html", "ImageMaid")]
+
+    def fake_app_readiness(_config_name, workspace_status, template_list=None):
+        return {
+            "kometa": {"state": "needs_setup"},
+            "imagemaid": {"state": "needs_setup"},
+        }
+
+    monkeypatch.setattr(qs_module, "_build_workspace_app_readiness_from_status", fake_app_readiness)
+
+    ctx = qs_module._build_workspace_status_context("cfg", template_list, available_configs=["cfg"])
+
+    assert ctx["step_statuses"]["900-kometa"] == "error"
+    assert ctx["step_statuses"]["915-imagemaid"] == "error"
+
+
+def test_workspace_app_readiness_route_returns_app_payload(client, monkeypatch, qs_module):
+    monkeypatch.setattr(
+        qs_module,
+        "_build_workspace_app_readiness",
+        lambda config_name: {
+            "generated_at": "2026-06-11T00:00:00Z",
+            "kometa": {"name": "Kometa", "summary": f"Config {config_name} ready"},
+            "imagemaid": {"name": "ImageMaid", "summary": "Prepare ImageMaid"},
+        },
+    )
+
+    with client.session_transaction() as sess:
+        sess["config_name"] = "cfg"
+
+    resp = client.get("/workspace_app_readiness")
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    assert payload["config_name"] == "cfg"
+    assert payload["apps"]["kometa"]["summary"] == "Config cfg ready"
+    assert payload["apps"]["imagemaid"]["summary"] == "Prepare ImageMaid"
+
+
 def test_workspace_context_promotes_trakt_to_required(monkeypatch, qs_module):
     rows = [
         _section_row(


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description


Title

Align app readiness across sidebar, app rows, and Start workflow cards

Description

This PR fixes inconsistent app readiness signals in Quickstart.

Previously, the sidebar READINESS / APPS summary used the newer workspace_app_readiness model, while the expanded APPS rows and Start workflow cards still relied on step_statuses. That allowed cases where readiness correctly showed Kometa/ImageMaid as not ready, but the app rows or Start cards still appeared green.

This change makes app readiness the source of truth for app-level status across the workspace.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
