### PR TITLE
tmdb_birthday and title_format added

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -354,6 +354,75 @@ def _parse_string_list_mapping(value):
     return normalized
 
 
+def _parse_tmdb_person_window(value):
+    if value is None:
+        return None
+
+    raw_text = None
+    parsed = value
+    if isinstance(value, str):
+        raw_text = value.strip()
+        if not raw_text:
+            return None
+        try:
+            parsed = json.loads(raw_text)
+        except Exception:
+            try:
+                parsed = ast.literal_eval(raw_text)
+            except Exception:
+                candidate = {}
+                valid_candidate = True
+                for part in re.split(r"[\n;,]+", raw_text):
+                    piece = str(part or "").strip()
+                    if not piece:
+                        continue
+                    if "=" in piece:
+                        key_text, raw_val = piece.split("=", 1)
+                    elif ":" in piece:
+                        key_text, raw_val = piece.split(":", 1)
+                    else:
+                        valid_candidate = False
+                        break
+                    key_text = key_text.strip()
+                    raw_val = raw_val.strip()
+                    if not key_text:
+                        valid_candidate = False
+                        break
+                    candidate[key_text] = raw_val
+                parsed = candidate if valid_candidate and candidate else raw_text
+
+    if not isinstance(parsed, dict):
+        return raw_text if raw_text is not None else value
+
+    normalized = {}
+    raw_this_month = parsed.get("this_month")
+    if raw_this_month not in (None, ""):
+        bool_value = _coerce_bool(raw_this_month)
+        normalized["this_month"] = bool_value if bool_value is not None else raw_this_month
+
+    for key in ("before", "after"):
+        raw_number = parsed.get(key)
+        if raw_number in (None, ""):
+            continue
+        number = _to_number(raw_number)
+        if number is None:
+            normalized[key] = raw_number
+        elif float(number).is_integer():
+            normalized[key] = int(number)
+        else:
+            normalized[key] = number
+
+    for raw_key, raw_value in parsed.items():
+        key_text = str(raw_key or "").strip()
+        if not key_text or key_text in normalized or key_text in {"this_month", "before", "after"}:
+            continue
+        if raw_value in (None, ""):
+            continue
+        normalized[key_text] = raw_value
+
+    return normalized or (raw_text if raw_text is not None else value)
+
+
 def _normalize_collection_template_var_value(key, value):
     if key in {"ignore_ids", "ignore_imdb_ids"}:
         list_values = _parse_string_list(value)
@@ -364,6 +433,8 @@ def _normalize_collection_template_var_value(key, value):
     if key in {"addons", "append_addons"}:
         mapping_values = _parse_string_list_mapping(value)
         return mapping_values if mapping_values else None
+    if key in {"tmdb_birthday", "tmdb_deathday"}:
+        return _parse_tmdb_person_window(value)
     if key == "remove_suffix":
         list_values = _parse_comma_string_list(value)
         return ",".join(list_values) if list_values else None

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -61,6 +61,13 @@
             "placeholder": "Custom collection summary format"
           },
           {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
+          },
+          {
             "key": "use_year_collections",
             "label": "Use Year Collections",
             "type": "toggle",
@@ -880,6 +887,13 @@
             "placeholder": "Custom collection summary format"
           },
           {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
+          },
+          {
             "key": "use_year_collections",
             "label": "Use Year Collections",
             "type": "toggle",
@@ -1636,6 +1650,13 @@
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
             "placeholder": "Custom collection summary format"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
           },
           {
             "key": "use_year_collections",
@@ -2396,6 +2417,13 @@
             "placeholder": "Custom collection summary format"
           },
           {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
+          },
+          {
             "key": "use_year_collections",
             "label": "Use Year Collections",
             "type": "toggle",
@@ -3152,6 +3180,13 @@
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
             "placeholder": "Custom collection summary format"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
           },
           {
             "key": "use_year_collections",
@@ -3911,6 +3946,13 @@
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
             "placeholder": "Custom collection summary format"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
           },
           {
             "key": "use_year_collections",
@@ -4774,6 +4816,13 @@
             "placeholder": "Custom collection summary format"
           },
           {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
+          },
+          {
             "key": "use_year_collections",
             "label": "Use Year Collections",
             "type": "toggle",
@@ -5633,6 +5682,13 @@
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
             "placeholder": "Custom collection summary format"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
           },
           {
             "key": "use_year_collections",
@@ -6557,6 +6613,13 @@
             "placeholder": "Custom collection summary format"
           },
           {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
+          },
+          {
             "key": "use_year_collections",
             "label": "Use Year Collections",
             "type": "toggle",
@@ -7313,6 +7376,13 @@
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
             "placeholder": "Custom collection summary format"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
           },
           {
             "key": "use_year_collections",
@@ -8072,6 +8142,13 @@
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
             "placeholder": "Custom collection summary format"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
           },
           {
             "key": "use_year_collections",
@@ -8934,6 +9011,13 @@
             "placeholder": "Custom collection summary format"
           },
           {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
+          },
+          {
             "key": "use_year_collections",
             "label": "Use Year Collections",
             "type": "toggle",
@@ -9690,6 +9774,13 @@
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
             "placeholder": "Custom collection summary format"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
           },
           {
             "key": "use_year_collections",
@@ -10450,6 +10541,13 @@
             "placeholder": "Custom collection summary format"
           },
           {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
+          },
+          {
             "key": "use_year_collections",
             "label": "Use Year Collections",
             "type": "toggle",
@@ -11208,6 +11306,13 @@
             "placeholder": "Custom collection summary format"
           },
           {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
+          },
+          {
             "key": "use_year_collections",
             "label": "Use Year Collections",
             "type": "toggle",
@@ -11964,6 +12069,13 @@
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
             "placeholder": "Custom collection summary format"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
           },
           {
             "key": "data_starting",
@@ -22927,6 +23039,13 @@
             "placeholder": "Custom collection summary format"
           },
           {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
+          },
+          {
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
@@ -26336,6 +26455,13 @@
             "placeholder": "Custom collection summary format"
           },
           {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
+          },
+          {
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
@@ -27652,6 +27778,13 @@
             "placeholder": "Custom collection summary format"
           },
           {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
+          },
+          {
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
@@ -28227,6 +28360,13 @@
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
             "placeholder": "Custom collection summary format"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
           },
           {
             "key": "limit",
@@ -28805,6 +28945,13 @@
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
             "placeholder": "Custom collection summary format"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
           },
           {
             "key": "limit",
@@ -29395,6 +29542,13 @@
             "placeholder": "Custom collection summary format"
           },
           {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
+          },
+          {
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
@@ -29981,6 +30135,13 @@
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
             "placeholder": "Custom collection summary format"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
           },
           {
             "key": "limit",
@@ -30571,6 +30732,13 @@
             "placeholder": "Custom collection summary format"
           },
           {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
+          },
+          {
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
@@ -31159,6 +31327,13 @@
             "placeholder": "Custom collection summary format"
           },
           {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
+          },
+          {
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
@@ -31745,6 +31920,13 @@
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
             "placeholder": "Custom collection summary format"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
           },
           {
             "key": "limit",
@@ -32338,6 +32520,13 @@
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
             "placeholder": "Custom collection summary format"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
           },
           {
             "key": "limit",
@@ -32945,6 +33134,13 @@
             "placeholder": "Custom collection summary format"
           },
           {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
+          },
+          {
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
@@ -33549,6 +33745,13 @@
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
             "placeholder": "Custom collection summary format"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
           },
           {
             "key": "limit",
@@ -35340,6 +35543,13 @@
             "placeholder": "Custom collection summary format"
           },
           {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
+          },
+          {
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
@@ -36266,6 +36476,13 @@
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
             "placeholder": "Custom collection summary format"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
           },
           {
             "key": "limit",
@@ -37199,6 +37416,13 @@
             "placeholder": "Custom collection summary format"
           },
           {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
+          },
+          {
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
@@ -37746,6 +37970,13 @@
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
             "placeholder": "Custom collection summary format"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
           },
           {
             "key": "limit",
@@ -38319,6 +38550,13 @@
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
             "placeholder": "Custom collection summary format"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
           },
           {
             "key": "limit",
@@ -38902,6 +39140,13 @@
             "placeholder": "Custom collection summary format"
           },
           {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
+          },
+          {
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
@@ -38966,6 +39211,13 @@
             "step": 1,
             "default": "25",
             "tooltip": "Replaces the data dynamic collection value. Controls the maximum number of collections to create."
+          },
+          {
+            "key": "tmdb_birthday",
+            "label": "TMDb Birthday",
+            "type": "text_input",
+            "tooltip": "Controls whether these TMDb person collections only run around a person's birthday. Enter a JSON-style object with any combination of <code>this_month</code>, <code>before</code>, and <code>after</code>. Examples: <code>{\"this_month\": true}</code>, <code>{\"before\": 7}</code>, or <code>{\"before\": 7, \"after\": 7}</code>.",
+            "placeholder": "{\"this_month\": true}"
           },
           {
             "key": "include",
@@ -39461,6 +39713,13 @@
             "placeholder": "Custom collection summary format"
           },
           {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
+          },
+          {
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
@@ -39525,6 +39784,13 @@
             "step": 1,
             "default": "25",
             "tooltip": "Replaces the data dynamic collection value. Controls the maximum number of collections to create."
+          },
+          {
+            "key": "tmdb_birthday",
+            "label": "TMDb Birthday",
+            "type": "text_input",
+            "tooltip": "Controls whether these TMDb person collections only run around a person's birthday. Enter a JSON-style object with any combination of <code>this_month</code>, <code>before</code>, and <code>after</code>. Examples: <code>{\"this_month\": true}</code>, <code>{\"before\": 7}</code>, or <code>{\"before\": 7, \"after\": 7}</code>.",
+            "placeholder": "{\"this_month\": true}"
           },
           {
             "key": "include",
@@ -40019,6 +40285,13 @@
             "placeholder": "Custom collection summary format"
           },
           {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
+          },
+          {
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
@@ -40083,6 +40356,13 @@
             "step": 1,
             "default": "25",
             "tooltip": "Replaces the data dynamic collection value. Controls the maximum number of collections to create."
+          },
+          {
+            "key": "tmdb_birthday",
+            "label": "TMDb Birthday",
+            "type": "text_input",
+            "tooltip": "Controls whether these TMDb person collections only run around a person's birthday. Enter a JSON-style object with any combination of <code>this_month</code>, <code>before</code>, and <code>after</code>. Examples: <code>{\"this_month\": true}</code>, <code>{\"before\": 7}</code>, or <code>{\"before\": 7, \"after\": 7}</code>.",
+            "placeholder": "{\"this_month\": true}"
           },
           {
             "key": "include",
@@ -40577,6 +40857,13 @@
             "placeholder": "Custom collection summary format"
           },
           {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
+          },
+          {
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
@@ -40641,6 +40928,13 @@
             "step": 1,
             "default": "25",
             "tooltip": "Replaces the data dynamic collection value. Controls the maximum number of collections to create."
+          },
+          {
+            "key": "tmdb_birthday",
+            "label": "TMDb Birthday",
+            "type": "text_input",
+            "tooltip": "Controls whether these TMDb person collections only run around a person's birthday. Enter a JSON-style object with any combination of <code>this_month</code>, <code>before</code>, and <code>after</code>. Examples: <code>{\"this_month\": true}</code>, <code>{\"before\": 7}</code>, or <code>{\"before\": 7, \"after\": 7}</code>.",
+            "placeholder": "{\"this_month\": true}"
           },
           {
             "key": "include",
@@ -41140,6 +41434,13 @@
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
             "placeholder": "Custom collection summary format"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
           },
           {
             "key": "limit",
@@ -43378,6 +43679,13 @@
             "placeholder": "Custom collection summary format"
           },
           {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
+          },
+          {
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
@@ -43899,6 +44207,13 @@
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
             "placeholder": "Custom collection summary format"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
           },
           {
             "key": "use_separator",
@@ -44427,6 +44742,13 @@
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
             "placeholder": "Custom collection summary format"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
           },
           {
             "key": "limit",
@@ -46908,6 +47230,13 @@
             "placeholder": "Custom collection summary format"
           },
           {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
+          },
+          {
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
@@ -47473,6 +47802,13 @@
             "placeholder": "Custom collection summary format"
           },
           {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
+          },
+          {
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
@@ -47960,6 +48296,13 @@
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
             "placeholder": "Custom collection summary format"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format"
           },
           {
             "key": "limit",

--- a/tests/test_collection_title_format_contract.py
+++ b/tests/test_collection_title_format_contract.py
@@ -1,0 +1,60 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+QS_COLLECTIONS_PATH = ROOT / "static" / "json" / "quickstart_collections.json"
+DEFAULTS_ROOT = ROOT / "config" / "kometa" / "defaults"
+
+
+def _build_qs_collection_map():
+    data = json.loads(QS_COLLECTIONS_PATH.read_text(encoding="utf-8"))
+    mapping = {}
+    for group in data:
+        for collection in group.get("collections", []):
+            alias = collection["id"].replace("collection_", "", 1)
+            mapping.setdefault(alias, []).append(collection)
+    return mapping
+
+
+def _expected_title_format_aliases():
+    qs_map = _build_qs_collection_map()
+    aliases = set()
+    for bucket in ("award", "both", "movie", "show"):
+        for path in sorted((DEFAULTS_ROOT / bucket).glob("*.yml")):
+            alias = path.stem
+            if alias not in qs_map:
+                continue
+            text = path.read_text(encoding="utf-8")
+            if "title_format:" in text:
+                aliases.add(alias)
+    return aliases
+
+
+def test_title_format_exists_for_every_supported_collection_family():
+    qs_map = _build_qs_collection_map()
+    expected_aliases = _expected_title_format_aliases()
+
+    missing = []
+    for alias in sorted(expected_aliases):
+        for collection in qs_map[alias]:
+            if collection.get("readonly"):
+                continue
+            keys = {item["key"] for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key")}
+            if "title_format" not in keys:
+                missing.append(collection["id"])
+
+    assert missing == []
+
+
+def test_title_format_uses_text_input_contract():
+    qs_map = _build_qs_collection_map()
+    expected_aliases = _expected_title_format_aliases()
+
+    for alias in sorted(expected_aliases):
+        for collection in qs_map[alias]:
+            if collection.get("readonly"):
+                continue
+            field = next(item for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key") == "title_format")
+            assert field["type"] == "text_input"
+            assert "default" not in field

--- a/tests/test_collection_title_format_contract.py
+++ b/tests/test_collection_title_format_contract.py
@@ -1,7 +1,6 @@
 import json
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 QS_COLLECTIONS_PATH = ROOT / "static" / "json" / "quickstart_collections.json"
 DEFAULTS_ROOT = ROOT / "config" / "kometa" / "defaults"

--- a/tests/test_collection_tmdb_birthday_contract.py
+++ b/tests/test_collection_tmdb_birthday_contract.py
@@ -1,7 +1,6 @@
 import json
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 QS_COLLECTIONS_PATH = ROOT / "static" / "json" / "quickstart_collections.json"
 DEFAULTS_ROOT = ROOT / "config" / "kometa" / "defaults"

--- a/tests/test_collection_tmdb_birthday_contract.py
+++ b/tests/test_collection_tmdb_birthday_contract.py
@@ -1,0 +1,60 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+QS_COLLECTIONS_PATH = ROOT / "static" / "json" / "quickstart_collections.json"
+DEFAULTS_ROOT = ROOT / "config" / "kometa" / "defaults"
+
+
+def _build_qs_collection_map():
+    data = json.loads(QS_COLLECTIONS_PATH.read_text(encoding="utf-8"))
+    mapping = {}
+    for group in data:
+        for collection in group.get("collections", []):
+            alias = collection["id"].replace("collection_", "", 1)
+            mapping.setdefault(alias, []).append(collection)
+    return mapping
+
+
+def _expected_tmdb_birthday_aliases():
+    qs_map = _build_qs_collection_map()
+    aliases = set()
+    for bucket in ("award", "both", "movie", "show"):
+        for path in sorted((DEFAULTS_ROOT / bucket).glob("*.yml")):
+            alias = path.stem
+            if alias not in qs_map:
+                continue
+            text = path.read_text(encoding="utf-8")
+            if "- tmdb_person" in text:
+                aliases.add(alias)
+    return aliases
+
+
+def test_tmdb_birthday_exists_for_every_tmdb_person_collection_family():
+    qs_map = _build_qs_collection_map()
+    expected_aliases = _expected_tmdb_birthday_aliases()
+
+    missing = []
+    for alias in sorted(expected_aliases):
+        for collection in qs_map[alias]:
+            if collection.get("readonly"):
+                continue
+            keys = {item["key"] for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key")}
+            if "tmdb_birthday" not in keys:
+                missing.append(collection["id"])
+
+    assert missing == []
+
+
+def test_tmdb_birthday_uses_text_input_contract():
+    qs_map = _build_qs_collection_map()
+    expected_aliases = _expected_tmdb_birthday_aliases()
+
+    for alias in sorted(expected_aliases):
+        for collection in qs_map[alias]:
+            if collection.get("readonly"):
+                continue
+            field = next(item for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key") == "tmdb_birthday")
+            assert field["type"] == "text_input"
+            assert field["placeholder"] == '{"this_month": true}'

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -1464,6 +1464,14 @@ def test_normalize_collection_template_var_value_handles_dynamic_family_controls
         "append_addons",
         '{"Top 250": ["IMDb Top 250"]}',
     ) == {"Top 250": ["IMDb Top 250"]}
+    assert output._normalize_collection_template_var_value(
+        "tmdb_birthday",
+        '{"this_month": true, "before": 7, "after": "2"}',
+    ) == {"this_month": True, "before": 7, "after": 2}
+    assert output._normalize_collection_template_var_value(
+        "tmdb_birthday",
+        "before=14, after=3",
+    ) == {"before": 14, "after": 3}
 
 
 def test_dynamic_family_template_var_normalization_matches_collection_export_shapes():


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Summary
Adds the next YAML-verified collection template-variable sweep to Quickstart by supporting title_format across the collection families that actually expose it in Kometa defaults, and adds tmdb_birthday support for the TMDb person-based families.
What changed
Added title_format to the relevant collection defaults in Quickstart, driven from the local Kometa YAML defaults rather than wiki assumptions.
Added tmdb_birthday to the TMDb person collection families:actor
director
producer
writer

Extended collection template-variable normalization so tmdb_birthday can round-trip cleanly through Quickstart output.
Accepted both JSON-style input and simple shorthand for tmdb_birthday, for example:{"this_month": true}
{"before": 7, "after": 7}
before=7, after=7

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
