### PR TITLE
Fix tsts

### DIFF
--- a/quickstart.py
+++ b/quickstart.py
@@ -7754,6 +7754,7 @@ def step(name):
     page_info = {}
     header_style = "single line"
     save_error = None
+    autosave_only = request.method == "POST" and request.headers.get("X-QS-Autosave-Only") == "1"
     if name == "900-final":
         return redirect(url_for("step", name="900-kometa"), code=302)
     persistence.ensure_session_config_name()
@@ -7831,6 +7832,11 @@ def step(name):
             else:
                 persistence.save_settings(request.referrer, request.form)
             header_style = request.form.get("header_style", "single line")
+
+        if autosave_only:
+            if save_error:
+                return jsonify(success=False, error=save_error), 400
+            return jsonify(success=True, config_name=session.get("config_name"))
 
     # --- Detect config change ---
     selected_config = request.form.get("configSelector") or previous_config

--- a/quickstart.py
+++ b/quickstart.py
@@ -2454,7 +2454,7 @@ def _is_meaningful_optional_status_input(value):
         return False
     text = str(value).strip().lower()
     # UI template placeholders can be persisted as defaults; they should not
-    # make an optional page look user-configured in the workspace menu.
+    # make an optional page look user-configured in the workspace menu
     return not (text.startswith("enter ") and any(token in text for token in ("token", "api key", "url", "client")))
 
 

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -2083,10 +2083,6 @@ function qsApplyActiveConfigUi (name, options = {}) {
 
   if (window.pageInfo) window.pageInfo.config_name = nextName
 
-  if (options && options.refreshWorkspace === false) {
-    return
-  }
-
   const workspaceStatus = options && typeof options === 'object' ? options.workspaceStatus : null
   if (workspaceStatus && typeof qsApplyWorkspaceStatus === 'function') {
     qsApplyWorkspaceStatus(Object.assign({ success: true, config_name: nextName }, workspaceStatus))
@@ -2957,10 +2953,13 @@ document.addEventListener('DOMContentLoaded', () => {
       body: formData,
       cache: 'no-store',
       credentials: 'same-origin',
-      headers: { Accept: 'text/html' }
+      headers: {
+        Accept: 'application/json',
+        'X-QS-Autosave-Only': '1'
+      }
     })
-    const text = await response.text()
-    if (!response.ok || text.includes('Invalid values:')) {
+    const payload = await response.json().catch(() => null)
+    if (!response.ok || !payload || payload.success !== true) {
       throw new Error('Current page could not be saved. Fix validation errors before switching configs.')
     }
     return { saved: true, skipped: false }
@@ -3004,7 +3003,6 @@ document.addEventListener('DOMContentLoaded', () => {
       confirmBtn.disabled = true
       confirmBtn.textContent = 'Saving...'
       window.QS_SWITCHING_CONFIG = true
-      qsApplyActiveConfigUi(target, { refreshWorkspace: false })
 
       try {
         if (typeof showNavigationLoadingOverlay === 'function') {
@@ -3043,7 +3041,6 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       } catch (err) {
         window.QS_SWITCHING_CONFIG = false
-        qsApplyActiveConfigUi(current, { refreshWorkspace: false })
         confirmBtn.disabled = false
         confirmBtn.textContent = 'Switch'
         if (typeof hideNavigationLoadingOverlay === 'function') {

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -2061,6 +2061,40 @@ function qsRefreshWorkspaceStatus (options = {}) {
   return Promise.resolve(null)
 }
 
+function qsApplyActiveConfigUi (name, options = {}) {
+  const nextName = String(name || '').trim()
+  if (!nextName) return
+
+  document.querySelectorAll('.qs-config-switch-trigger[data-current]').forEach((trigger) => {
+    trigger.dataset.current = nextName
+  })
+  document.querySelectorAll('.qs-main-page-meta-value').forEach((label) => {
+    label.textContent = nextName
+  })
+
+  const activeConfigInput = document.getElementById('qs-active-config-input')
+  if (activeConfigInput) activeConfigInput.value = nextName
+
+  const configSelector = document.getElementById('configSelector')
+  if (configSelector) configSelector.value = nextName
+
+  const configSwitchSelect = document.getElementById('configSwitchSelect')
+  if (configSwitchSelect) configSwitchSelect.value = nextName
+
+  if (window.pageInfo) window.pageInfo.config_name = nextName
+
+  if (options && options.refreshWorkspace === false) {
+    return
+  }
+
+  const workspaceStatus = options && typeof options === 'object' ? options.workspaceStatus : null
+  if (workspaceStatus && typeof qsApplyWorkspaceStatus === 'function') {
+    qsApplyWorkspaceStatus(Object.assign({ success: true, config_name: nextName }, workspaceStatus))
+  } else {
+    qsRefreshWorkspaceStatus({ immediate: true, configName: nextName })
+  }
+}
+
 let qsBulkValidationRequest = null
 
 function qsGetBulkSummaryCounts (summary) {
@@ -2576,6 +2610,7 @@ window.QSWorkspaceStatus = {
   apply: qsApplyWorkspaceStatus,
   recalculateFromSidebar: qsRecalculateReadinessFromSidebar
 }
+window.qsApplyActiveConfigUi = qsApplyActiveConfigUi
 
 document.addEventListener('qs:workspace-data-changed', (event) => {
   const detail = (event && event.detail) || {}
@@ -2932,15 +2967,33 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   if (select) {
-    modalEl.addEventListener('show.bs.modal', () => {
+    select.dataset.qsPendingTarget = select.value || ''
+    select.addEventListener('change', () => {
+      select.dataset.qsPendingTarget = select.value || ''
+    })
+    configTriggers.forEach((trigger) => {
+      if (!trigger || trigger.dataset.qsConfigSwitchBound === 'true') return
+      trigger.dataset.qsConfigSwitchBound = 'true'
+      trigger.addEventListener('click', () => {
+        const current = getCurrentConfig()
+        if (current) {
+          select.value = current
+          select.dataset.qsPendingTarget = current
+        }
+      })
+    })
+    modalEl.addEventListener('hidden.bs.modal', () => {
       const current = getCurrentConfig()
-      if (current) select.value = current
+      if (current) {
+        select.value = current
+        select.dataset.qsPendingTarget = current
+      }
     })
   }
 
   if (confirmBtn && select) {
     confirmBtn.addEventListener('click', async () => {
-      const target = select.value
+      const target = String(select.dataset.qsPendingTarget || select.value || '').trim()
       const current = getCurrentConfig()
       if (!target || target === current) {
         const modal = bootstrap.Modal.getInstance(modalEl)
@@ -2951,6 +3004,7 @@ document.addEventListener('DOMContentLoaded', () => {
       confirmBtn.disabled = true
       confirmBtn.textContent = 'Saving...'
       window.QS_SWITCHING_CONFIG = true
+      qsApplyActiveConfigUi(target, { refreshWorkspace: false })
 
       try {
         if (typeof showNavigationLoadingOverlay === 'function') {
@@ -2968,36 +3022,28 @@ document.addEventListener('DOMContentLoaded', () => {
           throw new Error(data.message || 'Failed to switch configs.')
         }
         const nextName = data.name || target
-        if (typeof window.qsApplyActiveConfigUi === 'function') {
-          window.qsApplyActiveConfigUi(nextName)
-        } else {
-          configTriggers.forEach((trigger) => {
-            if (trigger && trigger.dataset) {
-              trigger.dataset.current = nextName
-            }
-          })
-          document.querySelectorAll('.qs-main-page-meta-value').forEach((node) => {
-            node.textContent = nextName
-          })
-          const activeConfigInput = document.getElementById('qs-active-config-input')
-          if (activeConfigInput) {
-            activeConfigInput.value = nextName
-          }
-          if (window.pageInfo) {
-            window.pageInfo.config_name = nextName
-          }
-          if (data.workspace_status && typeof qsApplyWorkspaceStatus === 'function') {
-            qsApplyWorkspaceStatus(Object.assign({ success: true, config_name: nextName }, data.workspace_status))
-          } else {
-            qsRefreshWorkspaceStatus({ immediate: true, configName: nextName })
-          }
+        qsApplyActiveConfigUi(nextName, { workspaceStatus: data.workspace_status })
+        const modal = bootstrap.Modal.getInstance(modalEl)
+        if (modal) modal.hide()
+        try {
+          showToast('success', `Switched to config "${nextName}".`)
+        } catch (toastErr) {
+          // Navigation should not depend on toast rendering.
         }
-        showToast('success', `Switched to config "${nextName}".`)
         const nextConfig = encodeURIComponent(nextName)
         const nextUrl = `${window.location.pathname}?config_name=${nextConfig}`
-        setTimeout(() => window.location.assign(nextUrl), 150)
+        if (window.history && typeof window.history.replaceState === 'function') {
+          window.history.replaceState(null, '', nextUrl)
+        }
+        const navigate = () => window.location.replace(nextUrl)
+        if (typeof window.requestAnimationFrame === 'function') {
+          window.requestAnimationFrame(navigate)
+        } else {
+          navigate()
+        }
       } catch (err) {
         window.QS_SWITCHING_CONFIG = false
+        qsApplyActiveConfigUi(current, { refreshWorkspace: false })
         confirmBtn.disabled = false
         confirmBtn.textContent = 'Switch'
         if (typeof hideNavigationLoadingOverlay === 'function') {

--- a/templates/000-base.html
+++ b/templates/000-base.html
@@ -17,7 +17,7 @@
     integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
-    crossorigin="anonymous"></script>
+    crossorigin="anonymous" defer></script>
 
   <!-- Include FontAwesome & Bootstrap Icons -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"
@@ -27,12 +27,12 @@
 
   <!-- Include jQuery -->
   <script src="https://code.jquery.com/jquery-3.7.1.js" integrity="sha256-eKhayi8LEQwp4NKxN+CfCh+3qOVUtJn3QNZ0TciWLP4="
-    crossorigin="anonymous"></script>
+    crossorigin="anonymous" defer></script>
 
   <!-- Include SortableJS -->
   <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"
     integrity="sha384-eeLEhtwdMwD3X9y+8P3Cn7Idl/M+w8H4uZqkgD/2eJVkWIN1yKzEj6XegJ9dL3q0"
-    crossorigin="anonymous"></script>
+    crossorigin="anonymous" defer></script>
 
   <script>
     // Initialize Bootstrap tooltips with HTML images allowed (global)
@@ -74,9 +74,9 @@
     window.QS_TRAKT_REQUIREMENT_REASONS = {{ (trakt_requirement_reasons if trakt_requirement_reasons is defined else []) | tojson }};
     window.QS_MAL_REQUIREMENT_REASONS = {{ (mal_requirement_reasons if mal_requirement_reasons is defined else []) | tojson }};
   </script>
-  <script type="text/javascript" src="{{ url_for('static', filename='local-js/000-base.js') }}"></script>
-  <script type="text/javascript" src="{{ url_for('static', filename='local-js/pathValidation.js') }}"></script>
-  <script type="text/javascript" src="{{ url_for('static', filename='local-js/urlValidation.js') }}"></script>
+  <script type="text/javascript" src="{{ url_for('static', filename='local-js/000-base.js') }}" defer></script>
+  <script type="text/javascript" src="{{ url_for('static', filename='local-js/pathValidation.js') }}" defer></script>
+  <script type="text/javascript" src="{{ url_for('static', filename='local-js/urlValidation.js') }}" defer></script>
   <div class="header-container text-center">
     <img src="{{ url_for('static', filename='images/logo.webp') }}" alt="QUICKSTART" class="header-image" />
   </div>
@@ -141,10 +141,10 @@
   </div>
 
   <script type="text/javascript"
-    src="{{ url_for('static', filename='local-js/001-start.js') }}"></script>
+    src="{{ url_for('static', filename='local-js/001-start.js') }}" defer></script>
   {% if page_info['template_name'] != '001-start' %}
   <script type="text/javascript"
-    src="{{ url_for('static', filename='local-js/' + page_info['template_name'] + '.js') }}"></script>
+    src="{{ url_for('static', filename='local-js/' + page_info['template_name'] + '.js') }}" defer></script>
   {% endif %}
 
   <!-- Footer -->


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

This PR fixes the flaky workspace config switch flow, especially on non-start pages like TMDb.

Before this change, switching configs could fail in two ways: the quick-switch modal could lose the user’s selected target during the modal/open cycle, and the current page autosave could take the slow full-render path, which made the UI update and redirect racey. That led to false “still on old config” behavior and inconsistent autosave of the source config before switching.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
