### PR TITLE
Next vars

### DIFF
--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -441,6 +441,9 @@ def ensure_json_schema():
     """Ensure json-schema files exist and are up-to-date based on hash checks."""
     # branch = get_kometa_branch()
     branch = "nightly"
+    # Temporary override: use Kometa develop for local schema downloads.
+    # Remove the next 3 lines later to return to the shared branch logic.
+    branch = "develop"
 
     previous_hashes = load_previous_hashes()
     new_hashes = {}

--- a/modules/output.py
+++ b/modules/output.py
@@ -2947,9 +2947,13 @@ def build_config(header_style="standard", config_name=None):
     )
     library_names = movie_summary_names + show_summary_names
     library_details = helpers.get_library_summaries(library_names)
+    schema_header = f"# yaml-language-server: $schema=https://raw.githubusercontent.com/Kometa-Team/Kometa/{kometa_branch}/json-schema/config-schema.json"
+    # Temporary override: force VS Code/YAML LS to Kometa develop.
+    # Remove the next 3 lines later to fall back to the existing kometa_branch-based URL.
+    schema_header = "# yaml-language-server: $schema=https://raw.githubusercontent.com/Kometa-Team/Kometa/develop/json-schema/config-schema.json"
 
     yaml_content = (
-        f"# yaml-language-server: $schema=https://raw.githubusercontent.com/Kometa-Team/Kometa/{kometa_branch}/json-schema/config-schema.json\n\n"
+        f"{schema_header}\n\n"
         f"{add_border_to_ascii_art(section_heading('KOMETA', font=header_style)) if header_style not in ['none', 'single line'] else section_heading('KOMETA', font=header_style)}\n\n"
         f"#==================== {config_name} ====================#\n"
         f"# {config_name} config created by Quickstart on {timestamp}\n"

--- a/quickstart.py
+++ b/quickstart.py
@@ -9768,6 +9768,8 @@ def lookup_template_string_value():
     data = request.get_json(silent=True) or {}
     preset = str(data.get("preset") or "").strip()
     value = str(data.get("value") or "").strip()
+    library_name = str(data.get("library_name") or "").strip()
+    media_type = str(data.get("media_type") or "").strip()
 
     if not preset or not value:
         return jsonify({"error": "Lookup preset and value are required."}), 400
@@ -9799,6 +9801,26 @@ def lookup_template_string_value():
             return jsonify({"valid": False, "verified": False, "message": "TMDb lookup could not be verified with the configured API key."})
 
         return jsonify({"valid": False, "verified": False, "message": f"TMDb lookup failed with status {response.status_code}."})
+
+    if preset == "imdb_id_plex":
+        if not library_name:
+            return jsonify({"valid": False, "verified": False, "message": "Active Plex library is required for IMDb lookup."})
+        try:
+            result = helpers.find_item_by_imdb_id(library_name, value, media_type)
+        except Exception as exc:
+            return jsonify({"valid": False, "verified": False, "message": f"Plex lookup failed: {exc}."})
+
+        if result and result.get("title"):
+            title = str(result.get("title")).strip()
+            return jsonify({"valid": True, "verified": True, "label": title, "message": f"Plex: {title}"})
+
+        return jsonify(
+            {
+                "valid": False,
+                "verified": False,
+                "message": "IMDb ID format is valid, but no matching item was found in the active Plex library.",
+            }
+        )
 
     return jsonify({"error": f"Unsupported lookup preset: {preset}"}), 400
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -4231,6 +4231,21 @@ div#loading {
     flex: 0 0 170px;
 }
 
+.qs-template-variable-label {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    line-height: 1.2;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 0.35rem;
+    flex-wrap: wrap;
+}
+
+.qs-template-variable-label a {
+    white-space: normal;
+}
+
 .font-row .font-input-group {
     flex: 1 1 auto;
     min-width: 0;

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -17755,7 +17755,7 @@
             "label": "Collection Order",
             "type": "select",
             "tooltip": "Changes the Collection Order for all collections in a Defaults File.<br><br> Default is <b>Custom (sorted in a custom order)</b> ",
-            "default": "custom",
+            "default": "release",
             "options": [
               {
                 "value": "custom",
@@ -18204,7 +18204,7 @@
             "label": "Collection Order",
             "type": "select",
             "tooltip": "Changes the Collection Order for all collections in a Defaults File.<br><br> Default is <b>Custom (sorted in a custom order)</b> ",
-            "default": "custom",
+            "default": "release",
             "options": [
               {
                 "value": "custom",

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -9429,7 +9429,7 @@
           },
           {
             "key": "limit_episodes",
-            "label": "Limit",
+            "label": "New Episodes Limit",
             "tooltip": "Changes the Builder Limit of the New Episodes collection.",
             "type": "text_input",
             "default": "limit",
@@ -9460,7 +9460,7 @@
           },
           {
             "key": "limit_released",
-            "label": "Limit",
+            "label": "Newly Released Limit",
             "tooltip": "Changes the Builder Limit of the Newly Released collection.",
             "type": "text_input",
             "default": "limit",
@@ -14301,7 +14301,7 @@
           },
           {
             "key": "limit_1001_movies",
-            "label": "Limit",
+            "label": "1,001 To See Before You Die Limit",
             "tooltip": "Changes the Builder Limit of the 1,001 To See Before You Die collection.",
             "type": "text_input",
             "default": "limit",
@@ -14328,7 +14328,7 @@
           },
           {
             "key": "limit_afi_100",
-            "label": "Limit",
+            "label": "AFI 100 Years 100 Movies Limit",
             "tooltip": "Changes the Builder Limit of the AFI 100 Years 100 Movies collection.",
             "type": "text_input",
             "default": "limit",
@@ -14355,7 +14355,7 @@
           },
           {
             "key": "limit_boxofficemojo_100",
-            "label": "Limit",
+            "label": "Box Office Mojo All Time 100 Limit",
             "tooltip": "Changes the Builder Limit of the Box Office Mojo All Time 100 collection.",
             "type": "text_input",
             "default": "limit",
@@ -14382,7 +14382,7 @@
           },
           {
             "key": "limit_cannes",
-            "label": "Limit",
+            "label": "Cannes Palme d'Or Winners Limit",
             "tooltip": "Changes the Builder Limit of the Cannes Palme d'Or Winners collection.",
             "type": "text_input",
             "default": "limit",
@@ -14409,7 +14409,7 @@
           },
           {
             "key": "limit_edgarwright",
-            "label": "Limit",
+            "label": "Edgar Wright's 1,000 Favorites Limit",
             "tooltip": "Changes the Builder Limit of the Edgar Wright's 1,000 Favorites collection.",
             "type": "text_input",
             "default": "limit",
@@ -14436,7 +14436,7 @@
           },
           {
             "key": "limit_imdb_top_250",
-            "label": "Limit",
+            "label": "IMDb Top 250 (Letterboxd) Limit",
             "tooltip": "Changes the Builder Limit of the IMDb Top 250 (Letterboxd) collection.",
             "type": "text_input",
             "default": "limit",
@@ -14463,7 +14463,7 @@
           },
           {
             "key": "limit_top_500",
-            "label": "Limit",
+            "label": "Letterboxd Top 500 Limit",
             "tooltip": "Changes the Builder Limit of the Letterboxd Top 500 collection.",
             "type": "text_input",
             "default": "limit",
@@ -14490,7 +14490,7 @@
           },
           {
             "key": "limit_international",
-            "label": "Limit",
+            "label": "Top 250 International Limit",
             "tooltip": "Changes the Builder Limit of the Top 250 International collection.",
             "type": "text_input",
             "default": "limit",
@@ -14517,7 +14517,7 @@
           },
           {
             "key": "limit_science",
-            "label": "Limit",
+            "label": "Top 250 Sci-Fi Films Limit",
             "tooltip": "Changes the Builder Limit of the Top 250 Sci-Fi Films collection.",
             "type": "text_input",
             "default": "limit",
@@ -14544,7 +14544,7 @@
           },
           {
             "key": "limit_western",
-            "label": "Limit",
+            "label": "Top 100 Western Films Limit",
             "tooltip": "Changes the Builder Limit of the Top 100 Western Films collection.",
             "type": "text_input",
             "default": "limit",
@@ -14571,7 +14571,7 @@
           },
           {
             "key": "limit_silent",
-            "label": "Limit",
+            "label": "Top 100 Silent Films Limit",
             "tooltip": "Changes the Builder Limit of the Top 100 Silent Films collection.",
             "type": "text_input",
             "default": "limit",
@@ -14598,7 +14598,7 @@
           },
           {
             "key": "limit_million",
-            "label": "Limit",
+            "label": "One Million Watched Club Limit",
             "tooltip": "Changes the Builder Limit of the One Million Watched Club collection.",
             "type": "text_input",
             "default": "limit",
@@ -14625,7 +14625,7 @@
           },
           {
             "key": "limit_oscars",
-            "label": "Limit",
+            "label": "Oscar Best Picture Winners Limit",
             "tooltip": "Changes the Builder Limit of the Oscar Best Picture Winners collection.",
             "type": "text_input",
             "default": "limit",
@@ -14652,7 +14652,7 @@
           },
           {
             "key": "limit_rogerebert",
-            "label": "Limit",
+            "label": "Roger Ebert's Great Movies Limit",
             "tooltip": "Changes the Builder Limit of the Roger Ebert's Great Movies collection.",
             "type": "text_input",
             "default": "limit",
@@ -14679,7 +14679,7 @@
           },
           {
             "key": "limit_sight_sound",
-            "label": "Limit",
+            "label": "Sight & Sound Greatest Films Limit",
             "tooltip": "Changes the Builder Limit of the Sight & Sound Greatest Films collection.",
             "type": "text_input",
             "default": "limit",
@@ -14706,7 +14706,7 @@
           },
           {
             "key": "limit_animation",
-            "label": "Limit",
+            "label": "Top 100 Animation Limit",
             "tooltip": "Changes the Builder Limit of the Top 100 Animation collection.",
             "type": "text_input",
             "default": "limit",
@@ -14733,7 +14733,7 @@
           },
           {
             "key": "limit_black_directors",
-            "label": "Limit",
+            "label": "Top 250 Black-Directed Limit",
             "tooltip": "Changes the Builder Limit of the Top 250 Black-Directed collection.",
             "type": "text_input",
             "default": "limit",
@@ -14760,7 +14760,7 @@
           },
           {
             "key": "limit_documentaries",
-            "label": "Limit",
+            "label": "Top 250 Documentaries Limit",
             "tooltip": "Changes the Builder Limit of the Top 250 Documentaries collection.",
             "type": "text_input",
             "default": "limit",
@@ -14787,7 +14787,7 @@
           },
           {
             "key": "limit_horror",
-            "label": "Limit",
+            "label": "Top 250 Horror Limit",
             "tooltip": "Changes the Builder Limit of the Top 250 Horror collection.",
             "type": "text_input",
             "default": "limit",
@@ -14814,7 +14814,7 @@
           },
           {
             "key": "limit_most_fans",
-            "label": "Limit",
+            "label": "Top 250 Most Fans Limit",
             "tooltip": "Changes the Builder Limit of the Top 250 Most Fans collection.",
             "type": "text_input",
             "default": "limit",
@@ -14841,7 +14841,7 @@
           },
           {
             "key": "limit_women_directors",
-            "label": "Limit",
+            "label": "Top 250 Women-Directed Limit",
             "tooltip": "Changes the Builder Limit of the Top 250 Women-Directed collection.",
             "type": "text_input",
             "default": "limit",

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -189,6 +189,16 @@
             ]
           },
           {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -817,6 +827,16 @@
             ]
           },
           {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -1413,6 +1433,16 @@
                 "label": "Sync"
               }
             ]
+          },
+          {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
           },
           {
             "key": "collection_mode",
@@ -2013,6 +2043,16 @@
             ]
           },
           {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -2609,6 +2649,16 @@
                 "label": "Sync"
               }
             ]
+          },
+          {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
           },
           {
             "key": "collection_mode",
@@ -3220,6 +3270,16 @@
             ]
           },
           {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -3809,6 +3869,16 @@
                 "label": "Sync"
               }
             ]
+          },
+          {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
           },
           {
             "key": "collection_mode",
@@ -4429,6 +4499,16 @@
             ]
           },
           {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -5030,6 +5110,16 @@
             ]
           },
           {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -5626,6 +5716,16 @@
                 "label": "Sync"
               }
             ]
+          },
+          {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
           },
           {
             "key": "collection_mode",
@@ -6237,6 +6337,16 @@
             ]
           },
           {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -6815,6 +6925,16 @@
                 "label": "Sync"
               }
             ]
+          },
+          {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
           },
           {
             "key": "collection_mode",
@@ -7415,6 +7535,16 @@
             ]
           },
           {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -8011,6 +8141,16 @@
                 "label": "Sync"
               }
             ]
+          },
+          {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
           },
           {
             "key": "collection_mode",
@@ -8611,6 +8751,16 @@
             ]
           },
           {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -9199,6 +9349,16 @@
                 "label": "Sync"
               }
             ]
+          },
+          {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
           },
           {
             "key": "collection_mode",
@@ -10328,6 +10488,16 @@
             ]
           },
           {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 0,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -10910,6 +11080,16 @@
                 "label": "Sync"
               }
             ]
+          },
+          {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
           },
           {
             "key": "collection_mode",
@@ -11612,6 +11792,16 @@
                 "label": "Sync"
               }
             ]
+          },
+          {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
           },
           {
             "key": "collection_mode",
@@ -12360,6 +12550,16 @@
             ]
           },
           {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -13067,6 +13267,16 @@
             ]
           },
           {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -13424,6 +13634,16 @@
                 "label": "Sync"
               }
             ]
+          },
+          {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
           },
           {
             "key": "collection_mode",
@@ -14147,6 +14367,16 @@
                 "label": "Sync"
               }
             ]
+          },
+          {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
           },
           {
             "key": "collection_mode",
@@ -15277,6 +15507,16 @@
                 "label": "Sync"
               }
             ]
+          },
+          {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
           },
           {
             "key": "collection_mode",
@@ -16470,6 +16710,16 @@
             ]
           },
           {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -17445,6 +17695,16 @@
             ]
           },
           {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -17882,6 +18142,16 @@
                 "label": "Sync"
               }
             ]
+          },
+          {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
           },
           {
             "key": "collection_mode",
@@ -18748,6 +19018,16 @@
                 "label": "Sync"
               }
             ]
+          },
+          {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
           },
           {
             "key": "collection_mode",
@@ -31934,6 +32214,16 @@
             ]
           },
           {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -34268,6 +34558,16 @@
                 "label": "Sync"
               }
             ]
+          },
+          {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1
           },
           {
             "key": "collection_mode",

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -172,6 +172,23 @@
             ]
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -810,6 +827,23 @@
             ]
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -1416,6 +1450,23 @@
             "media_types": [
               "movie"
             ]
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "sync_mode",
@@ -2026,6 +2077,23 @@
             ]
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -2632,6 +2700,23 @@
             "media_types": [
               "movie"
             ]
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "sync_mode",
@@ -3253,6 +3338,23 @@
             ]
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -3852,6 +3954,23 @@
             "media_types": [
               "show"
             ]
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "sync_mode",
@@ -4482,6 +4601,23 @@
             ]
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -5093,6 +5229,23 @@
             ]
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -5699,6 +5852,23 @@
             "media_types": [
               "movie"
             ]
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "sync_mode",
@@ -6320,6 +6490,23 @@
             ]
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -6908,6 +7095,23 @@
             "media_types": [
               "movie"
             ]
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "sync_mode",
@@ -7518,6 +7722,23 @@
             ]
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -8124,6 +8345,23 @@
             "media_types": [
               "movie"
             ]
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "sync_mode",
@@ -8734,6 +8972,23 @@
             ]
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -9334,6 +9589,23 @@
             ]
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -9932,6 +10204,23 @@
             ]
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -10469,6 +10758,23 @@
               "color",
               "white"
             ]
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "sync_mode",
@@ -11063,6 +11369,23 @@
               "color",
               "white"
             ]
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "sync_mode",
@@ -11775,6 +12098,23 @@
               "color",
               "white"
             ]
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "sync_mode",
@@ -12533,6 +12873,23 @@
             ]
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -13250,6 +13607,23 @@
             ]
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -13617,6 +13991,23 @@
               "color",
               "white"
             ]
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "sync_mode",
@@ -14350,6 +14741,23 @@
             "media_types": [
               "show"
             ]
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "sync_mode",
@@ -15490,6 +15898,23 @@
               "color",
               "white"
             ]
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "sync_mode",
@@ -16693,6 +17118,23 @@
             ]
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -17266,6 +17708,23 @@
             "placeholder": "Add genre name (e.g. Politics)"
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -17676,6 +18135,16 @@
             "validation_preset": "tmdb_collection_id",
             "tooltip": "Exclude specific TMDb collections from these collections.",
             "placeholder": "Add TMDb collection ID (e.g. 131292)"
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br> Default is <b>2</b>. Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "default": 2
           },
           {
             "key": "sync_mode",
@@ -18125,6 +18594,16 @@
             "type": "text_input",
             "tooltip": "Optional override for where this default group appears in the Plex Collections page. Leave blank to keep the Kometa default order.",
             "placeholder": "Leave blank or enter a value like 040"
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br> Default is <b>2</b>. Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "default": 2
           },
           {
             "key": "sync_mode",
@@ -19001,6 +19480,24 @@
             "media_types": [
               "show"
             ]
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br> Default is <b>2</b>. Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "default": 2
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "sync_mode",
@@ -19896,6 +20393,23 @@
             "media_types": [
               "show"
             ]
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "collection_mode",
@@ -20812,6 +21326,23 @@
             "placeholder": "Add content rating (e.g. PG-13)"
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -21272,6 +21803,23 @@
             "type": "string_list",
             "tooltip": "Exclude specific content ratings from these collections.",
             "placeholder": "Add content rating (e.g. TV-14)"
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "collection_mode",
@@ -21737,6 +22285,23 @@
             "placeholder": "Add content rating (e.g. 15)"
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -22198,6 +22763,23 @@
             "type": "string_list",
             "tooltip": "Exclude specific content ratings from these collections.",
             "placeholder": "Add content rating (e.g. 12)"
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "collection_mode",
@@ -22663,6 +23245,23 @@
             "placeholder": "Add content rating (e.g. M)"
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -23124,6 +23723,23 @@
             "type": "string_list",
             "tooltip": "Exclude specific content ratings from these collections.",
             "placeholder": "Add content rating (e.g. PG)"
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "collection_mode",
@@ -23589,6 +24205,23 @@
             "placeholder": "Add content rating (e.g. PG-13)"
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -24050,6 +24683,23 @@
             "type": "string_list",
             "tooltip": "Exclude specific content ratings from these collections.",
             "placeholder": "Add content rating (e.g. 13)"
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "collection_mode",
@@ -24529,6 +25179,23 @@
             "type": "string_list",
             "tooltip": "Exclude specific countries from these collections.",
             "placeholder": "Add country name (e.g. France)"
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "sync_mode",
@@ -25019,6 +25686,23 @@
             "type": "string_list",
             "tooltip": "Exclude specific countries from these collections.",
             "placeholder": "Add country name (e.g. France)"
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "sync_mode",
@@ -25878,6 +26562,23 @@
             "type": "string_list",
             "tooltip": "Exclude specific regions from these collections.",
             "placeholder": "Add region name (e.g. Melanesia)"
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "sync_mode",
@@ -26950,6 +27651,23 @@
             "placeholder": "Add continent name (e.g. Europe)"
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -27674,6 +28392,23 @@
             "placeholder": "Add aspect ratio key (e.g. 1.65)"
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -28312,6 +29047,23 @@
             "mutually_exclusive_with": "include"
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -28761,6 +29513,23 @@
             "tooltip": "Exclude specific audio languages from these collections. Kometa code allows this with Include, but the wiki says not to combine them.",
             "placeholder": "Add language code (e.g. fr)",
             "mutually_exclusive_with": "include"
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "collection_mode",
@@ -29233,6 +30002,23 @@
             "tooltip": "Exclude specific subtitle languages from these collections. Kometa code allows this with Include, but the wiki says not to combine them.",
             "placeholder": "Add language code (e.g. fr)",
             "mutually_exclusive_with": "include"
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "collection_mode",
@@ -29749,6 +30535,23 @@
             "mutually_exclusive_with": "include"
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -30233,6 +31036,23 @@
             "tooltip": "Exclude specific people from these collections. Kometa code allows this with Include, but the wiki says not to combine them.",
             "placeholder": "Add person name (e.g. Jeremy Kleiner)",
             "mutually_exclusive_with": "include"
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "collection_mode",
@@ -30730,6 +31550,23 @@
             "mutually_exclusive_with": "include"
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -31223,6 +32060,23 @@
             "tooltip": "Exclude specific people from these collections. Kometa code allows this with Include, but the wiki says not to combine them.",
             "placeholder": "Add person name (e.g. Jeremy Kleiner)",
             "mutually_exclusive_with": "include"
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "collection_mode",
@@ -32197,6 +33051,23 @@
             "placeholder": "Add service key (e.g. netflix)"
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -33028,6 +33899,23 @@
             "mutually_exclusive_with": "include"
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -33464,6 +34352,23 @@
             "tooltip": "Exclude specific networks from these collections. Kometa code allows this with Include, but the wiki says not to combine them.",
             "placeholder": "Add network name (e.g. HBO)",
             "mutually_exclusive_with": "include"
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "collection_mode",
@@ -34541,6 +35446,23 @@
             "type": "string_list",
             "tooltip": "Exclude specific seasonal collections from these collections.",
             "placeholder": "Add seasonal key (e.g. halloween)"
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "sync_mode",
@@ -35642,6 +36564,23 @@
             "placeholder": "Add year (e.g. 2022)"
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -36068,6 +37007,23 @@
             "placeholder": "Add decade key (e.g. 2020)"
           },
           {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -36492,6 +37448,23 @@
             "type": "string_list",
             "tooltip": "Exclude specific decades from these collections.",
             "placeholder": "Add decade key (e.g. 2020)"
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex"
           },
           {
             "key": "collection_mode",

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -9410,8 +9410,11 @@
             "key": "limit",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit for all collections in this Defaults File.",
-            "type": "number",
-            "default": 100
+            "type": "text_input",
+            "default": 100,
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_episodes",
@@ -9428,11 +9431,14 @@
             "key": "limit_episodes",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit of the New Episodes collection.",
-            "type": "number",
+            "type": "text_input",
             "default": "limit",
             "media_types": [
               "show"
-            ]
+            ],
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "sonarr_add_missing_episodes",
@@ -9456,8 +9462,11 @@
             "key": "limit_released",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit of the Newly Released collection.",
-            "type": "number",
-            "default": "limit"
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_released",
@@ -9951,14 +9960,20 @@
             "label": "List Days",
             "type": "text_input",
             "default": "30",
-            "tooltip": "Changes the list_days attribute of the Builder for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the list_days attribute of the Builder for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "list_size",
             "label": "List Size",
             "type": "text_input",
             "default": "20",
-            "tooltip": "Changes the list_size attribute of the Builder for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the list_size attribute of the Builder for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_popular",
@@ -9972,13 +9987,19 @@
             "key": "list_days_popular",
             "label": "Plex Popular List Days",
             "type": "text_input",
-            "tooltip": "Changes the list_days attribute of the Plex Popular collection. Valid values are numbers greater than 0. Leave blank to inherit the family List Days value."
+            "tooltip": "Changes the list_days attribute of the Plex Popular collection. Valid values are numbers greater than 0. Leave blank to inherit the family List Days value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "list_size_popular",
             "label": "Plex Popular List Size",
             "type": "text_input",
-            "tooltip": "Changes the list_size attribute of the Plex Popular collection. Valid values are numbers greater than 0. Leave blank to inherit the family List Size value."
+            "tooltip": "Changes the list_size attribute of the Plex Popular collection. Valid values are numbers greater than 0. Leave blank to inherit the family List Size value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_watched",
@@ -9992,13 +10013,19 @@
             "key": "list_days_watched",
             "label": "Plex Watched List Days",
             "type": "text_input",
-            "tooltip": "Changes the list_days attribute of the Plex Watched collection. Valid values are numbers greater than 0. Leave blank to inherit the family List Days value."
+            "tooltip": "Changes the list_days attribute of the Plex Watched collection. Valid values are numbers greater than 0. Leave blank to inherit the family List Days value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "list_size_watched",
             "label": "Plex Watched List Size",
             "type": "text_input",
-            "tooltip": "Changes the list_size attribute of the Plex Watched collection. Valid values are numbers greater than 0. Leave blank to inherit the family List Size value."
+            "tooltip": "Changes the list_size attribute of the Plex Watched collection. Valid values are numbers greater than 0. Leave blank to inherit the family List Size value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "style",
@@ -10478,7 +10505,10 @@
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_top",
@@ -11064,7 +11094,10 @@
             "label": "Limit",
             "type": "text_input",
             "default": "100",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_airing",
@@ -11077,7 +11110,10 @@
             "key": "limit_airing",
             "label": "TMDb Airing Today Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the TMDb Airing Today collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the TMDb Airing Today collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_airing",
@@ -11110,7 +11146,10 @@
             "key": "limit_air",
             "label": "TMDb On The Air Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the TMDb On The Air collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the TMDb On The Air collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_air",
@@ -11143,7 +11182,10 @@
             "key": "limit_popular",
             "label": "TMDb Popular Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the TMDb Popular collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the TMDb Popular collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_popular",
@@ -11176,7 +11218,10 @@
             "key": "limit_top",
             "label": "TMDb Top Rated Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the TMDb Top Rated collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the TMDb Top Rated collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_top",
@@ -11209,7 +11254,10 @@
             "key": "limit_trending",
             "label": "TMDb Trending Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the TMDb Trending collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the TMDb Trending collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_trending",
@@ -11775,7 +11823,10 @@
             "label": "Limit",
             "type": "text_input",
             "default": "100",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_collected",
@@ -11788,7 +11839,10 @@
             "key": "limit_collected",
             "label": "Trakt Collected Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Trakt Collected collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Trakt Collected collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_collected",
@@ -11821,7 +11875,10 @@
             "key": "limit_popular",
             "label": "Trakt Popular Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Trakt Popular collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Trakt Popular collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_popular",
@@ -11854,7 +11911,10 @@
             "key": "limit_recommended",
             "label": "Trakt Recommended Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Trakt Recommended collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Trakt Recommended collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_recommended",
@@ -11887,7 +11947,10 @@
             "key": "limit_trending",
             "label": "Trakt Trending Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Trakt Trending collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Trakt Trending collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_trending",
@@ -11920,7 +11983,10 @@
             "key": "limit_watched",
             "label": "Trakt Watched Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Trakt Watched collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Trakt Watched collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_watched",
@@ -12483,7 +12549,10 @@
             "label": "Limit",
             "type": "text_input",
             "default": "100",
-            "tooltip": "Maximum number of items to return per Simkl list. Valid range is 1 to 500."
+            "tooltip": "Maximum number of items to return per Simkl list. Valid range is 1 to 500.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_trending_today",
@@ -12496,7 +12565,10 @@
             "key": "limit_trending_today",
             "label": "Simkl Trending Today Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Simkl Trending Today collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Simkl Trending Today collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_trending_today",
@@ -12529,7 +12601,10 @@
             "key": "limit_trending_week",
             "label": "Simkl Trending This Week Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Simkl Trending This Week collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Simkl Trending This Week collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_trending_week",
@@ -12562,7 +12637,10 @@
             "key": "limit_trending_month",
             "label": "Simkl Trending This Month Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Simkl Trending This Month collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Simkl Trending This Month collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_trending_month",
@@ -12595,7 +12673,10 @@
             "key": "limit_dvd",
             "label": "Simkl DVD Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Simkl DVD collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Simkl DVD collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_dvd",
@@ -12810,7 +12891,10 @@
             "label": "Limit",
             "type": "text_input",
             "default": "100",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_popular",
@@ -12823,7 +12907,10 @@
             "key": "limit_popular",
             "label": "AniList Popular Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the AniList Popular collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the AniList Popular collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_popular",
@@ -12856,7 +12943,10 @@
             "key": "limit_season",
             "label": "AniList Season Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the AniList Season collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the AniList Season collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_season",
@@ -12889,7 +12979,10 @@
             "key": "limit_top",
             "label": "AniList Top Rated Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the AniList Top Rated collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the AniList Top Rated collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_top",
@@ -12922,7 +13015,10 @@
             "key": "limit_trending",
             "label": "AniList Trending Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the AniList Trending collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the AniList Trending collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_trending",
@@ -13465,7 +13561,10 @@
             "label": "Limit",
             "type": "text_input",
             "default": "100",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "style",
@@ -13489,7 +13588,10 @@
             "key": "limit_favorited",
             "label": "MyAnimeList Favorited Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the MyAnimeList Favorited collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the MyAnimeList Favorited collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_favorited",
@@ -13522,7 +13624,10 @@
             "key": "limit_popular",
             "label": "MyAnimeList Popular Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the MyAnimeList Popular collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the MyAnimeList Popular collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_popular",
@@ -13555,7 +13660,10 @@
             "key": "limit_season",
             "label": "MyAnimeList Season Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the MyAnimeList Season collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the MyAnimeList Season collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_season",
@@ -13588,7 +13696,10 @@
             "key": "limit_airing",
             "label": "MyAnimeList Top Airing Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the MyAnimeList Top Airing collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the MyAnimeList Top Airing collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_airing",
@@ -13621,7 +13732,10 @@
             "key": "limit_top",
             "label": "MyAnimeList Top Rated Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the MyAnimeList Top Rated collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the MyAnimeList Top Rated collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_top",
@@ -14172,8 +14286,11 @@
             "key": "limit",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit for all collections in this Defaults File.",
-            "type": "number",
-            "default": 100
+            "type": "text_input",
+            "default": 100,
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_1001_movies",
@@ -14186,8 +14303,11 @@
             "key": "limit_1001_movies",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit of the 1,001 To See Before You Die collection.",
-            "type": "number",
-            "default": "limit"
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_1001_movies",
@@ -14210,8 +14330,11 @@
             "key": "limit_afi_100",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit of the AFI 100 Years 100 Movies collection.",
-            "type": "number",
-            "default": "limit"
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_afi_100",
@@ -14234,8 +14357,11 @@
             "key": "limit_boxofficemojo_100",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit of the Box Office Mojo All Time 100 collection.",
-            "type": "number",
-            "default": "limit"
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_boxofficemojo_100",
@@ -14258,8 +14384,11 @@
             "key": "limit_cannes",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit of the Cannes Palme d'Or Winners collection.",
-            "type": "number",
-            "default": "limit"
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_cannes",
@@ -14282,8 +14411,11 @@
             "key": "limit_edgarwright",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit of the Edgar Wright's 1,000 Favorites collection.",
-            "type": "number",
-            "default": "limit"
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_edgarwright",
@@ -14306,8 +14438,11 @@
             "key": "limit_imdb_top_250",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit of the IMDb Top 250 (Letterboxd) collection.",
-            "type": "number",
-            "default": "limit"
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_imdb_top_250",
@@ -14330,8 +14465,11 @@
             "key": "limit_top_500",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit of the Letterboxd Top 500 collection.",
-            "type": "number",
-            "default": "limit"
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_top_500",
@@ -14354,8 +14492,11 @@
             "key": "limit_international",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit of the Top 250 International collection.",
-            "type": "number",
-            "default": "limit"
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_international",
@@ -14378,8 +14519,11 @@
             "key": "limit_science",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit of the Top 250 Sci-Fi Films collection.",
-            "type": "number",
-            "default": "limit"
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_science",
@@ -14402,8 +14546,11 @@
             "key": "limit_western",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit of the Top 100 Western Films collection.",
-            "type": "number",
-            "default": "limit"
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_western",
@@ -14426,8 +14573,11 @@
             "key": "limit_silent",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit of the Top 100 Silent Films collection.",
-            "type": "number",
-            "default": "limit"
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_silent",
@@ -14450,8 +14600,11 @@
             "key": "limit_million",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit of the One Million Watched Club collection.",
-            "type": "number",
-            "default": "limit"
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_million",
@@ -14474,8 +14627,11 @@
             "key": "limit_oscars",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit of the Oscar Best Picture Winners collection.",
-            "type": "number",
-            "default": "limit"
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_oscars",
@@ -14498,8 +14654,11 @@
             "key": "limit_rogerebert",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit of the Roger Ebert's Great Movies collection.",
-            "type": "number",
-            "default": "limit"
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_rogerebert",
@@ -14522,8 +14681,11 @@
             "key": "limit_sight_sound",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit of the Sight & Sound Greatest Films collection.",
-            "type": "number",
-            "default": "limit"
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_sight_sound",
@@ -14546,8 +14708,11 @@
             "key": "limit_animation",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit of the Top 100 Animation collection.",
-            "type": "number",
-            "default": "limit"
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_animation",
@@ -14570,8 +14735,11 @@
             "key": "limit_black_directors",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit of the Top 250 Black-Directed collection.",
-            "type": "number",
-            "default": "limit"
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_black_directors",
@@ -14594,8 +14762,11 @@
             "key": "limit_documentaries",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit of the Top 250 Documentaries collection.",
-            "type": "number",
-            "default": "limit"
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_documentaries",
@@ -14618,8 +14789,11 @@
             "key": "limit_horror",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit of the Top 250 Horror collection.",
-            "type": "number",
-            "default": "limit"
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_horror",
@@ -14642,8 +14816,11 @@
             "key": "limit_most_fans",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit of the Top 250 Most Fans collection.",
-            "type": "number",
-            "default": "limit"
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_most_fans",
@@ -14666,8 +14843,11 @@
             "key": "limit_women_directors",
             "label": "Limit",
             "tooltip": "Changes the Builder Limit of the Top 250 Women-Directed collection.",
-            "type": "number",
-            "default": "limit"
+            "type": "text_input",
+            "default": "limit",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_women_directors",
@@ -15754,7 +15934,10 @@
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_commonsense",
@@ -16388,7 +16571,10 @@
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_separator",
@@ -17663,7 +17849,10 @@
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_separator",
@@ -18825,7 +19014,10 @@
             "label": "Limit",
             "type": "text_input",
             "default": "200",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_separator",
@@ -19828,7 +20020,10 @@
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_separator",
@@ -19848,7 +20043,10 @@
             "key": "limit_other",
             "label": "Other Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "exclude",
@@ -20284,7 +20482,10 @@
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_separator",
@@ -20304,7 +20505,10 @@
             "key": "limit_other",
             "label": "Other Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "exclude",
@@ -20741,7 +20945,10 @@
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_separator",
@@ -20761,7 +20968,10 @@
             "key": "limit_other",
             "label": "Other Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "exclude",
@@ -21198,7 +21408,10 @@
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_separator",
@@ -21218,7 +21431,10 @@
             "key": "limit_other",
             "label": "Other Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "exclude",
@@ -21655,7 +21871,10 @@
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_separator",
@@ -21675,7 +21894,10 @@
             "key": "limit_other",
             "label": "Other Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "exclude",
@@ -22112,7 +22334,10 @@
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_separator",
@@ -22132,7 +22357,10 @@
             "key": "limit_other",
             "label": "Other Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "exclude",
@@ -22569,7 +22797,10 @@
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_separator",
@@ -22589,7 +22820,10 @@
             "key": "limit_other",
             "label": "Other Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "exclude",
@@ -23026,7 +23260,10 @@
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_separator",
@@ -23046,7 +23283,10 @@
             "key": "limit_other",
             "label": "Other Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "exclude",
@@ -23488,7 +23728,10 @@
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_separator",
@@ -23519,7 +23762,10 @@
             "key": "limit_other",
             "label": "Other Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "exclude",
@@ -23955,7 +24201,10 @@
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_separator",
@@ -23986,7 +24235,10 @@
             "key": "limit_other",
             "label": "Other Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "exclude",
@@ -24423,7 +24675,10 @@
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_separator",
@@ -24454,7 +24709,10 @@
             "key": "limit_Northern Africa",
             "label": "Northern Africa Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Northern Africa collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Northern Africa collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_Eastern Africa",
@@ -24467,7 +24725,10 @@
             "key": "limit_Eastern Africa",
             "label": "Eastern Africa Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Eastern Africa collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Eastern Africa collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_Central Africa",
@@ -24480,7 +24741,10 @@
             "key": "limit_Central Africa",
             "label": "Central Africa Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Central Africa collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Central Africa collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_Southern Africa",
@@ -24493,7 +24757,10 @@
             "key": "limit_Southern Africa",
             "label": "Southern Africa Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Southern Africa collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Southern Africa collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_Western Africa",
@@ -24506,7 +24773,10 @@
             "key": "limit_Western Africa",
             "label": "Western Africa Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Western Africa collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Western Africa collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_Caribbean",
@@ -24519,7 +24789,10 @@
             "key": "limit_Caribbean",
             "label": "Caribbean Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Caribbean collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Caribbean collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_Central America",
@@ -24532,7 +24805,10 @@
             "key": "limit_Central America",
             "label": "Central America Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Central America collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Central America collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_South America",
@@ -24545,7 +24821,10 @@
             "key": "limit_South America",
             "label": "South America Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the South America collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the South America collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_North America",
@@ -24558,7 +24837,10 @@
             "key": "limit_North America",
             "label": "North America Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the North America collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the North America collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_Antarctica",
@@ -24571,7 +24853,10 @@
             "key": "limit_Antarctica",
             "label": "Antarctica Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Antarctica collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Antarctica collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_Central Asia",
@@ -24584,7 +24869,10 @@
             "key": "limit_Central Asia",
             "label": "Central Asia Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Central Asia collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Central Asia collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_Eastern Asia",
@@ -24597,7 +24885,10 @@
             "key": "limit_Eastern Asia",
             "label": "Eastern Asia Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Eastern Asia collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Eastern Asia collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_South-Eastern Asia",
@@ -24610,7 +24901,10 @@
             "key": "limit_South-Eastern Asia",
             "label": "South-Eastern Asia Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the South-Eastern Asia collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the South-Eastern Asia collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_Southern Asia",
@@ -24623,7 +24917,10 @@
             "key": "limit_Southern Asia",
             "label": "Southern Asia Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Southern Asia collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Southern Asia collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_Western Asia",
@@ -24636,7 +24933,10 @@
             "key": "limit_Western Asia",
             "label": "Western Asia Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Western Asia collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Western Asia collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_Eastern Europe",
@@ -24649,7 +24949,10 @@
             "key": "limit_Eastern Europe",
             "label": "Eastern Europe Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Eastern Europe collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Eastern Europe collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_Northern Europe",
@@ -24662,7 +24965,10 @@
             "key": "limit_Northern Europe",
             "label": "Northern Europe Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Northern Europe collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Northern Europe collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_Southern Europe",
@@ -24675,7 +24981,10 @@
             "key": "limit_Southern Europe",
             "label": "Southern Europe Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Southern Europe collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Southern Europe collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_Western Europe",
@@ -24688,7 +24997,10 @@
             "key": "limit_Western Europe",
             "label": "Western Europe Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Western Europe collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Western Europe collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_Australia and New Zealand",
@@ -24701,7 +25013,10 @@
             "key": "limit_Australia and New Zealand",
             "label": "Australia and New Zealand Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Australia and New Zealand collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Australia and New Zealand collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_Melanesia",
@@ -24714,7 +25029,10 @@
             "key": "limit_Melanesia",
             "label": "Melanesia Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Melanesia collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Melanesia collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_Micronesia",
@@ -24727,7 +25045,10 @@
             "key": "limit_Micronesia",
             "label": "Micronesia Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Micronesia collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Micronesia collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_Polynesia",
@@ -24740,7 +25061,10 @@
             "key": "limit_Polynesia",
             "label": "Polynesia Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Polynesia collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Polynesia collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_other",
@@ -24753,7 +25077,10 @@
             "key": "limit_other",
             "label": "Other Regions Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Other Regions collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Other Regions collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "exclude",
@@ -25673,7 +26000,10 @@
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_separator",
@@ -25704,7 +26034,10 @@
             "key": "limit_Africa",
             "label": "Africa Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Africa collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Africa collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_Americas",
@@ -25717,7 +26050,10 @@
             "key": "limit_Americas",
             "label": "Americas Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Americas collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Americas collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_Antarctica",
@@ -25730,7 +26066,10 @@
             "key": "limit_Antarctica",
             "label": "Antarctica Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Antarctica collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Antarctica collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_Asia",
@@ -25743,7 +26082,10 @@
             "key": "limit_Asia",
             "label": "Asia Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Asia collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Asia collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_Europe",
@@ -25756,7 +26098,10 @@
             "key": "limit_Europe",
             "label": "Europe Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Europe collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Europe collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_Oceania",
@@ -25769,7 +26114,10 @@
             "key": "limit_Oceania",
             "label": "Oceania Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Oceania collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Oceania collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_other",
@@ -25782,7 +26130,10 @@
             "key": "limit_other",
             "label": "Other Continents Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Other Continents collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Other Continents collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "exclude",
@@ -26351,7 +26702,10 @@
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_separator",
@@ -26371,7 +26725,10 @@
             "key": "limit_1.33",
             "label": "1.33 - Academy Aperture Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the 1.33 - Academy Aperture collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the 1.33 - Academy Aperture collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_1.65",
@@ -26384,7 +26741,10 @@
             "key": "limit_1.65",
             "label": "1.65 - Early Widescreen Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the 1.65 - Early Widescreen collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the 1.65 - Early Widescreen collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_1.66",
@@ -26397,7 +26757,10 @@
             "key": "limit_1.66",
             "label": "1.66 - European Widescreen Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the 1.66 - European Widescreen collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the 1.66 - European Widescreen collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_1.78",
@@ -26410,7 +26773,10 @@
             "key": "limit_1.78",
             "label": "1.78 - Widescreen TV Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the 1.78 - Widescreen TV collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the 1.78 - Widescreen TV collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_1.85",
@@ -26423,7 +26789,10 @@
             "key": "limit_1.85",
             "label": "1.85 - American Widescreen Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the 1.85 - American Widescreen collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the 1.85 - American Widescreen collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_2.2",
@@ -26436,7 +26805,10 @@
             "key": "limit_2.2",
             "label": "2.2 - 70mm Frame Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the 2.2 - 70mm Frame collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the 2.2 - 70mm Frame collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_2.35",
@@ -26449,7 +26821,10 @@
             "key": "limit_2.35",
             "label": "2.35 - Anamorphic Projection Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the 2.35 - Anamorphic Projection collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the 2.35 - Anamorphic Projection collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_2.77",
@@ -26462,7 +26837,10 @@
             "key": "limit_2.77",
             "label": "2.77 - Cinerama Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the 2.77 - Cinerama collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the 2.77 - Cinerama collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "exclude",
@@ -27046,7 +27424,10 @@
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_separator",
@@ -27496,7 +27877,10 @@
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_separator",
@@ -27516,7 +27900,10 @@
             "key": "limit_other",
             "label": "Other Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "include",
@@ -27962,7 +28349,10 @@
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_separator",
@@ -27982,7 +28372,10 @@
             "key": "limit_other",
             "label": "Other Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Other collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "include",
@@ -30415,14 +30808,20 @@
             "label": "Limit",
             "type": "text_input",
             "default": "500",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "discover_limit",
             "label": "Discover Limit",
             "type": "text_input",
             "default": "0",
-            "tooltip": "Changes the TMDb Discover limit used for the streaming availability builder. Use 0 to keep the defaults file behavior."
+            "tooltip": "Changes the TMDb Discover limit used for the streaming availability builder. Use 0 to keep the defaults file behavior.",
+            "input_type": "number",
+            "min": 0,
+            "step": 1
           },
           {
             "key": "use_separator",
@@ -32610,7 +33009,10 @@
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_separator",
@@ -32630,7 +33032,10 @@
             "key": "limit_aapi",
             "label": "Asian American Pacific Islander Movies Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Asian American Pacific Islander Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Asian American Pacific Islander Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_aapi",
@@ -32661,7 +33066,10 @@
             "key": "limit_black_history",
             "label": "Black History Month Movies Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Black History Month Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Black History Month Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_black_history",
@@ -32692,7 +33100,10 @@
             "key": "limit_christmas",
             "label": "Christmas Movies Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Christmas Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Christmas Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_christmas",
@@ -32723,7 +33134,10 @@
             "key": "limit_disabilities",
             "label": "Disability Month Movies Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Disability Month Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Disability Month Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_disabilities",
@@ -32754,7 +33168,10 @@
             "key": "limit_easter",
             "label": "Easter Movies Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Easter Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Easter Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_easter",
@@ -32785,7 +33202,10 @@
             "key": "limit_father",
             "label": "Father's Day Movies Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Father's Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Father's Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_father",
@@ -32816,7 +33236,10 @@
             "key": "limit_halloween",
             "label": "Halloween Movies Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Halloween Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Halloween Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_halloween",
@@ -32847,7 +33270,10 @@
             "key": "limit_independence",
             "label": "Independence Day Movies Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Independence Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Independence Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_independence",
@@ -32878,7 +33304,10 @@
             "key": "limit_labor",
             "label": "Labor Day Movies Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Labor Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Labor Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_labor",
@@ -32909,7 +33338,10 @@
             "key": "limit_lgbtq",
             "label": "LGBTQ Month Movies Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the LGBTQ Month Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the LGBTQ Month Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_lgbtq",
@@ -32940,7 +33372,10 @@
             "key": "limit_memorial",
             "label": "Memorial Day Movies Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Memorial Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Memorial Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_memorial",
@@ -32971,7 +33406,10 @@
             "key": "limit_mother",
             "label": "Mother's Day Movies Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Mother's Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Mother's Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_mother",
@@ -33002,7 +33440,10 @@
             "key": "limit_latinx",
             "label": "National Hispanic Heritage Movies Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the National Hispanic Heritage Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the National Hispanic Heritage Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_latinx",
@@ -33033,7 +33474,10 @@
             "key": "limit_years",
             "label": "New Year's Day Movies Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the New Year's Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the New Year's Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_years",
@@ -33064,7 +33508,10 @@
             "key": "limit_patrick",
             "label": "St. Patrick's Day Movies Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the St. Patrick's Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the St. Patrick's Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_patrick",
@@ -33095,7 +33542,10 @@
             "key": "limit_thanksgiving",
             "label": "Thanksgiving Movies Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Thanksgiving Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Thanksgiving Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_thanksgiving",
@@ -33126,7 +33576,10 @@
             "key": "limit_valentine",
             "label": "Valentine's Day Movies Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Valentine's Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Valentine's Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_valentine",
@@ -33157,7 +33610,10 @@
             "key": "limit_veteran",
             "label": "Veteran's Day Movies Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Veteran's Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Veteran's Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_veteran",
@@ -33188,7 +33644,10 @@
             "key": "limit_women",
             "label": "Women's History Month Movies Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Women's History Month Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value."
+            "tooltip": "Changes the Builder Limit of the Women's History Month Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "radarr_add_missing_women",
@@ -34202,7 +34661,10 @@
             "label": "Limit",
             "type": "text_input",
             "default": "10",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_separator",
@@ -34691,7 +35153,10 @@
             "label": "Limit",
             "type": "text_input",
             "default": "100",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_separator",
@@ -35114,7 +35579,10 @@
             "label": "Limit",
             "type": "text_input",
             "default": "100",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0."
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1
           },
           {
             "key": "use_separator",

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -172,6 +172,23 @@
             ]
           },
           {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -783,6 +800,23 @@
             ]
           },
           {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -1361,6 +1395,23 @@
             "type": "toggle",
             "media_types": [
               "movie"
+            ]
+          },
+          {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
             ]
           },
           {
@@ -1945,6 +1996,23 @@
             ]
           },
           {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -2388,7 +2456,7 @@
       },
       {
         "id": "collection_cesar",
-        "label": "César Awards",
+        "label": "C\u00e9sar Awards",
         "url": "https://kometa.wiki/en/nightly/defaults/award/cesar",
         "image_url": "https://kometa.wiki/en/nightly/assets/images/defaults/posters/cesar.png",
         "media_types": [
@@ -2510,8 +2578,8 @@
           },
           {
             "key": "use_best",
-            "label": "César Best Film Winners",
-            "tooltip": "Collection of César Award Winners.",
+            "label": "C\u00e9sar Best Film Winners",
+            "tooltip": "Collection of C\u00e9sar Award Winners.",
             "type": "toggle",
             "default": true
           },
@@ -2523,6 +2591,23 @@
             "type": "toggle",
             "media_types": [
               "movie"
+            ]
+          },
+          {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
             ]
           },
           {
@@ -2582,9 +2667,9 @@
           },
           {
             "key": "visible_home_best",
-            "label": "César Best Film Winners Visible Home",
+            "label": "C\u00e9sar Best Film Winners Visible Home",
             "type": "toggle",
-            "tooltip": "Changes the César Best Film Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "tooltip": "Changes the C\u00e9sar Best Film Winners collection visible on Home Tab (Only works with Plex Pass)",
             "default": false,
             "media_types": [
               "movie"
@@ -2592,9 +2677,9 @@
           },
           {
             "key": "visible_library_best",
-            "label": "César Best Film Winners Visible Library",
+            "label": "C\u00e9sar Best Film Winners Visible Library",
             "type": "toggle",
-            "tooltip": "Changes the César Best Film Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "tooltip": "Changes the C\u00e9sar Best Film Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
             "default": false,
             "media_types": [
               "movie"
@@ -2602,9 +2687,9 @@
           },
           {
             "key": "visible_shared_best",
-            "label": "César Best Film Winners Visible Shared",
+            "label": "C\u00e9sar Best Film Winners Visible Shared",
             "type": "toggle",
-            "tooltip": "Changes the César Best Film Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "tooltip": "Changes the C\u00e9sar Best Film Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
             "media_types": [
               "movie"
@@ -3115,6 +3200,23 @@
             "type": "toggle",
             "media_types": [
               "show"
+            ]
+          },
+          {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
             ]
           },
           {
@@ -3689,6 +3791,23 @@
             "type": "toggle",
             "media_types": [
               "show"
+            ]
+          },
+          {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
             ]
           },
           {
@@ -4293,6 +4412,23 @@
             ]
           },
           {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -4877,6 +5013,23 @@
             ]
           },
           {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -5455,6 +5608,23 @@
             "type": "toggle",
             "media_types": [
               "movie"
+            ]
+          },
+          {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
             ]
           },
           {
@@ -6050,6 +6220,23 @@
             ]
           },
           {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -6610,6 +6797,23 @@
             "type": "toggle",
             "media_types": [
               "movie"
+            ]
+          },
+          {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
             ]
           },
           {
@@ -7194,6 +7398,23 @@
             ]
           },
           {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -7772,6 +7993,23 @@
             "type": "toggle",
             "media_types": [
               "movie"
+            ]
+          },
+          {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
             ]
           },
           {
@@ -8356,6 +8594,23 @@
             ]
           },
           {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -8926,6 +9181,23 @@
             "type": "toggle",
             "media_types": [
               "movie"
+            ]
+          },
+          {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
             ]
           },
           {
@@ -10039,6 +10311,23 @@
             ]
           },
           {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -10603,6 +10892,23 @@
             "options": [
               "color",
               "white"
+            ]
+          },
+          {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
             ]
           },
           {
@@ -11288,6 +11594,23 @@
             "options": [
               "color",
               "white"
+            ]
+          },
+          {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
             ]
           },
           {
@@ -12020,6 +12343,23 @@
             ]
           },
           {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -12710,6 +13050,23 @@
             ]
           },
           {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -13049,6 +13406,23 @@
             "options": [
               "color",
               "white"
+            ]
+          },
+          {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
             ]
           },
           {
@@ -13755,6 +14129,23 @@
             "type": "toggle",
             "media_types": [
               "show"
+            ]
+          },
+          {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
             ]
           },
           {
@@ -14868,6 +15259,23 @@
             "options": [
               "color",
               "white"
+            ]
+          },
+          {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
             ]
           },
           {
@@ -16045,6 +16453,23 @@
             ]
           },
           {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -17003,6 +17428,23 @@
             "placeholder": "Add TMDb collection ID (e.g. 131292)"
           },
           {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -17423,6 +17865,23 @@
             "type": "text_input",
             "tooltip": "Optional override for where this default group appears in the Plex Collections page. Leave blank to keep the Kometa default order.",
             "placeholder": "Leave blank or enter a value like 040"
+          },
+          {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
           },
           {
             "key": "collection_mode",
@@ -18271,6 +18730,23 @@
             "type": "toggle",
             "media_types": [
               "show"
+            ]
+          },
+          {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
             ]
           },
           {
@@ -23775,6 +24251,23 @@
             "placeholder": "Add country name (e.g. France)"
           },
           {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -24246,6 +24739,23 @@
             "type": "string_list",
             "tooltip": "Exclude specific countries from these collections.",
             "placeholder": "Add country name (e.g. France)"
+          },
+          {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
           },
           {
             "key": "collection_mode",
@@ -25088,6 +25598,23 @@
             "type": "string_list",
             "tooltip": "Exclude specific regions from these collections.",
             "placeholder": "Add region name (e.g. Melanesia)"
+          },
+          {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
           },
           {
             "key": "collection_mode",
@@ -26143,6 +26670,23 @@
             "placeholder": "Add continent name (e.g. Europe)"
           },
           {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -26848,6 +27392,23 @@
             "type": "string_list",
             "tooltip": "Exclude specific aspect ratios from these collections.",
             "placeholder": "Add aspect ratio key (e.g. 1.65)"
+          },
+          {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
           },
           {
             "key": "collection_mode",
@@ -31356,6 +31917,23 @@
             "placeholder": "Add service key (e.g. netflix)"
           },
           {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
             "key": "collection_mode",
             "label": "Collection Mode",
             "type": "select",
@@ -33673,6 +34251,23 @@
             "type": "string_list",
             "tooltip": "Exclude specific seasonal collections from these collections.",
             "placeholder": "Add seasonal key (e.g. halloween)"
+          },
+          {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
           },
           {
             "key": "collection_mode",

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -2712,6 +2712,14 @@ document.addEventListener('DOMContentLoaded', function () {
           ? { valid: true }
           : { valid: false, message: 'Enter a numeric TMDb collection ID like 131292.' }
       },
+      imdb_id_plex: {
+        duplicateInsensitive: true,
+        normalize: value => value.toLowerCase(),
+        lookupService: 'plex',
+        validate: value => /^tt\d{7,8}$/i.test(value)
+          ? { valid: true }
+          : { valid: false, message: 'Enter an IMDb ID like tt1234567 or tt12345678.' }
+      },
       year: {
         duplicateInsensitive: true,
         normalize: value => value,
@@ -2860,8 +2868,10 @@ document.addEventListener('DOMContentLoaded', function () {
         return String(el?.value || '').trim().toLowerCase() === 'true'
       }
 
-      async function lookupTemplateStringValue (presetName, value) {
-        const cacheKey = `${presetName}:${value}`
+      async function lookupTemplateStringValue (presetName, value, context = {}) {
+        const libraryName = String(context.libraryName || '').trim()
+        const mediaType = String(context.mediaType || '').trim()
+        const cacheKey = `${presetName}:${libraryName}:${mediaType}:${value}`
         if (templateStringLookupCache.has(cacheKey)) {
           return templateStringLookupCache.get(cacheKey)
         }
@@ -2869,7 +2879,12 @@ document.addEventListener('DOMContentLoaded', function () {
           method: 'POST',
           credentials: 'same-origin',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ preset: presetName, value })
+          body: JSON.stringify({
+            preset: presetName,
+            value,
+            library_name: libraryName,
+            media_type: mediaType
+          })
         })
           .then(async (response) => {
             const data = await response.json().catch(() => ({}))
@@ -2907,6 +2922,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
         const presetName = inferTemplateStringListPreset(wrapper, input)
         const presetConfig = templateStringListPresetConfigs[presetName] || templateStringListPresetConfigs.generic_text
+        const libraryName = String(wrapper.dataset.libraryName || '').trim()
+        const mediaType = String(wrapper.dataset.mediaType || '').trim()
         ensureTemplateStringListDatalist(wrapper, input, presetConfig, presetName)
 
         function parseStoredStringList (rawValue) {
@@ -3091,6 +3108,42 @@ document.addEventListener('DOMContentLoaded', function () {
                     valid: Boolean(result.valid),
                     verified: Boolean(result.verified),
                     message: result.message || 'TMDb lookup failed.'
+                  })
+                })
+              }
+            } else if (item.valid && presetConfig.lookupService === 'plex') {
+              if (!getServiceValidationState('plex')) {
+                setLookupState(lookupMeta, {
+                  valid: false,
+                  verified: false,
+                  message: 'Plex not validated, so the IMDb ID could not be checked against the active library.'
+                })
+              } else if (!libraryName) {
+                setLookupState(lookupMeta, {
+                  valid: false,
+                  verified: false,
+                  message: 'Library context is unavailable for Plex lookup.'
+                })
+              } else {
+                setLookupState(lookupMeta, {
+                  valid: false,
+                  verified: false,
+                  message: 'Checking Plex library for this IMDb ID...'
+                })
+                lookupTemplateStringValue(presetName, item.value, { libraryName, mediaType }).then(result => {
+                  if (!lookupMeta.isConnected) return
+                  if (result.valid && result.verified && result.label) {
+                    setLookupState(lookupMeta, {
+                      valid: true,
+                      verified: true,
+                      message: `Plex: ${result.label}`
+                    })
+                    return
+                  }
+                  setLookupState(lookupMeta, {
+                    valid: Boolean(result.valid),
+                    verified: Boolean(result.verified),
+                    message: result.message || 'Plex lookup failed.'
                   })
                 })
               }

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -1300,11 +1300,11 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                             {'value': 'relative_latest', 'label': 'Relative Latest (latest-#)', 'kind': 'relative', 'prefix': 'latest-'},
                             {'value': 'year', 'label': 'Specific Year', 'kind': 'year'}
                         ] %}
-                        {% set label_width = item.label_width if item.label_width is defined else (240 if item.key is defined and (item.key.startswith('limit_') or item.key.startswith('list_days_') or item.key.startswith('list_size_')) else 170) %}
+                        {% set label_width = item.label_width if item.label_width is defined else ((320 if item.label|length > 24 else 240) if item.key is defined and (item.key.startswith('limit_') or item.key.startswith('list_days_') or item.key.startswith('list_size_')) else 170) %}
                         <div class="input-group mb-2" data-relative-year data-hidden-input="{{ input_name }}"
                             data-default-value="{{ item.default | default('', true) }}"
                             data-min-year="{{ item.min | default(1) }}">
-                            <span class="input-group-text" id="{{ input_name }}_text" style="width: {{ label_width }}px;">
+                            <span class="input-group-text qs-template-variable-label" id="{{ input_name }}_text" style="width: {{ label_width }}px;">
                                 {% if item.url %}
                                 <a href="{{ item.url }}" target="_blank">
                                     {{ item.label }}
@@ -1459,9 +1459,9 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                         </div>
                         {% elif item.type == 'text_input' %}
                         {% set is_number_input = item.input_type is defined and item.input_type == 'number' %}
-                        {% set label_width = item.label_width if item.label_width is defined else (240 if item.key is defined and (item.key.startswith('limit_') or item.key.startswith('list_days_') or item.key.startswith('list_size_')) else 170) %}
+                        {% set label_width = item.label_width if item.label_width is defined else ((320 if item.label|length > 24 else 240) if item.key is defined and (item.key.startswith('limit_') or item.key.startswith('list_days_') or item.key.startswith('list_size_')) else 170) %}
                         <div class="input-group mb-2">
-                            <span class="input-group-text" id="{{ input_name }}_text" style="width: {{ label_width }}px;">
+                            <span class="input-group-text qs-template-variable-label" id="{{ input_name }}_text" style="width: {{ label_width }}px;">
                                 {% if item.url %}
                                 <a href="{{ item.url }}" target="_blank">
                                     {{ item.label }}

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -1300,7 +1300,7 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                             {'value': 'relative_latest', 'label': 'Relative Latest (latest-#)', 'kind': 'relative', 'prefix': 'latest-'},
                             {'value': 'year', 'label': 'Specific Year', 'kind': 'year'}
                         ] %}
-                        {% set label_width = item.label_width if item.label_width is defined else 170 %}
+                        {% set label_width = item.label_width if item.label_width is defined else (240 if item.key is defined and (item.key.startswith('limit_') or item.key.startswith('list_days_') or item.key.startswith('list_size_')) else 170) %}
                         <div class="input-group mb-2" data-relative-year data-hidden-input="{{ input_name }}"
                             data-default-value="{{ item.default | default('', true) }}"
                             data-min-year="{{ item.min | default(1) }}">
@@ -1459,7 +1459,7 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                         </div>
                         {% elif item.type == 'text_input' %}
                         {% set is_number_input = item.input_type is defined and item.input_type == 'number' %}
-                        {% set label_width = item.label_width if item.label_width is defined else 170 %}
+                        {% set label_width = item.label_width if item.label_width is defined else (240 if item.key is defined and (item.key.startswith('limit_') or item.key.startswith('list_days_') or item.key.startswith('list_size_')) else 170) %}
                         <div class="input-group mb-2">
                             <span class="input-group-text" id="{{ input_name }}_text" style="width: {{ label_width }}px;">
                                 {% if item.url %}

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -1263,6 +1263,8 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                         {% set list_json = '[]' %}
                         {% endif %}
                         <div class="mb-2" data-template-string-list data-hidden-input="{{ input_name }}"
+                            data-library-name="{{ library.name }}"
+                            data-media-type="{{ library.type }}"
                             {% if item.key is defined %}data-template-variable-key="{{ item.key }}"{% endif %}
                             {% if item.mutually_exclusive_with %}data-mutually-exclusive-with="{{ item.mutually_exclusive_with }}"{% endif %}
                             {% if item.validation_preset %}data-validation-preset="{{ item.validation_preset }}"{% endif %}

--- a/tests/e2e/test_collection_layout_e2e.py
+++ b/tests/e2e/test_collection_layout_e2e.py
@@ -1,0 +1,78 @@
+import pytest
+
+
+@pytest.mark.e2e
+def test_collection_child_numeric_labels_do_not_clip(page, live_server):
+    page.goto(f"{live_server}/step/025-libraries", wait_until="domcontentloaded")
+    page.wait_for_timeout(500)
+
+    clipped = page.evaluate(
+        """async () => {
+          const existing = document.getElementById('qs-collection-label-clip-harness');
+          if (existing) existing.remove();
+
+          const labels = [
+            { key: 'limit_released', text: 'Newly Released Limit', width: 240 },
+            { key: 'list_days_popular', text: 'Plex Popular List Days', width: 240 },
+            { key: 'list_size_watched', text: 'Plex Watched List Size', width: 240 },
+            { key: 'limit_top_500', text: 'Letterboxd Top 500 Limit', width: 240 },
+            { key: 'limit_oscars', text: 'Oscar Best Picture Winners Limit', width: 320 },
+            { key: 'limit_rogerebert', text: "Roger Ebert's Great Movies Limit", width: 320 },
+            { key: 'limit_sight_sound', text: 'Sight & Sound Greatest Films Limit', width: 320 },
+          ];
+
+          const host = document.createElement('div');
+          host.id = 'qs-collection-label-clip-harness';
+          host.style.padding = '16px';
+          host.style.maxWidth = '1400px';
+          document.body.appendChild(host);
+
+          labels.forEach(item => {
+            const row = document.createElement('div');
+            row.className = 'input-group mb-2';
+            row.dataset.templateVariableKey = item.key;
+
+            const label = document.createElement('span');
+            label.className = 'input-group-text qs-template-variable-label';
+            label.style.width = `${item.width}px`;
+            label.textContent = item.text;
+
+            const icon = document.createElement('span');
+            icon.className = 'text-info ms-2';
+            icon.innerHTML = '<i class="bi bi-info-circle-fill"></i>';
+            label.appendChild(icon);
+
+            const input = document.createElement('input');
+            input.className = 'form-control';
+            input.type = 'number';
+
+            row.appendChild(label);
+            row.appendChild(input);
+            host.appendChild(row);
+          });
+
+          const findings = [];
+          host.querySelectorAll('[data-template-variable-key]').forEach(row => {
+            const key = String(row.dataset.templateVariableKey || '');
+            const label = row.querySelector('.input-group-text');
+            if (!label) return;
+
+            const clippedX = label.scrollWidth > label.clientWidth + 1;
+            const clippedY = label.scrollHeight > label.clientHeight + 1;
+            if (!clippedX && !clippedY) return;
+
+            findings.push({
+              key,
+              text: (label.innerText || '').trim(),
+              clientWidth: label.clientWidth,
+              scrollWidth: label.scrollWidth,
+              clientHeight: label.clientHeight,
+              scrollHeight: label.scrollHeight,
+            });
+          });
+
+          return findings;
+        }"""
+    )
+
+    assert clipped == []

--- a/tests/e2e/test_collection_layout_e2e.py
+++ b/tests/e2e/test_collection_layout_e2e.py
@@ -6,8 +6,7 @@ def test_collection_child_numeric_labels_do_not_clip(page, live_server):
     page.goto(f"{live_server}/step/025-libraries", wait_until="domcontentloaded")
     page.wait_for_timeout(500)
 
-    clipped = page.evaluate(
-        """async () => {
+    clipped = page.evaluate("""async () => {
           const existing = document.getElementById('qs-collection-label-clip-harness');
           if (existing) existing.remove();
 
@@ -72,7 +71,6 @@ def test_collection_child_numeric_labels_do_not_clip(page, live_server):
           });
 
           return findings;
-        }"""
-    )
+        }""")
 
     assert clipped == []

--- a/tests/test_collection_cache_builders_contract.py
+++ b/tests/test_collection_cache_builders_contract.py
@@ -1,0 +1,127 @@
+import json
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+
+ROOT = Path(__file__).resolve().parents[1]
+QS_COLLECTIONS_PATH = ROOT / "static" / "json" / "quickstart_collections.json"
+DEFAULTS_ROOT = ROOT / "config" / "kometa" / "defaults"
+YAML = YAML(typ="safe", pure=True)
+CACHE_TEMPLATES = {"custom", "mdb_smart"}
+
+
+def _build_qs_collection_map():
+    data = json.loads(QS_COLLECTIONS_PATH.read_text(encoding="utf-8"))
+    mapping = {}
+    for group in data:
+        for collection in group.get("collections", []):
+            alias = collection["id"].replace("collection_", "", 1)
+            mapping.setdefault(alias, []).append(collection)
+    return mapping
+
+
+def _iter_collection_default_files():
+    for bucket in ("award", "both", "movie", "show", "chart"):
+        yield from sorted((DEFAULTS_ROOT / bucket).glob("*.yml"))
+
+
+def _iter_template_entries(path: Path):
+    data = YAML.load(path.read_text(encoding="utf-8")) or {}
+    for section_name in ("collections", "dynamic_collections"):
+        section = data.get(section_name) or {}
+        if not isinstance(section, dict):
+            continue
+        for cfg in section.values():
+            if not isinstance(cfg, dict):
+                continue
+            template = cfg.get("template")
+            if isinstance(template, list):
+                yield from template
+            elif template is not None:
+                yield template
+
+
+def _expected_cache_builders_defaults():
+    qs_map = _build_qs_collection_map()
+    defaults = {}
+    for path in _iter_collection_default_files():
+        alias = path.stem
+        if alias not in qs_map:
+            continue
+        text = path.read_text(encoding="utf-8")
+        has_support = False
+        alias_default = None
+        for entry in _iter_template_entries(path):
+            if isinstance(entry, str) and entry in CACHE_TEMPLATES:
+                has_support = True
+                alias_default = 1 if alias_default is None else alias_default
+            elif isinstance(entry, dict) and entry.get("name") in CACHE_TEMPLATES:
+                has_support = True
+                value = entry.get("cache_builders")
+                if value is None:
+                    value = 1
+                alias_default = int(value)
+        if "cache_builders:" in text or "cache_builders_<<key>>:" in text:
+            has_support = True
+            if alias_default is None:
+                if "cache_builders: 0" in text:
+                    alias_default = 0
+                else:
+                    alias_default = 1
+        if has_support:
+            defaults[alias] = alias_default if alias_default is not None else 1
+    return defaults
+
+
+def test_cache_builders_exists_for_every_cache_capable_collection_family():
+    qs_map = _build_qs_collection_map()
+    expected_defaults = _expected_cache_builders_defaults()
+
+    missing = []
+    for alias, collections in qs_map.items():
+        if alias not in expected_defaults:
+            continue
+        for collection in collections:
+            keys = {
+                item["key"]
+                for item in collection.get("template_variables", [])
+                if isinstance(item, dict) and item.get("key")
+            }
+            if "cache_builders" not in keys:
+                missing.append(collection["id"])
+
+    assert missing == []
+
+
+def test_cache_builders_defaults_match_repo_defaults():
+    qs_map = _build_qs_collection_map()
+    expected_defaults = _expected_cache_builders_defaults()
+
+    for alias, expected_default in expected_defaults.items():
+        for collection in qs_map[alias]:
+            cache_field = next(
+                item
+                for item in collection.get("template_variables", [])
+                if isinstance(item, dict) and item.get("key") == "cache_builders"
+            )
+            assert cache_field["type"] == "text_input"
+            assert cache_field["input_type"] == "number"
+            assert cache_field["default"] == expected_default
+            assert cache_field["min"] == 0
+            assert cache_field["step"] == 1
+
+
+def test_cache_builders_is_not_inferred_for_basic_genre_or_network():
+    qs_map = _build_qs_collection_map()
+    expected_defaults = _expected_cache_builders_defaults()
+
+    for alias in ("basic", "genre", "network"):
+        assert alias not in expected_defaults
+        for collection in qs_map[alias]:
+            keys = {
+                item["key"]
+                for item in collection.get("template_variables", [])
+                if isinstance(item, dict) and item.get("key")
+            }
+            assert "cache_builders" not in keys

--- a/tests/test_collection_cache_builders_contract.py
+++ b/tests/test_collection_cache_builders_contract.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 from ruamel.yaml import YAML
 
-
 ROOT = Path(__file__).resolve().parents[1]
 QS_COLLECTIONS_PATH = ROOT / "static" / "json" / "quickstart_collections.json"
 DEFAULTS_ROOT = ROOT / "config" / "kometa" / "defaults"
@@ -83,11 +82,7 @@ def test_cache_builders_exists_for_every_cache_capable_collection_family():
         if alias not in expected_defaults:
             continue
         for collection in collections:
-            keys = {
-                item["key"]
-                for item in collection.get("template_variables", [])
-                if isinstance(item, dict) and item.get("key")
-            }
+            keys = {item["key"] for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key")}
             if "cache_builders" not in keys:
                 missing.append(collection["id"])
 
@@ -100,11 +95,7 @@ def test_cache_builders_defaults_match_repo_defaults():
 
     for alias, expected_default in expected_defaults.items():
         for collection in qs_map[alias]:
-            cache_field = next(
-                item
-                for item in collection.get("template_variables", [])
-                if isinstance(item, dict) and item.get("key") == "cache_builders"
-            )
+            cache_field = next(item for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key") == "cache_builders")
             assert cache_field["type"] == "text_input"
             assert cache_field["input_type"] == "number"
             assert cache_field["default"] == expected_default
@@ -119,9 +110,5 @@ def test_cache_builders_is_not_inferred_for_basic_genre_or_network():
     for alias in ("basic", "genre", "network"):
         assert alias not in expected_defaults
         for collection in qs_map[alias]:
-            keys = {
-                item["key"]
-                for item in collection.get("template_variables", [])
-                if isinstance(item, dict) and item.get("key")
-            }
+            keys = {item["key"] for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key")}
             assert "cache_builders" not in keys

--- a/tests/test_collection_ignore_imdb_ids_contract.py
+++ b/tests/test_collection_ignore_imdb_ids_contract.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 from ruamel.yaml import YAML
 
-
 ROOT = Path(__file__).resolve().parents[1]
 QS_COLLECTIONS_PATH = ROOT / "static" / "json" / "quickstart_collections.json"
 DEFAULTS_ROOT = ROOT / "config" / "kometa" / "defaults"
@@ -67,11 +66,7 @@ def test_ignore_imdb_ids_exists_for_every_shared_collection_family():
         for collection in qs_map[alias]:
             if collection.get("readonly"):
                 continue
-            keys = {
-                item["key"]
-                for item in collection.get("template_variables", [])
-                if isinstance(item, dict) and item.get("key")
-            }
+            keys = {item["key"] for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key")}
             if "ignore_imdb_ids" not in keys:
                 missing.append(collection["id"])
 
@@ -86,11 +81,7 @@ def test_ignore_imdb_ids_uses_string_list_with_imdb_preset():
         for collection in qs_map[alias]:
             if collection.get("readonly"):
                 continue
-            field = next(
-                item
-                for item in collection.get("template_variables", [])
-                if isinstance(item, dict) and item.get("key") == "ignore_imdb_ids"
-            )
+            field = next(item for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key") == "ignore_imdb_ids")
             assert field["type"] == "string_list"
             assert field["validation_preset"] == "imdb_id_plex"
             assert "default" not in field
@@ -101,9 +92,5 @@ def test_ignore_ids_is_not_added_yet():
 
     for collections in qs_map.values():
         for collection in collections:
-            keys = {
-                item["key"]
-                for item in collection.get("template_variables", [])
-                if isinstance(item, dict) and item.get("key")
-            }
+            keys = {item["key"] for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key")}
             assert "ignore_ids" not in keys

--- a/tests/test_collection_ignore_imdb_ids_contract.py
+++ b/tests/test_collection_ignore_imdb_ids_contract.py
@@ -1,0 +1,109 @@
+import json
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+
+ROOT = Path(__file__).resolve().parents[1]
+QS_COLLECTIONS_PATH = ROOT / "static" / "json" / "quickstart_collections.json"
+DEFAULTS_ROOT = ROOT / "config" / "kometa" / "defaults"
+YAML = YAML(typ="safe", pure=True)
+
+
+def _build_qs_collection_map():
+    data = json.loads(QS_COLLECTIONS_PATH.read_text(encoding="utf-8"))
+    mapping = {}
+    for group in data:
+        for collection in group.get("collections", []):
+            alias = collection["id"].replace("collection_", "", 1)
+            mapping.setdefault(alias, []).append(collection)
+    return mapping
+
+
+def _iter_collection_default_files():
+    for bucket in ("award", "both", "movie", "show", "chart"):
+        yield from sorted((DEFAULTS_ROOT / bucket).glob("*.yml"))
+
+
+def _iter_template_entries(path: Path):
+    data = YAML.load(path.read_text(encoding="utf-8")) or {}
+    for section_name in ("collections", "dynamic_collections"):
+        section = data.get(section_name) or {}
+        if not isinstance(section, dict):
+            continue
+        for cfg in section.values():
+            if not isinstance(cfg, dict):
+                continue
+            template = cfg.get("template")
+            if isinstance(template, list):
+                yield from template
+            elif template is not None:
+                yield template
+
+
+def _expected_ignore_imdb_ids_aliases():
+    qs_map = _build_qs_collection_map()
+    aliases = set()
+    for path in _iter_collection_default_files():
+        alias = path.stem
+        if alias not in qs_map:
+            continue
+        for entry in _iter_template_entries(path):
+            if isinstance(entry, str) and entry == "shared":
+                aliases.add(alias)
+                break
+            if isinstance(entry, dict) and entry.get("name") == "shared":
+                aliases.add(alias)
+                break
+    return aliases
+
+
+def test_ignore_imdb_ids_exists_for_every_shared_collection_family():
+    qs_map = _build_qs_collection_map()
+    expected_aliases = _expected_ignore_imdb_ids_aliases()
+
+    missing = []
+    for alias in expected_aliases:
+        for collection in qs_map[alias]:
+            if collection.get("readonly"):
+                continue
+            keys = {
+                item["key"]
+                for item in collection.get("template_variables", [])
+                if isinstance(item, dict) and item.get("key")
+            }
+            if "ignore_imdb_ids" not in keys:
+                missing.append(collection["id"])
+
+    assert missing == []
+
+
+def test_ignore_imdb_ids_uses_string_list_with_imdb_preset():
+    qs_map = _build_qs_collection_map()
+    expected_aliases = _expected_ignore_imdb_ids_aliases()
+
+    for alias in expected_aliases:
+        for collection in qs_map[alias]:
+            if collection.get("readonly"):
+                continue
+            field = next(
+                item
+                for item in collection.get("template_variables", [])
+                if isinstance(item, dict) and item.get("key") == "ignore_imdb_ids"
+            )
+            assert field["type"] == "string_list"
+            assert field["validation_preset"] == "imdb_id_plex"
+            assert "default" not in field
+
+
+def test_ignore_ids_is_not_added_yet():
+    qs_map = _build_qs_collection_map()
+
+    for collections in qs_map.values():
+        for collection in collections:
+            keys = {
+                item["key"]
+                for item in collection.get("template_variables", [])
+                if isinstance(item, dict) and item.get("key")
+            }
+            assert "ignore_ids" not in keys

--- a/tests/test_collection_minimum_items_contract.py
+++ b/tests/test_collection_minimum_items_contract.py
@@ -1,0 +1,127 @@
+import json
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+
+ROOT = Path(__file__).resolve().parents[1]
+QS_COLLECTIONS_PATH = ROOT / "static" / "json" / "quickstart_collections.json"
+DEFAULTS_ROOT = ROOT / "config" / "kometa" / "defaults"
+YAML = YAML(typ="safe", pure=True)
+MINIMUM_ITEM_TEMPLATES = {"shared", "separator", "collection", "tmdbshow"}
+
+
+def _build_qs_collection_map():
+    data = json.loads(QS_COLLECTIONS_PATH.read_text(encoding="utf-8"))
+    mapping = {}
+    for group in data:
+        for collection in group.get("collections", []):
+            alias = collection["id"].replace("collection_", "", 1)
+            mapping.setdefault(alias, []).append(collection)
+    return mapping
+
+
+def _iter_collection_default_files():
+    for bucket in ("award", "both", "movie", "show", "chart"):
+        yield from sorted((DEFAULTS_ROOT / bucket).glob("*.yml"))
+
+
+def _iter_template_entries(path: Path):
+    data = YAML.load(path.read_text(encoding="utf-8")) or {}
+    for section_name in ("collections", "dynamic_collections"):
+        section = data.get(section_name) or {}
+        if not isinstance(section, dict):
+            continue
+        for cfg in section.values():
+            if not isinstance(cfg, dict):
+                continue
+            template = cfg.get("template")
+            if isinstance(template, list):
+                yield from template
+            elif template is not None:
+                yield template
+
+
+def _expected_minimum_items_defaults():
+    qs_map = _build_qs_collection_map()
+    defaults = {}
+    for path in _iter_collection_default_files():
+        alias = path.stem
+        if alias not in qs_map:
+            continue
+        text = path.read_text(encoding="utf-8")
+        has_support = False
+        default_value = None
+        for entry in _iter_template_entries(path):
+            if isinstance(entry, str):
+                if entry in MINIMUM_ITEM_TEMPLATES:
+                    has_support = True
+                if entry in {"collection", "tmdbshow"}:
+                    default_value = default_value or 2
+            elif isinstance(entry, dict):
+                template_name = entry.get("name")
+                if template_name in MINIMUM_ITEM_TEMPLATES:
+                    has_support = True
+                if template_name in {"collection", "tmdbshow"}:
+                    default_value = default_value or 2
+        if "minimum_items:" in text or "minimum_items_<<key>>:" in text:
+            has_support = True
+            if "minimum_items: 2" in text and default_value is None:
+                default_value = 2
+        if has_support:
+            defaults[alias] = default_value
+    return defaults
+
+
+def test_minimum_items_exists_for_every_supported_non_readonly_collection_family():
+    qs_map = _build_qs_collection_map()
+    expected_defaults = _expected_minimum_items_defaults()
+
+    missing = []
+    for alias, collections in qs_map.items():
+        if alias not in expected_defaults:
+            continue
+        for collection in collections:
+            if collection.get("readonly"):
+                continue
+            keys = {
+                item["key"]
+                for item in collection.get("template_variables", [])
+                if isinstance(item, dict) and item.get("key")
+            }
+            if "minimum_items" not in keys:
+                missing.append(collection["id"])
+
+    assert missing == []
+
+
+def test_minimum_items_defaults_and_numeric_contract_match_repo_defaults():
+    qs_map = _build_qs_collection_map()
+    expected_defaults = _expected_minimum_items_defaults()
+
+    for alias, expected_default in expected_defaults.items():
+        for collection in qs_map[alias]:
+            if collection.get("readonly"):
+                continue
+            field = next(
+                item
+                for item in collection.get("template_variables", [])
+                if isinstance(item, dict) and item.get("key") == "minimum_items"
+            )
+            assert field["type"] == "text_input"
+            assert field["input_type"] == "number"
+            assert field["min"] == 1
+            assert field["step"] == 1
+            if expected_default is None:
+                assert "default" not in field
+            else:
+                assert field["default"] == expected_default
+
+
+def test_minimum_items_is_not_added_to_readonly_separator_cards():
+    qs_map = _build_qs_collection_map()
+
+    for alias in ("separator_award", "separator_chart"):
+        for collection in qs_map[alias]:
+            assert collection.get("readonly") is True
+            assert "template_variables" not in collection

--- a/tests/test_collection_minimum_items_contract.py
+++ b/tests/test_collection_minimum_items_contract.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 from ruamel.yaml import YAML
 
-
 ROOT = Path(__file__).resolve().parents[1]
 QS_COLLECTIONS_PATH = ROOT / "static" / "json" / "quickstart_collections.json"
 DEFAULTS_ROOT = ROOT / "config" / "kometa" / "defaults"
@@ -84,11 +83,7 @@ def test_minimum_items_exists_for_every_supported_non_readonly_collection_family
         for collection in collections:
             if collection.get("readonly"):
                 continue
-            keys = {
-                item["key"]
-                for item in collection.get("template_variables", [])
-                if isinstance(item, dict) and item.get("key")
-            }
+            keys = {item["key"] for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key")}
             if "minimum_items" not in keys:
                 missing.append(collection["id"])
 
@@ -103,11 +98,7 @@ def test_minimum_items_defaults_and_numeric_contract_match_repo_defaults():
         for collection in qs_map[alias]:
             if collection.get("readonly"):
                 continue
-            field = next(
-                item
-                for item in collection.get("template_variables", [])
-                if isinstance(item, dict) and item.get("key") == "minimum_items"
-            )
+            field = next(item for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key") == "minimum_items")
             assert field["type"] == "text_input"
             assert field["input_type"] == "number"
             assert field["min"] == 1

--- a/tests/test_collection_numeric_input_contract.py
+++ b/tests/test_collection_numeric_input_contract.py
@@ -48,3 +48,33 @@ def test_collection_numeric_template_inputs_use_number_metadata():
                 assert item.get("min") == expected_min, key
 
     assert matched > 0
+
+
+def test_collection_child_limit_labels_are_specific():
+    path = Path(__file__).resolve().parents[1] / "static" / "json" / "quickstart_collections.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    generic_child_labels = []
+    for group in payload:
+        if not isinstance(group, dict):
+            continue
+        for collection in group.get("collections", []):
+            if not isinstance(collection, dict):
+                continue
+            for item in collection.get("template_variables", []):
+                if not isinstance(item, dict):
+                    continue
+                key = item.get("key")
+                if isinstance(key, str) and key.startswith("limit_") and item.get("label") == "Limit":
+                    generic_child_labels.append(key)
+
+    assert generic_child_labels == []
+
+
+def test_collection_child_numeric_inputs_use_wider_default_label_width_rule():
+    path = Path(__file__).resolve().parents[1] / "templates" / "partials" / "_macros.html"
+    template = path.read_text(encoding="utf-8")
+
+    expected_rule = "item.key.startswith('limit_') or item.key.startswith('list_days_') or item.key.startswith('list_size_')"
+    assert template.count(expected_rule) >= 2
+    assert "(240 if item.key is defined" in template

--- a/tests/test_collection_numeric_input_contract.py
+++ b/tests/test_collection_numeric_input_contract.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+
+
+EXACT_KEYS = {
+    "data_depth",
+    "data_limit",
+    "discover_limit",
+    "limit",
+    "list_days",
+    "list_size",
+}
+PREFIXES = (
+    "limit_",
+    "list_days_",
+    "list_size_",
+)
+
+
+def _is_numeric_key(key):
+    if key in EXACT_KEYS:
+        return True
+    return any(key.startswith(prefix) for prefix in PREFIXES)
+
+
+def test_collection_numeric_template_inputs_use_number_metadata():
+    path = Path(__file__).resolve().parents[1] / "static" / "json" / "quickstart_collections.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    matched = 0
+    for group in payload:
+        if not isinstance(group, dict):
+            continue
+        for collection in group.get("collections", []):
+            if not isinstance(collection, dict):
+                continue
+            for item in collection.get("template_variables", []):
+                if not isinstance(item, dict):
+                    continue
+                key = item.get("key")
+                if not isinstance(key, str) or not _is_numeric_key(key):
+                    continue
+                matched += 1
+                assert item.get("type") == "text_input", key
+                assert item.get("input_type") == "number", key
+                assert item.get("step") == 1, key
+                expected_min = 0 if key == "discover_limit" else 1
+                assert item.get("min") == expected_min, key
+
+    assert matched > 0

--- a/tests/test_collection_numeric_input_contract.py
+++ b/tests/test_collection_numeric_input_contract.py
@@ -77,4 +77,5 @@ def test_collection_child_numeric_inputs_use_wider_default_label_width_rule():
 
     expected_rule = "item.key.startswith('limit_') or item.key.startswith('list_days_') or item.key.startswith('list_size_')"
     assert template.count(expected_rule) >= 2
-    assert "(240 if item.key is defined" in template
+    assert "320 if item.label|length > 24 else 240" in template
+    assert "qs-template-variable-label" in template

--- a/tests/test_collection_numeric_input_contract.py
+++ b/tests/test_collection_numeric_input_contract.py
@@ -1,7 +1,6 @@
 import json
 from pathlib import Path
 
-
 EXACT_KEYS = {
     "data_depth",
     "data_limit",

--- a/tests/test_collection_order_contract.py
+++ b/tests/test_collection_order_contract.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 from ruamel.yaml import YAML
 
-
 ROOT = Path(__file__).resolve().parents[1]
 QS_COLLECTIONS_PATH = ROOT / "static" / "json" / "quickstart_collections.json"
 DEFAULTS_ROOT = ROOT / "config" / "kometa" / "defaults"
@@ -90,11 +89,7 @@ def test_collection_order_exists_for_every_supported_collection_family():
         if alias not in expected_defaults:
             continue
         for collection in collections:
-            keys = {
-                item["key"]
-                for item in collection.get("template_variables", [])
-                if isinstance(item, dict) and item.get("key")
-            }
+            keys = {item["key"] for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key")}
             if "collection_order" not in keys:
                 missing.append(collection["id"])
 
@@ -107,11 +102,7 @@ def test_collection_order_defaults_match_repo_defaults():
 
     for alias, expected_default in expected_defaults.items():
         for collection in qs_map[alias]:
-            field = next(
-                item
-                for item in collection.get("template_variables", [])
-                if isinstance(item, dict) and item.get("key") == "collection_order"
-            )
+            field = next(item for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key") == "collection_order")
             assert field["type"] == "select"
             assert field["default"] == expected_default
 
@@ -123,9 +114,5 @@ def test_collection_order_is_not_inferred_for_streaming_seasonal_genre_or_networ
     for alias in ("streaming", "seasonal", "genre", "network", "basic"):
         assert alias not in expected_defaults
         for collection in qs_map[alias]:
-            keys = {
-                item["key"]
-                for item in collection.get("template_variables", [])
-                if isinstance(item, dict) and item.get("key")
-            }
+            keys = {item["key"] for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key")}
             assert "collection_order" not in keys

--- a/tests/test_collection_order_contract.py
+++ b/tests/test_collection_order_contract.py
@@ -1,0 +1,131 @@
+import json
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+
+ROOT = Path(__file__).resolve().parents[1]
+QS_COLLECTIONS_PATH = ROOT / "static" / "json" / "quickstart_collections.json"
+DEFAULTS_ROOT = ROOT / "config" / "kometa" / "defaults"
+YAML = YAML(typ="safe", pure=True)
+
+
+def _build_qs_collection_map():
+    data = json.loads(QS_COLLECTIONS_PATH.read_text(encoding="utf-8"))
+    mapping = {}
+    for group in data:
+        for collection in group.get("collections", []):
+            alias = collection["id"].replace("collection_", "", 1)
+            mapping.setdefault(alias, []).append(collection)
+    return mapping
+
+
+def _iter_collection_default_files():
+    for bucket in ("award", "both", "movie", "show", "chart"):
+        yield from sorted((DEFAULTS_ROOT / bucket).glob("*.yml"))
+
+
+def _iter_template_entries(path: Path):
+    data = YAML.load(path.read_text(encoding="utf-8")) or {}
+    for section_name in ("collections", "dynamic_collections"):
+        section = data.get(section_name) or {}
+        if not isinstance(section, dict):
+            continue
+        for cfg in section.values():
+            if not isinstance(cfg, dict):
+                continue
+            template = cfg.get("template")
+            if isinstance(template, list):
+                yield from template
+            elif template is not None:
+                yield template
+
+
+def _expected_collection_order_defaults():
+    qs_map = _build_qs_collection_map()
+    defaults = {}
+    release_templates = {"collection", "tmdbshow"}
+    for path in _iter_collection_default_files():
+        alias = path.stem
+        if alias not in qs_map:
+            continue
+        text = path.read_text(encoding="utf-8")
+        has_support = False
+        default_value = None
+        for entry in _iter_template_entries(path):
+            if isinstance(entry, str):
+                if entry == "custom":
+                    has_support = True
+                    default_value = default_value or "custom"
+                elif entry in release_templates:
+                    has_support = True
+                    default_value = default_value or "release"
+            elif isinstance(entry, dict):
+                template_name = entry.get("name")
+                if template_name == "custom":
+                    has_support = True
+                    default_value = str(entry.get("collection_order", "custom"))
+                elif template_name in release_templates:
+                    has_support = True
+                    default_value = str(entry.get("collection_order", "release"))
+        if alias == "collectionless":
+            has_support = True
+            default_value = "alpha"
+        elif "collection_order:" in text or "collection_order_<<key>>:" in text:
+            has_support = True
+            default_value = default_value or "custom"
+        if has_support:
+            if alias in defaults and defaults[alias] == "release":
+                continue
+            defaults[alias] = default_value or defaults.get(alias) or "custom"
+    return defaults
+
+
+def test_collection_order_exists_for_every_supported_collection_family():
+    qs_map = _build_qs_collection_map()
+    expected_defaults = _expected_collection_order_defaults()
+
+    missing = []
+    for alias, collections in qs_map.items():
+        if alias not in expected_defaults:
+            continue
+        for collection in collections:
+            keys = {
+                item["key"]
+                for item in collection.get("template_variables", [])
+                if isinstance(item, dict) and item.get("key")
+            }
+            if "collection_order" not in keys:
+                missing.append(collection["id"])
+
+    assert missing == []
+
+
+def test_collection_order_defaults_match_repo_defaults():
+    qs_map = _build_qs_collection_map()
+    expected_defaults = _expected_collection_order_defaults()
+
+    for alias, expected_default in expected_defaults.items():
+        for collection in qs_map[alias]:
+            field = next(
+                item
+                for item in collection.get("template_variables", [])
+                if isinstance(item, dict) and item.get("key") == "collection_order"
+            )
+            assert field["type"] == "select"
+            assert field["default"] == expected_default
+
+
+def test_collection_order_is_not_inferred_for_streaming_seasonal_genre_or_network():
+    qs_map = _build_qs_collection_map()
+    expected_defaults = _expected_collection_order_defaults()
+
+    for alias in ("streaming", "seasonal", "genre", "network", "basic"):
+        assert alias not in expected_defaults
+        for collection in qs_map[alias]:
+            keys = {
+                item["key"]
+                for item in collection.get("template_variables", [])
+                if isinstance(item, dict) and item.get("key")
+            }
+            assert "collection_order" not in keys

--- a/tests/test_collection_sync_mode_contract.py
+++ b/tests/test_collection_sync_mode_contract.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 from ruamel.yaml import YAML
 
-
 ROOT = Path(__file__).resolve().parents[1]
 QS_COLLECTIONS_PATH = ROOT / "static" / "json" / "quickstart_collections.json"
 DEFAULTS_ROOT = ROOT / "config" / "kometa" / "defaults"
@@ -17,11 +16,7 @@ def _build_qs_collection_map():
     for group in data:
         for collection in group.get("collections", []):
             alias = collection["id"].replace("collection_", "", 1)
-            mapping.setdefault(alias, set()).update(
-                item["key"]
-                for item in collection.get("template_variables", [])
-                if isinstance(item, dict) and item.get("key")
-            )
+            mapping.setdefault(alias, set()).update(item["key"] for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key"))
     return mapping
 
 

--- a/tests/test_collection_sync_mode_contract.py
+++ b/tests/test_collection_sync_mode_contract.py
@@ -1,0 +1,88 @@
+import json
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+
+ROOT = Path(__file__).resolve().parents[1]
+QS_COLLECTIONS_PATH = ROOT / "static" / "json" / "quickstart_collections.json"
+DEFAULTS_ROOT = ROOT / "config" / "kometa" / "defaults"
+YAML = YAML(typ="safe", pure=True)
+SYNC_TEMPLATES = {"custom", "filter", "mdb_smart"}
+
+
+def _build_qs_collection_map():
+    data = json.loads(QS_COLLECTIONS_PATH.read_text(encoding="utf-8"))
+    mapping = {}
+    for group in data:
+        for collection in group.get("collections", []):
+            alias = collection["id"].replace("collection_", "", 1)
+            mapping.setdefault(alias, set()).update(
+                item["key"]
+                for item in collection.get("template_variables", [])
+                if isinstance(item, dict) and item.get("key")
+            )
+    return mapping
+
+
+def _iter_collection_default_files():
+    for bucket in ("award", "both", "movie", "show", "chart"):
+        yield from sorted((DEFAULTS_ROOT / bucket).glob("*.yml"))
+
+
+def _template_names_for_default(path: Path):
+    data = YAML.load(path.read_text(encoding="utf-8")) or {}
+    names = set()
+    for section_name in ("collections", "dynamic_collections"):
+        section = data.get(section_name) or {}
+        if not isinstance(section, dict):
+            continue
+        for cfg in section.values():
+            if not isinstance(cfg, dict):
+                continue
+            template = cfg.get("template")
+            if isinstance(template, list):
+                for entry in template:
+                    if isinstance(entry, str):
+                        names.add(entry)
+                    elif isinstance(entry, dict) and entry.get("name"):
+                        names.add(str(entry["name"]))
+            elif isinstance(template, dict) and template.get("name"):
+                names.add(str(template["name"]))
+            elif isinstance(template, str):
+                names.add(template)
+    return names
+
+
+def _expected_sync_mode_aliases():
+    qs_map = _build_qs_collection_map()
+    aliases = set()
+    for path in _iter_collection_default_files():
+        alias = path.stem
+        if alias not in qs_map:
+            continue
+        text = path.read_text(encoding="utf-8")
+        has_direct_sync = "sync_mode:" in text or "sync_mode_<<key>>:" in text
+        inherits_sync = bool(_template_names_for_default(path) & SYNC_TEMPLATES)
+        if has_direct_sync or inherits_sync:
+            aliases.add(alias)
+    return aliases
+
+
+def test_sync_mode_exists_for_every_sync_capable_collection_family():
+    qs_map = _build_qs_collection_map()
+    expected_aliases = _expected_sync_mode_aliases()
+
+    missing = sorted(alias for alias in expected_aliases if "sync_mode" not in qs_map[alias])
+
+    assert missing == []
+
+
+def test_sync_mode_is_not_inferred_for_genre_or_network():
+    qs_map = _build_qs_collection_map()
+    expected_aliases = _expected_sync_mode_aliases()
+
+    assert "genre" not in expected_aliases
+    assert "network" not in expected_aliases
+    assert "sync_mode" not in qs_map["genre"]
+    assert "sync_mode" not in qs_map["network"]

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -118,6 +118,51 @@ def test_validate_apprise_rejects_empty_local_yaml(client, tmp_path):
     assert "must not be empty" in payload["error"]
 
 
+def test_lookup_template_string_value_imdb_id_plex_returns_plex_title(client, monkeypatch, qs_module):
+    monkeypatch.setattr(
+        qs_module.helpers,
+        "find_item_by_imdb_id",
+        lambda library_name, imdb_id, media_type: {"id": imdb_id, "title": "The Matrix"},
+    )
+
+    resp = client.post(
+        "/lookup_template_string_value",
+        json={
+            "preset": "imdb_id_plex",
+            "value": "tt0133093",
+            "library_name": "Movies",
+            "media_type": "movie",
+        },
+    )
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["valid"] is True
+    assert payload["verified"] is True
+    assert payload["label"] == "The Matrix"
+    assert payload["message"] == "Plex: The Matrix"
+
+
+def test_lookup_template_string_value_imdb_id_plex_warns_when_missing(client, monkeypatch, qs_module):
+    monkeypatch.setattr(qs_module.helpers, "find_item_by_imdb_id", lambda library_name, imdb_id, media_type: None)
+
+    resp = client.post(
+        "/lookup_template_string_value",
+        json={
+            "preset": "imdb_id_plex",
+            "value": "tt0133093",
+            "library_name": "Movies",
+            "media_type": "movie",
+        },
+    )
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["valid"] is False
+    assert payload["verified"] is False
+    assert "no matching item was found" in payload["message"]
+
+
 def test_validate_apprise_rejects_invalid_remote_yaml(client, monkeypatch, qs_module):
     class _Resp:
         status_code = 200


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

PR Description
This PR expands Quickstart’s collection template-variable support so the Libraries page can configure more of the YAML/defaults surface directly instead of falling behind Kometa defaults.
It adds the Quickstart JSON/template coverage for the collection vars we’ve been sweeping in:
shared visibility child toggles like visible_home_<key>, visible_library_<key>, and visible_shared_<key>
shared numeric controls such as limit, limit_<key>, list_days, list_days_<key>, list_size, list_size_<key>, minimum_items, and cache_builders
shared collection behavior keys like sync_mode and collection_order
ignore_imdb_ids
the top_250 to top_500 cleanup where applicable in Quickstart
It also includes a temporary workaround to force Quickstart’s schema download/header reference to Kometa develop instead of nightly. This is needed because the current nightly schema is rejecting config constructs that Quickstart is generating and that were previously working, which creates false validation failures while we sort out the upstream schema drift. The workaround is intentionally easy to remove later: the original branch-driven lines are still present, with the temporary develop override directly below them.


## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
