### PR TITLE
More features

### DIFF
--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -1042,6 +1042,253 @@ def load_quickstart_config(filename: str):
         return json.load(f)
 
 
+def _overlay_origin_alignment_defaults(origin):
+    origin_str = str(origin or "").strip().lower()
+    tokens = [token for token in re.split(r"[^a-z]+", origin_str) if token]
+    has_center = "center" in tokens
+
+    horizontal = "right" if "right" in tokens else "left"
+    if "left" not in tokens and has_center and "right" not in tokens:
+        horizontal = "center"
+
+    vertical = "bottom" if "bottom" in tokens else "top"
+    if "top" not in tokens and has_center and "bottom" not in tokens:
+        vertical = "center"
+
+    return horizontal, vertical
+
+
+def _overlay_template_var_keys(template_variables):
+    keys = set()
+    if isinstance(template_variables, dict):
+        keys.update(str(key) for key in template_variables.keys())
+    elif isinstance(template_variables, list):
+        for item in template_variables:
+            if isinstance(item, dict) and item.get("key"):
+                keys.add(str(item.get("key")))
+    return keys
+
+
+def _insert_overlay_mapping_fields(template_variables, inserted_fields, *, before_keys=None):
+    if not isinstance(template_variables, dict) or not inserted_fields:
+        return template_variables
+
+    before_keys = set(before_keys or ())
+    next_template_variables = {}
+    inserted = False
+
+    for key, value in template_variables.items():
+        if not inserted and key in before_keys:
+            for inserted_key, inserted_value in inserted_fields.items():
+                if inserted_key not in template_variables:
+                    next_template_variables[inserted_key] = inserted_value
+            inserted = True
+        next_template_variables[key] = value
+
+    if not inserted:
+        for inserted_key, inserted_value in inserted_fields.items():
+            if inserted_key not in next_template_variables:
+                next_template_variables[inserted_key] = inserted_value
+
+    template_variables.clear()
+    template_variables.update(next_template_variables)
+    return template_variables
+
+
+def _insert_overlay_list_fields(template_variables, inserted_fields, *, before_keys=None):
+    if not isinstance(template_variables, list) or not inserted_fields:
+        return template_variables
+
+    before_keys = set(before_keys or ())
+    existing_keys = _overlay_template_var_keys(template_variables)
+    next_template_variables = []
+    inserted = False
+
+    for item in template_variables:
+        item_key = item.get("key") if isinstance(item, dict) else None
+        if not inserted and item_key in before_keys:
+            for inserted_field in inserted_fields:
+                inserted_key = inserted_field.get("key")
+                if inserted_key and inserted_key not in existing_keys:
+                    next_template_variables.append(copy.deepcopy(inserted_field))
+            inserted = True
+        next_template_variables.append(item)
+
+    if not inserted:
+        for inserted_field in inserted_fields:
+            inserted_key = inserted_field.get("key")
+            if inserted_key and inserted_key not in existing_keys:
+                next_template_variables.append(copy.deepcopy(inserted_field))
+
+    template_variables[:] = next_template_variables
+    return template_variables
+
+
+def enrich_quickstart_overlay_config(config):
+    enriched = copy.deepcopy(config or [])
+
+    for group in enriched:
+        if not isinstance(group, dict):
+            continue
+        overlays = group.get("overlays", [])
+        if not isinstance(overlays, list):
+            continue
+        for overlay in overlays:
+            if not isinstance(overlay, dict):
+                continue
+            template_variables = overlay.get("template_variables")
+            if template_variables is None:
+                template_variables = {}
+                overlay["template_variables"] = template_variables
+            if not isinstance(template_variables, (dict, list)):
+                continue
+
+            existing_keys = _overlay_template_var_keys(template_variables)
+            default_offsets = overlay.get("default_offsets")
+            offsets_by_type = overlay.get("default_offsets_by_type")
+
+            supports_runtime_offsets = isinstance(default_offsets, dict) or (
+                isinstance(offsets_by_type, dict) and any(isinstance(value, dict) for value in offsets_by_type.values())
+            ) or "initial_horizontal_offset" in existing_keys or "initial_vertical_offset" in existing_keys
+
+            offset_defaults = default_offsets if isinstance(default_offsets, dict) else {}
+            if not offset_defaults and isinstance(offsets_by_type, dict):
+                for candidate in offsets_by_type.values():
+                    if isinstance(candidate, dict):
+                        offset_defaults = candidate
+                        break
+
+            if supports_runtime_offsets:
+                horizontal_default = 0
+                vertical_default = 0
+                if "initial_horizontal_offset" in existing_keys:
+                    if isinstance(template_variables, dict):
+                        horizontal_default = template_variables.get("initial_horizontal_offset", {}).get(
+                            "default",
+                            offset_defaults.get("horizontal", 0),
+                        )
+                    else:
+                        for item in template_variables:
+                            if isinstance(item, dict) and item.get("key") == "initial_horizontal_offset":
+                                horizontal_default = item.get("default", offset_defaults.get("horizontal", 0))
+                                break
+                else:
+                    horizontal_default = offset_defaults.get("horizontal", 0)
+
+                if "initial_vertical_offset" in existing_keys:
+                    if isinstance(template_variables, dict):
+                        vertical_default = template_variables.get("initial_vertical_offset", {}).get(
+                            "default",
+                            offset_defaults.get("vertical", 0),
+                        )
+                    else:
+                        for item in template_variables:
+                            if isinstance(item, dict) and item.get("key") == "initial_vertical_offset":
+                                vertical_default = item.get("default", offset_defaults.get("vertical", 0))
+                                break
+                else:
+                    vertical_default = offset_defaults.get("vertical", 0)
+
+                offset_fields_mapping = {
+                    "horizontal_offset": {
+                        "input_type": "number",
+                        "default": horizontal_default,
+                        "label": "Horizontal Offset",
+                    },
+                    "vertical_offset": {
+                        "input_type": "number",
+                        "default": vertical_default,
+                        "label": "Vertical Offset",
+                    },
+                }
+                offset_fields_list = [
+                    {
+                        "input_type": "number",
+                        "key": "horizontal_offset",
+                        "default": horizontal_default,
+                        "label": "Horizontal Offset",
+                    },
+                    {
+                        "input_type": "number",
+                        "key": "vertical_offset",
+                        "default": vertical_default,
+                        "label": "Vertical Offset",
+                    },
+                ]
+
+                if isinstance(template_variables, dict):
+                    _insert_overlay_mapping_fields(
+                        template_variables,
+                        offset_fields_mapping,
+                        before_keys={"horizontal_offset", "vertical_offset", "builder_level"},
+                    )
+                else:
+                    _insert_overlay_list_fields(
+                        template_variables,
+                        offset_fields_list,
+                        before_keys={"horizontal_offset", "vertical_offset", "builder_level"},
+                    )
+
+            supports_origin_alignment = (
+                isinstance(offset_defaults, dict)
+                and bool(offset_defaults.get("origin"))
+                and "horizontal_position" not in existing_keys
+                and "vertical_position" not in existing_keys
+            )
+
+            if supports_origin_alignment:
+                horizontal_align_default, vertical_align_default = _overlay_origin_alignment_defaults(offset_defaults.get("origin"))
+                align_fields_mapping = {
+                    "horizontal_align": {
+                        "input_type": "select",
+                        "default": horizontal_align_default,
+                        "label": "Horizontal Alignment",
+                        "options": ["left", "center", "right"],
+                    },
+                    "vertical_align": {
+                        "input_type": "select",
+                        "default": vertical_align_default,
+                        "label": "Vertical Alignment",
+                        "options": ["top", "center", "bottom"],
+                    },
+                }
+                align_fields_list = [
+                    {
+                        "input_type": "select",
+                        "key": "horizontal_align",
+                        "default": horizontal_align_default,
+                        "label": "Horizontal Alignment",
+                        "options": ["left", "center", "right"],
+                    },
+                    {
+                        "input_type": "select",
+                        "key": "vertical_align",
+                        "default": vertical_align_default,
+                        "label": "Vertical Alignment",
+                        "options": ["top", "center", "bottom"],
+                    },
+                ]
+
+                if isinstance(template_variables, dict):
+                    _insert_overlay_mapping_fields(
+                        template_variables,
+                        align_fields_mapping,
+                        before_keys={"horizontal_offset", "vertical_offset", "builder_level"},
+                    )
+                else:
+                    _insert_overlay_list_fields(
+                        template_variables,
+                        align_fields_list,
+                        before_keys={"horizontal_offset", "vertical_offset", "builder_level"},
+                    )
+
+    return enriched
+
+
+def load_quickstart_overlay_config():
+    return enrich_quickstart_overlay_config(load_quickstart_config("quickstart_overlays.json"))
+
+
 def get_top_imdb_items(library_id, media_type, placeholder_id=None):
     ts_log(f"Fetching Plex credentials for '010-plex'", level="DEBUG")
     plex_url, plex_token = persistence.get_stored_plex_credentials("010-plex")

--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -1147,9 +1147,12 @@ def enrich_quickstart_overlay_config(config):
             default_offsets = overlay.get("default_offsets")
             offsets_by_type = overlay.get("default_offsets_by_type")
 
-            supports_runtime_offsets = isinstance(default_offsets, dict) or (
-                isinstance(offsets_by_type, dict) and any(isinstance(value, dict) for value in offsets_by_type.values())
-            ) or "initial_horizontal_offset" in existing_keys or "initial_vertical_offset" in existing_keys
+            supports_runtime_offsets = (
+                isinstance(default_offsets, dict)
+                or (isinstance(offsets_by_type, dict) and any(isinstance(value, dict) for value in offsets_by_type.values()))
+                or "initial_horizontal_offset" in existing_keys
+                or "initial_vertical_offset" in existing_keys
+            )
 
             offset_defaults = default_offsets if isinstance(default_offsets, dict) else {}
             if not offset_defaults and isinstance(offsets_by_type, dict):

--- a/modules/importer.py
+++ b/modules/importer.py
@@ -634,7 +634,7 @@ def _resolve_overlay_id(raw_default: str, overlay_by_id: dict, overlay_by_alias:
 
 def infer_library_types(config_data: dict) -> tuple[dict[str, str], list[dict]]:
     collection_config = helpers.load_quickstart_config("quickstart_collections.json") or []
-    overlay_config = helpers.load_quickstart_config("quickstart_overlays.json") or []
+    overlay_config = helpers.load_quickstart_overlay_config() or []
     collection_by_id, collection_by_alias = _build_collection_index(collection_config)
     overlay_by_id, overlay_by_alias, _ = _build_overlay_index(overlay_config)
 
@@ -824,7 +824,7 @@ def prepare_import_payload(
     payload: dict[str, dict] = {}
 
     collection_config = helpers.load_quickstart_config("quickstart_collections.json") or []
-    overlay_config = helpers.load_quickstart_config("quickstart_overlays.json") or []
+    overlay_config = helpers.load_quickstart_overlay_config() or []
     attribute_config = helpers.load_quickstart_config("quickstart_attributes.json") or {}
     inferred_types, _ = infer_library_types(config_data)
 

--- a/modules/output.py
+++ b/modules/output.py
@@ -701,7 +701,7 @@ def _extract_offset_defaults(overlay):
 def _build_overlay_defaults():
     defaults = {}
     try:
-        data = helpers.load_quickstart_config("quickstart_overlays.json")
+        data = helpers.load_quickstart_overlay_config()
     except Exception as e:
         helpers.ts_log(f"Failed to load quickstart_overlays.json: {e}", level="ERROR")
         return defaults

--- a/quickstart.py
+++ b/quickstart.py
@@ -184,6 +184,15 @@ VALIDATION_REASON_LABELS = {
     "account_locked": "Account locked",
     "validation_error": "Validation error",
 }
+SETTINGS_AUTO_SORT_HUBS_VALUES = {
+    "sort_title",
+    "sort_title.desc",
+    "alpha",
+    "alpha.desc",
+    "configured",
+    "configured.desc",
+    "random",
+}
 
 
 def _copy_background_job(job):
@@ -509,6 +518,18 @@ QS_FINAL_VALIDATION_TTL_HOURS = 12
 
 def utc_now_iso():
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _normalize_auto_sort_hubs_value(value):
+    text = str(value or "").strip()
+    return text or None
+
+
+def _is_valid_auto_sort_hubs_value(value):
+    normalized = _normalize_auto_sort_hubs_value(value)
+    if normalized is None:
+        return True
+    return normalized in SETTINGS_AUTO_SORT_HUBS_VALUES
 
 
 def apply_validation_metadata(stored_data, status, reason=None, details=None, updated_at=None):
@@ -7800,6 +7821,8 @@ def step(name):
                 )
                 if normalization_errors:
                     validation_errors += normalization_errors
+        elif save_source_name == "settings" and not _is_valid_auto_sort_hubs_value(request.form.get("auto_sort_hubs")):
+            validation_errors.append("auto_sort_hubs must be one of: sort_title, sort_title.desc, alpha, alpha.desc, configured, configured.desc, random")
         if validation_errors:
             save_error = "Invalid values: " + " ".join(validation_errors)
         else:
@@ -10484,6 +10507,9 @@ def validate_all_services():
         ignore_imdb_ids_values = _parse_optional_id_list(settings_section.get("ignore_imdb_ids"))
         if any(not re.match(r"^tt\d{7,8}$", item, re.IGNORECASE) for item in ignore_imdb_ids_values):
             invalid_fields.append("ignore_imdb_ids")
+
+        if not _is_valid_auto_sort_hubs_value(settings_section.get("auto_sort_hubs")):
+            invalid_fields.append("auto_sort_hubs")
 
         check_regex("custom_repo", r"^(None|https?:\/\/[\da-z.-]+\.[a-z.]{2,6}([/\w.-]*)*\/?)$", flags=re.IGNORECASE, allow_blank=True)
 

--- a/quickstart.py
+++ b/quickstart.py
@@ -5334,7 +5334,7 @@ def generate_preview():
 
     # Lazy-load overlay metadata so we can honor JSON-defined URLs (e.g., edition overlays)
     if not hasattr(generate_preview, "_overlay_meta"):
-        overlay_cfg = helpers.load_quickstart_config("quickstart_overlays.json") or []
+        overlay_cfg = helpers.load_quickstart_overlay_config() or []
         meta = {}
         for group in overlay_cfg:
             for ov in group.get("overlays", []):
@@ -8178,54 +8178,13 @@ def step(name):
         settings = persistence.retrieve_settings(section)
         service_validations[key] = helpers.booler(settings.get("validated", False))
 
-    def add_offset_vars(config):  # noqa: ANN001
-        """
-        Ensure each overlay exposes positional offsets with sensible defaults.
-        """
-        for group in config or []:
-            overlays = group.get("overlays", [])
-            for ov in overlays:
-                tv = ov.get("template_variables")
-                if tv is None:
-                    tv = {}
-                    ov["template_variables"] = tv
-                elif not isinstance(tv, dict):
-                    # leave lists (legacy) untouched
-                    continue
-                offsets = ov.get("default_offsets", {}) if isinstance(ov.get("default_offsets"), dict) else {}
-                # Respect initial_* overrides (used for YAML naming) but surface as horizontal/vertical inputs
-                if "initial_horizontal_offset" in tv and isinstance(tv["initial_horizontal_offset"], dict):
-                    offsets["horizontal"] = tv["initial_horizontal_offset"].get("default", offsets.get("horizontal", 0))
-                if "initial_vertical_offset" in tv and isinstance(tv["initial_vertical_offset"], dict):
-                    offsets["vertical"] = tv["initial_vertical_offset"].get("default", offsets.get("vertical", 0))
-                h_def = offsets.get("horizontal", 0)
-                v_def = offsets.get("vertical", 0)
-                # Only add if not already present
-                tv.setdefault(
-                    "horizontal_offset",
-                    {
-                        "input_type": "number",
-                        "default": h_def,
-                        "label": "Horizontal Offset",
-                    },
-                )
-                tv.setdefault(
-                    "vertical_offset",
-                    {
-                        "input_type": "number",
-                        "default": v_def,
-                        "label": "Vertical Offset",
-                    },
-                )
-
     if needs_library_payload:
         helpers.ts_log(f"Loading attribute_config...", level="TIMING")
         attribute_config = helpers.load_quickstart_config("quickstart_attributes.json")
         helpers.ts_log(f"Loading collection_config...", level="TIMING")
         collection_config = helpers.load_quickstart_config("quickstart_collections.json")
         helpers.ts_log(f"Loading overlay_config...", level="TIMING")
-        overlay_config = helpers.load_quickstart_config("quickstart_overlays.json")
-        add_offset_vars(overlay_config)
+        overlay_config = helpers.load_quickstart_overlay_config()
         helpers.ts_log(f"Loading preview image data...", level="TIMING")
         image_data = _build_preview_image_data()
         overlay_fonts = list_overlay_fonts()
@@ -8667,7 +8626,7 @@ def library_fragment(library_id):
 
     attribute_config = helpers.load_quickstart_config("quickstart_attributes.json")
     collection_config = helpers.load_quickstart_config("quickstart_collections.json")
-    overlay_config = helpers.load_quickstart_config("quickstart_overlays.json")
+    overlay_config = helpers.load_quickstart_overlay_config()
 
     legacy_playlist_libraries = _migrate_legacy_playlist_libraries_to_library_toggles(movie_libraries, show_libraries)
     data = persistence.retrieve_settings("025-libraries")

--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -2124,8 +2124,6 @@ QUICKSTART_RECOMMENDATION_EXCLUSIONS: dict[tuple[str, str], str] = {
     ("library", "metadata_path"): "legacy_library_path_key_not_recommended",
     ("library", "overlay_path"): "legacy_library_path_key_not_recommended",
     ("library", "reapply_overlays"): "valid_but_not_recommended_for_quickstart",
-    ("overlay", "horizontal_align"): "offset_ui_workaround_available",
-    ("overlay", "vertical_align"): "offset_ui_workaround_available",
 }
 
 

--- a/static/local-js/overlayHandler.js
+++ b/static/local-js/overlayHandler.js
@@ -3611,6 +3611,45 @@ const OverlayHandler = {
         return { hAlign, vAlign }
       }
 
+      const buildOrigin = (hAlign = 'left', vAlign = 'top') => {
+        const safeH = ['left', 'center', 'right'].includes(hAlign) ? hAlign : 'left'
+        const safeV = ['top', 'center', 'bottom'].includes(vAlign) ? vAlign : 'top'
+
+        if (safeH === 'center' && safeV === 'center') return 'center'
+        if (safeH === 'center') return `${safeV}_center`
+        if (safeV === 'center') return `center_${safeH}`
+        return `${safeV}_${safeH}`
+      }
+
+      const getAlignmentInputs = (cfg) => {
+        const templateName = cfg?.container?.dataset?.overlayTemplate
+        if (!templateName || !cfg?.container) {
+          return { hAlignInput: null, vAlignInput: null }
+        }
+        return {
+          hAlignInput: cfg.container.querySelector(`[name="${templateName}[horizontal_align]"]`),
+          vAlignInput: cfg.container.querySelector(`[name="${templateName}[vertical_align]"]`)
+        }
+      }
+
+      const syncOriginFromAlignmentInputs = (cfg) => {
+        const { hAlignInput, vAlignInput } = getAlignmentInputs(cfg)
+        if (!hAlignInput && !vAlignInput) return false
+
+        const current = parseOrigin(cfg.origin || '')
+        const rawH = (hAlignInput?.value || hAlignInput?.dataset?.default || current.hAlign || '').toString().trim().toLowerCase()
+        const rawV = (vAlignInput?.value || vAlignInput?.dataset?.default || current.vAlign || '').toString().trim().toLowerCase()
+        const nextH = ['left', 'center', 'right'].includes(rawH) ? rawH : current.hAlign
+        const nextV = ['top', 'center', 'bottom'].includes(rawV) ? rawV : current.vAlign
+        const nextOrigin = buildOrigin(nextH, nextV)
+
+        if (nextOrigin && cfg.origin !== nextOrigin) {
+          cfg.origin = nextOrigin
+          return true
+        }
+        return false
+      }
+
       const getLayerMetrics = (cfg, layer) => {
         const baseW = Number(cfg.baseWidth) || baseWidth
         const baseH = Number(cfg.baseHeight) || baseHeight
@@ -3855,6 +3894,8 @@ const OverlayHandler = {
         if (!layer) return
         const { hInput, vInput } = getInputs(cfg)
         if (!hInput || !vInput) return
+
+        syncOriginFromAlignmentInputs(cfg)
 
         const { scaleX, scaleY } = getScale()
         if (!cfg.naturalWidth && layer.naturalWidth) {
@@ -4397,6 +4438,17 @@ const OverlayHandler = {
         configs.push(cfg)
         configsById.set(cfg.instanceId, cfg)
         const layer = addOverlayLayer(cfg)
+        const { hAlignInput, vAlignInput } = getAlignmentInputs(cfg)
+        ;[hAlignInput, vAlignInput].forEach(input => {
+          if (!input || input.dataset.overlayAlignBound === 'true') return
+          const refreshAlignment = () => {
+            syncOriginFromAlignmentInputs(cfg)
+            applyPosition(cfg)
+          }
+          input.addEventListener('input', refreshAlignment)
+          input.addEventListener('change', refreshAlignment)
+          input.dataset.overlayAlignBound = 'true'
+        })
 
         if (cfg.id === 'overlay_runtimes' && layer) {
           const { font } = getRuntimeVars(cfg)

--- a/templates/150-settings.html
+++ b/templates/150-settings.html
@@ -2,6 +2,7 @@
 {% include "001-navigation.html" %}
 {% include "modals/" + page_info['template_name'] + ".html" ignore missing %}
 <input type="hidden" id="qs-validate-tmdb" value="{{ 'true' if service_validations.tmdb else 'false' }}">
+{% set has_plex_pass = page_info.telemetry.plex_pass is sameas true %}
 <div id="validation-messages" class="alert alert-danger" role="alert" style="display: none;">
 </div>
 <div class="form-floating mb-2">
@@ -616,6 +617,41 @@
       </h2>
       <div id="collapseFour" class="accordion-collapse collapse" data-bs-parent="#accordionExample">
         <div class="accordion-body">
+          {% set auto_sort_hubs_value = data['settings'].get('auto_sort_hubs', '') %}
+          <div class="row mb-2">
+            <div class="col-md-12">
+              <div class="input-group">
+                <span class="input-group-text" style="width: 170px; justify-content: space-between;">
+                  Auto Sort Hubs
+                  <i class="bi bi-info-circle-fill text-info ms-3" data-bs-toggle="tooltip" data-bs-html="true"
+                    title="Automatically sorts Plex hubs on supported libraries.<br><br><b>Accepted Values:</b><br> - <code>sort_title</code><br> - <code>sort_title.desc</code><br> - <code>alpha</code><br> - <code>alpha.desc</code><br> - <code>configured</code><br> - <code>configured.desc</code><br> - <code>random</code><br><br><b>Requirement:</b> Plex Pass is required.">
+                  </i>
+                </span>
+
+                <select class="form-select" id="auto_sort_hubs" {% if has_plex_pass %}name="auto_sort_hubs"{% endif %}
+                  {% if not has_plex_pass %}disabled aria-disabled="true"{% endif %}>
+                  <option value="" {% if not auto_sort_hubs_value %}selected{% endif %}>Disabled / Not Set</option>
+                  <option value="sort_title" {% if auto_sort_hubs_value == 'sort_title' %}selected{% endif %}>Sort Title Ascending</option>
+                  <option value="sort_title.desc" {% if auto_sort_hubs_value == 'sort_title.desc' %}selected{% endif %}>Sort Title Descending</option>
+                  <option value="alpha" {% if auto_sort_hubs_value == 'alpha' %}selected{% endif %}>Alphabetical Ascending</option>
+                  <option value="alpha.desc" {% if auto_sort_hubs_value == 'alpha.desc' %}selected{% endif %}>Alphabetical Descending</option>
+                  <option value="configured" {% if auto_sort_hubs_value == 'configured' %}selected{% endif %}>Configured Order Ascending</option>
+                  <option value="configured.desc" {% if auto_sort_hubs_value == 'configured.desc' %}selected{% endif %}>Configured Order Descending</option>
+                  <option value="random" {% if auto_sort_hubs_value == 'random' %}selected{% endif %}>Random</option>
+                </select>
+                {% if not has_plex_pass %}
+                <input type="hidden" name="auto_sort_hubs" value="{{ auto_sort_hubs_value }}">
+                {% endif %}
+                <a href="https://kometa.wiki/en/nightly/config/settings/?h=auto_sort#auto-sort-hubs" target="_blank"
+                  class="btn btn-outline-secondary" data-bs-toggle="tooltip" title="Open Kometa auto_sort_hubs documentation">
+                  <i class="bi bi-box-arrow-up-right"></i>
+                </a>
+              </div>
+              {% if not has_plex_pass %}
+              <div class="form-text text-warning">Requires Plex Pass. Validate Plex first if this should be available.</div>
+              {% endif %}
+            </div>
+          </div>
 
           <div class="form-check form-switch">
             <input class="form-check-input" type="checkbox" id="missing_only_released" name="missing_only_released"

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 
@@ -66,6 +68,81 @@ def test_step_rejects_invalid_path_payload(client, isolated_config_dir):
     assert data is None
     assert validated is False
     assert user_entered is False
+
+
+def test_step_rejects_invalid_auto_sort_hubs_payload(client, isolated_config_dir):
+    from modules import database
+
+    config_name = "pytest_invalid_auto_sort_hubs"
+    step_name = "150-settings"
+
+    resp = client.post(
+        f"/step/{step_name}",
+        data={"configSelector": config_name, "auto_sort_hubs": "bogus"},
+        headers={"Referer": f"http://localhost/step/{step_name}"},
+    )
+    assert resp.status_code == 200
+    assert b"auto_sort_hubs must be one of" in resp.data
+
+    validated, user_entered, data = database.retrieve_section_data(config_name, "settings")
+    assert data is None
+    assert validated is False
+    assert user_entered is False
+
+
+def test_settings_page_disables_auto_sort_hubs_without_plex_pass(client, monkeypatch, qs_module):
+    original_retrieve_settings = qs_module.persistence.retrieve_settings
+
+    def fake_retrieve_settings(target):
+        data = original_retrieve_settings(target)
+        if target == "150-settings":
+            data.setdefault("settings", {})["auto_sort_hubs"] = "alpha"
+        elif target == "010-plex":
+            data.setdefault("plex", {})["telemetry"] = {"plex_pass": False}
+        elif target == "plex_telemetry":
+            data["plex_telemetry"] = {"plex_pass": False}
+        return data
+
+    monkeypatch.setattr(qs_module.persistence, "retrieve_settings", fake_retrieve_settings)
+
+    resp = client.get("/step/150-settings")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    match = re.search(r'<select class="form-select" id="auto_sort_hubs"([^>]*)>', html)
+    assert match is not None
+    attrs = match.group(1)
+    assert 'disabled aria-disabled="true"' in attrs
+    assert 'name="auto_sort_hubs"' not in attrs
+    assert 'name="auto_sort_hubs" value="alpha"' in html
+    assert "Requires Plex Pass. Validate Plex first if this should be available." in html
+
+
+def test_settings_page_enables_auto_sort_hubs_with_plex_pass(client, monkeypatch, qs_module):
+    original_retrieve_settings = qs_module.persistence.retrieve_settings
+
+    def fake_retrieve_settings(target):
+        data = original_retrieve_settings(target)
+        if target == "150-settings":
+            data.setdefault("settings", {})["auto_sort_hubs"] = "configured.desc"
+        elif target == "010-plex":
+            data.setdefault("plex", {})["telemetry"] = {"plex_pass": True}
+        elif target == "plex_telemetry":
+            data["plex_telemetry"] = {"plex_pass": True}
+        return data
+
+    monkeypatch.setattr(qs_module.persistence, "retrieve_settings", fake_retrieve_settings)
+
+    resp = client.get("/step/150-settings")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    match = re.search(r'<select class="form-select" id="auto_sort_hubs"([^>]*)>', html)
+    assert match is not None
+    attrs = match.group(1)
+    assert 'name="auto_sort_hubs"' in attrs
+    assert "disabled" not in attrs
+    assert 'value="configured.desc" selected' in html
 
 
 def test_validate_apprise_rejects_bad_url(client):

--- a/tests/test_importer_overlay_files.py
+++ b/tests/test_importer_overlay_files.py
@@ -372,6 +372,36 @@ def test_prepare_import_payload_accepts_status_use_key_template_variables():
     assert any("libraries.Shows.overlay_files[0].template_variables.use_ended" in line for line in report.lines)
 
 
+def test_prepare_import_payload_accepts_status_alignment_template_variables():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Shows": {
+                    "overlay_files": [
+                        {
+                            "default": "status",
+                            "template_variables": {
+                                "horizontal_align": "center",
+                                "vertical_align": "bottom",
+                            },
+                        }
+                    ]
+                }
+            }
+        },
+        set(),
+        {"Shows"},
+        set(),
+    )
+
+    libraries_payload = payload["libraries"]["libraries"]
+    assert libraries_payload["sho-library_shows-show-overlay_status"] is True
+    assert libraries_payload["sho-library_shows-show-template_overlay_status[horizontal_align]"] == "center"
+    assert libraries_payload["sho-library_shows-show-template_overlay_status[vertical_align]"] == "bottom"
+    assert any("libraries.Shows.overlay_files[0].template_variables.horizontal_align" in line for line in report.lines)
+    assert any("libraries.Shows.overlay_files[0].template_variables.vertical_align" in line for line in report.lines)
+
+
 def test_prepare_import_payload_accepts_streaming_use_key_template_variables():
     payload, report = importer.prepare_import_payload(
         {

--- a/tests/test_status_yaml_contract.py
+++ b/tests/test_status_yaml_contract.py
@@ -72,3 +72,17 @@ def test_status_yaml_contract_keeps_use_key_toggles(monkeypatch, qs_module):
     assert template_vars["use_returning"] is False
     assert template_vars["use_canceled"] is False
     assert template_vars["use_ended"] is False
+
+
+def test_status_yaml_contract_emits_alignment_template_variables(monkeypatch, qs_module):
+    payload = _build_library_payload(
+        {
+            "horizontal_align": "center",
+            "vertical_align": "bottom",
+        }
+    )
+
+    template_vars = _template_vars_from_yaml(_run_build_config_with_payload(qs_module, monkeypatch, payload))
+
+    assert template_vars["horizontal_align"] == "center"
+    assert template_vars["vertical_align"] == "bottom"

--- a/tests/test_template_gap_analyzer.py
+++ b/tests/test_template_gap_analyzer.py
@@ -262,7 +262,7 @@ def test_quickstart_recommendation_summary_excludes_legacy_or_not_recommended_li
     summary = module.build_quickstart_recommendation_summary(rows)
     ranked = module.serialize_ranked_summary(summary)
 
-    assert [item["key"] for item in ranked] == ["library_name"]
+    assert [item["key"] for item in ranked] == ["library_name", "horizontal_align"]
 
 
 def test_quickstart_recommendation_exclusion_summary_tracks_legacy_library_keys():
@@ -324,10 +324,9 @@ def test_quickstart_recommendation_exclusion_summary_tracks_legacy_library_keys(
         key=lambda item: str(item["key"]),
     )
 
-    assert [item["key"] for item in excluded] == ["metadata_path", "reapply_overlays", "vertical_align"]
+    assert [item["key"] for item in excluded] == ["metadata_path", "reapply_overlays"]
     assert excluded[0]["reason"] == "legacy_library_path_key_not_recommended"
     assert excluded[1]["reason"] == "valid_but_not_recommended_for_quickstart"
-    assert excluded[2]["reason"] == "offset_ui_workaround_available"
 
 
 def test_build_qs_collection_map_preserves_dynamic_family_edge_cases_for_repo_file():
@@ -810,7 +809,9 @@ def test_build_merged_fix_queue_suppresses_excluded_quickstart_only_keys():
 
     ranked = module.build_merged_fix_queue(verified_rows, importer_rows)
 
-    assert ranked == []
+    assert len(ranked) == 1
+    assert ranked[0]["key"] == "horizontal_align"
+    assert ranked[0]["action_targets"] == ["quickstart", "importer"]
 
 
 def test_looks_like_kometa_config_text_accepts_non_template_variable_configs():


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Title: Add Plex Pass-gated auto_sort_hubs support to Settings
Summary:
Adds auto_sort_hubs to the Settings page under Filtering and Display.
Uses the exact Kometa-supported values: sort_title, sort_title.desc, alpha, alpha.desc, configured, configured.desc, and random.
Gates the control behind Plex Pass by disabling it when Plex telemetry does not report Plex Pass and showing a clear inline requirement message.
Keeps the saved value intact when Plex Pass is unavailable so existing configs are not silently lost.
Adds server-side validation so invalid auto_sort_hubs values are rejected during save and bulk validation.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
