### PR TITLE
Fix ignore ids

### DIFF
--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -1082,6 +1082,30 @@ def _normalize_lookup_title(value):
     return normalized
 
 
+def find_item_by_title(library_name, title):
+    normalized_title = _normalize_lookup_title(title)
+    if not normalized_title:
+        return None
+
+    plex_url, plex_token = persistence.get_stored_plex_credentials("010-plex")
+    if not plex_url or not plex_token:
+        return None
+
+    plex = PlexServer(plex_url, plex_token, timeout=8)
+
+    try:
+        section = plex.library.section(library_name)
+    except Exception:
+        return None
+
+    results = section.search(title=title, maxresults=20)
+    for item in results or []:
+        item_title = str(getattr(item, "title", "") or "").strip()
+        if _normalize_lookup_title(item_title) == normalized_title:
+            return {"title": item_title}
+    return None
+
+
 def find_item_by_imdb_id(library_name, imdb_id, media_type, fallback_title=None):
     normalized_imdb_id = str(imdb_id or "").strip().lower()
     if not normalized_imdb_id:

--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -1069,27 +1069,66 @@ def get_plex_key_by_name(full_list, target_name):
     return None  # Or raise an exception if you prefer
 
 
-def find_item_by_imdb_id(library_name, imdb_id, media_type):
-    from modules import plex_connection
+def _extract_imdb_id_from_item(item):
+    for guid in getattr(item, "guids", []) or []:
+        guid_id = str(getattr(guid, "id", "") or "").strip().lower()
+        if guid_id.startswith("imdb://"):
+            return guid_id.replace("imdb://", "", 1)
+    return ""
 
-    if not imdb_id:
+
+def _normalize_lookup_title(value):
+    normalized = re.sub(r"\s+", " ", str(value or "").strip().lower())
+    return normalized
+
+
+def find_item_by_imdb_id(library_name, imdb_id, media_type, fallback_title=None):
+    normalized_imdb_id = str(imdb_id or "").strip().lower()
+    if not normalized_imdb_id:
         return None
 
-    plex = plex_connection.connect_to_plex()
-    if not plex:
+    plex_url, plex_token = persistence.get_stored_plex_credentials("010-plex")
+    if not plex_url or not plex_token:
         return None
 
-    section = plex.library.section(library_name)
-    if not section:
+    plex = PlexServer(plex_url, plex_token, timeout=8)
+
+    try:
+        section = plex.library.section(library_name)
+    except Exception:
         return None
 
-    # Search by IMDb ID
-    results = section.search(guid=f"imdb://{imdb_id}")
-    if not results:
+    def build_match(item, source):
+        title = str(getattr(item, "title", "") or "").strip()
+        if not title:
+            return None
+        return {"id": normalized_imdb_id, "title": title, "source": source}
+
+    def find_exact_imdb_match(candidates, source):
+        for item in candidates or []:
+            if _extract_imdb_id_from_item(item) == normalized_imdb_id:
+                return build_match(item, source)
         return None
 
-    item = results[0]
-    return {"id": imdb_id, "title": item.title}
+    direct_guid_match = find_exact_imdb_match(
+        section.search(guid=f"imdb://{normalized_imdb_id}"),
+        "plex-guid",
+    )
+    if direct_guid_match:
+        return direct_guid_match
+
+    if fallback_title:
+        title_results = section.search(title=fallback_title, maxresults=20)
+        exact_title_guid_match = find_exact_imdb_match(title_results, "plex-title-guid")
+        if exact_title_guid_match:
+            return exact_title_guid_match
+
+        normalized_fallback_title = _normalize_lookup_title(fallback_title)
+        for item in title_results or []:
+            if _normalize_lookup_title(getattr(item, "title", "")) == normalized_fallback_title:
+                return build_match(item, "plex-title")
+
+    return None
 
 
 def allowed_extensions_string():

--- a/modules/output.py
+++ b/modules/output.py
@@ -299,6 +299,13 @@ def _parse_string_list(value):
     return _coerce_string_list([value])
 
 
+def _normalize_collection_template_var_value(key, value):
+    if key in {"ignore_ids", "ignore_imdb_ids"}:
+        list_values = _parse_string_list(value)
+        return ",".join(list_values) if list_values else None
+    return value
+
+
 def _normalize_asset_directory_entry(value):
     if value is None:
         return None
@@ -1521,6 +1528,12 @@ def build_libraries_section(
                             template_vars[list_key] = list_values
                         else:
                             template_vars.pop(list_key, None)
+                    for template_key in list(template_vars.keys()):
+                        normalized_value = _normalize_collection_template_var_value(template_key, template_vars.get(template_key))
+                        if normalized_value is None:
+                            template_vars.pop(template_key, None)
+                        else:
+                            template_vars[template_key] = normalized_value
                     if template_vars:
                         file_entry["template_variables"] = template_vars
 

--- a/quickstart.py
+++ b/quickstart.py
@@ -9763,6 +9763,65 @@ def _get_active_tmdb_api_key():
     return str(api_key).strip()
 
 
+def _lookup_tmdb_by_imdb_id(imdb_id, media_type=""):
+    api_key = _get_active_tmdb_api_key()
+    if not api_key:
+        return {"valid": False, "verified": False, "message": "TMDb is not configured for the active config."}
+
+    try:
+        response = requests.get(
+            f"https://api.themoviedb.org/3/find/{imdb_id}",
+            params={"api_key": api_key, "external_source": "imdb_id"},
+            timeout=10,
+        )
+    except requests.RequestException as exc:
+        return {"valid": False, "verified": False, "message": f"TMDb lookup failed: {exc}."}
+
+    if response.status_code in {401, 403}:
+        return {"valid": False, "verified": False, "message": "TMDb lookup could not be verified with the configured API key."}
+
+    if response.status_code == 404:
+        return {"valid": False, "verified": True, "message": "TMDb did not find a matching IMDb ID."}
+
+    if response.status_code != 200:
+        return {"valid": False, "verified": False, "message": f"TMDb lookup failed with status {response.status_code}."}
+
+    payload = response.json() if response.content else {}
+    movie_results = payload.get("movie_results") if isinstance(payload.get("movie_results"), list) else []
+    tv_results = payload.get("tv_results") if isinstance(payload.get("tv_results"), list) else []
+
+    preferred_media_type = str(media_type or "").strip().lower()
+    ordered_results = []
+    if preferred_media_type == "movie":
+        ordered_results.extend(("movie", item) for item in movie_results)
+        ordered_results.extend(("show", item) for item in tv_results)
+    elif preferred_media_type == "show":
+        ordered_results.extend(("show", item) for item in tv_results)
+        ordered_results.extend(("movie", item) for item in movie_results)
+    else:
+        ordered_results.extend(("movie", item) for item in movie_results)
+        ordered_results.extend(("show", item) for item in tv_results)
+
+    for result_type, item in ordered_results:
+        if not isinstance(item, dict):
+            continue
+        label = str(item.get("title") or item.get("name") or "").strip()
+        if not label:
+            continue
+        tmdb_id = item.get("id")
+        tmdb_suffix = f" (TMDb {tmdb_id})" if tmdb_id not in [None, ""] else ""
+        media_label = "movie" if result_type == "movie" else "show"
+        return {
+            "valid": True,
+            "verified": True,
+            "label": label,
+            "result_type": result_type,
+            "message": f"TMDb {media_label}: {label}{tmdb_suffix}",
+        }
+
+    return {"valid": False, "verified": True, "message": "TMDb did not find a matching IMDb ID."}
+
+
 @app.route("/lookup_template_string_value", methods=["POST"])
 def lookup_template_string_value():
     data = request.get_json(silent=True) or {}
@@ -9805,8 +9864,29 @@ def lookup_template_string_value():
     if preset == "imdb_id_plex":
         if not library_name:
             return jsonify({"valid": False, "verified": False, "message": "Active Plex library is required for IMDb lookup."})
+
+        tmdb_result = _lookup_tmdb_by_imdb_id(value, media_type=media_type)
+        tmdb_label = str(tmdb_result.get("label") or "").strip()
+        tmdb_message = str(tmdb_result.get("message") or "").strip()
+        tmdb_result_type = str(tmdb_result.get("result_type") or "").strip().lower()
+        expected_media_type = str(media_type or "").strip().lower()
+
+        if tmdb_result.get("valid") and tmdb_result.get("verified") and tmdb_result_type and expected_media_type:
+            if tmdb_result_type != expected_media_type:
+                library_label = "movie library" if expected_media_type == "movie" else "show library"
+                id_label = "show" if tmdb_result_type == "show" else "movie"
+                return jsonify(
+                    {
+                        "valid": True,
+                        "verified": True,
+                        "label": tmdb_label,
+                        "level": "warning",
+                        "message": f"{tmdb_message}. This IMDb ID resolves to a {id_label}, but the active library is a {library_label}.",
+                    }
+                )
+
         try:
-            result = helpers.find_item_by_imdb_id(library_name, value, media_type)
+            result = helpers.find_item_by_imdb_id(library_name, value, media_type, fallback_title=tmdb_label)
         except Exception as exc:
             return jsonify({"valid": False, "verified": False, "message": f"Plex lookup failed: {exc}."})
 
@@ -9814,11 +9894,27 @@ def lookup_template_string_value():
             title = str(result.get("title")).strip()
             return jsonify({"valid": True, "verified": True, "label": title, "message": f"Plex: {title}"})
 
+        if tmdb_result.get("valid") and tmdb_result.get("verified"):
+            if tmdb_label and tmdb_message:
+                return jsonify(
+                    {
+                        "valid": True,
+                        "verified": True,
+                        "label": tmdb_label,
+                        "level": "warning",
+                        "message": f"{tmdb_message}. Plex could not confirm a match in the active library.",
+                    }
+                )
+            return jsonify(tmdb_result)
+
+        fallback_message = "IMDb ID format is valid, but no matching item was found in the active Plex library."
+        if tmdb_message:
+            fallback_message = f"{fallback_message} {tmdb_message}"
         return jsonify(
             {
                 "valid": False,
-                "verified": False,
-                "message": "IMDb ID format is valid, but no matching item was found in the active Plex library.",
+                "verified": bool(tmdb_result.get("verified")),
+                "message": fallback_message,
             }
         )
 

--- a/quickstart.py
+++ b/quickstart.py
@@ -9822,6 +9822,108 @@ def _lookup_tmdb_by_imdb_id(imdb_id, media_type=""):
     return {"valid": False, "verified": True, "message": "TMDb did not find a matching IMDb ID."}
 
 
+def _lookup_tmdb_external_ids(endpoint, tmdb_id, api_key):
+    if endpoint not in {"movie", "tv"} or not tmdb_id or not api_key:
+        return {}
+
+    try:
+        response = requests.get(
+            f"https://api.themoviedb.org/3/{endpoint}/{tmdb_id}/external_ids",
+            params={"api_key": api_key},
+            timeout=10,
+        )
+    except requests.RequestException:
+        return {}
+
+    if response.status_code != 200:
+        return {}
+
+    payload = response.json() if response.content else {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _lookup_tmdb_numeric_id(tmdb_id, media_type=""):
+    api_key = _get_active_tmdb_api_key()
+    if not api_key:
+        return {"valid": False, "verified": False, "message": "TMDb is not configured for the active config."}
+
+    preferred_media_type = str(media_type or "").strip().lower()
+    endpoint_order = []
+    if preferred_media_type == "movie":
+        endpoint_order = [("movie", "movie"), ("tv", "show"), ("collection", "collection"), ("person", "person")]
+    elif preferred_media_type == "show":
+        endpoint_order = [("tv", "show"), ("movie", "movie"), ("collection", "collection"), ("person", "person")]
+    else:
+        endpoint_order = [("movie", "movie"), ("tv", "show"), ("collection", "collection"), ("person", "person")]
+
+    for endpoint, result_type in endpoint_order:
+        try:
+            response = requests.get(
+                f"https://api.themoviedb.org/3/{endpoint}/{tmdb_id}",
+                params={"api_key": api_key},
+                timeout=10,
+            )
+        except requests.RequestException as exc:
+            return {"valid": False, "verified": False, "message": f"TMDb lookup failed: {exc}."}
+
+        if response.status_code in {401, 403}:
+            return {"valid": False, "verified": False, "message": "TMDb lookup could not be verified with the configured API key."}
+
+        if response.status_code == 404:
+            continue
+
+        if response.status_code != 200:
+            return {"valid": False, "verified": False, "message": f"TMDb lookup failed with status {response.status_code}."}
+
+        payload = response.json() if response.content else {}
+        label = str(payload.get("title") or payload.get("name") or "").strip()
+        if not label:
+            label = f"TMDb {result_type} {tmdb_id}"
+        external_ids = _lookup_tmdb_external_ids(endpoint, tmdb_id, api_key) if endpoint in {"movie", "tv"} else {}
+        tvdb_id = external_ids.get("tvdb_id")
+        id_suffix = f" (TMDb {tmdb_id})"
+        if tvdb_id not in [None, "", 0, "0"]:
+            id_suffix = f" (TMDb {tmdb_id}, TVDb {tvdb_id})"
+
+        return {
+            "valid": True,
+            "verified": True,
+            "label": label,
+            "result_type": result_type,
+            "tvdb_id": tvdb_id,
+            "message": f"TMDb {result_type}: {label}{id_suffix}",
+        }
+
+    return {"valid": False, "verified": True, "message": "TMDb did not find a matching numeric ID."}
+
+
+def _normalize_tmdb_library_media_type(value):
+    normalized = str(value or "").strip().lower()
+    if normalized in {"movie", "movies", "mov"}:
+        return "movie"
+    if normalized in {"show", "shows", "sho", "tv", "season", "seasons", "episode", "episodes"}:
+        return "show"
+    return normalized
+
+
+def _build_tmdb_library_type_warning(tmdb_message, tmdb_result_type, expected_media_type, value_label="ID"):
+    resolved_type = _normalize_tmdb_library_media_type(tmdb_result_type)
+    expected_type = _normalize_tmdb_library_media_type(expected_media_type)
+    if not resolved_type or expected_type not in {"movie", "show"}:
+        return ""
+    if resolved_type == expected_type:
+        return ""
+
+    library_label = "movie library" if expected_type == "movie" else "show/season/episode library"
+    readable_type = {
+        "movie": "movie",
+        "show": "show",
+        "collection": "collection",
+        "person": "person",
+    }.get(resolved_type, resolved_type)
+    return f"{tmdb_message}. This {value_label} resolves to a {readable_type}, but the active library is a {library_label}."
+
+
 @app.route("/lookup_template_string_value", methods=["POST"])
 def lookup_template_string_value():
     data = request.get_json(silent=True) or {}
@@ -9861,6 +9963,54 @@ def lookup_template_string_value():
 
         return jsonify({"valid": False, "verified": False, "message": f"TMDb lookup failed with status {response.status_code}."})
 
+    if preset == "numeric_id":
+        tmdb_result = _lookup_tmdb_numeric_id(value, media_type=media_type)
+        tmdb_label = str(tmdb_result.get("label") or "").strip()
+        tmdb_message = str(tmdb_result.get("message") or "").strip()
+        tmdb_result_type = str(tmdb_result.get("result_type") or "").strip().lower()
+        expected_media_type = str(media_type or "").strip().lower()
+
+        warning_message = _build_tmdb_library_type_warning(tmdb_message, tmdb_result_type, expected_media_type, value_label="numeric ID")
+        if tmdb_result.get("valid") and tmdb_result.get("verified") and warning_message:
+            return jsonify(
+                {
+                    "valid": True,
+                    "verified": True,
+                    "label": tmdb_label,
+                    "level": "warning",
+                    "message": warning_message,
+                }
+            )
+
+        if tmdb_result.get("valid") and tmdb_result.get("verified") and tmdb_label and library_name and tmdb_result_type in {"movie", "show"}:
+            try:
+                plex_match = helpers.find_item_by_title(library_name, tmdb_label)
+            except Exception as exc:
+                return jsonify({"valid": False, "verified": False, "message": f"Plex lookup failed: {exc}."})
+
+            if plex_match and plex_match.get("title"):
+                plex_title = str(plex_match.get("title")).strip()
+                return jsonify(
+                    {
+                        "valid": True,
+                        "verified": True,
+                        "label": plex_title,
+                        "message": f"Plex title match: {plex_title}. {tmdb_message}",
+                    }
+                )
+
+            return jsonify(
+                {
+                    "valid": True,
+                    "verified": True,
+                    "label": tmdb_label,
+                    "level": "warning",
+                    "message": f"{tmdb_message}. Plex could not confirm a match in the active library.",
+                }
+            )
+
+        return jsonify(tmdb_result)
+
     if preset == "imdb_id_plex":
         if not library_name:
             return jsonify({"valid": False, "verified": False, "message": "Active Plex library is required for IMDb lookup."})
@@ -9871,19 +10021,17 @@ def lookup_template_string_value():
         tmdb_result_type = str(tmdb_result.get("result_type") or "").strip().lower()
         expected_media_type = str(media_type or "").strip().lower()
 
-        if tmdb_result.get("valid") and tmdb_result.get("verified") and tmdb_result_type and expected_media_type:
-            if tmdb_result_type != expected_media_type:
-                library_label = "movie library" if expected_media_type == "movie" else "show library"
-                id_label = "show" if tmdb_result_type == "show" else "movie"
-                return jsonify(
-                    {
-                        "valid": True,
-                        "verified": True,
-                        "label": tmdb_label,
-                        "level": "warning",
-                        "message": f"{tmdb_message}. This IMDb ID resolves to a {id_label}, but the active library is a {library_label}.",
-                    }
-                )
+        warning_message = _build_tmdb_library_type_warning(tmdb_message, tmdb_result_type, expected_media_type, value_label="IMDb ID")
+        if tmdb_result.get("valid") and tmdb_result.get("verified") and warning_message:
+            return jsonify(
+                {
+                    "valid": True,
+                    "verified": True,
+                    "label": tmdb_label,
+                    "level": "warning",
+                    "message": warning_message,
+                }
+            )
 
         try:
             result = helpers.find_item_by_imdb_id(library_name, value, media_type, fallback_title=tmdb_label)

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -181,6 +181,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -836,6 +844,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -1459,6 +1475,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -2086,6 +2110,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -2709,6 +2741,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -3347,6 +3387,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -3963,6 +4011,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -4610,6 +4666,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -5238,6 +5302,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -5861,6 +5933,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -6499,6 +6579,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -7104,6 +7192,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -7731,6 +7827,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -8354,6 +8458,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -8981,6 +9093,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -9598,6 +9718,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -10213,6 +10341,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -10767,6 +10903,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -11378,6 +11522,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -12107,6 +12259,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -12882,6 +13042,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -13616,6 +13784,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -14000,6 +14176,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -14750,6 +14934,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -15907,6 +16099,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -17127,6 +17327,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -17715,6 +17923,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -19492,6 +19708,14 @@
             "default": 2
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -20402,6 +20626,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -21335,6 +21567,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -21812,6 +22052,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -22294,6 +22542,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -22772,6 +23028,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -23254,6 +23518,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -23732,6 +24004,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -24214,6 +24494,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -24692,6 +24980,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -25188,6 +25484,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -25695,6 +25999,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -26571,6 +26883,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -27660,6 +27980,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -28401,6 +28729,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -29056,6 +29392,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -29522,6 +29866,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -30011,6 +30363,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -30544,6 +30904,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -31045,6 +31413,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -31559,6 +31935,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -32069,6 +32453,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -33060,6 +33452,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -33908,6 +34308,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -34361,6 +34769,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -35455,6 +35871,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",
@@ -36573,6 +36997,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -37016,6 +37448,14 @@
             "step": 1
           },
           {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
+          },
+          {
             "key": "ignore_imdb_ids",
             "label": "Ignore IMDb IDs",
             "type": "string_list",
@@ -37457,6 +37897,14 @@
             "input_type": "number",
             "min": 1,
             "step": 1
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id"
           },
           {
             "key": "ignore_imdb_ids",

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -2972,7 +2972,9 @@ document.addEventListener('DOMContentLoaded', function () {
             return
           }
           target.classList.remove('d-none')
-          if (state.valid && state.verified) {
+          if (state.level === 'warning') {
+            target.classList.add('text-warning')
+          } else if (state.valid && state.verified) {
             target.classList.add('text-success')
           } else if (state.verified) {
             target.classList.add('text-danger')
@@ -3097,10 +3099,12 @@ document.addEventListener('DOMContentLoaded', function () {
                 lookupTemplateStringValue(presetName, item.value).then(result => {
                   if (!lookupMeta.isConnected) return
                   if (result.valid && result.verified && result.label) {
+                    const successMessage = result.message || `TMDb: ${result.label}`
                     setLookupState(lookupMeta, {
                       valid: true,
                       verified: true,
-                      message: `TMDb: ${result.label}`
+                      level: result.level,
+                      message: successMessage
                     })
                     return
                   }
@@ -3133,10 +3137,12 @@ document.addEventListener('DOMContentLoaded', function () {
                 lookupTemplateStringValue(presetName, item.value, { libraryName, mediaType }).then(result => {
                   if (!lookupMeta.isConnected) return
                   if (result.valid && result.verified && result.label) {
+                    const successMessage = result.message || `Plex: ${result.label}`
                     setLookupState(lookupMeta, {
                       valid: true,
                       verified: true,
-                      message: `Plex: ${result.label}`
+                      level: result.level,
+                      message: successMessage
                     })
                     return
                   }

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -2712,6 +2712,14 @@ document.addEventListener('DOMContentLoaded', function () {
           ? { valid: true }
           : { valid: false, message: 'Enter a numeric TMDb collection ID like 131292.' }
       },
+      numeric_id: {
+        duplicateInsensitive: true,
+        normalize: value => value,
+        lookupService: 'tmdb',
+        validate: value => /^\d+$/.test(value)
+          ? { valid: true }
+          : { valid: false, message: 'Enter a numeric ID like 603 or 1399.' }
+      },
       imdb_id_plex: {
         duplicateInsensitive: true,
         normalize: value => value.toLowerCase(),
@@ -3096,7 +3104,7 @@ document.addEventListener('DOMContentLoaded', function () {
                   verified: false,
                   message: 'Checking TMDb collection title...'
                 })
-                lookupTemplateStringValue(presetName, item.value).then(result => {
+                lookupTemplateStringValue(presetName, item.value, { libraryName, mediaType }).then(result => {
                   if (!lookupMeta.isConnected) return
                   if (result.valid && result.verified && result.label) {
                     const successMessage = result.message || `TMDb: ${result.label}`


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Fix collection ignore-ID handling in Quickstart.
This updates collection template support so ignore_ids is available alongside ignore_imdb_ids across the same collection families. It also fixes YAML generation for both fields so populated values emit as Kometa-style comma-separated strings and empty lists are omitted instead of leaking JSON-like values such as '[]' or '["..."]'.
The Libraries UI now validates numeric ignore_ids, resolves them against TMDb, enriches movie/show results with linked tvdb_id when available, and warns when the resolved media type does not fit the active library context. Numeric-ID lookups now also attempt a secondary Plex title confirmation, so TMDb-only matches no longer appear as confirmed library matches. In the same area, the frontend regression that dropped library context for TMDb-backed lookups was fixed, which restores the expected yellow warning state for mismatched or non-library-confirmed entries.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
