### PR TITLE
add reset to collections

### DIFF
--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -2440,6 +2440,12 @@ document.addEventListener('DOMContentLoaded', function () {
         modeSelect.addEventListener('change', () => updateHidden())
         valueInput.addEventListener('input', () => updateHidden())
         valueInput.addEventListener('blur', () => updateHidden())
+        hidden.addEventListener('change', () => {
+          const next = resolveInitial()
+          modeSelect.value = next.mode
+          valueInput.value = next.number
+          updateHidden()
+        })
 
         wrapper.dataset.listenerAdded = 'true'
       })
@@ -2666,6 +2672,13 @@ document.addEventListener('DOMContentLoaded', function () {
             }
           })
         }
+
+        hidden.addEventListener('change', () => {
+          const nextRaw = String(hidden.value || defaultValue || '').trim()
+          const nextParsed = parseSchedule(nextRaw)
+          applyParsed(nextParsed)
+          updateFromBuilder()
+        })
 
         builder.dataset.listenerAdded = 'true'
       })
@@ -4914,12 +4927,183 @@ function setupMappingListHandlers (prefix, scope) {
   })
 }
 
+async function runCollectionGroupReset (btn, group) {
+  if (!btn || !group || btn.dataset.resetBusy === 'true') return
+
+  const idleLabel = btn.dataset.resetIdleLabel || btn.textContent.trim() || 'Reset to Defaults'
+  btn.dataset.resetIdleLabel = idleLabel
+  btn.dataset.resetBusy = 'true'
+  btn.disabled = true
+  btn.setAttribute('aria-busy', 'true')
+  btn.textContent = 'Resetting...'
+
+  const pauseForPaint = async () => {
+    await new Promise(resolve => requestAnimationFrame(() => resolve()))
+    await new Promise(resolve => window.setTimeout(resolve, 0))
+  }
+  const escapeHtml = (value) => String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+  const getInputLabel = (input) => {
+    if (!input) return 'Field'
+    const describedBy = input.getAttribute('aria-describedby')
+    if (describedBy) {
+      const firstId = describedBy.split(' ')[0]
+      const el = document.getElementById(firstId)
+      if (el && el.textContent) return el.textContent.trim()
+    }
+    if (input.id) {
+      const label = document.querySelector(`label[for="${input.id}"]`)
+      if (label && label.textContent) return label.textContent.trim()
+    }
+    return input.name || input.id || 'Field'
+  }
+  const getDisplayValue = (input) => {
+    if (!input) return ''
+    if (input.tagName === 'SELECT') {
+      return input.selectedOptions?.[0]?.textContent?.trim() || input.value || ''
+    }
+    if (input.type === 'checkbox') return input.checked ? 'On' : 'Off'
+    if (input.type === 'radio') return input.checked ? 'Selected' : 'Not selected'
+    return input.value ?? ''
+  }
+  const getDefaultDisplayValue = (input, defaultValue) => {
+    if (!input) return ''
+    if (input.type === 'checkbox' || input.type === 'radio') {
+      const normalizedDefault = (defaultValue || '').toString().toLowerCase()
+      const normalizedValue = (input.value || '').toString().toLowerCase()
+      const checked = normalizedDefault === 'true' || normalizedDefault === normalizedValue
+      return checked ? (input.type === 'radio' ? 'Selected' : 'On') : (input.type === 'radio' ? 'Not selected' : 'Off')
+    }
+    if (input.tagName === 'SELECT') {
+      const option = Array.from(input.options).find(o => String(o.value) === String(defaultValue))
+      return option ? (option.textContent || '').trim() : (defaultValue ?? '')
+    }
+    return defaultValue ?? ''
+  }
+  const shouldDispatchCollectionChange = (input) => {
+    if (!input) return false
+    if (input.type === 'hidden') return true
+    if (input.type === 'checkbox' || input.type === 'radio') return true
+    return input.tagName === 'SELECT'
+  }
+  const flushQueuedChanges = async (inputs) => {
+    let index = 0
+    for (const input of inputs) {
+      input.dispatchEvent(new Event('change', { bubbles: true }))
+      index += 1
+      if (index % 20 === 0) {
+        await new Promise(resolve => window.setTimeout(resolve, 0))
+      }
+    }
+  }
+  const finalizeToast = (changes) => {
+    if (typeof showToast !== 'function') return
+    if (!changes.length) {
+      showToast('info', 'Already at defaults (no changes).')
+      return
+    }
+    const preview = changes.slice(0, 12)
+      .map(change => `${escapeHtml(change.label)}: ${escapeHtml(change.from)} → ${escapeHtml(change.to)}`)
+      .join('<br>')
+    const extraCount = changes.length - 12
+    const suffix = extraCount > 0 ? `<br>...and ${extraCount} more field${extraCount === 1 ? '' : 's'}.` : ''
+    showToast('info', `Reset to defaults (${changes.length} field${changes.length === 1 ? '' : 's'}):<br>${preview}${suffix}`)
+  }
+
+  try {
+    await pauseForPaint()
+
+    const changes = []
+    const touched = new Set()
+    const pendingChangeInputs = new Set()
+    group.dataset.resetting = 'true'
+
+    const recordReset = (input, defaultValue) => {
+      if (!input || touched.has(input)) return false
+      touched.add(input)
+      const from = getDisplayValue(input)
+      const to = getDefaultDisplayValue(input, defaultValue)
+      if (from !== to) {
+        changes.push({ label: getInputLabel(input), from, to })
+        return true
+      }
+      return false
+    }
+
+    const inputs = Array.from(group.querySelectorAll('input[data-default], select[data-default], textarea[data-default]'))
+    for (let index = 0; index < inputs.length; index += 1) {
+      const input = inputs[index]
+      if (input.disabled) continue
+      const defaultValue = input.dataset.default
+      if (defaultValue === undefined) continue
+
+      let changed = false
+      if (input.type === 'checkbox' || input.type === 'radio') {
+        const normalizedDefault = (defaultValue || '').toString().toLowerCase()
+        const normalizedValue = (input.value || '').toString().toLowerCase()
+        const nextChecked = normalizedDefault === 'true' || normalizedDefault === normalizedValue
+        changed = recordReset(input, defaultValue)
+        if (changed) input.checked = nextChecked
+      } else {
+        changed = recordReset(input, defaultValue)
+        if (changed) input.value = defaultValue
+      }
+
+      if (changed && shouldDispatchCollectionChange(input)) {
+        pendingChangeInputs.add(input)
+      }
+
+      if (index > 0 && index % 30 === 0) {
+        await new Promise(resolve => window.setTimeout(resolve, 0))
+      }
+    }
+
+    delete group.dataset.resetting
+
+    if (pendingChangeInputs.size) {
+      await flushQueuedChanges(pendingChangeInputs)
+    }
+
+    const trigger = group.querySelector('input:not([disabled]), select:not([disabled]), textarea:not([disabled])')
+    if (trigger && changes.length) {
+      trigger.dispatchEvent(new Event('change', { bubbles: true }))
+    }
+
+    if (typeof EventHandler !== 'undefined' && typeof EventHandler.updateAccordionHighlights === 'function') {
+      EventHandler.updateAccordionHighlights()
+    }
+    if (typeof ValidationHandler !== 'undefined' && typeof ValidationHandler.updateValidationState === 'function') {
+      ValidationHandler.updateValidationState()
+    }
+    finalizeToast(changes)
+  } finally {
+    delete group.dataset.resetting
+    btn.disabled = false
+    btn.removeAttribute('aria-busy')
+    btn.dataset.resetBusy = 'false'
+    btn.textContent = idleLabel
+  }
+}
+
 function wireOffsetReset (scope) {
   const root = scope || document
   root.querySelectorAll('.reset-offset-btn').forEach(btn => {
     if (btn.dataset.listenerAdded) return
     btn.addEventListener('click', () => {
       const group = btn.closest('.template-toggle-group')
+      if (group?.dataset?.collectionId) {
+        runCollectionGroupReset(btn, group).catch(error => {
+          console.error('[collection reset failed]', error)
+          if (typeof showToast === 'function') {
+            showToast('error', 'Reset to defaults failed.')
+          }
+        })
+        return
+      }
       if (group) {
         group.dataset.resetting = 'true'
       }

--- a/static/local-js/templateStringList.js
+++ b/static/local-js/templateStringList.js
@@ -576,6 +576,9 @@
 
       addBtn.addEventListener('click', addValue)
       input.addEventListener('input', clearTransientFeedback)
+      hidden.addEventListener('change', () => {
+        syncState(parseValues(), '', { emitChange: false })
+      })
       input.addEventListener('keydown', (event) => {
         if (event.key === 'Enter') {
           event.preventDefault()

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -1138,6 +1138,11 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                     {% set season = namespace(open=false) %}
                     <div class="child-toggle-wrapper ms-4 mt-2"
                         data-toggle-parent="{{ library.id }}-{{ collection.id }}" style="display: none;">
+                        <div class="d-flex align-items-center gap-2 flex-wrap mb-2">
+                            <button type="button" class="btn btn-sm btn-outline-secondary btn-overlay reset-offset-btn">
+                                Reset to Defaults
+                            </button>
+                        </div>
                         {% for item in ordered_collection_items
                         if (not item.media_types or library.type in item.media_types)
                         and (not item.key.startswith('visible_') or telemetry.plex_pass) %}
@@ -1161,6 +1166,7 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                             <input class="form-check-input template-child-toggle me-2" type="checkbox"
                                 id="{{ input_name }}" name="{{ input_name }}" value="true"
                                 data-parent-toggle="{{ library.id }}-{{ collection.id }}"
+                                data-default="{{ item.default | default('false', true) }}"
                                 {% if item.key is defined %}data-template-variable-key="{{ item.key }}"{% endif %}
                                 {% if item.mutually_exclusive_with %}data-mutually-exclusive-with="{{ item.mutually_exclusive_with }}"{% endif %}
                                 {% if disable_toggle
@@ -1188,6 +1194,7 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                             </span>
                             <select class="form-select" id="{{ input_name }}" name="{{ input_name }}"
                                 aria-describedby="{{ input_name }}_text"
+                                data-default="{{ item.default | default('', true) }}"
                                 {% if item.key is defined %}data-template-variable-key="{{ item.key }}"{% endif %}
                                 {% if item.mutually_exclusive_with %}data-mutually-exclusive-with="{{ item.mutually_exclusive_with }}"{% endif %}
                                 {% if item.validation_preset %}data-validation-preset="{{ item.validation_preset }}"{% endif %}
@@ -1262,6 +1269,13 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                         {% else %}
                         {% set list_json = '[]' %}
                         {% endif %}
+                        {% if item.default is defined and item.default is sequence and item.default is not string %}
+                        {% set list_default_json = item.default | tojson %}
+                        {% elif item.default is defined and item.default is string and item.default|trim %}
+                        {% set list_default_json = item.default %}
+                        {% else %}
+                        {% set list_default_json = '[]' %}
+                        {% endif %}
                         <div class="mb-2" data-template-string-list data-hidden-input="{{ input_name }}"
                             data-library-name="{{ library.name }}"
                             data-media-type="{{ library.type }}"
@@ -1291,7 +1305,8 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                             </div>
                             <div class="invalid-feedback d-none" data-template-string-feedback></div>
                             <ul class="list-group mt-2" data-template-string-items></ul>
-                            <input type="hidden" id="{{ input_name }}" name="{{ input_name }}" value="{{ list_json }}">
+                            <input type="hidden" id="{{ input_name }}" name="{{ input_name }}" value="{{ list_json }}"
+                                data-default='{{ list_default_json }}'>
                         </div>
                         {% elif item.type == 'relative_year' %}
                         {% set stored_val = data['libraries'].get(input_name, item.default) | default('', true) %}
@@ -1340,7 +1355,8 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                 data-relative-year-value inputmode="numeric"
                                 min="1" step="1" data-numeric-only="true" placeholder="Year or Offset"
                                 aria-label="Year or offset" {% if disable_toggle %}disabled{% endif %}>
-                            <input type="hidden" id="{{ input_name }}" name="{{ input_name }}" value="{{ stored_val }}">
+                            <input type="hidden" id="{{ input_name }}" name="{{ input_name }}" value="{{ stored_val }}"
+                                data-default="{{ item.default | default('', true) }}">
                         </div>
                         {% elif item.key is defined and item.key.startswith('schedule_') %}
                         {% set schedule_label = 'Schedule' %}
@@ -1457,7 +1473,8 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                     data-schedule-raw
                                     value="{{ stored_val }}" {% if disable_toggle %}disabled{% endif %}>
                             </details>
-                            <input type="hidden" id="{{ input_name }}" name="{{ input_name }}" value="{{ stored_val }}">
+                            <input type="hidden" id="{{ input_name }}" name="{{ input_name }}" value="{{ stored_val }}"
+                                data-default="{{ item.default | default('', true) }}">
                         </div>
                         {% elif item.type == 'text_input' %}
                         {% set is_number_input = item.input_type is defined and item.input_type == 'number' %}
@@ -1481,6 +1498,7 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                             </span>
                             <input type="{{ 'number' if is_number_input else 'text' }}" class="form-control" id="{{ input_name }}" name="{{ input_name }}"
                                 value="{{ data['libraries'].get(input_name, item.default) | default('', true) }}"
+                                data-default="{{ item.default | default('', true) }}"
                                 {% if item.key is defined %}data-template-variable-key="{{ item.key }}"{% endif %}
                                 {% if item.mutually_exclusive_with %}data-mutually-exclusive-with="{{ item.mutually_exclusive_with }}"{% endif %}
                                 {% if item.validation_preset %}data-validation-preset="{{ item.validation_preset }}"{% endif %}

--- a/tests/test_collection_reset_contract.py
+++ b/tests/test_collection_reset_contract.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+MACROS_PATH = Path(__file__).resolve().parents[1] / "templates" / "partials" / "_macros.html"
+
+
+def test_collection_template_variables_include_reset_button():
+    text = MACROS_PATH.read_text(encoding="utf-8")
+
+    assert 'data-toggle-parent="{{ library.id }}-{{ collection.id }}"' in text
+    assert 'class="btn btn-sm btn-outline-secondary btn-overlay reset-offset-btn"' in text
+    assert "Reset to Defaults" in text
+
+
+def test_collection_reset_contract_exposes_defaults_for_supported_field_types():
+    text = MACROS_PATH.read_text(encoding="utf-8")
+
+    assert 'data-default="{{ item.default | default(\'false\', true) }}"' in text
+    assert 'data-default="{{ item.default | default(\'\', true) }}"' in text
+    assert "data-default='{{ list_default_json }}'" in text

--- a/tests/test_collection_reset_contract.py
+++ b/tests/test_collection_reset_contract.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 MACROS_PATH = Path(__file__).resolve().parents[1] / "templates" / "partials" / "_macros.html"
 
 
@@ -15,6 +14,6 @@ def test_collection_template_variables_include_reset_button():
 def test_collection_reset_contract_exposes_defaults_for_supported_field_types():
     text = MACROS_PATH.read_text(encoding="utf-8")
 
-    assert 'data-default="{{ item.default | default(\'false\', true) }}"' in text
-    assert 'data-default="{{ item.default | default(\'\', true) }}"' in text
+    assert "data-default=\"{{ item.default | default('false', true) }}\"" in text
+    assert "data-default=\"{{ item.default | default('', true) }}\"" in text
     assert "data-default='{{ list_default_json }}'" in text


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Title
Add per-collection reset-to-defaults with safer collection UI sync
Description
This PR adds overlay-style Reset to Defaults support to collection configuration cards on the Libraries page, so collection template variables can be restored to their rendered Quickstart defaults without manually clearing fields one by one.
It also hardens the collection reset flow and the surrounding UI plumbing:
Adds a per-collection Reset to Defaults action to collection detail sections.
Extends reset handling to work with collection fields, including hidden-backed/custom controls.
Updates custom list/schedule/relative-year widgets so they resync correctly when their hidden source value changes during reset.
Fixes the collection render regression caused by fields that do not define a default value.
Optimizes large collection resets by using a collection-specific batched reset path with visible Resetting... feedback, instead of firing a heavy event storm across every field.
Adds contract coverage for the reset button/default wiring so this behavior stays aligned.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
