### PR TITLE
More library variabkes

### DIFF
--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -387,7 +387,7 @@ def build_qs_collection_map(qs_collections_path: Path) -> dict[str, set[str]]:
     return mapping
 
 
-def build_qs_overlay_map(qs_overlays_path: Path) -> dict[str, set[str]]:
+def build_qs_overlay_map(qs_overlays_path: Path, *, enrich_runtime_support: bool = True) -> dict[str, set[str]]:
     data = load_json(qs_overlays_path)
     mapping: dict[str, set[str]] = {}
     for group in data:
@@ -400,10 +400,43 @@ def build_qs_overlay_map(qs_overlays_path: Path) -> dict[str, set[str]]:
             if not oid:
                 continue
             alias = str(oid).replace("overlay_", "", 1)
+            keys = collect_qs_keys(overlay.get("template_variables"))
+
+            if enrich_runtime_support:
+                # Quickstart injects horizontal/vertical offset controls at render time
+                # for overlays that declare default offsets or initial offset aliases.
+                default_offsets = overlay.get("default_offsets")
+                default_offsets_by_type = overlay.get("default_offsets_by_type")
+                supports_runtime_offsets = False
+                supports_origin_alignment = False
+
+                if {"horizontal_offset", "vertical_offset", "initial_horizontal_offset", "initial_vertical_offset"} & keys:
+                    supports_runtime_offsets = True
+
+                if isinstance(default_offsets, dict):
+                    if any(axis in default_offsets for axis in ("horizontal", "vertical")):
+                        supports_runtime_offsets = True
+                    if default_offsets.get("origin") is not None:
+                        supports_origin_alignment = True
+
+                if isinstance(default_offsets_by_type, dict):
+                    for values in default_offsets_by_type.values():
+                        if not isinstance(values, dict):
+                            continue
+                        if any(axis in values for axis in ("horizontal", "vertical")):
+                            supports_runtime_offsets = True
+                        if values.get("origin") is not None:
+                            supports_origin_alignment = True
+
+                if supports_runtime_offsets:
+                    keys.update({"horizontal_offset", "vertical_offset"})
+                if supports_origin_alignment:
+                    keys.update({"horizontal_align", "vertical_align"})
+
             # Some Quickstart defaults intentionally reuse the same alias for
             # different media types. Merge their declared keys so later entries
             # do not erase earlier support and create false-positive gaps.
-            mapping.setdefault(alias, set()).update(collect_qs_keys(overlay.get("template_variables")))
+            mapping.setdefault(alias, set()).update(keys)
     return mapping
 
 
@@ -1028,6 +1061,10 @@ def make_periodic_persistor(callback, every_items: int, every_seconds: float):
 def accumulate_gap_summary(summary: dict[tuple[str, str | None, str], dict[str, Any]], row: dict[str, Any]) -> None:
     if not row.get("name_verified") or row.get("supported_in_quickstart"):
         return
+    accumulate_ranked_summary(summary, row)
+
+
+def accumulate_ranked_summary(summary: dict[tuple[str, str | None, str], dict[str, Any]], row: dict[str, Any]) -> None:
     bucket = summary.setdefault(
         (str(row.get("kind")), row.get("default"), str(row.get("key"))),
         {
@@ -1039,6 +1076,7 @@ def accumulate_gap_summary(summary: dict[tuple[str, str | None, str], dict[str, 
             "libraries": set(),
             "matched_default_files": set(),
             "supported_in_quickstart": False,
+            "quickstart_declared": False,
             "schema_declared": False,
             "kometa_declared": False,
             "validation_level": "",
@@ -1055,6 +1093,7 @@ def accumulate_gap_summary(summary: dict[tuple[str, str | None, str], dict[str, 
     for item in row.get("matched_default_files", []):
         bucket["matched_default_files"].add(item)
     bucket["supported_in_quickstart"] = bucket["supported_in_quickstart"] or bool(row.get("supported_in_quickstart"))
+    bucket["quickstart_declared"] = bucket["quickstart_declared"] or bool(row.get("quickstart_declared"))
     bucket["schema_declared"] = bucket["schema_declared"] or bool(row.get("schema_declared"))
     bucket["kometa_declared"] = bucket["kometa_declared"] or bool(row.get("kometa_declared"))
     bucket["validation_level"] = str(row.get("validation_level") or bucket["validation_level"])
@@ -1069,6 +1108,19 @@ def build_gap_summary(rows: list[dict[str, Any]]) -> dict[tuple[str, str | None,
     summary: dict[tuple[str, str | None, str], dict[str, Any]] = {}
     for row in rows:
         accumulate_gap_summary(summary, row)
+    return summary
+
+
+def accumulate_quickstart_recommendation_summary(summary: dict[tuple[str, str | None, str], dict[str, Any]], row: dict[str, Any]) -> None:
+    if not row.get("name_verified") or row.get("quickstart_declared"):
+        return
+    accumulate_ranked_summary(summary, row)
+
+
+def build_quickstart_recommendation_summary(rows: list[dict[str, Any]]) -> dict[tuple[str, str | None, str], dict[str, Any]]:
+    summary: dict[tuple[str, str | None, str], dict[str, Any]] = {}
+    for row in rows:
+        accumulate_quickstart_recommendation_summary(summary, row)
     return summary
 
 
@@ -1090,6 +1142,7 @@ def serialize_ranked_summary(summary: dict[tuple[str, str | None, str], dict[str
                 "libraries": sorted(item["libraries"]),
                 "matched_default_files": sorted(item["matched_default_files"]),
                 "supported_in_quickstart": item["supported_in_quickstart"],
+                "quickstart_declared": item["quickstart_declared"],
                 "schema_declared": item["schema_declared"],
                 "kometa_declared": item["kometa_declared"],
                 "validation_level": item["validation_level"],
@@ -1318,6 +1371,7 @@ def render_summary(report: dict[str, Any], json_output_path: Path) -> str:
     playlists = report.get("verified_gaps_by_kind", {}).get("playlist", [])
     libraries = report.get("verified_gaps_by_kind", {}).get("library", [])
     schema_backlog = report.get("schema_backlog_by_default", [])
+    quickstart_backlog = report.get("quickstart_backlog_by_default", [])
 
     lines = [
         "Template Variable Gap Summary",
@@ -1337,6 +1391,8 @@ def render_summary(report: dict[str, Any], json_output_path: Path) -> str:
         f"  kometa-declared verified gaps: {report.get('kometa_declared_gap_count', 0)}",
         f"  verified gaps missing from schema but supported by Kometa: {report.get('kometa_missing_schema_gap_count', 0)}",
         f"  value-shape verified gaps: {report.get('value_shape_verified_gap_count', 0)}",
+        f"  quickstart recommendations: {report.get('quickstart_recommendation_count', 0)}",
+        f"  runtime-supported quickstart recommendations: {report.get('quickstart_runtime_supported_recommendation_count', 0)}",
         f"  overlay gaps: {len(overlays)}",
         f"  collection gaps: {len(collections)}",
         f"  playlist gaps: {len(playlists)}",
@@ -1361,6 +1417,8 @@ def render_summary(report: dict[str, Any], json_output_path: Path) -> str:
             render_table("Collection Gaps", collections),
         ]
     )
+    if quickstart_backlog:
+        lines.append(render_grouped_default_table("Quickstart Backlog By Default", quickstart_backlog))
     if schema_backlog:
         lines.append(render_grouped_default_table("Schema Backlog By Default", schema_backlog))
     if playlists:
@@ -1423,6 +1481,7 @@ def main() -> None:
     try:
         qs_collections = build_qs_collection_map(qs_collections_path)
         qs_overlays = build_qs_overlay_map(qs_overlays_path)
+        qs_overlays_declared = build_qs_overlay_map(qs_overlays_path, enrich_runtime_support=False)
         qs_library_keys = build_qs_library_template_keys(qs_attributes_path)
         qs_global_keys = build_qs_global_supported_keys(qs_attributes_path)
         qs_playlist_keys = build_qs_playlist_supported_keys(qs_attributes_path)
@@ -1551,18 +1610,22 @@ def main() -> None:
             alias = row["default"]
             if kind == "collection":
                 supported = key in qs_collections.get(alias or "", set()) or key in qs_global_keys
+                quickstart_declared = supported
                 default_files = resolve_default_paths(alias or "", kind, kometa_defaults)
                 name_verified, matched_files = key_is_valid_for_default(key, default_files)
             elif kind == "overlay":
                 supported = overlay_key_supported_in_quickstart(alias, key, qs_overlays)
+                quickstart_declared = overlay_key_supported_in_quickstart(alias, key, qs_overlays_declared)
                 default_files = resolve_default_paths(alias or "", kind, kometa_defaults)
                 name_verified, matched_files = key_is_valid_for_default(key, default_files)
             elif kind == "playlist":
                 supported = key in qs_playlist_keys
+                quickstart_declared = supported
                 default_files = resolve_default_paths(alias or "", kind, kometa_defaults)
                 name_verified, matched_files = key_is_valid_for_default(key, default_files)
             else:
                 supported = key in qs_library_keys or key in qs_global_keys
+                quickstart_declared = supported
                 name_verified = True
                 matched_files = []
 
@@ -1571,6 +1634,7 @@ def main() -> None:
             validation_level = classify_validation_level(supported, schema_declared, name_verified)
             out = dict(row)
             out["supported_in_quickstart"] = supported
+            out["quickstart_declared"] = quickstart_declared
             out["schema_declared"] = schema_declared
             out["kometa_declared"] = name_verified
             out["validation_level"] = validation_level
@@ -1589,11 +1653,17 @@ def main() -> None:
             verify_callback("aggregating ranked gaps")
         flush_verification_checkpoint(len(all_rows), force=True)
         serializable_ranked = serialize_ranked_summary(summary)
+        quickstart_recommendation_ranked = serialize_ranked_summary(build_quickstart_recommendation_summary(all_rows))
 
         by_kind: dict[str, list[dict[str, Any]]] = {"overlay": [], "collection": [], "playlist": [], "library": []}
         for item in serializable_ranked:
             kind_key = item["kind"] if item["kind"] in by_kind else "library"
             by_kind[kind_key].append(item)
+
+        quickstart_recommendations_by_kind: dict[str, list[dict[str, Any]]] = {"overlay": [], "collection": [], "playlist": [], "library": []}
+        for item in quickstart_recommendation_ranked:
+            kind_key = item["kind"] if item["kind"] in quickstart_recommendations_by_kind else "library"
+            quickstart_recommendations_by_kind[kind_key].append(item)
 
         schema_backlog_summary: dict[tuple[str, str | None], dict[str, Any]] = {}
         for item in serializable_ranked:
@@ -1621,6 +1691,36 @@ def main() -> None:
                     "keys": sorted(item["keys"]),
                 }
                 for item in schema_backlog_summary.values()
+            ],
+            key=lambda item: (-item["occurrences"], -item["gap_count"], str(item["default"]), str(item["kind"])),
+        )
+
+        quickstart_backlog_summary: dict[tuple[str, str | None], dict[str, Any]] = {}
+        for item in quickstart_recommendation_ranked:
+            if not item["kometa_declared"] or item["quickstart_declared"]:
+                continue
+            bucket = quickstart_backlog_summary.setdefault(
+                (item["kind"], item["default"]),
+                {
+                    "kind": item["kind"],
+                    "default": item["default"],
+                    "occurrences": 0,
+                    "keys": set(),
+                },
+            )
+            bucket["occurrences"] += item["occurrences"]
+            bucket["keys"].add(item["key"])
+
+        quickstart_backlog_by_default = sorted(
+            [
+                {
+                    "kind": item["kind"],
+                    "default": item["default"],
+                    "occurrences": item["occurrences"],
+                    "gap_count": len(item["keys"]),
+                    "keys": sorted(item["keys"]),
+                }
+                for item in quickstart_backlog_summary.values()
             ],
             key=lambda item: (-item["occurrences"], -item["gap_count"], str(item["default"]), str(item["kind"])),
         )
@@ -1660,8 +1760,13 @@ def main() -> None:
             "kometa_declared_gap_count": sum(1 for item in serializable_ranked if item["kometa_declared"]),
             "kometa_missing_schema_gap_count": sum(1 for item in serializable_ranked if item["kometa_declared"] and not item["schema_declared"]),
             "value_shape_verified_gap_count": sum(1 for item in serializable_ranked if item["value_shape_verified_occurrences"] > 0),
+            "quickstart_recommendation_count": len(quickstart_recommendation_ranked),
+            "quickstart_runtime_supported_recommendation_count": sum(
+                1 for item in quickstart_recommendation_ranked if item["supported_in_quickstart"] and not item["quickstart_declared"]
+            ),
             "verification_notes": {
                 "name_verified": "Key name matched a variable declared or referenced in the corresponding built-in Kometa default or shared built-in templates.yml.",
+                "quickstart_declared": "Key name was explicitly declared in Quickstart's shipped support metadata or modeled alias mapping, without relying on runtime-injected overlay controls.",
                 "schema_declared": "Key name was found in Kometa's bundled config-schema.json. This is a secondary signal because the schema is not fully exhaustive.",
                 "kometa_declared": "Key name was found in Kometa's bundled built-in defaults/templates, which is treated as the stronger local source of truth.",
                 "validation_level": "works_in_kometa_missing_from_quickstart_and_schema means the key was not found in Quickstart or schema, but was found in Kometa built-in defaults/templates.",
@@ -1670,6 +1775,9 @@ def main() -> None:
             },
             "verified_gaps_ranked": serializable_ranked,
             "verified_gaps_by_kind": by_kind,
+            "quickstart_recommendations_ranked": quickstart_recommendation_ranked,
+            "quickstart_recommendations_by_kind": quickstart_recommendations_by_kind,
+            "quickstart_backlog_by_default": quickstart_backlog_by_default,
             "schema_backlog_by_default": schema_backlog_by_default,
             "all_rows": all_rows,
         }

--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -248,6 +248,13 @@ def file_signature(path: Path) -> dict[str, int]:
     return {"size": stat.st_size, "mtime_ns": stat.st_mtime_ns}
 
 
+def safe_file_signature(path: Path) -> dict[str, int] | None:
+    try:
+        return file_signature(path)
+    except FileNotFoundError:
+        return None
+
+
 def normalized_parts(path: Path) -> list[str]:
     parts: list[str] = []
     for part in path.parts:
@@ -822,7 +829,23 @@ def prefilter_yaml_files(
     total_files = len(input_files)
     for idx, path in enumerate(input_files, start=1):
         cache_key = str(path)
-        signature = file_signature(path)
+        signature = safe_file_signature(path)
+        if signature is None:
+            skip_record = {
+                "file": str(path),
+                "error_type": "FileNotFoundError",
+                "reason": "file disappeared before prefilter could inspect it",
+                "detail": f"FileNotFoundError: {path}",
+                "stage": "prefilter",
+            }
+            skipped_files.append(skip_record)
+            if isinstance(files_cache, dict):
+                files_cache.pop(cache_key, None)
+            if progress_callback:
+                progress_callback(idx, total_files, len(candidate_files), len(skipped_files), path)
+            if checkpoint_callback:
+                checkpoint_callback(idx, total_files)
+            continue
         cached = files_cache.get(cache_key) if isinstance(files_cache, dict) else None
         if isinstance(cached, dict) and cached.get("signature") == signature and "contains_template_variables" in cached:
             stats["cache_hits"] += 1
@@ -887,7 +910,23 @@ def scan_uploaded_configs(
     files_cache = cache_data.get("files", {}) if isinstance(cache_data, dict) else {}
     for idx, path in enumerate(input_files, start=1):
         cache_key = str(path)
-        signature = file_signature(path)
+        signature = safe_file_signature(path)
+        if signature is None:
+            skip_record = {
+                "file": str(path),
+                "error_type": "FileNotFoundError",
+                "reason": "file disappeared before parse could inspect it",
+                "detail": f"FileNotFoundError: {path}",
+                "stage": "parse",
+            }
+            skipped_files.append(skip_record)
+            if isinstance(files_cache, dict):
+                files_cache.pop(cache_key, None)
+            if progress_callback:
+                progress_callback(idx, total_files, parsed_count, len(skipped_files), path)
+            if checkpoint_callback:
+                checkpoint_callback(idx, total_files)
+            continue
         cached = files_cache.get(cache_key) if isinstance(files_cache, dict) else None
         if isinstance(cached, dict) and cached.get("signature") == signature and "scan_result" in cached:
             stats["cache_hits"] += 1

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -25733,6 +25733,174 @@
             "default": false
           },
           {
+            "key": "visible_home_1.33",
+            "label": "1.33 - Academy Aperture Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the 1.33 - Academy Aperture collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_1.33",
+            "label": "1.33 - Academy Aperture Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the 1.33 - Academy Aperture collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_1.33",
+            "label": "1.33 - Academy Aperture Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the 1.33 - Academy Aperture collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_1.65",
+            "label": "1.65 - Early Widescreen Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the 1.65 - Early Widescreen collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_1.65",
+            "label": "1.65 - Early Widescreen Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the 1.65 - Early Widescreen collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_1.65",
+            "label": "1.65 - Early Widescreen Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the 1.65 - Early Widescreen collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_1.66",
+            "label": "1.66 - European Widescreen Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the 1.66 - European Widescreen collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_1.66",
+            "label": "1.66 - European Widescreen Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the 1.66 - European Widescreen collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_1.66",
+            "label": "1.66 - European Widescreen Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the 1.66 - European Widescreen collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_1.78",
+            "label": "1.78 - Widescreen TV Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the 1.78 - Widescreen TV collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_1.78",
+            "label": "1.78 - Widescreen TV Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the 1.78 - Widescreen TV collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_1.78",
+            "label": "1.78 - Widescreen TV Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the 1.78 - Widescreen TV collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_1.85",
+            "label": "1.85 - American Widescreen Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the 1.85 - American Widescreen collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_1.85",
+            "label": "1.85 - American Widescreen Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the 1.85 - American Widescreen collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_1.85",
+            "label": "1.85 - American Widescreen Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the 1.85 - American Widescreen collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_2.2",
+            "label": "2.2 - 70mm Frame Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the 2.2 - 70mm Frame collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_2.2",
+            "label": "2.2 - 70mm Frame Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the 2.2 - 70mm Frame collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_2.2",
+            "label": "2.2 - 70mm Frame Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the 2.2 - 70mm Frame collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_2.35",
+            "label": "2.35 - Anamorphic Projection Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the 2.35 - Anamorphic Projection collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_2.35",
+            "label": "2.35 - Anamorphic Projection Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the 2.35 - Anamorphic Projection collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_2.35",
+            "label": "2.35 - Anamorphic Projection Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the 2.35 - Anamorphic Projection collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_2.77",
+            "label": "2.77 - Cinerama Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the 2.77 - Cinerama collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_2.77",
+            "label": "2.77 - Cinerama Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the 2.77 - Cinerama collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_2.77",
+            "label": "2.77 - Cinerama Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the 2.77 - Cinerama collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
             "key": "sort_by",
             "label": "Sort By",
             "type": "select",
@@ -26610,6 +26778,27 @@
             "default": false
           },
           {
+            "key": "visible_home_other",
+            "label": "Other Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_other",
+            "label": "Other Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_other",
+            "label": "Other Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
             "key": "sort_by",
             "label": "Sort By",
             "type": "select",
@@ -27040,6 +27229,27 @@
             "label": "Visible Shared",
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_other",
+            "label": "Other Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_other",
+            "label": "Other Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_other",
+            "label": "Other Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
           },
           {

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -17725,6 +17725,321 @@
             "default": false
           },
           {
+            "key": "visible_home_avp",
+            "label": "Alien / Predator Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Alien / Predator collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_avp",
+            "label": "Alien / Predator Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Alien / Predator collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_avp",
+            "label": "Alien / Predator Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Alien / Predator collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_arrow",
+            "label": "Arrowverse Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Arrowverse collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_arrow",
+            "label": "Arrowverse Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Arrowverse collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_arrow",
+            "label": "Arrowverse Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Arrowverse collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_dca",
+            "label": "DC Animated Universe Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the DC Animated Universe collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_dca",
+            "label": "DC Animated Universe Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the DC Animated Universe collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_dca",
+            "label": "DC Animated Universe Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the DC Animated Universe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_dcu",
+            "label": "DC Extended Universe Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the DC Extended Universe collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_dcu",
+            "label": "DC Extended Universe Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the DC Extended Universe collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_dcu",
+            "label": "DC Extended Universe Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the DC Extended Universe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_fast",
+            "label": "Fast & Furious Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Fast & Furious collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_fast",
+            "label": "Fast & Furious Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Fast & Furious collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_fast",
+            "label": "Fast & Furious Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Fast & Furious collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_marvel",
+            "label": "In Association with Marvel Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the In Association with Marvel collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_marvel",
+            "label": "In Association with Marvel Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the In Association with Marvel collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_marvel",
+            "label": "In Association with Marvel Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the In Association with Marvel collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_mcu",
+            "label": "Marvel Cinematic Universe Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Marvel Cinematic Universe collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_mcu",
+            "label": "Marvel Cinematic Universe Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Marvel Cinematic Universe collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_mcu",
+            "label": "Marvel Cinematic Universe Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Marvel Cinematic Universe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_middle",
+            "label": "Middle Earth Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Middle Earth collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_middle",
+            "label": "Middle Earth Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Middle Earth collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_middle",
+            "label": "Middle Earth Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Middle Earth collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_rocky",
+            "label": "Rocky / Creed Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Rocky / Creed collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_rocky",
+            "label": "Rocky / Creed Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Rocky / Creed collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_rocky",
+            "label": "Rocky / Creed Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Rocky / Creed collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_trek",
+            "label": "Star Trek Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Star Trek collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_trek",
+            "label": "Star Trek Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Star Trek collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_trek",
+            "label": "Star Trek Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Star Trek collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_star",
+            "label": "Star Wars Universe Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Star Wars Universe collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_star",
+            "label": "Star Wars Universe Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Star Wars Universe collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_star",
+            "label": "Star Wars Universe Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Star Wars Universe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_mummy",
+            "label": "The Mummy Universe Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the The Mummy Universe collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_mummy",
+            "label": "The Mummy Universe Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the The Mummy Universe collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_mummy",
+            "label": "The Mummy Universe Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the The Mummy Universe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_askew",
+            "label": "View Askewverse Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the View Askewverse collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_askew",
+            "label": "View Askewverse Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the View Askewverse collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_askew",
+            "label": "View Askewverse Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the View Askewverse collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_wizard",
+            "label": "Wizarding World Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Wizarding World collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_wizard",
+            "label": "Wizarding World Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Wizarding World collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_wizard",
+            "label": "Wizarding World Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Wizarding World collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_xmen",
+            "label": "X-Men Universe Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the X-Men Universe collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_xmen",
+            "label": "X-Men Universe Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the X-Men Universe collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_xmen",
+            "label": "X-Men Universe Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the X-Men Universe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
             "key": "collection_order",
             "label": "Collection Order",
             "type": "select",
@@ -18265,6 +18580,90 @@
             "label": "Visible Shared",
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_books",
+            "label": "Based on a Book Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Based on a Book collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_books",
+            "label": "Based on a Book Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Based on a Book collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_books",
+            "label": "Based on a Book Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Based on a Book collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_comics",
+            "label": "Based on a Comic Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Based on a Comic collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_comics",
+            "label": "Based on a Comic Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Based on a Comic collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_comics",
+            "label": "Based on a Comic Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Based on a Comic collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_true_story",
+            "label": "Based on a True Story Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Based on a True Story collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_true_story",
+            "label": "Based on a True Story Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Based on a True Story collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_true_story",
+            "label": "Based on a True Story Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Based on a True Story collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_video_games",
+            "label": "Based on a Video Game Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Based on a Video Game collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_video_games",
+            "label": "Based on a Video Game Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Based on a Video Game collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_video_games",
+            "label": "Based on a Video Game Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Based on a Video Game collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
           },
           {
@@ -19080,6 +19479,27 @@
             "default": false
           },
           {
+            "key": "visible_home_other",
+            "label": "Other Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_other",
+            "label": "Other Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_other",
+            "label": "Other Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
             "key": "sort_by",
             "label": "Sort By",
             "type": "select",
@@ -19500,6 +19920,27 @@
             "label": "Visible Shared",
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_other",
+            "label": "Other Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_other",
+            "label": "Other Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_other",
+            "label": "Other Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
           },
           {
@@ -19927,6 +20368,27 @@
             "default": false
           },
           {
+            "key": "visible_home_other",
+            "label": "Other Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_other",
+            "label": "Other Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_other",
+            "label": "Other Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
             "key": "sort_by",
             "label": "Sort By",
             "type": "select",
@@ -20348,6 +20810,27 @@
             "label": "Visible Shared",
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_other",
+            "label": "Other Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_other",
+            "label": "Other Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_other",
+            "label": "Other Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
           },
           {
@@ -20775,6 +21258,27 @@
             "default": false
           },
           {
+            "key": "visible_home_other",
+            "label": "Other Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_other",
+            "label": "Other Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_other",
+            "label": "Other Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
             "key": "sort_by",
             "label": "Sort By",
             "type": "select",
@@ -21196,6 +21700,27 @@
             "label": "Visible Shared",
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_other",
+            "label": "Other Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_other",
+            "label": "Other Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_other",
+            "label": "Other Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
           },
           {
@@ -21623,6 +22148,27 @@
             "default": false
           },
           {
+            "key": "visible_home_other",
+            "label": "Other Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_other",
+            "label": "Other Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_other",
+            "label": "Other Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
             "key": "sort_by",
             "label": "Sort By",
             "type": "select",
@@ -22044,6 +22590,27 @@
             "label": "Visible Shared",
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_other",
+            "label": "Other Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_other",
+            "label": "Other Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_other",
+            "label": "Other Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
           },
           {

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -30174,6 +30174,384 @@
             "default": false
           },
           {
+            "key": "visible_home_appletv",
+            "label": "Apple TV Movies/Shows Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Apple TV Movies/Shows collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_appletv",
+            "label": "Apple TV Movies/Shows Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Apple TV Movies/Shows collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_appletv",
+            "label": "Apple TV Movies/Shows Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Apple TV Movies/Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_bet",
+            "label": "BET+ Movies/Shows Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the BET+ Movies/Shows collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_bet",
+            "label": "BET+ Movies/Shows Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the BET+ Movies/Shows collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_bet",
+            "label": "BET+ Movies/Shows Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the BET+ Movies/Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_channel4",
+            "label": "Channel 4 Movies/Shows Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Channel 4 Movies/Shows collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_channel4",
+            "label": "Channel 4 Movies/Shows Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Channel 4 Movies/Shows collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_channel4",
+            "label": "Channel 4 Movies/Shows Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Channel 4 Movies/Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_crave",
+            "label": "Crave Movies/Shows Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Crave Movies/Shows collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_crave",
+            "label": "Crave Movies/Shows Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Crave Movies/Shows collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_crave",
+            "label": "Crave Movies/Shows Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Crave Movies/Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_crunchyroll",
+            "label": "Crunchyroll Shows Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Crunchyroll Shows collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_crunchyroll",
+            "label": "Crunchyroll Shows Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Crunchyroll Shows collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_crunchyroll",
+            "label": "Crunchyroll Shows Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Crunchyroll Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_discovery",
+            "label": "discovery+ Shows Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the discovery+ Shows collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_discovery",
+            "label": "discovery+ Shows Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the discovery+ Shows collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_discovery",
+            "label": "discovery+ Shows Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the discovery+ Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_disney",
+            "label": "Disney+ Movies/Shows Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Disney+ Movies/Shows collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_disney",
+            "label": "Disney+ Movies/Shows Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Disney+ Movies/Shows collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_disney",
+            "label": "Disney+ Movies/Shows Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Disney+ Movies/Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_hayu",
+            "label": "Hayu Shows Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Hayu Shows collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_hayu",
+            "label": "Hayu Shows Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Hayu Shows collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_hayu",
+            "label": "Hayu Shows Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Hayu Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_hulu",
+            "label": "Hulu Movies/Shows Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Hulu Movies/Shows collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_hulu",
+            "label": "Hulu Movies/Shows Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Hulu Movies/Shows collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_hulu",
+            "label": "Hulu Movies/Shows Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Hulu Movies/Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_itvx",
+            "label": "ITVX Movies/Shows Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the ITVX Movies/Shows collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_itvx",
+            "label": "ITVX Movies/Shows Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the ITVX Movies/Shows collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_itvx",
+            "label": "ITVX Movies/Shows Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the ITVX Movies/Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_hbomax",
+            "label": "HBO Max Movies/Shows Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the HBO Max Movies/Shows collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_hbomax",
+            "label": "HBO Max Movies/Shows Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the HBO Max Movies/Shows collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_hbomax",
+            "label": "HBO Max Movies/Shows Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the HBO Max Movies/Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_netflix",
+            "label": "Netflix Movies/Shows Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Netflix Movies/Shows collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_netflix",
+            "label": "Netflix Movies/Shows Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Netflix Movies/Shows collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_netflix",
+            "label": "Netflix Movies/Shows Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Netflix Movies/Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_now",
+            "label": "NOW Movies/Shows Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the NOW Movies/Shows collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_now",
+            "label": "NOW Movies/Shows Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the NOW Movies/Shows collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_now",
+            "label": "NOW Movies/Shows Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the NOW Movies/Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_paramount",
+            "label": "Paramount+ Movies/Shows Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Paramount+ Movies/Shows collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_paramount",
+            "label": "Paramount+ Movies/Shows Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Paramount+ Movies/Shows collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_paramount",
+            "label": "Paramount+ Movies/Shows Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Paramount+ Movies/Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_peacock",
+            "label": "Peacock Movies/Shows Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Peacock Movies/Shows collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_peacock",
+            "label": "Peacock Movies/Shows Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Peacock Movies/Shows collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_peacock",
+            "label": "Peacock Movies/Shows Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Peacock Movies/Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_amazon",
+            "label": "Prime Video Movies/Shows Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Prime Video Movies/Shows collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_amazon",
+            "label": "Prime Video Movies/Shows Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Prime Video Movies/Shows collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_amazon",
+            "label": "Prime Video Movies/Shows Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Prime Video Movies/Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_youtube",
+            "label": "YouTube Movies/Shows Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the YouTube Movies/Shows collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_youtube",
+            "label": "YouTube Movies/Shows Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the YouTube Movies/Shows collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_youtube",
+            "label": "YouTube Movies/Shows Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the YouTube Movies/Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_tubi",
+            "label": "tubi Movies/Shows Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the tubi Movies/Shows collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_tubi",
+            "label": "tubi Movies/Shows Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the tubi Movies/Shows collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_tubi",
+            "label": "tubi Movies/Shows Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the tubi Movies/Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
             "key": "sort_by",
             "label": "Sort By",
             "type": "select",
@@ -31938,6 +32316,576 @@
             "label": "Visible Shared",
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_aapi",
+            "label": "Asian American Pacific Islander Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Asian American Pacific Islander Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_aapi",
+            "label": "Asian American Pacific Islander Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Asian American Pacific Islander Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_aapi",
+            "label": "Asian American Pacific Islander Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Asian American Pacific Islander Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_black_history",
+            "label": "Black History Month Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Black History Month Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_black_history",
+            "label": "Black History Month Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Black History Month Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_black_history",
+            "label": "Black History Month Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Black History Month Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_christmas",
+            "label": "Christmas Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Christmas Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_christmas",
+            "label": "Christmas Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Christmas Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_christmas",
+            "label": "Christmas Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Christmas Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_disabilities",
+            "label": "Disability Month Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Disability Month Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_disabilities",
+            "label": "Disability Month Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Disability Month Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_disabilities",
+            "label": "Disability Month Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Disability Month Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_easter",
+            "label": "Easter Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Easter Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_easter",
+            "label": "Easter Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Easter Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_easter",
+            "label": "Easter Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Easter Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_father",
+            "label": "Father's Day Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Father's Day Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_father",
+            "label": "Father's Day Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Father's Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_father",
+            "label": "Father's Day Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Father's Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_halloween",
+            "label": "Halloween Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Halloween Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_halloween",
+            "label": "Halloween Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Halloween Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_halloween",
+            "label": "Halloween Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Halloween Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_independence",
+            "label": "Independence Day Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Independence Day Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_independence",
+            "label": "Independence Day Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Independence Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_independence",
+            "label": "Independence Day Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Independence Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_labor",
+            "label": "Labor Day Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Labor Day Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_labor",
+            "label": "Labor Day Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Labor Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_labor",
+            "label": "Labor Day Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Labor Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_lgbtq",
+            "label": "LGBTQ Month Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the LGBTQ Month Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_lgbtq",
+            "label": "LGBTQ Month Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the LGBTQ Month Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_lgbtq",
+            "label": "LGBTQ Month Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the LGBTQ Month Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_memorial",
+            "label": "Memorial Day Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Memorial Day Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_memorial",
+            "label": "Memorial Day Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Memorial Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_memorial",
+            "label": "Memorial Day Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Memorial Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_mother",
+            "label": "Mother's Day Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Mother's Day Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_mother",
+            "label": "Mother's Day Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Mother's Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_mother",
+            "label": "Mother's Day Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Mother's Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_latinx",
+            "label": "National Hispanic Heritage Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the National Hispanic Heritage Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_latinx",
+            "label": "National Hispanic Heritage Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the National Hispanic Heritage Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_latinx",
+            "label": "National Hispanic Heritage Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the National Hispanic Heritage Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_years",
+            "label": "New Year's Day Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the New Year's Day Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_years",
+            "label": "New Year's Day Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the New Year's Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_years",
+            "label": "New Year's Day Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the New Year's Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_patrick",
+            "label": "St. Patrick's Day Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the St. Patrick's Day Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_patrick",
+            "label": "St. Patrick's Day Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the St. Patrick's Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_patrick",
+            "label": "St. Patrick's Day Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the St. Patrick's Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_thanksgiving",
+            "label": "Thanksgiving Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Thanksgiving Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_thanksgiving",
+            "label": "Thanksgiving Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Thanksgiving Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_thanksgiving",
+            "label": "Thanksgiving Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Thanksgiving Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_valentine",
+            "label": "Valentine's Day Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Valentine's Day Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_valentine",
+            "label": "Valentine's Day Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Valentine's Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_valentine",
+            "label": "Valentine's Day Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Valentine's Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_veteran",
+            "label": "Veteran's Day Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Veteran's Day Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_veteran",
+            "label": "Veteran's Day Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Veteran's Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_veteran",
+            "label": "Veteran's Day Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Veteran's Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_women",
+            "label": "Women's History Month Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Women's History Month Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_women",
+            "label": "Women's History Month Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Women's History Month Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_women",
+            "label": "Women's History Month Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Women's History Month Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
             "media_types": [
               "movie"

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -23054,6 +23054,27 @@
             "default": false
           },
           {
+            "key": "visible_home_other",
+            "label": "Other Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_other",
+            "label": "Other Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_other",
+            "label": "Other Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
             "key": "sort_by",
             "label": "Sort By",
             "type": "select",
@@ -23485,6 +23506,27 @@
             "label": "Visible Shared",
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_other",
+            "label": "Other Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_other",
+            "label": "Other Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_other",
+            "label": "Other Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
           },
           {
@@ -24084,6 +24126,510 @@
             "default": false
           },
           {
+            "key": "visible_home_Northern Africa",
+            "label": "Northern Africa Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Northern Africa collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Northern Africa",
+            "label": "Northern Africa Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Northern Africa collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Northern Africa",
+            "label": "Northern Africa Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Northern Africa collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Eastern Africa",
+            "label": "Eastern Africa Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Eastern Africa collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Eastern Africa",
+            "label": "Eastern Africa Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Eastern Africa collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Eastern Africa",
+            "label": "Eastern Africa Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Eastern Africa collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Central Africa",
+            "label": "Central Africa Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Central Africa collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Central Africa",
+            "label": "Central Africa Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Central Africa collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Central Africa",
+            "label": "Central Africa Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Central Africa collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Southern Africa",
+            "label": "Southern Africa Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Southern Africa collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Southern Africa",
+            "label": "Southern Africa Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Southern Africa collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Southern Africa",
+            "label": "Southern Africa Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Southern Africa collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Western Africa",
+            "label": "Western Africa Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Western Africa collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Western Africa",
+            "label": "Western Africa Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Western Africa collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Western Africa",
+            "label": "Western Africa Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Western Africa collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Caribbean",
+            "label": "Caribbean Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Caribbean collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Caribbean",
+            "label": "Caribbean Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Caribbean collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Caribbean",
+            "label": "Caribbean Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Caribbean collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Central America",
+            "label": "Central America Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Central America collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Central America",
+            "label": "Central America Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Central America collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Central America",
+            "label": "Central America Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Central America collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_South America",
+            "label": "South America Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the South America collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_South America",
+            "label": "South America Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the South America collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_South America",
+            "label": "South America Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the South America collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_North America",
+            "label": "North America Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the North America collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_North America",
+            "label": "North America Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the North America collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_North America",
+            "label": "North America Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the North America collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Antarctica",
+            "label": "Antarctica Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Antarctica collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Antarctica",
+            "label": "Antarctica Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Antarctica collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Antarctica",
+            "label": "Antarctica Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Antarctica collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Central Asia",
+            "label": "Central Asia Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Central Asia collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Central Asia",
+            "label": "Central Asia Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Central Asia collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Central Asia",
+            "label": "Central Asia Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Central Asia collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Eastern Asia",
+            "label": "Eastern Asia Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Eastern Asia collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Eastern Asia",
+            "label": "Eastern Asia Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Eastern Asia collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Eastern Asia",
+            "label": "Eastern Asia Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Eastern Asia collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_South-Eastern Asia",
+            "label": "South-Eastern Asia Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the South-Eastern Asia collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_South-Eastern Asia",
+            "label": "South-Eastern Asia Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the South-Eastern Asia collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_South-Eastern Asia",
+            "label": "South-Eastern Asia Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the South-Eastern Asia collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Southern Asia",
+            "label": "Southern Asia Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Southern Asia collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Southern Asia",
+            "label": "Southern Asia Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Southern Asia collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Southern Asia",
+            "label": "Southern Asia Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Southern Asia collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Western Asia",
+            "label": "Western Asia Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Western Asia collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Western Asia",
+            "label": "Western Asia Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Western Asia collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Western Asia",
+            "label": "Western Asia Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Western Asia collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Eastern Europe",
+            "label": "Eastern Europe Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Eastern Europe collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Eastern Europe",
+            "label": "Eastern Europe Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Eastern Europe collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Eastern Europe",
+            "label": "Eastern Europe Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Eastern Europe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Northern Europe",
+            "label": "Northern Europe Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Northern Europe collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Northern Europe",
+            "label": "Northern Europe Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Northern Europe collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Northern Europe",
+            "label": "Northern Europe Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Northern Europe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Southern Europe",
+            "label": "Southern Europe Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Southern Europe collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Southern Europe",
+            "label": "Southern Europe Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Southern Europe collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Southern Europe",
+            "label": "Southern Europe Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Southern Europe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Western Europe",
+            "label": "Western Europe Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Western Europe collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Western Europe",
+            "label": "Western Europe Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Western Europe collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Western Europe",
+            "label": "Western Europe Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Western Europe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Australia and New Zealand",
+            "label": "Australia and New Zealand Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Australia and New Zealand collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Australia and New Zealand",
+            "label": "Australia and New Zealand Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Australia and New Zealand collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Australia and New Zealand",
+            "label": "Australia and New Zealand Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Australia and New Zealand collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Melanesia",
+            "label": "Melanesia Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Melanesia collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Melanesia",
+            "label": "Melanesia Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Melanesia collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Melanesia",
+            "label": "Melanesia Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Melanesia collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Micronesia",
+            "label": "Micronesia Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Micronesia collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Micronesia",
+            "label": "Micronesia Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Micronesia collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Micronesia",
+            "label": "Micronesia Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Micronesia collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Polynesia",
+            "label": "Polynesia Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Polynesia collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Polynesia",
+            "label": "Polynesia Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Polynesia collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Polynesia",
+            "label": "Polynesia Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Polynesia collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_other",
+            "label": "Other Regions Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Other Regions collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_other",
+            "label": "Other Regions Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Other Regions collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_other",
+            "label": "Other Regions Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Other Regions collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
             "key": "sort_by",
             "label": "Sort By",
             "type": "select",
@@ -24558,6 +25104,153 @@
             "label": "Visible Shared",
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Africa",
+            "label": "Africa Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Africa collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Africa",
+            "label": "Africa Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Africa collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Africa",
+            "label": "Africa Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Africa collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Americas",
+            "label": "Americas Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Americas collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Americas",
+            "label": "Americas Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Americas collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Americas",
+            "label": "Americas Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Americas collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Antarctica",
+            "label": "Antarctica Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Antarctica collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Antarctica",
+            "label": "Antarctica Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Antarctica collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Antarctica",
+            "label": "Antarctica Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Antarctica collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Asia",
+            "label": "Asia Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Asia collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Asia",
+            "label": "Asia Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Asia collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Asia",
+            "label": "Asia Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Asia collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Europe",
+            "label": "Europe Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Europe collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Europe",
+            "label": "Europe Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Europe collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Europe",
+            "label": "Europe Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Europe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_Oceania",
+            "label": "Oceania Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Oceania collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_Oceania",
+            "label": "Oceania Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Oceania collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_Oceania",
+            "label": "Oceania Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Oceania collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_other",
+            "label": "Other Continents Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Other Continents collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_other",
+            "label": "Other Continents Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Other Continents collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_other",
+            "label": "Other Continents Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Other Continents collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
           },
           {

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -33,6 +33,14 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "use_year_collections",
+            "label": "Use Year Collections",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Leave enabled to create the individual year collections for this award default. Turn it off to keep only the main award collections.",
+            "tooltip_variant": "info"
+          },
+          {
             "key": "data_starting",
             "label": "Data Starting",
             "type": "relative_year",
@@ -593,6 +601,14 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "use_year_collections",
+            "label": "Use Year Collections",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Leave enabled to create the individual year collections for this award default. Turn it off to keep only the main award collections.",
+            "tooltip_variant": "info"
+          },
+          {
             "key": "data_starting",
             "label": "Data Starting",
             "type": "relative_year",
@@ -1134,6 +1150,14 @@
             "type": "text_input",
             "default": "130",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "use_year_collections",
+            "label": "Use Year Collections",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Leave enabled to create the individual year collections for this award default. Turn it off to keep only the main award collections.",
+            "tooltip_variant": "info"
           },
           {
             "key": "data_starting",
@@ -1679,6 +1703,14 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "use_year_collections",
+            "label": "Use Year Collections",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Leave enabled to create the individual year collections for this award default. Turn it off to keep only the main award collections.",
+            "tooltip_variant": "info"
+          },
+          {
             "key": "data_starting",
             "label": "Data Starting",
             "type": "relative_year",
@@ -2220,6 +2252,14 @@
             "type": "text_input",
             "default": "130",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "use_year_collections",
+            "label": "Use Year Collections",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Leave enabled to create the individual year collections for this award default. Turn it off to keep only the main award collections.",
+            "tooltip_variant": "info"
           },
           {
             "key": "data_starting",
@@ -2764,6 +2804,14 @@
             "type": "text_input",
             "default": "130",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "use_year_collections",
+            "label": "Use Year Collections",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Leave enabled to create the individual year collections for this award default. Turn it off to keep only the main award collections.",
+            "tooltip_variant": "info"
           },
           {
             "key": "data_starting",
@@ -3311,6 +3359,14 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "use_year_collections",
+            "label": "Use Year Collections",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Leave enabled to create the individual year collections for this award default. Turn it off to keep only the main award collections.",
+            "tooltip_variant": "info"
+          },
+          {
             "key": "data_starting",
             "label": "Data Starting",
             "type": "relative_year",
@@ -3854,6 +3910,14 @@
             "type": "text_input",
             "default": "130",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "use_year_collections",
+            "label": "Use Year Collections",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Leave enabled to create the individual year collections for this award default. Turn it off to keep only the main award collections.",
+            "tooltip_variant": "info"
           },
           {
             "key": "data_starting",
@@ -4427,6 +4491,14 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "use_year_collections",
+            "label": "Use Year Collections",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Leave enabled to create the individual year collections for this award default. Turn it off to keep only the main award collections.",
+            "tooltip_variant": "info"
+          },
+          {
             "key": "data_starting",
             "label": "Data Starting",
             "type": "relative_year",
@@ -4968,6 +5040,14 @@
             "type": "text_input",
             "default": "130",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "use_year_collections",
+            "label": "Use Year Collections",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Leave enabled to create the individual year collections for this award default. Turn it off to keep only the main award collections.",
+            "tooltip_variant": "info"
           },
           {
             "key": "data_starting",
@@ -5514,6 +5594,14 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "use_year_collections",
+            "label": "Use Year Collections",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Leave enabled to create the individual year collections for this award default. Turn it off to keep only the main award collections.",
+            "tooltip_variant": "info"
+          },
+          {
             "key": "data_starting",
             "label": "Data Starting",
             "type": "relative_year",
@@ -6056,6 +6144,14 @@
             "type": "text_input",
             "default": "130",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "use_year_collections",
+            "label": "Use Year Collections",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Leave enabled to create the individual year collections for this award default. Turn it off to keep only the main award collections.",
+            "tooltip_variant": "info"
           },
           {
             "key": "data_starting",
@@ -6601,6 +6697,14 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "use_year_collections",
+            "label": "Use Year Collections",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Leave enabled to create the individual year collections for this award default. Turn it off to keep only the main award collections.",
+            "tooltip_variant": "info"
+          },
+          {
             "key": "data_starting",
             "label": "Data Starting",
             "type": "relative_year",
@@ -7144,6 +7248,14 @@
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
           },
           {
+            "key": "use_year_collections",
+            "label": "Use Year Collections",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Leave enabled to create the individual year collections for this award default. Turn it off to keep only the main award collections.",
+            "tooltip_variant": "info"
+          },
+          {
             "key": "data_starting",
             "label": "Data Starting",
             "type": "relative_year",
@@ -7685,6 +7797,14 @@
             "type": "text_input",
             "default": "130",
             "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+          },
+          {
+            "key": "use_year_collections",
+            "label": "Use Year Collections",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Leave enabled to create the individual year collections for this award default. Turn it off to keep only the main award collections.",
+            "tooltip_variant": "info"
           },
           {
             "key": "data_starting",

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -227,6 +227,66 @@
             ]
           },
           {
+            "key": "visible_home_best_picture",
+            "label": "Oscars Best Picture Winners Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Oscars Best Picture Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_best_picture",
+            "label": "Oscars Best Picture Winners Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Oscars Best Picture Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_best_picture",
+            "label": "Oscars Best Picture Winners Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Oscars Best Picture Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_best_director",
+            "label": "Oscars Best Director Winners Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Oscars Best Director Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_best_director",
+            "label": "Oscars Best Director Winners Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Oscars Best Director Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_best_director",
+            "label": "Oscars Best Director Winners Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Oscars Best Director Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "collection_order",
             "label": "Collection Order",
             "type": "select",
@@ -772,6 +832,36 @@
             "label": "Visible Shared",
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_golden",
+            "label": "Berlinale Golden Bears Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Berlinale Golden Bears collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_golden",
+            "label": "Berlinale Golden Bears Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Berlinale Golden Bears collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_golden",
+            "label": "Berlinale Golden Bears Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Berlinale Golden Bears collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
             "media_types": [
               "movie"
@@ -1329,6 +1419,36 @@
             ]
           },
           {
+            "key": "visible_home_best",
+            "label": "BAFTA Best Films Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the BAFTA Best Films collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_best",
+            "label": "BAFTA Best Films Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the BAFTA Best Films collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_best",
+            "label": "BAFTA Best Films Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the BAFTA Best Films collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "collection_order",
             "label": "Collection Order",
             "type": "select",
@@ -1880,6 +2000,36 @@
             ]
           },
           {
+            "key": "visible_home_palm",
+            "label": "Cannes Golden Palm Winners Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Cannes Golden Palm Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_palm",
+            "label": "Cannes Golden Palm Winners Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Cannes Golden Palm Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_palm",
+            "label": "Cannes Golden Palm Winners Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Cannes Golden Palm Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "collection_order",
             "label": "Collection Order",
             "type": "select",
@@ -2425,6 +2575,36 @@
             "label": "Visible Shared",
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_best",
+            "label": "César Best Film Winners Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the César Best Film Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_best",
+            "label": "César Best Film Winners Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the César Best Film Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_best",
+            "label": "César Best Film Winners Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the César Best Film Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
             "media_types": [
               "movie"
@@ -2984,6 +3164,27 @@
             "default": false
           },
           {
+            "key": "visible_home_best",
+            "label": "Critics Choice Best Picture Winners Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Critics Choice Best Picture Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_best",
+            "label": "Critics Choice Best Picture Winners Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Critics Choice Best Picture Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_best",
+            "label": "Critics Choice Best Picture Winners Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Critics Choice Best Picture Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
             "key": "collection_order",
             "label": "Collection Order",
             "type": "select",
@@ -3534,6 +3735,27 @@
             "label": "Visible Shared",
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_best",
+            "label": "Emmys Best in Category Winners Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Emmys Best in Category Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_best",
+            "label": "Emmys Best in Category Winners Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Emmys Best in Category Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_best",
+            "label": "Emmys Best in Category Winners Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Emmys Best in Category Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
           },
           {
@@ -4117,6 +4339,48 @@
             "default": false
           },
           {
+            "key": "visible_home_best_picture",
+            "label": "Golden Globes Best Picture Winners Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Golden Globes Best Picture Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_best_picture",
+            "label": "Golden Globes Best Picture Winners Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Golden Globes Best Picture Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_best_picture",
+            "label": "Golden Globes Best Picture Winners Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Golden Globes Best Picture Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_best_director",
+            "label": "Golden Globes Best Director Winners Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Golden Globes Best Director Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_best_director",
+            "label": "Golden Globes Best Director Winners Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Golden Globes Best Director Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_best_director",
+            "label": "Golden Globes Best Director Winners Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Golden Globes Best Director Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
             "key": "collection_order",
             "label": "Collection Order",
             "type": "select",
@@ -4668,6 +4932,36 @@
             ]
           },
           {
+            "key": "visible_home_best",
+            "label": "Independent Spirit Best Feature Winners Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Independent Spirit Best Feature Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_best",
+            "label": "Independent Spirit Best Feature Winners Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Independent Spirit Best Feature Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_best",
+            "label": "Independent Spirit Best Feature Winners Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Independent Spirit Best Feature Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "collection_order",
             "label": "Collection Order",
             "type": "select",
@@ -5213,6 +5507,36 @@
             "label": "Visible Shared",
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_all_time",
+            "label": "National Film Registry All Time Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the National Film Registry All Time collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_all_time",
+            "label": "National Film Registry All Time Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the National Film Registry All Time collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_all_time",
+            "label": "National Film Registry All Time Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the National Film Registry All Time collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
             "media_types": [
               "movie"
@@ -5772,6 +6096,27 @@
             "default": false
           },
           {
+            "key": "visible_home_pca",
+            "label": "People's Choice Award Winners Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the People's Choice Award Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_pca",
+            "label": "People's Choice Award Winners Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the People's Choice Award Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_pca",
+            "label": "People's Choice Award Winners Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the People's Choice Award Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
             "key": "collection_order",
             "label": "Collection Order",
             "type": "select",
@@ -6317,6 +6662,36 @@
             "label": "Visible Shared",
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_golden",
+            "label": "Golden Raspberry Award Winners Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Golden Raspberry Award Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_golden",
+            "label": "Golden Raspberry Award Winners Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Golden Raspberry Award Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_golden",
+            "label": "Golden Raspberry Award Winners Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Golden Raspberry Award Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
             "media_types": [
               "movie"
@@ -6874,6 +7249,36 @@
             ]
           },
           {
+            "key": "visible_home_golden",
+            "label": "Screen Actors Guild Award Winners Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Screen Actors Guild Award Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_golden",
+            "label": "Screen Actors Guild Award Winners Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Screen Actors Guild Award Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_golden",
+            "label": "Screen Actors Guild Award Winners Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Screen Actors Guild Award Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "collection_order",
             "label": "Collection Order",
             "type": "select",
@@ -7419,6 +7824,36 @@
             "label": "Visible Shared",
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_grand",
+            "label": "Grand Jury Winners Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Grand Jury Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_grand",
+            "label": "Grand Jury Winners Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Grand Jury Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_grand",
+            "label": "Grand Jury Winners Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Grand Jury Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
             "media_types": [
               "movie"
@@ -7976,6 +8411,36 @@
             ]
           },
           {
+            "key": "visible_home_best",
+            "label": "Toronto People's Choice Award Winners Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Toronto People's Choice Award Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_best",
+            "label": "Toronto People's Choice Award Winners Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Toronto People's Choice Award Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_best",
+            "label": "Toronto People's Choice Award Winners Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Toronto People's Choice Award Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "collection_order",
             "label": "Collection Order",
             "type": "select",
@@ -8513,6 +8978,36 @@
             "label": "Visible Shared",
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_golden",
+            "label": "Golden Lion Winners Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Golden Lion Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_golden",
+            "label": "Golden Lion Winners Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Golden Lion Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_golden",
+            "label": "Golden Lion Winners Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Golden Lion Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
             "media_types": [
               "movie"

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -9018,6 +9018,57 @@
             "default": false
           },
           {
+            "key": "visible_home_episodes",
+            "label": "New Episodes Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the New Episodes collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "visible_library_episodes",
+            "label": "New Episodes Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the New Episodes collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "visible_shared_episodes",
+            "label": "New Episodes Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the New Episodes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "visible_home_released",
+            "label": "Newly Released Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Newly Released collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_released",
+            "label": "Newly Released Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Newly Released collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_released",
+            "label": "Newly Released Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Newly Released collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
             "key": "sort_by",
             "label": "Sort By",
             "type": "select",
@@ -9447,6 +9498,48 @@
             "label": "Visible Shared",
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_popular",
+            "label": "Plex Popular Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Plex Popular collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_popular",
+            "label": "Plex Popular Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Plex Popular collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_popular",
+            "label": "Plex Popular Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Plex Popular collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_watched",
+            "label": "Plex Watched Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Plex Watched collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_watched",
+            "label": "Plex Watched Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Plex Watched collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_watched",
+            "label": "Plex Watched Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Plex Watched collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
           },
           {
@@ -9963,6 +10056,69 @@
             "label": "Visible Shared",
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_top",
+            "label": "IMDb Top 250 Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the IMDb Top 250 collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_top",
+            "label": "IMDb Top 250 Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the IMDb Top 250 collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_top",
+            "label": "IMDb Top 250 Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the IMDb Top 250 collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_popular",
+            "label": "IMDb Popular Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the IMDb Popular collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_popular",
+            "label": "IMDb Popular Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the IMDb Popular collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_popular",
+            "label": "IMDb Popular Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the IMDb Popular collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_lowest",
+            "label": "IMDb Lowest Rated Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the IMDb Lowest Rated collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_lowest",
+            "label": "IMDb Lowest Rated Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the IMDb Lowest Rated collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_lowest",
+            "label": "IMDb Lowest Rated Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the IMDb Lowest Rated collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
           },
           {
@@ -10530,6 +10686,111 @@
             "label": "Visible Shared",
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_airing",
+            "label": "TMDb Airing Today Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb Airing Today collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_airing",
+            "label": "TMDb Airing Today Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb Airing Today collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_airing",
+            "label": "TMDb Airing Today Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb Airing Today collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_air",
+            "label": "TMDb On The Air Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb On The Air collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_air",
+            "label": "TMDb On The Air Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb On The Air collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_air",
+            "label": "TMDb On The Air Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb On The Air collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_popular",
+            "label": "TMDb Popular Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb Popular collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_popular",
+            "label": "TMDb Popular Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb Popular collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_popular",
+            "label": "TMDb Popular Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb Popular collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_top",
+            "label": "TMDb Top Rated Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb Top Rated collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_top",
+            "label": "TMDb Top Rated Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb Top Rated collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_top",
+            "label": "TMDb Top Rated Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb Top Rated collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_trending",
+            "label": "TMDb Trending Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb Trending collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_trending",
+            "label": "TMDb Trending Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb Trending collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_trending",
+            "label": "TMDb Trending Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb Trending collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
           },
           {
@@ -11102,6 +11363,111 @@
             "default": false
           },
           {
+            "key": "visible_home_collected",
+            "label": "Trakt Collected Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Collected collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_collected",
+            "label": "Trakt Collected Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Collected collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_collected",
+            "label": "Trakt Collected Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Collected collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_popular",
+            "label": "Trakt Popular Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Popular collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_popular",
+            "label": "Trakt Popular Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Popular collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_popular",
+            "label": "Trakt Popular Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Popular collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_recommended",
+            "label": "Trakt Recommended Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Recommended collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_recommended",
+            "label": "Trakt Recommended Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Recommended collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_recommended",
+            "label": "Trakt Recommended Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Recommended collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_trending",
+            "label": "Trakt Trending Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Trending collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_trending",
+            "label": "Trakt Trending Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Trending collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_trending",
+            "label": "Trakt Trending Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Trending collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_watched",
+            "label": "Trakt Watched Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Watched collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_watched",
+            "label": "Trakt Watched Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Watched collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_watched",
+            "label": "Trakt Watched Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Watched collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
             "key": "collection_order",
             "label": "Collection Order",
             "type": "select",
@@ -11648,6 +12014,90 @@
             "default": false
           },
           {
+            "key": "visible_home_trending_today",
+            "label": "Simkl Trending Today Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Simkl Trending Today collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_trending_today",
+            "label": "Simkl Trending Today Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Simkl Trending Today collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_trending_today",
+            "label": "Simkl Trending Today Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Simkl Trending Today collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_trending_week",
+            "label": "Simkl Trending This Week Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Simkl Trending This Week collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_trending_week",
+            "label": "Simkl Trending This Week Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Simkl Trending This Week collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_trending_week",
+            "label": "Simkl Trending This Week Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Simkl Trending This Week collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_trending_month",
+            "label": "Simkl Trending This Month Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Simkl Trending This Month collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_trending_month",
+            "label": "Simkl Trending This Month Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Simkl Trending This Month collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_trending_month",
+            "label": "Simkl Trending This Month Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Simkl Trending This Month collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_dvd",
+            "label": "Simkl DVD Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Simkl DVD collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_dvd",
+            "label": "Simkl DVD Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Simkl DVD collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_dvd",
+            "label": "Simkl DVD Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Simkl DVD collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
             "key": "collection_order",
             "label": "Collection Order",
             "type": "select",
@@ -11857,6 +12307,90 @@
             "label": "Visible Shared",
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_popular",
+            "label": "AniList Popular Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the AniList Popular collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_popular",
+            "label": "AniList Popular Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the AniList Popular collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_popular",
+            "label": "AniList Popular Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the AniList Popular collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_season",
+            "label": "AniList Season Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the AniList Season collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_season",
+            "label": "AniList Season Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the AniList Season collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_season",
+            "label": "AniList Season Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the AniList Season collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_top",
+            "label": "AniList Top Rated Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the AniList Top Rated collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_top",
+            "label": "AniList Top Rated Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the AniList Top Rated collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_top",
+            "label": "AniList Top Rated Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the AniList Top Rated collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_trending",
+            "label": "AniList Trending Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the AniList Trending collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_trending",
+            "label": "AniList Trending Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the AniList Trending collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_trending",
+            "label": "AniList Trending Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the AniList Trending collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
           },
           {
@@ -12424,6 +12958,111 @@
             "label": "Visible Shared",
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_favorited",
+            "label": "MyAnimeList Favorited Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Favorited collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_favorited",
+            "label": "MyAnimeList Favorited Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Favorited collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_favorited",
+            "label": "MyAnimeList Favorited Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Favorited collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_popular",
+            "label": "MyAnimeList Popular Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Popular collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_popular",
+            "label": "MyAnimeList Popular Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Popular collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_popular",
+            "label": "MyAnimeList Popular Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Popular collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_season",
+            "label": "MyAnimeList Season Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Season collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_season",
+            "label": "MyAnimeList Season Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Season collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_season",
+            "label": "MyAnimeList Season Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Season collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_airing",
+            "label": "MyAnimeList Top Airing Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Top Airing collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_airing",
+            "label": "MyAnimeList Top Airing Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Top Airing collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_airing",
+            "label": "MyAnimeList Top Airing Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Top Airing collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_top",
+            "label": "MyAnimeList Top Rated Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Top Rated collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_top",
+            "label": "MyAnimeList Top Rated Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Top Rated collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_top",
+            "label": "MyAnimeList Top Rated Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the MyAnimeList Top Rated collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
           },
           {
@@ -13224,6 +13863,636 @@
             ]
           },
           {
+            "key": "visible_home_1001_movies",
+            "label": "1,001 To See Before You Die Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the 1,001 To See Before You Die collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_1001_movies",
+            "label": "1,001 To See Before You Die Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the 1,001 To See Before You Die collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_1001_movies",
+            "label": "1,001 To See Before You Die Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the 1,001 To See Before You Die collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_afi_100",
+            "label": "AFI 100 Years 100 Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the AFI 100 Years 100 Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_afi_100",
+            "label": "AFI 100 Years 100 Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the AFI 100 Years 100 Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_afi_100",
+            "label": "AFI 100 Years 100 Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the AFI 100 Years 100 Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Box Office Mojo All Time 100 collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Box Office Mojo All Time 100 collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Box Office Mojo All Time 100 collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_cannes",
+            "label": "Cannes Palme d'Or Winners Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Cannes Palme d'Or Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_cannes",
+            "label": "Cannes Palme d'Or Winners Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Cannes Palme d'Or Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_cannes",
+            "label": "Cannes Palme d'Or Winners Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Cannes Palme d'Or Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Edgar Wright's 1,000 Favorites collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Edgar Wright's 1,000 Favorites collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Edgar Wright's 1,000 Favorites collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the IMDb Top 250 (Letterboxd) collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the IMDb Top 250 (Letterboxd) collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the IMDb Top 250 (Letterboxd) collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_top_250",
+            "label": "Letterboxd Top 250 Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Letterboxd Top 250 collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_top_250",
+            "label": "Letterboxd Top 250 Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Letterboxd Top 250 collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_top_250",
+            "label": "Letterboxd Top 250 Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Letterboxd Top 250 collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_international",
+            "label": "Top 250 International Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 International collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_international",
+            "label": "Top 250 International Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 International collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_international",
+            "label": "Top 250 International Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 International collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_science",
+            "label": "Top 250 Sci-Fi Films Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Sci-Fi Films collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_science",
+            "label": "Top 250 Sci-Fi Films Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Sci-Fi Films collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_science",
+            "label": "Top 250 Sci-Fi Films Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Sci-Fi Films collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_western",
+            "label": "Top 100 Western Films Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Top 100 Western Films collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_western",
+            "label": "Top 100 Western Films Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Top 100 Western Films collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_western",
+            "label": "Top 100 Western Films Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Top 100 Western Films collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_silent",
+            "label": "Top 100 Silent Films Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Top 100 Silent Films collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_silent",
+            "label": "Top 100 Silent Films Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Top 100 Silent Films collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_silent",
+            "label": "Top 100 Silent Films Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Top 100 Silent Films collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_million",
+            "label": "One Million Watched Club Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the One Million Watched Club collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_million",
+            "label": "One Million Watched Club Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the One Million Watched Club collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_million",
+            "label": "One Million Watched Club Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the One Million Watched Club collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_oscars",
+            "label": "Oscar Best Picture Winners Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Oscar Best Picture Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_oscars",
+            "label": "Oscar Best Picture Winners Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Oscar Best Picture Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_oscars",
+            "label": "Oscar Best Picture Winners Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Oscar Best Picture Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_rogerebert",
+            "label": "Roger Ebert's Great Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Roger Ebert's Great Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_rogerebert",
+            "label": "Roger Ebert's Great Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Roger Ebert's Great Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_rogerebert",
+            "label": "Roger Ebert's Great Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Roger Ebert's Great Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_sight_sound",
+            "label": "Sight & Sound Greatest Films Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Sight & Sound Greatest Films collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_sight_sound",
+            "label": "Sight & Sound Greatest Films Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Sight & Sound Greatest Films collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_sight_sound",
+            "label": "Sight & Sound Greatest Films Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Sight & Sound Greatest Films collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_animation",
+            "label": "Top 100 Animation Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Top 100 Animation collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_animation",
+            "label": "Top 100 Animation Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Top 100 Animation collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_animation",
+            "label": "Top 100 Animation Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Top 100 Animation collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_black_directors",
+            "label": "Top 250 Black-Directed Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Black-Directed collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_black_directors",
+            "label": "Top 250 Black-Directed Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Black-Directed collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_black_directors",
+            "label": "Top 250 Black-Directed Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Black-Directed collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_documentaries",
+            "label": "Top 250 Documentaries Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Documentaries collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_documentaries",
+            "label": "Top 250 Documentaries Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Documentaries collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_documentaries",
+            "label": "Top 250 Documentaries Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Documentaries collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_horror",
+            "label": "Top 250 Horror Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Horror collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_horror",
+            "label": "Top 250 Horror Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Horror collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_horror",
+            "label": "Top 250 Horror Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Horror collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_most_fans",
+            "label": "Top 250 Most Fans Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Most Fans collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_most_fans",
+            "label": "Top 250 Most Fans Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Most Fans collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_most_fans",
+            "label": "Top 250 Most Fans Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Most Fans collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_women_directors",
+            "label": "Top 250 Women-Directed Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Women-Directed collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_women_directors",
+            "label": "Top 250 Women-Directed Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Women-Directed collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_women_directors",
+            "label": "Top 250 Women-Directed Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Top 250 Women-Directed collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "collection_order",
             "label": "Collection Order",
             "type": "select",
@@ -13748,6 +15017,102 @@
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "visible_home_commonsense",
+            "label": "Common Sense Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Common Sense Selection collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_commonsense",
+            "label": "Common Sense Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Common Sense Selection collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_commonsense",
+            "label": "Common Sense Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Common Sense Selection collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_metacritic",
+            "label": "Metacritic Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Metacritic Must See collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_metacritic",
+            "label": "Metacritic Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Metacritic Must See collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_metacritic",
+            "label": "Metacritic Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Metacritic Must See collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_home_stevenlu",
+            "label": "StevenLu Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the StevenLu's Popular Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_library_stevenlu",
+            "label": "StevenLu Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the StevenLu's Popular Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false
+          },
+          {
+            "key": "visible_shared_stevenlu",
+            "label": "StevenLu Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the StevenLu's Popular Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_home_pirated",
+            "label": "Pirated Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Top 10 Pirated Movies of the Week collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_library_pirated",
+            "label": "Pirated Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Top 10 Pirated Movies of the Week collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "visible_shared_pirated",
+            "label": "Pirated Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Top 10 Pirated Movies of the Week collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ]
           },
           {
             "key": "collection_order",

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -1084,10 +1084,46 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
 
                     {% if collection.template_variables %}
                     {% set is_seasonal = collection.id == 'collection_seasonal' %}
+                    {% set priority_use_key_collection_ids = [
+                        'collection_basic',
+                        'collection_anilist',
+                        'collection_imdb',
+                        'collection_letterboxd',
+                        'collection_myanimelist',
+                        'collection_simkl',
+                        'collection_tautulli',
+                        'collection_tmdb',
+                        'collection_trakt',
+                        'collection_other_chart'
+                    ] %}
+                    {% set ordered_collection_items = collection.template_variables %}
+                    {% if collection.id in priority_use_key_collection_ids %}
+                    {% set prioritized_collection_items = namespace(priority=[], remaining=[], used_keys=[]) %}
+                    {% for raw_item in collection.template_variables %}
+                    {% if raw_item.key is defined and raw_item.key.startswith('use_') %}
+                    {% set _ = prioritized_collection_items.priority.append(raw_item) %}
+                    {% set _ = prioritized_collection_items.used_keys.append(raw_item.key) %}
+                    {% set use_suffix = raw_item.key[4:] %}
+                    {% for sibling_item in collection.template_variables %}
+                    {% if sibling_item.key is defined and sibling_item.key in ['radarr_add_missing_' ~ use_suffix, 'sonarr_add_missing_' ~ use_suffix] %}
+                    {% if sibling_item.key not in prioritized_collection_items.used_keys %}
+                    {% set _ = prioritized_collection_items.priority.append(sibling_item) %}
+                    {% set _ = prioritized_collection_items.used_keys.append(sibling_item.key) %}
+                    {% endif %}
+                    {% endif %}
+                    {% endfor %}
+                    {% else %}
+                    {% if raw_item.key is not defined or raw_item.key not in prioritized_collection_items.used_keys %}
+                    {% set _ = prioritized_collection_items.remaining.append(raw_item) %}
+                    {% endif %}
+                    {% endif %}
+                    {% endfor %}
+                    {% set ordered_collection_items = prioritized_collection_items.priority + prioritized_collection_items.remaining %}
+                    {% endif %}
                     {% set season = namespace(open=false) %}
                     <div class="child-toggle-wrapper ms-4 mt-2"
                         data-toggle-parent="{{ library.id }}-{{ collection.id }}" style="display: none;">
-                        {% for item in collection.template_variables
+                        {% for item in ordered_collection_items
                         if (not item.media_types or library.type in item.media_types)
                         and (not item.key.startswith('visible_') or telemetry.plex_pass) %}
                         {% set clean_id = collection.id.replace('collection_', '') %}

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -1085,6 +1085,21 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                     {% if collection.template_variables %}
                     {% set is_seasonal = collection.id == 'collection_seasonal' %}
                     {% set priority_use_key_collection_ids = [
+                        'collection_oscars',
+                        'collection_berlinale',
+                        'collection_bafta',
+                        'collection_cannes',
+                        'collection_cesar',
+                        'collection_choice',
+                        'collection_emmy',
+                        'collection_golden',
+                        'collection_spirit',
+                        'collection_pca',
+                        'collection_razzie',
+                        'collection_sag',
+                        'collection_sundance',
+                        'collection_tiff',
+                        'collection_venice',
                         'collection_basic',
                         'collection_anilist',
                         'collection_imdb',

--- a/tests/test_template_gap_analyzer.py
+++ b/tests/test_template_gap_analyzer.py
@@ -63,6 +63,92 @@ def test_build_qs_overlay_map_includes_rating3_for_repo_quickstart_file():
     assert "rating_alignment" in overlay_map["ratings"]
 
 
+def test_build_qs_overlay_map_adds_runtime_offset_and_alignment_keys(tmp_path):
+    module = _load_gap_analyzer_module()
+    qs_overlays = tmp_path / "quickstart_overlays.json"
+    qs_overlays.write_text(
+        """
+[
+  {
+    "overlays": [
+      {
+        "id": "overlay_status",
+        "default_offsets": {
+          "horizontal": 15,
+          "vertical": 15,
+          "origin": "top_left"
+        },
+        "template_variables": [
+          {
+            "key": "use_airing"
+          }
+        ]
+      }
+    ]
+  }
+]
+""".strip(),
+        encoding="utf-8",
+    )
+
+    overlay_map = module.build_qs_overlay_map(qs_overlays)
+
+    assert overlay_map["status"] >= {
+        "use_airing",
+        "horizontal_offset",
+        "vertical_offset",
+        "horizontal_align",
+        "vertical_align",
+    }
+
+
+def test_build_qs_overlay_map_includes_runtime_offset_and_alignment_keys_for_repo_file():
+    module = _load_gap_analyzer_module()
+    qs_overlays = Path(__file__).resolve().parents[1] / "static" / "json" / "quickstart_overlays.json"
+
+    overlay_map = module.build_qs_overlay_map(qs_overlays)
+
+    assert "horizontal_offset" in overlay_map["resolution"]
+    assert "vertical_offset" in overlay_map["resolution"]
+    assert "horizontal_align" in overlay_map["resolution"]
+    assert "vertical_align" in overlay_map["resolution"]
+    assert "horizontal_offset" in overlay_map["status"]
+    assert "vertical_offset" in overlay_map["status"]
+
+
+def test_build_qs_overlay_map_can_skip_runtime_support_enrichment(tmp_path):
+    module = _load_gap_analyzer_module()
+    qs_overlays = tmp_path / "quickstart_overlays.json"
+    qs_overlays.write_text(
+        """
+[
+  {
+    "overlays": [
+      {
+        "id": "overlay_status",
+        "default_offsets": {
+          "horizontal": 15,
+          "vertical": 15,
+          "origin": "top_left"
+        },
+        "template_variables": [
+          {
+            "key": "use_airing"
+          }
+        ]
+      }
+    ]
+  }
+]
+""".strip(),
+        encoding="utf-8",
+    )
+
+    overlay_map = module.build_qs_overlay_map(qs_overlays, enrich_runtime_support=False)
+
+    assert overlay_map["status"] == {"use_airing"}
+
+
 def test_overlay_key_supported_in_quickstart_accepts_languages_use_subtitles_alias():
     module = _load_gap_analyzer_module()
 
@@ -83,3 +169,34 @@ def test_overlay_key_supported_in_quickstart_uses_direct_alias_match_when_availa
 
     assert module.overlay_key_supported_in_quickstart("ratings", "rating3", qs_overlays) is True
     assert module.overlay_key_supported_in_quickstart("ratings", "rating3_image", qs_overlays) is True
+
+
+def test_quickstart_recommendation_summary_includes_runtime_supported_overlay_keys():
+    module = _load_gap_analyzer_module()
+
+    rows = [
+        {
+            "kind": "overlay",
+            "default": "status",
+            "key": "horizontal_align",
+            "file": "config.yml",
+            "library": "Shows",
+            "matched_default_files": ["overlays/status.yml"],
+            "supported_in_quickstart": True,
+            "quickstart_declared": False,
+            "schema_declared": False,
+            "kometa_declared": True,
+            "validation_level": "supported_in_quickstart",
+            "name_verified": True,
+            "value_shape_verified": True,
+            "value_shape_rule": "string",
+        }
+    ]
+
+    summary = module.build_quickstart_recommendation_summary(rows)
+    ranked = module.serialize_ranked_summary(summary)
+
+    assert len(ranked) == 1
+    assert ranked[0]["key"] == "horizontal_align"
+    assert ranked[0]["supported_in_quickstart"] is True
+    assert ranked[0]["quickstart_declared"] is False


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Summary
This PR improves Quickstart’s template-gap reporting and closes the remaining child visibility-toggle gaps across collection defaults.
What Changed
Updated the template gap analyzer to distinguish:values already supported by Quickstart
values explicitly declared in Quickstart
true recommendation backlog items still worth adding

Added ranked recommendation and backlog reporting to the generated gap report output.
Extended static/json/quickstart_collections.json so collection defaults with real child use_* collections now also expose matching:visible_home_*
visible_library_*
visible_shared_*

Collection Families Covered
Child visibility toggles were added for remaining defaults in these areas:
other_chart
chart families:basic
tautulli
imdb
tmdb
trakt
simkl
anilist
myanimelist
letterboxd

award defaults
content defaults
location defaults
media defaults
production defaults
time defaults
Intentional Non-Changes
No child visibility toggles were added for structural-only controls such as:
use_separator
use_year_collections
They were also not added to defaults that do not expose real child collections, such as the people defaults.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
