### PR TITLE
more vars

### DIFF
--- a/modules/importer.py
+++ b/modules/importer.py
@@ -438,10 +438,15 @@ def _build_overlay_index(overlay_config: list[dict]) -> tuple[dict[str, dict], d
             alias = oid.replace("overlay_", "", 1)
             by_alias[alias] = oid
             if input_type == "radio" and radio_group and "value" in overlay:
+                radio_value = overlay.get("value")
                 radio_map[oid] = {
                     "group_name": str(radio_group),
-                    "value": overlay.get("value"),
+                    "value": radio_value,
                 }
+                if isinstance(radio_value, str):
+                    radio_alias = radio_value.strip()
+                    if radio_alias:
+                        by_alias[radio_alias] = oid
     return by_id, by_alias, radio_map
 
 

--- a/static/json/quickstart_overlays.json
+++ b/static/json/quickstart_overlays.json
@@ -33,6 +33,106 @@
               "red"
             ]
           },
+          "use_oscars": {
+            "label": "Use Oscars Best Picture",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_oscars_director": {
+            "label": "Use Oscars Best Director",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_golden": {
+            "label": "Use Golden Globe Winner",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_golden_director": {
+            "label": "Use Golden Globe Director",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_bafta": {
+            "label": "Use BAFTA Winner",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_cannes": {
+            "label": "Use Cannes Winner",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_berlinale": {
+            "label": "Use Berlinale Winner",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_venice": {
+            "label": "Use Venice Winner",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_sundance": {
+            "label": "Use Sundance Winner",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_emmys": {
+            "label": "Use Emmys Winner",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_choice": {
+            "label": "Use Critic's Choice Winner",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_spirit": {
+            "label": "Use Independent Spirit Award Winner",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_cesar": {
+            "label": "Use Cesar Winner",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_imdb": {
+            "label": "Use IMDb Top 250",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_letterboxd": {
+            "label": "Use Letterboxd Top 500",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_rottenverified": {
+            "label": "Use Rotten Tomatoes Verified Hot",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_rotten": {
+            "label": "Use Rotten Tomatoes Certified Fresh",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_metacritic": {
+            "label": "Use Metacritic Must See",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_common": {
+            "label": "Use Common Sense Selection",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_razzie": {
+            "label": "Use Razzies Winner",
+            "input_type": "toggle",
+            "default": true
+          },
           "horizontal_offset": {
             "input_type": "number",
             "default": 0,
@@ -326,6 +426,26 @@
             "input_type": "text",
             "label": "Ended Text",
             "default": "ENDED"
+          },
+          "use_airing": {
+            "label": "Use Airing",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_returning": {
+            "label": "Use Returning",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_canceled": {
+            "label": "Use Canceled",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ended": {
+            "label": "Use Ended",
+            "input_type": "toggle",
+            "default": true
           },
           "font": {
             "input_type": "text",
@@ -1210,6 +1330,36 @@
               "false"
             ]
           },
+          "use_g": {
+            "label": "Use G",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_pg": {
+            "label": "Use PG",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_pg-13": {
+            "label": "Use PG-13",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_r": {
+            "label": "Use R",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_nc-17": {
+            "label": "Use NC-17",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_nr": {
+            "label": "Use NR",
+            "input_type": "toggle",
+            "default": true
+          },
           "back_align": {
             "default": "center",
             "label": "Backdrop Alignment",
@@ -1295,6 +1445,36 @@
               "true",
               "false"
             ]
+          },
+          "use_tv-g": {
+            "label": "Use TV-G",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_tv-y": {
+            "label": "Use TV-Y",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_tv-pg": {
+            "label": "Use TV-PG",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_tv-14": {
+            "label": "Use TV-14",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_tv-ma": {
+            "label": "Use TV-MA",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_nr": {
+            "label": "Use NR",
+            "input_type": "toggle",
+            "default": true
           },
           "builder_level": {
             "input_type": "toggle",
@@ -1403,6 +1583,46 @@
               "false"
             ]
           },
+          "use_u": {
+            "label": "Use U",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_pg": {
+            "label": "Use PG",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_12": {
+            "label": "Use 12",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_12a": {
+            "label": "Use 12A",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_15": {
+            "label": "Use 15",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_18": {
+            "label": "Use 18",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_r18": {
+            "label": "Use R18",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_nr": {
+            "label": "Use NR",
+            "input_type": "toggle",
+            "default": true
+          },
           "builder_level": {
             "input_type": "toggle",
             "media_types": [
@@ -1509,6 +1729,41 @@
               "true",
               "false"
             ]
+          },
+          "use_0": {
+            "label": "Use 0",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_6": {
+            "label": "Use 6",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_12": {
+            "label": "Use 12",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_16": {
+            "label": "Use 16",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_18": {
+            "label": "Use 18",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_bpjm": {
+            "label": "Use BPjM",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_nr": {
+            "label": "Use NR",
+            "input_type": "toggle",
+            "default": true
           },
           "builder_level": {
             "input_type": "toggle",
@@ -1617,6 +1872,41 @@
               "false"
             ]
           },
+          "use_g": {
+            "label": "Use G",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_pg": {
+            "label": "Use PG",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_m": {
+            "label": "Use M",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ma": {
+            "label": "Use MA15+",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_r": {
+            "label": "Use R18+",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_x": {
+            "label": "Use X18+",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_nr": {
+            "label": "Use NR",
+            "input_type": "toggle",
+            "default": true
+          },
           "builder_level": {
             "input_type": "toggle",
             "media_types": [
@@ -1723,6 +2013,66 @@
               "true",
               "false"
             ]
+          },
+          "use_g": {
+            "label": "Use G",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_pg": {
+            "label": "Use PG",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_m": {
+            "label": "Use M",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_r13": {
+            "label": "Use R13",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_rp13": {
+            "label": "Use RP13",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_r15": {
+            "label": "Use R15",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_r16": {
+            "label": "Use R16",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_rp16": {
+            "label": "Use RP16",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_R18": {
+            "label": "Use R18",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_rp18": {
+            "label": "Use RP18",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_r": {
+            "label": "Use R",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_nr": {
+            "label": "Use NR",
+            "input_type": "toggle",
+            "default": true
           },
           "builder_level": {
             "input_type": "toggle",
@@ -1925,6 +2275,215 @@
             "default": 30
           },
           {
+            "type": "toggle",
+            "key": "use_1",
+            "label": "Use 1+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_2",
+            "label": "Use 2+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_3",
+            "label": "Use 3+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_4",
+            "label": "Use 4+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_5",
+            "label": "Use 5+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_6",
+            "label": "Use 6+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_7",
+            "label": "Use 7+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_8",
+            "label": "Use 8+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_9",
+            "label": "Use 9+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_10",
+            "label": "Use 10+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_11",
+            "label": "Use 11+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_12",
+            "label": "Use 12+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_13",
+            "label": "Use 13+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_14",
+            "label": "Use 14+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_15",
+            "label": "Use 15+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_16",
+            "label": "Use 16+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_17",
+            "label": "Use 17+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_18",
+            "label": "Use 18+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_nr",
+            "label": "Use NR",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
             "input_type": "number",
             "key": "horizontal_offset",
             "label": "Horizontal Offset",
@@ -2101,6 +2660,94 @@
           },
           {
             "type": "toggle",
+            "key": "use_1.33",
+            "label": "Use 1.33",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_1.65",
+            "label": "Use 1.65",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_1.66",
+            "label": "Use 1.66",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_1.78",
+            "label": "Use 1.78",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_1.85",
+            "label": "Use 1.85",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_2.2",
+            "label": "Use 2.2",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_2.35",
+            "label": "Use 2.35",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_2.77",
+            "label": "Use 2.77",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
             "key": "builder_level",
             "label": "Apply to Show",
             "value": "show",
@@ -2157,6 +2804,86 @@
               "compact",
               "standard"
             ]
+          },
+          "use_truehd_atmos": {
+            "label": "Use Dolby TrueHD Atmos",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_dtsx": {
+            "label": "Use DTS-X",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_plus_atmos": {
+            "label": "Use Dolby Digital+ / E-AC3",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_dolby_atmos": {
+            "label": "Use Dolby Atmos",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_truehd": {
+            "label": "Use Dolby TrueHD",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ma": {
+            "label": "Use DTS-HD-MA",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_flac": {
+            "label": "Use FLAC",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_pcm": {
+            "label": "Use PCM",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_hra": {
+            "label": "Use DTS-HD-HRA",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_plus": {
+            "label": "Use Dolby Digital+",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_dtses": {
+            "label": "Use DTS-ES",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_dts": {
+            "label": "Use DTS",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_digital": {
+            "label": "Use Dolby Digital",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_aac": {
+            "label": "Use AAC",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_mp3": {
+            "label": "Use MP3",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_opus": {
+            "label": "Use Opus",
+            "input_type": "toggle",
+            "default": true
           },
           "builder_level": {
             "input_type": "toggle",
@@ -2309,6 +3036,28 @@
             "key": "back_radius",
             "label": "Backdrop Radius",
             "default": 30
+          },
+          {
+            "type": "toggle",
+            "key": "use_dual",
+            "label": "Use Dual",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_multi",
+            "label": "Use Multi",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
           },
           {
             "type": "toggle",
@@ -3743,6 +4492,94 @@
           },
           {
             "type": "toggle",
+            "key": "use_remux",
+            "label": "Use REMUX",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_bluray",
+            "label": "Use BLU-RAY",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_web",
+            "label": "Use WEB",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_hdtv",
+            "label": "Use HDTV",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_dvd",
+            "label": "Use DVD",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_sdtv",
+            "label": "Use SDTV",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_telesync",
+            "label": "Use TELESYNC",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_cam",
+            "label": "Use CAM",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
             "key": "builder_level",
             "label": "Apply to Show",
             "value": "show",
@@ -3805,6 +4642,116 @@
               "color",
               "white"
             ]
+          },
+          "use_netflix": {
+            "label": "Use Netflix",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_amazon": {
+            "label": "Use Prime Video",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_disney": {
+            "label": "Use Disney+",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_hbomax": {
+            "label": "Use HBO Max",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_crunchyroll": {
+            "label": "Use Crunchyroll",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_movistar": {
+            "label": "Use Movistar Plus+",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_atresplayer": {
+            "label": "Use Atres Player",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_youtube": {
+            "label": "Use YouTube",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_hulu": {
+            "label": "Use Hulu",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_paramount": {
+            "label": "Use Paramount+",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_amc": {
+            "label": "Use AMC+",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_appletv": {
+            "label": "Use AppleTV",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_peacock": {
+            "label": "Use Peacock",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_discovery": {
+            "label": "Use discovery+",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_crave": {
+            "label": "Use Crave",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_now": {
+            "label": "Use NOW",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_channel4": {
+            "label": "Use Channel 4",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_itvx": {
+            "label": "Use ITVX",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_bet": {
+            "label": "Use BET+",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_hayu": {
+            "label": "Use hayu",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_tubi": {
+            "label": "Use tubi",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_filmin": {
+            "label": "Use filmin",
+            "input_type": "toggle",
+            "default": true
           },
           "builder_level": {
             "input_type": "toggle",

--- a/tests/test_aspect_yaml_contract.py
+++ b/tests/test_aspect_yaml_contract.py
@@ -1,0 +1,84 @@
+from ruamel.yaml import YAML
+
+
+def _template_vars_from_yaml(yaml_content):
+    parser = YAML(typ="safe", pure=True)
+    parsed = parser.load(yaml_content)
+    libraries = parsed.get("libraries", {})
+    movies = libraries.get("Movies", {})
+    overlays = movies.get("overlay_files", [])
+    assert overlays, "Expected at least one overlay entry for Movies"
+    aspect_entry = next((entry for entry in overlays if entry.get("default") == "aspect"), None)
+    assert aspect_entry is not None, "Expected aspect overlay entry"
+    return aspect_entry.get("template_variables", {})
+
+
+def _build_library_payload(template_vars):
+    data = {
+        "mov-library_movies-library": "Movies",
+        "mov-library_movies-collection_collectionless": True,
+        "mov-library_movies-movie-overlay_aspect": True,
+    }
+    for key, value in template_vars.items():
+        data[f"mov-library_movies-movie-template_overlay_aspect[{key}]"] = value
+    return {"validated": True, "libraries": data}
+
+
+def _run_build_config_with_payload(qs_module, monkeypatch, payload):
+    monkeypatch.setattr(
+        qs_module.output.helpers,
+        "get_template_list",
+        lambda: {
+            "libraries": {
+                "name": "Libraries",
+                "stem": "025-libraries",
+                "raw_name": "libraries",
+            }
+        },
+    )
+    monkeypatch.setattr(qs_module.output.helpers, "get_plex_summary", lambda: "Plex summary unavailable")
+    monkeypatch.setattr(qs_module.output.helpers, "get_quickstart_settings_summary", lambda: [])
+    monkeypatch.setattr(qs_module.output.helpers, "get_library_summaries", lambda _names: "Movies")
+
+    def fake_retrieve_settings(section):
+        if section == "025-libraries":
+            return payload
+        return {"validated": False}
+
+    monkeypatch.setattr(qs_module.output.persistence, "retrieve_settings", fake_retrieve_settings)
+    with qs_module.app.app_context():
+        validated, _validation_error, _config_data, yaml_content, _validation_errors = qs_module.output.build_config(
+            header_style="single line",
+            config_name="pytest_aspect_contract",
+        )
+    assert isinstance(validated, bool)
+    assert yaml_content
+    return yaml_content
+
+
+def test_aspect_yaml_contract_keeps_use_key_toggles(monkeypatch, qs_module):
+    payload = _build_library_payload(
+        {
+            "use_1.33": False,
+            "use_1.65": False,
+            "use_1.66": False,
+            "use_1.78": False,
+            "use_1.85": False,
+            "use_2.2": False,
+            "use_2.35": False,
+            "use_2.77": False,
+            "horizontal_offset": 0,
+            "vertical_offset": 150,
+        }
+    )
+
+    template_vars = _template_vars_from_yaml(_run_build_config_with_payload(qs_module, monkeypatch, payload))
+
+    assert template_vars["use_1.33"] is False
+    assert template_vars["use_1.65"] is False
+    assert template_vars["use_1.66"] is False
+    assert template_vars["use_1.78"] is False
+    assert template_vars["use_1.85"] is False
+    assert template_vars["use_2.2"] is False
+    assert template_vars["use_2.35"] is False
+    assert template_vars["use_2.77"] is False

--- a/tests/test_audio_codec_yaml_contract.py
+++ b/tests/test_audio_codec_yaml_contract.py
@@ -1,0 +1,101 @@
+from ruamel.yaml import YAML
+
+
+def _template_vars_from_yaml(yaml_content):
+    parser = YAML(typ="safe", pure=True)
+    parsed = parser.load(yaml_content)
+    libraries = parsed.get("libraries", {})
+    movies = libraries.get("Movies", {})
+    overlays = movies.get("overlay_files", [])
+    assert overlays, "Expected at least one overlay entry for Movies"
+    audio_codec_entry = next((entry for entry in overlays if entry.get("default") == "audio_codec"), None)
+    assert audio_codec_entry is not None, "Expected audio_codec overlay entry"
+    return audio_codec_entry.get("template_variables", {})
+
+
+def _build_library_payload(template_vars):
+    data = {
+        "mov-library_movies-library": "Movies",
+        "mov-library_movies-collection_collectionless": True,
+        "mov-library_movies-movie-overlay_audio_codec": True,
+    }
+    for key, value in template_vars.items():
+        data[f"mov-library_movies-movie-template_overlay_audio_codec[{key}]"] = value
+    return {"validated": True, "libraries": data}
+
+
+def _run_build_config_with_payload(qs_module, monkeypatch, payload):
+    monkeypatch.setattr(
+        qs_module.output.helpers,
+        "get_template_list",
+        lambda: {
+            "libraries": {
+                "name": "Libraries",
+                "stem": "025-libraries",
+                "raw_name": "libraries",
+            }
+        },
+    )
+    monkeypatch.setattr(qs_module.output.helpers, "get_plex_summary", lambda: "Plex summary unavailable")
+    monkeypatch.setattr(qs_module.output.helpers, "get_quickstart_settings_summary", lambda: [])
+    monkeypatch.setattr(qs_module.output.helpers, "get_library_summaries", lambda _names: "Movies")
+
+    def fake_retrieve_settings(section):
+        if section == "025-libraries":
+            return payload
+        return {"validated": False}
+
+    monkeypatch.setattr(qs_module.output.persistence, "retrieve_settings", fake_retrieve_settings)
+    with qs_module.app.app_context():
+        validated, _validation_error, _config_data, yaml_content, _validation_errors = qs_module.output.build_config(
+            header_style="single line",
+            config_name="pytest_audio_codec_contract",
+        )
+    assert isinstance(validated, bool)
+    assert yaml_content
+    return yaml_content
+
+
+def test_audio_codec_yaml_contract_keeps_official_use_toggles(monkeypatch, qs_module):
+    payload = _build_library_payload(
+        {
+            "use_truehd_atmos": False,
+            "use_dtsx": False,
+            "use_plus_atmos": False,
+            "use_dolby_atmos": False,
+            "use_truehd": False,
+            "use_ma": False,
+            "use_flac": False,
+            "use_pcm": False,
+            "use_hra": False,
+            "use_plus": False,
+            "use_dtses": False,
+            "use_dts": False,
+            "use_digital": False,
+            "use_aac": False,
+            "use_mp3": False,
+            "use_opus": False,
+            "style": "standard",
+            "horizontal_offset": 0,
+            "vertical_offset": 15,
+        }
+    )
+
+    template_vars = _template_vars_from_yaml(_run_build_config_with_payload(qs_module, monkeypatch, payload))
+
+    assert template_vars["use_truehd_atmos"] is False
+    assert template_vars["use_dtsx"] is False
+    assert template_vars["use_plus_atmos"] is False
+    assert template_vars["use_dolby_atmos"] is False
+    assert template_vars["use_truehd"] is False
+    assert template_vars["use_ma"] is False
+    assert template_vars["use_flac"] is False
+    assert template_vars["use_pcm"] is False
+    assert template_vars["use_hra"] is False
+    assert template_vars["use_plus"] is False
+    assert template_vars["use_dtses"] is False
+    assert template_vars["use_dts"] is False
+    assert template_vars["use_digital"] is False
+    assert template_vars["use_aac"] is False
+    assert template_vars["use_mp3"] is False
+    assert template_vars["use_opus"] is False

--- a/tests/test_content_rating_overlay_contracts.py
+++ b/tests/test_content_rating_overlay_contracts.py
@@ -2,7 +2,6 @@ from ruamel.yaml import YAML
 
 from modules import importer
 
-
 OVERLAY_CASES = [
     {
         "id": "us_movie",

--- a/tests/test_content_rating_overlay_contracts.py
+++ b/tests/test_content_rating_overlay_contracts.py
@@ -1,0 +1,257 @@
+from ruamel.yaml import YAML
+
+from modules import importer
+
+
+OVERLAY_CASES = [
+    {
+        "id": "us_movie",
+        "default_name": "content_rating_us_movie",
+        "overlay_key": "content_rating_us_movie",
+        "radio_value": "us_movie",
+        "library_name": "Movies",
+        "library_type": "movie",
+        "builder": "movie",
+        "template_vars": {
+            "use_g": False,
+            "use_pg": False,
+            "use_pg-13": False,
+            "use_r": False,
+            "use_nc-17": False,
+            "use_nr": False,
+        },
+    },
+    {
+        "id": "us_show",
+        "default_name": "content_rating_us_show",
+        "overlay_key": "content_rating_us_show",
+        "radio_value": "us_show",
+        "library_name": "Shows",
+        "library_type": "show",
+        "builder": "show",
+        "template_vars": {
+            "use_tv-g": False,
+            "use_tv-y": False,
+            "use_tv-pg": False,
+            "use_tv-14": False,
+            "use_tv-ma": False,
+            "use_nr": False,
+        },
+    },
+    {
+        "id": "uk",
+        "default_name": "content_rating_uk",
+        "overlay_key": "content_rating_uk",
+        "radio_value": "uk",
+        "library_name": "Movies",
+        "library_type": "movie",
+        "builder": "movie",
+        "template_vars": {
+            "use_u": False,
+            "use_pg": False,
+            "use_12": False,
+            "use_12a": False,
+            "use_15": False,
+            "use_18": False,
+            "use_r18": False,
+            "use_nr": False,
+        },
+    },
+    {
+        "id": "de",
+        "default_name": "content_rating_de",
+        "overlay_key": "content_rating_de",
+        "radio_value": "de",
+        "library_name": "Movies",
+        "library_type": "movie",
+        "builder": "movie",
+        "template_vars": {
+            "use_0": False,
+            "use_6": False,
+            "use_12": False,
+            "use_16": False,
+            "use_18": False,
+            "use_bpjm": False,
+            "use_nr": False,
+        },
+    },
+    {
+        "id": "au",
+        "default_name": "content_rating_au",
+        "overlay_key": "content_rating_au",
+        "radio_value": "au",
+        "library_name": "Movies",
+        "library_type": "movie",
+        "builder": "movie",
+        "template_vars": {
+            "use_g": False,
+            "use_pg": False,
+            "use_m": False,
+            "use_ma": False,
+            "use_r": False,
+            "use_x": False,
+            "use_nr": False,
+        },
+    },
+    {
+        "id": "nz",
+        "default_name": "content_rating_nz",
+        "overlay_key": "content_rating_nz",
+        "radio_value": "nz",
+        "library_name": "Movies",
+        "library_type": "movie",
+        "builder": "movie",
+        "template_vars": {
+            "use_g": False,
+            "use_pg": False,
+            "use_m": False,
+            "use_r13": False,
+            "use_rp13": False,
+            "use_r15": False,
+            "use_r16": False,
+            "use_rp16": False,
+            "use_R18": False,
+            "use_rp18": False,
+            "use_r": False,
+            "use_nr": False,
+        },
+    },
+    {
+        "id": "commonsense",
+        "default_name": "commonsense",
+        "overlay_key": "content_rating_commonsense",
+        "radio_value": "commonsense",
+        "library_name": "Movies",
+        "library_type": "movie",
+        "builder": "movie",
+        "template_vars": {
+            "use_1": False,
+            "use_2": False,
+            "use_3": False,
+            "use_4": False,
+            "use_5": False,
+            "use_6": False,
+            "use_7": False,
+            "use_8": False,
+            "use_9": False,
+            "use_10": False,
+            "use_11": False,
+            "use_12": False,
+            "use_13": False,
+            "use_14": False,
+            "use_15": False,
+            "use_16": False,
+            "use_17": False,
+            "use_18": False,
+            "use_nr": False,
+        },
+    },
+]
+
+
+def _base_parts(case):
+    if case["library_type"] == "movie":
+        return "mov-library_movies", "Movies"
+    return "sho-library_shows", "Shows"
+
+
+def _build_form_payload(case):
+    base, library_name = _base_parts(case)
+    builder = case["builder"]
+    overlay_key = case["overlay_key"]
+    data = {
+        f"{base}-library": library_name,
+        f"{base}-collection_collectionless": True,
+        f"{base}-{builder}-overlay_content_rating": case["radio_value"],
+    }
+    prefix = f"{base}-{builder}-template_overlay_{overlay_key}"
+    for key, value in case["template_vars"].items():
+        data[f"{prefix}[{key}]"] = value
+    return {"validated": True, "libraries": data}
+
+
+def _run_build_config_with_payload(qs_module, monkeypatch, payload):
+    monkeypatch.setattr(
+        qs_module.output.helpers,
+        "get_template_list",
+        lambda: {
+            "libraries": {
+                "name": "Libraries",
+                "stem": "025-libraries",
+                "raw_name": "libraries",
+            }
+        },
+    )
+    monkeypatch.setattr(qs_module.output.helpers, "get_plex_summary", lambda: "Plex summary unavailable")
+    monkeypatch.setattr(qs_module.output.helpers, "get_quickstart_settings_summary", lambda: [])
+    monkeypatch.setattr(qs_module.output.helpers, "get_library_summaries", lambda _names: "Content Ratings")
+
+    def fake_retrieve_settings(section):
+        if section == "025-libraries":
+            return payload
+        return {"validated": False}
+
+    monkeypatch.setattr(qs_module.output.persistence, "retrieve_settings", fake_retrieve_settings)
+    with qs_module.app.app_context():
+        validated, _validation_error, _config_data, yaml_content, _validation_errors = qs_module.output.build_config(
+            header_style="single line",
+            config_name="pytest_content_rating_contract",
+        )
+    assert isinstance(validated, bool)
+    assert yaml_content
+    return yaml_content
+
+
+def _template_vars_from_yaml(yaml_content, case):
+    parser = YAML(typ="safe", pure=True)
+    parsed = parser.load(yaml_content)
+    overlays = parsed.get("libraries", {}).get(case["library_name"], {}).get("overlay_files", [])
+    assert overlays, f"Expected overlay_files for {case['library_name']}"
+    matching = [entry for entry in overlays if entry.get("default") == case["default_name"]]
+    assert matching, f"Expected {case['default_name']} overlay entry"
+    if case["builder"] == "show":
+        for entry in matching:
+            tv = entry.get("template_variables", {})
+            if tv.get("builder_level", "show") == "show":
+                return tv
+        raise AssertionError(f"Expected show-level template variables for {case['default_name']}")
+    return matching[0].get("template_variables", {})
+
+
+def test_prepare_import_payload_accepts_content_rating_use_key_template_variables():
+    for case in OVERLAY_CASES:
+        payload, report = importer.prepare_import_payload(
+            {
+                "libraries": {
+                    case["library_name"]: {
+                        "overlay_files": [
+                            {
+                                "default": case["default_name"],
+                                "template_variables": case["template_vars"],
+                            }
+                        ]
+                    }
+                }
+            },
+            {"Movies"} if case["library_type"] == "movie" else set(),
+            {"Shows"} if case["library_type"] == "show" else set(),
+            set(),
+        )
+
+        libraries_payload = payload["libraries"]["libraries"]
+        base, _ = _base_parts(case)
+        enabled_key = f"{base}-{case['builder']}-overlay_content_rating"
+        template_prefix = f"{base}-{case['builder']}-template_overlay_{case['overlay_key']}"
+        assert libraries_payload[enabled_key] == case["radio_value"]
+        for key in case["template_vars"]:
+            field_key = f"{template_prefix}[{key}]"
+            assert libraries_payload[field_key] is False
+            assert any(f"template_variables.{key}" in line for line in report.lines)
+
+
+def test_content_rating_yaml_contract_keeps_use_key_toggles(monkeypatch, qs_module):
+    for case in OVERLAY_CASES:
+        yaml_content = _run_build_config_with_payload(qs_module, monkeypatch, _build_form_payload(case))
+        template_vars = _template_vars_from_yaml(yaml_content, case)
+        for key in case["template_vars"]:
+            assert template_vars[key] is False

--- a/tests/test_importer_overlay_files.py
+++ b/tests/test_importer_overlay_files.py
@@ -73,3 +73,351 @@ def test_prepare_import_payload_accepts_resolution_template_variables():
     assert any("libraries.Movies.overlay_files[0].template_variables.use_resolution" in line for line in report.lines)
     assert any("libraries.Movies.overlay_files[0].template_variables.use_1080p" in line for line in report.lines)
     assert any("libraries.Movies.overlay_files[0].template_variables.use_extended" in line for line in report.lines)
+
+
+def test_prepare_import_payload_accepts_audio_codec_template_variables():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Movies": {
+                    "overlay_files": [
+                        {
+                            "default": "audio_codec",
+                            "template_variables": {
+                                "use_truehd_atmos": False,
+                                "use_dtsx": False,
+                                "use_plus_atmos": False,
+                                "use_dolby_atmos": False,
+                                "use_truehd": False,
+                                "use_ma": False,
+                                "use_flac": False,
+                                "use_pcm": False,
+                                "use_hra": False,
+                                "use_plus": False,
+                                "use_dtses": False,
+                                "use_dts": False,
+                                "use_digital": False,
+                                "use_aac": False,
+                                "use_mp3": False,
+                                "use_opus": False,
+                            },
+                        }
+                    ]
+                }
+            }
+        },
+        {"Movies"},
+        set(),
+        set(),
+    )
+
+    libraries_payload = payload["libraries"]["libraries"]
+    assert libraries_payload["mov-library_movies-movie-overlay_audio_codec"] is True
+    assert libraries_payload["mov-library_movies-movie-template_overlay_audio_codec[use_truehd_atmos]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_audio_codec[use_dtsx]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_audio_codec[use_plus_atmos]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_audio_codec[use_dolby_atmos]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_audio_codec[use_truehd]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_audio_codec[use_ma]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_audio_codec[use_flac]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_audio_codec[use_pcm]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_audio_codec[use_hra]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_audio_codec[use_plus]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_audio_codec[use_dtses]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_audio_codec[use_dts]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_audio_codec[use_digital]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_audio_codec[use_aac]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_audio_codec[use_mp3]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_audio_codec[use_opus]"] is False
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_truehd_atmos" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_dtsx" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_opus" in line for line in report.lines)
+
+
+def test_prepare_import_payload_accepts_aspect_use_key_template_variables():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Movies": {
+                    "overlay_files": [
+                        {
+                            "default": "aspect",
+                            "template_variables": {
+                                "use_1.33": False,
+                                "use_1.65": False,
+                                "use_1.66": False,
+                                "use_1.78": False,
+                                "use_1.85": False,
+                                "use_2.2": False,
+                                "use_2.35": False,
+                                "use_2.77": False,
+                            },
+                        }
+                    ]
+                }
+            }
+        },
+        {"Movies"},
+        set(),
+        set(),
+    )
+
+    libraries_payload = payload["libraries"]["libraries"]
+    assert libraries_payload["mov-library_movies-movie-overlay_aspect"] is True
+    assert libraries_payload["mov-library_movies-movie-template_overlay_aspect[use_1.33]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_aspect[use_1.65]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_aspect[use_1.66]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_aspect[use_1.78]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_aspect[use_1.85]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_aspect[use_2.2]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_aspect[use_2.35]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_aspect[use_2.77]"] is False
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_1.33" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_1.78" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_2.77" in line for line in report.lines)
+
+
+def test_prepare_import_payload_accepts_video_format_use_key_template_variables():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Movies": {
+                    "overlay_files": [
+                        {
+                            "default": "video_format",
+                            "template_variables": {
+                                "use_remux": False,
+                                "use_bluray": False,
+                                "use_web": False,
+                                "use_hdtv": False,
+                                "use_dvd": False,
+                                "use_sdtv": False,
+                                "use_telesync": False,
+                                "use_cam": False,
+                            },
+                        }
+                    ]
+                }
+            }
+        },
+        {"Movies"},
+        set(),
+        set(),
+    )
+
+    libraries_payload = payload["libraries"]["libraries"]
+    assert libraries_payload["mov-library_movies-movie-overlay_video_format"] is True
+    assert libraries_payload["mov-library_movies-movie-template_overlay_video_format[use_remux]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_video_format[use_bluray]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_video_format[use_web]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_video_format[use_hdtv]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_video_format[use_dvd]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_video_format[use_sdtv]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_video_format[use_telesync]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_video_format[use_cam]"] is False
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_remux" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_hdtv" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_cam" in line for line in report.lines)
+
+
+def test_prepare_import_payload_accepts_language_count_use_key_template_variables():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Movies": {
+                    "overlay_files": [
+                        {
+                            "default": "language_count",
+                            "template_variables": {
+                                "use_dual": False,
+                                "use_multi": False,
+                            },
+                        }
+                    ]
+                }
+            }
+        },
+        {"Movies"},
+        set(),
+        set(),
+    )
+
+    libraries_payload = payload["libraries"]["libraries"]
+    assert libraries_payload["mov-library_movies-movie-overlay_language_count"] is True
+    assert libraries_payload["mov-library_movies-movie-template_overlay_language_count[use_dual]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_language_count[use_multi]"] is False
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_dual" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_multi" in line for line in report.lines)
+
+
+def test_prepare_import_payload_accepts_status_use_key_template_variables():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Shows": {
+                    "overlay_files": [
+                        {
+                            "default": "status",
+                            "template_variables": {
+                                "use_airing": False,
+                                "use_returning": False,
+                                "use_canceled": False,
+                                "use_ended": False,
+                            },
+                        }
+                    ]
+                }
+            }
+        },
+        set(),
+        {"Shows"},
+        set(),
+    )
+
+    libraries_payload = payload["libraries"]["libraries"]
+    assert libraries_payload["sho-library_shows-show-overlay_status"] is True
+    assert libraries_payload["sho-library_shows-show-template_overlay_status[use_airing]"] is False
+    assert libraries_payload["sho-library_shows-show-template_overlay_status[use_returning]"] is False
+    assert libraries_payload["sho-library_shows-show-template_overlay_status[use_canceled]"] is False
+    assert libraries_payload["sho-library_shows-show-template_overlay_status[use_ended]"] is False
+    assert any("libraries.Shows.overlay_files[0].template_variables.use_airing" in line for line in report.lines)
+    assert any("libraries.Shows.overlay_files[0].template_variables.use_returning" in line for line in report.lines)
+    assert any("libraries.Shows.overlay_files[0].template_variables.use_ended" in line for line in report.lines)
+
+
+def test_prepare_import_payload_accepts_streaming_use_key_template_variables():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Movies": {
+                    "overlay_files": [
+                        {
+                            "default": "streaming",
+                            "template_variables": {
+                                "use_netflix": False,
+                                "use_amazon": False,
+                                "use_disney": False,
+                                "use_hbomax": False,
+                                "use_crunchyroll": False,
+                                "use_movistar": False,
+                                "use_atresplayer": False,
+                                "use_youtube": False,
+                                "use_hulu": False,
+                                "use_paramount": False,
+                                "use_amc": False,
+                                "use_appletv": False,
+                                "use_peacock": False,
+                                "use_discovery": False,
+                                "use_crave": False,
+                                "use_now": False,
+                                "use_channel4": False,
+                                "use_itvx": False,
+                                "use_bet": False,
+                                "use_hayu": False,
+                                "use_tubi": False,
+                                "use_filmin": False,
+                            },
+                        }
+                    ]
+                }
+            }
+        },
+        {"Movies"},
+        set(),
+        set(),
+    )
+
+    libraries_payload = payload["libraries"]["libraries"]
+    assert libraries_payload["mov-library_movies-movie-overlay_streaming"] is True
+    assert libraries_payload["mov-library_movies-movie-template_overlay_streaming[use_netflix]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_streaming[use_amazon]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_streaming[use_disney]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_streaming[use_hbomax]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_streaming[use_crunchyroll]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_streaming[use_movistar]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_streaming[use_atresplayer]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_streaming[use_youtube]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_streaming[use_hulu]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_streaming[use_paramount]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_streaming[use_amc]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_streaming[use_appletv]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_streaming[use_peacock]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_streaming[use_discovery]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_streaming[use_crave]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_streaming[use_now]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_streaming[use_channel4]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_streaming[use_itvx]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_streaming[use_bet]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_streaming[use_hayu]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_streaming[use_tubi]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_streaming[use_filmin]"] is False
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_netflix" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_paramount" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_filmin" in line for line in report.lines)
+
+
+def test_prepare_import_payload_accepts_ribbon_use_key_template_variables():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Movies": {
+                    "overlay_files": [
+                        {
+                            "default": "ribbon",
+                            "template_variables": {
+                                "use_oscars": False,
+                                "use_oscars_director": False,
+                                "use_golden": False,
+                                "use_golden_director": False,
+                                "use_bafta": False,
+                                "use_cannes": False,
+                                "use_berlinale": False,
+                                "use_venice": False,
+                                "use_sundance": False,
+                                "use_emmys": False,
+                                "use_choice": False,
+                                "use_spirit": False,
+                                "use_cesar": False,
+                                "use_imdb": False,
+                                "use_letterboxd": False,
+                                "use_rottenverified": False,
+                                "use_rotten": False,
+                                "use_metacritic": False,
+                                "use_common": False,
+                                "use_razzie": False,
+                            },
+                        }
+                    ]
+                }
+            }
+        },
+        {"Movies"},
+        set(),
+        set(),
+    )
+
+    libraries_payload = payload["libraries"]["libraries"]
+    assert libraries_payload["mov-library_movies-movie-overlay_ribbon"] is True
+    assert libraries_payload["mov-library_movies-movie-template_overlay_ribbon[use_oscars]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_ribbon[use_oscars_director]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_ribbon[use_golden]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_ribbon[use_golden_director]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_ribbon[use_bafta]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_ribbon[use_cannes]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_ribbon[use_berlinale]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_ribbon[use_venice]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_ribbon[use_sundance]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_ribbon[use_emmys]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_ribbon[use_choice]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_ribbon[use_spirit]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_ribbon[use_cesar]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_ribbon[use_imdb]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_ribbon[use_letterboxd]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_ribbon[use_rottenverified]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_ribbon[use_rotten]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_ribbon[use_metacritic]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_ribbon[use_common]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_ribbon[use_razzie]"] is False
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_oscars" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_imdb" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_razzie" in line for line in report.lines)

--- a/tests/test_language_count_yaml_contract.py
+++ b/tests/test_language_count_yaml_contract.py
@@ -1,0 +1,70 @@
+from ruamel.yaml import YAML
+
+
+def _template_vars_from_yaml(yaml_content):
+    parser = YAML(typ="safe", pure=True)
+    parsed = parser.load(yaml_content)
+    libraries = parsed.get("libraries", {})
+    movies = libraries.get("Movies", {})
+    overlays = movies.get("overlay_files", [])
+    assert overlays, "Expected at least one overlay entry for Movies"
+    overlay_entry = next((entry for entry in overlays if entry.get("default") == "language_count"), None)
+    assert overlay_entry is not None, "Expected language_count overlay entry"
+    return overlay_entry.get("template_variables", {})
+
+
+def _build_library_payload(template_vars):
+    data = {
+        "mov-library_movies-library": "Movies",
+        "mov-library_movies-collection_collectionless": True,
+        "mov-library_movies-movie-overlay_language_count": True,
+    }
+    for key, value in template_vars.items():
+        data[f"mov-library_movies-movie-template_overlay_language_count[{key}]"] = value
+    return {"validated": True, "libraries": data}
+
+
+def _run_build_config_with_payload(qs_module, monkeypatch, payload):
+    monkeypatch.setattr(
+        qs_module.output.helpers,
+        "get_template_list",
+        lambda: {
+            "libraries": {
+                "name": "Libraries",
+                "stem": "025-libraries",
+                "raw_name": "libraries",
+            }
+        },
+    )
+    monkeypatch.setattr(qs_module.output.helpers, "get_plex_summary", lambda: "Plex summary unavailable")
+    monkeypatch.setattr(qs_module.output.helpers, "get_quickstart_settings_summary", lambda: [])
+    monkeypatch.setattr(qs_module.output.helpers, "get_library_summaries", lambda _names: "Movies")
+
+    def fake_retrieve_settings(section):
+        if section == "025-libraries":
+            return payload
+        return {"validated": False}
+
+    monkeypatch.setattr(qs_module.output.persistence, "retrieve_settings", fake_retrieve_settings)
+    with qs_module.app.app_context():
+        validated, _validation_error, _config_data, yaml_content, _validation_errors = qs_module.output.build_config(
+            header_style="single line",
+            config_name="pytest_language_count_contract",
+        )
+    assert isinstance(validated, bool)
+    assert yaml_content
+    return yaml_content
+
+
+def test_language_count_yaml_contract_keeps_use_key_toggles(monkeypatch, qs_module):
+    payload = _build_library_payload(
+        {
+            "use_dual": False,
+            "use_multi": False,
+        }
+    )
+
+    template_vars = _template_vars_from_yaml(_run_build_config_with_payload(qs_module, monkeypatch, payload))
+
+    assert template_vars["use_dual"] is False
+    assert template_vars["use_multi"] is False

--- a/tests/test_ribbon_yaml_contract.py
+++ b/tests/test_ribbon_yaml_contract.py
@@ -1,0 +1,106 @@
+from ruamel.yaml import YAML
+
+
+def _template_vars_from_yaml(yaml_content):
+    parser = YAML(typ="safe", pure=True)
+    parsed = parser.load(yaml_content)
+    libraries = parsed.get("libraries", {})
+    movies = libraries.get("Movies", {})
+    overlays = movies.get("overlay_files", [])
+    assert overlays, "Expected at least one overlay entry for Movies"
+    overlay_entry = next((entry for entry in overlays if entry.get("default") == "ribbon"), None)
+    assert overlay_entry is not None, "Expected ribbon overlay entry"
+    return overlay_entry.get("template_variables", {})
+
+
+def _build_library_payload(template_vars):
+    data = {
+        "mov-library_movies-library": "Movies",
+        "mov-library_movies-collection_collectionless": True,
+        "mov-library_movies-movie-overlay_ribbon": True,
+    }
+    for key, value in template_vars.items():
+        data[f"mov-library_movies-movie-template_overlay_ribbon[{key}]"] = value
+    return {"validated": True, "libraries": data}
+
+
+def _run_build_config_with_payload(qs_module, monkeypatch, payload):
+    monkeypatch.setattr(
+        qs_module.output.helpers,
+        "get_template_list",
+        lambda: {
+            "libraries": {
+                "name": "Libraries",
+                "stem": "025-libraries",
+                "raw_name": "libraries",
+            }
+        },
+    )
+    monkeypatch.setattr(qs_module.output.helpers, "get_plex_summary", lambda: "Plex summary unavailable")
+    monkeypatch.setattr(qs_module.output.helpers, "get_quickstart_settings_summary", lambda: [])
+    monkeypatch.setattr(qs_module.output.helpers, "get_library_summaries", lambda _names: "Movies")
+
+    def fake_retrieve_settings(section):
+        if section == "025-libraries":
+            return payload
+        return {"validated": False}
+
+    monkeypatch.setattr(qs_module.output.persistence, "retrieve_settings", fake_retrieve_settings)
+    with qs_module.app.app_context():
+        validated, _validation_error, _config_data, yaml_content, _validation_errors = qs_module.output.build_config(
+            header_style="single line",
+            config_name="pytest_ribbon_contract",
+        )
+    assert isinstance(validated, bool)
+    assert yaml_content
+    return yaml_content
+
+
+def test_ribbon_yaml_contract_keeps_use_key_toggles(monkeypatch, qs_module):
+    payload = _build_library_payload(
+        {
+            "use_oscars": False,
+            "use_oscars_director": False,
+            "use_golden": False,
+            "use_golden_director": False,
+            "use_bafta": False,
+            "use_cannes": False,
+            "use_berlinale": False,
+            "use_venice": False,
+            "use_sundance": False,
+            "use_emmys": False,
+            "use_choice": False,
+            "use_spirit": False,
+            "use_cesar": False,
+            "use_imdb": False,
+            "use_letterboxd": False,
+            "use_rottenverified": False,
+            "use_rotten": False,
+            "use_metacritic": False,
+            "use_common": False,
+            "use_razzie": False,
+        }
+    )
+
+    template_vars = _template_vars_from_yaml(_run_build_config_with_payload(qs_module, monkeypatch, payload))
+
+    assert template_vars["use_oscars"] is False
+    assert template_vars["use_oscars_director"] is False
+    assert template_vars["use_golden"] is False
+    assert template_vars["use_golden_director"] is False
+    assert template_vars["use_bafta"] is False
+    assert template_vars["use_cannes"] is False
+    assert template_vars["use_berlinale"] is False
+    assert template_vars["use_venice"] is False
+    assert template_vars["use_sundance"] is False
+    assert template_vars["use_emmys"] is False
+    assert template_vars["use_choice"] is False
+    assert template_vars["use_spirit"] is False
+    assert template_vars["use_cesar"] is False
+    assert template_vars["use_imdb"] is False
+    assert template_vars["use_letterboxd"] is False
+    assert template_vars["use_rottenverified"] is False
+    assert template_vars["use_rotten"] is False
+    assert template_vars["use_metacritic"] is False
+    assert template_vars["use_common"] is False
+    assert template_vars["use_razzie"] is False

--- a/tests/test_status_yaml_contract.py
+++ b/tests/test_status_yaml_contract.py
@@ -1,0 +1,74 @@
+from ruamel.yaml import YAML
+
+
+def _template_vars_from_yaml(yaml_content):
+    parser = YAML(typ="safe", pure=True)
+    parsed = parser.load(yaml_content)
+    libraries = parsed.get("libraries", {})
+    shows = libraries.get("Shows", {})
+    overlays = shows.get("overlay_files", [])
+    assert overlays, "Expected at least one overlay entry for Shows"
+    overlay_entry = next((entry for entry in overlays if entry.get("default") == "status"), None)
+    assert overlay_entry is not None, "Expected status overlay entry"
+    return overlay_entry.get("template_variables", {})
+
+
+def _build_library_payload(template_vars):
+    data = {
+        "sho-library_shows-library": "Shows",
+        "sho-library_shows-collection_collectionless": True,
+        "sho-library_shows-show-overlay_status": True,
+    }
+    for key, value in template_vars.items():
+        data[f"sho-library_shows-show-template_overlay_status[{key}]"] = value
+    return {"validated": True, "libraries": data}
+
+
+def _run_build_config_with_payload(qs_module, monkeypatch, payload):
+    monkeypatch.setattr(
+        qs_module.output.helpers,
+        "get_template_list",
+        lambda: {
+            "libraries": {
+                "name": "Libraries",
+                "stem": "025-libraries",
+                "raw_name": "libraries",
+            }
+        },
+    )
+    monkeypatch.setattr(qs_module.output.helpers, "get_plex_summary", lambda: "Plex summary unavailable")
+    monkeypatch.setattr(qs_module.output.helpers, "get_quickstart_settings_summary", lambda: [])
+    monkeypatch.setattr(qs_module.output.helpers, "get_library_summaries", lambda _names: "Shows")
+
+    def fake_retrieve_settings(section):
+        if section == "025-libraries":
+            return payload
+        return {"validated": False}
+
+    monkeypatch.setattr(qs_module.output.persistence, "retrieve_settings", fake_retrieve_settings)
+    with qs_module.app.app_context():
+        validated, _validation_error, _config_data, yaml_content, _validation_errors = qs_module.output.build_config(
+            header_style="single line",
+            config_name="pytest_status_contract",
+        )
+    assert isinstance(validated, bool)
+    assert yaml_content
+    return yaml_content
+
+
+def test_status_yaml_contract_keeps_use_key_toggles(monkeypatch, qs_module):
+    payload = _build_library_payload(
+        {
+            "use_airing": False,
+            "use_returning": False,
+            "use_canceled": False,
+            "use_ended": False,
+        }
+    )
+
+    template_vars = _template_vars_from_yaml(_run_build_config_with_payload(qs_module, monkeypatch, payload))
+
+    assert template_vars["use_airing"] is False
+    assert template_vars["use_returning"] is False
+    assert template_vars["use_canceled"] is False
+    assert template_vars["use_ended"] is False

--- a/tests/test_streaming_yaml_contract.py
+++ b/tests/test_streaming_yaml_contract.py
@@ -1,0 +1,110 @@
+from ruamel.yaml import YAML
+
+
+def _template_vars_from_yaml(yaml_content):
+    parser = YAML(typ="safe", pure=True)
+    parsed = parser.load(yaml_content)
+    libraries = parsed.get("libraries", {})
+    movies = libraries.get("Movies", {})
+    overlays = movies.get("overlay_files", [])
+    assert overlays, "Expected at least one overlay entry for Movies"
+    overlay_entry = next((entry for entry in overlays if entry.get("default") == "streaming"), None)
+    assert overlay_entry is not None, "Expected streaming overlay entry"
+    return overlay_entry.get("template_variables", {})
+
+
+def _build_library_payload(template_vars):
+    data = {
+        "mov-library_movies-library": "Movies",
+        "mov-library_movies-collection_collectionless": True,
+        "mov-library_movies-movie-overlay_streaming": True,
+    }
+    for key, value in template_vars.items():
+        data[f"mov-library_movies-movie-template_overlay_streaming[{key}]"] = value
+    return {"validated": True, "libraries": data}
+
+
+def _run_build_config_with_payload(qs_module, monkeypatch, payload):
+    monkeypatch.setattr(
+        qs_module.output.helpers,
+        "get_template_list",
+        lambda: {
+            "libraries": {
+                "name": "Libraries",
+                "stem": "025-libraries",
+                "raw_name": "libraries",
+            }
+        },
+    )
+    monkeypatch.setattr(qs_module.output.helpers, "get_plex_summary", lambda: "Plex summary unavailable")
+    monkeypatch.setattr(qs_module.output.helpers, "get_quickstart_settings_summary", lambda: [])
+    monkeypatch.setattr(qs_module.output.helpers, "get_library_summaries", lambda _names: "Movies")
+
+    def fake_retrieve_settings(section):
+        if section == "025-libraries":
+            return payload
+        return {"validated": False}
+
+    monkeypatch.setattr(qs_module.output.persistence, "retrieve_settings", fake_retrieve_settings)
+    with qs_module.app.app_context():
+        validated, _validation_error, _config_data, yaml_content, _validation_errors = qs_module.output.build_config(
+            header_style="single line",
+            config_name="pytest_streaming_contract",
+        )
+    assert isinstance(validated, bool)
+    assert yaml_content
+    return yaml_content
+
+
+def test_streaming_yaml_contract_keeps_use_key_toggles(monkeypatch, qs_module):
+    payload = _build_library_payload(
+        {
+            "use_netflix": False,
+            "use_amazon": False,
+            "use_disney": False,
+            "use_hbomax": False,
+            "use_crunchyroll": False,
+            "use_movistar": False,
+            "use_atresplayer": False,
+            "use_youtube": False,
+            "use_hulu": False,
+            "use_paramount": False,
+            "use_amc": False,
+            "use_appletv": False,
+            "use_peacock": False,
+            "use_discovery": False,
+            "use_crave": False,
+            "use_now": False,
+            "use_channel4": False,
+            "use_itvx": False,
+            "use_bet": False,
+            "use_hayu": False,
+            "use_tubi": False,
+            "use_filmin": False,
+        }
+    )
+
+    template_vars = _template_vars_from_yaml(_run_build_config_with_payload(qs_module, monkeypatch, payload))
+
+    assert template_vars["use_netflix"] is False
+    assert template_vars["use_amazon"] is False
+    assert template_vars["use_disney"] is False
+    assert template_vars["use_hbomax"] is False
+    assert template_vars["use_crunchyroll"] is False
+    assert template_vars["use_movistar"] is False
+    assert template_vars["use_atresplayer"] is False
+    assert template_vars["use_youtube"] is False
+    assert template_vars["use_hulu"] is False
+    assert template_vars["use_paramount"] is False
+    assert template_vars["use_amc"] is False
+    assert template_vars["use_appletv"] is False
+    assert template_vars["use_peacock"] is False
+    assert template_vars["use_discovery"] is False
+    assert template_vars["use_crave"] is False
+    assert template_vars["use_now"] is False
+    assert template_vars["use_channel4"] is False
+    assert template_vars["use_itvx"] is False
+    assert template_vars["use_bet"] is False
+    assert template_vars["use_hayu"] is False
+    assert template_vars["use_tubi"] is False
+    assert template_vars["use_filmin"] is False

--- a/tests/test_video_format_yaml_contract.py
+++ b/tests/test_video_format_yaml_contract.py
@@ -1,0 +1,82 @@
+from ruamel.yaml import YAML
+
+
+def _template_vars_from_yaml(yaml_content):
+    parser = YAML(typ="safe", pure=True)
+    parsed = parser.load(yaml_content)
+    libraries = parsed.get("libraries", {})
+    movies = libraries.get("Movies", {})
+    overlays = movies.get("overlay_files", [])
+    assert overlays, "Expected at least one overlay entry for Movies"
+    video_format_entry = next((entry for entry in overlays if entry.get("default") == "video_format"), None)
+    assert video_format_entry is not None, "Expected video_format overlay entry"
+    return video_format_entry.get("template_variables", {})
+
+
+def _build_library_payload(template_vars):
+    data = {
+        "mov-library_movies-library": "Movies",
+        "mov-library_movies-collection_collectionless": True,
+        "mov-library_movies-movie-overlay_video_format": True,
+    }
+    for key, value in template_vars.items():
+        data[f"mov-library_movies-movie-template_overlay_video_format[{key}]"] = value
+    return {"validated": True, "libraries": data}
+
+
+def _run_build_config_with_payload(qs_module, monkeypatch, payload):
+    monkeypatch.setattr(
+        qs_module.output.helpers,
+        "get_template_list",
+        lambda: {
+            "libraries": {
+                "name": "Libraries",
+                "stem": "025-libraries",
+                "raw_name": "libraries",
+            }
+        },
+    )
+    monkeypatch.setattr(qs_module.output.helpers, "get_plex_summary", lambda: "Plex summary unavailable")
+    monkeypatch.setattr(qs_module.output.helpers, "get_quickstart_settings_summary", lambda: [])
+    monkeypatch.setattr(qs_module.output.helpers, "get_library_summaries", lambda _names: "Movies")
+
+    def fake_retrieve_settings(section):
+        if section == "025-libraries":
+            return payload
+        return {"validated": False}
+
+    monkeypatch.setattr(qs_module.output.persistence, "retrieve_settings", fake_retrieve_settings)
+    with qs_module.app.app_context():
+        validated, _validation_error, _config_data, yaml_content, _validation_errors = qs_module.output.build_config(
+            header_style="single line",
+            config_name="pytest_video_format_contract",
+        )
+    assert isinstance(validated, bool)
+    assert yaml_content
+    return yaml_content
+
+
+def test_video_format_yaml_contract_keeps_use_key_toggles(monkeypatch, qs_module):
+    payload = _build_library_payload(
+        {
+            "use_remux": False,
+            "use_bluray": False,
+            "use_web": False,
+            "use_hdtv": False,
+            "use_dvd": False,
+            "use_sdtv": False,
+            "use_telesync": False,
+            "use_cam": False,
+        }
+    )
+
+    template_vars = _template_vars_from_yaml(_run_build_config_with_payload(qs_module, monkeypatch, payload))
+
+    assert template_vars["use_remux"] is False
+    assert template_vars["use_bluray"] is False
+    assert template_vars["use_web"] is False
+    assert template_vars["use_hdtv"] is False
+    assert template_vars["use_dvd"] is False
+    assert template_vars["use_sdtv"] is False
+    assert template_vars["use_telesync"] is False
+    assert template_vars["use_cam"] is False


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Summary
This PR expands Quickstart support for Kometa overlay use_<<key>> template variables across a large set of default overlays, and fixes one importer gap for radio-style content rating overlays.

What Changed
Added schema/UI support plus importer/YAML contract coverage for official use_* toggles on:

ribbon
status
content_rating_us_movie
content_rating_us_show
content_rating_uk
content_rating_de
content_rating_au
content_rating_nz
commonsense
aspect
audio_codec
language_count
resolution / edition
video_format
streaming
Also fixed modules/importer.py so radio-group overlays resolve by overlay value aliases as well as overlay_* IDs. This removes a false positive where default: commonsense exported by Quickstart could not be imported back cleanly.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
