### PR TITLE
Fix test results

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -306,6 +306,13 @@ def _normalize_collection_template_var_value(key, value):
     return value
 
 
+def _normalize_settings_section_value(key, value):
+    if key in {"ignore_ids", "ignore_imdb_ids"}:
+        list_values = _parse_string_list(value)
+        return ",".join(list_values) if list_values else None
+    return value
+
+
 def _normalize_asset_directory_entry(value):
     if value is None:
         return None
@@ -3231,14 +3238,23 @@ def build_config(header_style="standard", config_name=None):
                         ordered_section[key] = value
                 cleaned_data["trakt"] = ordered_section
 
-        # Ensure `asset_directory` is serialized as a proper YAML list
-        if dump_name == "settings" and "asset_directory" in cleaned_data.get("settings", {}):
-            if isinstance(cleaned_data["settings"]["asset_directory"], str):
-                # Convert multi-line string into a list
-                cleaned_data["settings"]["asset_directory"] = _normalize_asset_directory_values(cleaned_data["settings"]["asset_directory"])
-            elif isinstance(cleaned_data["settings"]["asset_directory"], list):
-                # Ensure all list items are strings
-                cleaned_data["settings"]["asset_directory"] = _normalize_asset_directory_values(cleaned_data["settings"]["asset_directory"])
+        # Ensure settings multi-value inputs are normalized for YAML output.
+        if dump_name == "settings" and isinstance(cleaned_data.get("settings"), dict):
+            settings_block = cleaned_data["settings"]
+            for setting_key in list(settings_block.keys()):
+                normalized_value = _normalize_settings_section_value(setting_key, settings_block.get(setting_key))
+                if normalized_value is None:
+                    settings_block.pop(setting_key, None)
+                else:
+                    settings_block[setting_key] = normalized_value
+
+            if "asset_directory" in settings_block:
+                if isinstance(settings_block["asset_directory"], str):
+                    # Convert multi-line string into a list
+                    settings_block["asset_directory"] = _normalize_asset_directory_values(settings_block["asset_directory"])
+                elif isinstance(settings_block["asset_directory"], list):
+                    # Ensure all list items are strings
+                    settings_block["asset_directory"] = _normalize_asset_directory_values(settings_block["asset_directory"])
 
         # Dump the cleaned data to YAML
         with io.StringIO() as stream:

--- a/quickstart.py
+++ b/quickstart.py
@@ -1,5 +1,6 @@
 import argparse
 import gzip
+import inspect
 import io
 import json
 import os
@@ -10065,8 +10066,17 @@ def lookup_template_string_value():
         if not library_name:
             return jsonify({"valid": False, "verified": False, "message": "Active Plex library is required for IMDb lookup."})
 
+        find_item_by_imdb_id = helpers.find_item_by_imdb_id
         try:
-            result = helpers.find_item_by_imdb_id(library_name, value, media_type, fallback_title=tmdb_label)
+            supports_fallback_title = "fallback_title" in inspect.signature(find_item_by_imdb_id).parameters
+        except (TypeError, ValueError):
+            supports_fallback_title = True
+
+        try:
+            if supports_fallback_title:
+                result = find_item_by_imdb_id(library_name, value, media_type, fallback_title=tmdb_label)
+            else:
+                result = find_item_by_imdb_id(library_name, value, media_type)
         except Exception as exc:
             return jsonify({"valid": False, "verified": False, "message": f"Plex lookup failed: {exc}."})
 

--- a/quickstart.py
+++ b/quickstart.py
@@ -8154,9 +8154,29 @@ def step(name):
     attribute_config = {}
     collection_config = []
     overlay_config = []
-    service_validations = {}
+    service_validations = {
+        "plex": False,
+        "tmdb": False,
+        "omdb": False,
+        "mdblist": False,
+        "anidb": False,
+        "trakt": False,
+        "mal": False,
+    }
     overlay_fonts = []
     image_data = {}
+    service_validation_sources = [
+        ("010-plex", "plex"),
+        ("020-tmdb", "tmdb"),
+        ("050-omdb", "omdb"),
+        ("060-mdblist", "mdblist"),
+        ("100-anidb", "anidb"),
+        ("130-trakt", "trakt"),
+        ("140-mal", "mal"),
+    ]
+    for section, key in service_validation_sources:
+        settings = persistence.retrieve_settings(section)
+        service_validations[key] = helpers.booler(settings.get("validated", False))
 
     def add_offset_vars(config):  # noqa: ANN001
         """
@@ -8210,18 +8230,6 @@ def step(name):
         image_data = _build_preview_image_data()
         overlay_fonts = list_overlay_fonts()
 
-        service_validation_sources = [
-            ("010-plex", "plex"),
-            ("020-tmdb", "tmdb"),
-            ("050-omdb", "omdb"),
-            ("060-mdblist", "mdblist"),
-            ("100-anidb", "anidb"),
-            ("130-trakt", "trakt"),
-            ("140-mal", "mal"),
-        ]
-        for section, key in service_validation_sources:
-            settings = persistence.retrieve_settings(section)
-            service_validations[key] = helpers.booler(settings.get("validated", False))
     workspace_status = _build_workspace_status_context(config_name, file_list, available_configs=available_configs)
     jump_to_validations = workspace_status.get("jump_to_validations", {})
     step_statuses = workspace_status.get("step_statuses", {})
@@ -9924,6 +9932,27 @@ def _build_tmdb_library_type_warning(tmdb_message, tmdb_result_type, expected_me
     return f"{tmdb_message}. This {value_label} resolves to a {readable_type}, but the active library is a {library_label}."
 
 
+def _parse_optional_id_list(value):
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+
+    text = str(value).strip()
+    if not text or text.lower() == "none":
+        return []
+
+    if text.startswith("[") and text.endswith("]"):
+        try:
+            parsed = json.loads(text)
+        except Exception:
+            parsed = None
+        if isinstance(parsed, list):
+            return [str(item).strip() for item in parsed if str(item).strip()]
+
+    return [item.strip() for item in text.split(",") if item.strip()]
+
+
 @app.route("/lookup_template_string_value", methods=["POST"])
 def lookup_template_string_value():
     data = request.get_json(silent=True) or {}
@@ -10011,10 +10040,7 @@ def lookup_template_string_value():
 
         return jsonify(tmdb_result)
 
-    if preset == "imdb_id_plex":
-        if not library_name:
-            return jsonify({"valid": False, "verified": False, "message": "Active Plex library is required for IMDb lookup."})
-
+    if preset in {"imdb_id_plex", "imdb_id_tmdb"}:
         tmdb_result = _lookup_tmdb_by_imdb_id(value, media_type=media_type)
         tmdb_label = str(tmdb_result.get("label") or "").strip()
         tmdb_message = str(tmdb_result.get("message") or "").strip()
@@ -10032,6 +10058,12 @@ def lookup_template_string_value():
                     "message": warning_message,
                 }
             )
+
+        if preset == "imdb_id_tmdb":
+            return jsonify(tmdb_result)
+
+        if not library_name:
+            return jsonify({"valid": False, "verified": False, "message": "Active Plex library is required for IMDb lookup."})
 
         try:
             result = helpers.find_item_by_imdb_id(library_name, value, media_type, fallback_title=tmdb_label)
@@ -10477,8 +10509,14 @@ def validate_all_services():
         check_regex("item_refresh_delay", r"^(0|[1-9]\d*)$")
         check_regex("minimum_items", r"^[1-9]\d*$")
         check_regex("run_again_delay", r"^(0|[1-9]\d*)$")
-        check_regex("ignore_ids", r"^(None|\d{1,8}(,\d{1,8})*)$", flags=re.IGNORECASE, allow_blank=True)
-        check_regex("ignore_imdb_ids", r"^(None|tt\d{7,8}(,tt\d{7,8})*)$", flags=re.IGNORECASE, allow_blank=True)
+        ignore_ids_values = _parse_optional_id_list(settings_section.get("ignore_ids"))
+        if any(not re.match(r"^\d{1,8}$", item) for item in ignore_ids_values):
+            invalid_fields.append("ignore_ids")
+
+        ignore_imdb_ids_values = _parse_optional_id_list(settings_section.get("ignore_imdb_ids"))
+        if any(not re.match(r"^tt\d{7,8}$", item, re.IGNORECASE) for item in ignore_imdb_ids_values):
+            invalid_fields.append("ignore_imdb_ids")
+
         check_regex("custom_repo", r"^(None|https?:\/\/[\da-z.-]+\.[a-z.]{2,6}([/\w.-]*)*\/?)$", flags=re.IGNORECASE, allow_blank=True)
 
         asset_dirs = settings_section.get("asset_directory") if isinstance(settings_section, dict) else None

--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -386,6 +386,8 @@ def collect_declared_yaml_patterns(raw: Any, *, parent_key: str | None = None) -
     elif isinstance(raw, list):
         for item in raw:
             if isinstance(item, str):
+                if parent_key == "template":
+                    continue
                 token = item.strip()
                 if token and re.fullmatch(r"[A-Za-z0-9_<>-]+(?:\.[A-Za-z0-9_<>-]+)?", token) and token not in RESERVED:
                     patterns.add(token)
@@ -543,9 +545,6 @@ def build_schema_key_set(schema_path: Path) -> set[str]:
 
 def resolve_default_paths(alias: str, kind: str, kometa_defaults: Path) -> list[Path]:
     support_files: list[Path] = []
-    shared_templates = kometa_defaults / "templates.yml"
-    if shared_templates.exists():
-        support_files.append(shared_templates)
     if kind == "overlay":
         path = kometa_defaults / "overlays" / f"{alias}.yml"
         if path.exists():
@@ -605,9 +604,118 @@ RESERVED = {
 }
 
 
+def kometa_defaults_root_for(path: Path) -> Path:
+    for candidate in [path.parent, *path.parents]:
+        if candidate.name == "defaults":
+            return candidate
+    return path.parent
+
+
+def extract_template_names(raw: Any) -> set[str]:
+    names: set[str] = set()
+    if isinstance(raw, str):
+        token = raw.strip()
+        if token:
+            names.add(token)
+    elif isinstance(raw, dict):
+        name = raw.get("name")
+        if name:
+            names.add(str(name))
+    elif isinstance(raw, list):
+        for item in raw:
+            names.update(extract_template_names(item))
+    return names
+
+
+@lru_cache(maxsize=None)
+def load_template_sections(path: Path) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
+    parsed = load_yaml(path) or {}
+    local_templates = parsed.get("templates") if isinstance(parsed, dict) else {}
+    if not isinstance(local_templates, dict):
+        local_templates = {}
+
+    shared_templates: dict[str, dict[str, Any]] = {}
+    if not isinstance(parsed, dict):
+        return parsed, shared_templates
+
+    defaults_root = kometa_defaults_root_for(path)
+    external_templates = parsed.get("external_templates")
+    template_defaults: list[str] = []
+    if isinstance(external_templates, dict):
+        external_default = external_templates.get("default")
+        if isinstance(external_default, str):
+            template_defaults.append(external_default)
+        elif isinstance(external_default, list):
+            template_defaults.extend(str(item) for item in external_default if item)
+
+    for template_default in template_defaults:
+        template_path = defaults_root / f"{template_default}.yml"
+        if not template_path.exists():
+            continue
+        shared_parsed = load_yaml(template_path) or {}
+        shared_section = shared_parsed.get("templates") if isinstance(shared_parsed, dict) else {}
+        if isinstance(shared_section, dict):
+            for template_name, template_cfg in shared_section.items():
+                shared_templates[str(template_name)] = template_cfg
+
+    return parsed, shared_templates
+
+
+def _collect_template_patterns(
+    template_name: str,
+    local_templates: dict[str, Any],
+    shared_templates: dict[str, dict[str, Any]],
+    seen: set[str] | None = None,
+) -> set[str]:
+    if seen is None:
+        seen = set()
+    if template_name in seen:
+        return set()
+    seen.add(template_name)
+
+    template_cfg = local_templates.get(template_name)
+    if template_cfg is None:
+        template_cfg = shared_templates.get(template_name)
+    if not isinstance(template_cfg, dict):
+        return set()
+
+    patterns = collect_declared_yaml_patterns(template_cfg)
+    for nested_template in extract_template_names(template_cfg.get("template")):
+        patterns.update(_collect_template_patterns(nested_template, local_templates, shared_templates, seen))
+    return patterns
+
+
 @lru_cache(maxsize=None)
 def patterns_from_default_file(path: Path) -> set[str]:
-    patterns: set[str] = set()
+    try:
+        parsed, shared_templates = load_template_sections(path)
+    except Exception:
+        parsed = None
+        shared_templates = {}
+    if isinstance(parsed, dict):
+        patterns: set[str] = set()
+        external_templates = parsed.get("external_templates")
+        if isinstance(external_templates, dict):
+            template_variables = external_templates.get("template_variables")
+            patterns.update(collect_declared_yaml_patterns(template_variables))
+
+        local_templates = parsed.get("templates")
+        if not isinstance(local_templates, dict):
+            local_templates = {}
+
+        for section_name in ("collections", "dynamic_collections", "overlays", "playlists"):
+            section = parsed.get(section_name)
+            if not isinstance(section, dict):
+                continue
+            for entry_cfg in section.values():
+                if not isinstance(entry_cfg, dict):
+                    continue
+                patterns.update(collect_declared_yaml_patterns(entry_cfg))
+                for template_name in extract_template_names(entry_cfg.get("template")):
+                    patterns.update(_collect_template_patterns(template_name, local_templates, shared_templates))
+        return patterns
+
+    patterns = set()
     for raw_line in path.read_text(encoding="utf-8").splitlines():
         line = raw_line.rstrip()
         km = KEY_RE.match(line)
@@ -617,19 +725,11 @@ def patterns_from_default_file(path: Path) -> set[str]:
             token = km.group(1)
         elif lm:
             token = lm.group(1)
-        if not token:
-            continue
-        if token in RESERVED:
+        if not token or token in RESERVED:
             continue
         patterns.add(token)
         if token.endswith(".exists"):
             patterns.add(token[: -len(".exists")])
-    try:
-        parsed = load_yaml(path)
-    except Exception:
-        parsed = None
-    if parsed is not None:
-        patterns.update(collect_declared_yaml_patterns(parsed))
     return patterns
 
 

--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -736,6 +736,9 @@ def patterns_from_default_file(path: Path) -> set[str]:
 def key_matches_pattern(key: str, pattern: str) -> bool:
     if key == pattern:
         return True
+    literal_pattern = PLACEHOLDER_RE.sub("", pattern)
+    if not re.search(r"[A-Za-z0-9_.-]", literal_pattern):
+        return False
     regex = "^" + PLACEHOLDER_RE.sub(lambda _: r"[^:\s]+", re.escape(pattern)) + "$"
     return re.match(regex, key) is not None
 

--- a/static/local-js/150-settings.js
+++ b/static/local-js/150-settings.js
@@ -10,6 +10,10 @@ document.addEventListener('DOMContentLoaded', function () {
   let syncUsersModal = document.getElementById('syncUsersModal')
   let excludeUsersModal = document.getElementById('excludeUsersModal')
 
+  if (window.QSTemplateStringLists && typeof window.QSTemplateStringLists.setup === 'function') {
+    window.QSTemplateStringLists.setup(document)
+  }
+
   function ensureSettingsModalRoot (modalEl) {
     if (!modalEl || !document.body) return modalEl
     const modalId = modalEl.id
@@ -257,16 +261,6 @@ document.addEventListener('DOMContentLoaded', function () {
       errorMessage: 'Please enter a valid integer (0 or greater).'
     },
     {
-      id: 'ignore_ids',
-      regex: /^(|None|\d{1,8}(,\d{1,8})*)$/i,
-      errorMessage: 'Please enter a valid CSV list of numeric IDs (1-8 digits), "None", or leave blank.'
-    },
-    {
-      id: 'ignore_imdb_ids',
-      regex: /^(|None|tt\d{7,8}(,tt\d{7,8})*)$/i,
-      errorMessage: 'Please enter a valid CSV list of IMDb IDs (e.g., tt1234567), "None", or leave blank.'
-    },
-    {
       id: 'custom_repo',
       regex: /^(|None|https?:\/\/[\da-z.-]+\.[a-z.]{2,6}([/\w.-]*)*\/?)$/i,
       errorMessage: 'Please enter a valid URL, "None", or leave blank.'
@@ -307,6 +301,13 @@ document.addEventListener('DOMContentLoaded', function () {
       }
     }
 
+    if (window.QSTemplateStringLists && typeof window.QSTemplateStringLists.validateAll === 'function') {
+      const templateListsValid = window.QSTemplateStringLists.validateAll(configForm || document)
+      if (!templateListsValid) {
+        isFormValid = false
+      }
+    }
+
     updateValidationMessages(isFormValid)
     return isFormValid
   }
@@ -327,6 +328,12 @@ document.addEventListener('DOMContentLoaded', function () {
       })
     }
   })
+
+  if (configForm) {
+    configForm.addEventListener('qs:template-string-list-change', function () {
+      settingsTouched = true
+    })
+  }
 
   const assetDirectoryContainer = document.getElementById('asset_directory_container')
   const addAssetDirectoryButton = document.getElementById('add-asset-directory')

--- a/static/local-js/templateStringList.js
+++ b/static/local-js/templateStringList.js
@@ -1,0 +1,608 @@
+/* global CustomEvent */
+
+(function () {
+  const templateStringListPresetConfigs = {
+    generic_text: {
+      duplicateInsensitive: false,
+      normalize: value => value,
+      validate: value => {
+        if (!value) return { valid: false, message: 'Enter a value before adding it.' }
+        return { valid: true }
+      }
+    },
+    name_like: {
+      duplicateInsensitive: true,
+      normalize: value => value.replace(/\s+/g, ' '),
+      validate: value => {
+        const normalized = String(value || '').trim()
+        if (!normalized) return { valid: false, message: 'Enter a text value before adding it.' }
+        try {
+          if (!/[\p{L}\p{N}]/u.test(normalized)) {
+            return { valid: false, message: 'Enter a text value with letters or numbers.' }
+          }
+          if (!/^[\p{L}\p{N} .,&'’:+\-/()!]+$/u.test(normalized)) {
+            return { valid: false, message: 'Use letters, numbers, spaces, or common punctuation only.' }
+          }
+        } catch (_error) {
+          if (!/[A-Za-z0-9]/.test(normalized)) {
+            return { valid: false, message: 'Enter a text value with letters or numbers.' }
+          }
+          if (!/^[A-Za-z0-9 .,&':+\-/()!]+$/.test(normalized)) {
+            return { valid: false, message: 'Use letters, numbers, spaces, or common punctuation only.' }
+          }
+        }
+        return { valid: true }
+      }
+    },
+    tmdb_collection_id: {
+      duplicateInsensitive: true,
+      normalize: value => value,
+      lookupService: 'tmdb',
+      validate: value => /^\d+$/.test(value)
+        ? { valid: true }
+        : { valid: false, message: 'Enter a numeric TMDb collection ID like 131292.' }
+    },
+    numeric_id: {
+      duplicateInsensitive: true,
+      normalize: value => value,
+      lookupService: 'tmdb',
+      validate: value => /^\d+$/.test(value)
+        ? { valid: true }
+        : { valid: false, message: 'Enter a numeric ID like 603 or 1399.' }
+    },
+    imdb_id_tmdb: {
+      duplicateInsensitive: true,
+      normalize: value => value.toLowerCase(),
+      lookupService: 'tmdb',
+      validate: value => /^tt\d{7,8}$/i.test(value)
+        ? { valid: true }
+        : { valid: false, message: 'Enter an IMDb ID like tt1234567 or tt12345678.' }
+    },
+    imdb_id_plex: {
+      duplicateInsensitive: true,
+      normalize: value => value.toLowerCase(),
+      lookupService: 'plex',
+      validate: value => /^tt\d{7,8}$/i.test(value)
+        ? { valid: true }
+        : { valid: false, message: 'Enter an IMDb ID like tt1234567 or tt12345678.' }
+    },
+    year: {
+      duplicateInsensitive: true,
+      normalize: value => value,
+      validate: value => /^\d{4}$/.test(value)
+        ? { valid: true }
+        : { valid: false, message: 'Enter a 4-digit year like 2022.' }
+    },
+    decade: {
+      duplicateInsensitive: true,
+      normalize: value => value,
+      validate: value => /^\d{3,4}0$/.test(value)
+        ? { valid: true }
+        : { valid: false, message: 'Enter a decade key ending in 0 like 2020.' }
+    },
+    language_code: {
+      duplicateInsensitive: true,
+      normalize: value => value.toLowerCase(),
+      suggestions: ['en', 'fr', 'es', 'de', 'it', 'pt', 'ja', 'ko', 'zh', 'ru', 'ar', 'hi', 'fil', 'myn', 'rom', 'tai'],
+      validate: value => /^[a-z]{2,3}$/.test(value)
+        ? { valid: true }
+        : { valid: false, message: 'Enter a 2 or 3 letter language code like fr or fil.' }
+    },
+    aspect_key: {
+      duplicateInsensitive: true,
+      normalize: value => value,
+      suggestions: ['1.33', '1.65', '1.66', '1.78', '1.85', '2.2', '2.35', '2.77'],
+      allowedValues: new Set(['1.33', '1.65', '1.66', '1.78', '1.85', '2.2', '2.35', '2.77']),
+      validate: value => templateStringListPresetConfigs.aspect_key.allowedValues.has(value)
+        ? { valid: true }
+        : { valid: false, message: 'Enter a supported aspect ratio key like 1.78 or 2.35.' }
+    },
+    resolution_key: {
+      duplicateInsensitive: true,
+      normalize: value => value.toLowerCase(),
+      suggestions: ['4k', '1080', '720', '480', '8k', '2k', '576', 'sd'],
+      allowedValues: new Set(['4k', '1080', '720', '480', '8k', '2k', '144', '240', '360', '576', 'sd']),
+      validate: value => templateStringListPresetConfigs.resolution_key.allowedValues.has(value)
+        ? { valid: true }
+        : { valid: false, message: 'Enter a supported resolution key like 4k, 1080, 720, 480, or sd.' }
+    },
+    streaming_key: {
+      duplicateInsensitive: true,
+      normalize: value => value.toLowerCase(),
+      suggestions: ['netflix', 'disney', 'amazon', 'hulu', 'hbomax', 'paramount', 'peacock'],
+      allowedValues: new Set(['channel4', 'appletv', 'bet', 'crave', 'crunchyroll', 'discovery', 'disney', 'itvx', 'hbomax', 'hayu', 'hulu', 'movistar', 'atresplayer', 'netflix', 'now', 'paramount', 'peacock', 'amazon', 'amc', 'filmin', 'youtube', 'tubi']),
+      validate: value => templateStringListPresetConfigs.streaming_key.allowedValues.has(value)
+        ? { valid: true }
+        : { valid: false, message: 'Enter a supported streaming service key like netflix, disney, or amazon.' }
+    },
+    universe_key: {
+      duplicateInsensitive: true,
+      normalize: value => value.toLowerCase(),
+      suggestions: ['mcu', 'star', 'trek', 'wizard', 'fast'],
+      allowedValues: new Set(['avp', 'arrow', 'askew', 'conjuring', 'dca', 'dcu', 'fast', 'marvel', 'mcu', 'middle', 'rocky', 'trek', 'star', 'mummy', 'wizard', 'xmen']),
+      validate: value => templateStringListPresetConfigs.universe_key.allowedValues.has(value)
+        ? { valid: true }
+        : { valid: false, message: 'Enter a supported universe key like mcu, star, trek, or wizard.' }
+    },
+    based_key: {
+      duplicateInsensitive: true,
+      normalize: value => value.toLowerCase(),
+      suggestions: ['books', 'comics', 'true_story', 'video_games'],
+      allowedValues: new Set(['books', 'comics', 'true_story', 'video_games']),
+      validate: value => templateStringListPresetConfigs.based_key.allowedValues.has(value)
+        ? { valid: true }
+        : { valid: false, message: 'Enter a supported media outlet key like books or video_games.' }
+    },
+    seasonal_key: {
+      duplicateInsensitive: true,
+      normalize: value => value.toLowerCase(),
+      suggestions: ['christmas', 'halloween', 'valentine', 'years', 'women'],
+      allowedValues: new Set(['years', 'valentine', 'patrick', 'easter', 'mother', 'memorial', 'father', 'independence', 'labor', 'halloween', 'veteran', 'thanksgiving', 'christmas', 'aapi', 'disabilities', 'black_history', 'lgbtq', 'latinx', 'women']),
+      validate: value => templateStringListPresetConfigs.seasonal_key.allowedValues.has(value)
+        ? { valid: true }
+        : { valid: false, message: 'Enter a supported seasonal key like halloween, christmas, or women.' }
+    },
+    content_rating: {
+      duplicateInsensitive: true,
+      normalize: value => value.replace(/\s+/g, ' '),
+      validate: value => /^[A-Za-z0-9][A-Za-z0-9 +\-./()]*$/.test(value)
+        ? { valid: true }
+        : { valid: false, message: 'Enter a content rating like PG-13, TV-14, 15, or M.' }
+    }
+  }
+
+  function inferTemplateStringListPreset (wrapper, input) {
+    const explicitPreset = String(wrapper.dataset.validationPreset || input.dataset.validationPreset || '').trim()
+    if (explicitPreset && templateStringListPresetConfigs[explicitPreset]) return explicitPreset
+
+    const placeholder = String(input.getAttribute('placeholder') || '').trim().toLowerCase()
+    if (placeholder.includes('tmdb collection id')) return 'tmdb_collection_id'
+    if (placeholder.includes('year (e.g. 2022)')) return 'year'
+    if (placeholder.includes('decade key')) return 'decade'
+    if (placeholder.includes('language code')) return 'language_code'
+    if (placeholder.includes('aspect ratio key')) return 'aspect_key'
+    if (placeholder.includes('resolution key')) return 'resolution_key'
+    if (placeholder.includes('service key')) return 'streaming_key'
+    if (placeholder.includes('universe key')) return 'universe_key'
+    if (placeholder.includes('media outlet key')) return 'based_key'
+    if (placeholder.includes('seasonal key')) return 'seasonal_key'
+    if (placeholder.includes('content rating')) return 'content_rating'
+    if (
+      placeholder.includes('genre name') ||
+      placeholder.includes('person name') ||
+      placeholder.includes('studio name') ||
+      placeholder.includes('network name') ||
+      placeholder.includes('country name') ||
+      placeholder.includes('region name') ||
+      placeholder.includes('continent name')
+    ) {
+      return 'name_like'
+    }
+    return 'generic_text'
+  }
+
+  function ensureTemplateStringListDatalist (wrapper, input, presetConfig, presetName) {
+    if (!wrapper || !input || !presetConfig || !Array.isArray(presetConfig.suggestions) || !presetConfig.suggestions.length) return
+    if (presetConfig.suggestions.length > 50) return
+    const existingListId = input.getAttribute('list')
+    if (existingListId && document.getElementById(existingListId)) return
+    const hiddenId = String(wrapper.dataset.hiddenInput || input.id || 'template-string-list').replace(/[^A-Za-z0-9_-]+/g, '_')
+    const datalistId = `${hiddenId}_${presetName}_options`
+    let datalist = document.getElementById(datalistId)
+    if (!datalist) {
+      datalist = document.createElement('datalist')
+      datalist.id = datalistId
+      presetConfig.suggestions.forEach(value => {
+        const option = document.createElement('option')
+        option.value = value
+        datalist.appendChild(option)
+      })
+      wrapper.appendChild(datalist)
+    }
+    input.setAttribute('list', datalistId)
+  }
+
+  function setupTemplateStringListHandlers (scope) {
+    const templateStringLookupCache = window.__qsTemplateStringLookupCache || new Map()
+    window.__qsTemplateStringLookupCache = templateStringLookupCache
+
+    function getServiceValidationState (serviceName) {
+      const el = document.getElementById(`qs-validate-${serviceName}`)
+      return String(el?.value || '').trim().toLowerCase() === 'true'
+    }
+
+    async function lookupTemplateStringValue (presetName, value, context = {}) {
+      const libraryName = String(context.libraryName || '').trim()
+      const mediaType = String(context.mediaType || '').trim()
+      const cacheKey = `${presetName}:${libraryName}:${mediaType}:${value}`
+      if (templateStringLookupCache.has(cacheKey)) {
+        return templateStringLookupCache.get(cacheKey)
+      }
+      const request = fetch('/lookup_template_string_value', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          preset: presetName,
+          value,
+          library_name: libraryName,
+          media_type: mediaType
+        })
+      })
+        .then(async (response) => {
+          const data = await response.json().catch(() => ({}))
+          if (!response.ok) {
+            return {
+              valid: false,
+              verified: false,
+              message: data.error || data.message || `Lookup failed (${response.status})`
+            }
+          }
+          return data
+        })
+        .catch(() => ({
+          valid: false,
+          verified: false,
+          message: 'Lookup unavailable right now.'
+        }))
+      templateStringLookupCache.set(cacheKey, request)
+      return request
+    }
+
+    const root = scope || document
+    root.querySelectorAll('[data-template-string-list]').forEach(wrapper => {
+      if (wrapper.dataset.listenerAdded) return
+      const hiddenId = wrapper.dataset.hiddenInput
+      const hidden = hiddenId ? document.getElementById(hiddenId) : wrapper.querySelector('input[type="hidden"]')
+      const input = wrapper.querySelector('input[type="text"]')
+      const addBtn = wrapper.querySelector('[data-template-string-add]')
+      const list = wrapper.querySelector('[data-template-string-items]')
+      const feedback = wrapper.querySelector('[data-template-string-feedback]')
+      const templateVariableKey = String(wrapper.dataset.templateVariableKey || '').trim()
+      const mutuallyExclusiveWith = String(wrapper.dataset.mutuallyExclusiveWith || '').trim()
+
+      if (!hidden || !input || !addBtn || !list) return
+
+      const presetName = inferTemplateStringListPreset(wrapper, input)
+      const presetConfig = templateStringListPresetConfigs[presetName] || templateStringListPresetConfigs.generic_text
+      const libraryName = String(wrapper.dataset.libraryName || '').trim()
+      const mediaType = String(wrapper.dataset.mediaType || '').trim()
+      ensureTemplateStringListDatalist(wrapper, input, presetConfig, presetName)
+
+      function parseStoredStringList (rawValue) {
+        const raw = String(rawValue || '').trim()
+        if (!raw) return []
+        try {
+          const parsed = JSON.parse(raw)
+          if (Array.isArray(parsed)) {
+            return parsed.map(item => String(item).trim()).filter(Boolean)
+          }
+        } catch (_error) {
+          // Fall through to support legacy storage.
+        }
+        if (raw.toLowerCase() === 'none') return []
+        return raw.split(',').map(item => item.trim()).filter(Boolean)
+      }
+
+      function getCounterpartHiddenId () {
+        if (!hiddenId || !templateVariableKey || !mutuallyExclusiveWith) return ''
+        const suffix = `_${templateVariableKey}`
+        if (!hiddenId.endsWith(suffix)) return ''
+        return `${hiddenId.slice(0, -suffix.length)}_${mutuallyExclusiveWith}`
+      }
+
+      function getCounterpartWrapper () {
+        const counterpartHiddenId = getCounterpartHiddenId()
+        if (!counterpartHiddenId) return null
+        return document.querySelector(`[data-template-string-list][data-hidden-input="${counterpartHiddenId}"]`)
+      }
+
+      function getCounterpartValues () {
+        const counterpartWrapper = getCounterpartWrapper()
+        if (counterpartWrapper && typeof counterpartWrapper.__qsTemplateStringListGetValues === 'function') {
+          return counterpartWrapper.__qsTemplateStringListGetValues()
+        }
+        const counterpartHiddenId = getCounterpartHiddenId()
+        const counterpartHidden = counterpartHiddenId ? document.getElementById(counterpartHiddenId) : null
+        return parseStoredStringList(counterpartHidden?.value)
+      }
+
+      function setLookupState (target, state) {
+        if (!target) return
+        target.textContent = state?.message || ''
+        target.className = 'small mt-1'
+        if (!state?.message) {
+          target.classList.add('d-none')
+          return
+        }
+        target.classList.remove('d-none')
+        if (state.level === 'warning') {
+          target.classList.add('text-warning')
+        } else if (state.valid && state.verified) {
+          target.classList.add('text-success')
+        } else if (state.verified) {
+          target.classList.add('text-danger')
+        } else {
+          target.classList.add('text-warning')
+        }
+      }
+
+      function setFeedback (message, persistent = false, level = 'error') {
+        const isError = Boolean(message) && level === 'error'
+        if (feedback) {
+          feedback.textContent = message || ''
+          feedback.classList.toggle('d-none', !message)
+          feedback.classList.toggle('d-block', Boolean(message))
+          feedback.classList.toggle('invalid-feedback', isError)
+          feedback.classList.toggle('text-warning', Boolean(message) && level === 'warning')
+          feedback.classList.toggle('small', Boolean(message) && level === 'warning')
+        }
+        input.classList.toggle('is-invalid', isError)
+        input.setCustomValidity(persistent && isError && message ? message : '')
+      }
+
+      function clearTransientFeedback () {
+        if (input.validationMessage) return
+        setFeedback('')
+      }
+
+      function parseValues () {
+        return parseStoredStringList(hidden.value)
+      }
+
+      function validateValue (rawValue) {
+        const normalizedRaw = String(rawValue || '').trim()
+        const normalized = presetConfig.normalize ? presetConfig.normalize(normalizedRaw) : normalizedRaw
+        const result = presetConfig.validate ? presetConfig.validate(normalized) : { valid: Boolean(normalized) }
+        return {
+          value: normalized,
+          valid: Boolean(result.valid),
+          message: result.message || 'Enter a valid value.'
+        }
+      }
+
+      function duplicateKeyForValue (value) {
+        return presetConfig.duplicateInsensitive ? String(value || '').toLowerCase() : String(value || '')
+      }
+
+      function analyzeValues (values) {
+        const seen = new Set()
+        const analyzed = []
+        values.forEach(rawValue => {
+          const checked = validateValue(rawValue)
+          if (!checked.value) return
+          const duplicateKey = duplicateKeyForValue(checked.value)
+          if (seen.has(duplicateKey)) return
+          seen.add(duplicateKey)
+          analyzed.push(checked)
+        })
+        return analyzed
+      }
+
+      function renderList (items) {
+        list.replaceChildren()
+        items.forEach((item, index) => {
+          const li = document.createElement('li')
+          li.className = 'list-group-item d-flex justify-content-between align-items-center'
+          if (!item.valid) li.classList.add('list-group-item-danger')
+
+          const textWrap = document.createElement('div')
+          textWrap.className = 'd-flex flex-column'
+
+          const titleRow = document.createElement('div')
+          titleRow.className = 'd-flex align-items-center gap-2'
+
+          const textSpan = document.createElement('span')
+          textSpan.textContent = item.value
+          titleRow.appendChild(textSpan)
+
+          if (!item.valid) {
+            const badge = document.createElement('span')
+            badge.className = 'badge text-bg-danger'
+            badge.textContent = 'Invalid'
+            badge.title = item.message
+            titleRow.appendChild(badge)
+          }
+
+          textWrap.appendChild(titleRow)
+
+          const lookupMeta = document.createElement('div')
+          lookupMeta.className = 'small mt-1 d-none'
+          textWrap.appendChild(lookupMeta)
+
+          const button = document.createElement('button')
+          button.type = 'button'
+          button.className = 'btn btn-sm btn-danger'
+          button.setAttribute('aria-label', 'Remove')
+          const icon = document.createElement('i')
+          icon.className = 'bi bi-x-lg'
+          button.appendChild(icon)
+          li.append(textWrap, button)
+          list.appendChild(li)
+
+          button.addEventListener('click', () => {
+            const updated = items
+              .filter((_, itemIndex) => itemIndex !== index)
+              .map(entry => entry.value)
+            syncState(updated)
+          })
+
+          if (item.valid && presetConfig.lookupService === 'tmdb') {
+            if (!getServiceValidationState('tmdb')) {
+              setLookupState(lookupMeta, {
+                valid: false,
+                verified: false,
+                message: 'TMDb not validated, so the item could not be checked.'
+              })
+            } else {
+              setLookupState(lookupMeta, {
+                valid: false,
+                verified: false,
+                message: 'Checking TMDb...'
+              })
+              lookupTemplateStringValue(presetName, item.value, { libraryName, mediaType }).then(result => {
+                if (!lookupMeta.isConnected) return
+                if (result.valid && result.verified && result.label) {
+                  const successMessage = result.message || `TMDb: ${result.label}`
+                  setLookupState(lookupMeta, {
+                    valid: true,
+                    verified: true,
+                    level: result.level,
+                    message: successMessage
+                  })
+                  return
+                }
+                setLookupState(lookupMeta, {
+                  valid: Boolean(result.valid),
+                  verified: Boolean(result.verified),
+                  level: result.level,
+                  message: result.message || 'TMDb lookup failed.'
+                })
+              })
+            }
+          } else if (item.valid && presetConfig.lookupService === 'plex') {
+            if (!getServiceValidationState('plex')) {
+              setLookupState(lookupMeta, {
+                valid: false,
+                verified: false,
+                message: 'Plex not validated, so the IMDb ID could not be checked against the active library.'
+              })
+            } else if (!libraryName) {
+              setLookupState(lookupMeta, {
+                valid: false,
+                verified: false,
+                message: 'Library context is unavailable for Plex lookup.'
+              })
+            } else {
+              setLookupState(lookupMeta, {
+                valid: false,
+                verified: false,
+                message: 'Checking Plex library for this IMDb ID...'
+              })
+              lookupTemplateStringValue(presetName, item.value, { libraryName, mediaType }).then(result => {
+                if (!lookupMeta.isConnected) return
+                if (result.valid && result.verified && result.label) {
+                  const successMessage = result.message || `Plex: ${result.label}`
+                  setLookupState(lookupMeta, {
+                    valid: true,
+                    verified: true,
+                    level: result.level,
+                    message: successMessage
+                  })
+                  return
+                }
+                setLookupState(lookupMeta, {
+                  valid: Boolean(result.valid),
+                  verified: Boolean(result.verified),
+                  level: result.level,
+                  message: result.message || 'Plex lookup failed.'
+                })
+              })
+            }
+          }
+        })
+      }
+
+      function syncState (values, transientMessage = '', options = {}) {
+        const previousSerialized = String(hidden.value || '')
+        const analyzed = analyzeValues(values)
+        const normalizedValues = analyzed.map(item => item.value)
+        let feedbackMessage = transientMessage || ''
+        let feedbackLevel = 'error'
+
+        if (!options.skipMutualExclusion && mutuallyExclusiveWith && normalizedValues.length) {
+          const counterpartValues = getCounterpartValues()
+          if (counterpartValues.length && !feedbackMessage) {
+            feedbackMessage = 'Include and Exclude are both set. Kometa code allows this, but the wiki says not to combine them.'
+            feedbackLevel = 'warning'
+          }
+        }
+
+        hidden.value = JSON.stringify(normalizedValues)
+        renderList(analyzed)
+
+        const invalidItems = analyzed.filter(item => !item.valid)
+        if (invalidItems.length) {
+          const message = invalidItems.length === 1
+            ? `${invalidItems[0].message} Remove or fix the invalid entry.`
+            : `${invalidItems[0].message} Remove or fix the invalid entries.`
+          setFeedback(message, true)
+        } else {
+          setFeedback(feedbackMessage || '', false, feedbackLevel)
+        }
+
+        if (options.emitChange !== false && String(hidden.value || '') !== previousSerialized) {
+          hidden.dispatchEvent(new Event('change', { bubbles: true }))
+          wrapper.dispatchEvent(new CustomEvent('qs:template-string-list-change', {
+            bubbles: true,
+            detail: {
+              hiddenInput: hidden.id || hidden.name || hiddenId || '',
+              values: normalizedValues
+            }
+          }))
+        }
+
+        return analyzed
+      }
+
+      function addValue () {
+        const checked = validateValue(input.value)
+        if (!checked.value) {
+          setFeedback('Enter a value before adding it.', false)
+          return
+        }
+        if (!checked.valid) {
+          setFeedback(checked.message, false)
+          return
+        }
+        const current = analyzeValues(parseValues())
+        if (current.some(item => duplicateKeyForValue(item.value) === duplicateKeyForValue(checked.value))) {
+          setFeedback('That value is already in the list.', false)
+          return
+        }
+        current.push(checked)
+        syncState(current.map(item => item.value))
+        input.value = ''
+        clearTransientFeedback()
+      }
+
+      wrapper.__qsTemplateStringListGetValues = () => parseValues()
+      wrapper.__qsTemplateStringListSync = syncState
+      wrapper.__qsTemplateStringListValidate = () => {
+        const analyzed = syncState(parseValues(), '', { emitChange: false })
+        return analyzed.every(item => item.valid) && !input.validationMessage
+      }
+      syncState(parseValues(), '', { emitChange: false })
+
+      addBtn.addEventListener('click', addValue)
+      input.addEventListener('input', clearTransientFeedback)
+      input.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') {
+          event.preventDefault()
+          addValue()
+        }
+      })
+
+      wrapper.dataset.listenerAdded = 'true'
+    })
+  }
+
+  function validateAllTemplateStringLists (scope) {
+    let allValid = true
+    const root = scope || document
+    root.querySelectorAll('[data-template-string-list]').forEach(wrapper => {
+      if (typeof wrapper.__qsTemplateStringListValidate === 'function') {
+        if (!wrapper.__qsTemplateStringListValidate()) {
+          allValid = false
+        }
+      }
+    })
+    return allValid
+  }
+
+  window.QSTemplateStringLists = {
+    presetConfigs: templateStringListPresetConfigs,
+    setup: setupTemplateStringListHandlers,
+    validateAll: validateAllTemplateStringLists
+  }
+})()

--- a/templates/000-base.html
+++ b/templates/000-base.html
@@ -77,6 +77,7 @@
   <script type="text/javascript" src="{{ url_for('static', filename='local-js/000-base.js') }}" defer></script>
   <script type="text/javascript" src="{{ url_for('static', filename='local-js/pathValidation.js') }}" defer></script>
   <script type="text/javascript" src="{{ url_for('static', filename='local-js/urlValidation.js') }}" defer></script>
+  <script type="text/javascript" src="{{ url_for('static', filename='local-js/templateStringList.js') }}" defer></script>
   <div class="header-container text-center">
     <img src="{{ url_for('static', filename='images/logo.webp') }}" alt="QUICKSTART" class="header-image" />
   </div>

--- a/templates/150-settings.html
+++ b/templates/150-settings.html
@@ -1,6 +1,7 @@
 {% extends "000-base.html" %} {% block content %}
 {% include "001-navigation.html" %}
 {% include "modals/" + page_info['template_name'] + ".html" ignore missing %}
+<input type="hidden" id="qs-validate-tmdb" value="{{ 'true' if service_validations.tmdb else 'false' }}">
 <div id="validation-messages" class="alert alert-danger" role="alert" style="display: none;">
 </div>
 <div class="form-floating mb-2">
@@ -746,37 +747,77 @@
           </div>
 
           <div class="row">
+            {% set stored_ignore_ids = data['settings'].get('ignore_ids') %}
+            {% if stored_ignore_ids is string %}
+              {% set stored_ignore_ids_text = stored_ignore_ids.strip() %}
+              {% if not stored_ignore_ids_text or stored_ignore_ids_text.lower() == 'none' %}
+                {% set ignore_ids_json = '[]' %}
+              {% elif stored_ignore_ids_text.startswith('[') and stored_ignore_ids_text.endswith(']') %}
+                {% set ignore_ids_json = stored_ignore_ids_text %}
+              {% else %}
+                {% set ignore_ids_json = (stored_ignore_ids_text.split(',') | map('trim') | reject('equalto', '') | list | tojson) %}
+              {% endif %}
+            {% elif stored_ignore_ids is sequence and stored_ignore_ids is not string %}
+              {% set ignore_ids_json = stored_ignore_ids | tojson %}
+            {% else %}
+              {% set ignore_ids_json = '[]' %}
+            {% endif %}
             <div class="col-md-6">
-              <div class="input-group mb-2">
-                <span class="input-group-text" id="ignore_ids_text"
-                  style="width: 170px; justify-content: space-between;">
+              <div class="mb-2" data-template-string-list data-hidden-input="ignore_ids"
+                data-validation-preset="numeric_id">
+                <div class="input-group">
+                  <span class="input-group-text" id="ignore_ids_text" style="width: 170px;">
                   Ignore IDs
                   <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true" style="margin-left: 10px;"
                     title="Set a list or comma-separated string of TMDb/TVDb IDs to ignore in all collections.">
                     <i class="bi bi-info-circle-fill"></i>
                   </span>
-                </span>
-
-                <input type="text" class="form-control" id="ignore_ids" name="ignore_ids"
-                  value="{{ data['settings']['ignore_ids'] }}">
+                  </span>
+                  <input type="text" class="form-control" id="ignore_ids_input" aria-describedby="ignore_ids_text"
+                    placeholder="Add numeric ID" data-validation-preset="numeric_id">
+                  <button class="btn nav-button" type="button" data-template-string-add>Add</button>
+                </div>
+                <div class="invalid-feedback d-none" data-template-string-feedback></div>
+                <ul class="list-group mt-2" data-template-string-items></ul>
+                <input type="hidden" id="ignore_ids" name="ignore_ids" value="{{ ignore_ids_json }}">
               </div>
-              <div class="error-message text-danger"></div>
             </div>
 
+            {% set stored_ignore_imdb_ids = data['settings'].get('ignore_imdb_ids') %}
+            {% if stored_ignore_imdb_ids is string %}
+              {% set stored_ignore_imdb_ids_text = stored_ignore_imdb_ids.strip() %}
+              {% if not stored_ignore_imdb_ids_text or stored_ignore_imdb_ids_text.lower() == 'none' %}
+                {% set ignore_imdb_ids_json = '[]' %}
+              {% elif stored_ignore_imdb_ids_text.startswith('[') and stored_ignore_imdb_ids_text.endswith(']') %}
+                {% set ignore_imdb_ids_json = stored_ignore_imdb_ids_text %}
+              {% else %}
+                {% set ignore_imdb_ids_json = (stored_ignore_imdb_ids_text.split(',') | map('trim') | reject('equalto', '') | list | tojson) %}
+              {% endif %}
+            {% elif stored_ignore_imdb_ids is sequence and stored_ignore_imdb_ids is not string %}
+              {% set ignore_imdb_ids_json = stored_ignore_imdb_ids | tojson %}
+            {% else %}
+              {% set ignore_imdb_ids_json = '[]' %}
+            {% endif %}
             <div class="col-md-6">
-              <div class="input-group mb-2">
-                <span class="input-group-text" id="ignore_imdb_ids_text">
+              <div class="mb-2" data-template-string-list data-hidden-input="ignore_imdb_ids"
+                data-validation-preset="imdb_id_tmdb">
+                <div class="input-group">
+                  <span class="input-group-text" id="ignore_imdb_ids_text" style="width: 170px;">
                   Ignore IMDb IDs
                   <span class="text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true" style="margin-left: 10px;"
                     title="Set a list or comma-separated string of IMDb IDs to ignore in all collections.">
                     <i class="bi bi-info-circle-fill"></i>
                   </span>
-                </span>
-
-                <input type="text" class="form-control" id="ignore_imdb_ids" name="ignore_imdb_ids"
-                  value="{{ data['settings']['ignore_imdb_ids'] }}">
+                  </span>
+                  <input type="text" class="form-control" id="ignore_imdb_ids_input"
+                    aria-describedby="ignore_imdb_ids_text" placeholder="Add IMDb ID"
+                    data-validation-preset="imdb_id_tmdb">
+                  <button class="btn nav-button" type="button" data-template-string-add>Add</button>
+                </div>
+                <div class="invalid-feedback d-none" data-template-string-feedback></div>
+                <ul class="list-group mt-2" data-template-string-items></ul>
+                <input type="hidden" id="ignore_imdb_ids" name="ignore_imdb_ids" value="{{ ignore_imdb_ids_json }}">
               </div>
-              <div class="error-message text-danger"></div>
             </div>
           </div>
 

--- a/tests/test_collection_ignore_imdb_ids_contract.py
+++ b/tests/test_collection_ignore_imdb_ids_contract.py
@@ -87,10 +87,15 @@ def test_ignore_imdb_ids_uses_string_list_with_imdb_preset():
             assert "default" not in field
 
 
-def test_ignore_ids_is_not_added_yet():
+def test_ignore_ids_uses_string_list_with_numeric_preset():
     qs_map = _build_qs_collection_map()
+    expected_aliases = _expected_ignore_imdb_ids_aliases()
 
-    for collections in qs_map.values():
-        for collection in collections:
-            keys = {item["key"] for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key")}
-            assert "ignore_ids" not in keys
+    for alias in expected_aliases:
+        for collection in qs_map[alias]:
+            if collection.get("readonly"):
+                continue
+            field = next(item for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key") == "ignore_ids")
+            assert field["type"] == "string_list"
+            assert field["validation_preset"] == "numeric_id"
+            assert "default" not in field

--- a/tests/test_ratings_yaml_contract.py
+++ b/tests/test_ratings_yaml_contract.py
@@ -214,10 +214,13 @@ def test_playlist_files_follow_library_output_order(monkeypatch, qs_module):
         "libraries": {
             "sho-library_zshows-library": "Z Shows",
             "sho-library_zshows-playlist": "true",
+            "sho-library_zshows-collection_collectionless": True,
             "mov-library_amovies-library": "A Movies",
             "mov-library_amovies-playlist": "true",
+            "mov-library_amovies-collection_collectionless": True,
             "mov-library_bmovies-library": "B Movies",
             "mov-library_bmovies-playlist": "true",
+            "mov-library_bmovies-collection_collectionless": True,
         },
     }
 

--- a/tests/test_template_gap_analyzer.py
+++ b/tests/test_template_gap_analyzer.py
@@ -260,6 +260,35 @@ def test_key_is_valid_for_default_uses_repo_yaml_for_streaming_and_letterboxd_ca
     assert imdb_top_250_valid is True
 
 
+def test_key_is_valid_for_default_only_uses_referenced_template_chain():
+    module = _load_gap_analyzer_module()
+    root = Path(__file__).resolve().parents[1]
+    kometa_defaults = root / "config" / "kometa" / "defaults"
+
+    based_defaults = module.resolve_default_paths("based", "collection", kometa_defaults)
+    genre_defaults = module.resolve_default_paths("genre", "collection", kometa_defaults)
+    network_defaults = module.resolve_default_paths("network", "collection", kometa_defaults)
+    streaming_defaults = module.resolve_default_paths("streaming", "collection", kometa_defaults)
+    seasonal_defaults = module.resolve_default_paths("seasonal", "collection", kometa_defaults)
+    collectionless_defaults = module.resolve_default_paths("collectionless", "collection", kometa_defaults)
+    movie_franchise_defaults = module.resolve_default_paths("franchise", "collection", kometa_defaults)
+    show_franchise_default = [root / "config" / "kometa" / "defaults" / "show" / "franchise.yml"]
+
+    assert module.key_is_valid_for_default("collection_order", based_defaults)[0] is False
+    assert module.key_is_valid_for_default("collection_order", genre_defaults)[0] is False
+    assert module.key_is_valid_for_default("collection_order", streaming_defaults)[0] is False
+    assert module.key_is_valid_for_default("sync_mode", genre_defaults)[0] is False
+    assert module.key_is_valid_for_default("sync_mode", network_defaults)[0] is False
+
+    assert module.key_is_valid_for_default("sync_mode", streaming_defaults)[0] is True
+    assert module.key_is_valid_for_default("sync_mode", seasonal_defaults)[0] is True
+    assert module.key_is_valid_for_default("collection_order", collectionless_defaults)[0] is True
+    assert module.key_is_valid_for_default("collection_order", movie_franchise_defaults)[0] is True
+    assert module.key_is_valid_for_default("sync_mode", movie_franchise_defaults)[0] is True
+    assert module.key_is_valid_for_default("collection_order", show_franchise_default)[0] is True
+    assert module.key_is_valid_for_default("sync_mode", show_franchise_default)[0] is True
+
+
 def test_quickstart_recommendation_summary_uses_yaml_verified_collection_edges():
     module = _load_gap_analyzer_module()
 


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Title: Align shared ID list handling, YAML output, and gap analysis with Kometa defaults
Summary:
This branch consolidates Quickstart’s string-list handling for Kometa IDs, fixes YAML serialization for settings-level ignore lists, and tightens the template gap analyzer so recommendations are based on the real Kometa YAML/template chain instead of broad shared-template assumptions.
What changed:
Added a shared templateStringList.js helper and wired the Settings page to use the same list-style add/validate/lookup UX as Libraries for ignore_ids and ignore_imdb_ids.
Enabled TMDb-backed validation on the Settings page and passed service validation state into templates so lookups degrade cleanly when TMDb is not validated.
Expanded backend lookup handling:support TMDb-only IMDb resolution via imdb_id_tmdb
keep Plex-aware IMDb lookup via imdb_id_plex
warn when an ID resolves to the wrong media type for the active library
normalize optional stored ID lists from CSV/JSON-style inputs

Fixed settings validation and YAML output so ignore_ids and ignore_imdb_ids are treated as proper multi-value fields instead of raw freeform strings.
Normalized settings serialization in modules/output.py so generated YAML writes:ignore_imdb_ids: tt1234567,tt0050083
not JSON-looking strings like '[]' or quoted Python-list text

Fixed the template gap analyzer so Kometa support is verified from the actual default file and referenced template chain only.stop treating templates.yml as globally applicable
ignore placeholder-only patterns like <<final_use>>
avoid harvesting template: list entries as supported keys


## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
