### PR TITLE
Next missing feature

### DIFF
--- a/modules/importer.py
+++ b/modules/importer.py
@@ -534,7 +534,14 @@ def _build_attribute_sets(
     template_var_keys = set()
     simple_attribute_keys = set()
     top_level_map: dict[str, str] = {}
-    special_template_vars = {"placeholder_imdb_id", "sep_style", "collection_mode", "use_separator"}
+    special_template_vars = {
+        "placeholder_imdb_id",
+        "placeholder_tmdb_movie",
+        "placeholder_tvdb_show",
+        "sep_style",
+        "collection_mode",
+        "use_separator",
+    }
     simple_types = {"boolean_toggle", "select", "text_input", "number"}
     mass_update_defs: dict[str, dict] = {}
     toggle_select_defs: dict[str, dict] = {}
@@ -1326,7 +1333,7 @@ def prepare_import_payload(
             if isinstance(lib_template_vars, dict):
                 for key, value in lib_template_vars.items():
                     if key in template_vars or key in special_template_vars:
-                        if key == "placeholder_imdb_id":
+                        if key in {"placeholder_imdb_id", "placeholder_tmdb_movie", "placeholder_tvdb_show"}:
                             name = f"{lib_id}-attribute_template_variables[{key}]"
                             libraries_data[name] = value
                         elif key == "sep_style":

--- a/modules/output.py
+++ b/modules/output.py
@@ -2472,7 +2472,9 @@ def build_libraries_section(
         template_data = templates.get(template_key, {})
 
         sep_color_key = None
-        placeholder_key = None
+        placeholder_imdb_key = None
+        placeholder_tmdb_movie_key = None
+        placeholder_tvdb_show_key = None
         language_key = None
         collection_mode_key = None
 
@@ -2480,14 +2482,20 @@ def build_libraries_section(
             if key.endswith("-template_variables[use_separator]") and key.startswith(f"{library_type}-library_{template_key}"):
                 sep_color_key = key
             if key.endswith("-attribute_template_variables[placeholder_imdb_id]") and key.startswith(f"{library_type}-library_{template_key}"):
-                placeholder_key = key
+                placeholder_imdb_key = key
+            if key.endswith("-attribute_template_variables[placeholder_tmdb_movie]") and key.startswith(f"{library_type}-library_{template_key}"):
+                placeholder_tmdb_movie_key = key
+            if key.endswith("-attribute_template_variables[placeholder_tvdb_show]") and key.startswith(f"{library_type}-library_{template_key}"):
+                placeholder_tvdb_show_key = key
             if key.endswith("-template_variables[language]") and key.startswith(f"{library_type}-library_{template_key}"):
                 language_key = key
             if key.endswith("-template_variables[collection_mode]") and key.startswith(f"{library_type}-library_{template_key}"):
                 collection_mode_key = key
 
         sep_color = template_data.get(sep_color_key)
-        placeholder_id = template_data.get(placeholder_key)
+        placeholder_imdb_id = template_data.get(placeholder_imdb_key)
+        placeholder_tmdb_movie = template_data.get(placeholder_tmdb_movie_key)
+        placeholder_tvdb_show = template_data.get(placeholder_tvdb_show_key)
         language_value = template_data.get(language_key)
         collection_mode_value = template_data.get(collection_mode_key)
 
@@ -2496,8 +2504,16 @@ def build_libraries_section(
         if sep_color:
             template_vars["sep_style"] = sep_color
 
-        if placeholder_id:
-            template_vars["placeholder_imdb_id"] = placeholder_id
+        if library_type == "mov":
+            if placeholder_tmdb_movie:
+                template_vars["placeholder_tmdb_movie"] = placeholder_tmdb_movie
+            elif placeholder_imdb_id:
+                template_vars["placeholder_imdb_id"] = placeholder_imdb_id
+        else:
+            if placeholder_tvdb_show:
+                template_vars["placeholder_tvdb_show"] = placeholder_tvdb_show
+            elif placeholder_imdb_id:
+                template_vars["placeholder_imdb_id"] = placeholder_imdb_id
 
         if language_value:
             template_vars["language"] = language_value

--- a/quickstart.py
+++ b/quickstart.py
@@ -170,7 +170,7 @@ VALIDATION_REASON_LABELS = {
     "invalid_paths": "Invalid paths",
     "invalid_arr_overrides": "Invalid Arr overrides",
     "missing_library_defaults": "Missing library defaults",
-    "missing_placeholder_imdb": "Missing placeholder IMDb ID",
+    "missing_separator_placeholder": "Missing separator placeholder",
     "invalid_metadata_files": "Invalid metadata files",
     "invalid_collection_files": "Invalid collection files",
     "invalid_overlay_files": "Invalid overlay files",
@@ -416,7 +416,7 @@ QS_ERROR_REASONS = {
     "invalid_fields",
     "invalid_metadata_files",
     "missing_library_defaults",
-    "missing_placeholder_imdb",
+    "missing_separator_placeholder",
 }
 LIBRARY_RADARR_FIELDS = [
     "url",
@@ -10484,11 +10484,29 @@ def validate_all_services():
                         use_separator = find_library_value(lib_id, ["template_variables[use_separator]", "attribute_use_separator"])
                         if is_blank_value(use_separator) or str(use_separator).strip().lower() == "none":
                             continue
-                        placeholder = find_library_value(lib_id, ["attribute_template_variables[placeholder_imdb_id]", "template_variables[placeholder_imdb_id]"])
+                        placeholder_keys = [
+                            "attribute_template_variables[placeholder_imdb_id]",
+                            "template_variables[placeholder_imdb_id]",
+                        ]
+                        if str(lib_id).startswith("mov-"):
+                            placeholder_keys.extend(
+                                [
+                                    "attribute_template_variables[placeholder_tmdb_movie]",
+                                    "template_variables[placeholder_tmdb_movie]",
+                                ]
+                            )
+                        else:
+                            placeholder_keys.extend(
+                                [
+                                    "attribute_template_variables[placeholder_tvdb_show]",
+                                    "template_variables[placeholder_tvdb_show]",
+                                ]
+                            )
+                        placeholder = find_library_value(lib_id, placeholder_keys)
                         if is_blank_value(placeholder):
                             missing_placeholders.append(library_names.get(lib_id, lib_id))
                 if libraries_reason is None and missing_placeholders:
-                    libraries_reason = "missing_placeholder_imdb"
+                    libraries_reason = "missing_separator_placeholder"
 
                 if libraries_reason is None:
                     for lib_id in selected_library_ids:
@@ -10505,7 +10523,7 @@ def validate_all_services():
                 reason=libraries_reason,
                 details=(
                     missing_placeholders
-                    if libraries_reason == "missing_placeholder_imdb"
+                    if libraries_reason == "missing_separator_placeholder"
                     else arr_override_errors if libraries_reason == "invalid_arr_overrides" else auto_sort_hubs_errors if libraries_reason == "invalid_library_settings" else None
                 ),
             )
@@ -10659,7 +10677,7 @@ def validate_all_services():
         "invalid_paths": "Invalid paths",
         "invalid_arr_overrides": "Invalid Arr overrides",
         "missing_library_defaults": "Missing library defaults",
-        "missing_placeholder_imdb": "Missing placeholder IMDb ID",
+        "missing_separator_placeholder": "Missing separator placeholder",
         "invalid_fields": "Invalid fields",
         "no_webhooks": "No webhooks configured",
         "disabled": "Disabled",

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -12078,6 +12078,14 @@
             "placeholder": "Custom dynamic collection title format"
           },
           {
+            "key": "use_year_collections",
+            "label": "Use Year Collections",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Leave enabled to create the individual year collections for this award default. Turn it off to keep only the main award collections.",
+            "tooltip_variant": "info"
+          },
+          {
             "key": "data_starting",
             "label": "Data Starting",
             "type": "relative_year",

--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -3329,7 +3329,7 @@ $(document).ready(function () {
     no_libraries: 'No libraries selected',
     invalid_paths: 'Invalid paths',
     missing_library_defaults: 'Missing library defaults',
-    missing_placeholder_imdb: 'Missing placeholder IMDb ID',
+    missing_separator_placeholder: 'Missing separator placeholder',
     invalid_fields: 'Invalid fields',
     no_webhooks: 'No webhooks configured',
     disabled: 'Disabled',

--- a/static/local-js/overlayHandler.js
+++ b/static/local-js/overlayHandler.js
@@ -17,7 +17,7 @@ const OverlayHandler = {
         const selectedStyle = separatorDropdown.value !== 'none'
         OverlayHandler.updateSeparatorToggles(libraryId, selectedStyle)
         OverlayHandler.updateSeparatorPreview(fieldId, separatorDropdown.value)
-        OverlayHandler.toggleImdbPlaceholder(libraryId, isMovie ? 'movie' : 'show', selectedStyle)
+        OverlayHandler.toggleSeparatorPlaceholder(libraryId, selectedStyle)
         OverlayHandler.updateHiddenInputs(libraryId, isMovie)
         EventHandler.updateAccordionHighlights()
       })
@@ -28,9 +28,20 @@ const OverlayHandler = {
       const initialSelected = separatorDropdown.value !== 'none'
       OverlayHandler.updateSeparatorToggles(libraryId, initialSelected)
       OverlayHandler.updateSeparatorPreview(fieldId, separatorDropdown.value)
-      OverlayHandler.toggleImdbPlaceholder(libraryId, isMovie ? 'movie' : 'show', initialSelected)
+      OverlayHandler.toggleSeparatorPlaceholder(libraryId, initialSelected)
       OverlayHandler.updateHiddenInputs(libraryId, isMovie)
       EventHandler.updateAccordionHighlights()
+    }
+
+    const placeholderWrapper = OverlayHandler.getSeparatorPlaceholderWrapper(libraryId)
+    const sourceSelect = placeholderWrapper?.querySelector('.separator-placeholder-source')
+    if (sourceSelect && !sourceSelect.dataset.listenerAdded) {
+      sourceSelect.addEventListener('change', () => {
+        const separatorsEnabled = separatorDropdown ? separatorDropdown.value !== 'none' : true
+        OverlayHandler.syncSeparatorPlaceholderFields(placeholderWrapper, { show: separatorsEnabled })
+        EventHandler.updateAccordionHighlights()
+      })
+      sourceSelect.dataset.listenerAdded = 'true'
     }
   },
 
@@ -100,14 +111,10 @@ const OverlayHandler = {
     const selectedValue = useSeparatorsDropdown.value
     const isEnabled = selectedValue !== 'none'
 
-    // Clear IMDb placeholder selection if separator is disabled
+    // Clear separator placeholder values if separator is disabled
     if (!isEnabled) {
-      const imdbDropdown = document.querySelector(`#${libraryId}-attribute_template_variables_placeholder_imdb_id`)
-      if (imdbDropdown) {
-        imdbDropdown.value = ''
-        const optionsToRemove = [...imdbDropdown.options].slice(1) // skip the first option
-        optionsToRemove.forEach(opt => imdbDropdown.remove(opt.index))
-      }
+      const placeholderWrapper = OverlayHandler.getSeparatorPlaceholderWrapper(libraryId)
+      OverlayHandler.syncSeparatorPlaceholderFields(placeholderWrapper, { show: false })
     }
 
     // Create hidden inputs dynamically if missing
@@ -144,72 +151,53 @@ const OverlayHandler = {
     OverlayHandler.updateSeparatorPreview(fieldId, selectedValue)
   },
 
-  toggleImdbPlaceholder: function (libraryId, mediaType, show) {
-    const dropdown = document.getElementById(`${libraryId}-attribute_template_variables_placeholder_imdb_id`)
-    if (!dropdown) {
-      console.error(`[ERROR] IMDb dropdown not found for libraryId: ${libraryId}`)
-      return
-    }
-
-    const libraryName = dropdown.dataset.libraryId
-    const imdbBlock = document.querySelector(`.imdb-placeholder-wrapper[data-library-id="${libraryName}"]`)
-    if (!imdbBlock) {
-      console.error(`[ERROR] IMDb block not found for libraryName: ${libraryName}`)
-      return
-    }
-
-    if (show) {
-      imdbBlock.classList.remove('visually-hidden')
-      const currentValue = dropdown.value
-      OverlayHandler.populateImdbDropdown(dropdown, libraryName, mediaType, currentValue)
-    } else {
-      imdbBlock.classList.add('visually-hidden')
-    }
+  getSeparatorPlaceholderWrapper: function (libraryId) {
+    return document.querySelector(`[data-separator-placeholder-wrapper="true"][data-library-prefix="${libraryId}"]`)
   },
 
-  populateImdbDropdown: function (dropdown, libraryName, mediaType, placeholderId = '') {
-    console.log(`[DEBUG] Fetching top IMDb items for "${libraryName}" (type=${mediaType})`)
+  syncSeparatorPlaceholderFields: function (wrapper, options = {}) {
+    if (!wrapper) return
 
-    const url = `/get_top_imdb_items/${encodeURIComponent(libraryName)}?type=${mediaType}` + (placeholderId ? `&placeholder_id=${placeholderId}` : '')
+    const show = options.show !== false
+    const libraryType = String(wrapper.dataset.libraryType || '').trim().toLowerCase()
+    const allowedSources = libraryType === 'movie' ? ['imdb', 'tmdb_movie'] : ['imdb', 'tvdb_show']
+    const sourceSelect = wrapper.querySelector('.separator-placeholder-source')
+    const fieldInputs = Array.from(wrapper.querySelectorAll('[data-separator-placeholder-input]'))
+    if (!sourceSelect || !fieldInputs.length) return
 
-    fetch(url)
-      .then(res => res.json())
-      .then(data => {
-        if (data.status === 'success') {
-          // Clear existing options
-          dropdown.replaceChildren()
+    const valueBySource = {}
+    fieldInputs.forEach(input => {
+      valueBySource[input.dataset.separatorPlaceholderInput] = String(input.value || '').trim()
+      input.classList.remove('is-invalid')
+    })
 
-          // Add "None" option
-          const noneOption = document.createElement('option')
-          noneOption.value = ''
-          noneOption.textContent = 'None'
-          dropdown.appendChild(noneOption)
+    let activeSource = String(sourceSelect.value || '').trim()
+    if (!allowedSources.includes(activeSource)) {
+      activeSource = allowedSources.find(source => valueBySource[source]) || 'imdb'
+    }
+    sourceSelect.value = activeSource
+    sourceSelect.disabled = !show
+    sourceSelect.classList.remove('is-invalid')
+    wrapper.classList.toggle('visually-hidden', !show)
 
-          // Add items
-          data.items.forEach(item => {
-            const option = document.createElement('option')
-            option.value = item.id
-            option.textContent = `${item.title} (${item.id})`
-            dropdown.appendChild(option)
-          })
+    fieldInputs.forEach(input => {
+      const source = String(input.dataset.separatorPlaceholderInput || '').trim()
+      const fieldGroup = input.closest('.separator-placeholder-field')
+      const isActive = show && source === activeSource
+      if (fieldGroup) fieldGroup.classList.toggle('d-none', !isActive)
+      if (!isActive) {
+        input.value = ''
+      }
+    })
+  },
 
-          // Insert saved placeholder item if returned separately
-          if (data.saved_item) {
-            const savedOption = document.createElement('option')
-            savedOption.value = data.saved_item.id
-            savedOption.textContent = `${data.saved_item.title} (${data.saved_item.id}) (Not in Top 25)`
-            dropdown.appendChild(savedOption)
-          }
-
-          // Restore previous selection
-          dropdown.value = placeholderId || ''
-        } else {
-          console.warn('Failed to load IMDb titles for', libraryName, data.message)
-        }
-      })
-      .catch(err => {
-        console.error('IMDb fetch failed for', libraryName, err)
-      })
+  toggleSeparatorPlaceholder: function (libraryId, show) {
+    const wrapper = OverlayHandler.getSeparatorPlaceholderWrapper(libraryId)
+    if (!wrapper) {
+      console.error(`[ERROR] Separator placeholder block not found for libraryId: ${libraryId}`)
+      return
+    }
+    OverlayHandler.syncSeparatorPlaceholderFields(wrapper, { show })
   },
 
   /**
@@ -4988,25 +4976,24 @@ const OverlayHandler = {
 }
 
 function bootstrapOverlayHandler () {
-  const imdbDropdowns = document.querySelectorAll('.placeholder-imdb-dropdown')
+  const separatorPlaceholders = document.querySelectorAll('[data-separator-placeholder-wrapper="true"]')
 
-  imdbDropdowns.forEach(dropdown => {
-    const libraryId = dropdown.id.split('-attribute_template_variables')[0]
-    const isMovie = dropdown.dataset.libraryType === 'movie'
-    const libraryName = dropdown.dataset.libraryId
+  separatorPlaceholders.forEach(wrapper => {
+    const libraryId = String(wrapper.dataset.libraryPrefix || '').trim()
+    const isMovie = wrapper.dataset.libraryType === 'movie'
+    if (!libraryId) return
 
     // 1. Initialize overlay dropdowns and separator preview
     OverlayHandler.initializeOverlays(libraryId, isMovie)
-
-    // 2. Populate IMDb dropdown options
-    const currentValue = dropdown.value
-    OverlayHandler.populateImdbDropdown(dropdown, libraryName, isMovie ? 'movie' : 'show', currentValue)
+    OverlayHandler.syncSeparatorPlaceholderFields(wrapper, {
+      show: String(document.querySelector(`[name="${libraryId}-template_variables[use_separator]"]`)?.value || '').trim() !== 'none'
+    })
   })
 
-  // 3. Sync parent/child toggle checked state
+  // 2. Sync parent/child toggle checked state
   setupParentChildToggleSync()
 
-  // 4. Toggle child wrapper visibility for both collections and overlays
+  // 3. Toggle child wrapper visibility for both collections and overlays
   document.querySelectorAll('input[data-template-group]').forEach(parent => {
     const parentId = parent.id
     const childWrapper = document.querySelector(`.child-toggle-wrapper[data-toggle-parent="${parentId}"]`)
@@ -5021,7 +5008,7 @@ function bootstrapOverlayHandler () {
     })
   })
 
-  // 5. Initialize overlay previews (combined + per-overlay)
+  // 4. Initialize overlay previews (combined + per-overlay)
   OverlayHandler.initializeOverlayBoards()
   OverlayHandler.initializeOverlayPositioners()
   OverlayHandler.initializeJumpButtons()

--- a/static/local-js/validationHandler.js
+++ b/static/local-js/validationHandler.js
@@ -150,23 +150,28 @@ const ValidationHandler = {
     const validatePlaceholderSelection = () => {
       let allPlaceholdersValid = true
 
-      document.querySelectorAll('.placeholder-imdb-dropdown').forEach(dropdown => {
-        dropdown.classList.remove('is-invalid')
+      document.querySelectorAll('[data-separator-placeholder-wrapper="true"]').forEach(wrapper => {
+        const sourceSelect = wrapper.querySelector('.separator-placeholder-source')
+        const activeField = wrapper.querySelector('.separator-placeholder-field:not(.d-none) [data-separator-placeholder-input]')
+        if (!sourceSelect) return
 
-        const libraryId = dropdown.dataset.libraryId
-        const libraryType = dropdown.dataset.libraryType
-        const libraryPrefix = libraryType === 'movie' ? 'mov' : 'sho'
+        sourceSelect.classList.remove('is-invalid')
+        wrapper.querySelectorAll('[data-separator-placeholder-input]').forEach(input => input.classList.remove('is-invalid'))
 
-        const separatorDropdown = document.querySelector(`[name="${libraryPrefix}-library_${libraryId.replace(/\s+/g, '').toLowerCase()}-template_variables[use_separator]"]`)
+        const libraryPrefix = String(wrapper.dataset.libraryPrefix || '').trim()
+        const separatorDropdown = libraryPrefix
+          ? document.querySelector(`[name="${libraryPrefix}-template_variables[use_separator]"]`)
+          : null
 
         if (separatorDropdown && separatorDropdown.value !== 'none') {
-          if (!dropdown.value) {
-            console.log(`[DEBUG] Placeholder missing for library: ${libraryId}`)
+          const activeValue = String(activeField?.value || '').trim()
+          if (!activeField || !activeValue) {
+            console.log(`[DEBUG] Separator placeholder missing for library prefix: ${libraryPrefix}`)
             allPlaceholdersValid = false
-            dropdown.classList.add('is-invalid')
+            sourceSelect.classList.add('is-invalid')
+            if (activeField) activeField.classList.add('is-invalid')
 
-            // Bubble up red invalid highlight properly
-            let parent = dropdown.closest('.accordion-item')
+            let parent = wrapper.closest('.accordion-item')
             while (parent) {
               const header = parent.querySelector(':scope > .accordion-header')
               if (header) {
@@ -176,10 +181,9 @@ const ValidationHandler = {
               parent = parent.parentElement?.closest('.accordion-item')
             }
           } else {
-            console.log(`[DEBUG] Valid placeholder selected for: ${libraryId}`)
+            console.log(`[DEBUG] Valid separator placeholder selected for: ${libraryPrefix}`)
 
-            // Valid and relevant placeholder, bubble up green
-            let parent = dropdown.closest('.accordion-item')
+            let parent = wrapper.closest('.accordion-item')
             while (parent) {
               const header = parent.querySelector(':scope > .accordion-header')
               if (header) {
@@ -213,7 +217,7 @@ const ValidationHandler = {
     } else {
       console.log('[DEBUG] Some validations failed! Disabling navigation.')
       ValidationHandler.showValidationMessage(
-        'Each selected library must have at least one highlighted item, a valid Placeholder IMDb must be selected if a Separator is enabled, and any path fields must be valid.',
+        'Each selected library must have at least one highlighted item, a valid separator placeholder must be selected if a separator is enabled, and any path fields must be valid.',
         'danger'
       )
       ValidationHandler.disableNavigation(false)

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -338,34 +338,110 @@ prefix if yml_location == "top_level" else
     </div>
 </div>
 
-{# IMDb placeholder dropdown (conditionally shown with JS) #}
+{# Separator placeholder controls (conditionally shown with JS) #}
 {% if prefix == "use_separator" %}
-{% set imdb_select_name = library.id ~ "-attribute_template_variables[placeholder_imdb_id]" %}
-{% set imdb_select_id = imdb_select_name.replace("[", "_").replace("]", "") %}
-{% set imdb_data = data.libraries.get(imdb_select_name, "") %}
-<div class="row mt-2 imdb-placeholder-wrapper visually-hidden" data-library-id="{{ library.name }}"
-    data-library-type="{{ 'movie' if library.id.startswith('mov-') else 'show' }}">
-    <div class="col-md-6">
+{% set library_media_type = 'movie' if library.id.startswith('mov-') else 'show' %}
+{% set source_select_id = library.id ~ "-attribute_template_variables_placeholder_source" %}
+{% set imdb_name = library.id ~ "-attribute_template_variables[placeholder_imdb_id]" %}
+{% set imdb_id = imdb_name.replace("[", "_").replace("]", "") %}
+{% set imdb_data = data.libraries.get(imdb_name, "") %}
+{% set tmdb_name = library.id ~ "-attribute_template_variables[placeholder_tmdb_movie]" %}
+{% set tmdb_id = tmdb_name.replace("[", "_").replace("]", "") %}
+{% set tmdb_data = data.libraries.get(tmdb_name, "") %}
+{% set tvdb_name = library.id ~ "-attribute_template_variables[placeholder_tvdb_show]" %}
+{% set tvdb_id = tvdb_name.replace("[", "_").replace("]", "") %}
+{% set tvdb_data = data.libraries.get(tvdb_name, "") %}
+{% if library_media_type == 'movie' and tmdb_data %}
+{% set active_source = 'tmdb_movie' %}
+{% elif library_media_type == 'show' and tvdb_data %}
+{% set active_source = 'tvdb_show' %}
+{% elif imdb_data %}
+{% set active_source = 'imdb' %}
+{% else %}
+{% set active_source = 'imdb' %}
+{% endif %}
+<div class="row mt-2 separator-placeholder-wrapper visually-hidden"
+    data-separator-placeholder-wrapper="true"
+    data-library-id="{{ library.name }}"
+    data-library-prefix="{{ library.id }}"
+    data-library-type="{{ library_media_type }}">
+    <div class="col-12 col-xl-5">
         <div class="input-group mb-2">
-            <span class="input-group-text" id="{{ imdb_select_id }}_text">
+            <span class="input-group-text" id="{{ source_select_id }}_text">
                 <a href="https://kometa.wiki/en/nightly/defaults/separators/#important-note" target="_blank"
-                    rel="noopener noreferrer">Placeholder IMDb ID</a>
+                    rel="noopener noreferrer">Placeholder Source</a>
                 <span class="text-{{ tooltip_variant }} ms-3" data-bs-toggle="tooltip" data-bs-html="true"
-                    title="Choose an item to use as the placeholder for the Separator.">
+                    title="Choose exactly one placeholder source for separators in this library.">
                     <i
                         class="bi {% if tooltip_variant == 'danger' %}bi-exclamation-circle-fill{% else %}bi-info-circle-fill{% endif %}"></i>
                 </span>
             </span>
-            <select class="form-select placeholder-imdb-dropdown" id="{{ imdb_select_id }}"
-                name="{{ imdb_select_name }}" aria-describedby="{{ imdb_select_id }}_text"
-                data-library-id="{{ library.name }}"
-                data-library-type="{{ 'movie' if library.id.startswith('mov-') else 'show' }}">
-                <option value="">None</option>
-                {% if imdb_data %}
-                <option selected value="{{ imdb_data }}">{{ imdb_data }}</option>
+            <select class="form-select separator-placeholder-source" id="{{ source_select_id }}"
+                aria-describedby="{{ source_select_id }}_text"
+                data-default="imdb"
+                data-library-type="{{ library_media_type }}"
+                data-active-source="{{ active_source }}">
+                <option value="imdb" {% if active_source == 'imdb' %}selected{% endif %}>IMDb ID</option>
+                {% if library_media_type == 'movie' %}
+                <option value="tmdb_movie" {% if active_source == 'tmdb_movie' %}selected{% endif %}>TMDb Movie ID</option>
+                {% else %}
+                <option value="tvdb_show" {% if active_source == 'tvdb_show' %}selected{% endif %}>TVDb Show ID</option>
                 {% endif %}
             </select>
         </div>
+    </div>
+    <div class="col-12 col-xl-7">
+        <div class="input-group mb-2 separator-placeholder-field" data-placeholder-source="imdb">
+            <span class="input-group-text" id="{{ imdb_id }}_text">
+                <a href="https://kometa.wiki/en/nightly/defaults/separators/#important-note" target="_blank"
+                    rel="noopener noreferrer">Placeholder IMDb ID</a>
+            </span>
+            <input type="text" class="form-control" id="{{ imdb_id }}" name="{{ imdb_name }}"
+                value="{{ imdb_data | default('', true) }}"
+                data-default=""
+                data-separator-placeholder-input="imdb"
+                aria-describedby="{{ imdb_id }}_text"
+                placeholder="tt1234567"
+                pattern="tt\d{7,8}"
+                title="IMDb IDs must look like tt1234567"
+                inputmode="text"
+                autocapitalize="off">
+        </div>
+        {% if library_media_type == 'movie' %}
+        <div class="input-group mb-2 separator-placeholder-field d-none" data-placeholder-source="tmdb_movie">
+            <span class="input-group-text" id="{{ tmdb_id }}_text">
+                <a href="https://kometa.wiki/en/nightly/defaults/separators/#important-note" target="_blank"
+                    rel="noopener noreferrer">Placeholder TMDb Movie ID</a>
+            </span>
+            <input type="text" class="form-control" id="{{ tmdb_id }}" name="{{ tmdb_name }}"
+                value="{{ tmdb_data | default('', true) }}"
+                data-default=""
+                data-separator-placeholder-input="tmdb_movie"
+                aria-describedby="{{ tmdb_id }}_text"
+                placeholder="603"
+                pattern="\d+"
+                title="TMDb movie IDs must be numeric"
+                inputmode="numeric"
+                data-numeric-only="true">
+        </div>
+        {% else %}
+        <div class="input-group mb-2 separator-placeholder-field d-none" data-placeholder-source="tvdb_show">
+            <span class="input-group-text" id="{{ tvdb_id }}_text">
+                <a href="https://kometa.wiki/en/nightly/defaults/separators/#important-note" target="_blank"
+                    rel="noopener noreferrer">Placeholder TVDb Show ID</a>
+            </span>
+            <input type="text" class="form-control" id="{{ tvdb_id }}" name="{{ tvdb_name }}"
+                value="{{ tvdb_data | default('', true) }}"
+                data-default=""
+                data-separator-placeholder-input="tvdb_show"
+                aria-describedby="{{ tvdb_id }}_text"
+                placeholder="121361"
+                pattern="\d+"
+                title="TVDb show IDs must be numeric"
+                inputmode="numeric"
+                data-numeric-only="true">
+        </div>
+        {% endif %}
     </div>
 </div>
 {% endif %}

--- a/tests/test_collection_child_override_contract.py
+++ b/tests/test_collection_child_override_contract.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 QS_COLLECTIONS_PATH = ROOT / "static" / "json" / "quickstart_collections.json"
+AWARD_DEFAULTS_ROOT = ROOT / "config" / "kometa" / "defaults" / "award"
 
 
 def _load_collections():
@@ -152,3 +153,20 @@ def test_year_collections_master_toggle_does_not_get_fake_child_name_or_summary_
 
         assert "name_year_collections" not in keys
         assert "summary_year_collections" not in keys
+
+
+def test_award_defaults_with_year_dynamic_support_expose_use_year_collections():
+    expected_ids = set()
+    for path in sorted(AWARD_DEFAULTS_ROOT.glob("*.yml")):
+        text = path.read_text(encoding="utf-8")
+        if "use_year_collections" not in text:
+            continue
+        expected_ids.add(f"collection_{path.stem}")
+
+    actual_ids = set()
+    for collection in _load_collections():
+        keys = _keys(collection)
+        if "use_year_collections" in keys:
+            actual_ids.add(collection.get("id"))
+
+    assert expected_ids <= actual_ids

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -3913,6 +3913,76 @@ def test_build_libraries_section_includes_separator_placeholder_imdb_id(app):
     assert template_variables["collection_mode"] == "hide"
 
 
+def test_build_libraries_section_includes_separator_placeholder_tmdb_movie(app):
+    from modules import output
+
+    with app.app_context():
+        libraries_section = output.build_libraries_section(
+            {"mov-library_movies-library": "Movies"},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {
+                "movies": {
+                    "mov-library_movies-template_variables[use_separator]": "gray",
+                    "mov-library_movies-attribute_template_variables[placeholder_tmdb_movie]": "603",
+                    "mov-library_movies-template_variables[language]": "en",
+                }
+            },
+            {},
+            {},
+            {},
+        )
+
+    template_variables = libraries_section["libraries"]["Movies"]["template_variables"]
+    assert template_variables["sep_style"] == "gray"
+    assert template_variables["placeholder_tmdb_movie"] == "603"
+    assert "placeholder_imdb_id" not in template_variables
+
+
+def test_build_libraries_section_includes_separator_placeholder_tvdb_show(app):
+    from modules import output
+
+    with app.app_context():
+        libraries_section = output.build_libraries_section(
+            {},
+            {"sho-library_shows-library": "Shows"},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {
+                "shows": {
+                    "sho-library_shows-template_variables[use_separator]": "gray",
+                    "sho-library_shows-attribute_template_variables[placeholder_tvdb_show]": "121361",
+                    "sho-library_shows-template_variables[language]": "en",
+                }
+            },
+            {},
+            {},
+        )
+
+    template_variables = libraries_section["libraries"]["Shows"]["template_variables"]
+    assert template_variables["sep_style"] == "gray"
+    assert template_variables["placeholder_tvdb_show"] == "121361"
+    assert "placeholder_imdb_id" not in template_variables
+
+
 def test_reorder_library_section_keeps_settings_and_operations_before_library_files():
     from modules import output
 

--- a/tests/test_importer_library_services.py
+++ b/tests/test_importer_library_services.py
@@ -90,3 +90,27 @@ def test_prepare_import_payload_maps_library_auto_sort_hubs():
     libraries = payload["libraries"]["libraries"]
     assert libraries["mov-library_movies-top_level_auto_sort_hubs"] == "configured.desc"
     assert any("libraries.Movies.auto_sort_hubs" in line for line in report.lines)
+
+
+def test_prepare_import_payload_maps_movie_separator_placeholder_tmdb_movie():
+    payload, report = importer.prepare_import_payload(
+        {"libraries": {"Movies": {"template_variables": {"placeholder_tmdb_movie": 603}}}},
+        {"Movies"},
+        set(),
+    )
+
+    libraries = payload["libraries"]["libraries"]
+    assert libraries["mov-library_movies-attribute_template_variables[placeholder_tmdb_movie]"] == 603
+    assert any("libraries.Movies.template_variables.placeholder_tmdb_movie" in line for line in report.lines)
+
+
+def test_prepare_import_payload_maps_show_separator_placeholder_tvdb_show():
+    payload, report = importer.prepare_import_payload(
+        {"libraries": {"Shows": {"template_variables": {"placeholder_tvdb_show": 121361}}}},
+        set(),
+        {"Shows"},
+    )
+
+    libraries = payload["libraries"]["libraries"]
+    assert libraries["sho-library_shows-attribute_template_variables[placeholder_tvdb_show]"] == 121361
+    assert any("libraries.Shows.template_variables.placeholder_tvdb_show" in line for line in report.lines)


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Title
Add separator placeholder source support and complete award use_year_collections coverage
Description
This PR improves Quickstart support for Kometa separator placeholders and closes the remaining award-family gap for use_year_collections.
Separator placeholder support is now library-type aware:
Movie libraries can use exactly one of placeholder_imdb_id or placeholder_tmdb_movie
Show libraries can use exactly one of placeholder_imdb_id or placeholder_tvdb_show
The UI now enforces mutual exclusion, hides the inactive field, and clears inactive values so only the chosen Kometa key is emitted
Backend support was updated to match:
importer accepts placeholder_tmdb_movie and placeholder_tvdb_show
output emits the correct Kometa separator placeholder key for the active library type
bulk validation now checks for a generic separator placeholder requirement instead of IMDb-only
validation/status messaging was updated from “Missing placeholder IMDb ID” to “Missing separator placeholder”
This PR also completes the award use_year_collections sweep:
collection_venice now exposes use_year_collections
a regression test now derives expected award families from config/kometa/defaults/award/*.yml and verifies Quickstart exposes use_year_collections wherever the defaults do

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
