### PR TITLE
Collection arr/automation shared keys

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -303,6 +303,9 @@ def _normalize_collection_template_var_value(key, value):
     if key in {"ignore_ids", "ignore_imdb_ids"}:
         list_values = _parse_string_list(value)
         return ",".join(list_values) if list_values else None
+    if key in {"radarr_tag", "sonarr_tag", "item_radarr_tag", "item_sonarr_tag"}:
+        list_values = _parse_string_list(value)
+        return list_values if list_values else None
     return value
 
 

--- a/modules/output.py
+++ b/modules/output.py
@@ -299,9 +299,73 @@ def _parse_string_list(value):
     return _coerce_string_list([value])
 
 
+def _parse_comma_string_list(value):
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return _coerce_string_list(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return []
+        if stripped.startswith("[") and stripped.endswith("]"):
+            try:
+                parsed = json.loads(stripped)
+            except Exception:
+                parsed = None
+            if isinstance(parsed, list):
+                return _coerce_string_list(parsed)
+            try:
+                parsed = ast.literal_eval(stripped)
+            except Exception:
+                parsed = None
+            if isinstance(parsed, list):
+                return _coerce_string_list(parsed)
+        return _coerce_string_list(part.strip() for part in stripped.split(","))
+    return _coerce_string_list([value])
+
+
+def _parse_string_list_mapping(value):
+    if value is None:
+        return {}
+    parsed = value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return {}
+        try:
+            parsed = json.loads(stripped)
+        except Exception:
+            try:
+                parsed = ast.literal_eval(stripped)
+            except Exception:
+                parsed = None
+    if not isinstance(parsed, dict):
+        return {}
+
+    normalized = {}
+    for raw_key, raw_values in parsed.items():
+        key_text = str(raw_key or "").strip()
+        if not key_text:
+            continue
+        values = _parse_comma_string_list(raw_values)
+        if values:
+            normalized[key_text] = values
+    return normalized
+
+
 def _normalize_collection_template_var_value(key, value):
     if key in {"ignore_ids", "ignore_imdb_ids"}:
         list_values = _parse_string_list(value)
+        return ",".join(list_values) if list_values else None
+    if key in {"append_include"}:
+        list_values = _parse_string_list(value)
+        return list_values if list_values else None
+    if key in {"addons", "append_addons"}:
+        mapping_values = _parse_string_list_mapping(value)
+        return mapping_values if mapping_values else None
+    if key == "remove_suffix":
+        list_values = _parse_comma_string_list(value)
         return ",".join(list_values) if list_values else None
     if key in {"radarr_tag", "sonarr_tag", "item_radarr_tag", "item_sonarr_tag"}:
         list_values = _parse_string_list(value)

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -254,6 +254,25 @@
             ]
           },
           {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -974,6 +993,25 @@
             ]
           },
           {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -1659,6 +1697,25 @@
             "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
             "type": "string_list",
             "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
             "media_types": [
               "movie"
             ]
@@ -2354,6 +2411,25 @@
             ]
           },
           {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -2824,7 +2900,7 @@
       },
       {
         "id": "collection_cesar",
-        "label": "César Awards",
+        "label": "C\u00e9sar Awards",
         "url": "https://kometa.wiki/en/nightly/defaults/award/cesar",
         "image_url": "https://kometa.wiki/en/nightly/assets/images/defaults/posters/cesar.png",
         "media_types": [
@@ -2946,8 +3022,8 @@
           },
           {
             "key": "use_best",
-            "label": "César Best Film Winners",
-            "tooltip": "Collection of César Award Winners.",
+            "label": "C\u00e9sar Best Film Winners",
+            "tooltip": "Collection of C\u00e9sar Award Winners.",
             "type": "toggle",
             "default": true
           },
@@ -3044,6 +3120,25 @@
             ]
           },
           {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -3127,9 +3222,9 @@
           },
           {
             "key": "visible_home_best",
-            "label": "César Best Film Winners Visible Home",
+            "label": "C\u00e9sar Best Film Winners Visible Home",
             "type": "toggle",
-            "tooltip": "Changes the César Best Film Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "tooltip": "Changes the C\u00e9sar Best Film Winners collection visible on Home Tab (Only works with Plex Pass)",
             "default": false,
             "media_types": [
               "movie"
@@ -3137,9 +3232,9 @@
           },
           {
             "key": "visible_library_best",
-            "label": "César Best Film Winners Visible Library",
+            "label": "C\u00e9sar Best Film Winners Visible Library",
             "type": "toggle",
-            "tooltip": "Changes the César Best Film Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "tooltip": "Changes the C\u00e9sar Best Film Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
             "default": false,
             "media_types": [
               "movie"
@@ -3147,9 +3242,9 @@
           },
           {
             "key": "visible_shared_best",
-            "label": "César Best Film Winners Visible Shared",
+            "label": "C\u00e9sar Best Film Winners Visible Shared",
             "type": "toggle",
-            "tooltip": "Changes the César Best Film Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "tooltip": "Changes the C\u00e9sar Best Film Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
             "media_types": [
               "movie"
@@ -3788,6 +3883,87 @@
             "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
             "type": "string_list",
             "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_folder",
+            "label": "Sonarr Root Folder",
+            "tooltip": "Override Sonarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Sonarr root folder path",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "sonarr_monitor",
+            "label": "Sonarr Monitor",
+            "tooltip": "Override Sonarr monitor for all collections in this Defaults File.<br><br>Choose how Sonarr monitors episodes when adding a show.",
+            "type": "select",
+            "options": [
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First Season"
+              },
+              {
+                "value": "latest",
+                "label": "Latest Season"
+              }
+            ],
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing",
+            "label": "Upgrade existing media in Sonarr",
+            "tooltip": "Override Sonarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Sonarr quality profile.",
+            "type": "toggle",
             "media_types": [
               "show"
             ]
@@ -4519,6 +4695,87 @@
             "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
             "type": "string_list",
             "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_folder",
+            "label": "Sonarr Root Folder",
+            "tooltip": "Override Sonarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Sonarr root folder path",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "sonarr_monitor",
+            "label": "Sonarr Monitor",
+            "tooltip": "Override Sonarr monitor for all collections in this Defaults File.<br><br>Choose how Sonarr monitors episodes when adding a show.",
+            "type": "select",
+            "options": [
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First Season"
+              },
+              {
+                "value": "latest",
+                "label": "Latest Season"
+              }
+            ],
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing",
+            "label": "Upgrade existing media in Sonarr",
+            "tooltip": "Override Sonarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Sonarr quality profile.",
+            "type": "toggle",
             "media_types": [
               "show"
             ]
@@ -5282,6 +5539,87 @@
             ]
           },
           {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_folder",
+            "label": "Sonarr Root Folder",
+            "tooltip": "Override Sonarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Sonarr root folder path",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "sonarr_monitor",
+            "label": "Sonarr Monitor",
+            "tooltip": "Override Sonarr monitor for all collections in this Defaults File.<br><br>Choose how Sonarr monitors episodes when adding a show.",
+            "type": "select",
+            "options": [
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First Season"
+              },
+              {
+                "value": "latest",
+                "label": "Latest Season"
+              }
+            ],
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing",
+            "label": "Upgrade existing media in Sonarr",
+            "tooltip": "Override Sonarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Sonarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -5975,6 +6313,25 @@
             ]
           },
           {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -6660,6 +7017,25 @@
             "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
             "type": "string_list",
             "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
             "media_types": [
               "movie"
             ]
@@ -7414,6 +7790,87 @@
             ]
           },
           {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_folder",
+            "label": "Sonarr Root Folder",
+            "tooltip": "Override Sonarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Sonarr root folder path",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "sonarr_monitor",
+            "label": "Sonarr Monitor",
+            "tooltip": "Override Sonarr monitor for all collections in this Defaults File.<br><br>Choose how Sonarr monitors episodes when adding a show.",
+            "type": "select",
+            "options": [
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First Season"
+              },
+              {
+                "value": "latest",
+                "label": "Latest Season"
+              }
+            ],
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing",
+            "label": "Upgrade existing media in Sonarr",
+            "tooltip": "Override Sonarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Sonarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -8081,6 +8538,25 @@
             "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
             "type": "string_list",
             "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
             "media_types": [
               "movie"
             ]
@@ -8776,6 +9252,25 @@
             ]
           },
           {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -9461,6 +9956,25 @@
             "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
             "type": "string_list",
             "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
             "media_types": [
               "movie"
             ]
@@ -10156,6 +10670,25 @@
             ]
           },
           {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -10833,6 +11366,25 @@
             "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
             "type": "string_list",
             "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
             "media_types": [
               "movie"
             ]
@@ -12789,6 +13341,87 @@
             ]
           },
           {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_folder",
+            "label": "Sonarr Root Folder",
+            "tooltip": "Override Sonarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Sonarr root folder path",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "sonarr_monitor",
+            "label": "Sonarr Monitor",
+            "tooltip": "Override Sonarr monitor for all collections in this Defaults File.<br><br>Choose how Sonarr monitors episodes when adding a show.",
+            "type": "select",
+            "options": [
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First Season"
+              },
+              {
+                "value": "latest",
+                "label": "Latest Season"
+              }
+            ],
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing",
+            "label": "Upgrade existing media in Sonarr",
+            "tooltip": "Override Sonarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Sonarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -13626,6 +14259,87 @@
             "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
             "type": "string_list",
             "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_folder",
+            "label": "Sonarr Root Folder",
+            "tooltip": "Override Sonarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Sonarr root folder path",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "sonarr_monitor",
+            "label": "Sonarr Monitor",
+            "tooltip": "Override Sonarr monitor for all collections in this Defaults File.<br><br>Choose how Sonarr monitors episodes when adding a show.",
+            "type": "select",
+            "options": [
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First Season"
+              },
+              {
+                "value": "latest",
+                "label": "Latest Season"
+              }
+            ],
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing",
+            "label": "Upgrade existing media in Sonarr",
+            "tooltip": "Override Sonarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Sonarr quality profile.",
+            "type": "toggle",
             "media_types": [
               "show"
             ]
@@ -14517,6 +15231,87 @@
             ]
           },
           {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_folder",
+            "label": "Sonarr Root Folder",
+            "tooltip": "Override Sonarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Sonarr root folder path",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "sonarr_monitor",
+            "label": "Sonarr Monitor",
+            "tooltip": "Override Sonarr monitor for all collections in this Defaults File.<br><br>Choose how Sonarr monitors episodes when adding a show.",
+            "type": "select",
+            "options": [
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First Season"
+              },
+              {
+                "value": "latest",
+                "label": "Latest Season"
+              }
+            ],
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing",
+            "label": "Upgrade existing media in Sonarr",
+            "tooltip": "Override Sonarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Sonarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -15364,6 +16159,87 @@
             ]
           },
           {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_folder",
+            "label": "Sonarr Root Folder",
+            "tooltip": "Override Sonarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Sonarr root folder path",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "sonarr_monitor",
+            "label": "Sonarr Monitor",
+            "tooltip": "Override Sonarr monitor for all collections in this Defaults File.<br><br>Choose how Sonarr monitors episodes when adding a show.",
+            "type": "select",
+            "options": [
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First Season"
+              },
+              {
+                "value": "latest",
+                "label": "Latest Season"
+              }
+            ],
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing",
+            "label": "Upgrade existing media in Sonarr",
+            "tooltip": "Override Sonarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Sonarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -15858,6 +16734,87 @@
             "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
             "type": "string_list",
             "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_folder",
+            "label": "Sonarr Root Folder",
+            "tooltip": "Override Sonarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Sonarr root folder path",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "sonarr_monitor",
+            "label": "Sonarr Monitor",
+            "tooltip": "Override Sonarr monitor for all collections in this Defaults File.<br><br>Choose how Sonarr monitors episodes when adding a show.",
+            "type": "select",
+            "options": [
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First Season"
+              },
+              {
+                "value": "latest",
+                "label": "Latest Season"
+              }
+            ],
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing",
+            "label": "Upgrade existing media in Sonarr",
+            "tooltip": "Override Sonarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Sonarr quality profile.",
+            "type": "toggle",
             "media_types": [
               "show"
             ]
@@ -16721,6 +17678,87 @@
             "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
             "type": "string_list",
             "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_folder",
+            "label": "Sonarr Root Folder",
+            "tooltip": "Override Sonarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Sonarr root folder path",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "sonarr_monitor",
+            "label": "Sonarr Monitor",
+            "tooltip": "Override Sonarr monitor for all collections in this Defaults File.<br><br>Choose how Sonarr monitors episodes when adding a show.",
+            "type": "select",
+            "options": [
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First Season"
+              },
+              {
+                "value": "latest",
+                "label": "Latest Season"
+              }
+            ],
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing",
+            "label": "Upgrade existing media in Sonarr",
+            "tooltip": "Override Sonarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Sonarr quality profile.",
+            "type": "toggle",
             "media_types": [
               "show"
             ]
@@ -17943,6 +18981,25 @@
             "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
             "type": "string_list",
             "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
             "media_types": [
               "movie"
             ]
@@ -19279,6 +20336,87 @@
             ]
           },
           {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_folder",
+            "label": "Sonarr Root Folder",
+            "tooltip": "Override Sonarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Sonarr root folder path",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "sonarr_monitor",
+            "label": "Sonarr Monitor",
+            "tooltip": "Override Sonarr monitor for all collections in this Defaults File.<br><br>Choose how Sonarr monitors episodes when adding a show.",
+            "type": "select",
+            "options": [
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First Season"
+              },
+              {
+                "value": "latest",
+                "label": "Latest Season"
+              }
+            ],
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing",
+            "label": "Upgrade existing media in Sonarr",
+            "tooltip": "Override Sonarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Sonarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -20358,6 +21496,16 @@
             ]
           },
           {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -20815,6 +21963,89 @@
             "min": 1,
             "step": 1,
             "default": 2
+          },
+          {
+            "key": "sonarr_add_missing",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "sonarr_folder",
+            "label": "Sonarr Root Folder",
+            "tooltip": "Override Sonarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Sonarr root folder path",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "sonarr_tag",
+            "label": "Sonarr Tag",
+            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "sonarr_monitor",
+            "label": "Sonarr Monitor",
+            "tooltip": "Override Sonarr monitor for all collections in this Defaults File.<br><br>Choose how Sonarr monitors episodes when adding a show.",
+            "type": "select",
+            "options": [
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First Season"
+              },
+              {
+                "value": "latest",
+                "label": "Latest Season"
+              }
+            ],
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
           },
           {
             "key": "sync_mode",
@@ -21819,6 +23050,87 @@
             "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
             "type": "string_list",
             "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_folder",
+            "label": "Sonarr Root Folder",
+            "tooltip": "Override Sonarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Sonarr root folder path",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "sonarr_monitor",
+            "label": "Sonarr Monitor",
+            "tooltip": "Override Sonarr monitor for all collections in this Defaults File.<br><br>Choose how Sonarr monitors episodes when adding a show.",
+            "type": "select",
+            "options": [
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First Season"
+              },
+              {
+                "value": "latest",
+                "label": "Latest Season"
+              }
+            ],
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing",
+            "label": "Upgrade existing media in Sonarr",
+            "tooltip": "Override Sonarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Sonarr quality profile.",
+            "type": "toggle",
             "media_types": [
               "show"
             ]
@@ -23311,6 +24623,87 @@
             "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
             "type": "string_list",
             "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_folder",
+            "label": "Sonarr Root Folder",
+            "tooltip": "Override Sonarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Sonarr root folder path",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "sonarr_monitor",
+            "label": "Sonarr Monitor",
+            "tooltip": "Override Sonarr monitor for all collections in this Defaults File.<br><br>Choose how Sonarr monitors episodes when adding a show.",
+            "type": "select",
+            "options": [
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First Season"
+              },
+              {
+                "value": "latest",
+                "label": "Latest Season"
+              }
+            ],
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing",
+            "label": "Upgrade existing media in Sonarr",
+            "tooltip": "Override Sonarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Sonarr quality profile.",
+            "type": "toggle",
             "media_types": [
               "show"
             ]
@@ -36108,6 +37501,87 @@
             ]
           },
           {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_folder",
+            "label": "Sonarr Root Folder",
+            "tooltip": "Override Sonarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Sonarr root folder path",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "sonarr_monitor",
+            "label": "Sonarr Monitor",
+            "tooltip": "Override Sonarr monitor for all collections in this Defaults File.<br><br>Choose how Sonarr monitors episodes when adding a show.",
+            "type": "select",
+            "options": [
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First Season"
+              },
+              {
+                "value": "latest",
+                "label": "Latest Season"
+              }
+            ],
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing",
+            "label": "Upgrade existing media in Sonarr",
+            "tooltip": "Override Sonarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Sonarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -38611,6 +40085,25 @@
             "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
             "type": "string_list",
             "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
             "media_types": [
               "movie"
             ]

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -197,6 +197,63 @@
             "validation_preset": "imdb_id_plex"
           },
           {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -860,6 +917,63 @@
             "validation_preset": "imdb_id_plex"
           },
           {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -1491,6 +1605,63 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex"
+          },
+          {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
           },
           {
             "key": "sync_mode",
@@ -2126,6 +2297,63 @@
             "validation_preset": "imdb_id_plex"
           },
           {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -2596,7 +2824,7 @@
       },
       {
         "id": "collection_cesar",
-        "label": "C\u00e9sar Awards",
+        "label": "César Awards",
         "url": "https://kometa.wiki/en/nightly/defaults/award/cesar",
         "image_url": "https://kometa.wiki/en/nightly/assets/images/defaults/posters/cesar.png",
         "media_types": [
@@ -2718,8 +2946,8 @@
           },
           {
             "key": "use_best",
-            "label": "C\u00e9sar Best Film Winners",
-            "tooltip": "Collection of C\u00e9sar Award Winners.",
+            "label": "César Best Film Winners",
+            "tooltip": "Collection of César Award Winners.",
             "type": "toggle",
             "default": true
           },
@@ -2757,6 +2985,63 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex"
+          },
+          {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
           },
           {
             "key": "sync_mode",
@@ -2842,9 +3127,9 @@
           },
           {
             "key": "visible_home_best",
-            "label": "C\u00e9sar Best Film Winners Visible Home",
+            "label": "César Best Film Winners Visible Home",
             "type": "toggle",
-            "tooltip": "Changes the C\u00e9sar Best Film Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "tooltip": "Changes the César Best Film Winners collection visible on Home Tab (Only works with Plex Pass)",
             "default": false,
             "media_types": [
               "movie"
@@ -2852,9 +3137,9 @@
           },
           {
             "key": "visible_library_best",
-            "label": "C\u00e9sar Best Film Winners Visible Library",
+            "label": "César Best Film Winners Visible Library",
             "type": "toggle",
-            "tooltip": "Changes the C\u00e9sar Best Film Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "tooltip": "Changes the César Best Film Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
             "default": false,
             "media_types": [
               "movie"
@@ -2862,9 +3147,9 @@
           },
           {
             "key": "visible_shared_best",
-            "label": "C\u00e9sar Best Film Winners Visible Shared",
+            "label": "César Best Film Winners Visible Shared",
             "type": "toggle",
-            "tooltip": "Changes the C\u00e9sar Best Film Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "tooltip": "Changes the César Best Film Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
             "media_types": [
               "movie"
@@ -3401,6 +3686,111 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex"
+          },
+          {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_add_missing",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_search",
+            "label": "Search media when added to Sonarr",
+            "tooltip": "Override Sonarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Sonarr",
+            "tooltip": "Override Sonarr monitor_existing for all collections in this Defaults File.<br><br>Marks all existing media from collections as 'monitored' in Sonarr.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_tag",
+            "label": "Sonarr Tag",
+            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
           },
           {
             "key": "sync_mode",
@@ -4027,6 +4417,111 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex"
+          },
+          {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_add_missing",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_search",
+            "label": "Search media when added to Sonarr",
+            "tooltip": "Override Sonarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Sonarr",
+            "tooltip": "Override Sonarr monitor_existing for all collections in this Defaults File.<br><br>Marks all existing media from collections as 'monitored' in Sonarr.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_tag",
+            "label": "Sonarr Tag",
+            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
           },
           {
             "key": "sync_mode",
@@ -4682,6 +5177,111 @@
             "validation_preset": "imdb_id_plex"
           },
           {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_add_missing",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_search",
+            "label": "Search media when added to Sonarr",
+            "tooltip": "Override Sonarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Sonarr",
+            "tooltip": "Override Sonarr monitor_existing for all collections in this Defaults File.<br><br>Marks all existing media from collections as 'monitored' in Sonarr.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_tag",
+            "label": "Sonarr Tag",
+            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -5318,6 +5918,63 @@
             "validation_preset": "imdb_id_plex"
           },
           {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -5949,6 +6606,63 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex"
+          },
+          {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
           },
           {
             "key": "sync_mode",
@@ -6595,6 +7309,111 @@
             "validation_preset": "imdb_id_plex"
           },
           {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_add_missing",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_search",
+            "label": "Search media when added to Sonarr",
+            "tooltip": "Override Sonarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Sonarr",
+            "tooltip": "Override Sonarr monitor_existing for all collections in this Defaults File.<br><br>Marks all existing media from collections as 'monitored' in Sonarr.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_tag",
+            "label": "Sonarr Tag",
+            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -7208,6 +8027,63 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex"
+          },
+          {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
           },
           {
             "key": "sync_mode",
@@ -7843,6 +8719,63 @@
             "validation_preset": "imdb_id_plex"
           },
           {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -8474,6 +9407,63 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex"
+          },
+          {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
           },
           {
             "key": "sync_mode",
@@ -9109,6 +10099,63 @@
             "validation_preset": "imdb_id_plex"
           },
           {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -9732,6 +10779,63 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex"
+          },
+          {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
           },
           {
             "key": "sync_mode",
@@ -10789,6 +11893,26 @@
                 ]
               }
             ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
           }
         ]
       },
@@ -10919,6 +12043,26 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex"
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
           },
           {
             "key": "sync_mode",
@@ -11538,6 +12682,111 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex"
+          },
+          {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_add_missing",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_search",
+            "label": "Search media when added to Sonarr",
+            "tooltip": "Override Sonarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Sonarr",
+            "tooltip": "Override Sonarr monitor_existing for all collections in this Defaults File.<br><br>Marks all existing media from collections as 'monitored' in Sonarr.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_tag",
+            "label": "Sonarr Tag",
+            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
           },
           {
             "key": "sync_mode",
@@ -12275,6 +13524,111 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex"
+          },
+          {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_add_missing",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_search",
+            "label": "Search media when added to Sonarr",
+            "tooltip": "Override Sonarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Sonarr",
+            "tooltip": "Override Sonarr monitor_existing for all collections in this Defaults File.<br><br>Marks all existing media from collections as 'monitored' in Sonarr.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_tag",
+            "label": "Sonarr Tag",
+            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
           },
           {
             "key": "sync_mode",
@@ -13058,6 +14412,111 @@
             "validation_preset": "imdb_id_plex"
           },
           {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_add_missing",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_search",
+            "label": "Search media when added to Sonarr",
+            "tooltip": "Override Sonarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Sonarr",
+            "tooltip": "Override Sonarr monitor_existing for all collections in this Defaults File.<br><br>Marks all existing media from collections as 'monitored' in Sonarr.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_tag",
+            "label": "Sonarr Tag",
+            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -13800,6 +15259,111 @@
             "validation_preset": "imdb_id_plex"
           },
           {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_add_missing",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_search",
+            "label": "Search media when added to Sonarr",
+            "tooltip": "Override Sonarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Sonarr",
+            "tooltip": "Override Sonarr monitor_existing for all collections in this Defaults File.<br><br>Marks all existing media from collections as 'monitored' in Sonarr.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_tag",
+            "label": "Sonarr Tag",
+            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -14192,6 +15756,111 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex"
+          },
+          {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_add_missing",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_search",
+            "label": "Search media when added to Sonarr",
+            "tooltip": "Override Sonarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Sonarr",
+            "tooltip": "Override Sonarr monitor_existing for all collections in this Defaults File.<br><br>Marks all existing media from collections as 'monitored' in Sonarr.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_tag",
+            "label": "Sonarr Tag",
+            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
           },
           {
             "key": "sync_mode",
@@ -14950,6 +16619,111 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex"
+          },
+          {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_add_missing",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_search",
+            "label": "Search media when added to Sonarr",
+            "tooltip": "Override Sonarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Sonarr",
+            "tooltip": "Override Sonarr monitor_existing for all collections in this Defaults File.<br><br>Marks all existing media from collections as 'monitored' in Sonarr.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_tag",
+            "label": "Sonarr Tag",
+            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
           },
           {
             "key": "sync_mode",
@@ -16115,6 +17889,63 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex"
+          },
+          {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
           },
           {
             "key": "sync_mode",
@@ -17343,6 +19174,111 @@
             "validation_preset": "imdb_id_plex"
           },
           {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_add_missing",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_search",
+            "label": "Search media when added to Sonarr",
+            "tooltip": "Override Sonarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Sonarr",
+            "tooltip": "Override Sonarr monitor_existing for all collections in this Defaults File.<br><br>Marks all existing media from collections as 'monitored' in Sonarr.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_tag",
+            "label": "Sonarr Tag",
+            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -18322,6 +20258,26 @@
                 ]
               }
             ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
           }
         ]
       },
@@ -18361,6 +20317,45 @@
             "min": 1,
             "step": 1,
             "default": 2
+          },
+          {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
           },
           {
             "key": "sync_mode",
@@ -19722,6 +21717,111 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex"
+          },
+          {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_add_missing",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_search",
+            "label": "Search media when added to Sonarr",
+            "tooltip": "Override Sonarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Sonarr",
+            "tooltip": "Override Sonarr monitor_existing for all collections in this Defaults File.<br><br>Marks all existing media from collections as 'monitored' in Sonarr.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_tag",
+            "label": "Sonarr Tag",
+            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
           },
           {
             "key": "sync_mode",
@@ -21109,6 +23209,111 @@
                 ]
               }
             ]
+          },
+          {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_add_missing",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_search",
+            "label": "Search media when added to Sonarr",
+            "tooltip": "Override Sonarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Sonarr",
+            "tooltip": "Override Sonarr monitor_existing for all collections in this Defaults File.<br><br>Marks all existing media from collections as 'monitored' in Sonarr.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_tag",
+            "label": "Sonarr Tag",
+            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
           }
         ]
       },
@@ -21985,6 +24190,16 @@
                 ]
               }
             ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
           }
         ]
       },
@@ -22471,6 +24686,16 @@
                   "episode"
                 ]
               }
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
             ]
           }
         ]
@@ -22960,6 +25185,26 @@
                 ]
               }
             ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
           }
         ]
       },
@@ -23447,6 +25692,26 @@
                   "episode"
                 ]
               }
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
             ]
           }
         ]
@@ -23936,6 +26201,26 @@
                 ]
               }
             ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
           }
         ]
       },
@@ -24423,6 +26708,26 @@
                   "episode"
                 ]
               }
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
             ]
           }
         ]
@@ -24912,6 +27217,26 @@
                 ]
               }
             ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
           }
         ]
       },
@@ -25400,6 +27725,26 @@
                 ]
               }
             ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
           }
         ]
       }
@@ -25500,6 +27845,16 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex"
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
           },
           {
             "key": "sync_mode",
@@ -26015,6 +28370,16 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex"
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
           },
           {
             "key": "sync_mode",
@@ -26899,6 +29264,26 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex"
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
           },
           {
             "key": "sync_mode",
@@ -27996,6 +30381,26 @@
             "validation_preset": "imdb_id_plex"
           },
           {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
             "key": "sync_mode",
             "label": "Sync Mode",
             "type": "select",
@@ -28743,6 +31148,26 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex"
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
           },
           {
             "key": "sync_mode",
@@ -29789,6 +32214,26 @@
                 ]
               }
             ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
           }
         ]
       },
@@ -30286,6 +32731,26 @@
                 ]
               }
             ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
           }
         ]
       },
@@ -30782,6 +33247,26 @@
                   "episode"
                 ]
               }
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
             ]
           }
         ]
@@ -31300,6 +33785,26 @@
                   "episode"
                 ]
               }
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
             ]
           }
         ]
@@ -31821,6 +34326,16 @@
                 ]
               }
             ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
           }
         ]
       },
@@ -32341,6 +34856,16 @@
                 ]
               }
             ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
           }
         ]
       },
@@ -32860,6 +35385,16 @@
                   "episode"
                 ]
               }
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
             ]
           }
         ]
@@ -33466,6 +36001,111 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex"
+          },
+          {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_add_missing",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_search",
+            "label": "Search media when added to Sonarr",
+            "tooltip": "Override Sonarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Sonarr",
+            "tooltip": "Override Sonarr monitor_existing for all collections in this Defaults File.<br><br>Marks all existing media from collections as 'monitored' in Sonarr.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "sonarr_tag",
+            "label": "Sonarr Tag",
+            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Sonarr tag",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
           },
           {
             "key": "sync_mode",
@@ -34705,6 +37345,26 @@
                 ]
               }
             ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
           }
         ]
       },
@@ -35167,6 +37827,16 @@
                   "episode"
                 ]
               }
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
             ]
           }
         ]
@@ -35887,6 +38557,63 @@
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
             "validation_preset": "imdb_id_plex"
+          },
+          {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
           },
           {
             "key": "sync_mode",
@@ -37394,6 +40121,26 @@
                 ]
               }
             ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ]
           }
         ]
       },
@@ -37845,6 +40592,16 @@
                 ]
               }
             ]
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ]
           }
         ]
       },
@@ -38295,6 +41052,16 @@
                   "episode"
                 ]
               }
+            ]
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
             ]
           }
         ]

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -13,7 +13,8 @@
         ],
         "readonly": true,
         "tooltip": "Please select your desired Separator style from the respective Attributes section, which will allow you to enable this Separator.",
-        "tooltip_variant": "danger"
+        "tooltip_variant": "danger",
+        "template_variables": []
       },
       {
         "id": "collection_oscars",
@@ -11874,7 +11875,8 @@
         ],
         "readonly": true,
         "tooltip": "Please select your desired Separator style from the respective Attributes section, which will allow you to enable this Separator.",
-        "tooltip_variant": "danger"
+        "tooltip_variant": "danger",
+        "template_variables": []
       },
       {
         "id": "collection_basic",
@@ -20990,6 +20992,22 @@
             "placeholder": "Add genre name (e.g. Politics)"
           },
           {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional genres that should be grouped into that collection.",
+            "key_placeholder": "Base genre (e.g. Drama)",
+            "value_placeholder": "Add comma-separated genres (e.g. Crime, Mystery)"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional genres mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base genre (e.g. Drama)",
+            "value_placeholder": "Add comma-separated genres (e.g. Crime, Mystery)"
+          },
+          {
             "key": "minimum_items",
             "label": "Minimum Items",
             "type": "text_input",
@@ -21445,6 +21463,29 @@
             "validation_preset": "tmdb_collection_id",
             "tooltip": "Exclude specific TMDb collections from these collections.",
             "placeholder": "Add TMDb collection ID (e.g. 131292)"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional franchises that should be grouped into that collection.",
+            "key_placeholder": "Base franchise (e.g. Star Wars)",
+            "value_placeholder": "Add comma-separated franchises (e.g. The Clone Wars, Rebels)"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional franchises mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base franchise (e.g. Star Wars)",
+            "value_placeholder": "Add comma-separated franchises (e.g. The Clone Wars, Rebels)"
+          },
+          {
+            "key": "remove_suffix",
+            "label": "Remove Suffix",
+            "type": "string_list",
+            "tooltip": "Remove these suffixes from the generated collection titles for this Defaults File.",
+            "placeholder": "Add suffix (e.g. Collection)"
           },
           {
             "key": "minimum_items",
@@ -21953,6 +21994,22 @@
             "type": "text_input",
             "tooltip": "Optional override for where this default group appears in the Plex Collections page. Leave blank to keep the Kometa default order.",
             "placeholder": "Leave blank or enter a value like 040"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional franchises that should be grouped into that collection.",
+            "key_placeholder": "Base franchise (e.g. Star Wars)",
+            "value_placeholder": "Add comma-separated franchises (e.g. The Clone Wars, Rebels)"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional franchises mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base franchise (e.g. Star Wars)",
+            "value_placeholder": "Add comma-separated franchises (e.g. The Clone Wars, Rebels)"
           },
           {
             "key": "minimum_items",
@@ -25149,11 +25206,42 @@
             "step": 1
           },
           {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these US content ratings. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add rating (e.g. PG-13)",
+            "mutually_exclusive_with": "exclude"
+          },
+          {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional US content ratings to the default include list for this Defaults File.",
+            "placeholder": "Add rating (e.g. PG-13)"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
             "tooltip": "Exclude specific content ratings from these collections.",
             "placeholder": "Add content rating (e.g. PG-13)"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional US content ratings that should be grouped into that collection.",
+            "key_placeholder": "Base rating (e.g. PG-13)",
+            "value_placeholder": "Add comma-separated ratings (e.g. TV-14, TV-PG)"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional US content ratings mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base rating (e.g. PG-13)",
+            "value_placeholder": "Add comma-separated ratings (e.g. TV-14, TV-PG)"
           },
           {
             "key": "minimum_items",
@@ -25646,11 +25734,42 @@
             "step": 1
           },
           {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these US content ratings. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add rating (e.g. PG-13)",
+            "mutually_exclusive_with": "exclude"
+          },
+          {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional US content ratings to the default include list for this Defaults File.",
+            "placeholder": "Add rating (e.g. PG-13)"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
             "tooltip": "Exclude specific content ratings from these collections.",
             "placeholder": "Add content rating (e.g. TV-14)"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional US content ratings that should be grouped into that collection.",
+            "key_placeholder": "Base rating (e.g. PG-13)",
+            "value_placeholder": "Add comma-separated ratings (e.g. TV-14, TV-PG)"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional US content ratings mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base rating (e.g. PG-13)",
+            "value_placeholder": "Add comma-separated ratings (e.g. TV-14, TV-PG)"
           },
           {
             "key": "minimum_items",
@@ -26144,11 +26263,42 @@
             "step": 1
           },
           {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these UK content ratings. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add rating (e.g. 15)",
+            "mutually_exclusive_with": "exclude"
+          },
+          {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional UK content ratings to the default include list for this Defaults File.",
+            "placeholder": "Add rating (e.g. 15)"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
             "tooltip": "Exclude specific content ratings from these collections.",
             "placeholder": "Add content rating (e.g. 15)"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional UK content ratings that should be grouped into that collection.",
+            "key_placeholder": "Base rating (e.g. 15)",
+            "value_placeholder": "Add comma-separated ratings (e.g. 12, 18)"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional UK content ratings mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base rating (e.g. 15)",
+            "value_placeholder": "Add comma-separated ratings (e.g. 12, 18)"
           },
           {
             "key": "minimum_items",
@@ -26652,11 +26802,42 @@
             "step": 1
           },
           {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these DE content ratings. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add rating (e.g. 16)",
+            "mutually_exclusive_with": "exclude"
+          },
+          {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional DE content ratings to the default include list for this Defaults File.",
+            "placeholder": "Add rating (e.g. 16)"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
             "tooltip": "Exclude specific content ratings from these collections.",
             "placeholder": "Add content rating (e.g. 12)"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional DE content ratings that should be grouped into that collection.",
+            "key_placeholder": "Base rating (e.g. 16)",
+            "value_placeholder": "Add comma-separated ratings (e.g. 12, 18)"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional DE content ratings mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base rating (e.g. 16)",
+            "value_placeholder": "Add comma-separated ratings (e.g. 12, 18)"
           },
           {
             "key": "minimum_items",
@@ -27160,11 +27341,42 @@
             "step": 1
           },
           {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these AU content ratings. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add rating (e.g. MA15+)",
+            "mutually_exclusive_with": "exclude"
+          },
+          {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional AU content ratings to the default include list for this Defaults File.",
+            "placeholder": "Add rating (e.g. MA15+)"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
             "tooltip": "Exclude specific content ratings from these collections.",
             "placeholder": "Add content rating (e.g. M)"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional AU content ratings that should be grouped into that collection.",
+            "key_placeholder": "Base rating (e.g. MA15+)",
+            "value_placeholder": "Add comma-separated ratings (e.g. M, R18+)"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional AU content ratings mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base rating (e.g. MA15+)",
+            "value_placeholder": "Add comma-separated ratings (e.g. M, R18+)"
           },
           {
             "key": "minimum_items",
@@ -27668,11 +27880,42 @@
             "step": 1
           },
           {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these NZ content ratings. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add rating (e.g. M)",
+            "mutually_exclusive_with": "exclude"
+          },
+          {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional NZ content ratings to the default include list for this Defaults File.",
+            "placeholder": "Add rating (e.g. M)"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
             "tooltip": "Exclude specific content ratings from these collections.",
             "placeholder": "Add content rating (e.g. PG)"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional NZ content ratings that should be grouped into that collection.",
+            "key_placeholder": "Base rating (e.g. M)",
+            "value_placeholder": "Add comma-separated ratings (e.g. PG, R16)"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional NZ content ratings mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base rating (e.g. M)",
+            "value_placeholder": "Add comma-separated ratings (e.g. PG, R16)"
           },
           {
             "key": "minimum_items",
@@ -28176,11 +28419,42 @@
             "step": 1
           },
           {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these MAL content ratings. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add rating (e.g. PG-13)",
+            "mutually_exclusive_with": "exclude"
+          },
+          {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional MAL content ratings to the default include list for this Defaults File.",
+            "placeholder": "Add rating (e.g. PG-13)"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
             "tooltip": "Exclude specific content ratings from these collections.",
             "placeholder": "Add content rating (e.g. PG-13)"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional MAL content ratings that should be grouped into that collection.",
+            "key_placeholder": "Base rating (e.g. PG-13)",
+            "value_placeholder": "Add comma-separated ratings (e.g. G, R)"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional MAL content ratings mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base rating (e.g. PG-13)",
+            "value_placeholder": "Add comma-separated ratings (e.g. G, R)"
           },
           {
             "key": "minimum_items",
@@ -28684,11 +28958,42 @@
             "step": 1
           },
           {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these CS content ratings. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add rating (e.g. 15)",
+            "mutually_exclusive_with": "exclude"
+          },
+          {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional CS content ratings to the default include list for this Defaults File.",
+            "placeholder": "Add rating (e.g. 15)"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
             "tooltip": "Exclude specific content ratings from these collections.",
             "placeholder": "Add content rating (e.g. 13)"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional CS content ratings that should be grouped into that collection.",
+            "key_placeholder": "Base rating (e.g. 15)",
+            "value_placeholder": "Add comma-separated ratings (e.g. 12, 18)"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional CS content ratings mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base rating (e.g. 15)",
+            "value_placeholder": "Add comma-separated ratings (e.g. 12, 18)"
           },
           {
             "key": "minimum_items",
@@ -29208,11 +29513,42 @@
             "step": 1
           },
           {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these countries. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add country (e.g. France)",
+            "mutually_exclusive_with": "exclude"
+          },
+          {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional countries to the default include list for this Defaults File.",
+            "placeholder": "Add country (e.g. France)"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
             "tooltip": "Exclude specific countries from these collections.",
             "placeholder": "Add country name (e.g. France)"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional countries that should be grouped into that collection.",
+            "key_placeholder": "Base country (e.g. France)",
+            "value_placeholder": "Add comma-separated countries (e.g. Belgium, Switzerland)"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional countries mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base country (e.g. France)",
+            "value_placeholder": "Add comma-separated countries (e.g. Belgium, Switzerland)"
           },
           {
             "key": "minimum_items",
@@ -29733,11 +30069,42 @@
             "step": 1
           },
           {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these countries. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add country (e.g. France)",
+            "mutually_exclusive_with": "exclude"
+          },
+          {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional countries to the default include list for this Defaults File.",
+            "placeholder": "Add country (e.g. France)"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
             "tooltip": "Exclude specific countries from these collections.",
             "placeholder": "Add country name (e.g. France)"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional countries that should be grouped into that collection.",
+            "key_placeholder": "Base country (e.g. France)",
+            "value_placeholder": "Add comma-separated countries (e.g. Belgium, Switzerland)"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional countries mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base country (e.g. France)",
+            "value_placeholder": "Add comma-separated countries (e.g. Belgium, Switzerland)"
           },
           {
             "key": "minimum_items",
@@ -30627,11 +30994,42 @@
             "step": 1
           },
           {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these regions. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add region (e.g. US)",
+            "mutually_exclusive_with": "exclude"
+          },
+          {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional regions to the default include list for this Defaults File.",
+            "placeholder": "Add region (e.g. US)"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
             "tooltip": "Exclude specific regions from these collections.",
             "placeholder": "Add region name (e.g. Melanesia)"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional regions that should be grouped into that collection.",
+            "key_placeholder": "Base region (e.g. US)",
+            "value_placeholder": "Add comma-separated regions (e.g. CA, MX)"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional regions mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base region (e.g. US)",
+            "value_placeholder": "Add comma-separated regions (e.g. CA, MX)"
           },
           {
             "key": "minimum_items",
@@ -31742,11 +32140,42 @@
             "step": 1
           },
           {
+            "key": "include",
+            "label": "Include",
+            "type": "string_list",
+            "tooltip": "Only create collections for these continents. Kometa code allows this with Exclude, but the wiki says not to combine them.",
+            "placeholder": "Add continent (e.g. Europe)",
+            "mutually_exclusive_with": "exclude"
+          },
+          {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional continents to the default include list for this Defaults File.",
+            "placeholder": "Add continent (e.g. Europe)"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
             "tooltip": "Exclude specific continents from these collections.",
             "placeholder": "Add continent name (e.g. Europe)"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional continents that should be grouped into that collection.",
+            "key_placeholder": "Base continent (e.g. Europe)",
+            "value_placeholder": "Add comma-separated continents (e.g. Asia, Africa)"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional continents mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base continent (e.g. Europe)",
+            "value_placeholder": "Add comma-separated continents (e.g. Asia, Africa)"
           },
           {
             "key": "minimum_items",
@@ -33193,12 +33622,35 @@
             "mutually_exclusive_with": "exclude"
           },
           {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional resolutions to the default include list for this Defaults File.",
+            "placeholder": "Add resolution key (e.g. 4k)"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
             "tooltip": "Exclude specific resolutions from these collections. Kometa code allows this with Include, but the wiki says not to combine them.",
             "placeholder": "Add resolution key (e.g. 4k)",
             "mutually_exclusive_with": "include"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional resolutions that should be grouped into that collection.",
+            "key_placeholder": "Base resolution (e.g. 4k)",
+            "value_placeholder": "Add comma-separated resolutions (e.g. 2160p, uhd)"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional resolutions mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base resolution (e.g. 4k)",
+            "value_placeholder": "Add comma-separated resolutions (e.g. 2160p, uhd)"
           },
           {
             "key": "minimum_items",
@@ -33687,6 +34139,13 @@
             "tooltip": "Only create collections for these audio languages. Kometa code allows this with Exclude, but the wiki says not to combine them.",
             "placeholder": "Add language code (e.g. fr)",
             "mutually_exclusive_with": "exclude"
+          },
+          {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional audio languages to the default include list for this Defaults File.",
+            "placeholder": "Add language code (e.g. fr)"
           },
           {
             "key": "exclude",
@@ -34204,6 +34663,13 @@
             "tooltip": "Only create collections for these subtitle languages. Kometa code allows this with Exclude, but the wiki says not to combine them.",
             "placeholder": "Add language code (e.g. fr)",
             "mutually_exclusive_with": "exclude"
+          },
+          {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional subtitle languages to the default include list for this Defaults File.",
+            "placeholder": "Add language code (e.g. fr)"
           },
           {
             "key": "exclude",
@@ -38405,12 +38871,35 @@
             "mutually_exclusive_with": "exclude"
           },
           {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional studios to the default include list for this Defaults File.",
+            "placeholder": "Add studio (e.g. A24)"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
             "tooltip": "Exclude specific studios from these collections. Kometa code allows this with Include, but the wiki says not to combine them.",
             "placeholder": "Add studio name (e.g. Marvel Studios)",
             "mutually_exclusive_with": "include"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional studios that should be grouped into that collection.",
+            "key_placeholder": "Base studio (e.g. A24)",
+            "value_placeholder": "Add comma-separated studios (e.g. Neon, IFC Films)"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional studios mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base studio (e.g. A24)",
+            "value_placeholder": "Add comma-separated studios (e.g. Neon, IFC Films)"
           },
           {
             "key": "minimum_items",
@@ -38888,12 +39377,35 @@
             "mutually_exclusive_with": "exclude"
           },
           {
+            "key": "append_include",
+            "label": "Append Include",
+            "type": "string_list",
+            "tooltip": "Append additional networks to the default include list for this Defaults File.",
+            "placeholder": "Add network (e.g. HBO)"
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
             "tooltip": "Exclude specific networks from these collections. Kometa code allows this with Include, but the wiki says not to combine them.",
             "placeholder": "Add network name (e.g. HBO)",
             "mutually_exclusive_with": "include"
+          },
+          {
+            "key": "addons",
+            "label": "Addons",
+            "type": "mapping_list",
+            "tooltip": "Map a base value to additional networks that should be grouped into that collection.",
+            "key_placeholder": "Base network (e.g. HBO)",
+            "value_placeholder": "Add comma-separated networks (e.g. Max, HBO Max)"
+          },
+          {
+            "key": "append_addons",
+            "label": "Append Addons",
+            "type": "mapping_list",
+            "tooltip": "Append additional networks mappings to the default addons dictionary for this Defaults File.",
+            "key_placeholder": "Base network (e.g. HBO)",
+            "value_placeholder": "Add comma-separated networks (e.g. Max, HBO Max)"
           },
           {
             "key": "minimum_items",

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -3236,11 +3236,165 @@ document.addEventListener('DOMContentLoaded', function () {
         syncState(parseValues())
 
         addBtn.addEventListener('click', addValue)
+        hidden.addEventListener('change', () => {
+          syncState(parseValues())
+        })
         input.addEventListener('input', clearTransientFeedback)
         input.addEventListener('keydown', (event) => {
           if (event.key === 'Enter') {
             event.preventDefault()
             addValue()
+          }
+        })
+
+        wrapper.dataset.listenerAdded = 'true'
+      })
+    }
+
+    function setupTemplateMappingListHandlers (scope) {
+      const root = scope || document
+      root.querySelectorAll('[data-template-mapping-list]').forEach(wrapper => {
+        if (wrapper.dataset.listenerAdded) return
+
+        const hiddenId = wrapper.dataset.hiddenInput
+        const hidden = hiddenId ? document.getElementById(hiddenId) : wrapper.querySelector('input[type="hidden"]')
+        const keyInput = wrapper.querySelector('[data-template-mapping-key]')
+        const valueInput = wrapper.querySelector('[data-template-mapping-value]')
+        const addBtn = wrapper.querySelector('[data-template-mapping-add]')
+        const list = wrapper.querySelector('[data-template-mapping-items]')
+        const feedback = wrapper.querySelector('[data-template-mapping-feedback]')
+
+        if (!hidden || !keyInput || !valueInput || !addBtn || !list) return
+
+        function parseValuesList (rawValue) {
+          if (Array.isArray(rawValue)) {
+            return rawValue.map(item => String(item).trim()).filter(Boolean)
+          }
+          const text = String(rawValue || '').trim()
+          if (!text) return []
+          return text.split(',').map(item => item.trim()).filter(Boolean)
+        }
+
+        function parseStoredMapping (rawValue) {
+          const raw = String(rawValue || '').trim()
+          if (!raw) return {}
+          try {
+            const parsed = JSON.parse(raw)
+            if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+              return parsed
+            }
+          } catch (e) {
+            // fall through to empty mapping
+          }
+          return {}
+        }
+
+        function setFeedback (message = '') {
+          if (!feedback) return
+          feedback.textContent = message
+          feedback.classList.toggle('d-none', !message)
+          feedback.classList.toggle('d-block', Boolean(message))
+        }
+
+        function normalizeMapping (mapping) {
+          const normalized = {}
+          Object.entries(mapping || {}).forEach(([rawKey, rawValues]) => {
+            const key = String(rawKey || '').trim()
+            if (!key) return
+            const values = parseValuesList(rawValues)
+            if (!values.length) return
+            normalized[key] = values
+          })
+          return normalized
+        }
+
+        function renderList (mapping) {
+          list.replaceChildren()
+          Object.entries(mapping).forEach(([key, values]) => {
+            const li = document.createElement('li')
+            li.className = 'list-group-item d-flex justify-content-between align-items-center'
+
+            const textWrap = document.createElement('div')
+            textWrap.className = 'd-flex flex-column'
+
+            const title = document.createElement('span')
+            title.textContent = key
+            textWrap.appendChild(title)
+
+            const details = document.createElement('div')
+            details.className = 'small text-muted'
+            details.textContent = values.join(', ')
+            textWrap.appendChild(details)
+
+            const button = document.createElement('button')
+            button.type = 'button'
+            button.className = 'btn btn-sm btn-danger'
+            button.setAttribute('aria-label', 'Remove')
+            const icon = document.createElement('i')
+            icon.className = 'bi bi-x-lg'
+            button.appendChild(icon)
+
+            li.append(textWrap, button)
+            list.appendChild(li)
+
+            button.addEventListener('click', () => {
+              const current = normalizeMapping(parseStoredMapping(hidden.value))
+              delete current[key]
+              hidden.value = JSON.stringify(current)
+              renderList(current)
+              setFeedback('')
+            })
+          })
+        }
+
+        function syncState (mapping, message = '') {
+          const normalized = normalizeMapping(mapping)
+          hidden.value = JSON.stringify(normalized)
+          renderList(normalized)
+          setFeedback(message)
+          return normalized
+        }
+
+        function addEntry () {
+          const key = String(keyInput.value || '').trim()
+          if (!key) {
+            setFeedback('Enter a key before adding it.')
+            return
+          }
+          const values = parseValuesList(valueInput.value)
+          if (!values.length) {
+            setFeedback('Enter at least one value before adding it.')
+            return
+          }
+          const current = normalizeMapping(parseStoredMapping(hidden.value))
+          current[key] = values
+          syncState(current)
+          keyInput.value = ''
+          valueInput.value = ''
+        }
+
+        syncState(parseStoredMapping(hidden.value))
+
+        addBtn.addEventListener('click', addEntry)
+        hidden.addEventListener('change', () => {
+          syncState(parseStoredMapping(hidden.value))
+        })
+        keyInput.addEventListener('input', () => {
+          setFeedback('')
+        })
+        valueInput.addEventListener('input', () => {
+          setFeedback('')
+        })
+        keyInput.addEventListener('keydown', (event) => {
+          if (event.key === 'Enter') {
+            event.preventDefault()
+            addEntry()
+          }
+        })
+        valueInput.addEventListener('keydown', (event) => {
+          if (event.key === 'Enter') {
+            event.preventDefault()
+            addEntry()
           }
         })
 
@@ -3887,6 +4041,7 @@ document.addEventListener('DOMContentLoaded', function () {
       setupCustomStringListHandlers('mass_content_rating_update', card)
       setupCustomStringListHandlers('mass_genre_mapper', card)
       setupTemplateStringListHandlers(card)
+      setupTemplateMappingListHandlers(card)
       setupMappingListHandlers('genre_mapper', card)
       setupMappingListHandlers('content_rating_mapper', card)
       wireOverlayDetailToggles(card)
@@ -4376,6 +4531,8 @@ document.addEventListener('DOMContentLoaded', function () {
     setupCustomStringListHandlers('metadata_backup')
     setupCustomStringListHandlers('mass_content_rating_update')
     setupCustomStringListHandlers('mass_genre_mapper')
+    setupTemplateStringListHandlers()
+    setupTemplateMappingListHandlers()
     setupMappingListHandlers('genre_mapper')
     setupMappingListHandlers('content_rating_mapper')
 

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -1303,10 +1303,54 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                 <button class="btn nav-button" type="button" data-template-string-add
                                     {% if disable_toggle %}disabled{% endif %}>Add</button>
                             </div>
-                            <div class="invalid-feedback d-none" data-template-string-feedback></div>
-                            <ul class="list-group mt-2" data-template-string-items></ul>
-                            <input type="hidden" id="{{ input_name }}" name="{{ input_name }}" value="{{ list_json }}"
-                                data-default='{{ list_default_json }}'>
+                        <div class="invalid-feedback d-none" data-template-string-feedback></div>
+                        <ul class="list-group mt-2" data-template-string-items></ul>
+                        <input type="hidden" id="{{ input_name }}" name="{{ input_name }}" value="{{ list_json }}"
+                            data-default='{{ list_default_json }}'>
+                        </div>
+                        {% elif item.type == 'mapping_list' %}
+                        {% set stored_map = data['libraries'].get(input_name) %}
+                        {% if stored_map is string %}
+                        {% set map_json = stored_map %}
+                        {% elif stored_map is mapping %}
+                        {% set map_json = stored_map | tojson %}
+                        {% else %}
+                        {% set map_json = '{}' %}
+                        {% endif %}
+                        {% if item.default is defined and item.default is mapping %}
+                        {% set map_default_json = item.default | tojson %}
+                        {% elif item.default is defined and item.default is string and item.default|trim %}
+                        {% set map_default_json = item.default %}
+                        {% else %}
+                        {% set map_default_json = '{}' %}
+                        {% endif %}
+                        <div class="mb-2" data-template-mapping-list data-hidden-input="{{ input_name }}">
+                            <div class="input-group">
+                                <span class="input-group-text" id="{{ input_name }}_text" style="width: 170px;">
+                                    {{ item.label }}
+                                    {% if item.tooltip %}
+                                    <span class="text-{{ item.tooltip_variant or 'info' }} ms-2" data-bs-toggle="tooltip"
+                                        data-bs-html="true" title="{{ item.tooltip }}">
+                                        <i
+                                            class="bi {% if item.tooltip_variant == 'danger' %}bi-exclamation-circle-fill{% else %}bi-info-circle-fill{% endif %}"></i>
+                                    </span>
+                                    {% endif %}
+                                </span>
+                                <input type="text" class="form-control" data-template-mapping-key
+                                    aria-describedby="{{ input_name }}_text"
+                                    placeholder="{{ item.key_placeholder | default('Add key') }}"
+                                    {% if disable_toggle %}disabled{% endif %}>
+                                <input type="text" class="form-control" data-template-mapping-value
+                                    aria-describedby="{{ input_name }}_text"
+                                    placeholder="{{ item.value_placeholder | default('Add comma-separated values') }}"
+                                    {% if disable_toggle %}disabled{% endif %}>
+                                <button class="btn nav-button" type="button" data-template-mapping-add
+                                    {% if disable_toggle %}disabled{% endif %}>Add</button>
+                            </div>
+                            <div class="invalid-feedback d-none" data-template-mapping-feedback></div>
+                            <ul class="list-group mt-2" data-template-mapping-items></ul>
+                            <input type="hidden" id="{{ input_name }}" name="{{ input_name }}" value="{{ map_json }}"
+                                data-default='{{ map_default_json }}'>
                         </div>
                         {% elif item.type == 'relative_year' %}
                         {% set stored_val = data['libraries'].get(input_name, item.default) | default('', true) %}

--- a/tests/test_collection_arr_shared_contract.py
+++ b/tests/test_collection_arr_shared_contract.py
@@ -1,0 +1,161 @@
+import json
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+ROOT = Path(__file__).resolve().parents[1]
+QS_COLLECTIONS_PATH = ROOT / "static" / "json" / "quickstart_collections.json"
+DEFAULTS_ROOT = ROOT / "config" / "kometa" / "defaults"
+YAML_LOADER = YAML(typ="safe", pure=True)
+
+MOVIE_ARR_KEYS = {
+    "radarr_add_missing",
+    "radarr_folder",
+    "radarr_tag",
+    "item_radarr_tag",
+    "radarr_monitor",
+    "radarr_upgrade_existing",
+    "radarr_monitor_existing",
+    "radarr_search",
+}
+SHOW_ARR_KEYS = {
+    "sonarr_add_missing",
+    "sonarr_folder",
+    "sonarr_tag",
+    "item_sonarr_tag",
+    "sonarr_monitor",
+    "sonarr_upgrade_existing",
+    "sonarr_monitor_existing",
+    "sonarr_search",
+}
+TOGGLE_KEYS = {
+    "radarr_add_missing",
+    "sonarr_add_missing",
+    "radarr_monitor",
+    "radarr_upgrade_existing",
+    "radarr_monitor_existing",
+    "sonarr_upgrade_existing",
+    "sonarr_monitor_existing",
+    "radarr_search",
+    "sonarr_search",
+}
+STRING_LIST_KEYS = {"radarr_tag", "sonarr_tag", "item_radarr_tag", "item_sonarr_tag"}
+TEXT_INPUT_KEYS = {"radarr_folder", "sonarr_folder"}
+SONARR_MONITOR_OPTIONS = ["all", "none", "future", "missing", "existing", "pilot", "first", "latest"]
+
+
+def _build_qs_collection_map():
+    data = json.loads(QS_COLLECTIONS_PATH.read_text(encoding="utf-8"))
+    mapping = {}
+    for group in data:
+        for collection in group.get("collections", []):
+            alias = collection["id"].replace("collection_", "", 1)
+            mapping.setdefault(alias, []).append(collection)
+    return mapping
+
+
+def _iter_collection_default_files():
+    for bucket in ("award", "both", "movie", "show", "chart"):
+        yield from sorted((DEFAULTS_ROOT / bucket).glob("*.yml"))
+
+
+def _template_names(path: Path):
+    data = YAML_LOADER.load(path.read_text(encoding="utf-8")) or {}
+    names = set()
+    for section_name in ("collections", "dynamic_collections"):
+        section = data.get(section_name) or {}
+        if not isinstance(section, dict):
+            continue
+        for cfg in section.values():
+            if not isinstance(cfg, dict):
+                continue
+            for template_key in ("template", "other_template"):
+                template = cfg.get(template_key)
+                if isinstance(template, list):
+                    for entry in template:
+                        if isinstance(entry, str):
+                            names.add(entry)
+                        elif isinstance(entry, dict) and entry.get("name"):
+                            names.add(str(entry["name"]))
+                elif isinstance(template, dict) and template.get("name"):
+                    names.add(str(template["name"]))
+                elif isinstance(template, str):
+                    names.add(template)
+    return names
+
+
+def _expected_arr_shared_defaults():
+    expected = {}
+    all_keys = MOVIE_ARR_KEYS | SHOW_ARR_KEYS
+    for path in _iter_collection_default_files():
+        alias = path.stem
+        text = path.read_text(encoding="utf-8")
+        names = _template_names(path)
+        supported = expected.setdefault(alias, set())
+        for key in all_keys:
+            if key.startswith("item_"):
+                if "shared" in names or f"{key}:" in text or f"{key}_<<key>>:" in text:
+                    supported.add(key)
+                continue
+            if "arr" in names or f"{key}:" in text or f"{key}_<<key>>:" in text:
+                supported.add(key)
+    return expected
+
+
+def test_arr_shared_keys_exist_for_every_supported_non_readonly_collection_family():
+    qs_map = _build_qs_collection_map()
+    expected = _expected_arr_shared_defaults()
+
+    missing = []
+    for alias, collections in qs_map.items():
+        supported = expected.get(alias, set())
+        if not supported:
+            continue
+        for collection in collections:
+            if collection.get("readonly"):
+                continue
+            keys = {item["key"] for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key")}
+            media_types = set(collection.get("media_types") or [])
+            expected_keys = set()
+            if "movie" in media_types:
+                expected_keys |= supported & MOVIE_ARR_KEYS
+            if "show" in media_types:
+                expected_keys |= supported & SHOW_ARR_KEYS
+            for key in sorted(expected_keys - keys):
+                missing.append(f"{collection['id']}:{key}")
+
+    assert missing == []
+
+
+def test_arr_shared_key_types_match_the_defaults_contract():
+    qs_map = _build_qs_collection_map()
+    expected = _expected_arr_shared_defaults()
+
+    for alias, collections in qs_map.items():
+        supported = expected.get(alias, set())
+        if not supported:
+            continue
+        for collection in collections:
+            if collection.get("readonly"):
+                continue
+            media_types = set(collection.get("media_types") or [])
+            expected_keys = set()
+            if "movie" in media_types:
+                expected_keys |= supported & MOVIE_ARR_KEYS
+            if "show" in media_types:
+                expected_keys |= supported & SHOW_ARR_KEYS
+
+            for key in expected_keys:
+                field = next(item for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key") == key)
+                if key in TOGGLE_KEYS:
+                    assert field["type"] == "toggle"
+                elif key in STRING_LIST_KEYS:
+                    assert field["type"] == "string_list"
+                    assert "default" not in field
+                elif key in TEXT_INPUT_KEYS:
+                    assert field["type"] == "text_input"
+                elif key == "sonarr_monitor":
+                    assert field["type"] == "select"
+                    assert [option["value"] for option in field["options"]] == SONARR_MONITOR_OPTIONS
+                else:
+                    raise AssertionError(f"Unhandled ARR/shared contract key {key}")

--- a/tests/test_collection_dynamic_family_contract.py
+++ b/tests/test_collection_dynamic_family_contract.py
@@ -1,0 +1,115 @@
+import json
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+QS_COLLECTIONS_PATH = ROOT / "static" / "json" / "quickstart_collections.json"
+DEFAULTS_ROOT = ROOT / "config" / "kometa" / "defaults"
+
+FIELD_TYPES = {
+    "include": "string_list",
+    "append_include": "string_list",
+    "addons": "mapping_list",
+    "append_addons": "mapping_list",
+    "remove_suffix": "string_list",
+}
+
+
+def _build_qs_collection_map():
+    data = json.loads(QS_COLLECTIONS_PATH.read_text(encoding="utf-8"))
+    mapping = {}
+    for group in data:
+        for collection in group.get("collections", []):
+            alias = collection["id"].replace("collection_", "", 1)
+            mapping.setdefault(alias, []).append(collection)
+    return mapping
+
+
+def _expected_dynamic_family_defaults():
+    expected = {}
+    bucket_media_types = {
+        "both": {"movie", "show"},
+        "movie": {"movie"},
+        "show": {"show"},
+    }
+
+    for bucket, media_types in bucket_media_types.items():
+        for path in sorted((DEFAULTS_ROOT / bucket).glob("*.yml")):
+            text = path.read_text(encoding="utf-8")
+            keys = set()
+            if re.search(r"(?m)^\s*include\s*:", text):
+                keys.update({"include", "append_include"})
+            if re.search(r"(?m)^\s*addons\s*:", text):
+                keys.update({"addons", "append_addons"})
+            if re.search(r"(?m)^\s*remove_suffix\s*:", text):
+                keys.add("remove_suffix")
+            if not keys:
+                continue
+
+            alias = path.stem
+            media_key_map = expected.setdefault(alias, {})
+            for media_type in media_types:
+                media_key_map.setdefault(media_type, set()).update(keys)
+
+    return expected
+
+
+def test_dynamic_family_keys_exist_for_every_yaml_backed_collection_family():
+    qs_map = _build_qs_collection_map()
+    expected = _expected_dynamic_family_defaults()
+
+    missing = []
+    for alias, collections in qs_map.items():
+        alias_expected = expected.get(alias)
+        if not alias_expected:
+            continue
+        for collection in collections:
+            if collection.get("readonly"):
+                continue
+            media_types = set(collection.get("media_types") or [])
+            expected_keys = set()
+            for media_type in media_types:
+                expected_keys.update(alias_expected.get(media_type, set()))
+            if not expected_keys:
+                continue
+
+            keys = {
+                item["key"]
+                for item in collection.get("template_variables", [])
+                if isinstance(item, dict) and item.get("key")
+            }
+            for key in sorted(expected_keys - keys):
+                missing.append(f"{collection['id']}:{','.join(sorted(media_types))}:{key}")
+
+    assert missing == []
+
+
+def test_dynamic_family_key_types_match_the_defaults_contract():
+    qs_map = _build_qs_collection_map()
+    expected = _expected_dynamic_family_defaults()
+
+    for alias, collections in qs_map.items():
+        alias_expected = expected.get(alias)
+        if not alias_expected:
+            continue
+        for collection in collections:
+            if collection.get("readonly"):
+                continue
+            media_types = set(collection.get("media_types") or [])
+            expected_keys = set()
+            for media_type in media_types:
+                expected_keys.update(alias_expected.get(media_type, set()))
+            if not expected_keys:
+                continue
+
+            for key in sorted(expected_keys):
+                field = next(
+                    item
+                    for item in collection.get("template_variables", [])
+                    if isinstance(item, dict) and item.get("key") == key
+                )
+                assert field["type"] == FIELD_TYPES[key]
+                if key in {"addons", "append_addons"}:
+                    assert field.get("key_placeholder")
+                    assert field.get("value_placeholder")

--- a/tests/test_collection_dynamic_family_contract.py
+++ b/tests/test_collection_dynamic_family_contract.py
@@ -2,7 +2,6 @@ import json
 import re
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 QS_COLLECTIONS_PATH = ROOT / "static" / "json" / "quickstart_collections.json"
 DEFAULTS_ROOT = ROOT / "config" / "kometa" / "defaults"
@@ -74,11 +73,7 @@ def test_dynamic_family_keys_exist_for_every_yaml_backed_collection_family():
             if not expected_keys:
                 continue
 
-            keys = {
-                item["key"]
-                for item in collection.get("template_variables", [])
-                if isinstance(item, dict) and item.get("key")
-            }
+            keys = {item["key"] for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key")}
             for key in sorted(expected_keys - keys):
                 missing.append(f"{collection['id']}:{','.join(sorted(media_types))}:{key}")
 
@@ -104,11 +99,7 @@ def test_dynamic_family_key_types_match_the_defaults_contract():
                 continue
 
             for key in sorted(expected_keys):
-                field = next(
-                    item
-                    for item in collection.get("template_variables", [])
-                    if isinstance(item, dict) and item.get("key") == key
-                )
+                field = next(item for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key") == key)
                 assert field["type"] == FIELD_TYPES[key]
                 if key in {"addons", "append_addons"}:
                     assert field.get("key_placeholder")

--- a/tests/test_collection_schema_contract.py
+++ b/tests/test_collection_schema_contract.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import jsonschema
 from ruamel.yaml import YAML
 
-
 ROOT = Path(__file__).resolve().parents[1]
 SCHEMA_PATH = ROOT / "config" / ".schema" / "collection-schema.json"
 DEFAULTS_ROOTS = [
@@ -30,10 +29,7 @@ def test_collection_schema_validates_all_top_level_collection_defaults():
                 key=lambda err: (".".join(str(part) for part in err.absolute_path), err.validator, err.message),
             )
             if errors:
-                formatted = [
-                    f"{'.'.join(str(part) for part in err.absolute_path) or '<root>'}: {err.message}"
-                    for err in errors[:10]
-                ]
+                formatted = [f"{'.'.join(str(part) for part in err.absolute_path) or '<root>'}: {err.message}" for err in errors[:10]]
                 failures.append(f"{path.relative_to(ROOT)}: " + " | ".join(formatted))
 
     assert not failures, "\n".join(failures)

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -1160,6 +1160,64 @@ def test_build_libraries_section_preserves_chart_builder_size_template_variables
     assert content_rating_us_entry["template_variables"]["limit_other"] == "5"
 
 
+def test_build_libraries_section_normalizes_collection_arr_tag_lists(app):
+    from modules import output
+
+    with app.app_context():
+        libraries_section = output.build_libraries_section(
+            {"mov-library_movies-library": "Movies"},
+            {"sho-library_shows-library": "Shows"},
+            {
+                "movies": {
+                    "mov-library_movies-collection_franchise": True,
+                    "mov-library_movies-template_collection_franchise_radarr_folder": r"C:\Media\Movies",
+                    "mov-library_movies-template_collection_franchise_radarr_tag": '["4k", "favorite"]',
+                    "mov-library_movies-template_collection_franchise_item_radarr_tag": '["collected", "franchise"]',
+                }
+            },
+            {
+                "shows": {
+                    "sho-library_shows-collection_franchise": True,
+                    "sho-library_shows-template_collection_franchise_sonarr_folder": r"C:\Media\Shows",
+                    "sho-library_shows-template_collection_franchise_sonarr_monitor": "future",
+                    "sho-library_shows-template_collection_franchise_sonarr_tag": '["ongoing", "priority"]',
+                    "sho-library_shows-template_collection_franchise_item_sonarr_tag": '["watched", "tracked"]',
+                }
+            },
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+        )
+
+    movie_entry = next(
+        (entry for entry in libraries_section["libraries"]["Movies"]["collection_files"] if entry.get("default") == "franchise"),
+        None,
+    )
+    show_entry = next(
+        (entry for entry in libraries_section["libraries"]["Shows"]["collection_files"] if entry.get("default") == "franchise"),
+        None,
+    )
+
+    assert movie_entry is not None
+    assert show_entry is not None
+    assert movie_entry["template_variables"]["radarr_folder"] == r"C:\Media\Movies"
+    assert movie_entry["template_variables"]["radarr_tag"] == ["4k", "favorite"]
+    assert movie_entry["template_variables"]["item_radarr_tag"] == ["collected", "franchise"]
+    assert show_entry["template_variables"]["sonarr_folder"] == r"C:\Media\Shows"
+    assert show_entry["template_variables"]["sonarr_monitor"] == "future"
+    assert show_entry["template_variables"]["sonarr_tag"] == ["ongoing", "priority"]
+    assert show_entry["template_variables"]["item_sonarr_tag"] == ["watched", "tracked"]
+
+
 def test_build_libraries_section_emits_library_arr_overrides(app):
     from modules import output
 

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -1448,6 +1448,65 @@ def test_collapse_collection_data_template_vars_removes_flat_data_keys_from_all_
             assert isinstance(template_variables["data"], dict)
 
 
+def test_normalize_collection_template_var_value_handles_dynamic_family_controls():
+    from modules import output
+
+    assert output._normalize_collection_template_var_value("append_include", '["US", "CA", "US"]') == ["US", "CA"]
+    assert output._normalize_collection_template_var_value("remove_suffix", '["Collection", " Edition ", "Collection"]') == "Collection,Edition"
+    assert output._normalize_collection_template_var_value(
+        "addons",
+        '{"Action": ["Adventure", "Adventure", "Thriller"], "Drama": "Crime, Mystery", "": ["Skip"]}',
+    ) == {
+        "Action": ["Adventure", "Thriller"],
+        "Drama": ["Crime", "Mystery"],
+    }
+    assert output._normalize_collection_template_var_value(
+        "append_addons",
+        '{"Top 250": ["IMDb Top 250"]}',
+    ) == {"Top 250": ["IMDb Top 250"]}
+
+
+def test_dynamic_family_template_var_normalization_matches_collection_export_shapes():
+    from modules import output
+
+    template_vars = {
+        "include": '["US", "CA"]',
+        "append_include": '["MX", "CA"]',
+        "addons": '{"US": ["Canada", "Mexico"], "CA": "United States"}',
+        "append_addons": '{"US": ["Brazil"]}',
+        "remove_suffix": '["Collection"]',
+    }
+
+    for list_key in ("include", "exclude", "exclude_prefix"):
+        if list_key not in template_vars:
+            continue
+        list_values = output._parse_string_list(template_vars.get(list_key))
+        if list_values:
+            template_vars[list_key] = list_values
+        else:
+            template_vars.pop(list_key, None)
+
+    for template_key in list(template_vars.keys()):
+        normalized_value = output._normalize_collection_template_var_value(template_key, template_vars.get(template_key))
+        if normalized_value is None:
+            template_vars.pop(template_key, None)
+        else:
+            template_vars[template_key] = normalized_value
+
+    assert template_vars == {
+        "include": ["US", "CA"],
+        "append_include": ["MX", "CA"],
+        "addons": {
+            "US": ["Canada", "Mexico"],
+            "CA": ["United States"],
+        },
+        "append_addons": {
+            "US": ["Brazil"],
+        },
+        "remove_suffix": "Collection",
+    }
+
+
 def test_build_config_prunes_default_horizontal_ratings_offsets(app, monkeypatch):
     from flask import session
     from modules import output

--- a/tests/test_overlay_schema_contract.py
+++ b/tests/test_overlay_schema_contract.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import jsonschema
 from ruamel.yaml import YAML
 
-
 ROOT = Path(__file__).resolve().parents[1]
 SCHEMA_PATH = ROOT / "config" / ".schema" / "overlay-schema.json"
 OVERLAYS_ROOT = ROOT / "config" / "kometa" / "defaults" / "overlays"
@@ -23,10 +22,7 @@ def test_overlay_schema_validates_all_top_level_overlay_defaults():
             key=lambda err: (".".join(str(part) for part in err.absolute_path), err.validator, err.message),
         )
         if errors:
-            formatted = [
-                f"{'.'.join(str(part) for part in err.absolute_path) or '<root>'}: {err.message}"
-                for err in errors[:10]
-            ]
+            formatted = [f"{'.'.join(str(part) for part in err.absolute_path) or '<root>'}: {err.message}" for err in errors[:10]]
             failures.append(f"{path.name}: " + " | ".join(formatted))
 
     assert not failures, "\n".join(failures)


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Title
Add collection ARR shared keys and dynamic-family list controls to Quickstart
Description
Summary
This PR expands Quickstart collection support to better match Kometa defaults and output behavior.
It adds the shared collection ARR/automation keys across supported collection families, and introduces the next dynamic-family batch for YAML-backed collection controls:
include
append_include
addons
append_addons
remove_suffix
It also wires these through the libraries UI, final YAML export, and regression tests.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
