### PR TITLE
Fix order of use key

### DIFF
--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -400,6 +400,20 @@ def build_qs_overlay_map(qs_overlays_path: Path) -> dict[str, set[str]]:
     return mapping
 
 
+def overlay_key_supported_in_quickstart(alias: str | None, key: str, qs_overlays: dict[str, set[str]]) -> bool:
+    alias_text = str(alias or "")
+    if key in qs_overlays.get(alias_text, set()):
+        return True
+
+    # Quickstart models subtitle language flags as a dedicated overlay alias,
+    # while user configs legitimately express that selection as
+    # default: languages + template_variables.use_subtitles: true.
+    if alias_text == "languages" and key == "use_subtitles":
+        return key in qs_overlays.get("languages_subtitles", set())
+
+    return False
+
+
 def build_qs_library_template_keys(qs_attributes_path: Path) -> set[str]:
     data = load_json(qs_attributes_path)
     keys: set[str] = set(QS_SPECIAL_LIBRARY_TEMPLATE_KEYS)
@@ -1501,7 +1515,7 @@ def main() -> None:
                 default_files = resolve_default_paths(alias or "", kind, kometa_defaults)
                 name_verified, matched_files = key_is_valid_for_default(key, default_files)
             elif kind == "overlay":
-                supported = key in qs_overlays.get(alias or "", set())
+                supported = overlay_key_supported_in_quickstart(alias, key, qs_overlays)
                 default_files = resolve_default_paths(alias or "", kind, kometa_defaults)
                 name_verified, matched_files = key_is_valid_for_default(key, default_files)
             elif kind == "playlist":

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -26153,6 +26153,27 @@
             "default": true
           },
           {
+            "key": "originals_only",
+            "label": "Originals Only",
+            "url": "https://kometa.wiki/en/nightly/defaults/both/streaming/#template-variables",
+            "tooltip": "Switches supported services from \"currently streaming on this service\" to that service's original productions. This cannot be combined with Region and only works for select services such as Amazon, Apple TV, Disney, Max, Hulu, Netflix, Paramount, Peacock.",
+            "tooltip_variant": "warning",
+            "type": "toggle",
+            "default": false,
+            "mutually_exclusive_with": "region"
+          },
+          {
+            "key": "region",
+            "label": "Region",
+            "url": "https://kometa.wiki/en/nightly/defaults/both/streaming/#template-variables",
+            "type": "select",
+            "tooltip": "Optional ISO 3166-1 country code used for streaming availability, such as US, CA, GB, or ES. Leave blank to use the default provider region. Do not combine this with Originals Only.",
+            "options_source": "iso_3166_1_regions",
+            "include_blank_option": true,
+            "blank_option_label": "Default Region (Kometa default: US)",
+            "mutually_exclusive_with": "originals_only"
+          },
+          {
             "key": "use_appletv",
             "label": "Apple TV Movies/Shows",
             "tooltip": "Collection of Movies/Shows Streaming on Apple TV.",

--- a/static/json/quickstart_overlays.json
+++ b/static/json/quickstart_overlays.json
@@ -3125,6 +3125,411 @@
               "half"
             ]
           },
+          "use_en": {
+            "label": "Use EN",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_de": {
+            "label": "Use DE",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_fr": {
+            "label": "Use FR",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_es": {
+            "label": "Use ES",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_pt": {
+            "label": "Use PT",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ja": {
+            "label": "Use JA",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ko": {
+            "label": "Use KO",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_zh": {
+            "label": "Use ZH",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_da": {
+            "label": "Use DA",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ru": {
+            "label": "Use RU",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_it": {
+            "label": "Use IT",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_hi": {
+            "label": "Use HI",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_te": {
+            "label": "Use TE",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_fa": {
+            "label": "Use FA",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_th": {
+            "label": "Use TH",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_nl": {
+            "label": "Use NL",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_no": {
+            "label": "Use NO",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_is": {
+            "label": "Use IS",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_sv": {
+            "label": "Use SV",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_tr": {
+            "label": "Use TR",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_pl": {
+            "label": "Use PL",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_cs": {
+            "label": "Use CS",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_uk": {
+            "label": "Use UK",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_hu": {
+            "label": "Use HU",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ar": {
+            "label": "Use AR",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_bg": {
+            "label": "Use BG",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_bn": {
+            "label": "Use BN",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_bs": {
+            "label": "Use BS",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ca": {
+            "label": "Use CA",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_cy": {
+            "label": "Use CY",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_el": {
+            "label": "Use EL",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_et": {
+            "label": "Use ET",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_eu": {
+            "label": "Use EU",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_fi": {
+            "label": "Use FI",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_tl": {
+            "label": "Use TL",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_fil": {
+            "label": "Use FIL",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_gl": {
+            "label": "Use GL",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_he": {
+            "label": "Use HE",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_hr": {
+            "label": "Use HR",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_id": {
+            "label": "Use ID",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ka": {
+            "label": "Use KA",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_kk": {
+            "label": "Use KK",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_kn": {
+            "label": "Use KN",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_la": {
+            "label": "Use LA",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_lt": {
+            "label": "Use LT",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_lv": {
+            "label": "Use LV",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_mk": {
+            "label": "Use MK",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ml": {
+            "label": "Use ML",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_mr": {
+            "label": "Use MR",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ms": {
+            "label": "Use MS",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_nb": {
+            "label": "Use NB",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_nn": {
+            "label": "Use NN",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_pa": {
+            "label": "Use PA",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ro": {
+            "label": "Use RO",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_sk": {
+            "label": "Use SK",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_sl": {
+            "label": "Use SL",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_sq": {
+            "label": "Use SQ",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_sr": {
+            "label": "Use SR",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_so": {
+            "label": "Use SO",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_sw": {
+            "label": "Use SW",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ta": {
+            "label": "Use TA",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ur": {
+            "label": "Use UR",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_vi": {
+            "label": "Use VI",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_bm": {
+            "label": "Use BM",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ln": {
+            "label": "Use LN",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_wo": {
+            "label": "Use WO",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_myn": {
+            "label": "Use MYN",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_iu": {
+            "label": "Use IU",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_rom": {
+            "label": "Use ROM",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_am": {
+            "label": "Use AM",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_su": {
+            "label": "Use SU",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_zu": {
+            "label": "Use ZU",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_lb": {
+            "label": "Use LB",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_mos": {
+            "label": "Use MOS",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_af": {
+            "label": "Use AF",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_mn": {
+            "label": "Use MN",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_kh": {
+            "label": "Use KH",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_li": {
+            "label": "Use LI",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ga": {
+            "label": "Use GA",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ay": {
+            "label": "Use AY",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_lo": {
+            "label": "Use LO",
+            "input_type": "toggle",
+            "default": true
+          },
           "font": {
             "label": "Font",
             "input_type": "text",
@@ -3380,6 +3785,411 @@
               "square",
               "half"
             ]
+          },
+          "use_en": {
+            "label": "Use EN",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_de": {
+            "label": "Use DE",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_fr": {
+            "label": "Use FR",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_es": {
+            "label": "Use ES",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_pt": {
+            "label": "Use PT",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ja": {
+            "label": "Use JA",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ko": {
+            "label": "Use KO",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_zh": {
+            "label": "Use ZH",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_da": {
+            "label": "Use DA",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ru": {
+            "label": "Use RU",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_it": {
+            "label": "Use IT",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_hi": {
+            "label": "Use HI",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_te": {
+            "label": "Use TE",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_fa": {
+            "label": "Use FA",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_th": {
+            "label": "Use TH",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_nl": {
+            "label": "Use NL",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_no": {
+            "label": "Use NO",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_is": {
+            "label": "Use IS",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_sv": {
+            "label": "Use SV",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_tr": {
+            "label": "Use TR",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_pl": {
+            "label": "Use PL",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_cs": {
+            "label": "Use CS",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_uk": {
+            "label": "Use UK",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_hu": {
+            "label": "Use HU",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ar": {
+            "label": "Use AR",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_bg": {
+            "label": "Use BG",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_bn": {
+            "label": "Use BN",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_bs": {
+            "label": "Use BS",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ca": {
+            "label": "Use CA",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_cy": {
+            "label": "Use CY",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_el": {
+            "label": "Use EL",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_et": {
+            "label": "Use ET",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_eu": {
+            "label": "Use EU",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_fi": {
+            "label": "Use FI",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_tl": {
+            "label": "Use TL",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_fil": {
+            "label": "Use FIL",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_gl": {
+            "label": "Use GL",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_he": {
+            "label": "Use HE",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_hr": {
+            "label": "Use HR",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_id": {
+            "label": "Use ID",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ka": {
+            "label": "Use KA",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_kk": {
+            "label": "Use KK",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_kn": {
+            "label": "Use KN",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_la": {
+            "label": "Use LA",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_lt": {
+            "label": "Use LT",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_lv": {
+            "label": "Use LV",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_mk": {
+            "label": "Use MK",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ml": {
+            "label": "Use ML",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_mr": {
+            "label": "Use MR",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ms": {
+            "label": "Use MS",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_nb": {
+            "label": "Use NB",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_nn": {
+            "label": "Use NN",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_pa": {
+            "label": "Use PA",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ro": {
+            "label": "Use RO",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_sk": {
+            "label": "Use SK",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_sl": {
+            "label": "Use SL",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_sq": {
+            "label": "Use SQ",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_sr": {
+            "label": "Use SR",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_so": {
+            "label": "Use SO",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_sw": {
+            "label": "Use SW",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ta": {
+            "label": "Use TA",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ur": {
+            "label": "Use UR",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_vi": {
+            "label": "Use VI",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_bm": {
+            "label": "Use BM",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ln": {
+            "label": "Use LN",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_wo": {
+            "label": "Use WO",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_myn": {
+            "label": "Use MYN",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_iu": {
+            "label": "Use IU",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_rom": {
+            "label": "Use ROM",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_am": {
+            "label": "Use AM",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_su": {
+            "label": "Use SU",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_zu": {
+            "label": "Use ZU",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_lb": {
+            "label": "Use LB",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_mos": {
+            "label": "Use MOS",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_af": {
+            "label": "Use AF",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_mn": {
+            "label": "Use MN",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_kh": {
+            "label": "Use KH",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_li": {
+            "label": "Use LI",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ga": {
+            "label": "Use GA",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_ay": {
+            "label": "Use AY",
+            "input_type": "toggle",
+            "default": true
+          },
+          "use_lo": {
+            "label": "Use LO",
+            "input_type": "toggle",
+            "default": true
           },
           "font": {
             "label": "Font",

--- a/static/json/quickstart_overlays.json
+++ b/static/json/quickstart_overlays.json
@@ -407,26 +407,6 @@
             "default": 14,
             "label": "Last (Days)"
           },
-          "text_airing": {
-            "input_type": "text",
-            "label": "Airing Text",
-            "default": "AIRING"
-          },
-          "text_returning": {
-            "input_type": "text",
-            "label": "Returning Text",
-            "default": "RETURNING"
-          },
-          "text_canceled": {
-            "input_type": "text",
-            "label": "Canceled Text",
-            "default": "CANCELED"
-          },
-          "text_ended": {
-            "input_type": "text",
-            "label": "Ended Text",
-            "default": "ENDED"
-          },
           "use_airing": {
             "label": "Use Airing",
             "input_type": "toggle",
@@ -446,6 +426,26 @@
             "label": "Use Ended",
             "input_type": "toggle",
             "default": true
+          },
+          "text_airing": {
+            "input_type": "text",
+            "label": "Airing Text",
+            "default": "AIRING"
+          },
+          "text_returning": {
+            "input_type": "text",
+            "label": "Returning Text",
+            "default": "RETURNING"
+          },
+          "text_canceled": {
+            "input_type": "text",
+            "label": "Canceled Text",
+            "default": "CANCELED"
+          },
+          "text_ended": {
+            "input_type": "text",
+            "label": "Ended Text",
+            "default": "ENDED"
           },
           "font": {
             "input_type": "text",
@@ -2191,90 +2191,6 @@
             "default": 15
           },
           {
-            "input_type": "hidden",
-            "key": "font",
-            "default": "Inter-Medium.ttf"
-          },
-          {
-            "input_type": "hidden",
-            "key": "font_size",
-            "default": 55
-          },
-          {
-            "input_type": "hidden",
-            "key": "font_color",
-            "default": "#FFFFFFFF"
-          },
-          {
-            "input_type": "number",
-            "key": "stroke_width",
-            "label": "Stroke Width",
-            "default": 1,
-            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0."
-          },
-          {
-            "input_type": "text",
-            "key": "stroke_color",
-            "label": "Stroke Color",
-            "default": "#00000000",
-            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA."
-          },
-          {
-            "input_type": "select",
-            "key": "back_align",
-            "label": "Backdrop Alignment",
-            "default": "center",
-            "options": [
-              "left",
-              "center",
-              "right",
-              "top",
-              "bottom"
-            ]
-          },
-          {
-            "input_type": "text",
-            "key": "back_color",
-            "label": "Backdrop Color",
-            "default": "#00000099"
-          },
-          {
-            "input_type": "number",
-            "key": "back_height",
-            "label": "Backdrop Height",
-            "default": 105
-          },
-          {
-            "input_type": "number",
-            "key": "back_width",
-            "label": "Backdrop Width",
-            "default": 305
-          },
-          {
-            "input_type": "text",
-            "key": "back_line_color",
-            "label": "Backdrop Line Color",
-            "default": "#00000000"
-          },
-          {
-            "input_type": "number",
-            "key": "back_line_width",
-            "label": "Backdrop Line Width",
-            "default": 1
-          },
-          {
-            "input_type": "number",
-            "key": "back_padding",
-            "label": "Backdrop Padding",
-            "default": 1
-          },
-          {
-            "input_type": "number",
-            "key": "back_radius",
-            "label": "Backdrop Radius",
-            "default": 30
-          },
-          {
             "type": "toggle",
             "key": "use_1",
             "label": "Use 1+",
@@ -2484,6 +2400,90 @@
             ]
           },
           {
+            "input_type": "hidden",
+            "key": "font",
+            "default": "Inter-Medium.ttf"
+          },
+          {
+            "input_type": "hidden",
+            "key": "font_size",
+            "default": 55
+          },
+          {
+            "input_type": "hidden",
+            "key": "font_color",
+            "default": "#FFFFFFFF"
+          },
+          {
+            "input_type": "number",
+            "key": "stroke_width",
+            "label": "Stroke Width",
+            "default": 1,
+            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0."
+          },
+          {
+            "input_type": "text",
+            "key": "stroke_color",
+            "label": "Stroke Color",
+            "default": "#00000000",
+            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA."
+          },
+          {
+            "input_type": "select",
+            "key": "back_align",
+            "label": "Backdrop Alignment",
+            "default": "center",
+            "options": [
+              "left",
+              "center",
+              "right",
+              "top",
+              "bottom"
+            ]
+          },
+          {
+            "input_type": "text",
+            "key": "back_color",
+            "label": "Backdrop Color",
+            "default": "#00000099"
+          },
+          {
+            "input_type": "number",
+            "key": "back_height",
+            "label": "Backdrop Height",
+            "default": 105
+          },
+          {
+            "input_type": "number",
+            "key": "back_width",
+            "label": "Backdrop Width",
+            "default": 305
+          },
+          {
+            "input_type": "text",
+            "key": "back_line_color",
+            "label": "Backdrop Line Color",
+            "default": "#00000000"
+          },
+          {
+            "input_type": "number",
+            "key": "back_line_width",
+            "label": "Backdrop Line Width",
+            "default": 1
+          },
+          {
+            "input_type": "number",
+            "key": "back_padding",
+            "label": "Backdrop Padding",
+            "default": 1
+          },
+          {
+            "input_type": "number",
+            "key": "back_radius",
+            "label": "Backdrop Radius",
+            "default": 30
+          },
+          {
             "input_type": "number",
             "key": "horizontal_offset",
             "label": "Horizontal Offset",
@@ -2558,6 +2558,94 @@
             "key": "text",
             "label": "Text",
             "default": "1.78"
+          },
+          {
+            "type": "toggle",
+            "key": "use_1.33",
+            "label": "Use 1.33",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_1.65",
+            "label": "Use 1.65",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_1.66",
+            "label": "Use 1.66",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_1.78",
+            "label": "Use 1.78",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_1.85",
+            "label": "Use 1.85",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_2.2",
+            "label": "Use 2.2",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_2.35",
+            "label": "Use 2.35",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_2.77",
+            "label": "Use 2.77",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
           },
           {
             "input_type": "text",
@@ -2657,94 +2745,6 @@
             "key": "vertical_offset",
             "label": "Vertical Offset",
             "default": 150
-          },
-          {
-            "type": "toggle",
-            "key": "use_1.33",
-            "label": "Use 1.33",
-            "value": "true",
-            "default": true,
-            "options": [
-              "true",
-              "false"
-            ]
-          },
-          {
-            "type": "toggle",
-            "key": "use_1.65",
-            "label": "Use 1.65",
-            "value": "true",
-            "default": true,
-            "options": [
-              "true",
-              "false"
-            ]
-          },
-          {
-            "type": "toggle",
-            "key": "use_1.66",
-            "label": "Use 1.66",
-            "value": "true",
-            "default": true,
-            "options": [
-              "true",
-              "false"
-            ]
-          },
-          {
-            "type": "toggle",
-            "key": "use_1.78",
-            "label": "Use 1.78",
-            "value": "true",
-            "default": true,
-            "options": [
-              "true",
-              "false"
-            ]
-          },
-          {
-            "type": "toggle",
-            "key": "use_1.85",
-            "label": "Use 1.85",
-            "value": "true",
-            "default": true,
-            "options": [
-              "true",
-              "false"
-            ]
-          },
-          {
-            "type": "toggle",
-            "key": "use_2.2",
-            "label": "Use 2.2",
-            "value": "true",
-            "default": true,
-            "options": [
-              "true",
-              "false"
-            ]
-          },
-          {
-            "type": "toggle",
-            "key": "use_2.35",
-            "label": "Use 2.35",
-            "value": "true",
-            "default": true,
-            "options": [
-              "true",
-              "false"
-            ]
-          },
-          {
-            "type": "toggle",
-            "key": "use_2.77",
-            "label": "Use 2.77",
-            "value": "true",
-            "default": true,
-            "options": [
-              "true",
-              "false"
-            ]
           },
           {
             "type": "toggle",
@@ -2983,6 +2983,28 @@
         ],
         "template_variables": [
           {
+            "type": "toggle",
+            "key": "use_dual",
+            "label": "Use Dual",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_multi",
+            "label": "Use Multi",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
             "input_type": "select",
             "key": "back_align",
             "label": "Backdrop Alignment",
@@ -3036,28 +3058,6 @@
             "key": "back_radius",
             "label": "Backdrop Radius",
             "default": 30
-          },
-          {
-            "type": "toggle",
-            "key": "use_dual",
-            "label": "Use Dual",
-            "value": "true",
-            "default": true,
-            "options": [
-              "true",
-              "false"
-            ]
-          },
-          {
-            "type": "toggle",
-            "key": "use_multi",
-            "label": "Use Multi",
-            "value": "true",
-            "default": true,
-            "options": [
-              "true",
-              "false"
-            ]
           },
           {
             "type": "toggle",
@@ -4404,93 +4404,6 @@
             "default": "HDTV"
           },
           {
-            "input_type": "text",
-            "key": "font",
-            "label": "Font",
-            "default": "Inter-Medium.ttf"
-          },
-          {
-            "input_type": "number",
-            "key": "font_size",
-            "label": "Font Size",
-            "default": 55
-          },
-          {
-            "input_type": "text",
-            "key": "font_color",
-            "label": "Font Color",
-            "default": "#FFFFFFFF"
-          },
-          {
-            "input_type": "number",
-            "key": "stroke_width",
-            "label": "Stroke Width",
-            "default": 1,
-            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0."
-          },
-          {
-            "input_type": "text",
-            "key": "stroke_color",
-            "label": "Stroke Color",
-            "default": "#00000000",
-            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA."
-          },
-          {
-            "input_type": "select",
-            "key": "back_align",
-            "label": "Backdrop Alignment",
-            "default": "center",
-            "options": [
-              "left",
-              "center",
-              "right",
-              "top",
-              "bottom"
-            ]
-          },
-          {
-            "input_type": "text",
-            "key": "back_color",
-            "label": "Backdrop Color",
-            "default": "#00000099"
-          },
-          {
-            "input_type": "number",
-            "key": "back_height",
-            "label": "Backdrop Height",
-            "default": 105
-          },
-          {
-            "input_type": "number",
-            "key": "back_width",
-            "label": "Backdrop Width",
-            "default": 305
-          },
-          {
-            "input_type": "text",
-            "key": "back_line_color",
-            "label": "Backdrop Line Color",
-            "default": "#00000000"
-          },
-          {
-            "input_type": "number",
-            "key": "back_line_width",
-            "label": "Backdrop Line Width",
-            "default": 1
-          },
-          {
-            "input_type": "number",
-            "key": "back_padding",
-            "label": "Backdrop Padding",
-            "default": 1
-          },
-          {
-            "input_type": "number",
-            "key": "back_radius",
-            "label": "Backdrop Radius",
-            "default": 30
-          },
-          {
             "type": "toggle",
             "key": "use_remux",
             "label": "Use REMUX",
@@ -4577,6 +4490,93 @@
               "true",
               "false"
             ]
+          },
+          {
+            "input_type": "text",
+            "key": "font",
+            "label": "Font",
+            "default": "Inter-Medium.ttf"
+          },
+          {
+            "input_type": "number",
+            "key": "font_size",
+            "label": "Font Size",
+            "default": 55
+          },
+          {
+            "input_type": "text",
+            "key": "font_color",
+            "label": "Font Color",
+            "default": "#FFFFFFFF"
+          },
+          {
+            "input_type": "number",
+            "key": "stroke_width",
+            "label": "Stroke Width",
+            "default": 1,
+            "tooltip": "Font Stroke Width for the Overlay. Use any number greater than 0."
+          },
+          {
+            "input_type": "text",
+            "key": "stroke_color",
+            "label": "Stroke Color",
+            "default": "#00000000",
+            "tooltip": "Font Stroke Color for the Overlay. Hex format: #RRGGBBAA."
+          },
+          {
+            "input_type": "select",
+            "key": "back_align",
+            "label": "Backdrop Alignment",
+            "default": "center",
+            "options": [
+              "left",
+              "center",
+              "right",
+              "top",
+              "bottom"
+            ]
+          },
+          {
+            "input_type": "text",
+            "key": "back_color",
+            "label": "Backdrop Color",
+            "default": "#00000099"
+          },
+          {
+            "input_type": "number",
+            "key": "back_height",
+            "label": "Backdrop Height",
+            "default": 105
+          },
+          {
+            "input_type": "number",
+            "key": "back_width",
+            "label": "Backdrop Width",
+            "default": 305
+          },
+          {
+            "input_type": "text",
+            "key": "back_line_color",
+            "label": "Backdrop Line Color",
+            "default": "#00000000"
+          },
+          {
+            "input_type": "number",
+            "key": "back_line_width",
+            "label": "Backdrop Line Width",
+            "default": 1
+          },
+          {
+            "input_type": "number",
+            "key": "back_padding",
+            "label": "Backdrop Padding",
+            "default": 1
+          },
+          {
+            "input_type": "number",
+            "key": "back_radius",
+            "label": "Backdrop Radius",
+            "default": 30
           },
           {
             "type": "toggle",

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -1958,6 +1958,123 @@ document.addEventListener('DOMContentLoaded', function () {
       })
     }
 
+    function setupCollectionTemplateFieldRules (scope) {
+      const root = scope || document
+
+      function normalizeFieldValue (input) {
+        if (!input) return
+        const preset = String(input.dataset.validationPreset || '').trim()
+        if (preset === 'iso_3166_1_code' && input.type !== 'checkbox') {
+          const raw = String(input.value || '')
+          const cleaned = raw.replace(/[^a-z]/gi, '').slice(0, 2).toUpperCase()
+          if (raw !== cleaned) input.value = cleaned
+        }
+      }
+
+      function isActiveField (input) {
+        if (!input) return false
+        if (input.type === 'checkbox') return !!input.checked
+        return String(input.value || '').trim().length > 0
+      }
+
+      function setFieldDisabledState (input, disabled) {
+        if (!input) return
+        input.disabled = !!disabled
+      }
+
+      function syncMutualState (group) {
+        if (!group) return
+        const fields = Array.from(group.querySelectorAll('[data-template-variable-key][data-mutually-exclusive-with]'))
+        if (!fields.length) return
+
+        const fieldByKey = new Map()
+        fields.forEach(field => {
+          const key = String(field.dataset.templateVariableKey || '').trim()
+          if (key && !fieldByKey.has(key)) fieldByKey.set(key, field)
+        })
+
+        let hasConflict = false
+        fields.forEach(field => {
+          const key = String(field.dataset.templateVariableKey || '').trim()
+          const counterpartKey = String(field.dataset.mutuallyExclusiveWith || '').trim()
+          if (!key || !counterpartKey) return
+
+          const counterpart = fieldByKey.get(counterpartKey)
+          if (!counterpart) return
+
+          const fieldActive = isActiveField(field)
+          const counterpartActive = isActiveField(counterpart)
+          if (fieldActive && counterpartActive) hasConflict = true
+
+          if (fieldActive && !counterpartActive) {
+            setFieldDisabledState(counterpart, true)
+          } else if (!counterpartActive) {
+            setFieldDisabledState(counterpart, false)
+          }
+        })
+
+        let warning = group.querySelector('[data-collection-mutual-warning]')
+        if (!warning) {
+          warning = document.createElement('div')
+          warning.className = 'alert alert-warning py-2 px-3 mb-2 small d-none'
+          warning.dataset.collectionMutualWarning = 'true'
+          warning.textContent = 'Originals Only and Region cannot both be set at the same time.'
+          const anchor = group.querySelector('.child-toggle-wrapper')
+          if (anchor) {
+            anchor.insertAdjacentElement('afterbegin', warning)
+          } else {
+            group.appendChild(warning)
+          }
+        }
+        warning.classList.toggle('d-none', !hasConflict)
+      }
+
+      root.querySelectorAll('[data-collection-config="true"]').forEach(group => {
+        if (group.dataset.templateFieldRulesBound === 'true') return
+
+        const fields = Array.from(group.querySelectorAll('[data-template-variable-key]'))
+        fields.forEach(input => {
+          const preset = String(input.dataset.validationPreset || '').trim()
+          if (preset === 'iso_3166_1_code' && input.type !== 'checkbox') {
+            const feedbackId = `${input.id}_feedback`
+            let feedback = document.getElementById(feedbackId)
+            if (!feedback) {
+              feedback = document.createElement('div')
+              feedback.id = feedbackId
+              feedback.className = 'invalid-feedback'
+              feedback.textContent = 'Enter a 2-letter ISO 3166-1 region code.'
+              input.insertAdjacentElement('afterend', feedback)
+            }
+
+            const validateRegion = () => {
+              normalizeFieldValue(input)
+              const value = String(input.value || '').trim()
+              const valid = !value || /^[A-Z]{2}$/.test(value)
+              input.classList.toggle('is-invalid', !valid)
+              input.setCustomValidity(valid ? '' : 'Enter a 2-letter ISO 3166-1 region code.')
+            }
+
+            input.addEventListener('input', validateRegion)
+            input.addEventListener('change', validateRegion)
+            input.addEventListener('blur', validateRegion)
+            validateRegion()
+          }
+
+          input.addEventListener('input', () => {
+            normalizeFieldValue(input)
+            syncMutualState(group)
+          })
+          input.addEventListener('change', () => {
+            normalizeFieldValue(input)
+            syncMutualState(group)
+          })
+        })
+
+        syncMutualState(group)
+        group.dataset.templateFieldRulesBound = 'true'
+      })
+    }
+
     function initStylePreviewGrids (scope) {
       const root = scope || document
       root.querySelectorAll('[data-style-preview-grid]').forEach(grid => {
@@ -3675,6 +3792,7 @@ document.addEventListener('DOMContentLoaded', function () {
       sortLanguageSelects(card)
       setupOverlayLanguageWeightBuilders(card)
       initNumericOnlyInputs(card)
+      setupCollectionTemplateFieldRules(card)
       initStylePreviewGrids(card)
       initRelativeYearInputs(card)
       initScheduleBuilders(card)
@@ -4171,6 +4289,7 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     setupParentChildToggleVisibility()
+    setupCollectionTemplateFieldRules()
     setupCustomStringListHandlers('mass_genre_update')
     setupCustomStringListHandlers('radarr_remove_by_tag')
     setupCustomStringListHandlers('sonarr_remove_by_tag')

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -1649,7 +1649,22 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                                 <div class="overlay-template-section mt-2" id="{{ details_id }}"
                                                     style="display: none;">
                                                 {% set is_mapping = overlay.template_variables is mapping %}
-                                                {% set tv_items = overlay.template_variables.items() if is_mapping else overlay.template_variables %}
+                                                {% set raw_tv_items = overlay.template_variables.items() if is_mapping else overlay.template_variables %}
+                                                {% if is_mapping and overlay.id in ['overlay_languages', 'overlay_languages_subtitles'] %}
+                                                {% set priority_tv_items = [] %}
+                                                {% set remaining_tv_items = [] %}
+                                                {% for tv_item in raw_tv_items %}
+                                                {% set tv_item_name = tv_item[0] %}
+                                                {% if tv_item_name.startswith('use_') and tv_item_name not in ['use_lowercase', 'use_subtitles'] %}
+                                                {% set _ = priority_tv_items.append(tv_item) %}
+                                                {% else %}
+                                                {% set _ = remaining_tv_items.append(tv_item) %}
+                                                {% endif %}
+                                                {% endfor %}
+                                                {% set tv_items = priority_tv_items + remaining_tv_items %}
+                                                {% else %}
+                                                {% set tv_items = raw_tv_items %}
+                                                {% endif %}
                                                 {% set seen_vars = [] %}
                                                 {% for item in tv_items %}
                                                 {% if is_mapping %}

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -1109,7 +1109,10 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                         <div class="form-check form-switch d-flex align-items-center mb-1">
                             <input class="form-check-input template-child-toggle me-2" type="checkbox"
                                 id="{{ input_name }}" name="{{ input_name }}" value="true"
-                                data-parent-toggle="{{ library.id }}-{{ collection.id }}" {% if disable_toggle
+                                data-parent-toggle="{{ library.id }}-{{ collection.id }}"
+                                {% if item.key is defined %}data-template-variable-key="{{ item.key }}"{% endif %}
+                                {% if item.mutually_exclusive_with %}data-mutually-exclusive-with="{{ item.mutually_exclusive_with }}"{% endif %}
+                                {% if disable_toggle
                                 %}disabled{% endif %} {% if not disable_toggle and
                                 (stored_true or (not has_stored and default_true)) %}checked{% endif %}>
                             <input type="hidden" name="{{ input_name }}" value="false">
@@ -1120,6 +1123,7 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                             {% endif %}
                         </div>
                         {% elif item.type == 'select' %}
+                        {% set stored_select_val = data['libraries'].get(input_name, item.default) | default('', true) %}
                         <div class="input-group mb-2">
                             <span class="input-group-text" id="{{ input_name }}_text" style="width: 170px;">
                                 {{ item.label }}
@@ -1132,7 +1136,26 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                 {% endif %}
                             </span>
                             <select class="form-select" id="{{ input_name }}" name="{{ input_name }}"
-                                aria-describedby="{{ input_name }}_text" {% if disable_toggle %}disabled{% endif %}>
+                                aria-describedby="{{ input_name }}_text"
+                                {% if item.key is defined %}data-template-variable-key="{{ item.key }}"{% endif %}
+                                {% if item.mutually_exclusive_with %}data-mutually-exclusive-with="{{ item.mutually_exclusive_with }}"{% endif %}
+                                {% if item.validation_preset %}data-validation-preset="{{ item.validation_preset }}"{% endif %}
+                                {% if disable_toggle %}disabled{% endif %}>
+                                {% if item.include_blank_option %}
+                                <option value="" {% if not stored_select_val %}selected{% endif %}>
+                                    {{ item.blank_option_label | default('Default') }}
+                                </option>
+                                {% endif %}
+                                {% if item.options_source == 'iso_3166_1_regions' %}
+                                <option value="US" {% if stored_select_val == 'US' %}selected{% endif %}>United States</option>
+                                {% for code, region in data['iso_3166_1_regions'] | sort(attribute='1') %}
+                                {% if code != "US" %}
+                                <option value="{{ code }}" {% if stored_select_val == code %}selected{% endif %}>
+                                    {{ region }}
+                                </option>
+                                {% endif %}
+                                {% endfor %}
+                                {% else %}
                                 {% for val in item.options %}
                                 {% if val is string %}
                                 {% set option_value = val %}
@@ -1145,16 +1168,16 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                 val.media_types) %}
                                 {% endif %}
                                 {% if show_option %}
-                                <option value="{{ option_value }}" {% if data['libraries'][input_name]==option_value or
-                                    (not data['libraries'][input_name] and item.default==option_value) %} selected {%
-                                    endif %}>
+                                <option value="{{ option_value }}" {% if stored_select_val == option_value %}selected{% endif %}>
                                     {{ option_label }}
                                 </option>
                                 {% endif %}
                                 {% endfor %}
+                                {% endif %}
                             </select>
                         </div>
                         {% set preview_options = [] %}
+                        {% if item.options is defined %}
                         {% for val in item.options %}
                         {% if val is mapping and val.image_url %}
                         {% set show_preview = (val.media_types is not defined) or (library.type in val.media_types) %}
@@ -1163,6 +1186,7 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                         {% endif %}
                         {% endif %}
                         {% endfor %}
+                        {% endif %}
                         {% if preview_options %}
                         <div class="style-preview-grid mb-2" data-style-preview-grid data-style-select="{{ input_name }}">
                             {% for val in preview_options %}
@@ -1404,13 +1428,20 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                             </span>
                             <input type="{{ 'number' if is_number_input else 'text' }}" class="form-control" id="{{ input_name }}" name="{{ input_name }}"
                                 value="{{ data['libraries'].get(input_name, item.default) | default('', true) }}"
+                                {% if item.key is defined %}data-template-variable-key="{{ item.key }}"{% endif %}
+                                {% if item.mutually_exclusive_with %}data-mutually-exclusive-with="{{ item.mutually_exclusive_with }}"{% endif %}
+                                {% if item.validation_preset %}data-validation-preset="{{ item.validation_preset }}"{% endif %}
                                 {% if is_number_input %}
                                 min="{{ item.min | default(1) }}" step="{{ item.step | default(1) }}" inputmode="numeric"
                                 data-numeric-only="true"
                                 data-default-value="{{ item.default | default('', true) }}"
                                 {% else %}
-                                minlength="1" pattern="[\x20-\x7E]+"
-                                title="Only ASCII characters allowed (no accents or emojis)"
+                                {% if item.minlength is defined %}minlength="{{ item.minlength }}"{% else %}minlength="1"{% endif %}
+                                pattern="{{ item.text_pattern | default('[\\x20-\\x7E]+') }}"
+                                title="{{ item.text_title | default('Only ASCII characters allowed (no accents or emojis)') }}"
+                                {% if item.maxlength is defined %}maxlength="{{ item.maxlength }}"{% endif %}
+                                {% if item.inputmode is defined %}inputmode="{{ item.inputmode }}"{% endif %}
+                                {% if item.autocapitalize is defined %}autocapitalize="{{ item.autocapitalize }}"{% endif %}
                                 {% endif %}
                                 {% if disable_toggle %}disabled{% endif %}>
                         </div>

--- a/tests/test_importer_overlay_files.py
+++ b/tests/test_importer_overlay_files.py
@@ -250,6 +250,77 @@ def test_prepare_import_payload_accepts_language_count_use_key_template_variable
     assert any("libraries.Movies.overlay_files[0].template_variables.use_multi" in line for line in report.lines)
 
 
+def test_prepare_import_payload_accepts_languages_audio_use_key_template_variables():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Movies": {
+                    "overlay_files": [
+                        {
+                            "default": "languages",
+                            "template_variables": {
+                                "use_en": False,
+                                "use_ja": False,
+                                "use_fil": False,
+                                "use_myn": False,
+                            },
+                        }
+                    ]
+                }
+            }
+        },
+        {"Movies"},
+        set(),
+        set(),
+    )
+
+    libraries_payload = payload["libraries"]["libraries"]
+    assert libraries_payload["mov-library_movies-movie-overlay_languages"] is True
+    assert libraries_payload["mov-library_movies-movie-template_overlay_languages[use_en]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_languages[use_ja]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_languages[use_fil]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_languages[use_myn]"] is False
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_en" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_fil" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_myn" in line for line in report.lines)
+
+
+def test_prepare_import_payload_accepts_languages_subtitles_use_key_template_variables():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Movies": {
+                    "overlay_files": [
+                        {
+                            "default": "languages",
+                            "template_variables": {
+                                "use_subtitles": True,
+                                "use_en": False,
+                                "use_ja": False,
+                                "use_fil": False,
+                                "use_myn": False,
+                            },
+                        }
+                    ]
+                }
+            }
+        },
+        {"Movies"},
+        set(),
+        set(),
+    )
+
+    libraries_payload = payload["libraries"]["libraries"]
+    assert libraries_payload["mov-library_movies-movie-overlay_languages_subtitles"] is True
+    assert libraries_payload["mov-library_movies-movie-template_overlay_languages_subtitles[use_en]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_languages_subtitles[use_ja]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_languages_subtitles[use_fil]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_languages_subtitles[use_myn]"] is False
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_subtitles" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_en" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_myn" in line for line in report.lines)
+
+
 def test_prepare_import_payload_accepts_status_use_key_template_variables():
     payload, report = importer.prepare_import_payload(
         {

--- a/tests/test_template_gap_analyzer.py
+++ b/tests/test_template_gap_analyzer.py
@@ -56,4 +56,30 @@ def test_build_qs_overlay_map_includes_rating3_for_repo_quickstart_file():
 
     assert "rating3" in overlay_map["ratings"]
     assert "rating3_image" in overlay_map["ratings"]
+    assert "rating3_font" in overlay_map["ratings"]
+    assert "rating3_font_size" in overlay_map["ratings"]
+    assert "rating3_font_color" in overlay_map["ratings"]
+    assert "rating3_vertical_offset" in overlay_map["ratings"]
     assert "rating_alignment" in overlay_map["ratings"]
+
+
+def test_overlay_key_supported_in_quickstart_accepts_languages_use_subtitles_alias():
+    module = _load_gap_analyzer_module()
+
+    qs_overlays = {
+        "languages": {"style", "languages"},
+        "languages_subtitles": {"style", "languages", "use_subtitles"},
+    }
+
+    assert module.overlay_key_supported_in_quickstart("languages", "use_subtitles", qs_overlays) is True
+
+
+def test_overlay_key_supported_in_quickstart_uses_direct_alias_match_when_available():
+    module = _load_gap_analyzer_module()
+
+    qs_overlays = {
+        "ratings": {"rating1", "rating2", "rating3", "rating3_image"},
+    }
+
+    assert module.overlay_key_supported_in_quickstart("ratings", "rating3", qs_overlays) is True
+    assert module.overlay_key_supported_in_quickstart("ratings", "rating3_image", qs_overlays) is True


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description


Summary

This branch expands Quickstart’s Kometa defaults coverage, fixes false positives in the template-gap analyzer, and improves the Quickstart workflow UX for app readiness and next steps.

What Changed

Added missing overlay use_<key> support across multiple defaults so Quickstart can expose more Kometa template variables directly in the UI.
Added/fixed overlay child-toggle presentation so use_<key> controls appear in the expected place at the top of their sections when details are expanded.
Fixed template-gap analyzer false positives for already-supported overlay variables, including use_subtitles and rating-related mappings.
Improved Quickstart readiness/navigation UX so users can better understand when Kometa/ImageMaid are ready and what to open next.
Added streaming collection support for:
originals_only
region
Changed streaming region from a loose text field to a proper dropdown backed by the shared ISO region list.
Added mutual-exclusion handling so streaming originals_only and region cannot be meaningfully set together in the UI.
Overlay Coverage Added/Expanded

Resolution/Edition
Audio Codec
Aspect Ratio
Video Format
Streaming
Ribbon
Content Rating variants
Common Sense
Language Count
Status
Language Flags / Subtitle Flags
Why

Reduce drift between Quickstart and supported Kometa defaults/template variables.
Eliminate misleading gap-report results so follow-up work targets real missing coverage.
Make the Quickstart flow clearer for new users after setup/validation.
Prevent invalid or confusing collection configuration for streaming region/originals behavior.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [ ] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
