### PR TITLE
auto_sort_hubs library level

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -2668,12 +2668,14 @@ def build_libraries_section(
         remove_key = f"{library_type}-library_{lib_id}-top_level_remove_overlays"
         reset_key = f"{library_type}-library_{lib_id}-top_level_reset_overlays"
         schedule_key = f"{library_type}-library_{lib_id}-top_level_schedule"
+        auto_sort_hubs_key = f"{library_type}-library_{lib_id}-top_level_auto_sort_hubs"
         schedule_overlays_key = f"{library_type}-library_{lib_id}-top_level_schedule_overlays"
         report_path_key = f"{library_type}-library_{lib_id}-top_level_report_path"
 
         remove_overlays = top_group.get(remove_key)
         reset_overlays = top_group.get(reset_key)
         schedule = top_group.get(schedule_key)
+        auto_sort_hubs = top_group.get(auto_sort_hubs_key)
         schedule_overlays = top_group.get(schedule_overlays_key)
         report_path = top_group.get(report_path_key)
 
@@ -2681,6 +2683,8 @@ def build_libraries_section(
             entry["report_path"] = report_path
         if schedule not in [None, ""]:
             entry["schedule"] = schedule
+        if auto_sort_hubs not in [None, ""]:
+            entry["auto_sort_hubs"] = auto_sort_hubs
         if remove_overlays:
             entry["remove_overlays"] = True
         if reset_overlays not in [None, "None", ""]:
@@ -2692,6 +2696,7 @@ def build_libraries_section(
             helpers.ts_log(f"Top Level for {lib_id}: {top_group}", level="DEBUG")
             helpers.ts_log(f"{report_path_key} = {report_path}", level="DEBUG")
             helpers.ts_log(f"{schedule_key} = {schedule}", level="DEBUG")
+            helpers.ts_log(f"{auto_sort_hubs_key} = {auto_sort_hubs}", level="DEBUG")
             helpers.ts_log(f"{remove_key} = {remove_overlays}", level="DEBUG")
             helpers.ts_log(f"{reset_key} = {reset_overlays}", level="DEBUG")
             helpers.ts_log(f"{schedule_overlays_key} = {schedule_overlays}", level="DEBUG")
@@ -2746,6 +2751,7 @@ def reorder_library_section(library_data):
     Reorders library data so that:
     - `report_path` appears first.
     - `schedule` comes next.
+    - `auto_sort_hubs` comes after `schedule`.
     - `remove_overlays`, `reset_overlays`, and `schedule_overlays` come after that.
     - `template_variables` next.
     - `settings` appears before `radarr` / `sonarr` / `operations`.
@@ -2765,7 +2771,11 @@ def reorder_library_section(library_data):
     if "schedule" in library_data:
         reordered_data["schedule"] = library_data["schedule"]
 
-    # 3. Then remove/reset overlays
+    # 3. Then library-level hub sorting
+    if "auto_sort_hubs" in library_data:
+        reordered_data["auto_sort_hubs"] = library_data["auto_sort_hubs"]
+
+    # 4. Then remove/reset overlays
     if "remove_overlays" in library_data:
         reordered_data["remove_overlays"] = library_data["remove_overlays"]
     if "reset_overlays" in library_data:
@@ -2773,21 +2783,21 @@ def reorder_library_section(library_data):
     if "schedule_overlays" in library_data:
         reordered_data["schedule_overlays"] = library_data["schedule_overlays"]
 
-    # 4. Then template_variables
+    # 5. Then template_variables
     if "template_variables" in library_data:
         reordered_data["template_variables"] = library_data["template_variables"]
 
-    # 5. Then library settings
+    # 6. Then library settings
     if "settings" in library_data:
         reordered_data["settings"] = library_data["settings"]
 
-    # 6. Then per-library Arr overrides
+    # 7. Then per-library Arr overrides
     if "radarr" in library_data:
         reordered_data["radarr"] = library_data["radarr"]
     if "sonarr" in library_data:
         reordered_data["sonarr"] = library_data["sonarr"]
 
-    # 7. Reorder operations
+    # 8. Reorder operations
     operations_order = [
         "assets_for_all",
         "assets_for_all_collections",

--- a/quickstart.py
+++ b/quickstart.py
@@ -1567,6 +1567,22 @@ def _validate_library_overlay_files(libraries_data, selected_library_ids):
     return errors
 
 
+def _validate_library_auto_sort_hubs(libraries_data, selected_library_ids):
+    if not isinstance(libraries_data, dict):
+        return []
+
+    errors = []
+    allowed_values = ", ".join(sorted(SETTINGS_AUTO_SORT_HUBS_VALUES))
+    for lib_id in selected_library_ids or []:
+        value = libraries_data.get(f"{lib_id}-top_level_auto_sort_hubs")
+        if _is_valid_auto_sort_hubs_value(value):
+            continue
+        library_name = libraries_data.get(f"{lib_id}-library") or lib_id
+        errors.append(f"{library_name}: auto_sort_hubs must be one of: {allowed_values}")
+
+    return errors
+
+
 def _validate_and_organize_library_file_request(kind, data, type_key, location_key):
     validator_info = LIBRARY_FILE_VALIDATORS.get(kind)
     if not validator_info:
@@ -7809,6 +7825,7 @@ def step(name):
             validation_errors += _validate_library_collection_files(incoming_libraries, selected_library_ids)
             validation_errors += _validate_library_metadata_files(incoming_libraries, selected_library_ids)
             validation_errors += _validate_library_overlay_files(incoming_libraries, selected_library_ids)
+            validation_errors += _validate_library_auto_sort_hubs(incoming_libraries, selected_library_ids)
             for lib_id in selected_library_ids:
                 override_result = _validate_library_service_overrides(lib_id, incoming_libraries)
                 if not override_result.get("valid") and not override_result.get("skipped"):
@@ -8691,12 +8708,15 @@ def autosave_library(library_id):
         collection_errors = _validate_library_collection_files(incoming_libraries, selected_library_ids)
         metadata_errors = _validate_library_metadata_files(incoming_libraries, selected_library_ids)
         overlay_errors = _validate_library_overlay_files(incoming_libraries, selected_library_ids)
+        auto_sort_hubs_errors = _validate_library_auto_sort_hubs(incoming_libraries, selected_library_ids)
         if collection_errors:
             return jsonify({"success": False, "error": "Invalid collection files.", "errors": collection_errors}), 400
         if metadata_errors:
             return jsonify({"success": False, "error": "Invalid metadata files.", "errors": metadata_errors}), 400
         if overlay_errors:
             return jsonify({"success": False, "error": "Invalid overlay files.", "errors": overlay_errors}), 400
+        if auto_sort_hubs_errors:
+            return jsonify({"success": False, "error": "Invalid library settings.", "errors": auto_sort_hubs_errors}), 400
         normalized_libraries, normalization_errors, changed = _normalize_library_file_entries_payload(
             incoming_libraries,
             config_name,
@@ -8969,6 +8989,7 @@ def copy_library_settings():
         source_collection_errors = _validate_library_collection_files(libraries_data, [source_prefix])
         source_metadata_errors = _validate_library_metadata_files(libraries_data, [source_prefix])
         source_overlay_errors = _validate_library_overlay_files(libraries_data, [source_prefix])
+        source_auto_sort_hubs_errors = _validate_library_auto_sort_hubs(libraries_data, [source_prefix])
         if source_errors:
             return (
                 jsonify(
@@ -9009,6 +9030,17 @@ def copy_library_settings():
                         "success": False,
                         "error": "Invalid overlay files found in source library: " + " ".join(source_overlay_errors),
                         "errors": source_overlay_errors,
+                    }
+                ),
+                400,
+            )
+        if source_auto_sort_hubs_errors:
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "error": "Invalid library settings found in source library: " + " ".join(source_auto_sort_hubs_errors),
+                        "errors": source_auto_sort_hubs_errors,
                     }
                 ),
                 400,
@@ -10396,6 +10428,7 @@ def validate_all_services():
             collection_file_errors = _validate_library_collection_files(libraries_data, selected_library_ids)
             metadata_file_errors = _validate_library_metadata_files(libraries_data, selected_library_ids)
             overlay_file_errors = _validate_library_overlay_files(libraries_data, selected_library_ids)
+            auto_sort_hubs_errors = _validate_library_auto_sort_hubs(libraries_data, selected_library_ids)
             arr_override_errors = []
             if path_errors:
                 libraries_reason = "invalid_paths"
@@ -10405,6 +10438,8 @@ def validate_all_services():
                 libraries_reason = "invalid_overlay_files"
             elif metadata_file_errors:
                 libraries_reason = "invalid_metadata_files"
+            elif auto_sort_hubs_errors:
+                libraries_reason = "invalid_library_settings"
             else:
 
                 def has_minimal_library_yaml_selection(lib_id):
@@ -10468,7 +10503,12 @@ def validate_all_services():
                 "libraries",
                 libraries_reason is None,
                 reason=libraries_reason,
-                details=(missing_placeholders if libraries_reason == "missing_placeholder_imdb" else arr_override_errors if libraries_reason == "invalid_arr_overrides" else None),
+                details=(
+                    missing_placeholders if libraries_reason == "missing_placeholder_imdb"
+                    else arr_override_errors if libraries_reason == "invalid_arr_overrides"
+                    else auto_sort_hubs_errors if libraries_reason == "invalid_library_settings"
+                    else None
+                ),
             )
 
     # Bulk validation for settings

--- a/quickstart.py
+++ b/quickstart.py
@@ -10504,10 +10504,9 @@ def validate_all_services():
                 libraries_reason is None,
                 reason=libraries_reason,
                 details=(
-                    missing_placeholders if libraries_reason == "missing_placeholder_imdb"
-                    else arr_override_errors if libraries_reason == "invalid_arr_overrides"
-                    else auto_sort_hubs_errors if libraries_reason == "invalid_library_settings"
-                    else None
+                    missing_placeholders
+                    if libraries_reason == "missing_placeholder_imdb"
+                    else arr_override_errors if libraries_reason == "invalid_arr_overrides" else auto_sort_hubs_errors if libraries_reason == "invalid_library_settings" else None
                 ),
             )
 

--- a/static/json/quickstart_attributes.json
+++ b/static/json/quickstart_attributes.json
@@ -221,6 +221,56 @@
       "yml_location": "top_level"
     },
     {
+      "prefix": "top_level_auto_sort_hubs",
+      "type": "select",
+      "accordion": "miscellaneous",
+      "media_types": [
+        "movie",
+        "show"
+      ],
+      "title": "Auto Sort Hubs",
+      "wiki": "https://kometa.wiki/en/nightly/config/settings/?h=auto_sort#auto-sort-hubs",
+      "description": "Override Plex Recommendation Hub sorting for this library. This requires Plex Pass. Leave blank to keep Plex or global Kometa behavior.",
+      "tooltip_variant": "info",
+      "container_class": "",
+      "yml_location": "top_level",
+      "requires_plex_pass": true,
+      "options": [
+        [
+          "",
+          "Disabled / Not Set"
+        ],
+        [
+          "sort_title",
+          "Sort Title Ascending"
+        ],
+        [
+          "sort_title.desc",
+          "Sort Title Descending"
+        ],
+        [
+          "alpha",
+          "Alphabetical Ascending"
+        ],
+        [
+          "alpha.desc",
+          "Alphabetical Descending"
+        ],
+        [
+          "configured",
+          "Configured Order Ascending"
+        ],
+        [
+          "configured.desc",
+          "Configured Order Descending"
+        ],
+        [
+          "random",
+          "Random"
+        ]
+      ]
+    },
+    {
       "prefix": "top_level_remove_overlays",
       "type": "boolean_toggle",
       "accordion": "overlays",

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -285,7 +285,7 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
 
 {% macro select_section(library, data, prefix, title, description, wiki, options,
 preview_image=False, tooltip_variant="info", container_class="border rounded p-3 mb-2",
-yml_location="attribute") %}
+yml_location="attribute", telemetry=None, requires_plex_pass=False) %}
 
 {# raw_prefix can contain brackets for name, but needs cleaning for id #}
 {% set raw_prefix =
@@ -296,6 +296,12 @@ prefix if yml_location == "top_level" else
 
 {% set field_id = (library.id ~ "-" ~ raw_prefix).replace("[", "_").replace("]", "") %}
 {% set field_name = library.id ~ "-" ~ raw_prefix %}
+{% set selected = data.libraries.get(field_name, '') %}
+{% set has_plex_pass = false %}
+{% if telemetry is mapping and telemetry.get("plex_pass") is sameas true %}
+{% set has_plex_pass = true %}
+{% endif %}
+{% set disable_for_plex_pass = requires_plex_pass and not has_plex_pass %}
 <div class="{{ container_class }}">
     <div class="row">
         <div class="col-md-6 mb-2">
@@ -308,14 +314,17 @@ prefix if yml_location == "top_level" else
                             class="bi {% if tooltip_variant == 'danger' %}bi-exclamation-circle-fill{% else %}bi-info-circle-fill{% endif %}"></i>
                     </span>
                 </span>
-                <select class="form-select" id="{{ field_id }}" name="{{ field_name }}"
-                    aria-describedby="{{ field_id }}_text" {% if preview_image %}data-preview="true" {% endif %}>
-                    {% set selected = data.libraries.get(field_name, '') %}
+                <select class="form-select" id="{{ field_id }}" {% if not disable_for_plex_pass %}name="{{ field_name }}"{% endif %}
+                    aria-describedby="{{ field_id }}_text" {% if preview_image %}data-preview="true" {% endif %}{% if disable_for_plex_pass %} disabled aria-disabled="true"{% endif %}>
                     {% for value, label in options %}
                     <option value="{{ value }}" {% if selected==value %}selected{% endif %}>{{ label }}</option>
                     {% endfor %}
                 </select>
             </div>
+            {% if disable_for_plex_pass %}
+            <input type="hidden" name="{{ field_name }}" value="{{ selected }}">
+            <div class="form-text text-warning">Requires Plex Pass. Validate Plex first if this should be available.</div>
+            {% endif %}
         </div>
 
         {% if preview_image and prefix != "placeholder_imdb_id" %}

--- a/templates/partials/_movie_attributes.html
+++ b/templates/partials/_movie_attributes.html
@@ -28,7 +28,9 @@
         preview_image=true,
         tooltip_variant=section.tooltip_variant,
         container_class=section.container_class,
-        yml_location=section.yml_location
+        yml_location=section.yml_location,
+        telemetry=telemetry,
+        requires_plex_pass=section.requires_plex_pass | default(false)
         ) }}
         {% endfor %}
       </div>
@@ -62,7 +64,9 @@
         section.options,
         tooltip_variant=section.tooltip_variant,
         container_class=section.container_class,
-        yml_location=section.yml_location
+        yml_location=section.yml_location,
+        telemetry=telemetry,
+        requires_plex_pass=section.requires_plex_pass | default(false)
         ) }}
         {% elif section.type == 'boolean_toggle' %}
         {{ macros.boolean_toggle_section(
@@ -210,7 +214,9 @@
         section.options,
         tooltip_variant=section.tooltip_variant,
         container_class=section.container_class,
-        yml_location=section.yml_location
+        yml_location=section.yml_location,
+        telemetry=telemetry,
+        requires_plex_pass=section.requires_plex_pass | default(false)
         ) }}
 
         {% elif section.type == 'text_input' and section.prefix == 'asset_directory' %}
@@ -277,7 +283,9 @@
               section.options,
               tooltip_variant=section.tooltip_variant,
               container_class=section.container_class,
-              yml_location=section.yml_location
+              yml_location=section.yml_location,
+              telemetry=telemetry,
+              requires_plex_pass=section.requires_plex_pass | default(false)
             ) }}
           {% elif section.type == 'text_input' and section.prefix == 'asset_directory' %}
             {{ macros.asset_directory_list_section(

--- a/templates/partials/_show_attributes.html
+++ b/templates/partials/_show_attributes.html
@@ -28,7 +28,9 @@
         preview_image=true,
         tooltip_variant=section.tooltip_variant,
         container_class=section.container_class,
-        yml_location=section.yml_location
+        yml_location=section.yml_location,
+        telemetry=telemetry,
+        requires_plex_pass=section.requires_plex_pass | default(false)
         ) }}
         {% endfor %}
       </div>
@@ -62,7 +64,9 @@
         section.options,
         tooltip_variant=section.tooltip_variant,
         container_class=section.container_class,
-        yml_location=section.yml_location
+        yml_location=section.yml_location,
+        telemetry=telemetry,
+        requires_plex_pass=section.requires_plex_pass | default(false)
         ) }}
         {% elif section.type == 'boolean_toggle' %}
         {{ macros.boolean_toggle_section(
@@ -210,7 +214,9 @@
         section.options,
         tooltip_variant=section.tooltip_variant,
         container_class=section.container_class,
-        yml_location=section.yml_location
+        yml_location=section.yml_location,
+        telemetry=telemetry,
+        requires_plex_pass=section.requires_plex_pass | default(false)
         ) }}
 
         {% elif section.type == 'text_input' and section.prefix == 'asset_directory' %}
@@ -277,7 +283,9 @@
               section.options,
               tooltip_variant=section.tooltip_variant,
               container_class=section.container_class,
-              yml_location=section.yml_location
+              yml_location=section.yml_location,
+              telemetry=telemetry,
+              requires_plex_pass=section.requires_plex_pass | default(false)
             ) }}
           {% elif section.type == 'text_input' and section.prefix == 'asset_directory' %}
             {{ macros.asset_directory_list_section(

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -145,6 +145,51 @@ def test_settings_page_enables_auto_sort_hubs_with_plex_pass(client, monkeypatch
     assert 'value="configured.desc" selected' in html
 
 
+def test_validate_library_auto_sort_hubs_rejects_invalid_value(qs_module):
+    errors = qs_module._validate_library_auto_sort_hubs(
+        {
+            "mov-library_movies-library": "Movies",
+            "mov-library_movies-top_level_auto_sort_hubs": "bogus",
+        },
+        ["mov-library_movies"],
+    )
+
+    assert errors == [
+        "Movies: auto_sort_hubs must be one of: alpha, alpha.desc, configured, configured.desc, random, sort_title, sort_title.desc"
+    ]
+
+
+def test_library_fragment_disables_auto_sort_hubs_without_plex_pass(client, monkeypatch, qs_module):
+    monkeypatch.setattr(
+        qs_module,
+        "_build_library_lists",
+        lambda: ([{"id": "mov-library_movies", "name": "Movies", "type": "movie"}], [], {"plex_pass": False}),
+    )
+    monkeypatch.setattr(qs_module, "_migrate_legacy_playlist_libraries_to_library_toggles", lambda *_args: set())
+    monkeypatch.setattr(qs_module, "_build_preview_image_data", lambda: {"movie": {}, "show": {}})
+
+    original_retrieve_settings = qs_module.persistence.retrieve_settings
+
+    def fake_retrieve_settings(target):
+        if target == "025-libraries":
+            return {"libraries": {"mov-library_movies-top_level_auto_sort_hubs": "alpha"}}
+        return original_retrieve_settings(target)
+
+    monkeypatch.setattr(qs_module.persistence, "retrieve_settings", fake_retrieve_settings)
+
+    resp = client.get("/library_fragment/mov-library_movies")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    match = re.search(r'<select class="form-select" id="mov-library_movies-top_level_auto_sort_hubs"([^>]*)>', html)
+    assert match is not None
+    attrs = match.group(1)
+    assert 'disabled aria-disabled="true"' in attrs
+    assert 'name="mov-library_movies-top_level_auto_sort_hubs"' not in attrs
+    assert 'name="mov-library_movies-top_level_auto_sort_hubs" value="alpha"' in html
+    assert "Requires Plex Pass. Validate Plex first if this should be available." in html
+
+
 def test_validate_apprise_rejects_bad_url(client):
     resp = client.post("/validate_apprise", json={"apprise_location": "not-a-url"})
     assert resp.status_code == 400
@@ -3591,6 +3636,34 @@ def test_build_libraries_section_emits_schedule_overlays(app):
     assert list(movies.keys())[:2] == ["schedule_overlays", "template_variables"]
 
 
+def test_build_libraries_section_emits_auto_sort_hubs(app):
+    from modules import output
+
+    with app.app_context():
+        libraries_section = output.build_libraries_section(
+            {"mov-library_movies-library": "Movies"},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {"movies": {"mov-library_movies-top_level_auto_sort_hubs": "configured.desc"}},
+            {},
+        )
+
+    movies = libraries_section["libraries"]["Movies"]
+    assert movies["auto_sort_hubs"] == "configured.desc"
+    assert list(movies.keys())[:2] == ["auto_sort_hubs", "template_variables"]
+
+
 def test_build_libraries_section_keeps_default_ratings_overlay_when_overlay_files_exist(app):
     from modules import output
 
@@ -3849,6 +3922,7 @@ def test_reorder_library_section_keeps_settings_and_operations_before_library_fi
         {
             "report_path": "config/Movies_Report.yml",
             "schedule": "weekly(mon)",
+            "auto_sort_hubs": "configured.desc",
             "schedule_overlays": "weekly(wed)",
             "template_variables": {"sep_style": "gray"},
             "metadata_files": [{"folder": "config/example/metadata"}],
@@ -3863,6 +3937,7 @@ def test_reorder_library_section_keeps_settings_and_operations_before_library_fi
     assert list(reordered.keys()) == [
         "report_path",
         "schedule",
+        "auto_sort_hubs",
         "schedule_overlays",
         "template_variables",
         "settings",

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -154,9 +154,7 @@ def test_validate_library_auto_sort_hubs_rejects_invalid_value(qs_module):
         ["mov-library_movies"],
     )
 
-    assert errors == [
-        "Movies: auto_sort_hubs must be one of: alpha, alpha.desc, configured, configured.desc, random, sort_title, sort_title.desc"
-    ]
+    assert errors == ["Movies: auto_sort_hubs must be one of: alpha, alpha.desc, configured, configured.desc, random, sort_title, sort_title.desc"]
 
 
 def test_library_fragment_disables_auto_sort_hubs_without_plex_pass(client, monkeypatch, qs_module):

--- a/tests/test_importer_library_services.py
+++ b/tests/test_importer_library_services.py
@@ -78,3 +78,15 @@ def test_prepare_import_payload_maps_library_schedule():
     libraries = payload["libraries"]["libraries"]
     assert libraries["mov-library_movies-top_level_schedule"] == "weekly(saturday)"
     assert any("libraries.Movies.schedule" in line for line in report.lines)
+
+
+def test_prepare_import_payload_maps_library_auto_sort_hubs():
+    payload, report = importer.prepare_import_payload(
+        {"libraries": {"Movies": {"auto_sort_hubs": "configured.desc"}}},
+        {"Movies"},
+        set(),
+    )
+
+    libraries = payload["libraries"]["libraries"]
+    assert libraries["mov-library_movies-top_level_auto_sort_hubs"] == "configured.desc"
+    assert any("libraries.Movies.auto_sort_hubs" in line for line in report.lines)


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Title: Add library-level auto_sort_hubs support with Plex Pass gating
Summary
This adds auto_sort_hubs at the library level in Quickstart, matching the existing global settings support and the underlying Kometa schema support.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
