### PR TITLE
added overlay variables

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -2065,11 +2065,7 @@ def build_libraries_section(
                                 "vertical_offset",
                             }
                             keep_keys.update(
-                                {
-                                    f"use_{resolution_level}_{resolution_variant}"
-                                    for resolution_level in resolution_levels
-                                    for resolution_variant in resolution_variants
-                                }
+                                {f"use_{resolution_level}_{resolution_variant}" for resolution_level in resolution_levels for resolution_variant in resolution_variants}
                             )
                             for key in list(tv.keys()):
                                 if key not in keep_keys:

--- a/modules/output.py
+++ b/modules/output.py
@@ -2019,6 +2019,8 @@ def build_libraries_section(
                             tv["use_resolution"] = False
                             use_resolution_val = False
                         if use_edition_val is True:
+                            resolution_levels = ["4k", "1080p", "720p", "576p", "480p"]
+                            resolution_variants = ["dvhdrplus", "dvhdr", "plus", "dv", "hlg", "hdr"]
                             keep_keys = {
                                 "builder_level",
                                 "use_edition",
@@ -2031,6 +2033,8 @@ def build_libraries_section(
                                 "use_dv",
                                 "use_hlg",
                                 "use_hdr",
+                                "use_plus",
+                                "use_dvhdr",
                                 "use_dvhdrplus",
                                 "use_extended",
                                 "use_uncut",
@@ -2060,6 +2064,13 @@ def build_libraries_section(
                                 "horizontal_offset",
                                 "vertical_offset",
                             }
+                            keep_keys.update(
+                                {
+                                    f"use_{resolution_level}_{resolution_variant}"
+                                    for resolution_level in resolution_levels
+                                    for resolution_variant in resolution_variants
+                                }
+                            )
                             for key in list(tv.keys()):
                                 if key not in keep_keys:
                                     tv.pop(key, None)

--- a/static/json/quickstart_overlays.json
+++ b/static/json/quickstart_overlays.json
@@ -4460,8 +4460,140 @@
           },
           {
             "type": "toggle",
+            "key": "use_4k_dvhdrplus",
+            "label": "Use 4k DV/HDR10+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_4k_dvhdr",
+            "label": "Use 4k DV/HDR10",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_4k_plus",
+            "label": "Use 4k HDR10+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_4k_dv",
+            "label": "Use 4k Dolby Vision",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_4k_hlg",
+            "label": "Use 4k HLG",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_4k_hdr",
+            "label": "Use 4k HDR",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
             "key": "use_1080p",
             "label": "Use 1080p",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_1080p_dvhdrplus",
+            "label": "Use 1080p DV/HDR10+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_1080p_dvhdr",
+            "label": "Use 1080p DV/HDR10",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_1080p_plus",
+            "label": "Use 1080p HDR10+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_1080p_dv",
+            "label": "Use 1080p Dolby Vision",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_1080p_hlg",
+            "label": "Use 1080p HLG",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_1080p_hdr",
+            "label": "Use 1080p HDR",
             "value": "true",
             "default": true,
             "options": [
@@ -4482,6 +4614,72 @@
           },
           {
             "type": "toggle",
+            "key": "use_720p_dvhdrplus",
+            "label": "Use 720p DV/HDR10+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_720p_dvhdr",
+            "label": "Use 720p DV/HDR10",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_720p_plus",
+            "label": "Use 720p HDR10+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_720p_dv",
+            "label": "Use 720p Dolby Vision",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_720p_hlg",
+            "label": "Use 720p HLG",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_720p_hdr",
+            "label": "Use 720p HDR",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
             "key": "use_576p",
             "label": "Use 576p",
             "value": "true",
@@ -4493,8 +4691,118 @@
           },
           {
             "type": "toggle",
+            "key": "use_576p_dvhdrplus",
+            "label": "Use 576p DV/HDR10+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_576p_dvhdr",
+            "label": "Use 576p DV/HDR10",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_576p_plus",
+            "label": "Use 576p HDR10+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_576p_dv",
+            "label": "Use 576p Dolby Vision",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_576p_hdr",
+            "label": "Use 576p HDR",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
             "key": "use_480p",
             "label": "Use 480p",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_480p_dvhdrplus",
+            "label": "Use 480p DV/HDR10+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_480p_dvhdr",
+            "label": "Use 480p DV/HDR10",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_480p_plus",
+            "label": "Use 480p HDR10+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_480p_dv",
+            "label": "Use 480p Dolby Vision",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_480p_hdr",
+            "label": "Use 480p HDR",
             "value": "true",
             "default": true,
             "options": [
@@ -4528,6 +4836,28 @@
             "type": "toggle",
             "key": "use_hdr",
             "label": "Use HDR",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_plus",
+            "label": "Use HDR10+",
+            "value": "true",
+            "default": true,
+            "options": [
+              "true",
+              "false"
+            ]
+          },
+          {
+            "type": "toggle",
+            "key": "use_dvhdr",
+            "label": "Use DV/HDR10",
             "value": "true",
             "default": true,
             "options": [

--- a/tests/test_importer_overlay_files.py
+++ b/tests/test_importer_overlay_files.py
@@ -46,8 +46,15 @@ def test_prepare_import_payload_accepts_resolution_template_variables():
                                 "use_resolution": False,
                                 "use_edition": True,
                                 "use_4k": False,
+                                "use_4k_dvhdrplus": False,
                                 "use_1080p": False,
+                                "use_1080p_dv": False,
+                                "use_720p_hdr": False,
+                                "use_576p_dvhdr": False,
+                                "use_480p_plus": False,
                                 "use_dv": False,
+                                "use_plus": False,
+                                "use_dvhdr": False,
                                 "use_extended": False,
                                 "use_openmatte": False,
                             },
@@ -66,12 +73,21 @@ def test_prepare_import_payload_accepts_resolution_template_variables():
     assert libraries_payload["mov-library_movies-movie-template_overlay_resolution[use_resolution]"] is False
     assert libraries_payload["mov-library_movies-movie-template_overlay_resolution[use_edition]"] is True
     assert libraries_payload["mov-library_movies-movie-template_overlay_resolution[use_4k]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_resolution[use_4k_dvhdrplus]"] is False
     assert libraries_payload["mov-library_movies-movie-template_overlay_resolution[use_1080p]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_resolution[use_1080p_dv]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_resolution[use_720p_hdr]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_resolution[use_576p_dvhdr]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_resolution[use_480p_plus]"] is False
     assert libraries_payload["mov-library_movies-movie-template_overlay_resolution[use_dv]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_resolution[use_plus]"] is False
+    assert libraries_payload["mov-library_movies-movie-template_overlay_resolution[use_dvhdr]"] is False
     assert libraries_payload["mov-library_movies-movie-template_overlay_resolution[use_extended]"] is False
     assert libraries_payload["mov-library_movies-movie-template_overlay_resolution[use_openmatte]"] is False
     assert any("libraries.Movies.overlay_files[0].template_variables.use_resolution" in line for line in report.lines)
     assert any("libraries.Movies.overlay_files[0].template_variables.use_1080p" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_1080p_dv" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[0].template_variables.use_plus" in line for line in report.lines)
     assert any("libraries.Movies.overlay_files[0].template_variables.use_extended" in line for line in report.lines)
 
 

--- a/tests/test_resolution_yaml_contract.py
+++ b/tests/test_resolution_yaml_contract.py
@@ -62,8 +62,15 @@ def test_resolution_yaml_contract_keeps_child_filters_when_edition_enabled(monke
             "use_edition": True,
             "use_resolution": True,
             "use_4k": False,
+            "use_4k_dvhdrplus": False,
             "use_1080p": False,
+            "use_1080p_dv": False,
+            "use_720p_hdr": False,
+            "use_576p_dvhdr": False,
+            "use_480p_plus": False,
             "use_dv": False,
+            "use_plus": False,
+            "use_dvhdr": False,
             "use_extended": False,
             "use_openmatte": False,
             "horizontal_offset": 15,
@@ -74,8 +81,15 @@ def test_resolution_yaml_contract_keeps_child_filters_when_edition_enabled(monke
     template_vars = _template_vars_from_yaml(_run_build_config_with_payload(qs_module, monkeypatch, payload))
 
     assert template_vars["use_4k"] is False
+    assert template_vars["use_4k_dvhdrplus"] is False
     assert template_vars["use_1080p"] is False
+    assert template_vars["use_1080p_dv"] is False
+    assert template_vars["use_720p_hdr"] is False
+    assert template_vars["use_576p_dvhdr"] is False
+    assert template_vars["use_480p_plus"] is False
     assert template_vars["use_dv"] is False
+    assert template_vars["use_plus"] is False
+    assert template_vars["use_dvhdr"] is False
     assert template_vars["use_extended"] is False
     assert template_vars["use_openmatte"] is False
 


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Title: Add resolution overlay variant toggles to Quickstart
This PR expands Quickstart’s overlay_resolution support to cover the upstream Kometa resolution variant toggles that were missing from the schema and getting dropped during YAML generation.
Changes:
Added the supported composite resolution toggles to static/json/quickstart_overlays.json
Included per-resolution variants such as:use_4k_dvhdrplus, use_4k_dvhdr, use_4k_plus, use_4k_dv, use_4k_hlg, use_4k_hdr
use_1080p_dvhdrplus, use_1080p_dvhdr, use_1080p_plus, use_1080p_dv, use_1080p_hlg, use_1080p_hdr
equivalent 720p, 576p, and 480p variants

Added global resolution toggles use_plus and use_dvhdr
Updated modules/output.py so resolution overlays preserve the full supported variant matrix instead of trimming them out with the old fixed allowlist
Added test coverage for importer payload generation and final YAML contract output

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
