### PR TITLE
Next additions

### DIFF
--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -1245,18 +1245,8 @@ def extract_importer_findings_from_data(data: dict[str, Any], path: Path) -> lis
             lib_name, remainder = _split_library_status_path(status_path, libraries_payload if isinstance(libraries_payload, dict) else {})
             lib_cfg = libraries_payload.get(lib_name) if lib_name and isinstance(libraries_payload, dict) else None
             if not remainder:
-                findings.append(
-                    _importer_row(
-                        file=path,
-                        kind="library",
-                        library=lib_name,
-                        key="library_type",
-                        status=mapped_status,
-                        reason=reason,
-                        raw_path=status_path,
-                        section="libraries",
-                    )
-                )
+                # Bare library container statuses are importer/analyzer bookkeeping,
+                # not a real user-facing Kometa config key.
                 continue
 
             section_match = re.match(r"(collection_files|overlay_files)\[(\d+)\](?:\.(.*))?$", remainder)
@@ -2082,6 +2072,8 @@ def build_gap_summary(rows: list[dict[str, Any]]) -> dict[tuple[str, str | None,
 
 
 def accumulate_importer_summary(summary: dict[tuple[str, str | None, str, str, str], dict[str, Any]], row: dict[str, Any]) -> None:
+    if get_merged_fix_queue_exclusion(row):
+        return
     bucket = summary.setdefault(
         (
             str(row.get("kind")),
@@ -2128,6 +2120,7 @@ QUICKSTART_RECOMMENDATION_EXCLUSIONS: dict[tuple[str, str], str] = {
     ("library", "metadata_path"): "legacy_library_path_key_not_recommended",
     ("library", "overlay_path"): "legacy_library_path_key_not_recommended",
     ("library", "reapply_overlays"): "valid_but_not_recommended_for_quickstart",
+    ("library", "library_type"): "internal_importer_or_analyzer_metadata",
 }
 
 
@@ -2135,6 +2128,17 @@ def get_quickstart_recommendation_exclusion(row: dict[str, Any]) -> str | None:
     kind = str(row.get("kind") or "")
     key = str(row.get("key") or "")
     return QUICKSTART_RECOMMENDATION_EXCLUSIONS.get((kind, key))
+
+
+MERGED_FIX_QUEUE_EXCLUSIONS: dict[tuple[str, str], str] = {
+    ("library", "library_type"): "internal_importer_or_analyzer_metadata",
+}
+
+
+def get_merged_fix_queue_exclusion(row: dict[str, Any]) -> str | None:
+    kind = str(row.get("kind") or "")
+    key = str(row.get("key") or "")
+    return MERGED_FIX_QUEUE_EXCLUSIONS.get((kind, key))
 
 
 def accumulate_quickstart_recommendation_summary(summary: dict[tuple[str, str | None, str], dict[str, Any]], row: dict[str, Any]) -> None:
@@ -2315,6 +2319,8 @@ def build_merged_fix_queue(
 
     ranked: list[dict[str, Any]] = []
     for bucket in queue.values():
+        if get_merged_fix_queue_exclusion(bucket):
+            continue
         action_targets: list[str] = []
         if bucket["needs_schema_support"]:
             action_targets.append("schema")

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -433,6 +433,26 @@
             ]
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_best_picture",
             "label": "Oscars Best Picture Winners Visible Home",
             "type": "toggle",
@@ -463,6 +483,26 @@
             ]
           },
           {
+            "key": "hub_priority_best_picture",
+            "label": "Oscars Best Picture Winners Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_best_picture",
+              "visible_library_best_picture",
+              "visible_shared_best_picture"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_best_director",
             "label": "Oscars Best Director Winners Visible Home",
             "type": "toggle",
@@ -488,6 +528,26 @@
             "type": "toggle",
             "tooltip": "Changes the Oscars Best Director Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_best_director",
+            "label": "Oscars Best Director Winners Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_best_director",
+              "visible_library_best_director",
+              "visible_shared_best_director"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -1236,6 +1296,26 @@
             ]
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_golden",
             "label": "Berlinale Golden Bears Visible Home",
             "type": "toggle",
@@ -1261,6 +1341,26 @@
             "type": "toggle",
             "tooltip": "Changes the Berlinale Golden Bears collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_golden",
+            "label": "Berlinale Golden Bears Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_golden",
+              "visible_library_golden",
+              "visible_shared_golden"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -2009,6 +2109,26 @@
             ]
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_best",
             "label": "BAFTA Best Films Visible Home",
             "type": "toggle",
@@ -2034,6 +2154,26 @@
             "type": "toggle",
             "tooltip": "Changes the BAFTA Best Films collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_best",
+            "label": "BAFTA Best Films Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_best",
+              "visible_library_best",
+              "visible_shared_best"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -2782,6 +2922,26 @@
             ]
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_palm",
             "label": "Cannes Golden Palm Winners Visible Home",
             "type": "toggle",
@@ -2807,6 +2967,26 @@
             "type": "toggle",
             "tooltip": "Changes the Cannes Golden Palm Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_palm",
+            "label": "Cannes Golden Palm Winners Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_palm",
+              "visible_library_palm",
+              "visible_shared_palm"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -3170,7 +3350,7 @@
       },
       {
         "id": "collection_cesar",
-        "label": "C\u00e9sar Awards",
+        "label": "César Awards",
         "url": "https://kometa.wiki/en/nightly/defaults/award/cesar",
         "image_url": "https://kometa.wiki/en/nightly/assets/images/defaults/posters/cesar.png",
         "media_types": [
@@ -3342,23 +3522,23 @@
           },
           {
             "key": "use_best",
-            "label": "C\u00e9sar Best Film Winners",
-            "tooltip": "Collection of C\u00e9sar Award Winners.",
+            "label": "César Best Film Winners",
+            "tooltip": "Collection of César Award Winners.",
             "type": "toggle",
             "default": true
           },
           {
             "key": "name_best",
-            "label": "C\u00e9sar Best Film Winners Name",
+            "label": "César Best Film Winners Name",
             "type": "text_input",
-            "tooltip": "Override the collection name for the C\u00e9sar Best Film Winners collection. Leave blank to inherit the family Name Format value.",
+            "tooltip": "Override the collection name for the César Best Film Winners collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format"
           },
           {
             "key": "summary_best",
-            "label": "C\u00e9sar Best Film Winners Summary",
+            "label": "César Best Film Winners Summary",
             "type": "text_input",
-            "tooltip": "Override the collection summary for the C\u00e9sar Best Film Winners collection. Leave blank to inherit the family Summary Format value.",
+            "tooltip": "Override the collection summary for the César Best Film Winners collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format"
           },
           {
@@ -3555,10 +3735,30 @@
             ]
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_best",
-            "label": "C\u00e9sar Best Film Winners Visible Home",
+            "label": "César Best Film Winners Visible Home",
             "type": "toggle",
-            "tooltip": "Changes the C\u00e9sar Best Film Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "tooltip": "Changes the César Best Film Winners collection visible on Home Tab (Only works with Plex Pass)",
             "default": false,
             "media_types": [
               "movie"
@@ -3566,9 +3766,9 @@
           },
           {
             "key": "visible_library_best",
-            "label": "C\u00e9sar Best Film Winners Visible Library",
+            "label": "César Best Film Winners Visible Library",
             "type": "toggle",
-            "tooltip": "Changes the C\u00e9sar Best Film Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "tooltip": "Changes the César Best Film Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
             "default": false,
             "media_types": [
               "movie"
@@ -3576,10 +3776,30 @@
           },
           {
             "key": "visible_shared_best",
-            "label": "C\u00e9sar Best Film Winners Visible Shared",
+            "label": "César Best Film Winners Visible Shared",
             "type": "toggle",
-            "tooltip": "Changes the C\u00e9sar Best Film Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "tooltip": "Changes the César Best Film Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_best",
+            "label": "César Best Film Winners Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_best",
+              "visible_library_best",
+              "visible_shared_best"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -4440,6 +4660,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_best",
             "label": "Critics Choice Best Picture Winners Visible Home",
             "type": "toggle",
@@ -4459,6 +4696,23 @@
             "type": "toggle",
             "tooltip": "Changes the Critics Choice Best Picture Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_best",
+            "label": "Critics Choice Best Picture Winners Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_best",
+              "visible_library_best",
+              "visible_shared_best"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "collection_order",
@@ -5316,6 +5570,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_best",
             "label": "Emmys Best in Category Winners Visible Home",
             "type": "toggle",
@@ -5335,6 +5606,23 @@
             "type": "toggle",
             "tooltip": "Changes the Emmys Best in Category Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_best",
+            "label": "Emmys Best in Category Winners Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_best",
+              "visible_library_best",
+              "visible_shared_best"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "collection_order",
@@ -6233,6 +6521,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_best_picture",
             "label": "Golden Globes Best Picture Winners Visible Home",
             "type": "toggle",
@@ -6254,6 +6559,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_best_picture",
+            "label": "Golden Globes Best Picture Winners Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_best_picture",
+              "visible_library_best_picture",
+              "visible_shared_best_picture"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_best_director",
             "label": "Golden Globes Best Director Winners Visible Home",
             "type": "toggle",
@@ -6273,6 +6595,23 @@
             "type": "toggle",
             "tooltip": "Changes the Golden Globes Best Director Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_best_director",
+            "label": "Golden Globes Best Director Winners Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_best_director",
+              "visible_library_best_director",
+              "visible_shared_best_director"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "collection_order",
@@ -7018,6 +7357,26 @@
             ]
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_best",
             "label": "Independent Spirit Best Feature Winners Visible Home",
             "type": "toggle",
@@ -7043,6 +7402,26 @@
             "type": "toggle",
             "tooltip": "Changes the Independent Spirit Best Feature Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_best",
+            "label": "Independent Spirit Best Feature Winners Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_best",
+              "visible_library_best",
+              "visible_shared_best"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -7791,6 +8170,26 @@
             ]
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_all_time",
             "label": "National Film Registry All Time Visible Home",
             "type": "toggle",
@@ -7816,6 +8215,26 @@
             "type": "toggle",
             "tooltip": "Changes the National Film Registry All Time collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_all_time",
+            "label": "National Film Registry All Time Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_all_time",
+              "visible_library_all_time",
+              "visible_shared_all_time"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -8676,6 +9095,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_pca",
             "label": "People's Choice Award Winners Visible Home",
             "type": "toggle",
@@ -8695,6 +9131,23 @@
             "type": "toggle",
             "tooltip": "Changes the People's Choice Award Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_pca",
+            "label": "People's Choice Award Winners Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_pca",
+              "visible_library_pca",
+              "visible_shared_pca"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "collection_order",
@@ -9440,6 +9893,26 @@
             ]
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_golden",
             "label": "Golden Raspberry Award Winners Visible Home",
             "type": "toggle",
@@ -9465,6 +9938,26 @@
             "type": "toggle",
             "tooltip": "Changes the Golden Raspberry Award Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_golden",
+            "label": "Golden Raspberry Award Winners Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_golden",
+              "visible_library_golden",
+              "visible_shared_golden"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -10213,6 +10706,26 @@
             ]
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_golden",
             "label": "Screen Actors Guild Award Winners Visible Home",
             "type": "toggle",
@@ -10238,6 +10751,26 @@
             "type": "toggle",
             "tooltip": "Changes the Screen Actors Guild Award Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_golden",
+            "label": "Screen Actors Guild Award Winners Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_golden",
+              "visible_library_golden",
+              "visible_shared_golden"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -10986,6 +11519,26 @@
             ]
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_grand",
             "label": "Grand Jury Winners Visible Home",
             "type": "toggle",
@@ -11011,6 +11564,26 @@
             "type": "toggle",
             "tooltip": "Changes the Grand Jury Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_grand",
+            "label": "Grand Jury Winners Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_grand",
+              "visible_library_grand",
+              "visible_shared_grand"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -11759,6 +12332,26 @@
             ]
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_best",
             "label": "Toronto People's Choice Award Winners Visible Home",
             "type": "toggle",
@@ -11784,6 +12377,26 @@
             "type": "toggle",
             "tooltip": "Changes the Toronto People's Choice Award Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_best",
+            "label": "Toronto People's Choice Award Winners Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_best",
+              "visible_library_best",
+              "visible_shared_best"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -12532,6 +13145,26 @@
             ]
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_golden",
             "label": "Golden Lion Winners Visible Home",
             "type": "toggle",
@@ -12557,6 +13190,26 @@
             "type": "toggle",
             "tooltip": "Changes the Golden Lion Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_golden",
+            "label": "Golden Lion Winners Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_golden",
+              "visible_library_golden",
+              "visible_shared_golden"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -13182,6 +13835,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_episodes",
             "label": "New Episodes Visible Home",
             "type": "toggle",
@@ -13212,6 +13882,26 @@
             ]
           },
           {
+            "key": "hub_priority_episodes",
+            "label": "New Episodes Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_episodes",
+              "visible_library_episodes",
+              "visible_shared_episodes"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "show"
+            ]
+          },
+          {
             "key": "visible_home_released",
             "label": "Newly Released Visible Home",
             "type": "toggle",
@@ -13231,6 +13921,23 @@
             "type": "toggle",
             "tooltip": "Changes the Newly Released collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_released",
+            "label": "Newly Released Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_released",
+              "visible_library_released",
+              "visible_shared_released"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "sort_by",
@@ -13876,6 +14583,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_popular",
             "label": "Plex Popular Visible Home",
             "type": "toggle",
@@ -13897,6 +14621,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_popular",
+            "label": "Plex Popular Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_popular",
+              "visible_library_popular",
+              "visible_shared_popular"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_watched",
             "label": "Plex Watched Visible Home",
             "type": "toggle",
@@ -13916,6 +14657,23 @@
             "type": "toggle",
             "tooltip": "Changes the Plex Watched collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_watched",
+            "label": "Plex Watched Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_watched",
+              "visible_library_watched",
+              "visible_shared_watched"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "collection_order",
@@ -14758,6 +15516,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_top",
             "label": "IMDb Top 250 Visible Home",
             "type": "toggle",
@@ -14777,6 +15552,23 @@
             "type": "toggle",
             "tooltip": "Changes the IMDb Top 250 collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_top",
+            "label": "IMDb Top 250 Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_top",
+              "visible_library_top",
+              "visible_shared_top"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_popular",
@@ -14800,6 +15592,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_popular",
+            "label": "IMDb Popular Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_popular",
+              "visible_library_popular",
+              "visible_shared_popular"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_lowest",
             "label": "IMDb Lowest Rated Visible Home",
             "type": "toggle",
@@ -14819,6 +15628,23 @@
             "type": "toggle",
             "tooltip": "Changes the IMDb Lowest Rated collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_lowest",
+            "label": "IMDb Lowest Rated Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_lowest",
+              "visible_library_lowest",
+              "visible_shared_lowest"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "collection_order",
@@ -15786,6 +16612,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_airing",
             "label": "TMDb Airing Today Visible Home",
             "type": "toggle",
@@ -15805,6 +16648,23 @@
             "type": "toggle",
             "tooltip": "Changes the TMDb Airing Today collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_airing",
+            "label": "TMDb Airing Today Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_airing",
+              "visible_library_airing",
+              "visible_shared_airing"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_air",
@@ -15828,6 +16688,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_air",
+            "label": "TMDb On The Air Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_air",
+              "visible_library_air",
+              "visible_shared_air"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_popular",
             "label": "TMDb Popular Visible Home",
             "type": "toggle",
@@ -15847,6 +16724,23 @@
             "type": "toggle",
             "tooltip": "Changes the TMDb Popular collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_popular",
+            "label": "TMDb Popular Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_popular",
+              "visible_library_popular",
+              "visible_shared_popular"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_top",
@@ -15870,6 +16764,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_top",
+            "label": "TMDb Top Rated Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_top",
+              "visible_library_top",
+              "visible_shared_top"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_trending",
             "label": "TMDb Trending Visible Home",
             "type": "toggle",
@@ -15889,6 +16800,23 @@
             "type": "toggle",
             "tooltip": "Changes the TMDb Trending collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_trending",
+            "label": "TMDb Trending Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_trending",
+              "visible_library_trending",
+              "visible_shared_trending"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "collection_order",
@@ -16858,6 +17786,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_collected",
             "label": "Trakt Collected Visible Home",
             "type": "toggle",
@@ -16877,6 +17822,23 @@
             "type": "toggle",
             "tooltip": "Changes the Trakt Collected collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_collected",
+            "label": "Trakt Collected Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_collected",
+              "visible_library_collected",
+              "visible_shared_collected"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_popular",
@@ -16900,6 +17862,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_popular",
+            "label": "Trakt Popular Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_popular",
+              "visible_library_popular",
+              "visible_shared_popular"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_recommended",
             "label": "Trakt Recommended Visible Home",
             "type": "toggle",
@@ -16919,6 +17898,23 @@
             "type": "toggle",
             "tooltip": "Changes the Trakt Recommended collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_recommended",
+            "label": "Trakt Recommended Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_recommended",
+              "visible_library_recommended",
+              "visible_shared_recommended"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_trending",
@@ -16942,6 +17938,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_trending",
+            "label": "Trakt Trending Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_trending",
+              "visible_library_trending",
+              "visible_shared_trending"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_watched",
             "label": "Trakt Watched Visible Home",
             "type": "toggle",
@@ -16961,6 +17974,23 @@
             "type": "toggle",
             "tooltip": "Changes the Trakt Watched collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_watched",
+            "label": "Trakt Watched Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_watched",
+              "visible_library_watched",
+              "visible_shared_watched"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "collection_order",
@@ -17877,6 +18907,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_trending_today",
             "label": "Simkl Trending Today Visible Home",
             "type": "toggle",
@@ -17896,6 +18943,23 @@
             "type": "toggle",
             "tooltip": "Changes the Simkl Trending Today collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_trending_today",
+            "label": "Simkl Trending Today Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_trending_today",
+              "visible_library_trending_today",
+              "visible_shared_trending_today"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_trending_week",
@@ -17919,6 +18983,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_trending_week",
+            "label": "Simkl Trending This Week Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_trending_week",
+              "visible_library_trending_week",
+              "visible_shared_trending_week"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_trending_month",
             "label": "Simkl Trending This Month Visible Home",
             "type": "toggle",
@@ -17940,6 +19021,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_trending_month",
+            "label": "Simkl Trending This Month Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_trending_month",
+              "visible_library_trending_month",
+              "visible_shared_trending_month"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_dvd",
             "label": "Simkl DVD Visible Home",
             "type": "toggle",
@@ -17959,6 +19057,23 @@
             "type": "toggle",
             "tooltip": "Changes the Simkl DVD collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_dvd",
+            "label": "Simkl DVD Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_dvd",
+              "visible_library_dvd",
+              "visible_shared_dvd"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "collection_order",
@@ -18548,6 +19663,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_popular",
             "label": "AniList Popular Visible Home",
             "type": "toggle",
@@ -18567,6 +19699,23 @@
             "type": "toggle",
             "tooltip": "Changes the AniList Popular collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_popular",
+            "label": "AniList Popular Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_popular",
+              "visible_library_popular",
+              "visible_shared_popular"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_season",
@@ -18590,6 +19739,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_season",
+            "label": "AniList Season Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_season",
+              "visible_library_season",
+              "visible_shared_season"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_top",
             "label": "AniList Top Rated Visible Home",
             "type": "toggle",
@@ -18611,6 +19777,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_top",
+            "label": "AniList Top Rated Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_top",
+              "visible_library_top",
+              "visible_shared_top"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_trending",
             "label": "AniList Trending Visible Home",
             "type": "toggle",
@@ -18630,6 +19813,23 @@
             "type": "toggle",
             "tooltip": "Changes the AniList Trending collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_trending",
+            "label": "AniList Trending Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_trending",
+              "visible_library_trending",
+              "visible_shared_trending"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "collection_order",
@@ -19597,6 +20797,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_favorited",
             "label": "MyAnimeList Favorited Visible Home",
             "type": "toggle",
@@ -19616,6 +20833,23 @@
             "type": "toggle",
             "tooltip": "Changes the MyAnimeList Favorited collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_favorited",
+            "label": "MyAnimeList Favorited Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_favorited",
+              "visible_library_favorited",
+              "visible_shared_favorited"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_popular",
@@ -19639,6 +20873,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_popular",
+            "label": "MyAnimeList Popular Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_popular",
+              "visible_library_popular",
+              "visible_shared_popular"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_season",
             "label": "MyAnimeList Season Visible Home",
             "type": "toggle",
@@ -19658,6 +20909,23 @@
             "type": "toggle",
             "tooltip": "Changes the MyAnimeList Season collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_season",
+            "label": "MyAnimeList Season Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_season",
+              "visible_library_season",
+              "visible_shared_season"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_airing",
@@ -19681,6 +20949,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_airing",
+            "label": "MyAnimeList Top Airing Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_airing",
+              "visible_library_airing",
+              "visible_shared_airing"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_top",
             "label": "MyAnimeList Top Rated Visible Home",
             "type": "toggle",
@@ -19700,6 +20985,23 @@
             "type": "toggle",
             "tooltip": "Changes the MyAnimeList Top Rated collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_top",
+            "label": "MyAnimeList Top Rated Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_top",
+              "visible_library_top",
+              "visible_shared_top"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "collection_order",
@@ -21176,6 +22478,26 @@
             ]
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_1001_movies",
             "label": "1,001 To See Before You Die Visible Home",
             "type": "toggle",
@@ -21201,6 +22523,26 @@
             "type": "toggle",
             "tooltip": "Changes the 1,001 To See Before You Die collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_1001_movies",
+            "label": "1,001 To See Before You Die Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_1001_movies",
+              "visible_library_1001_movies",
+              "visible_shared_1001_movies"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -21236,6 +22578,26 @@
             ]
           },
           {
+            "key": "hub_priority_afi_100",
+            "label": "AFI 100 Years 100 Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_afi_100",
+              "visible_library_afi_100",
+              "visible_shared_afi_100"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_boxofficemojo_100",
             "label": "Box Office Mojo All Time 100 Visible Home",
             "type": "toggle",
@@ -21261,6 +22623,26 @@
             "type": "toggle",
             "tooltip": "Changes the Box Office Mojo All Time 100 collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_boxofficemojo_100",
+            "label": "Box Office Mojo All Time 100 Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_boxofficemojo_100",
+              "visible_library_boxofficemojo_100",
+              "visible_shared_boxofficemojo_100"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -21296,6 +22678,26 @@
             ]
           },
           {
+            "key": "hub_priority_cannes",
+            "label": "Cannes Palme d'Or Winners Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_cannes",
+              "visible_library_cannes",
+              "visible_shared_cannes"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_edgarwright",
             "label": "Edgar Wright's 1,000 Favorites Visible Home",
             "type": "toggle",
@@ -21321,6 +22723,26 @@
             "type": "toggle",
             "tooltip": "Changes the Edgar Wright's 1,000 Favorites collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_edgarwright",
+            "label": "Edgar Wright's 1,000 Favorites Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_edgarwright",
+              "visible_library_edgarwright",
+              "visible_shared_edgarwright"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -21356,6 +22778,26 @@
             ]
           },
           {
+            "key": "hub_priority_imdb_top_250",
+            "label": "IMDb Top 250 (Letterboxd) Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_imdb_top_250",
+              "visible_library_imdb_top_250",
+              "visible_shared_imdb_top_250"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_top_500",
             "label": "Letterboxd Top 500 Visible Home",
             "type": "toggle",
@@ -21381,6 +22823,26 @@
             "type": "toggle",
             "tooltip": "Changes the Letterboxd Top 500 collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_top_500",
+            "label": "Letterboxd Top 500 Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_top_500",
+              "visible_library_top_500",
+              "visible_shared_top_500"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -21416,6 +22878,26 @@
             ]
           },
           {
+            "key": "hub_priority_international",
+            "label": "Top 250 International Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_international",
+              "visible_library_international",
+              "visible_shared_international"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_science",
             "label": "Top 250 Sci-Fi Films Visible Home",
             "type": "toggle",
@@ -21441,6 +22923,26 @@
             "type": "toggle",
             "tooltip": "Changes the Top 250 Sci-Fi Films collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_science",
+            "label": "Top 250 Sci-Fi Films Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_science",
+              "visible_library_science",
+              "visible_shared_science"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -21476,6 +22978,26 @@
             ]
           },
           {
+            "key": "hub_priority_western",
+            "label": "Top 100 Western Films Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_western",
+              "visible_library_western",
+              "visible_shared_western"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_silent",
             "label": "Top 100 Silent Films Visible Home",
             "type": "toggle",
@@ -21501,6 +23023,26 @@
             "type": "toggle",
             "tooltip": "Changes the Top 100 Silent Films collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_silent",
+            "label": "Top 100 Silent Films Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_silent",
+              "visible_library_silent",
+              "visible_shared_silent"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -21536,6 +23078,26 @@
             ]
           },
           {
+            "key": "hub_priority_million",
+            "label": "One Million Watched Club Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_million",
+              "visible_library_million",
+              "visible_shared_million"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_oscars",
             "label": "Oscar Best Picture Winners Visible Home",
             "type": "toggle",
@@ -21561,6 +23123,26 @@
             "type": "toggle",
             "tooltip": "Changes the Oscar Best Picture Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_oscars",
+            "label": "Oscar Best Picture Winners Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_oscars",
+              "visible_library_oscars",
+              "visible_shared_oscars"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -21596,6 +23178,26 @@
             ]
           },
           {
+            "key": "hub_priority_rogerebert",
+            "label": "Roger Ebert's Great Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_rogerebert",
+              "visible_library_rogerebert",
+              "visible_shared_rogerebert"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_sight_sound",
             "label": "Sight & Sound Greatest Films Visible Home",
             "type": "toggle",
@@ -21621,6 +23223,26 @@
             "type": "toggle",
             "tooltip": "Changes the Sight & Sound Greatest Films collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_sight_sound",
+            "label": "Sight & Sound Greatest Films Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_sight_sound",
+              "visible_library_sight_sound",
+              "visible_shared_sight_sound"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -21656,6 +23278,26 @@
             ]
           },
           {
+            "key": "hub_priority_animation",
+            "label": "Top 100 Animation Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_animation",
+              "visible_library_animation",
+              "visible_shared_animation"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_black_directors",
             "label": "Top 250 Black-Directed Visible Home",
             "type": "toggle",
@@ -21681,6 +23323,26 @@
             "type": "toggle",
             "tooltip": "Changes the Top 250 Black-Directed collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_black_directors",
+            "label": "Top 250 Black-Directed Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_black_directors",
+              "visible_library_black_directors",
+              "visible_shared_black_directors"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -21716,6 +23378,26 @@
             ]
           },
           {
+            "key": "hub_priority_documentaries",
+            "label": "Top 250 Documentaries Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_documentaries",
+              "visible_library_documentaries",
+              "visible_shared_documentaries"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_horror",
             "label": "Top 250 Horror Visible Home",
             "type": "toggle",
@@ -21741,6 +23423,26 @@
             "type": "toggle",
             "tooltip": "Changes the Top 250 Horror collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_horror",
+            "label": "Top 250 Horror Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_horror",
+              "visible_library_horror",
+              "visible_shared_horror"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -21776,6 +23478,26 @@
             ]
           },
           {
+            "key": "hub_priority_most_fans",
+            "label": "Top 250 Most Fans Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_most_fans",
+              "visible_library_most_fans",
+              "visible_shared_most_fans"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_women_directors",
             "label": "Top 250 Women-Directed Visible Home",
             "type": "toggle",
@@ -21801,6 +23523,26 @@
             "type": "toggle",
             "tooltip": "Changes the Top 250 Women-Directed collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_women_directors",
+            "label": "Top 250 Women-Directed Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_women_directors",
+              "visible_library_women_directors",
+              "visible_shared_women_directors"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -22670,6 +24412,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_commonsense",
             "label": "Common Sense Visible Home",
             "type": "toggle",
@@ -22689,6 +24448,23 @@
             "type": "toggle",
             "tooltip": "Changes the Common Sense Selection collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_commonsense",
+            "label": "Common Sense Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_commonsense",
+              "visible_library_commonsense",
+              "visible_shared_commonsense"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_metacritic",
@@ -22712,6 +24488,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_metacritic",
+            "label": "Metacritic Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_metacritic",
+              "visible_library_metacritic",
+              "visible_shared_metacritic"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_stevenlu",
             "label": "StevenLu Visible Home",
             "type": "toggle",
@@ -22731,6 +24524,26 @@
             "type": "toggle",
             "tooltip": "Changes the StevenLu's Popular Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_stevenlu",
+            "label": "StevenLu Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_stevenlu",
+              "visible_library_stevenlu",
+              "visible_shared_stevenlu"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -22761,6 +24574,26 @@
             "type": "toggle",
             "tooltip": "Changes the Top 10 Pirated Movies of the Week collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_pirated",
+            "label": "Pirated Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_pirated",
+              "visible_library_pirated",
+              "visible_shared_pirated"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -23290,6 +25123,23 @@
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "sort_by",
@@ -23948,6 +25798,23 @@
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "collection_order",
@@ -24623,6 +26490,23 @@
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "collection_order",
@@ -26093,6 +27977,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_avp",
             "label": "Alien / Predator Visible Home",
             "type": "toggle",
@@ -26112,6 +28013,23 @@
             "type": "toggle",
             "tooltip": "Changes the Alien / Predator collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_avp",
+            "label": "Alien / Predator Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_avp",
+              "visible_library_avp",
+              "visible_shared_avp"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_arrow",
@@ -26135,6 +28053,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_arrow",
+            "label": "Arrowverse Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_arrow",
+              "visible_library_arrow",
+              "visible_shared_arrow"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_dca",
             "label": "DC Animated Universe Visible Home",
             "type": "toggle",
@@ -26154,6 +28089,23 @@
             "type": "toggle",
             "tooltip": "Changes the DC Animated Universe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_dca",
+            "label": "DC Animated Universe Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_dca",
+              "visible_library_dca",
+              "visible_shared_dca"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_dcu",
@@ -26177,6 +28129,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_dcu",
+            "label": "DC Extended Universe Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_dcu",
+              "visible_library_dcu",
+              "visible_shared_dcu"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_fast",
             "label": "Fast & Furious Visible Home",
             "type": "toggle",
@@ -26196,6 +28165,23 @@
             "type": "toggle",
             "tooltip": "Changes the Fast & Furious collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_fast",
+            "label": "Fast & Furious Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_fast",
+              "visible_library_fast",
+              "visible_shared_fast"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_marvel",
@@ -26219,6 +28205,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_marvel",
+            "label": "In Association with Marvel Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_marvel",
+              "visible_library_marvel",
+              "visible_shared_marvel"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_mcu",
             "label": "Marvel Cinematic Universe Visible Home",
             "type": "toggle",
@@ -26238,6 +28241,23 @@
             "type": "toggle",
             "tooltip": "Changes the Marvel Cinematic Universe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_mcu",
+            "label": "Marvel Cinematic Universe Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_mcu",
+              "visible_library_mcu",
+              "visible_shared_mcu"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_middle",
@@ -26261,6 +28281,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_middle",
+            "label": "Middle Earth Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_middle",
+              "visible_library_middle",
+              "visible_shared_middle"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_rocky",
             "label": "Rocky / Creed Visible Home",
             "type": "toggle",
@@ -26280,6 +28317,23 @@
             "type": "toggle",
             "tooltip": "Changes the Rocky / Creed collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_rocky",
+            "label": "Rocky / Creed Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_rocky",
+              "visible_library_rocky",
+              "visible_shared_rocky"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_trek",
@@ -26303,6 +28357,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_trek",
+            "label": "Star Trek Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_trek",
+              "visible_library_trek",
+              "visible_shared_trek"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_star",
             "label": "Star Wars Universe Visible Home",
             "type": "toggle",
@@ -26322,6 +28393,23 @@
             "type": "toggle",
             "tooltip": "Changes the Star Wars Universe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_star",
+            "label": "Star Wars Universe Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_star",
+              "visible_library_star",
+              "visible_shared_star"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_mummy",
@@ -26345,6 +28433,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_mummy",
+            "label": "The Mummy Universe Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_mummy",
+              "visible_library_mummy",
+              "visible_shared_mummy"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_askew",
             "label": "View Askewverse Visible Home",
             "type": "toggle",
@@ -26364,6 +28469,23 @@
             "type": "toggle",
             "tooltip": "Changes the View Askewverse collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_askew",
+            "label": "View Askewverse Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_askew",
+              "visible_library_askew",
+              "visible_shared_askew"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_wizard",
@@ -26387,6 +28509,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_wizard",
+            "label": "Wizarding World Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_wizard",
+              "visible_library_wizard",
+              "visible_shared_wizard"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_xmen",
             "label": "X-Men Universe Visible Home",
             "type": "toggle",
@@ -26406,6 +28545,23 @@
             "type": "toggle",
             "tooltip": "Changes the X-Men Universe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_xmen",
+            "label": "X-Men Universe Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_xmen",
+              "visible_library_xmen",
+              "visible_shared_xmen"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "collection_order",
@@ -27084,6 +29240,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_books",
             "label": "Based on a Book Visible Home",
             "type": "toggle",
@@ -27103,6 +29276,23 @@
             "type": "toggle",
             "tooltip": "Changes the Based on a Book collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_books",
+            "label": "Based on a Book Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_books",
+              "visible_library_books",
+              "visible_shared_books"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_comics",
@@ -27126,6 +29316,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_comics",
+            "label": "Based on a Comic Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_comics",
+              "visible_library_comics",
+              "visible_shared_comics"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_true_story",
             "label": "Based on a True Story Visible Home",
             "type": "toggle",
@@ -27147,6 +29354,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_true_story",
+            "label": "Based on a True Story Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_true_story",
+              "visible_library_true_story",
+              "visible_shared_true_story"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_video_games",
             "label": "Based on a Video Game Visible Home",
             "type": "toggle",
@@ -27166,6 +29390,23 @@
             "type": "toggle",
             "tooltip": "Changes the Based on a Video Game collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_video_games",
+            "label": "Based on a Video Game Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_video_games",
+              "visible_library_video_games",
+              "visible_shared_video_games"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "sort_by",
@@ -28303,6 +30544,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_other",
             "label": "Other Visible Home",
             "type": "toggle",
@@ -28322,6 +30580,23 @@
             "type": "toggle",
             "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_other",
+            "label": "Other Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_other",
+              "visible_library_other",
+              "visible_shared_other"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "sort_by",
@@ -28887,6 +31162,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_other",
             "label": "Other Visible Home",
             "type": "toggle",
@@ -28906,6 +31198,23 @@
             "type": "toggle",
             "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_other",
+            "label": "Other Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_other",
+              "visible_library_other",
+              "visible_shared_other"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "sort_by",
@@ -29472,6 +31781,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_other",
             "label": "Other Visible Home",
             "type": "toggle",
@@ -29491,6 +31817,23 @@
             "type": "toggle",
             "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_other",
+            "label": "Other Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_other",
+              "visible_library_other",
+              "visible_shared_other"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "sort_by",
@@ -30067,6 +32410,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_other",
             "label": "Other Visible Home",
             "type": "toggle",
@@ -30086,6 +32446,23 @@
             "type": "toggle",
             "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_other",
+            "label": "Other Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_other",
+              "visible_library_other",
+              "visible_shared_other"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "sort_by",
@@ -30662,6 +33039,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_other",
             "label": "Other Visible Home",
             "type": "toggle",
@@ -30681,6 +33075,23 @@
             "type": "toggle",
             "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_other",
+            "label": "Other Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_other",
+              "visible_library_other",
+              "visible_shared_other"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "sort_by",
@@ -31257,6 +33668,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_other",
             "label": "Other Visible Home",
             "type": "toggle",
@@ -31276,6 +33704,23 @@
             "type": "toggle",
             "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_other",
+            "label": "Other Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_other",
+              "visible_library_other",
+              "visible_shared_other"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "sort_by",
@@ -31852,6 +34297,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_other",
             "label": "Other Visible Home",
             "type": "toggle",
@@ -31871,6 +34333,23 @@
             "type": "toggle",
             "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_other",
+            "label": "Other Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_other",
+              "visible_library_other",
+              "visible_shared_other"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "sort_by",
@@ -32447,6 +34926,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_other",
             "label": "Other Visible Home",
             "type": "toggle",
@@ -32466,6 +34962,23 @@
             "type": "toggle",
             "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_other",
+            "label": "Other Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_other",
+              "visible_library_other",
+              "visible_shared_other"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "sort_by",
@@ -33085,6 +35598,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_other",
             "label": "Other Visible Home",
             "type": "toggle",
@@ -33104,6 +35634,23 @@
             "type": "toggle",
             "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_other",
+            "label": "Other Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_other",
+              "visible_library_other",
+              "visible_shared_other"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "sort_by",
@@ -33697,6 +36244,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_other",
             "label": "Other Visible Home",
             "type": "toggle",
@@ -33716,6 +36280,23 @@
             "type": "toggle",
             "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_other",
+            "label": "Other Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_other",
+              "visible_library_other",
+              "visible_shared_other"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "sort_by",
@@ -35010,6 +37591,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_Northern Africa",
             "label": "Northern Africa Visible Home",
             "type": "toggle",
@@ -35029,6 +37627,23 @@
             "type": "toggle",
             "tooltip": "Changes the Northern Africa collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_Northern Africa",
+            "label": "Northern Africa Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Northern Africa",
+              "visible_library_Northern Africa",
+              "visible_shared_Northern Africa"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_Eastern Africa",
@@ -35052,6 +37667,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_Eastern Africa",
+            "label": "Eastern Africa Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Eastern Africa",
+              "visible_library_Eastern Africa",
+              "visible_shared_Eastern Africa"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_Central Africa",
             "label": "Central Africa Visible Home",
             "type": "toggle",
@@ -35071,6 +37703,23 @@
             "type": "toggle",
             "tooltip": "Changes the Central Africa collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_Central Africa",
+            "label": "Central Africa Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Central Africa",
+              "visible_library_Central Africa",
+              "visible_shared_Central Africa"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_Southern Africa",
@@ -35094,6 +37743,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_Southern Africa",
+            "label": "Southern Africa Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Southern Africa",
+              "visible_library_Southern Africa",
+              "visible_shared_Southern Africa"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_Western Africa",
             "label": "Western Africa Visible Home",
             "type": "toggle",
@@ -35113,6 +37779,23 @@
             "type": "toggle",
             "tooltip": "Changes the Western Africa collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_Western Africa",
+            "label": "Western Africa Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Western Africa",
+              "visible_library_Western Africa",
+              "visible_shared_Western Africa"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_Caribbean",
@@ -35136,6 +37819,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_Caribbean",
+            "label": "Caribbean Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Caribbean",
+              "visible_library_Caribbean",
+              "visible_shared_Caribbean"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_Central America",
             "label": "Central America Visible Home",
             "type": "toggle",
@@ -35155,6 +37855,23 @@
             "type": "toggle",
             "tooltip": "Changes the Central America collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_Central America",
+            "label": "Central America Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Central America",
+              "visible_library_Central America",
+              "visible_shared_Central America"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_South America",
@@ -35178,6 +37895,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_South America",
+            "label": "South America Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_South America",
+              "visible_library_South America",
+              "visible_shared_South America"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_North America",
             "label": "North America Visible Home",
             "type": "toggle",
@@ -35197,6 +37931,23 @@
             "type": "toggle",
             "tooltip": "Changes the North America collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_North America",
+            "label": "North America Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_North America",
+              "visible_library_North America",
+              "visible_shared_North America"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_Antarctica",
@@ -35220,6 +37971,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_Antarctica",
+            "label": "Antarctica Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Antarctica",
+              "visible_library_Antarctica",
+              "visible_shared_Antarctica"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_Central Asia",
             "label": "Central Asia Visible Home",
             "type": "toggle",
@@ -35239,6 +38007,23 @@
             "type": "toggle",
             "tooltip": "Changes the Central Asia collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_Central Asia",
+            "label": "Central Asia Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Central Asia",
+              "visible_library_Central Asia",
+              "visible_shared_Central Asia"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_Eastern Asia",
@@ -35262,6 +38047,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_Eastern Asia",
+            "label": "Eastern Asia Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Eastern Asia",
+              "visible_library_Eastern Asia",
+              "visible_shared_Eastern Asia"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_South-Eastern Asia",
             "label": "South-Eastern Asia Visible Home",
             "type": "toggle",
@@ -35281,6 +38083,23 @@
             "type": "toggle",
             "tooltip": "Changes the South-Eastern Asia collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_South-Eastern Asia",
+            "label": "South-Eastern Asia Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_South-Eastern Asia",
+              "visible_library_South-Eastern Asia",
+              "visible_shared_South-Eastern Asia"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_Southern Asia",
@@ -35304,6 +38123,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_Southern Asia",
+            "label": "Southern Asia Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Southern Asia",
+              "visible_library_Southern Asia",
+              "visible_shared_Southern Asia"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_Western Asia",
             "label": "Western Asia Visible Home",
             "type": "toggle",
@@ -35323,6 +38159,23 @@
             "type": "toggle",
             "tooltip": "Changes the Western Asia collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_Western Asia",
+            "label": "Western Asia Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Western Asia",
+              "visible_library_Western Asia",
+              "visible_shared_Western Asia"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_Eastern Europe",
@@ -35346,6 +38199,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_Eastern Europe",
+            "label": "Eastern Europe Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Eastern Europe",
+              "visible_library_Eastern Europe",
+              "visible_shared_Eastern Europe"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_Northern Europe",
             "label": "Northern Europe Visible Home",
             "type": "toggle",
@@ -35365,6 +38235,23 @@
             "type": "toggle",
             "tooltip": "Changes the Northern Europe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_Northern Europe",
+            "label": "Northern Europe Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Northern Europe",
+              "visible_library_Northern Europe",
+              "visible_shared_Northern Europe"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_Southern Europe",
@@ -35388,6 +38275,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_Southern Europe",
+            "label": "Southern Europe Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Southern Europe",
+              "visible_library_Southern Europe",
+              "visible_shared_Southern Europe"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_Western Europe",
             "label": "Western Europe Visible Home",
             "type": "toggle",
@@ -35407,6 +38311,23 @@
             "type": "toggle",
             "tooltip": "Changes the Western Europe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_Western Europe",
+            "label": "Western Europe Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Western Europe",
+              "visible_library_Western Europe",
+              "visible_shared_Western Europe"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_Australia and New Zealand",
@@ -35430,6 +38351,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_Australia and New Zealand",
+            "label": "Australia and New Zealand Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Australia and New Zealand",
+              "visible_library_Australia and New Zealand",
+              "visible_shared_Australia and New Zealand"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_Melanesia",
             "label": "Melanesia Visible Home",
             "type": "toggle",
@@ -35449,6 +38387,23 @@
             "type": "toggle",
             "tooltip": "Changes the Melanesia collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_Melanesia",
+            "label": "Melanesia Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Melanesia",
+              "visible_library_Melanesia",
+              "visible_shared_Melanesia"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_Micronesia",
@@ -35472,6 +38427,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_Micronesia",
+            "label": "Micronesia Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Micronesia",
+              "visible_library_Micronesia",
+              "visible_shared_Micronesia"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_Polynesia",
             "label": "Polynesia Visible Home",
             "type": "toggle",
@@ -35493,6 +38465,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_Polynesia",
+            "label": "Polynesia Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Polynesia",
+              "visible_library_Polynesia",
+              "visible_shared_Polynesia"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_other",
             "label": "Other Regions Visible Home",
             "type": "toggle",
@@ -35512,6 +38501,23 @@
             "type": "toggle",
             "tooltip": "Changes the Other Regions collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_other",
+            "label": "Other Regions Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_other",
+              "visible_library_other",
+              "visible_shared_other"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "sort_by",
@@ -36296,6 +39302,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_Africa",
             "label": "Africa Visible Home",
             "type": "toggle",
@@ -36315,6 +39338,23 @@
             "type": "toggle",
             "tooltip": "Changes the Africa collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_Africa",
+            "label": "Africa Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Africa",
+              "visible_library_Africa",
+              "visible_shared_Africa"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_Americas",
@@ -36338,6 +39378,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_Americas",
+            "label": "Americas Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Americas",
+              "visible_library_Americas",
+              "visible_shared_Americas"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_Antarctica",
             "label": "Antarctica Visible Home",
             "type": "toggle",
@@ -36357,6 +39414,23 @@
             "type": "toggle",
             "tooltip": "Changes the Antarctica collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_Antarctica",
+            "label": "Antarctica Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Antarctica",
+              "visible_library_Antarctica",
+              "visible_shared_Antarctica"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_Asia",
@@ -36380,6 +39454,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_Asia",
+            "label": "Asia Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Asia",
+              "visible_library_Asia",
+              "visible_shared_Asia"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_Europe",
             "label": "Europe Visible Home",
             "type": "toggle",
@@ -36399,6 +39490,23 @@
             "type": "toggle",
             "tooltip": "Changes the Europe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_Europe",
+            "label": "Europe Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Europe",
+              "visible_library_Europe",
+              "visible_shared_Europe"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_Oceania",
@@ -36422,6 +39530,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_Oceania",
+            "label": "Oceania Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_Oceania",
+              "visible_library_Oceania",
+              "visible_shared_Oceania"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_other",
             "label": "Other Continents Visible Home",
             "type": "toggle",
@@ -36441,6 +39566,23 @@
             "type": "toggle",
             "tooltip": "Changes the Other Continents collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_other",
+            "label": "Other Continents Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_other",
+              "visible_library_other",
+              "visible_shared_other"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "sort_by",
@@ -37219,6 +40361,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_1.33",
             "label": "1.33 - Academy Aperture Visible Home",
             "type": "toggle",
@@ -37238,6 +40397,23 @@
             "type": "toggle",
             "tooltip": "Changes the 1.33 - Academy Aperture collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_1.33",
+            "label": "1.33 - Academy Aperture Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_1.33",
+              "visible_library_1.33",
+              "visible_shared_1.33"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_1.65",
@@ -37261,6 +40437,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_1.65",
+            "label": "1.65 - Early Widescreen Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_1.65",
+              "visible_library_1.65",
+              "visible_shared_1.65"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_1.66",
             "label": "1.66 - European Widescreen Visible Home",
             "type": "toggle",
@@ -37280,6 +40473,23 @@
             "type": "toggle",
             "tooltip": "Changes the 1.66 - European Widescreen collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_1.66",
+            "label": "1.66 - European Widescreen Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_1.66",
+              "visible_library_1.66",
+              "visible_shared_1.66"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_1.78",
@@ -37303,6 +40513,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_1.78",
+            "label": "1.78 - Widescreen TV Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_1.78",
+              "visible_library_1.78",
+              "visible_shared_1.78"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_1.85",
             "label": "1.85 - American Widescreen Visible Home",
             "type": "toggle",
@@ -37322,6 +40549,23 @@
             "type": "toggle",
             "tooltip": "Changes the 1.85 - American Widescreen collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_1.85",
+            "label": "1.85 - American Widescreen Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_1.85",
+              "visible_library_1.85",
+              "visible_shared_1.85"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_2.2",
@@ -37345,6 +40589,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_2.2",
+            "label": "2.2 - 70mm Frame Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_2.2",
+              "visible_library_2.2",
+              "visible_shared_2.2"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_2.35",
             "label": "2.35 - Anamorphic Projection Visible Home",
             "type": "toggle",
@@ -37366,6 +40627,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_2.35",
+            "label": "2.35 - Anamorphic Projection Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_2.35",
+              "visible_library_2.35",
+              "visible_shared_2.35"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_2.77",
             "label": "2.77 - Cinerama Visible Home",
             "type": "toggle",
@@ -37385,6 +40663,23 @@
             "type": "toggle",
             "tooltip": "Changes the 2.77 - Cinerama collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_2.77",
+            "label": "2.77 - Cinerama Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_2.77",
+              "visible_library_2.77",
+              "visible_shared_2.77"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "sort_by",
@@ -37921,6 +41216,23 @@
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "sort_by",
@@ -38482,6 +41794,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_other",
             "label": "Other Visible Home",
             "type": "toggle",
@@ -38501,6 +41830,23 @@
             "type": "toggle",
             "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_other",
+            "label": "Other Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_other",
+              "visible_library_other",
+              "visible_shared_other"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "sort_by",
@@ -39062,6 +42408,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_other",
             "label": "Other Visible Home",
             "type": "toggle",
@@ -39081,6 +42444,23 @@
             "type": "toggle",
             "tooltip": "Changes the Other collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_other",
+            "label": "Other Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_other",
+              "visible_library_other",
+              "visible_shared_other"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "sort_by",
@@ -39661,6 +43041,23 @@
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "sort_by",
@@ -40245,6 +43642,26 @@
             ]
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "sort_by",
             "label": "Sort By",
             "type": "select",
@@ -40817,6 +44234,26 @@
             ]
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "sort_by",
             "label": "Sort By",
             "type": "select",
@@ -41384,6 +44821,26 @@
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -43272,6 +46729,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_appletv",
             "label": "Apple TV Movies/Shows Visible Home",
             "type": "toggle",
@@ -43291,6 +46765,23 @@
             "type": "toggle",
             "tooltip": "Changes the Apple TV Movies/Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_appletv",
+            "label": "Apple TV Movies/Shows Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_appletv",
+              "visible_library_appletv",
+              "visible_shared_appletv"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_bet",
@@ -43314,6 +46805,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_bet",
+            "label": "BET+ Movies/Shows Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_bet",
+              "visible_library_bet",
+              "visible_shared_bet"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_channel4",
             "label": "Channel 4 Movies/Shows Visible Home",
             "type": "toggle",
@@ -43333,6 +46841,23 @@
             "type": "toggle",
             "tooltip": "Changes the Channel 4 Movies/Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_channel4",
+            "label": "Channel 4 Movies/Shows Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_channel4",
+              "visible_library_channel4",
+              "visible_shared_channel4"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_crave",
@@ -43356,6 +46881,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_crave",
+            "label": "Crave Movies/Shows Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_crave",
+              "visible_library_crave",
+              "visible_shared_crave"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_crunchyroll",
             "label": "Crunchyroll Shows Visible Home",
             "type": "toggle",
@@ -43375,6 +46917,23 @@
             "type": "toggle",
             "tooltip": "Changes the Crunchyroll Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_crunchyroll",
+            "label": "Crunchyroll Shows Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_crunchyroll",
+              "visible_library_crunchyroll",
+              "visible_shared_crunchyroll"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_discovery",
@@ -43398,6 +46957,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_discovery",
+            "label": "discovery+ Shows Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_discovery",
+              "visible_library_discovery",
+              "visible_shared_discovery"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_disney",
             "label": "Disney+ Movies/Shows Visible Home",
             "type": "toggle",
@@ -43417,6 +46993,23 @@
             "type": "toggle",
             "tooltip": "Changes the Disney+ Movies/Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_disney",
+            "label": "Disney+ Movies/Shows Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_disney",
+              "visible_library_disney",
+              "visible_shared_disney"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_hayu",
@@ -43440,6 +47033,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_hayu",
+            "label": "Hayu Shows Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_hayu",
+              "visible_library_hayu",
+              "visible_shared_hayu"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_hulu",
             "label": "Hulu Movies/Shows Visible Home",
             "type": "toggle",
@@ -43459,6 +47069,23 @@
             "type": "toggle",
             "tooltip": "Changes the Hulu Movies/Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_hulu",
+            "label": "Hulu Movies/Shows Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_hulu",
+              "visible_library_hulu",
+              "visible_shared_hulu"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_itvx",
@@ -43482,6 +47109,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_itvx",
+            "label": "ITVX Movies/Shows Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_itvx",
+              "visible_library_itvx",
+              "visible_shared_itvx"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_hbomax",
             "label": "HBO Max Movies/Shows Visible Home",
             "type": "toggle",
@@ -43501,6 +47145,23 @@
             "type": "toggle",
             "tooltip": "Changes the HBO Max Movies/Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_hbomax",
+            "label": "HBO Max Movies/Shows Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_hbomax",
+              "visible_library_hbomax",
+              "visible_shared_hbomax"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_netflix",
@@ -43524,6 +47185,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_netflix",
+            "label": "Netflix Movies/Shows Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_netflix",
+              "visible_library_netflix",
+              "visible_shared_netflix"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_now",
             "label": "NOW Movies/Shows Visible Home",
             "type": "toggle",
@@ -43543,6 +47221,23 @@
             "type": "toggle",
             "tooltip": "Changes the NOW Movies/Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_now",
+            "label": "NOW Movies/Shows Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_now",
+              "visible_library_now",
+              "visible_shared_now"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_paramount",
@@ -43566,6 +47261,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_paramount",
+            "label": "Paramount+ Movies/Shows Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_paramount",
+              "visible_library_paramount",
+              "visible_shared_paramount"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_peacock",
             "label": "Peacock Movies/Shows Visible Home",
             "type": "toggle",
@@ -43585,6 +47297,23 @@
             "type": "toggle",
             "tooltip": "Changes the Peacock Movies/Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_peacock",
+            "label": "Peacock Movies/Shows Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_peacock",
+              "visible_library_peacock",
+              "visible_shared_peacock"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "visible_home_amazon",
@@ -43608,6 +47337,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_amazon",
+            "label": "Prime Video Movies/Shows Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_amazon",
+              "visible_library_amazon",
+              "visible_shared_amazon"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_youtube",
             "label": "YouTube Movies/Shows Visible Home",
             "type": "toggle",
@@ -43629,6 +47375,23 @@
             "default": false
           },
           {
+            "key": "hub_priority_youtube",
+            "label": "YouTube Movies/Shows Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_youtube",
+              "visible_library_youtube",
+              "visible_shared_youtube"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "visible_home_tubi",
             "label": "tubi Movies/Shows Visible Home",
             "type": "toggle",
@@ -43648,6 +47411,23 @@
             "type": "toggle",
             "tooltip": "Changes the tubi Movies/Shows collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority_tubi",
+            "label": "tubi Movies/Shows Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_tubi",
+              "visible_library_tubi",
+              "visible_shared_tubi"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "sort_by",
@@ -44157,6 +47937,23 @@
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "sort_by",
@@ -44698,6 +48495,23 @@
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "sort_by",
@@ -46631,6 +50445,26 @@
             ]
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_aapi",
             "label": "Asian American Pacific Islander Movies Visible Home",
             "type": "toggle",
@@ -46656,6 +50490,26 @@
             "type": "toggle",
             "tooltip": "Changes the Asian American Pacific Islander Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_aapi",
+            "label": "Asian American Pacific Islander Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_aapi",
+              "visible_library_aapi",
+              "visible_shared_aapi"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -46691,6 +50545,26 @@
             ]
           },
           {
+            "key": "hub_priority_black_history",
+            "label": "Black History Month Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_black_history",
+              "visible_library_black_history",
+              "visible_shared_black_history"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_christmas",
             "label": "Christmas Movies Visible Home",
             "type": "toggle",
@@ -46716,6 +50590,26 @@
             "type": "toggle",
             "tooltip": "Changes the Christmas Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_christmas",
+            "label": "Christmas Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_christmas",
+              "visible_library_christmas",
+              "visible_shared_christmas"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -46751,6 +50645,26 @@
             ]
           },
           {
+            "key": "hub_priority_disabilities",
+            "label": "Disability Month Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_disabilities",
+              "visible_library_disabilities",
+              "visible_shared_disabilities"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_easter",
             "label": "Easter Movies Visible Home",
             "type": "toggle",
@@ -46776,6 +50690,26 @@
             "type": "toggle",
             "tooltip": "Changes the Easter Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_easter",
+            "label": "Easter Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_easter",
+              "visible_library_easter",
+              "visible_shared_easter"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -46811,6 +50745,26 @@
             ]
           },
           {
+            "key": "hub_priority_father",
+            "label": "Father's Day Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_father",
+              "visible_library_father",
+              "visible_shared_father"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_halloween",
             "label": "Halloween Movies Visible Home",
             "type": "toggle",
@@ -46836,6 +50790,26 @@
             "type": "toggle",
             "tooltip": "Changes the Halloween Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_halloween",
+            "label": "Halloween Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_halloween",
+              "visible_library_halloween",
+              "visible_shared_halloween"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -46871,6 +50845,26 @@
             ]
           },
           {
+            "key": "hub_priority_independence",
+            "label": "Independence Day Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_independence",
+              "visible_library_independence",
+              "visible_shared_independence"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_labor",
             "label": "Labor Day Movies Visible Home",
             "type": "toggle",
@@ -46896,6 +50890,26 @@
             "type": "toggle",
             "tooltip": "Changes the Labor Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_labor",
+            "label": "Labor Day Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_labor",
+              "visible_library_labor",
+              "visible_shared_labor"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -46931,6 +50945,26 @@
             ]
           },
           {
+            "key": "hub_priority_lgbtq",
+            "label": "LGBTQ Month Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_lgbtq",
+              "visible_library_lgbtq",
+              "visible_shared_lgbtq"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_memorial",
             "label": "Memorial Day Movies Visible Home",
             "type": "toggle",
@@ -46956,6 +50990,26 @@
             "type": "toggle",
             "tooltip": "Changes the Memorial Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_memorial",
+            "label": "Memorial Day Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_memorial",
+              "visible_library_memorial",
+              "visible_shared_memorial"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -46991,6 +51045,26 @@
             ]
           },
           {
+            "key": "hub_priority_mother",
+            "label": "Mother's Day Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_mother",
+              "visible_library_mother",
+              "visible_shared_mother"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_latinx",
             "label": "National Hispanic Heritage Movies Visible Home",
             "type": "toggle",
@@ -47016,6 +51090,26 @@
             "type": "toggle",
             "tooltip": "Changes the National Hispanic Heritage Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_latinx",
+            "label": "National Hispanic Heritage Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_latinx",
+              "visible_library_latinx",
+              "visible_shared_latinx"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -47051,6 +51145,26 @@
             ]
           },
           {
+            "key": "hub_priority_years",
+            "label": "New Year's Day Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_years",
+              "visible_library_years",
+              "visible_shared_years"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_patrick",
             "label": "St. Patrick's Day Movies Visible Home",
             "type": "toggle",
@@ -47076,6 +51190,26 @@
             "type": "toggle",
             "tooltip": "Changes the St. Patrick's Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_patrick",
+            "label": "St. Patrick's Day Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_patrick",
+              "visible_library_patrick",
+              "visible_shared_patrick"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -47111,6 +51245,26 @@
             ]
           },
           {
+            "key": "hub_priority_thanksgiving",
+            "label": "Thanksgiving Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_thanksgiving",
+              "visible_library_thanksgiving",
+              "visible_shared_thanksgiving"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_valentine",
             "label": "Valentine's Day Movies Visible Home",
             "type": "toggle",
@@ -47136,6 +51290,26 @@
             "type": "toggle",
             "tooltip": "Changes the Valentine's Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_valentine",
+            "label": "Valentine's Day Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_valentine",
+              "visible_library_valentine",
+              "visible_shared_valentine"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -47171,6 +51345,26 @@
             ]
           },
           {
+            "key": "hub_priority_veteran",
+            "label": "Veteran's Day Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_veteran",
+              "visible_library_veteran",
+              "visible_shared_veteran"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
             "key": "visible_home_women",
             "label": "Women's History Month Movies Visible Home",
             "type": "toggle",
@@ -47196,6 +51390,26 @@
             "type": "toggle",
             "tooltip": "Changes the Women's History Month Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "hub_priority_women",
+            "label": "Women's History Month Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_women",
+              "visible_library_women",
+              "visible_shared_women"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
             "media_types": [
               "movie"
             ]
@@ -47754,6 +51968,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "sort_by",
             "label": "Sort By",
             "type": "select",
@@ -48260,6 +52491,23 @@
             "default": false
           },
           {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+          },
+          {
             "key": "sort_by",
             "label": "Sort By",
             "type": "select",
@@ -48754,6 +53002,23 @@
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
           },
           {
             "key": "sort_by",

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -1982,6 +1982,58 @@ document.addEventListener('DOMContentLoaded', function () {
         input.disabled = !!disabled
       }
 
+      function syncTemplateRequirementState (group) {
+        if (!group) return
+
+        const fieldByKey = new Map()
+        Array.from(group.querySelectorAll('[data-template-variable-key]')).forEach(field => {
+          const key = String(field.dataset.templateVariableKey || '').trim()
+          if (key && !fieldByKey.has(key)) fieldByKey.set(key, field)
+        })
+
+        const dependentFields = Array.from(group.querySelectorAll('[data-template-variable-key][data-requires-any-of-template-keys]'))
+        dependentFields.forEach(field => {
+          if (field.dataset.requirementBaseDisabled === undefined) {
+            field.dataset.requirementBaseDisabled = field.disabled ? 'true' : 'false'
+          }
+
+          const baseDisabled = field.dataset.requirementBaseDisabled === 'true'
+          const requiresPlexPass = field.dataset.requiresPlexPass === 'true'
+          const plexPassAvailable = field.dataset.plexPassAvailable !== 'false'
+          const wrapper = field.closest('[data-collection-field-wrapper="true"]')
+          const requiredKeys = String(field.dataset.requiresAnyOfTemplateKeys || '')
+            .split(',')
+            .map(key => key.trim())
+            .filter(Boolean)
+          const anyActive = requiredKeys.some(key => isActiveField(fieldByKey.get(key)))
+          const shouldDisableForDependency = !anyActive
+          const shouldDisable = baseDisabled || (requiresPlexPass && !plexPassAvailable) || shouldDisableForDependency
+
+          field.disabled = shouldDisable
+
+          if (!wrapper || (requiresPlexPass && !plexPassAvailable)) return
+
+          const hintId = field.id ? `${field.id}_requirement_hint` : ''
+          let hint = hintId ? group.querySelector(`[data-requirement-hint-for="${field.id}"]`) : null
+          if (!hint && hintId) {
+            hint = document.createElement('div')
+            hint.className = 'form-text text-warning mb-2 d-none'
+            hint.id = hintId
+            hint.dataset.requirementHintFor = field.id
+            wrapper.insertAdjacentElement('afterend', hint)
+          }
+          if (!hint) return
+
+          if (shouldDisableForDependency) {
+            hint.textContent = String(field.dataset.requirementHint || 'Requires one of Visible Home, Visible Library, or Visible Shared to be enabled first.').trim()
+            hint.classList.remove('d-none')
+          } else {
+            hint.classList.add('d-none')
+            hint.textContent = ''
+          }
+        })
+      }
+
       function syncMutualState (group) {
         if (!group) return
         const fields = Array.from(group.querySelectorAll('[data-template-variable-key][data-mutually-exclusive-with]'))
@@ -2063,14 +2115,17 @@ document.addEventListener('DOMContentLoaded', function () {
           input.addEventListener('input', () => {
             normalizeFieldValue(input)
             syncMutualState(group)
+            syncTemplateRequirementState(group)
           })
           input.addEventListener('change', () => {
             normalizeFieldValue(input)
             syncMutualState(group)
+            syncTemplateRequirementState(group)
           })
         })
 
         syncMutualState(group)
+        syncTemplateRequirementState(group)
         group.dataset.templateFieldRulesBound = 'true'
       })
     }

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -1221,6 +1221,7 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                     {% set ordered_collection_items = prioritized_collection_items.priority + prioritized_collection_items.remaining %}
                     {% endif %}
                     {% set season = namespace(open=false) %}
+                    {% set has_plex_pass = telemetry is mapping and telemetry.get("plex_pass") is sameas true %}
                     <div class="child-toggle-wrapper ms-4 mt-2"
                         data-toggle-parent="{{ library.id }}-{{ collection.id }}" style="display: none;">
                         <div class="d-flex align-items-center gap-2 flex-wrap mb-2">
@@ -1233,6 +1234,8 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                         and (not item.key.startswith('visible_') or telemetry.plex_pass) %}
                         {% set clean_id = collection.id.replace('collection_', '') %}
                         {% set input_name = (library.id ~ '-template_collection_' ~ clean_id ~ '_' ~ item.key) if item.key is defined else '' %}
+                        {% set field_requires_plex_pass = item.requires_plex_pass is defined and item.requires_plex_pass %}
+                        {% set field_disabled = disable_toggle or (field_requires_plex_pass and not has_plex_pass) %}
 
                         {% if is_seasonal and item.key is defined and item.key.startswith('use_') %}
                         {% if season.open %}
@@ -1254,7 +1257,7 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                 data-default="{{ item.default | default('false', true) }}"
                                 {% if item.key is defined %}data-template-variable-key="{{ item.key }}"{% endif %}
                                 {% if item.mutually_exclusive_with %}data-mutually-exclusive-with="{{ item.mutually_exclusive_with }}"{% endif %}
-                                {% if disable_toggle
+                                {% if field_disabled
                                 %}disabled{% endif %} {% if not disable_toggle and
                                 (stored_true or (not has_stored and default_true)) %}checked{% endif %}>
                             <input type="hidden" name="{{ input_name }}" value="false">
@@ -1266,7 +1269,7 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                         </div>
                         {% elif item.type == 'select' %}
                         {% set stored_select_val = data['libraries'].get(input_name, item.default) | default('', true) %}
-                        <div class="input-group mb-2">
+                        <div class="input-group mb-2" data-collection-field-wrapper="true">
                             <span class="input-group-text" id="{{ input_name }}_text" style="width: 170px;">
                                 {{ item.label }}
                                 {% if item.tooltip %}
@@ -1319,6 +1322,10 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                 {% endif %}
                             </select>
                         </div>
+                        {% if field_requires_plex_pass and not has_plex_pass %}
+                        <input type="hidden" name="{{ input_name }}" value="{{ stored_select_val }}">
+                        <div class="form-text text-warning mb-2">Requires Plex Pass. Validate Plex first if this should be available.</div>
+                        {% endif %}
                         {% set preview_options = [] %}
                         {% if item.options is defined %}
                         {% for val in item.options %}
@@ -1446,7 +1453,7 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                             {'value': 'relative_latest', 'label': 'Relative Latest (latest-#)', 'kind': 'relative', 'prefix': 'latest-'},
                             {'value': 'year', 'label': 'Specific Year', 'kind': 'year'}
                         ] %}
-                        {% set label_width = item.label_width if item.label_width is defined else ((320 if item.label|length > 24 else 240) if item.key is defined and (item.key.startswith('limit_') or item.key.startswith('list_days_') or item.key.startswith('list_size_')) else 170) %}
+                        {% set label_width = item.label_width if item.label_width is defined else ((320 if item.label|length > 24 else 240) if item.key is defined and (item.key.startswith('limit_') or item.key.startswith('list_days_') or item.key.startswith('list_size_') or item.key.startswith('hub_priority_')) else 170) %}
                         <div class="input-group mb-2" data-relative-year data-hidden-input="{{ input_name }}"
                             data-default-value="{{ item.default | default('', true) }}"
                             data-min-year="{{ item.min | default(1) }}">
@@ -1607,8 +1614,8 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                         </div>
                         {% elif item.type == 'text_input' %}
                         {% set is_number_input = item.input_type is defined and item.input_type == 'number' %}
-                        {% set label_width = item.label_width if item.label_width is defined else ((320 if item.label|length > 24 else 240) if item.key is defined and (item.key.startswith('limit_') or item.key.startswith('list_days_') or item.key.startswith('list_size_')) else 170) %}
-                        <div class="input-group mb-2">
+                        {% set label_width = item.label_width if item.label_width is defined else ((320 if item.label|length > 24 else 240) if item.key is defined and (item.key.startswith('limit_') or item.key.startswith('list_days_') or item.key.startswith('list_size_') or item.key.startswith('hub_priority_')) else 170) %}
+                        <div class="input-group mb-2" data-collection-field-wrapper="true">
                             <span class="input-group-text qs-template-variable-label" id="{{ input_name }}_text" style="width: {{ label_width }}px;">
                                 {% if item.url %}
                                 <a href="{{ item.url }}" target="_blank">
@@ -1629,6 +1636,8 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                 value="{{ data['libraries'].get(input_name, item.default) | default('', true) }}"
                                 data-default="{{ item.default | default('', true) }}"
                                 {% if item.key is defined %}data-template-variable-key="{{ item.key }}"{% endif %}
+                                {% if field_requires_plex_pass %}data-requires-plex-pass="true" data-plex-pass-available="{{ 'true' if has_plex_pass else 'false' }}"{% endif %}
+                                {% if item.requires_any_of_template_keys is defined and item.requires_any_of_template_keys %}data-requires-any-of-template-keys="{{ item.requires_any_of_template_keys | join(',') }}" data-requirement-hint="{{ item.requirement_hint | default('', true) }}"{% endif %}
                                 {% if item.mutually_exclusive_with %}data-mutually-exclusive-with="{{ item.mutually_exclusive_with }}"{% endif %}
                                 {% if item.validation_preset %}data-validation-preset="{{ item.validation_preset }}"{% endif %}
                                 {% if is_number_input %}
@@ -1643,8 +1652,12 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                 {% if item.inputmode is defined %}inputmode="{{ item.inputmode }}"{% endif %}
                                 {% if item.autocapitalize is defined %}autocapitalize="{{ item.autocapitalize }}"{% endif %}
                                 {% endif %}
-                                {% if disable_toggle %}disabled{% endif %}>
+                                {% if field_disabled %}disabled{% endif %}>
                         </div>
+                        {% if field_requires_plex_pass and not has_plex_pass %}
+                        <input type="hidden" name="{{ input_name }}" value="{{ data['libraries'].get(input_name, item.default) | default('', true) }}">
+                        <div class="form-text text-warning mb-2">Requires Plex Pass. Validate Plex first if this should be available.</div>
+                        {% endif %}
                         {% endif %}
 
                         {% if is_seasonal and item.key is defined and item.key.startswith('schedule_') and season.open %}

--- a/tests/test_collection_numeric_input_contract.py
+++ b/tests/test_collection_numeric_input_contract.py
@@ -5,11 +5,13 @@ EXACT_KEYS = {
     "data_depth",
     "data_limit",
     "discover_limit",
+    "hub_priority",
     "limit",
     "list_days",
     "list_size",
 }
 PREFIXES = (
+    "hub_priority_",
     "limit_",
     "list_days_",
     "list_size_",
@@ -74,7 +76,70 @@ def test_collection_child_numeric_inputs_use_wider_default_label_width_rule():
     path = Path(__file__).resolve().parents[1] / "templates" / "partials" / "_macros.html"
     template = path.read_text(encoding="utf-8")
 
-    expected_rule = "item.key.startswith('limit_') or item.key.startswith('list_days_') or item.key.startswith('list_size_')"
+    expected_rule = "item.key.startswith('limit_') or item.key.startswith('list_days_') or item.key.startswith('list_size_') or item.key.startswith('hub_priority_')"
     assert template.count(expected_rule) >= 2
     assert "320 if item.label|length > 24 else 240" in template
     assert "qs-template-variable-label" in template
+
+
+def test_collections_with_hub_visibility_controls_expose_hub_priority():
+    path = Path(__file__).resolve().parents[1] / "static" / "json" / "quickstart_collections.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    matched = 0
+    for group in payload:
+        if not isinstance(group, dict):
+            continue
+        for collection in group.get("collections", []):
+            if not isinstance(collection, dict):
+                continue
+            items = [item for item in collection.get("template_variables", []) if isinstance(item, dict)]
+            keys = {item.get("key") for item in items if isinstance(item.get("key"), str)}
+            if not {"visible_home", "visible_library", "visible_shared"}.issubset(keys):
+                continue
+            matched += 1
+            hub_priority = next((item for item in items if item.get("key") == "hub_priority"), None)
+            assert hub_priority is not None, collection.get("id")
+            assert hub_priority.get("type") == "text_input", collection.get("id")
+            assert hub_priority.get("input_type") == "number", collection.get("id")
+            assert hub_priority.get("min") == 1, collection.get("id")
+            assert hub_priority.get("step") == 1, collection.get("id")
+            assert hub_priority.get("requires_plex_pass") is True, collection.get("id")
+            assert hub_priority.get("requires_any_of_template_keys") == ["visible_home", "visible_library", "visible_shared"], collection.get("id")
+
+    assert matched > 0
+
+
+def test_collection_child_hub_priority_tracks_child_visibility_keys():
+    path = Path(__file__).resolve().parents[1] / "static" / "json" / "quickstart_collections.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    matched = 0
+    for group in payload:
+        if not isinstance(group, dict):
+            continue
+        for collection in group.get("collections", []):
+            if not isinstance(collection, dict):
+                continue
+            items = [item for item in collection.get("template_variables", []) if isinstance(item, dict)]
+            by_key = {item.get("key"): item for item in items if isinstance(item.get("key"), str)}
+            for key, item in by_key.items():
+                if not key.startswith("visible_shared_"):
+                    continue
+                suffix = key.removeprefix("visible_shared_")
+                matched += 1
+                child_hub_key = f"hub_priority_{suffix}"
+                child_hub = by_key.get(child_hub_key)
+                assert child_hub is not None, f"{collection.get('id')} missing {child_hub_key}"
+                assert child_hub.get("type") == "text_input", child_hub_key
+                assert child_hub.get("input_type") == "number", child_hub_key
+                assert child_hub.get("min") == 1, child_hub_key
+                assert child_hub.get("step") == 1, child_hub_key
+                assert child_hub.get("requires_plex_pass") is True, child_hub_key
+                assert child_hub.get("requires_any_of_template_keys") == [
+                    f"visible_home_{suffix}",
+                    f"visible_library_{suffix}",
+                    f"visible_shared_{suffix}",
+                ], child_hub_key
+
+    assert matched > 0

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -1338,6 +1338,49 @@ def test_build_libraries_section_normalizes_collection_arr_tag_lists(app):
     assert show_entry["template_variables"]["item_sonarr_tag"] == ["watched", "tracked"]
 
 
+def test_build_libraries_section_emits_collection_hub_priority(app):
+    from modules import output
+
+    with app.app_context():
+        libraries_section = output.build_libraries_section(
+            {"mov-library_movies-library": "Movies"},
+            {},
+            {
+                "movies": {
+                    "mov-library_movies-collection_content_rating_uk": True,
+                    "mov-library_movies-template_collection_content_rating_uk_visible_home": "true",
+                    "mov-library_movies-template_collection_content_rating_uk_hub_priority": "2",
+                    "mov-library_movies-template_collection_content_rating_uk_visible_home_12A": "true",
+                    "mov-library_movies-template_collection_content_rating_uk_hub_priority_12A": "1",
+                }
+            },
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+        )
+
+    movie_entry = next(
+        (entry for entry in libraries_section["libraries"]["Movies"]["collection_files"] if entry.get("default") == "content_rating_uk"),
+        None,
+    )
+
+    assert movie_entry is not None
+    assert movie_entry["template_variables"]["visible_home"] is True
+    assert movie_entry["template_variables"]["hub_priority"] == "2"
+    assert movie_entry["template_variables"]["visible_home_12A"] is True
+    assert movie_entry["template_variables"]["hub_priority_12A"] == "1"
+
+
 def test_build_libraries_section_expands_franchise_dynamic_child_override_maps(app):
     from modules import output
 

--- a/tests/test_template_gap_analyzer.py
+++ b/tests/test_template_gap_analyzer.py
@@ -242,6 +242,22 @@ def test_quickstart_recommendation_summary_excludes_legacy_or_not_recommended_li
             "value_shape_rule": "string",
         },
         {
+            "kind": "library",
+            "default": None,
+            "key": "library_type",
+            "file": "config.yml",
+            "library": "Movies",
+            "matched_default_files": ["config/config.yml"],
+            "supported_in_quickstart": False,
+            "quickstart_declared": False,
+            "schema_declared": False,
+            "kometa_declared": False,
+            "validation_level": "importer_metadata_only",
+            "name_verified": True,
+            "value_shape_verified": True,
+            "value_shape_rule": "string",
+        },
+        {
             "kind": "overlay",
             "default": "status",
             "key": "horizontal_align",
@@ -302,6 +318,22 @@ def test_quickstart_recommendation_exclusion_summary_tracks_legacy_library_keys(
             "value_shape_rule": "boolean",
         },
         {
+            "kind": "library",
+            "default": None,
+            "key": "library_type",
+            "file": "config.yml",
+            "library": "Movies",
+            "matched_default_files": ["config/config.yml"],
+            "supported_in_quickstart": False,
+            "quickstart_declared": False,
+            "schema_declared": False,
+            "kometa_declared": False,
+            "validation_level": "importer_metadata_only",
+            "name_verified": True,
+            "value_shape_verified": True,
+            "value_shape_rule": "string",
+        },
+        {
             "kind": "overlay",
             "default": "status",
             "key": "vertical_align",
@@ -324,9 +356,10 @@ def test_quickstart_recommendation_exclusion_summary_tracks_legacy_library_keys(
         key=lambda item: str(item["key"]),
     )
 
-    assert [item["key"] for item in excluded] == ["metadata_path", "reapply_overlays"]
-    assert excluded[0]["reason"] == "legacy_library_path_key_not_recommended"
-    assert excluded[1]["reason"] == "valid_but_not_recommended_for_quickstart"
+    assert [item["key"] for item in excluded] == ["library_type", "metadata_path", "reapply_overlays"]
+    assert excluded[0]["reason"] == "internal_importer_or_analyzer_metadata"
+    assert excluded[1]["reason"] == "legacy_library_path_key_not_recommended"
+    assert excluded[2]["reason"] == "valid_but_not_recommended_for_quickstart"
 
 
 def test_build_qs_collection_map_preserves_dynamic_family_edge_cases_for_repo_file():
@@ -812,6 +845,83 @@ def test_build_merged_fix_queue_suppresses_excluded_quickstart_only_keys():
     assert len(ranked) == 1
     assert ranked[0]["key"] == "horizontal_align"
     assert ranked[0]["action_targets"] == ["quickstart", "importer"]
+
+
+def test_build_merged_fix_queue_excludes_internal_library_type_metadata():
+    module = _load_gap_analyzer_module()
+
+    verified_rows = [
+        {
+            "kind": "library",
+            "default": None,
+            "key": "library_name",
+            "occurrences": 4,
+            "files": ["config.yml"],
+            "libraries": ["Movies"],
+            "matched_default_files": ["config/config.yml"],
+            "supported_in_quickstart": False,
+            "quickstart_declared": False,
+            "schema_declared": True,
+            "kometa_declared": True,
+            "validation_level": "works_in_kometa_missing_from_quickstart",
+        }
+    ]
+    importer_rows = [
+        {
+            "kind": "library",
+            "default": None,
+            "key": "library_type",
+            "import_status": "unmapped",
+            "reason_class": "library_type_unknown",
+            "occurrences": 9,
+            "files": ["config.yml"],
+            "libraries": ["Movies"],
+            "reasons": ["Library type could not be determined."],
+        },
+        {
+            "kind": "library",
+            "default": None,
+            "key": "library_name",
+            "import_status": "unmapped",
+            "reason_class": "missing_template_variable_support",
+            "occurrences": 2,
+            "files": ["config.yml"],
+            "libraries": ["Movies"],
+            "reasons": ["Template variable not available in Quickstart."],
+        },
+    ]
+
+    ranked = module.build_merged_fix_queue(verified_rows, importer_rows)
+
+    assert len(ranked) == 1
+    assert ranked[0]["key"] == "library_name"
+    assert ranked[0]["action_targets"] == ["quickstart", "importer"]
+
+
+def test_extract_importer_findings_from_data_ignores_bare_library_container_status():
+    module = _load_gap_analyzer_module()
+
+    original_prepare = module.importer.prepare_import_payload
+    original_parse = module.importer._parse_report_details
+
+    class _DummyReport:
+        lines = []
+
+    def _fake_prepare_import_payload(*_args, **_kwargs):
+        return {}, _DummyReport()
+
+    def _fake_parse_report_details(_lines):
+        return {"libraries.Movies": "unmapped"}, {"libraries.Movies": "Library type could not be determined."}
+
+    module.importer.prepare_import_payload = _fake_prepare_import_payload
+    module.importer._parse_report_details = _fake_parse_report_details
+    try:
+        findings = module.extract_importer_findings_from_data({"libraries": {"Movies": {}}}, Path("sample.yml"))
+    finally:
+        module.importer.prepare_import_payload = original_prepare
+        module.importer._parse_report_details = original_parse
+
+    assert findings == []
 
 
 def test_looks_like_kometa_config_text_accepts_non_template_variable_configs():


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

PR Description
Adds hub_priority support to Quickstart collection defaults on the Libraries page, including the shared child-key pattern used by Kometa defaults.
This change adds:
Family-level hub_priority
Child-level hub_priority_<key> support where the collection family already exposes child visible_home_<key>, visible_library_<key>, and visible_shared_<key> toggles
UI behavior was tightened so hub_priority is only usable when it actually makes sense:
Hidden/disabled when Plex Pass is unavailable
Disabled until at least one matching hub visibility toggle is enabled
Dependency logic works for both the base field and child overrides like hub_priority_12A
Also included:
JSON sweep across supported collection families
Macro/rendering updates for Plex Pass-gated collection fields
Libraries page dependency logic for hub-priority requirements
Contract and backend tests covering base and child-key output

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
