### PR TITLE
Fixes

### DIFF
--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -748,8 +748,10 @@ def extract_template_names(raw: Any) -> set[str]:
 
 
 @lru_cache(maxsize=None)
-def load_template_sections(path: Path) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
-    parsed = load_yaml(path) or {}
+def load_template_sections(path: Path) -> tuple[Any, dict[str, dict[str, Any]]]:
+    parsed, _encoding = load_yaml(path)
+    if parsed is None:
+        parsed = {}
     local_templates = parsed.get("templates") if isinstance(parsed, dict) else {}
     if not isinstance(local_templates, dict):
         local_templates = {}
@@ -772,7 +774,9 @@ def load_template_sections(path: Path) -> tuple[dict[str, Any], dict[str, dict[s
         template_path = defaults_root / f"{template_default}.yml"
         if not template_path.exists():
             continue
-        shared_parsed = load_yaml(template_path) or {}
+        shared_parsed, _shared_encoding = load_yaml(template_path)
+        if shared_parsed is None:
+            shared_parsed = {}
         shared_section = shared_parsed.get("templates") if isinstance(shared_parsed, dict) else {}
         if isinstance(shared_section, dict):
             for template_name, template_cfg in shared_section.items():

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -76,6 +76,14 @@
             "tooltip_variant": "info"
           },
           {
+            "key": "winning",
+            "label": "Winning Only",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Keep enabled to limit this award default to winning titles only. Turn it off to allow non-winning nominees or related award entries when the underlying default supports them.",
+            "tooltip_variant": "info"
+          },
+          {
             "key": "data_starting",
             "label": "Data Starting",
             "type": "relative_year",
@@ -902,6 +910,14 @@
             "tooltip_variant": "info"
           },
           {
+            "key": "winning",
+            "label": "Winning Only",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Keep enabled to limit this award default to winning titles only. Turn it off to allow non-winning nominees or related award entries when the underlying default supports them.",
+            "tooltip_variant": "info"
+          },
+          {
             "key": "data_starting",
             "label": "Data Starting",
             "type": "relative_year",
@@ -1664,6 +1680,14 @@
             "type": "toggle",
             "default": true,
             "tooltip": "Leave enabled to create the individual year collections for this award default. Turn it off to keep only the main award collections.",
+            "tooltip_variant": "info"
+          },
+          {
+            "key": "winning",
+            "label": "Winning Only",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Keep enabled to limit this award default to winning titles only. Turn it off to allow non-winning nominees or related award entries when the underlying default supports them.",
             "tooltip_variant": "info"
           },
           {
@@ -2432,6 +2456,14 @@
             "tooltip_variant": "info"
           },
           {
+            "key": "winning",
+            "label": "Winning Only",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Keep enabled to limit this award default to winning titles only. Turn it off to allow non-winning nominees or related award entries when the underlying default supports them.",
+            "tooltip_variant": "info"
+          },
+          {
             "key": "data_starting",
             "label": "Data Starting",
             "type": "relative_year",
@@ -3138,7 +3170,7 @@
       },
       {
         "id": "collection_cesar",
-        "label": "César Awards",
+        "label": "C\u00e9sar Awards",
         "url": "https://kometa.wiki/en/nightly/defaults/award/cesar",
         "image_url": "https://kometa.wiki/en/nightly/assets/images/defaults/posters/cesar.png",
         "media_types": [
@@ -3194,6 +3226,14 @@
             "type": "toggle",
             "default": true,
             "tooltip": "Leave enabled to create the individual year collections for this award default. Turn it off to keep only the main award collections.",
+            "tooltip_variant": "info"
+          },
+          {
+            "key": "winning",
+            "label": "Winning Only",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Keep enabled to limit this award default to winning titles only. Turn it off to allow non-winning nominees or related award entries when the underlying default supports them.",
             "tooltip_variant": "info"
           },
           {
@@ -3302,23 +3342,23 @@
           },
           {
             "key": "use_best",
-            "label": "César Best Film Winners",
-            "tooltip": "Collection of César Award Winners.",
+            "label": "C\u00e9sar Best Film Winners",
+            "tooltip": "Collection of C\u00e9sar Award Winners.",
             "type": "toggle",
             "default": true
           },
           {
             "key": "name_best",
-            "label": "César Best Film Winners Name",
+            "label": "C\u00e9sar Best Film Winners Name",
             "type": "text_input",
-            "tooltip": "Override the collection name for the César Best Film Winners collection. Leave blank to inherit the family Name Format value.",
+            "tooltip": "Override the collection name for the C\u00e9sar Best Film Winners collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format"
           },
           {
             "key": "summary_best",
-            "label": "César Best Film Winners Summary",
+            "label": "C\u00e9sar Best Film Winners Summary",
             "type": "text_input",
-            "tooltip": "Override the collection summary for the César Best Film Winners collection. Leave blank to inherit the family Summary Format value.",
+            "tooltip": "Override the collection summary for the C\u00e9sar Best Film Winners collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format"
           },
           {
@@ -3516,9 +3556,9 @@
           },
           {
             "key": "visible_home_best",
-            "label": "César Best Film Winners Visible Home",
+            "label": "C\u00e9sar Best Film Winners Visible Home",
             "type": "toggle",
-            "tooltip": "Changes the César Best Film Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "tooltip": "Changes the C\u00e9sar Best Film Winners collection visible on Home Tab (Only works with Plex Pass)",
             "default": false,
             "media_types": [
               "movie"
@@ -3526,9 +3566,9 @@
           },
           {
             "key": "visible_library_best",
-            "label": "César Best Film Winners Visible Library",
+            "label": "C\u00e9sar Best Film Winners Visible Library",
             "type": "toggle",
-            "tooltip": "Changes the César Best Film Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "tooltip": "Changes the C\u00e9sar Best Film Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
             "default": false,
             "media_types": [
               "movie"
@@ -3536,9 +3576,9 @@
           },
           {
             "key": "visible_shared_best",
-            "label": "César Best Film Winners Visible Shared",
+            "label": "C\u00e9sar Best Film Winners Visible Shared",
             "type": "toggle",
-            "tooltip": "Changes the César Best Film Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "tooltip": "Changes the C\u00e9sar Best Film Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
             "media_types": [
               "movie"
@@ -3960,6 +4000,14 @@
             "type": "toggle",
             "default": true,
             "tooltip": "Leave enabled to create the individual year collections for this award default. Turn it off to keep only the main award collections.",
+            "tooltip_variant": "info"
+          },
+          {
+            "key": "winning",
+            "label": "Winning Only",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Keep enabled to limit this award default to winning titles only. Turn it off to allow non-winning nominees or related award entries when the underlying default supports them.",
             "tooltip_variant": "info"
           },
           {
@@ -4831,6 +4879,14 @@
             "tooltip_variant": "info"
           },
           {
+            "key": "winning",
+            "label": "Winning Only",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Keep enabled to limit this award default to winning titles only. Turn it off to allow non-winning nominees or related award entries when the underlying default supports them.",
+            "tooltip_variant": "info"
+          },
+          {
             "key": "data_starting",
             "label": "Data Starting",
             "type": "relative_year",
@@ -5696,6 +5752,14 @@
             "type": "toggle",
             "default": true,
             "tooltip": "Leave enabled to create the individual year collections for this award default. Turn it off to keep only the main award collections.",
+            "tooltip_variant": "info"
+          },
+          {
+            "key": "winning",
+            "label": "Winning Only",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Keep enabled to limit this award default to winning titles only. Turn it off to allow non-winning nominees or related award entries when the underlying default supports them.",
             "tooltip_variant": "info"
           },
           {
@@ -6628,6 +6692,14 @@
             "tooltip_variant": "info"
           },
           {
+            "key": "winning",
+            "label": "Winning Only",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Keep enabled to limit this award default to winning titles only. Turn it off to allow non-winning nominees or related award entries when the underlying default supports them.",
+            "tooltip_variant": "info"
+          },
+          {
             "key": "data_starting",
             "label": "Data Starting",
             "type": "relative_year",
@@ -7390,6 +7462,14 @@
             "type": "toggle",
             "default": true,
             "tooltip": "Leave enabled to create the individual year collections for this award default. Turn it off to keep only the main award collections.",
+            "tooltip_variant": "info"
+          },
+          {
+            "key": "winning",
+            "label": "Winning Only",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Keep enabled to limit this award default to winning titles only. Turn it off to allow non-winning nominees or related award entries when the underlying default supports them.",
             "tooltip_variant": "info"
           },
           {
@@ -8156,6 +8236,14 @@
             "type": "toggle",
             "default": true,
             "tooltip": "Leave enabled to create the individual year collections for this award default. Turn it off to keep only the main award collections.",
+            "tooltip_variant": "info"
+          },
+          {
+            "key": "winning",
+            "label": "Winning Only",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Keep enabled to limit this award default to winning titles only. Turn it off to allow non-winning nominees or related award entries when the underlying default supports them.",
             "tooltip_variant": "info"
           },
           {
@@ -9026,6 +9114,14 @@
             "tooltip_variant": "info"
           },
           {
+            "key": "winning",
+            "label": "Winning Only",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Keep enabled to limit this award default to winning titles only. Turn it off to allow non-winning nominees or related award entries when the underlying default supports them.",
+            "tooltip_variant": "info"
+          },
+          {
             "key": "data_starting",
             "label": "Data Starting",
             "type": "relative_year",
@@ -9788,6 +9884,14 @@
             "type": "toggle",
             "default": true,
             "tooltip": "Leave enabled to create the individual year collections for this award default. Turn it off to keep only the main award collections.",
+            "tooltip_variant": "info"
+          },
+          {
+            "key": "winning",
+            "label": "Winning Only",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Keep enabled to limit this award default to winning titles only. Turn it off to allow non-winning nominees or related award entries when the underlying default supports them.",
             "tooltip_variant": "info"
           },
           {
@@ -10556,6 +10660,14 @@
             "tooltip_variant": "info"
           },
           {
+            "key": "winning",
+            "label": "Winning Only",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Keep enabled to limit this award default to winning titles only. Turn it off to allow non-winning nominees or related award entries when the underlying default supports them.",
+            "tooltip_variant": "info"
+          },
+          {
             "key": "data_starting",
             "label": "Data Starting",
             "type": "relative_year",
@@ -11321,6 +11433,14 @@
             "tooltip_variant": "info"
           },
           {
+            "key": "winning",
+            "label": "Winning Only",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Keep enabled to limit this award default to winning titles only. Turn it off to allow non-winning nominees or related award entries when the underlying default supports them.",
+            "tooltip_variant": "info"
+          },
+          {
             "key": "data_starting",
             "label": "Data Starting",
             "type": "relative_year",
@@ -12083,6 +12203,14 @@
             "type": "toggle",
             "default": true,
             "tooltip": "Leave enabled to create the individual year collections for this award default. Turn it off to keep only the main award collections.",
+            "tooltip_variant": "info"
+          },
+          {
+            "key": "winning",
+            "label": "Winning Only",
+            "type": "toggle",
+            "default": true,
+            "tooltip": "Keep enabled to limit this award default to winning titles only. Turn it off to allow non-winning nominees or related award entries when the underlying default supports them.",
             "tooltip_variant": "info"
           },
           {

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -3034,11 +3034,9 @@ document.addEventListener('DOMContentLoaded', () => {
           window.history.replaceState(null, '', nextUrl)
         }
         const navigate = () => window.location.replace(nextUrl)
-        if (typeof window.requestAnimationFrame === 'function') {
-          window.requestAnimationFrame(navigate)
-        } else {
-          navigate()
-        }
+        // Yield one task so the updated config badge/state becomes observable
+        // before the page unload starts.
+        window.setTimeout(navigate, 0)
       } catch (err) {
         window.QS_SWITCHING_CONFIG = false
         confirmBtn.disabled = false

--- a/tests/test_collection_child_override_contract.py
+++ b/tests/test_collection_child_override_contract.py
@@ -170,3 +170,20 @@ def test_award_defaults_with_year_dynamic_support_expose_use_year_collections():
             actual_ids.add(collection.get("id"))
 
     assert expected_ids <= actual_ids
+
+
+def test_award_defaults_with_imdb_award_winning_support_expose_winning():
+    expected_ids = set()
+    for path in sorted(AWARD_DEFAULTS_ROOT.glob("*.yml")):
+        text = path.read_text(encoding="utf-8")
+        if "winning:" not in text:
+            continue
+        expected_ids.add(f"collection_{path.stem}")
+
+    actual_ids = set()
+    for collection in _load_collections():
+        keys = _keys(collection)
+        if "winning" in keys:
+            actual_ids.add(collection.get("id"))
+
+    assert expected_ids <= actual_ids


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Title: Add winning support for award collections in Quickstart
Body:
Summary
This PR adds the missing winning template variable to Quickstart’s award collection family.
Changes
Added a Winning Only toggle to all non-separator award collections in static/json/quickstart_collections.json
Set the default to true to match the Kometa award defaults behavior
Added a regression test to ensure award defaults using winning: in the local YAML are surfaced in Quickstart

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
