### PR TITLE
Add ruff to pre-commit and fix existing lint violations

### DIFF
--- a/.github/workflows/validate-pull.yml
+++ b/.github/workflows/validate-pull.yml
@@ -181,6 +181,33 @@ jobs:
           git push
 
 
+  run-tests:
+    name: Run Test Suite
+    runs-on: ubuntu-latest
+    if: needs.validate-changes.outputs.part == 'true' || needs.validate-changes.outputs.build == 'true'
+    needs: [ validate-changes ]
+    steps:
+
+      - name: Check Out Repo
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install Dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: Run Tests
+        run: pytest
+
+
   get-version:
     name: Get Version
     runs-on: ubuntu-latest
@@ -347,7 +374,7 @@ jobs:
   failure-notification:
     name: Failure Notification
     runs-on: ubuntu-latest
-    needs: [ get-version, build-executable, add-links ]
+    needs: [ run-tests, get-version, build-executable, add-links ]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     steps:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,8 @@ repos:
     rev: v17.1.2
     hooks:
       - id: standard
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.18
+    hooks:
+      - id: ruff
+        args: [ --fix ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: '^.*bootstrap.bundle.js$'
+exclude: '^.*bootstrap.bundle.js$|^tests/fixtures/'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -3264,7 +3264,7 @@ def normalize_config_name_for_storage(config_name: str | None) -> str:
     if not raw:
         return "default"
 
-    name = Path(raw).name.strip().lower()
+    name = Path(raw.replace("\\", "/")).name.strip().lower()
     if name.endswith("_config.yml"):
         name = name[:-11]
     elif name.endswith("_config.yaml"):

--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -17,7 +17,6 @@ import copy
 
 from pathlib import Path
 from plexapi.server import PlexServer
-from plexapi.exceptions import NotFound
 from modules import persistence
 
 import requests

--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -17,7 +17,7 @@ import copy
 
 from pathlib import Path
 from plexapi.server import PlexServer
-from plexapi.exceptions import BadRequest, NotFound, Unauthorized
+from plexapi.exceptions import NotFound
 from modules import persistence
 
 import requests
@@ -633,7 +633,7 @@ def check_for_update():
 
 def get_running_os():
     # Preserve build for backward compatibility, even if unused
-    build = os.getenv("BUILD_OS", "local").lower()
+    build = os.getenv("BUILD_OS", "local").lower()  # noqa: F841
 
     # 1. Docker check via env
     if os.getenv("QUICKSTART_DOCKER", "False").lower() in ["true", "1"]:
@@ -1293,7 +1293,7 @@ def load_quickstart_overlay_config():
 
 
 def get_top_imdb_items(library_id, media_type, placeholder_id=None):
-    ts_log(f"Fetching Plex credentials for '010-plex'", level="DEBUG")
+    ts_log("Fetching Plex credentials for '010-plex'", level="DEBUG")
     plex_url, plex_token = persistence.get_stored_plex_credentials("010-plex")
 
     ts_log(f"Connecting to Plex with URL: {plex_url}", level="DEBUG")
@@ -2128,8 +2128,9 @@ def rotate_logs():
 def initialize_logging():
     os.makedirs(LOG_DIR, exist_ok=True)
     rotate_logs()
-    with open(LOG_FILE, "w", encoding="utf-8") as f:
-        ts_log(f"New log started at {datetime.datetime.now()}", level="INFO")
+    with open(LOG_FILE, "w", encoding="utf-8"):
+        pass
+    ts_log(f"New log started at {datetime.datetime.now()}", level="INFO")
 
 
 def redact_string(text):
@@ -2541,7 +2542,8 @@ def _ensure_venv(kometa_dir: Path, logs: list[str], venv_name: str = "kometa-ven
     Create (if missing) and validate a venv at <kometa_dir>/kometa-venv.
     Returns (python_bin, pip_bin) or None on failure.
     """
-    import shutil, time
+    import shutil
+    import time
 
     is_windows = os.name == "nt"
     venv_dir = kometa_dir / venv_name

--- a/modules/logscan.py
+++ b/modules/logscan.py
@@ -842,7 +842,6 @@ class LogscanAnalyzer:
         git_kometa_errors = []
         pmm_legacy_errors = []
         image_size = []
-        incomplete_errors = []
         internal_server_errors = []
         lsio_errors = []
         mal_connection_errors = []

--- a/modules/output.py
+++ b/modules/output.py
@@ -17,9 +17,9 @@ from ruamel.yaml import YAML
 from ruamel.yaml.scalarstring import PlainScalarString
 from ruamel.yaml.comments import CommentedSeq
 
-_EMPTY_OUTPUT = object()
-
 from modules import helpers, persistence, database
+
+_EMPTY_OUTPUT = object()
 
 LIBRARY_RADARR_FIELDS = {
     "url": "string",

--- a/modules/output.py
+++ b/modules/output.py
@@ -1435,24 +1435,6 @@ def build_libraries_section(
         operations = {}
         attr_group = attributes.get(lib_id, {})
         # Begin: Mass Genre Update Section
-        mass_genre_update_keys = [
-            "tmdb",
-            "tvdb",
-            "imdb",
-            "omdb",
-            "anidb",
-            "anidb_3_0",
-            "anidb_2_5",
-            "anidb_2_0",
-            "anidb_1_5",
-            "anidb_1_0",
-            "anidb_0_5",
-            "mal",
-            "lock",
-            "unlock",
-            "remove",
-            "reset",
-        ]
         mass_genre_update = []
 
         # Grab the full reordered list from hidden input
@@ -2754,7 +2736,7 @@ def build_libraries_section(
         )
 
     if app.config["QS_DEBUG"]:
-        helpers.ts_log(f"Generated YAML Output:\n", level="DEBUG")
+        helpers.ts_log("Generated YAML Output:\n", level="DEBUG")
         buf = io.BytesIO()
         YAML().dump({"libraries": libraries_section}, buf)
         helpers.ts_log(buf.getvalue().decode("utf-8"))
@@ -2953,7 +2935,7 @@ def build_config(header_style="standard", config_name=None):
         # Format playlist_files data
         formatted_playlist_files = _format_playlist_files(libraries_list)
         if app.config["QS_DEBUG"]:
-            helpers.ts_log(f"Formatted playlist_files data:", formatted_playlist_files, level="DEBUG")
+            helpers.ts_log("Formatted playlist_files data:", formatted_playlist_files, level="DEBUG")
 
         # Replace in config_data
         config_data["playlist_files"] = formatted_playlist_files
@@ -2978,7 +2960,7 @@ def build_config(header_style="standard", config_name=None):
         if app.config["QS_DEBUG"]:
             helpers.ts_log(f"Cleaned Webhooks Data AFTER Removing Empty Values: {cleaned_webhooks}", level="DEBUG")
             if "webhooks" not in config_data:
-                helpers.ts_log(f"Webhooks section completely removed.", level="DEBUG")
+                helpers.ts_log("Webhooks section completely removed.", level="DEBUG")
 
     if "apprise" in config_data:
         apprise_data = config_data["apprise"]
@@ -3012,7 +2994,7 @@ def build_config(header_style="standard", config_name=None):
 
         # Debugging
         if app.config["QS_DEBUG"]:
-            helpers.ts_log(f"Raw nested libraries data:", nested_libraries_data, level="DEBUG")
+            helpers.ts_log("Raw nested libraries data:", nested_libraries_data, level="DEBUG")
 
         # Extract selected libraries
         movie_libraries = {
@@ -3034,8 +3016,8 @@ def build_config(header_style="standard", config_name=None):
 
         # Debugging
         if app.config["QS_DEBUG"]:
-            helpers.ts_log(f"Movie Library Names:", movie_library_names, level="DEBUG")
-            helpers.ts_log(f"Show Library Names:", show_library_names, level="DEBUG")
+            helpers.ts_log("Movie Library Names:", movie_library_names, level="DEBUG")
+            helpers.ts_log("Show Library Names:", show_library_names, level="DEBUG")
 
         def group_by_library(prefix, names, normalize_overlays=False):
             """

--- a/modules/persistence.py
+++ b/modules/persistence.py
@@ -308,7 +308,7 @@ def save_settings(raw_source, form_data):
     )
 
     if app.config["QS_DEBUG"]:
-        helpers.ts_log(f"Data saved successfully.", level="DEBUG")
+        helpers.ts_log("Data saved successfully.", level="DEBUG")
 
 
 def get_stored_plex_credentials(name):
@@ -327,7 +327,7 @@ def get_stored_plex_credentials(name):
         if plex_url and plex_token:
             return plex_url, plex_token
         if app.config["QS_DEBUG"]:
-            helpers.ts_log(f"Plex URL or Token is missing in stored settings", level="ERROR")
+            helpers.ts_log("Plex URL or Token is missing in stored settings", level="ERROR")
     except Exception as e:
         if app.config["QS_DEBUG"]:
             helpers.ts_log(f"Failed to retrieve Plex credentials: {e}", level="ERROR")
@@ -340,7 +340,7 @@ def update_stored_plex_libraries(name, movie_libraries, show_libraries, music_li
         # Fetch existing settings from DB before updating
         settings_before = retrieve_settings(name)
         if app.config["QS_DEBUG"]:
-            helpers.ts_log(f"Settings before update:", settings_before, level="DEBUG")
+            helpers.ts_log("Settings before update:", settings_before, level="DEBUG")
 
         if "plex" not in settings_before:
             settings_before["plex"] = {}
@@ -374,7 +374,7 @@ def update_stored_plex_libraries(name, movie_libraries, show_libraries, music_li
         # Fetch updated settings from DB after updating
         settings_after = retrieve_settings(name)
         if app.config["QS_DEBUG"]:
-            helpers.ts_log(f"Settings after update:", settings_after, level="DEBUG")
+            helpers.ts_log("Settings after update:", settings_after, level="DEBUG")
 
     except Exception as e:
         helpers.ts_log(f"Failed to update Plex libraries in DB: {e}", level="ERROR")

--- a/modules/validations.py
+++ b/modules/validations.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import requests
 from ruamel.yaml import YAML
-from flask import current_app as app
 from flask import jsonify, flash
 from plexapi.server import PlexServer
 
@@ -823,7 +822,7 @@ def validate_gotify_server(data):
 
     try:
         response_json = response.json()
-    except JSONDecodeError as e:
+    except JSONDecodeError:
         status = response.status_code
         content_type = response.headers.get("Content-Type")
         helpers.ts_log(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.ruff]
+line-length = 180
+target-version = "py313"
+extend-exclude = [".direnv", "config"]
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]

--- a/quickstart.py
+++ b/quickstart.py
@@ -11097,7 +11097,6 @@ def kometa_status():
 
 @app.route("/tail-log")
 def tail_log():
-    kometa_root = helpers.get_kometa_root_path()
     log_path = helpers.get_kometa_log_dir() / "meta.log"
 
     if not log_path.exists():
@@ -11223,7 +11222,6 @@ def tail_log():
 
 @app.route("/logscan/analyze", methods=["GET"])
 def logscan_analyze():
-    kometa_root = helpers.get_kometa_root_path()
     log_path = helpers.get_kometa_log_dir() / "meta.log"
     config_name = session.get("config_name")
     normalized_name = (config_name or "").strip().lower().replace(" ", "_") or "default"

--- a/quickstart.py
+++ b/quickstart.py
@@ -52,12 +52,11 @@ from werkzeug.datastructures import MultiDict
 from werkzeug.utils import secure_filename
 
 from werkzeug.wrappers import Request
-
-Request.max_form_parts = 100000  # Allow more form fields if needed
-
 from flask_session import Session
 from modules import validations, output, persistence, helpers, database, logscan, importer, path_validation, url_validation
 from typing import Dict, Any
+
+Request.max_form_parts = 100000  # Allow more form fields if needed
 
 # Shared in-memory background job store
 BACKGROUND_JOBS: Dict[str, Dict[str, Any]] = {}
@@ -5612,10 +5611,10 @@ def serve_preview_image(filename):
     return send_file(os.path.join(IMAGES_FOLDER, "default.png"), mimetype="image/png")
     try:
         data = request.get_json()
-        helpers.ts_log(f"Received data: %s", data, level="INFO")  # Log the received data
+        helpers.ts_log("Received data: %s", data, level="INFO")  # Log the received data
         return jsonify({"status": "success"})
     except Exception as e:
-        helpers.ts_log(f"Error updating libraries: %s", str(e), level="ERROR")
+        helpers.ts_log("Error updating libraries: %s", str(e), level="ERROR")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -6666,20 +6665,6 @@ def import_config_preview():
         if isinstance(value, list):
             return {str(v).strip() for v in value if str(v).strip()}
         return set()
-
-    def parse_base_plex_libraries(base_name: str):
-        if not base_name:
-            return set(), set()
-        try:
-            _validated, _user_entered, stored = database.retrieve_section_data(base_name, "plex")
-        except Exception:
-            return set(), set()
-        if not isinstance(stored, dict):
-            return set(), set()
-        plex_block = stored.get("plex") if isinstance(stored.get("plex"), dict) else stored
-        if not isinstance(plex_block, dict):
-            return set(), set()
-        return parse_list(plex_block.get("tmp_movie_libraries", "")), parse_list(plex_block.get("tmp_show_libraries", ""))
 
     def parse_base_plex_libraries(base_name: str):
         if not base_name:
@@ -8094,7 +8079,7 @@ def step(name):
             helpers.ts_log(f"Telemetry fallback triggered due to missing or invalid telemetry for config: {selected_config}", level="WARNING")
     else:
         if app.config["QS_DEBUG"]:
-            helpers.ts_log(f"Using telemetry from fresh plex_data", level="DEBUG")
+            helpers.ts_log("Using telemetry from fresh plex_data", level="DEBUG")
 
     page_info["telemetry"] = telemetry_data
 
@@ -8104,19 +8089,19 @@ def step(name):
 
     # Debugging extracted values
     if app.config["QS_DEBUG"]:
-        helpers.ts_log(f"Extracted movie libraries:", movie_libraries_raw, level="DEBUG")
-        helpers.ts_log(f"Extracted show libraries:", show_libraries_raw, level="DEBUG")
+        helpers.ts_log("Extracted movie libraries:", movie_libraries_raw, level="DEBUG")
+        helpers.ts_log("Extracted show libraries:", show_libraries_raw, level="DEBUG")
 
     # Ensure it's a string before splitting
     if not isinstance(movie_libraries_raw, str):
         if app.config["QS_DEBUG"]:
-            helpers.ts_log(f"tmp_movie_libraries is not a string!", level="ERROR")
+            helpers.ts_log("tmp_movie_libraries is not a string!", level="ERROR")
 
         movie_libraries_raw = ""
 
     if not isinstance(show_libraries_raw, str):
         if app.config["QS_DEBUG"]:
-            helpers.ts_log(f"tmp_show_libraries is not a string!", level="ERROR")
+            helpers.ts_log("tmp_show_libraries is not a string!", level="ERROR")
 
         show_libraries_raw = ""
 
@@ -8154,7 +8139,7 @@ def step(name):
         data["libraries"]["sho-template_variables"] = {}
 
     if app.config["QS_DEBUG"]:
-        helpers.ts_log(f"************************************************************************", level="DEBUG")
+        helpers.ts_log("************************************************************************", level="DEBUG")
         helpers.ts_log(f"Data retrieved for {name}", level="DEBUG")
 
     (
@@ -8219,13 +8204,13 @@ def step(name):
         service_validations[key] = helpers.booler(settings.get("validated", False))
 
     if needs_library_payload:
-        helpers.ts_log(f"Loading attribute_config...", level="TIMING")
+        helpers.ts_log("Loading attribute_config...", level="TIMING")
         attribute_config = helpers.load_quickstart_config("quickstart_attributes.json")
-        helpers.ts_log(f"Loading collection_config...", level="TIMING")
+        helpers.ts_log("Loading collection_config...", level="TIMING")
         collection_config = helpers.load_quickstart_config("quickstart_collections.json")
-        helpers.ts_log(f"Loading overlay_config...", level="TIMING")
+        helpers.ts_log("Loading overlay_config...", level="TIMING")
         overlay_config = helpers.load_quickstart_overlay_config()
-        helpers.ts_log(f"Loading preview image data...", level="TIMING")
+        helpers.ts_log("Loading preview image data...", level="TIMING")
         image_data = _build_preview_image_data()
         overlay_fonts = list_overlay_fonts()
 
@@ -8431,9 +8416,9 @@ def step(name):
         return html
 
     else:
-        helpers.ts_log(f"Loading quickstart_root...", level="TIMING")
+        helpers.ts_log("Loading quickstart_root...", level="TIMING")
         page_info["quickstart_root"] = helpers.get_app_root()
-        helpers.ts_log(f"Start render_template...", level="TIMING")
+        helpers.ts_log("Start render_template...", level="TIMING")
 
     configured_ids = _configured_library_ids(data.get("libraries", {}))
     configured_counts = {
@@ -10715,10 +10700,10 @@ def validate_all_services():
 
     failed_keys = [key for key, result in results.items() if result.get("status") == "failed"]
     failed_labels = [format_with_reason(key, results[key]) for key in failed_keys]
-    failed_detail = f" Failed: {', '.join(failed_labels)}." if failed_labels else ""
+    failed_detail = f" Failed: {', '.join(failed_labels)}." if failed_labels else ""  # noqa: F841
     skipped_keys = [key for key, result in results.items() if result.get("status") == "skipped"]
     skipped_labels = [format_with_reason(key, results[key]) for key in skipped_keys]
-    skipped_detail = f" Skipped: {', '.join(skipped_labels)}." if skipped_labels else ""
+    skipped_detail = f" Skipped: {', '.join(skipped_labels)}." if skipped_labels else ""  # noqa: F841
     ok = summary.get("validated", 0)
     failed = summary.get("failed", 0)
     skipped = summary.get("skipped", 0)
@@ -18924,7 +18909,7 @@ if __name__ == "__main__":
         with app_in.app_context():
             while True:
                 app_in.config["VERSION_CHECK"] = helpers.check_for_update()
-                helpers.ts_log(f"Checked for updates.", level="INFO")
+                helpers.ts_log("Checked for updates.", level="INFO")
                 time.sleep(86400)
 
     update_thread = threading.Thread(target=start_update_thread, args=(app,), daemon=True)
@@ -18967,19 +18952,19 @@ if __name__ == "__main__":
             has_tray = True
         else:
             has_tray = False
-    except (ModuleNotFoundError, ImportError) as ie:
+    except (ModuleNotFoundError, ImportError):
         has_tray = False
 
     if not has_tray:
         # Headless mode: skip system tray
-        helpers.ts_log(f"Running in headless mode — no system tray will be shown...", level="INFO")
+        helpers.ts_log("Running in headless mode — no system tray will be shown...", level="INFO")
         if app.config["QUICKSTART_DOCKER"]:
-            helpers.ts_log(f"Quickstart is Running inside Docker.", level="INFO")
+            helpers.ts_log("Quickstart is Running inside Docker.", level="INFO")
             helpers.ts_log(f"Access it at http://<your-server-ip>:{running_port}", level="INFO")
-            helpers.ts_log(f"Note: This IP is the HOST machine IP, not the container IP.", level="INFO")
+            helpers.ts_log("Note: This IP is the HOST machine IP, not the container IP.", level="INFO")
         else:
             ip_address = get_lan_ip()
-            helpers.ts_log(f"Quickstart is Running", level="INFO")
+            helpers.ts_log("Quickstart is Running", level="INFO")
             helpers.ts_log(f"Access it at http://{ip_address}:{running_port}", level="INFO")
 
         helpers.ts_log(
@@ -19060,7 +19045,7 @@ if __name__ == "__main__":
                     8000,
                 )
 
-                helpers.ts_log(f"Quickstart is Running", level="INFO")
+                helpers.ts_log("Quickstart is Running", level="INFO")
                 helpers.ts_log(f"Access it locally at: http://localhost:{running_port}", level="INFO")
                 helpers.ts_log(f"Access it from other devices at: http://{ip_address}:{running_port}", level="INFO")
                 helpers.ts_log(
@@ -19107,7 +19092,7 @@ if __name__ == "__main__":
             def change_port(self):
                 global port
                 try:
-                    helpers.ts_log(f"Launching custom port input dialog...", level="DEBUG")
+                    helpers.ts_log("Launching custom port input dialog...", level="DEBUG")
 
                     dialog = QInputDialog(self.dialog_parent)
                     dialog.setWindowTitle("Change Port")
@@ -19123,7 +19108,7 @@ if __name__ == "__main__":
 
                     # Execute dialog
                     if dialog.exec() != QInputDialog.Accepted:
-                        helpers.ts_log(f"Port change canceled by user.", level="INFO")
+                        helpers.ts_log("Port change canceled by user.", level="INFO")
                         return
 
                     new_port = dialog.intValue()
@@ -19158,7 +19143,7 @@ if __name__ == "__main__":
             def quit_app(self):
                 global server_thread, update_thread
 
-                helpers.ts_log(f"Shutting down Quickstart...", level="INFO")
+                helpers.ts_log("Shutting down Quickstart...", level="INFO")
 
                 # Stop tray icon
                 self.tray.hide()
@@ -19166,11 +19151,11 @@ if __name__ == "__main__":
                 # Optionally stop Flask server (if you have added a stop hook)
                 # For now, just wait for background threads to finish
                 if server_thread and server_thread.is_alive():
-                    helpers.ts_log(f"Waiting for server thread to exit...", level="DEBUG")
+                    helpers.ts_log("Waiting for server thread to exit...", level="DEBUG")
                     server_thread.join(timeout=2)
 
                 if update_thread and update_thread.is_alive():
-                    helpers.ts_log(f"Waiting for update thread to exit...", level="DEBUG")
+                    helpers.ts_log("Waiting for update thread to exit...", level="DEBUG")
                     update_thread.join(timeout=2)
 
                 # Exit the Qt app loop
@@ -19178,7 +19163,7 @@ if __name__ == "__main__":
 
             def restart_quickstart(self):
                 """Cleanly restart the Quickstart application."""
-                helpers.ts_log(f"Restarting Quickstart...", level="INFO")
+                helpers.ts_log("Restarting Quickstart...", level="INFO")
                 self.tray.hide()
 
                 python = sys.executable

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 playwright>=1.60.0
 pytest>=9.1.1
 pytest-playwright>=0.8.0
+ruff==0.15.18

--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -211,10 +211,13 @@ def yaml_type_matches_focus(document_type: str, focus: str) -> bool:
 
 
 def is_probable_non_config_artifact(path: Path) -> bool:
-    filename = path.name
+    # Uploaded paths may carry Windows-style separators even when this analyzer runs on
+    # a POSIX host, where pathlib won't split on backslashes — normalize before splitting.
+    normalized = str(path).replace("\\", "/")
+    filename = normalized.rsplit("/", 1)[-1]
     if any(pattern.match(filename) for pattern in PROBABLE_ARTIFACT_NAME_PATTERNS):
         return True
-    lower_parts = {part.lower() for part in path.parts}
+    lower_parts = {part.lower() for part in normalized.split("/") if part}
     if lower_parts.intersection(PROBABLE_ARTIFACT_PATH_PARTS) and filename.lower().startswith("parsed_"):
         return True
     return False

--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -11,7 +11,6 @@ import tempfile
 import time
 import warnings
 import zipfile
-from collections import defaultdict
 from datetime import date, datetime
 from functools import lru_cache
 from pathlib import Path
@@ -24,7 +23,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from modules import importer
+from modules import importer  # noqa: E402
 
 try:
     import py7zr

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,16 +10,30 @@ _LOADED = {}
 
 def _seed_schema_files(config_dir):
     repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-    schema_root = os.path.join(repo_root, "config", ".schema")
+    # `config/.schema` is a gitignored local cache that the app populates at runtime by
+    # downloading from GitHub. It won't exist on a fresh checkout (e.g. CI), so fall back
+    # to the checked-in fixtures in tests/fixtures/schema to keep tests reproducible offline.
+    schema_roots = [
+        os.path.join(repo_root, "config", ".schema"),
+        os.path.join(os.path.dirname(__file__), "fixtures", "schema"),
+    ]
     target_schema_root = os.path.join(str(config_dir), ".schema")
     os.makedirs(target_schema_root, exist_ok=True)
-    for current_root, _dirs, files in os.walk(schema_root):
-        rel_root = os.path.relpath(current_root, schema_root)
-        target_root = target_schema_root if rel_root == "." else os.path.join(target_schema_root, rel_root)
-        os.makedirs(target_root, exist_ok=True)
-        for name in files:
-            source = os.path.join(current_root, name)
-            shutil.copy2(source, os.path.join(target_root, name))
+    copied = set()
+    for schema_root in schema_roots:
+        if not os.path.isdir(schema_root):
+            continue
+        for current_root, _dirs, files in os.walk(schema_root):
+            rel_root = os.path.relpath(current_root, schema_root)
+            target_root = target_schema_root if rel_root == "." else os.path.join(target_schema_root, rel_root)
+            for name in files:
+                rel_name = name if rel_root == "." else os.path.join(rel_root, name)
+                if rel_name in copied:
+                    continue
+                os.makedirs(target_root, exist_ok=True)
+                source = os.path.join(current_root, name)
+                shutil.copy2(source, os.path.join(target_root, name))
+                copied.add(rel_name)
 
 
 def _load_app(config_dir, kometa_root):

--- a/tests/fixtures/kometa/defaults/award/bafta.yml
+++ b/tests/fixtures/kometa/defaults/award/bafta.yml
@@ -1,0 +1,60 @@
+##############################################################################
+#       British Academy of Film and Television Arts Awards Collections       #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#             https://kometa.wiki/en/latest/defaults/award/bafta             #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: 130
+
+collections:
+  BAFTA Best Films:
+    variables:
+      key: best
+    template:
+      - name: shared
+        sort: BAFTA !
+        allowed_libraries: movie
+        image: award/bafta/winner
+        translation_key: bafta_best
+      - name: arr
+      - name: custom
+    imdb_award:
+      event_id: ev0000123
+      event_year: all
+      category_filter: 
+        - best film
+        - best film from any source
+      winning: true
+
+dynamic_collections:
+  BAFTA Awards:
+    type: imdb_awards
+    sync: true
+    data:
+      event_id: ev0000123
+      starting: latest-4
+      ending: latest
+    title_format: BAFTA <<key_name>>
+    template:
+      - use_year_collections
+      - imdb_award
+      - shared
+      - arr
+      - custom
+    template_variables:
+      winning:
+        default: true
+      collection_order:
+        default: release
+      allowed_libraries:
+        default: movie
+      image:
+        default: award/bafta/<<key>>
+      translation_key:
+        default: bafta_year
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/award/berlinale.yml
+++ b/tests/fixtures/kometa/defaults/award/berlinale.yml
@@ -1,0 +1,58 @@
+##############################################################################
+#                         Berlinale Awards Collections                       #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#           https://kometa.wiki/en/latest/defaults/award/berlinale           #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: 130
+
+collections:
+  Berlinale Golden Bears:
+    variables:
+      key: golden
+    template:
+      - name: shared
+        sort: Berlinale !
+        allowed_libraries: movie
+        image: award/berlinale/winner
+        translation_key: berlinale_best
+      - name: arr
+      - name: custom
+    imdb_award:
+      event_id: ev0000091
+      event_year: all
+      award_filter: golden berlin bear
+      winning: true
+
+dynamic_collections:
+  Berlinale Awards:
+    type: imdb_awards
+    sync: true
+    data:
+      event_id: ev0000091
+      starting: latest-4
+      ending: latest
+    title_format: Berlinale <<key_name>>
+    template:
+      - use_year_collections
+      - imdb_award
+      - shared
+      - arr
+      - custom
+    template_variables:
+      winning:
+        default: true
+      collection_order:
+        default: release
+      allowed_libraries:
+        default: movie
+      image:
+        default: award/berlinale/<<key>>
+      translation_key:
+        default: berlinale_year
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/award/cannes.yml
+++ b/tests/fixtures/kometa/defaults/award/cannes.yml
@@ -1,0 +1,58 @@
+##############################################################################
+#                         Cannes Awards Collections                          #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#            https://kometa.wiki/en/latest/defaults/award/cannes             #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: 130
+
+collections:
+  Cannes Golden Palm Winners:
+    variables:
+      key: palm
+    template:
+      - name: shared
+        sort: Cannes !
+        allowed_libraries: movie
+        image: award/cannes/winner
+        translation_key: cannes_best
+      - name: arr
+      - name: custom
+    imdb_award:
+      event_id: ev0000147
+      event_year: all
+      award_filter: palme d'or
+      winning: true
+
+dynamic_collections:
+  Cannes Awards:
+    type: imdb_awards
+    sync: true
+    data:
+      event_id: ev0000147
+      starting: latest-4
+      ending: latest
+    title_format: Cannes <<key_name>>
+    template:
+      - use_year_collections
+      - imdb_award
+      - shared
+      - arr
+      - custom
+    template_variables:
+      winning:
+        default: true
+      collection_order:
+        default: release
+      allowed_libraries:
+        default: movie
+      image:
+        default: award/cannes/<<key>>
+      translation_key:
+        default: cannes_year
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/award/cesar.yml
+++ b/tests/fixtures/kometa/defaults/award/cesar.yml
@@ -1,0 +1,59 @@
+##############################################################################
+#                         Cesar Awards Collections                           #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#             https://kometa.wiki/en/latest/defaults/award/cesar             #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: 130
+
+collections:
+  César Best Film Winners:
+    variables:
+      key: best
+    template:
+      - name: shared
+        sort: César !
+        allowed_libraries: movie
+        image: award/cesar/winner
+        translation_key: cesar_best
+      - name: arr
+      - name: custom
+    imdb_award:
+      event_id: ev0000157
+      event_year: all
+      award_filter: César
+      category_filter: best film (meilleur film)
+      winning: true
+
+dynamic_collections:
+  Cesar Awards:
+    type: imdb_awards
+    sync: true
+    data:
+      event_id: ev0000157
+      starting: latest-4
+      ending: latest
+    title_format: César <<key_name>>
+    template:
+      - use_year_collections
+      - imdb_award
+      - shared
+      - arr
+      - custom
+    template_variables:
+      winning:
+        default: true
+      collection_order:
+        default: release
+      allowed_libraries:
+        default: movie
+      image:
+        default: award/cesar/<<key>>
+      translation_key:
+        default: cesar_year
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/award/choice.yml
+++ b/tests/fixtures/kometa/defaults/award/choice.yml
@@ -1,0 +1,56 @@
+##############################################################################
+#                     Critics Choice Awards Collections                      #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#            https://kometa.wiki/en/latest/defaults/award/choice             #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: 130
+
+collections:
+  Critics Choice Best Picture Winners:
+    variables:
+      key: best
+    template:
+      - name: shared
+        sort: Choice !
+        allowed_libraries: movie
+        image: award/choice/winner
+        translation_key: choice_best
+      - name: arr
+      - name: custom
+    imdb_award:
+      event_id: ev0000133
+      event_year: all
+      category_filter: best picture
+      winning: true
+
+dynamic_collections:
+  Critics Choice Awards:
+    type: imdb_awards
+    sync: true
+    data:
+      event_id: ev0000133
+      starting: latest-4
+      ending: latest
+    title_format: Critics Choice Awards <<key_name>>
+    template:
+      - use_year_collections
+      - imdb_award
+      - shared
+      - arr
+      - custom
+    template_variables:
+      winning:
+        default: true
+      collection_order:
+        default: release
+      image:
+        default: award/choice/<<key>>
+      translation_key:
+        default: choice_year
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/award/emmy.yml
+++ b/tests/fixtures/kometa/defaults/award/emmy.yml
@@ -1,0 +1,80 @@
+##############################################################################
+#                          Emmy Awards Collections                           #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#             https://kometa.wiki/en/latest/defaults/award/emmy              #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: 130
+
+collections:
+  Emmys Best in Category Winners:
+    variables:
+      key: best
+    template:
+      - name: shared
+        sort: Emmys !
+        allowed_libraries: show
+        image: award/emmys/winner
+        translation_key: emmy_best
+      - name: arr
+      - name: custom
+    imdb_award:
+      event_id: ev0000223
+      event_year: all
+      category_filter:
+        - best comedy series
+        - best comedy show
+        - best dramatic anthology series
+        - best dramatic program
+        - best dramatic series
+        - best dramatic series - less than one hour
+        - best dramatic series - one hour or longer
+        - best series - half hour or less
+        - best series - one hour or more
+        - outstanding animated program
+        - outstanding animated program (for programming less than one hour)
+        - outstanding animated program (for programming more than one hour)
+        - outstanding animated program (for programming one hour or less)
+        - outstanding animated program (for programming one hour or more)
+        - outstanding animated programming
+        - outstanding comedy series
+        - outstanding drama series
+        - outstanding drama series - continuing
+        - outstanding drama/comedy - limited episodes
+        - outstanding dramatic program
+        - outstanding dramatic series
+        - outstanding miniseries
+        - outstanding series - comedy
+        - outstanding series - drama
+      winning: true
+
+dynamic_collections:
+  Emmy Awards:
+    type: imdb_awards
+    sync: true
+    data:
+      event_id: ev0000223
+      starting: latest-4
+      ending: latest
+    title_format: Emmys <<key_name>>
+    template:
+      - use_year_collections
+      - imdb_award
+      - shared
+      - arr
+      - custom
+    template_variables:
+      winning:
+        default: true
+      collection_order:
+        default: release
+      image:
+        default: award/emmys/winner/<<key>>
+      translation_key:
+        default: emmy_year
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/award/golden.yml
+++ b/tests/fixtures/kometa/defaults/award/golden.yml
@@ -1,0 +1,92 @@
+##############################################################################
+#                      Golden Globes Awards Collections                      #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#            https://kometa.wiki/en/latest/defaults/award/golden             #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: 130
+
+collections:
+  Golden Globes Best Picture Winners:
+    variables:
+      key: best_picture
+    template:
+      - name: shared
+        sort: Golden Globe !1
+        allowed_libraries: movie
+        image: award/golden/best_picture_winner
+        translation_key: golden_picture
+      - name: arr
+      - name: custom
+    delete_collections_named:
+      - Golden Globe Best Motion Pictures
+    imdb_award:
+      event_id: ev0000292
+      event_year: all
+      category_filter:
+        - best animated feature film
+        - best animated film
+        - best foreign film
+        - best foreign language film
+        - best foreign-language foreign film
+        - best motion picture - animated
+        - best motion picture - comedy
+        - best motion picture - comedy or musical
+        - best motion picture - drama
+        - best motion picture - foreign language
+        - best motion picture - musical
+        - best motion picture - musical or comedy
+        - best motion picture - non-english language
+        - best motion picture, musical or comedy
+        - best picture
+      winning: true
+
+  Golden Globes Best Director Winners:
+    variables:
+      key: best_director
+    template:
+      - name: shared
+        sort: Golden Globes !2
+        allowed_libraries: movie
+        image: award/golden/best_director_winner
+        translation_key: golden_director
+      - name: arr
+      - name: custom
+    imdb_award:
+      event_id: ev0000292
+      event_year: all
+      category_filter:
+        - best director
+        - best director - motion picture
+      winning: true
+    
+dynamic_collections:
+  Golden Globes Awards:
+    type: imdb_awards
+    sync: true
+    data:
+      event_id: ev0000292
+      starting: latest-4
+      ending: latest
+    title_format: Golden Globe <<key_name>>
+    template:
+      - use_year_collections
+      - imdb_award
+      - shared
+      - arr
+      - custom
+    template_variables:
+      winning:
+        default: true
+      collection_order:
+        default: release
+      image:
+        default: award/golden/winner/<<key>>
+      translation_key:
+        default: golden_year
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/award/nfr.yml
+++ b/tests/fixtures/kometa/defaults/award/nfr.yml
@@ -1,0 +1,57 @@
+##############################################################################
+#                 National Film Registry Awards Collections                  #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#              https://kometa.wiki/en/latest/defaults/award/nfr              #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: 130
+
+collections:
+  National Film Registry All Time:
+    variables:
+      key: all_time
+    template:
+      - name: shared
+        sort: National Film Registry !
+        allowed_libraries: movie
+        image: award/nfr/all_time
+        translation_key: nfr_best
+      - name: arr
+      - name: custom
+    imdb_award:
+      event_id: ev0000468
+      event_year: all
+      winning: true
+
+dynamic_collections:
+  National Film Registry Awards:
+    type: imdb_awards
+    sync: true
+    data:
+      event_id: ev0000468
+      starting: latest-4
+      ending: latest
+    title_format: National Film Registry <<key_name>>
+    template:
+      - use_year_collections
+      - imdb_award
+      - shared
+      - arr
+      - custom
+    template_variables:
+      winning:
+        default: true
+      collection_order:
+        default: release
+      allowed_libraries:
+        default: movie
+      image:
+        default: award/nfr/<<key>>
+      translation_key:
+        default: nfr_year
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/award/oscars.yml
+++ b/tests/fixtures/kometa/defaults/award/oscars.yml
@@ -1,0 +1,83 @@
+##############################################################################
+#                    Academy Awards (Oscars) Collections                     #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#            https://kometa.wiki/en/latest/defaults/award/oscars             #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: 130
+
+collections:
+  Oscars Best Picture Winners:
+    variables:
+      key: best_picture
+    template:
+      - name: shared
+        sort: Oscars !1
+        allowed_libraries: movie
+        image: award/oscars/best_picture_winner
+        translation_key: oscars_picture
+      - name: arr
+      - name: custom
+    imdb_award:
+      event_id: ev0000003
+      event_year: all
+      category_filter:
+        - best motion picture of the year
+        - best picture
+        - best picture, production
+        - best picture, unique and artistic production
+      winning: true
+
+  Oscars Best Director Winners:
+    variables:
+      key: best_director
+    template:
+      - name: shared
+        sort: Oscars !2
+        allowed_libraries: movie
+        image: award/oscars/best_director_winner
+        translation_key: oscars_director
+      - name: arr
+      - name: custom
+    imdb_award:
+      event_id: ev0000003
+      event_year: all
+      category_filter:
+        - best achievement in directing
+        - best director
+        - best director, comedy picture
+        - best director, dramatic picture
+      winning: true
+
+dynamic_collections:
+  Oscars Winners Awards:
+    type: imdb_awards
+    sync: true
+    data:
+      event_id: ev0000003
+      starting: latest-4
+      ending: latest
+    title_format: Oscars Winners <<key_name>>
+    template:
+      - use_year_collections
+      - imdb_award
+      - shared
+      - arr
+      - custom
+    template_variables:
+      winning:
+        default: true
+      collection_order:
+        default: release
+      allowed_libraries:
+        default: movie
+      image:
+        default: award/oscars/winner/<<key>>
+      translation_key:
+        default: oscars_year
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/award/pca.yml
+++ b/tests/fixtures/kometa/defaults/award/pca.yml
@@ -1,0 +1,64 @@
+##############################################################################
+#                    People's Choice Awards Collections                      #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#              https://kometa.wiki/en/latest/defaults/award/pca              #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: 130
+
+collections:
+  Peoples Choice Award Winners:
+    variables:
+      key: best
+    template:
+      - name: shared
+        sort: People's Choice Awards !
+        image: award/pca/winner
+        translation_key: pca_best
+      - name: arr
+      - name: custom
+    imdb_award:
+      event_id: ev0000530
+      event_year: all
+      category_filter:
+        - all-time favorite tv program
+        - favorite all-time motion picture
+        - favorite motion picture
+        - favorite movie
+        - favorite non-musical motion picture
+        - favorite overall motion picture
+        - favorite tv show
+        - the movie of 2022
+        - the show of 2021
+      winning: true
+
+dynamic_collections:
+  Peoples Choice Awards:
+    type: imdb_awards
+    sync: true
+    data:
+      event_id: ev0000530
+      starting: latest-4
+      ending: latest
+    title_format: People's Choice Awards <<key_name>>
+    template:
+      - use_year_collections
+      - imdb_award
+      - shared
+      - arr
+      - custom
+    template_variables:
+      winning:
+        default: true
+      collection_order:
+        default: release
+      image:
+        default: award/pca/<<key>>
+      translation_key:
+        default: pca_year
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/award/razzie.yml
+++ b/tests/fixtures/kometa/defaults/award/razzie.yml
@@ -1,0 +1,58 @@
+##############################################################################
+#                         Razzie Awards Collections                          #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#            https://kometa.wiki/en/latest/defaults/award/razzie             #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: 130
+
+collections:
+  Razzies Golden Raspberry Winners:
+    variables:
+      key: golden
+    template:
+      - name: shared
+        sort: Razzie !
+        allowed_libraries: movie
+        image: award/razzie/winner
+        translation_key: razzie_worst
+      - name: arr
+      - name: custom
+    imdb_award:
+      event_id: ev0000558
+      event_year: all
+      category_filter: worst picture
+      winning: true
+
+dynamic_collections:
+  Razzie Awards:
+    type: imdb_awards
+    sync: true
+    data:
+      event_id: ev0000558
+      starting: latest-4
+      ending: latest
+    title_format: Razzie <<key_name>>
+    template:
+      - use_year_collections
+      - imdb_award
+      - shared
+      - arr
+      - custom
+    template_variables:
+      winning:
+        default: true
+      collection_order:
+        default: release
+      allowed_libraries:
+        default: movie
+      image:
+        default: award/razzie/<<key>>
+      translation_key:
+        default: razzie_year
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/award/sag.yml
+++ b/tests/fixtures/kometa/defaults/award/sag.yml
@@ -1,0 +1,61 @@
+##############################################################################
+#                   Screen Actors Guild Awards Collections                   #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#              https://kometa.wiki/en/latest/defaults/award/sag              #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: 130
+
+collections:
+  Screen Actors Guild Award Winners:
+    variables:
+      key: best
+    template:
+      - name: shared
+        sort: Screen Actors Guild !
+        image: award/sag/winner
+        translation_key: sag_best
+      - name: arr
+      - name: custom
+    imdb_award:
+      event_id: ev0000598
+      event_year: all
+      category_filter:
+        - outstanding performance by a cast
+        - outstanding performance by a cast in a motion picture
+        - outstanding performance by a cast in a theatrical motion picture
+        - outstanding performance by an ensemble in a comedy series
+        - outstanding performance by an ensemble in a drama series
+        - outstanding performance by the cast of a theatrical motion picture
+      winning: true
+
+dynamic_collections:
+ Screen Actors Guild Awards:
+    type: imdb_awards
+    sync: true
+    data:
+      event_id: ev0000598
+      starting: latest-4
+      ending: latest
+    title_format: Screen Actors Guild Awards <<key_name>>
+    template:
+      - use_year_collections
+      - imdb_award
+      - shared
+      - arr
+      - custom
+    template_variables:
+      winning:
+        default: true
+      collection_order:
+        default: release
+      image:
+        default: award/sag/<<key>>
+      translation_key:
+        default: sag_year
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/award/separator_award.yml
+++ b/tests/fixtures/kometa/defaults/award/separator_award.yml
@@ -1,0 +1,19 @@
+##############################################################################
+#                        Award Separator Collections                         #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#        https://kometa.wiki/en/latest/defaults/award/separator_award        #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: 130
+
+collections:
+  Award Collections:
+    template:
+      - name: separator
+        separator: award
+        key_name: Award
+        translation_key: separator

--- a/tests/fixtures/kometa/defaults/award/spirit.yml
+++ b/tests/fixtures/kometa/defaults/award/spirit.yml
@@ -1,0 +1,58 @@
+##############################################################################
+#                   Independent Spirit Awards Collections                    #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#            https://kometa.wiki/en/latest/defaults/award/spirit             #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: 130
+
+collections:
+  Independent Spirit Best Feature Winners:
+    variables:
+      key: best
+    template:
+      - name: shared
+        sort: Independent Spirit Awards !1
+        allowed_libraries: movie
+        image: award/spirit/winner
+        translation_key: spirit_best
+      - name: arr
+      - name: custom
+    imdb_award:
+      event_id: ev0000349
+      event_year: all
+      category_filter: best feature
+      winning: true
+
+dynamic_collections:
+  Independent Spirit Award Awards:
+    type: imdb_awards
+    sync: true
+    data:
+      event_id: ev0000349
+      starting: latest-4
+      ending: latest
+    title_format: Independent Spirit Awards <<key_name>>
+    template:
+      - use_year_collections
+      - imdb_award
+      - shared
+      - arr
+      - custom
+    template_variables:
+      winning:
+        default: true
+      collection_order:
+        default: release
+      allowed_libraries:
+        default: movie
+      image:
+        default: award/spirit/<<key>>
+      translation_key:
+        default: spirit_year
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/award/sundance.yml
+++ b/tests/fixtures/kometa/defaults/award/sundance.yml
@@ -1,0 +1,58 @@
+##############################################################################
+#                        Sundance Awards Collections                         #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#           https://kometa.wiki/en/latest/defaults/award/sundance            #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: 130
+
+collections:
+  Sundance Grand Jury Winners:
+    variables:
+      key: grand
+    template:
+      - name: shared
+        sort: Sundance !1
+        allowed_libraries: movie
+        image: award/sundance/grand_jury_winner
+        translation_key: sundance_best
+      - name: arr
+      - name: custom
+    imdb_award:
+      event_id: ev0000631
+      event_year: all
+      award_filter: grand jury prize
+      winning: true
+
+dynamic_collections:
+  Sundance Film Festival:
+    type: imdb_awards
+    sync: true
+    data:
+      event_id: ev0000631
+      starting: latest-4
+      ending: latest
+    title_format: Sundance Film Festival <<key_name>>
+    template:
+      - use_year_collections
+      - imdb_award
+      - shared
+      - arr
+      - custom
+    template_variables:
+      winning:
+        default: true
+      collection_order:
+        default: release
+      allowed_libraries:
+        default: movie
+      image:
+        default: award/sundance/<<key>>
+      translation_key:
+        default: sundance_year
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/award/tiff.yml
+++ b/tests/fixtures/kometa/defaults/award/tiff.yml
@@ -1,0 +1,65 @@
+##############################################################################
+#           Toronto International Film Festival Awards Collections           #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#             https://kometa.wiki/en/latest/defaults/award/tiff              #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: 130
+
+collections:
+  Toronto People's Choice Award Winners:
+    variables:
+      key: best
+    template:
+      - name: shared
+        sort: Toronto International Film Festival !
+        allowed_libraries: movie
+        image: award/tiff/winner
+        translation_key: tiff_best
+      - name: arr
+      - name: custom
+    imdb_award:
+      event_id: ev0000659
+      event_year: all
+      award_filter:
+        - people's choice award
+        - grolsch people's choice award
+      category_filter:
+        - best film
+        - people's choice award
+        - grolsch people's choice award
+        - gala or special presentations
+      winning: true
+
+dynamic_collections:
+  Toronto International Film Festival Awards:
+    type: imdb_awards
+    sync: true
+    data:
+      event_id: ev0000659
+      starting: latest-4
+      ending: latest
+    title_format: Toronto International Film Festival <<key_name>>
+    template:
+      - use_year_collections
+      - imdb_award
+      - shared
+      - arr
+      - custom
+    template_variables:
+      winning:
+        default: true
+      collection_order:
+        default: release
+      allowed_libraries:
+        default: movie
+      image:
+        default: award/tiff/<<key>>
+      translation_key:
+        default: tiff_year
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/award/venice.yml
+++ b/tests/fixtures/kometa/defaults/award/venice.yml
@@ -1,0 +1,66 @@
+##############################################################################
+#                         Venice Awards Collections                          #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#            https://kometa.wiki/en/latest/defaults/award/venice             #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: 130
+
+collections:
+  Venice Golden Lions:
+    variables:
+      key: golden
+    template:
+      - name: shared
+        sort: Venice !
+        allowed_libraries: movie
+        image: award/venice/winner
+        translation_key: venice_best
+      - name: arr
+      - name: custom
+    imdb_award:
+      event_id: ev0000681
+      event_year: all
+      award_filter:
+        - golden lion
+        - international critics award
+        - grand international award
+      category_filter:
+        - golden lion
+        - best feature film
+        - best film
+        - grand international award
+      winning: true
+
+dynamic_collections:
+  Venice Awards:
+    type: imdb_awards
+    sync: true
+    data:
+      event_id: ev0000681
+      starting: latest-4
+      ending: latest
+    title_format: Venice <<key_name>>
+    template:
+      - use_year_collections
+      - imdb_award
+      - shared
+      - arr
+      - custom
+    template_variables:
+      winning:
+        default: true
+      collection_order:
+        default: release
+      allowed_libraries:
+        default: movie
+      image:
+        default: award/venice/<<key>>
+      translation_key:
+        default: venice_year
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/both/actor.yml
+++ b/tests/fixtures/kometa/defaults/both/actor.yml
@@ -1,0 +1,46 @@
+##############################################################################
+#                             Actor Collections                              #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#             https://kometa.wiki/en/latest/defaults/both/actor              #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "140"
+
+collections:
+  Actors Collections:
+    template:
+      - name: separator
+        separator: actor
+        key_name: Actors
+        translation_key: separator
+
+dynamic_collections:
+  Top Actors:
+    type: actor
+    data:
+      depth: 5
+      limit: 25
+    title_format: <<key_name>>
+    template:
+      - tmdb_person
+      - smart_filter
+      - shared
+    template_variables:
+      tmdb_person:
+        default: <<value>>
+      tmdb_person_offset:
+        default: 0
+      search_term:
+        default: actor
+      search_value:
+        default: tmdb
+      translation_key:
+        default: actor
+      style:
+        default: bw
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/both/aspect.yml
+++ b/tests/fixtures/kometa/defaults/both/aspect.yml
@@ -1,0 +1,54 @@
+##############################################################################
+#                         Aspect Ratio Collections                           #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#             https://kometa.wiki/en/latest/defaults/both/aspect             #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "125"
+
+collections:
+  Aspect Ratio Collections:
+    template:
+      - name: separator
+        separator: aspect
+        key_name: Aspect Ratio
+        translation_key: separator
+
+dynamic_collections:
+  Aspect:
+    type: custom
+    data:
+      "1.33": 1.33 - Academy Aperture
+      "1.65": 1.65 - Early Widescreen
+      "1.66": 1.66 - European Widescreen
+      "1.78": 1.78 - Widescreen TV
+      "1.85": 1.85 - American Widescreen
+      "2.2": 2.2 - 70mm Frame
+      "2.35": 2.35 - Anamorphic Projection
+      "2.77": 2.77 - Cinerama
+    title_format: <<key_name>>
+    template:
+      - filter
+      - shared
+    template_variables:
+      filter_term:
+        default: aspect
+      filter_value:
+        "1.33": 1.33
+        "1.65": 1.65
+        "1.66": 1.66
+        "1.78": 1.78
+        "1.85": 1.85
+        "2.2": 2.2
+        "2.35": 2.35
+        "2.77": 2.77
+      image:
+        default: aspect/<<key>>
+      translation_key:
+        default: aspect
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/both/audio_language.yml
+++ b/tests/fixtures/kometa/defaults/both/audio_language.yml
@@ -1,0 +1,233 @@
+##############################################################################
+#                         Audio Language Collections                         #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#         https://kometa.wiki/en/latest/defaults/both/audio_language         #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "090"
+
+collections:
+  Audio Language Collections:
+    template:
+      - name: separator
+        separator: audio_language
+        key_name: Audio Language
+        translation_key: separator
+
+dynamic_collections:
+  Audio Language:
+    type: audio_language
+    title_format: <<key_name>> Audio
+    other_name: Other Audio
+    template:
+      - smart_filter
+      - shared
+    other_template:
+      - other_collection
+      - smart_filter
+      - shared
+    template_variables:
+      search_term:
+        default: audio_language
+      image:
+        default: audio_language/<<key>>
+      translation_key:
+        default: audio_language
+        other: audio_language_other
+      dynamic:
+        default: true
+    include:
+      - ab     # Abkhazian
+      - aa     # Afar
+      - af     # Afrikaans
+      - ak     # Akan
+      - sq     # Albanian
+      - am     # Amharic
+      - ar     # Arabic
+      - an     # Aragonese
+      - hy     # Armenian
+      - as     # Assamese
+      - av     # Avaric
+      - ae     # Avestan
+      - ay     # Aymara
+      - az     # Azerbaijani
+      - bm     # Bambara
+      - ba     # Bashkir
+      - eu     # Basque
+      - be     # Belarusian
+      - bn     # Bengali
+      - bi     # Bislama
+      - bs     # Bosnian
+      - br     # Breton
+      - bg     # Bulgarian
+      - my     # Burmese
+      - ca     # Catalan, Valencian
+      - km     # Central Khmer
+      - ch     # Chamorro
+      - ce     # Chechen
+      - ny     # Chichewa, Chewa, Nyanja 
+      - zh     # Chinese
+      - cu     # Church Slavic, Old Slavonic, Church Slavonic, Old Bulgarian, Old Church Slavonic
+      - cv     # Chuvash
+      - kw     # Cornish
+      - co     # Corsican
+      - cr     # Cree
+      - hr     # Croatian
+      - cs     # Czech
+      - da     # Danish
+      - dv     # Divehi, Dhivehi, Maldivian
+      - nl     # Dutch, Flemish
+      - dz     # Dzongkha
+      - en     # English
+      - eo     # Esperanto
+      - et     # Estonian
+      - ee     # Ewe
+      - fo     # Faroese
+      - fj     # Fijian
+      - fil    # Filipino
+      - fi     # Finnish
+      - fr     # French
+      - ff     # Fulah
+      - gd     # Gaelic, Scottish Gaelic
+      - gl     # Galician
+      - lg     # Ganda
+      - ka     # Georgian
+      - de     # German
+      - el     # Greek, Modern (1453–)
+      - gn     # Guarani
+      - gu     # Gujarati
+      - ht     # Haitian, Haitian Creole
+      - ha     # Hausa
+      - he     # Hebrew
+      - hz     # Herero
+      - hi     # Hindi
+      - ho     # Hiri Motu
+      - hu     # Hungarian
+      - is     # Icelandic
+      - io     # Ido
+      - ig     # Igbo
+      - id     # Indonesian
+      - ia     # Interlingua (International Auxiliary Language Association)
+      - ie     # Interlingue, Occidental
+      - iu     # Inuktitut
+      - ik     # Inupiaq
+      - ga     # Irish
+      - it     # Italian
+      - ja     # Japanese
+      - jv     # Javanese
+      - kl     # Kalaallisut, Greenlandic
+      - kn     # Kannada
+      - kr     # Kanuri
+      - ks     # Kashmiri
+      - kk     # Kazakh
+      - ki     # Kikuyu, Gikuyu
+      - rw     # Kinyarwanda
+      - ky     # Kirghiz, Kyrgyz
+      - kv     # Komi
+      - kg     # Kongo
+      - ko     # Korean
+      - kj     # Kuanyama, Kwanyama
+      - ku     # Kurdish
+      - lo     # Lao
+      - la     # Latin
+      - lv     # Latvian
+      - li     # Limburgan, Limburger, Limburgish
+      - ln     # Lingala
+      - lt     # Lithuanian
+      - lu     # Luba-Katanga
+      - lb     # Luxembourgish, Letzeburgesch
+      - mk     # Macedonian
+      - mg     # Malagasy
+      - ms     # Malay
+      - ml     # Malayalam
+      - mt     # Maltese
+      - gv     # Manx
+      - mi     # Maori
+      - mr     # Marathi
+      - mh     # Marshallese
+      - myn    # Mayan
+      - mn     # Mongolian
+      - na     # Nauru
+      - nv     # Navajo, Navaho
+      - ng     # Ndonga
+      - ne     # Nepali
+      - nd     # North Ndebele
+      - se     # Northern Sami
+      - no     # Norwegian
+      - nb     # Norwegian Bokmål
+      - nn     # Norwegian Nynorsk
+      - oc     # Occitan
+      - oj     # Ojibwa
+      - or     # Oriya
+      - om     # Oromo
+      - os     # Ossetian, Ossetic
+      - pi     # Pali
+      - ps     # Pashto, Pushto
+      - fa     # Persian
+      - pl     # Polish
+      - pt     # Portuguese
+      - pa     # Punjabi, Panjabi
+      - qu     # Quechua
+      - ro     # Romanian, Moldavian, Moldovan
+      - rm     # Romansh
+      - rom    # Romany
+      - rn     # Rundi
+      - ru     # Russian
+      - sm     # Samoan
+      - sg     # Sango
+      - sa     # Sanskrit
+      - sc     # Sardinian
+      - sr     # Serbian
+      - sn     # Shona
+      - ii     # Sichuan Yi, Nuosu
+      - sd     # Sindhi
+      - si     # Sinhala, Sinhalese
+      - sk     # Slovak
+      - sl     # Slovenian
+      - so     # Somali
+      - nr     # South Ndebele
+      - st     # Southern Sotho
+      - es     # Spanish, Castilian
+      - su     # Sundanese
+      - sw     # Swahili
+      - ss     # Swati
+      - sv     # Swedish
+      - tl     # Tagalog
+      - ty     # Tahitian
+      - tai    # Tai
+      - tg     # Tajik
+      - ta     # Tamil
+      - tt     # Tatar
+      - te     # Telugu
+      - th     # Thai
+      - bo     # Tibetan
+      - ti     # Tigrinya
+      - to     # Tonga (Tonga Islands)
+      - ts     # Tsonga
+      - tn     # Tswana
+      - tr     # Turkish
+      - tk     # Turkmen
+      - tw     # Twi
+      - ug     # Uighur, Uyghur
+      - uk     # Ukrainian
+      - ur     # Urdu
+      - uz     # Uzbek
+      - ve     # Venda
+      - vi     # Vietnamese
+      - vo     # Volapük
+      - wa     # Walloon
+      - cy     # Welsh
+      - fy     # Western Frisian
+      - wo     # Wolof
+      - xh     # Xhosa
+      - yi     # Yiddish
+      - yo     # Yoruba
+      - za     # Zhuang, Chuang
+      - zu     # Zulu
+    key_name_override:
+      myn: Mayan  
+

--- a/tests/fixtures/kometa/defaults/both/based.yml
+++ b/tests/fixtures/kometa/defaults/both/based.yml
@@ -1,0 +1,45 @@
+##############################################################################
+#                         "Based On..." Collections                          #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#             https://kometa.wiki/en/latest/defaults/both/based              #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "085"
+
+collections:
+  Based on... Collections:
+    template:
+      - name: separator
+        separator: based
+        key_name: Based on...
+        translation_key: separator
+
+dynamic_collections:
+  Based:
+    type: custom
+    data:
+      books: Book
+      comics: Comic
+      true_story: True Story
+      video_games: Video Game
+    title_format: Based on a <<key_name>>
+    template:
+      - based
+      - shared
+      - arr
+    template_variables:
+      keywords:
+        books: based on book, based on novel
+        comics: based on comic, based on comic book
+        true_story: based on true story
+        video_games: based on video game
+      image:
+        default: based/<<key_name_encoded>>
+      translation_key:
+        default: based
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/both/collectionless.yml
+++ b/tests/fixtures/kometa/defaults/both/collectionless.yml
@@ -1,0 +1,59 @@
+##############################################################################
+#                         Collectionless Collection                          #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#         https://kometa.wiki/en/latest/defaults/both/collectionless         #
+##############################################################################
+
+templates:
+  collectionless:
+    default:
+      # check1
+      exclude_prefix:
+        - "!"
+        - "~"
+        # check2
+      sort_title: ~_Collectionless
+      collection_order: alpha
+      url_poster: https://raw.githubusercontent.com/Kometa-Team/Default-Images/master/collectionless.jpg
+    optional:
+      - collection_mode
+      - exclude
+      - summary_collectionless
+      - name_collectionless
+      - tmdb_movie
+      - tmdb_show
+      - tmdb_list
+      - tvdb_movie
+      - tvdb_show
+      - tvdb_list
+      - imdb_id
+      - imdb_list
+      - plex_search
+      - mdblist_list
+      - trakt_list
+    tmdb_movie: <<tmdb_movie>>
+    tmdb_show: <<tmdb_show>>
+    tmdb_list: <<tmdb_list>>
+    tvdb_movie: <<tvdb_movie>>
+    tvdb_show: <<tvdb_show>>
+    tvdb_list: <<tvdb_list>>
+    imdb_id: <<imdb_id>>
+    imdb_list: <<imdb_list>>
+    plex_search: <<plex_search>>
+    mdblist_list: <<mdblist_list>>
+    trakt_list: <<trakt_list>>
+    translation_key: collectionless
+    url_poster: <<url_poster>>
+    collection_order: <<collection_order>>
+    sort_title: <<sort_title>>
+    summary: <<summary_collectionless>>
+    name: <<name_collectionless>>
+    plex_collectionless:
+      exclude_prefix: <<exclude_prefix>>
+      exclude: <<exclude>>
+
+collections:
+  Collectionless:
+    template:
+      - name: collectionless

--- a/tests/fixtures/kometa/defaults/both/content_rating_au.yml
+++ b/tests/fixtures/kometa/defaults/both/content_rating_au.yml
@@ -1,0 +1,153 @@
+##############################################################################
+#                       AU Content Rating Collections                        #
+#                           Adapted by 2wenty2wo                             #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#       https://kometa.wiki/en/latest/defaults/both/content_rating_au        #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "110"
+
+collections:
+  AU Ratings Collections:
+    template:
+      - name: separator
+        separator: content_rating
+        key_name: Ratings
+        translation_key: separator
+
+dynamic_collections:
+  AU Content Rating:
+    type: content_rating
+    title_format: <<key_name>> <<library_typeU>>s
+    other_name: Not Rated <<library_typeU>>s
+    template:
+      - smart_filter
+      - shared
+    other_template:
+      - other_collection
+      - smart_filter
+      - shared
+    template_variables:
+      search_term:
+        default: content_rating
+      image:
+        default: content_rating/au/<<key_name>>
+        other: content_rating/au/NR
+      translation_key:
+        default: content_rating
+        other: content_rating_other
+      dynamic:
+        default: true
+    include:
+      - G
+      - PG
+      - M
+      - MA15+
+      - R18+
+      - X18+
+    addons:
+      G:
+        - au/G
+        - de/0
+        - U
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - "01"
+        - "02"
+        - "03"
+        - "04"
+        - "05"
+        - "06"
+        - G
+        - TV-G
+        - TV-Y
+        - G - All Ages
+        - gb/U
+        - gb/0+
+        - E
+        - gb/E
+        - A
+        - no/A
+        - no/5
+        - no/05
+      PG:
+        - au/PG
+        - de/6
+        - gb/9+
+        - TV-PG
+        - TV-Y7
+        - TV-Y7-FV
+        - PG
+        - 7
+        - 8
+        - 9
+        - 10
+        - 11
+        - "07"
+        - "08"
+        - "09"
+        - PG - Children
+        - no/6
+        - no/06
+        - no/7
+        - no/07
+        - no/9
+        - no/09
+        - no/10
+        - no/11
+      M:
+        - au/M
+        - de/12
+        - gb/12
+        - no/12
+        - gb/15
+        - gb/14+
+        - TV-14
+        - 12
+        - 13
+        - 14
+        - 15
+        - PG-13 - Teens 13 or older
+        - PG-13
+        - no/15
+      MA15+:
+        - au/MA15+
+        - au/MA 15+
+        - de/16
+        - no/16
+        - A-17
+        - TVMA
+        - TV-MA
+        - R
+        - 16
+        - 17
+        - M/PG
+      R18+:
+        - au/R 18+
+        - au/R18+
+        - de/18
+        - gb/18
+        - M
+        - 18
+        - R - 17+ (violence & profanity)
+        - no/18
+        - R18
+        - gb/X
+        - X
+        - NC-17
+        - R+ - Mild Nudity
+        - Rx - Hentai
+      X18+:
+        - gb/R18
+        - au/X 18+
+        - de/BPjM Restricted
+        - BPjM Restricted

--- a/tests/fixtures/kometa/defaults/both/content_rating_cs.yml
+++ b/tests/fixtures/kometa/defaults/both/content_rating_cs.yml
@@ -1,0 +1,292 @@
+##############################################################################
+#                   CommonSense Content Rating Collections                   #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#       https://kometa.wiki/en/latest/defaults/both/content_rating_cs        #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "110"
+
+collections:
+  CS Ratings Collections:
+    template:
+      - name: separator
+        separator: content_rating
+        key_name: Ratings
+        translation_key: separator
+
+dynamic_collections:
+  CommonSense Content Rating:
+    type: content_rating
+    title_format: Age <<key_name>>+ <<library_typeU>>s
+    other_name: Not Rated <<library_typeU>>s
+    template:
+      - smart_filter
+      - shared
+    other_template:
+      - other_collection
+      - smart_filter
+      - shared
+    template_variables:
+      search_term:
+        default: content_rating
+      image:
+        default: content_rating/cs/<<key_name>>
+        other: content_rating/cs/NR
+      translation_key:
+        default: content_rating_cs
+        other: content_rating_other
+      order:
+        1: "01_"
+        2: "02_"
+        3: "03_"
+        4: "04_"
+        5: "05_"
+        6: "06_"
+        7: "07_"
+        8: "08_"
+        9: "09_"
+        10: "10_"
+        11: "11_"
+        12: "12_"
+        13: "13_"
+        14: "14_"
+        15: "15_"
+        16: "16_"
+        17: "17_"
+        18: "18_"
+      dynamic:
+        default: true
+    include:
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+      - 6
+      - 7
+      - 8
+      - 9
+      - 10
+      - 11
+      - 12
+      - 13
+      - 14
+      - 15
+      - 16
+      - 17
+      - 18
+    addons:
+      1:
+        - gb/U
+        - gb/0+
+        - G
+        - TV-G
+        - TV-Y
+        - E
+        - gb/E
+        - G - All Ages
+        - A
+        - no/A
+        - no/5
+        - no/05
+        - "01"
+      2:
+        - gb/U
+        - gb/0+
+        - G
+        - TV-G
+        - TV-Y
+        - E
+        - gb/E
+        - G - All Ages
+        - A
+        - no/A
+        - no/5
+        - no/05
+        - "02"
+      3:
+        - gb/U
+        - gb/0+
+        - G
+        - TV-G
+        - TV-Y
+        - E
+        - gb/E
+        - G - All Ages
+        - A
+        - no/A
+        - no/5
+        - no/05
+        - "03"
+      4:
+        - gb/U
+        - gb/0+
+        - G
+        - TV-G
+        - TV-Y
+        - E
+        - gb/E
+        - G - All Ages
+        - A
+        - no/A
+        - no/5
+        - no/05
+        - "04"
+      5:
+        - gb/U
+        - gb/0+
+        - G
+        - TV-G
+        - TV-Y
+        - E
+        - gb/E
+        - G - All Ages
+        - A
+        - no/A
+        - no/5
+        - no/05
+        - "05"
+      6:
+        - gb/U
+        - gb/0+
+        - G
+        - TV-G
+        - TV-Y
+        - E
+        - gb/E
+        - G - All Ages
+        - no/6
+        - no/06
+        - no/7
+        - no/07
+        - "06"
+      7:
+        - gb/PG
+        - TV-PG
+        - TV-Y7
+        - TV-Y7-FV
+        - PG
+        - PG - Children
+        - no/6
+        - no/06
+        - no/7
+        - no/07
+        - "07"
+      8:
+        - gb/PG
+        - TV-PG
+        - TV-Y7
+        - TV-Y7-FV
+        - PG
+        - PG - Children
+        - no/6
+        - no/06
+        - no/7
+        - no/07
+        - "08"
+      9:
+        - gb/PG
+        - TV-PG
+        - TV-Y7
+        - TV-Y7-FV
+        - PG
+        - PG - Children
+        - gb/9+
+        - no/9
+        - no/09
+        - no/10
+        - "09"
+      10:
+        - gb/PG
+        - TV-PG
+        - TV-Y7
+        - TV-Y7-FV
+        - PG
+        - PG - Children
+        - gb/9+
+        - no/9
+        - no/09
+        - no/10
+      11:
+        - gb/PG
+        - TV-PG
+        - TV-Y7
+        - TV-Y7-FV
+        - PG
+        - PG - Children
+        - gb/9+
+        - no/9
+        - no/09
+        - no/10
+        - no/11
+      12:
+        - gb/12
+        - gb/12A
+        - 12+
+        - PG
+        - PG - Children
+        - no/11
+        - no/12
+      13:
+        - gb/12
+        - gb/12A
+        - 12+
+        - PG-13
+        - PG-13 - Teens 13 or older
+        - no/11
+        - no/12
+      14:
+        - gb/12
+        - 12
+        - gb/12A
+        - 12+
+        - PG-13
+        - TV-14
+        - PG-13 - Teens 13 or older
+        - no/11
+        - no/12
+      15:
+        - gb/15
+        - gb/14+
+        - TV-14
+        - PG-13 - Teens 13 or older
+        - no/15
+        - no/16
+      16:
+        - gb/15
+        - gb/14+
+        - TV-14
+        - PG-13 - Teens 13 or older
+        - no/15
+        - no/16
+      17:
+        - gb/18
+        - gb/15
+        - gb/14+
+        - TV-14
+        - R
+        - R - 17+ (violence & profanity)
+        - TVMA
+        - TV-MA
+        - MA-17
+        - no/18
+        - no/15
+        - no/16
+      18:
+        - gb/18
+        - MA-17
+        - TVMA
+        - TV-MA
+        - R
+        - gb/R18
+        - gb/X
+        - X
+        - NC-17
+        - R - 17+ (violence & profanity)
+        - R+ - Mild Nudity
+        - Rx - Hentai
+        - no/18

--- a/tests/fixtures/kometa/defaults/both/content_rating_de.yml
+++ b/tests/fixtures/kometa/defaults/both/content_rating_de.yml
@@ -1,0 +1,137 @@
+##############################################################################
+#                       DE Content Rating Collections                        #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#       https://kometa.wiki/en/latest/defaults/both/content_rating_de        #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "110"
+
+collections:
+  DE Ratings Collections:
+    template:
+      - name: separator
+        separator: content_rating
+        key_name: Ratings
+        translation_key: separator
+
+dynamic_collections:
+  DE Content Rating:
+    type: content_rating
+    title_format: <<key_name>> <<library_typeU>>s
+    other_name: Not Rated <<library_typeU>>s
+    template:
+      - smart_filter
+      - shared
+    other_template:
+      - other_collection
+      - smart_filter
+      - shared
+    template_variables:
+      search_term:
+        default: content_rating
+      image:
+        default: content_rating/de/<<key_name>>
+        other: content_rating/de/NR
+      translation_key:
+        default: content_rating
+        other: content_rating_other
+      dynamic:
+        default: true
+    include:
+      - 0
+      - 6
+      - 12
+      - 16
+      - 18
+      - BPjM
+    addons:
+      0:
+        - de/0
+        - U
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - "01"
+        - "02"
+        - "03"
+        - "04"
+        - "05"
+        - G
+        - TV-G
+        - TV-Y
+        - G - All Ages
+        - gb/U
+        - gb/0+
+        - E
+        - gb/E
+        - A
+        - no/A
+        - no/5
+        - no/05
+      6:
+        - de/6
+        - gb/9+
+        - TV-PG
+        - TV-Y7
+        - TV-Y7-FV
+        - PG
+        - 7
+        - 8
+        - 9
+        - 10
+        - 11
+        - "07"
+        - "08"
+        - "09"
+        - PG - Children
+        - no/6
+        - no/06
+        - no/7
+        - no/07
+        - no/9
+        - no/09
+        - no/10
+        - no/11
+      12:
+        - de/12
+        - gb/12
+        - no/12
+        - gb/15
+        - gb/14+
+        - TV-14
+        - 13
+        - 14
+        - 15
+        - PG-13 - Teens 13 or older
+        - PG-13
+        - no/15
+      16:
+        - de/16
+        - no/16
+        - A-17
+        - TVMA
+        - TV-MA
+        - R
+        - 17
+        - M/PG
+      18:
+        - de/18
+        - gb/18
+        - M
+        - no/18
+        - R18
+        - gb/R18
+        - gb/X
+        - X
+        - NC-17
+        - R+ - Mild Nudity
+        - Rx - Hentai
+      BPjM:
+        - de/BPjM Restricted
+        - BPjM Restricted

--- a/tests/fixtures/kometa/defaults/both/content_rating_mal.yml
+++ b/tests/fixtures/kometa/defaults/both/content_rating_mal.yml
@@ -1,0 +1,125 @@
+##############################################################################
+#                       MAL Content Rating Collections                       #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#       https://kometa.wiki/en/latest/defaults/both/content_rating_mal       #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "110"
+
+collections:
+  MAL Ratings Collections:
+    template:
+      - name: separator
+        separator: content_rating
+        key_name: Ratings
+        translation_key: separator
+
+dynamic_collections:
+  MAL Content Ratings:
+    type: content_rating
+    title_format: <<key_name>> <<library_typeU>>s
+    other_name: Not Rated <<library_typeU>>s
+    template:
+      - smart_filter
+      - shared
+    other_template:
+      - other_collection
+      - smart_filter
+      - shared
+    template_variables:
+      search_term:
+        default: content_rating
+      image:
+        default: content_rating/mal/<<key_name_encoded>>
+        other: content_rating/mal/NR
+      translation_key:
+        default: content_rating
+        other: content_rating_other
+      dynamic:
+        default: true
+    include:
+      - "G"
+      - "PG"
+      - "PG-13"
+      - "R"
+      - "R+"
+      - "Rx"
+    addons:
+      G:
+        - gb/U
+        - gb/0+
+        - U
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - "0"
+        - "01"
+        - "02"
+        - "03"
+        - "04"
+        - "05"
+        - "06"
+        - G - All Ages
+        - TV-G
+        - A
+        - no/A
+      PG:
+        - TV-Y7
+        - TV-Y7-FV
+        - 7
+        - 8
+        - 9
+        - "07"
+        - "08"
+        - "09"
+        - gb/PG
+        - gb/9+
+        - 10
+        - 11
+        - 12
+        - PG - Children
+        - no/5
+        - no/05
+        - no/6
+        - no/06
+        - no/7
+        - no/07
+      PG-13:
+        - 13
+        - gb/12A
+        - 12+
+        - TV-13
+        - gb/14+
+        - gb/15
+        - 14
+        - 15
+        - 16
+        - PG-13 - Teens 13 or older
+        - no/9
+        - no/09
+        - no/10
+        - no/11
+        - no/12
+      R:
+        - 17
+        - 18
+        - gb/18
+        - MA-17
+        - NC-17
+        - TVMA
+        - R - 17+ (violence & profanity)
+        - no/15
+        - no/16
+        - no/18
+      R+:
+        - R+ - Mild Nudity
+      Rx:
+        - Rx - Hentai

--- a/tests/fixtures/kometa/defaults/both/content_rating_nz.yml
+++ b/tests/fixtures/kometa/defaults/both/content_rating_nz.yml
@@ -1,0 +1,168 @@
+##############################################################################
+#                       NZ Content Rating Collections                        #
+#                           Adapted by nzvengeance                           #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#       https://kometa.wiki/en/latest/defaults/both/content_rating_nz        #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "110"
+
+collections:
+  NZ Ratings Collections:
+    template:
+      - name: separator
+        separator: content_rating
+        key_name: Ratings
+        translation_key: separator
+
+dynamic_collections:
+  NZ Content Rating:
+    type: content_rating
+    title_format: <<key_name>> <<library_typeU>>s
+    other_name: Not Rated <<library_typeU>>s
+    template:
+      - smart_filter
+      - shared
+    other_template:
+      - other_collection
+      - smart_filter
+      - shared
+    template_variables:
+      search_term:
+        default: content_rating
+      image:
+        default: content_rating/nz/<<key_name>>
+        other: content_rating/nz/NR
+      translation_key:
+        default: content_rating
+        other: content_rating_other
+      dynamic:
+        default: true
+    include:
+      - G
+      - PG
+      - M
+      - R13
+      - RP13
+      - R15
+      - R16
+      - RP16
+      - R18
+      - RP18
+      - R
+    addons:
+      G:
+        - au/G
+        - de/0
+        - U
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - "01"
+        - "02"
+        - "03"
+        - "04"
+        - "05"
+        - "06"
+        - G
+        - TV-G
+        - TV-Y
+        - G - All Ages
+        - gb/U
+        - gb/0+
+        - E
+        - gb/E
+        - A
+        - no/A
+        - no/5
+        - no/05
+      PG:
+        - au/PG
+        - de/6
+        - gb/9+
+        - TV-PG
+        - TV-Y7
+        - TV-Y7-FV
+        - PG
+        - 7
+        - 8
+        - 9
+        - 10
+        - 11
+        - "07"
+        - "08"
+        - "09"
+        - PG - Children
+        - no/6
+        - no/06
+        - no/7
+        - no/07
+        - no/9
+        - no/09
+        - no/10
+        - no/11
+      M:
+        - au/M
+        - de/12
+        - gb/12
+        - no/12
+        - gb/15
+        - gb/14+
+        - TV-14
+        - 12
+        - 13
+        - 14
+        - 15
+        - PG-13 - Teens 13 or older
+        - PG-13
+        - no/15
+      R13:
+        - 13
+        - 14
+      RP13:
+        - 14
+      R15:
+        - au/MA15+
+        - de/16
+        - no/16
+        - A-17
+        - TVMA
+        - TV-MA
+        - R
+        - 16
+        - 17
+        - M/PG
+      R16:
+        - 16
+        - 17
+      RP16:
+        - 17
+      R18:
+        - au/R 18+
+        - de/18
+        - gb/18
+        - M
+        - 18
+        - R - 17+ (violence & profanity)
+        - no/18
+        - R18
+        - gb/R18
+        - gb/X
+        - X
+        - NC-17
+        - R+ - Mild Nudity
+        - Rx - Hentai
+      RP18:
+        - 18
+      R:
+        - au/X 18+
+        - de/BPjM Restricted
+        - BPjM Restricted

--- a/tests/fixtures/kometa/defaults/both/content_rating_uk.yml
+++ b/tests/fixtures/kometa/defaults/both/content_rating_uk.yml
@@ -1,0 +1,155 @@
+##############################################################################
+#                       UK Content Rating Collections                        #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#       https://kometa.wiki/en/latest/defaults/both/content_rating_uk        #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "110"
+
+collections:
+  UK Ratings Collections:
+    template:
+      - name: separator
+        separator: content_rating
+        key_name: Ratings
+        translation_key: separator
+
+dynamic_collections:
+  UK Content Rating:
+    type: content_rating
+    title_format: <<key_name>> <<library_typeU>>s
+    other_name: Not Rated <<library_typeU>>s
+    template:
+      - smart_filter
+      - shared
+    other_template:
+      - other_collection
+      - smart_filter
+      - shared
+    template_variables:
+      search_term:
+        default: content_rating
+      image:
+        default: content_rating/uk/<<key_name>>
+        other: content_rating/uk/NR
+      translation_key:
+        default: content_rating
+        other: content_rating_other
+      dynamic:
+        default: true
+    include:
+      - U
+      - PG
+      - 12
+      - 12A
+      - 15
+      - 18
+      - R18
+    addons:
+      U:
+        - gb/U
+        - gb/Uc
+        - gb/0+
+        - gb/6+
+        - gb/Kids & Family
+        - G
+        - TV-Y
+        - TV-G
+        - E
+        - gb/E
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - "01"
+        - "02"
+        - "03"
+        - "04"
+        - "05"
+        - "06"
+        - G - All Ages
+        - A
+        - no/A
+      PG:
+        - gb/PG
+        - gb/9+
+        - gb/7
+        - gb/7+
+        - TV-PG
+        - TV-Y7
+        - TV-Y7-FV
+        - 7
+        - 8
+        - 9
+        - 10
+        - 11
+        - "07"
+        - "08"
+        - "09"
+        - PG - Children
+        - no/5
+        - no/05
+        - no/6
+        - no/06
+        - no/7
+        - no/07
+      12:
+        - gb/12
+        - gb/A
+        - gb/Caution
+        - gb/G
+        - PG-13 - Teens 13 or older
+        - no/9
+        - no/09
+        - no/10
+        - no/11
+        - no/12
+      12A:
+        - gb/12A
+        - 12+
+        - PG-13
+        - TV-13
+        - 12
+        - PG-13 - Teens 13 or older
+        - no/9
+        - no/09
+        - no/10
+        - no/11
+        - no/12
+      15:
+        - gb/15
+        - gb/14+
+        - gb/16
+        - gb/16+
+        - gb/AA
+        - TV-14
+        - 13
+        - 14
+        - PG-13 - Teens 13 or older
+        - no/15
+        - no/16
+      18:
+        - gb/18
+        - gb/18+ 
+        - MA-17
+        - TVMA
+        - TV-MA
+        - R
+        - 16
+        - 17
+        - NC-17
+        - R - 17+ (violence & profanity)
+        - gb/X
+        - no/18
+      R18:
+        - gb/R18
+        - X
+        - R+ - Mild Nudity
+        - Rx - Hentai

--- a/tests/fixtures/kometa/defaults/both/genre.yml
+++ b/tests/fixtures/kometa/defaults/both/genre.yml
@@ -1,0 +1,278 @@
+##############################################################################
+#                             Genre Collections                              #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#             https://kometa.wiki/en/latest/defaults/both/genre              #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "060"
+
+collections:
+  Genre Collections:
+    template:
+      - name: separator
+        separator: genre
+        key_name: Genre
+        translation_key: separator
+
+dynamic_collections:
+  Genre:
+    type: genre
+    title_format: <<key_name>> <<library_typeU>>s
+    template:
+      - smart_filter
+      - shared
+    template_variables:
+      search_term:
+        default: genre
+      image:
+        default: genre/<<original_key_name_encoded>>
+        Abenteuer: genre/Adventure
+        Acción: genre/Action
+        Acción y Aventura: genre/Action%20%26%20Adventure
+        Actie: genre/Action
+        Actie & Avontuur: genre/Action%20%26%20Adventure
+        Action & Abenteuer: genre/Action%20%26%20Adventure
+        Action & eventyr: genre/Action%20%26%20Adventure
+        Action & Äventyr: genre/Action%20%26%20Adventure
+        Action et Aventure: genre/Action%20%26%20Adventure
+        Akció: genre/Action
+        Akció és Kaland: genre/Action%20%26%20Adventure
+        Aktion: genre/Action
+        Aktion & Eventyr: genre/Action%20%26%20Adventure
+        Animación: genre/Animation
+        Animatie: genre/Animation
+        Animazione: genre/Animation
+        Animação: genre/Animation
+        Animering: genre/Animation
+        Animáció: genre/Animation
+        Aventura: genre/Adventure
+        Aventure: genre/Adventure
+        Avontuur: genre/Adventure
+        Avventura: genre/Adventure
+        Azione: genre/Action
+        Azione & Avventura: genre/Action%20%26%20Adventure
+        Ação: genre/Action
+        Ação e Aventura: genre/Action%20%26%20Adventure
+        Bambini: genre/Kids
+        Barn: genre/Kids
+        Brott: genre/Crime
+        Børn: genre/Kids
+        Bűnügyi: genre/Crime
+        Ciencia Ficción: genre/Science%20Fiction
+        Ciencia Ficción y Fantasía: genre/Sci-Fi%20%26%20Fantasy
+        Comedia: genre/Comedy
+        Commedia: genre/Comedy
+        Comédia: genre/Comedy
+        Comédie: genre/Comedy
+        Crianças: genre/Kids
+        Crimen: genre/Crime
+        Crimine: genre/Crime
+        Családi: genre/Family
+        Des gamins: genre/Kids
+        Documentaire: genre/Documentary
+        Documental: genre/Documentary
+        Documentario: genre/Documentary
+        Documentário: genre/Documentary
+        Dokumentar: genre/Documentary
+        Dokumentation: genre/Documentary
+        Dokumentumfilm: genre/Documentary
+        Dokumentär: genre/Documentary
+        Dramatiques: genre/Drama
+        Drame: genre/Drama
+        Drammatico: genre/Drama
+        Dráma: genre/Drama
+        Eventyr: genre/Adventure
+        Famiglia: genre/Family
+        Familia: genre/Family
+        Familial: genre/Family
+        Familie: genre/Family
+        Familj: genre/Family
+        Famille: genre/Family
+        Família: genre/Family
+        Fantaisies: genre/Fantasy
+        Fantascienza: genre/Science%20Fiction
+        Fantascienza e Fantasy: genre/Sci-Fi%20%26%20Fantasy
+        Fantasi: genre/Fantasy
+        Fantasia: genre/Fantasy
+        Fantasie: genre/Fantasy
+        Fantastique: genre/Fantasy
+        Fantasía: genre/Fantasy
+        Feuilleton: genre/Soap
+        Ficção científica: genre/Science%20Fiction
+        Ficção científica e fantasia: genre/Sci-Fi%20%26%20Fantasy
+        Film TV: genre/TV%20Movie
+        Filme de ação: genre/Thriller
+        Filme para TV: genre/TV%20Movie
+        Forbrytelser: genre/Crime
+        Geschiedenis: genre/History
+        Guerra: genre/War
+        Guerra e Politica: genre/War%20%26%20Politics
+        Guerra e Política: genre/War%20%26%20Politics
+        Guerra y Política: genre/War%20%26%20Politics
+        Guerre: genre/War
+        Guerre & Politique: genre/War%20%26%20Politics
+        Gyerekeknek: genre/Kids
+        Gyser: genre/Horror
+        Histoire: genre/History
+        Historia: genre/History
+        Historie: genre/History
+        Historiques: genre/History
+        História: genre/History
+        Horreur: genre/Horror
+        Háború: genre/War
+        Háború és Politika: genre/War%20%26%20Politics
+        Hírek: genre/News
+        Kaland: genre/Adventure
+        Kinder: genre/Kids
+        Komedi: genre/Comedy
+        Komedie: genre/Comedy
+        Komödie: genre/Comedy
+        Krieg: genre/War
+        Krieg & Politik: genre/War%20%26%20Politics
+        Krig: genre/War
+        Krig & Politik: genre/War%20%26%20Politics
+        Krig & politik: genre/War%20%26%20Politics
+        Krig og politikk: genre/War%20%26%20Politics
+        Krimi: genre/Crime
+        Misdaad: genre/Crime
+        Misterio: genre/Mystery
+        Mistero: genre/Mystery
+        Mistério: genre/Mystery
+        Musica: genre/Music
+        Musik: genre/Music
+        Musikk: genre/Music
+        Musique: genre/Music
+        Musiques: genre/Music
+        Mysterie: genre/Mystery
+        Mysterium: genre/Mystery
+        Mystère: genre/Mystery
+        Música: genre/Music
+        Nachrichten: genre/News
+        Niños: genre/Kids
+        Noticias: genre/News
+        Notizie: genre/News
+        Notícia: genre/News
+        Nouvelles: genre/News
+        Nyheder: genre/News
+        Nyheter: genre/News
+        Ocidental: genre/Western
+        Oeste: genre/Western
+        Orrore: genre/Horror
+        Realidad: genre/Reality
+        Realidade: genre/Reality
+        Realität: genre/Reality
+        Realtà: genre/Reality
+        Rejtély: genre/Mystery
+        Romanse: genre/Romance
+        Romantik: genre/Romance
+        Romantikus: genre/Romance
+        Romantiques: genre/Romance
+        Romanze: genre/Romance
+        Romanzo: genre/Romance
+        Réalité: genre/Reality
+        Sabão: genre/Soap
+        Sci-Fi & Fantasi: genre/Sci-Fi%20%26%20Fantasy
+        Sci-fi og fantasi: genre/Sci-Fi%20%26%20Fantasy
+        Sci-Fi és Fantasy: genre/Sci-Fi%20%26%20Fantasy
+        Science-Fiction: genre/Science%20Fiction
+        Science-fiction: genre/Science%20Fiction
+        Science-fiction et fantaisie: genre/Sci-Fi%20%26%20Fantasy
+        Skrekk: genre/Horror
+        Skräck: genre/Horror
+        Storia: genre/History
+        Suspense: genre/Thriller
+        Szappanopera: genre/Soap
+        Såpa: genre/Soap
+        Sæbe: genre/Soap
+        Telefilme: genre/TV%20Movie
+        Telenovela: genre/Soap
+        Tudományos-Fantasztikus: genre/Science%20Fiction
+        TV Film: genre/TV%20Movie
+        TV film: genre/TV%20Movie
+        Téléfilm: genre/TV%20Movie
+        Történelem: genre/History
+        Verbrechen: genre/Crime
+        Västerländsk: genre/Western
+        Vígjáték: genre/Comedy
+        Zene: genre/Music
+        Äventyr: genre/Adventure
+        Анимация: genre/Animation
+        Война: genre/War
+        Война и политика: genre/War%20%26%20Politics
+        Детски: genre/Kids
+        Документален: genre/Documentary
+        Документальное кино: genre/Documentary
+        Драма: genre/Drama
+        Екшън: genre/Action
+        Екшън и приключения: genre/Action%20%26%20Adventure
+        История: genre/History
+        Комедия: genre/Comedy
+        Криминал: genre/Crime
+        Криминален: genre/Crime
+        Мистерия: genre/Mystery
+        Музика: genre/Music
+        Научна фантастика: genre/Science%20Fiction
+        Научна фантастика и фентъзи: genre/Sci-Fi%20%26%20Fantasy
+        Новини: genre/News
+        Приключение: genre/Adventure
+        Приключенски: genre/Adventure
+        Приключенческий экшн: genre/Action%20%26%20Adventure
+        Риалити: genre/Reality
+        Романтичен: genre/Romance
+        Сапунена опера: genre/Soap
+        Семеен: genre/Family
+        Семейное: genre/Family
+        ТВ Филм: genre/TV%20Movie
+        Трилър: genre/Thriller
+        Уестърн: genre/Western
+        Ужаси: genre/Horror
+        Фентъзи: genre/Fantasy
+        Фэнтези: genre/Fantasy
+        Экшн: genre/Action
+      translation_key:
+        default: genre
+      dynamic:
+        default: true
+    addons:
+      Action:
+        - Action/Adventure
+        - Action/adventure
+        - Action & Adventure
+        - Action & adventure
+        - Action and Adventure
+        - Action and adventure
+      Adventure:
+        - Action/Adventure
+        - Action/adventure
+        - Action & Adventure
+        - Action & adventure
+        - Action and Adventure
+        - Action and adventure
+      Biopic:
+        - Biography
+      Family:
+        - Kids & Family
+      Fantasy:
+        - SciFi & Fantasy
+        - Science Fiction & Fantasy
+        - Science-Fiction & Fantasy
+        - Sci-Fi & Fantasy
+      Film Noir:
+        Film-Noir
+      Politics:
+        - War & Politics
+      Science Fiction:
+        - SciFi
+        - Sci-Fi
+        - Science-Fiction
+        - SciFi & Fantasy
+        - Science Fiction & Fantasy
+        - Sci-Fi & Fantasy
+      Talk Show:
+        - Talk
+      War:
+        - War & Politics

--- a/tests/fixtures/kometa/defaults/both/resolution.yml
+++ b/tests/fixtures/kometa/defaults/both/resolution.yml
@@ -1,0 +1,82 @@
+##############################################################################
+#                           Resolution Collections                           #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#          https://kometa.wiki/en/latest/defaults/both/resolution            #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "120"
+    conditionals:
+      image:
+        default: resolution/<<key>>
+        conditions:
+          - style: standards
+            value: resolution/standards/<<key>>
+      key_name:
+        conditions:
+          - style: standards
+            key: 480
+            value: SD
+          - style: standards
+            key: 720
+            value: HD Ready
+          - style: standards
+            key: 1080
+            value: Full HD
+          - style: standards
+            key: 4k
+            value: Ultra HD
+
+collections:
+  Resolution Collections:
+    template:
+      - name: separator
+        separator: resolution
+        key_name: Resolution
+        translation_key: separator
+
+dynamic_collections:    
+  Resolution:
+    type: resolution
+    title_format: <<key_name>> <<library_typeU>>s
+    other_name: Other Resolutions <<library_typeU>>s
+    template:
+      - smart_filter
+      - shared
+    other_template:
+      - other_collection
+      - smart_filter
+      - shared
+    template_variables:
+      search_term:
+        default: resolution
+      translation_key:
+        default: resolution
+        other: resolution_other
+      order:
+        4k: "1_"
+        1080: "2_"
+        720: "3_"
+        480: "4_"
+      dynamic:
+        default: true
+    include:
+      - 4k
+      - 1080
+      - 720
+      - 480
+    addons:
+      4k:
+        - 8k
+      1080:
+        - 2k
+      480:
+        - 144
+        - 240
+        - 360
+        - sd
+        - 576
+        

--- a/tests/fixtures/kometa/defaults/both/streaming.yml
+++ b/tests/fixtures/kometa/defaults/both/streaming.yml
@@ -1,0 +1,196 @@
+##############################################################################
+#                           Streaming Collections                            #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#           https://kometa.wiki/en/latest/defaults/both/streaming            #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "030"
+
+templates:
+  streaming:
+    optional:
+      - use_<<key>>
+      - use_<<tmdb_key>>
+      - allowed_libraries
+      - originals_only
+      - delete_collections_named
+    conditionals:
+
+      discover_sort:
+        conditions:
+          - originals_only: false
+            library_type: movie
+            value: popularity.desc
+          - originals_only: false
+            library_type: show
+            value: popularity.desc
+      originals:
+        conditions:
+          - originals_only: true
+            value: originals
+      discover_region:
+        conditions:
+          - originals_only: false
+            value: <<region>>
+      final_tmdb_key:
+        default: <<tmdb_key>>
+        conditions:
+          - region: [CA, AU, NL, ES]
+            tmdb_key: [9]
+            value: 119
+
+      discover_with:
+        conditions:
+          - originals_only: false
+            value: <<final_tmdb_key>>
+      discover_limit:
+        conditions:
+          - originals_only: false
+            value: 0
+      allowed_streaming:
+        conditions:
+          - originals_only: true
+            tmdb_key: [103, 1759, 41, 2300, 230, 283, 510, 39, 37, 188]
+            value: False
+          - region.not: GB
+            tmdb_key: [103, 41, 2300, 39]
+            value: False
+          - region.not: ES
+            tmdb_key: [149, 339, 2241, 62, 2162, 63]
+            value: False
+          - region.not: CA
+            tmdb_key: [230]
+            value: False
+          - region: CA
+            tmdb_key: [1899, 37]
+            value: False
+      final_use:
+        conditions:
+          - use_<<key>>.exists: true
+            value: <<use_<<key>>>>
+          - use_all: false
+            value: false
+    default:
+      region: "US"
+      limit: "500"
+      sync_mode: sync
+      sync_mode_<<key>>: <<sync_mode>>
+      discover_with_<<key>>: <<discover_with>>
+      sort_by: release.desc
+      sort_by_<<key>>: <<sort_by>>
+      delete_collections_named_<<key>>: <<delete_collections_named>>
+    run_definition:
+      - <<final_use>>
+      - <<use_<<tmdb_key>>>>
+      - <<allowed_libraries>>
+      - <<allowed_streaming>>
+    cache_builders: 1
+    smart_label: <<sort_by_<<key>>>>
+    sync_mode: <<sync_mode_<<key>>>>
+    mdblist_list: https://mdblist.com/lists/k0meta/<<key>>-<<originals>>
+    delete_collections_named: <<delete_collections_named_<<key>>>>
+    limit: <<limit>>
+    tmdb_discover:
+      limit: <<discover_limit>>
+      with_watch_providers: <<discover_with_<<key>>>>
+      watch_region: <<discover_region>>
+      sort_by: <<discover_sort>>
+
+collections:
+  Streaming Collections:
+    template:
+      - name: separator
+        separator: streaming
+        key_name: Streaming
+        translation_key: separator
+
+dynamic_collections:
+  Streaming:
+    type: custom
+    data:
+      channel4: Channel 4
+      appletv: Apple TV
+      bet: BET+
+      crave: Crave
+      crunchyroll: Crunchyroll
+      discovery: discovery+
+      disney: Disney+
+      itvx: ITVX
+      hbomax: HBO Max
+      hayu: hayu
+      hulu: Hulu
+      movistar: Movistar Plus+
+      atresplayer: Atres Player
+      netflix: Netflix
+      now: NOW
+      paramount: Paramount+
+      peacock: Peacock
+      amazon: Prime Video
+      amc: AMC+
+      filmin: Filmin
+      youtube: YouTube
+      tubi: tubi
+    title_format: <<key_name>> <<library_typeU>>s
+    template:
+      - streaming
+      - shared
+      - arr
+    template_variables:
+      image:
+        default: streaming/<<style>>/<<key_name_encoded>>
+      tmdb_key:
+        channel4: 103
+        appletv: 350
+        bet: 1759
+        crave: 230
+        crunchyroll: 283
+        discovery: 510
+        disney: 337
+        hbomax: 1899
+        hayu: 223
+        hulu: 15
+        itvx: 41|2300
+        movistar: 149|339|2241
+        netflix: 8
+        now: 39
+        paramount: 531|1770
+        peacock: 387
+        amazon: 9
+        amc: 528|1854
+        filmin: 63
+        showtime: 37
+        youtube: 188
+        tubi: 73
+        atresplayer: 62|2162
+      originals_only:
+        default: false
+      allowed_libraries:
+        hayu: show
+        discovery: show
+        crunchyroll: show
+      translation_key:
+        default: streaming
+      dynamic:
+        default: true
+      style:
+        default: color
+      delete_collections_named:
+        channel4:
+          - All 4 Movies
+          - All 4 Shows
+        paramount:
+          - Showtime Movies
+          - Showtime Shows
+        itvx:
+          - BritBox Movies
+          - BritBox Shows
+        hbomax:
+          - Max Movies
+          - Max Shows
+        appletv:
+          - Apple TV+ Movies
+          - Apple TV+ Shows

--- a/tests/fixtures/kometa/defaults/both/studio.yml
+++ b/tests/fixtures/kometa/defaults/both/studio.yml
@@ -1,0 +1,726 @@
+##############################################################################
+#                             Studio Collections                             #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#            https://kometa.wiki/en/latest/defaults/both/studio              #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "070"
+
+collections:
+  Studio Collections:
+    template:
+      - name: separator
+        separator: studio
+        key_name: Studio
+        translation_key: separator
+
+dynamic_collections:
+  Studio:
+    type: studio
+    title_format: <<key_name>>
+    template:
+      - smart_filter
+      - shared
+    template_variables:
+      search_term:
+        default: studio.is
+      search_term2:
+        20th Century Studios: studio
+      search_value2:
+        20th Century Studios: 20th Century
+      image:
+        default: studio/<<key_encoded>>
+      translation_key:
+        default: studio
+      dynamic:
+        default: true
+    include:
+      #### ANIMES ########################################################################################################
+      - 8bit
+      - A-1 Pictures
+      - A.C.G.T.
+      - Acca effe
+      - Actas
+      - AIC
+      - Ajia-Do
+      - Akatsuki
+      - Animation Do
+      - Ankama
+      - APPP
+      - Arms
+      - Artland
+      - Artmic
+      - Arvo Animation
+      - Asahi Production
+      - Ashi Productions
+      - asread.
+      - AtelierPontdarc
+      - B.CMAY PICTURES
+      - Bandai Namco Pictures
+      - Bee Train
+      - Berlanti Productions
+      - Bibury Animation Studios
+      - bilibili
+      - Bones
+      - Brain's Base
+      - Bridge
+      - BUG FILMS
+      - C-Station
+      - C2C
+      - Children's Playground Entertainment
+      - Cloud Hearts
+      - CloverWorks
+      - Colored Pencil Animation
+      - CoMix Wave Films
+      - Connect
+      - Craftar Studios
+      - Creators in Pack
+      - CygamesPictures
+      - David Production
+      - Diomedéa
+      - DLE
+      - Doga Kobo
+      - domerica
+      - Drive
+      - EMT Squared
+      - Encourage Films
+      - ENGI
+      - feel.
+      - Felix Film
+      - Fenz
+      - GAINAX
+      - Gallop
+      - Geek Toys
+      - Gekkou
+      - Gemba
+      - GENCO
+      - Geno Studio
+      - GoHands
+      - Gonzo
+      - Graphinica
+      - Group Tac
+      - Hal Film Maker
+      - Haoliners Animation League
+      - Hoods Entertainment
+      - Hotline
+      - J.C.Staff
+      - Jumondou
+      - Kadokawa
+      - Khara
+      - Kinema Citrus
+      - Kyoto Animation
+      - Lan Studio
+      - LandQ Studio
+      - Lay-duce
+      - Lerche
+      - LIDENFILMS
+      - M.S.C
+      - Madhouse
+      - Magic Bus
+      - Maho Film
+      - Manglobe
+      - MAPPA
+      - Millepensee
+      - Namu Animation
+      - NAZ
+      - Nexus
+      - Nippon Animation
+      - Nomad
+      - Nut
+      - Okuruto Noboru
+      - OLM
+      - Orange
+      - Ordet
+      - OZ
+      - P.A. Works
+      - P.I.C.S.
+      - Passione
+      - Pb Animation Co. Ltd
+      - Pierrot
+      - Pine Jam
+      - Platinum Vision
+      - Polygon Pictures
+      - Pony Canyon
+      - Production +h.
+      - Production I.G
+      - Production IMS
+      - Production Reed
+      - Project No.9
+      - Quad
+      - Radix
+      - Revoroot
+      - Saetta
+      - SANZIGEN
+      - Satelight
+      - Science SARU
+      - Sentai Filmworks
+      - Seven Arcs
+      - Shaft
+      - Shin-Ei Animation
+      - Shogakukan
+      - Shuka
+      - Signal.MD
+      - Silver
+      - SILVER LINK.
+      - Square Enix
+      - Staple Entertainment
+      - Studio 3Hz
+      - Studio A-CAT
+      - Studio Bind
+      - Studio Blanc.
+      - Studio Chizu
+      - Studio Comet
+      - Studio Deen
+      - Studio Elle
+      - Studio Ghibli
+      - Studio Flad
+      - Studio Gokumi
+      - Studio Guts
+      - Studio Hibari
+      - Studio Kafka
+      - Studio Kai
+      - Studio Mir
+      - studio MOTHER
+      - Studio Palette
+      - Studio Rikka
+      - Studio Signpost
+      - Studio VOLN
+      - STUDIO4°C
+      - Sunrise Beyond
+      - Sunrise
+      - SynergySP
+      - Tatsunoko Production
+      - Telecom Animation Film
+      - Tezuka Productions
+      - TMS Entertainment
+      - TNK
+      - Toei Animation
+      - Topcraft
+      - Triangle Staff
+      - Trigger
+      - TROYCA
+      - TYO Animations
+      - Typhoon Graphics
+      - ufotable
+      - V1 Studio
+      - W-Toon Studio
+      - Wawayu Animation
+      - White Fox
+      - Wit Studio
+      - Wolfsbane
+      - Xebec
+      - Yokohama Animation Lab
+      - Yostar Pictures
+      - Yumeta Company
+      - Zero-G
+      - Zexcs
+
+
+      #### MOVIES & TV SHOWS ###############################################################################################
+      - 3 Arts Entertainment
+      - 6th & Idaho
+      - 20th Century Animation
+      - 20th Century Studios
+      - 20th Century Fox Television
+      - 21 Laps Entertainment
+      - 87Eleven
+      - 87North Productions
+      - 101 Studios
+      - 1492 Pictures
+      - A Bigger Boat
+      - A+E Studios
+      - A24
+      - Aardman
+      - Aamir Khan Productions
+      - ABC Signature
+      - ABC Studios
+      - Ace Entertainment
+      - AGBO
+      - Amazon Studios
+      - Amblin Entertainment
+      - AMC Studios
+      - Anima Sola Productions
+      - Annapurna Pictures
+      - Ardustry Entertainment
+      - Artisan Entertainment
+      - Artists First
+      - Atlas Entertainment
+      - Atresmedia
+      - Bad Hat Harry Productions
+      - Bad Robot
+      - Bad Wolf
+      - Barunson E&A
+      - Bakken Record
+      - Bardel Entertainment
+      - BBC Studios
+      - Bill Melendez Productions
+      - Blade
+      - Bleecker Street
+      - Blown Deadline Productions
+      - Blue Ice Pictures
+      - Blue Sky Studios
+      - Bluegrass Films
+      - Blueprint Pictures
+      - Blumhouse Productions
+      - Blur Studio
+      - Bold Films
+      - Bona Film Group
+      - Bonanza Productions
+      - Boo Pictures
+      - Bosque Ranch Productions
+      - Box to Box Films
+      - Brandywine Productions
+      - Broken Lizard Industries
+      - Broken Road Productions
+      - Calt Production
+      - Canal+
+      - Carnival Films
+      - Carolco
+      - Cartoon Saloon
+      - Carsey-Werner Company
+      - Castle Rock Entertainment
+      - CBS Productions
+      - CBS Studios
+      - CBS Television Studios
+      - Centropolis Entertainment
+      - Chernin Entertainment
+      - Chimp Television
+      - Chris Morgan Productions
+      - Cinergi Pictures Entertainment
+      - Codeblack Entertainment
+      - Columbia Pictures
+      - Constantin Film
+      - Cowboy Films
+      - Cross Creek Pictures
+      - Dark Horse Entertainment
+      - Davis Entertainment
+      - DC Comics
+      - Dimension Films
+      - Dino De Laurentiis Company
+      - Disney Television Animation
+      - DisneyToon Studios
+      - Don Simpson Jerry Bruckheimer Films
+      - Doozer
+      - Dreams Salon Entertainment Culture
+      - DreamWorks Studios
+      - DreamWorks Pictures
+      - Dropout
+      - Dynamic Planning
+      - Eleventh Hour Films
+      - EMJAG Productions
+      - Endeavor Content
+      - Entertainment 360
+      - Entertainment One
+      - Eon Productions
+      - Everest Entertainment
+      - Expectation Entertainment
+      - Exposure Labs
+      - Fandango
+      - Fields Entertainment
+      - Film4 Productions
+      - FilmDistrict
+      - FilmNation Entertainment
+      - Flynn Picture Company
+      - Focus Features
+      - Food Network
+      - Fortiche Production
+      - Fox Television Studios
+      - Freckle Films
+      - Frederator Studios
+      - FremantleMedia
+      - Fuqua Films
+      - Gallagher Films Ltd
+      - Gary Sanchez Productions
+      - Gaumont
+      - Generator Entertainment
+      - Golden Harvest
+      - Gracie Films
+      - Green Hat Films
+      - Grindstone Entertainment Group
+      - Hallmark
+      - HandMade Films
+      - Happy Madison Productions
+      - HartBeat Productions
+      - Hartswood Films
+      - Hasbro
+      - HBO
+      - Heyday Films
+      - Hughes Entertainment
+      - Hungry Man
+      - Hurwitz & Schlossberg Productions
+      - Hyperobject Industries
+      - Icon Entertainment International
+      - IFC Films
+      - Illumination Entertainment
+      - Imagin
+      - Imperative Entertainment
+      - Impossible Factual
+      - Ingenious Media
+      - Irwin Entertainment
+      - Jerry Bruckheimer Films
+      - Jessie Films
+      - Jinks-Cohen Company
+      - Kazak Productions
+      - Kennedy Miller Productions
+      - Kilter Films
+      - Kjam Media
+      - Kudos
+      - Kurtzman Orci
+      - Laika Entertainment
+      - Landscape Entertainment
+      - Laura Ziskin Productions
+      - Leftfield Pictures
+      - Legendary Pictures
+      - Let's Not Turn This Into a Whole Big Production
+      - Lifetime
+      - Levity Entertainment Group
+      - Lightstorm Entertainment
+      - Likely Story
+      - Lionsgate
+      - Live Entertainment
+      - Lord Miller Productions
+      - Lucasfilm Ltd
+      - Magic Light Pictures
+      - Magnolia Pictures
+      - Malevolent Films
+      - Mandalay Entertainment
+      - Mandarin
+      - Mandarin Motion Pictures Limited
+      - Marv Films
+      - Marvel Animation
+      - Marvel Studios
+      - Matt Tolmach Productions
+      - Maximum Effort
+      - Media Res
+      - Metro-Goldwyn-Mayer
+      - Michael Patrick King Productions
+      - Millennium Films
+      - Miramax
+      - NEON
+      - Netflix
+      - New Line Cinema
+      - Nickelodeon Animation Studio
+      - NorthSouth Productions
+      - Nu Boyana Film Studios
+      - O2 Filmes
+      - Open Road Films
+      - Original Film
+      - Orion Pictures
+      - Palomar
+      - Paramount Animation
+      - Paramount Pictures
+      - Paramount Television Studios
+      - Participant
+      - Phoenix Pictures
+      - Piki Films
+      - Pixar
+      - Plan B Entertainment
+      - PlayStation Productions
+      - Playtone
+      - Plum Pictures
+      - Powerhouse Animation Studios
+      - PRA
+      - Prescience
+      - Prospect Park
+      - Pulse Films
+      - Radar Pictures
+      - RadicalMedia
+      - Railsplitter Pictures
+      - Rankin Bass Productions
+      - RatPac Entertainment
+      - Red Dog Culture House
+      - Regency Pictures
+      - Reveille Productions
+      - Rip Cord Productions
+      - RocketScience
+      - Savoy Pictures
+      - Scenic Labs
+      - Scion Films
+      - Scott Free Productions
+      - Sculptor Media
+      - Screen Gems
+      - Sean Daniel Company
+      - Searchlight Pictures
+      - Secret Hideout
+      - See-Saw Films
+      - Serendipity Pictures
+      - Shaw Brothers
+      - Show East
+      - Showtime Networks
+      - Sil-Metropole Organisation
+      - Silverback Films
+      - Siren Pictures
+      - SISTER
+      - Sixteen String Jack Productions
+      - SKA Films
+      - Sky studios
+      - Skydance
+      - Sony Pictures Animation
+      - Sony Pictures
+      - Sphère Média Plus
+      - Spyglass Entertainment
+      - Stöð 2
+      - Star Thrower Entertainment
+      - Stark Raving Black Productions
+      - StudioCanal
+      - Studio 8
+      - Studio Babelsberg
+      - Studio Dragon
+      - Studio Live
+      - STX Entertainment
+      - Summit Entertainment
+      - Syfy
+      - Syncopy
+      - T-Street Productions
+      - Tall Ship Productions
+      - Team Downey
+      - Temple Street Productions
+      - The Cat in the Hat Productions
+      - The Donners' Company
+      - The Jim Henson Company
+      - The Kennedy-Marshall Company
+      - The Linson Company
+      - The Littlefield Company
+      - The Mark Gordon Company
+      - The Sea Change Project
+      - The Stone Quarry
+      - The Weinstein Company
+      - Tim Burton Productions
+      - TOHO
+      - Thunder Road
+      - Titmouse
+      - Tomorrow Studios
+      - Touchstone Pictures
+      - Touchstone Television
+      - Trademark Films
+      - Triage Entertainment
+      - Tribeca Productions
+      - TriStar Pictures
+      - TSG Entertainment
+      - Twisted Pictures
+      - UCP
+      - United Artists
+      - Universal Animation Studios
+      - Universal Pictures
+      - Universal Television
+      - Vancouver Media
+      - Vertigo Entertainment
+      - Village Roadshow Pictures
+      - W. Chump and Sons
+      - Walden Media
+      - Walt Disney Animation Studios
+      - Walt Disney Pictures
+      - Walt Disney Productions
+      - Warner Animation Group
+      - Warner Bros. Pictures
+      - Warner Bros. Television
+      - Warner Premiere
+      - warparty
+      - Waverly Films
+      - Wayfare Entertainment
+      - Williams Street
+      - Whitaker Entertainment
+      - Wiedemann & Berg Television
+      - Winkler Films
+      - Wolf Entertainment
+      - Working Title Films
+    addons:
+      8bit:
+        - 8-bit
+      20th Century Studios:
+        - 20th Century
+        - 20th Century Animation
+        - 20th Century Fox
+      AIC:
+        - AIC ASTA
+        - AIC A.S.T.A
+        - AIC Build
+        - AAIC PLUS+
+        - AIC RIGHTS
+        - AIC Spirits
+      Ajia-Do:
+        - Ajiado
+      Amazon Studios:
+        - Amazon
+      Amblin Entertainment:
+        - Amblin Television
+      APPP:
+        - A.P.P.P.
+      asread.:
+        - Asread
+      AtelierPontdarc:
+        - Atelier Pontdarc
+      B.CMAY PICTURES:
+        - G.CMay Animation & Film
+      Bandai Namco Pictures:
+        - Bandai Visual
+        - Bandai Visual Company
+      BBC Studios:
+        - BBC
+        - BBC Studios Natural History Unit
+      Bibury Animation Studios:
+        - Bibury Animation CG
+      Blue Sky Studios:
+        - Blue Sky Films
+      Canal+:
+        - Canal+ Polska
+      Cloud Hearts:
+        - CLOUDHEARTS
+      Columbia Pictures:
+        - Columbia TriStar
+      CoMix Wave Films:
+        - CoMix Wave
+      Craftar Studios:
+        - Craftar
+      CygamesPictures:
+        - Cygames Pictures
+      DC Comics:
+        - DC Films
+        - DC Entertainment
+      DreamWorks Studios:
+        - DreamWorks
+        - DreamWorks Animation
+        - DreamWorks Animation Television
+        - DreamWorks Classics
+      Dropout:
+        - CollegeHumor
+        - CollegeHumor Media
+      EMT Squared:
+        - EMT²0
+      feel.:
+        - Feel
+      Gallop:
+        - Studio Gallop
+      Gaumont:
+        - Gaumont International Television
+      Geek Toys:
+        - GEEKTOYS
+      Gekkou:
+        - GEKKOU Production
+      GoHands:
+        - Go Hands
+      Gonzo:
+        - Gonzo Digimation
+      Hallmark:
+        - Hallmark+
+        - Hallmark Channel
+        - Hallmark Entertainment
+        - Hallmark Media
+        - Hallmark Movies & Mysteries
+        - The Hallmark Channel
+      Haoliners Animation League:
+        - Haoliners Huimeng Animation
+        - Haoliners Animation
+      Illumination Entertainment:
+        - Illumination
+        - Illumination Films
+      J.C.Staff:
+        - J.C. Staff
+      Khara:
+        - Studio Khara
+      Lan Studio:
+        - Studio LAN
+      Legendary Pictures:
+        - Legendary Television
+      LIDENFILMS:
+        - Liden Films
+      Lucasfilm Ltd:
+        - Lucasfilm
+        - Lucasfilm Animation
+      Mandarin:
+        - Mandarin Films
+        - Mandarin Television
+      Marvel Studios:
+        - Marvel Enterprises
+        - Marvel Entertainment
+        - Marvel
+      Metro-Goldwyn-Mayer:
+        - MGM
+      New Line Cinema:
+        - New Line
+      Nexus:
+        - Nexus Factory
+      P.A. Works:
+        - P.A.WORKS
+      Paramount Pictures:
+        - Paramount
+      Pierrot:
+        - Pierrot Plus
+        - Studio Pierrot
+      Pixar:
+        - Pixar Animation Studios
+      Plan B Entertainment:
+        - PlanB Entertainment
+      Platinum Vision:
+        - PlatinumVision
+      Production +h.:
+        - Production +h
+      Rankin Bass Productions:
+        - Rankin/Bass Productions
+        - Videocraft International
+      RatPac Entertainment:
+        - Dune Entertainment
+      Regency Pictures:
+        - Regency Enterprises
+        - New Regency Pictures
+        - Monarchy Enterprises S.a.r.l.
+      Science SARU:
+        - Science Saru
+      Searchlight Pictures:
+        - Fox Searchlight Pictures
+      Seven Arcs:
+        - Seven
+        - Seven Arcs Pictures
+      Shogakukan:
+        - Shogakukan Production
+      Signal.MD:
+        - Signal MD
+      Silver:
+        - Studio Silver
+      SILVER LINK.:
+        - Silver Link
+      Sky studios:
+        - British Sky Broadcasting
+        - British Sky Broadcasting(BSkyB)
+      Skydance:
+        - Skydance Media
+      Sony Pictures:
+        - Sony
+        - Sony Pictures Animation
+        - Sony Pictures Television Studios
+      Studio Blanc.:
+        - Studio Blanc
+      Studio Deen:
+        - Studio DEEN
+      STX Entertainment:
+        - STX Films
+      The Kennedy-Marshall Company:
+        - The Kennedy/Marshall Company
+      The Mark Gordon Company:
+        - Tiger Aspect Productions
+      TOHO:
+        - Toho Pictures
+        - Toho Pictures, Inc.
+      TMS Entertainment:
+        - Tokyo Movie Shinsha
+      Toei Animation:
+        - Toei
+      TriStar Pictures:
+        - TriStar
+      Universal Pictures:
+        - Universal
+        - Universal Animation Studios
+      Walt Disney Pictures:
+        - Disney
+      Warner Animation Group:
+        - Warner Bros. Cartoon Studios
+        - Warner Animation
+      Warner Bros. Pictures:
+        - Warner
+        - Warner Animation Group
+      Yokohama Animation Lab:
+        - Yokohama Animation Laboratory

--- a/tests/fixtures/kometa/defaults/both/subtitle_language.yml
+++ b/tests/fixtures/kometa/defaults/both/subtitle_language.yml
@@ -1,0 +1,233 @@
+##############################################################################
+#                       Subtitle Language Collections                        #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#       https://kometa.wiki/en/latest/defaults/both/subtitle_language        #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "095"
+
+collections:
+  Subtitle Language Collections:
+    template:
+      - name: separator
+        separator: subtitle_language
+        key_name: Subtitle Language
+        translation_key: separator
+
+dynamic_collections:
+  Subtitle Language:
+    type: subtitle_language
+    title_format: <<key_name>> Subtitles
+    other_name: Other Subtitles
+    template:
+      - smart_filter
+      - shared
+    other_template:
+      - other_collection
+      - smart_filter
+      - shared
+    template_variables:
+      search_term:
+        default: subtitle_language
+      image:
+        default: subtitle_language/<<key>>
+      translation_key:
+        default: subtitle_language
+        other: subtitle_language_other
+      dynamic:
+        default: true
+    include:
+      - ab     # Abkhazian
+      - aa     # Afar
+      - af     # Afrikaans
+      - ak     # Akan
+      - sq     # Albanian
+      - am     # Amharic
+      - ar     # Arabic
+      - an     # Aragonese
+      - hy     # Armenian
+      - as     # Assamese
+      - av     # Avaric
+      - ae     # Avestan
+      - ay     # Aymara
+      - az     # Azerbaijani
+      - bm     # Bambara
+      - ba     # Bashkir
+      - eu     # Basque
+      - be     # Belarusian
+      - bn     # Bengali
+      - bi     # Bislama
+      - bs     # Bosnian
+      - br     # Breton
+      - bg     # Bulgarian
+      - my     # Burmese
+      - ca     # Catalan, Valencian
+      - km     # Central Khmer
+      - ch     # Chamorro
+      - ce     # Chechen
+      - ny     # Chichewa, Chewa, Nyanja 
+      - zh     # Chinese
+      - cu     # Church Slavic, Old Slavonic, Church Slavonic, Old Bulgarian, Old Church Slavonic
+      - cv     # Chuvash
+      - kw     # Cornish
+      - co     # Corsican
+      - cr     # Cree
+      - hr     # Croatian
+      - cs     # Czech
+      - da     # Danish
+      - dv     # Divehi, Dhivehi, Maldivian
+      - nl     # Dutch, Flemish
+      - dz     # Dzongkha
+      - en     # English
+      - eo     # Esperanto
+      - et     # Estonian
+      - ee     # Ewe
+      - fo     # Faroese
+      - fj     # Fijian
+      - fil    # Filipino
+      - fi     # Finnish
+      - fr     # French
+      - ff     # Fulah
+      - gd     # Gaelic, Scottish Gaelic
+      - gl     # Galician
+      - lg     # Ganda
+      - ka     # Georgian
+      - de     # German
+      - el     # Greek, Modern (1453–)
+      - gn     # Guarani
+      - gu     # Gujarati
+      - ht     # Haitian, Haitian Creole
+      - ha     # Hausa
+      - he     # Hebrew
+      - hz     # Herero
+      - hi     # Hindi
+      - ho     # Hiri Motu
+      - hu     # Hungarian
+      - is     # Icelandic
+      - io     # Ido
+      - ig     # Igbo
+      - id     # Indonesian
+      - ia     # Interlingua (International Auxiliary Language Association)
+      - ie     # Interlingue, Occidental
+      - iu     # Inuktitut
+      - ik     # Inupiaq
+      - ga     # Irish
+      - it     # Italian
+      - ja     # Japanese
+      - jv     # Javanese
+      - kl     # Kalaallisut, Greenlandic
+      - kn     # Kannada
+      - kr     # Kanuri
+      - ks     # Kashmiri
+      - kk     # Kazakh
+      - ki     # Kikuyu, Gikuyu
+      - rw     # Kinyarwanda
+      - ky     # Kirghiz, Kyrgyz
+      - kv     # Komi
+      - kg     # Kongo
+      - ko     # Korean
+      - kj     # Kuanyama, Kwanyama
+      - ku     # Kurdish
+      - lo     # Lao
+      - la     # Latin
+      - lv     # Latvian
+      - li     # Limburgan, Limburger, Limburgish
+      - ln     # Lingala
+      - lt     # Lithuanian
+      - lu     # Luba-Katanga
+      - lb     # Luxembourgish, Letzeburgesch
+      - mk     # Macedonian
+      - mg     # Malagasy
+      - ms     # Malay
+      - ml     # Malayalam
+      - mt     # Maltese
+      - gv     # Manx
+      - mi     # Maori
+      - mr     # Marathi
+      - mh     # Marshallese
+      - myn    # Mayan
+      - mn     # Mongolian
+      - na     # Nauru
+      - nv     # Navajo, Navaho
+      - ng     # Ndonga
+      - ne     # Nepali
+      - nd     # North Ndebele
+      - se     # Northern Sami
+      - no     # Norwegian
+      - nb     # Norwegian Bokmål
+      - nn     # Norwegian Nynorsk
+      - oc     # Occitan
+      - oj     # Ojibwa
+      - or     # Oriya
+      - om     # Oromo
+      - os     # Ossetian, Ossetic
+      - pi     # Pali
+      - ps     # Pashto, Pushto
+      - fa     # Persian
+      - pl     # Polish
+      - pt     # Portuguese
+      - pa     # Punjabi, Panjabi
+      - qu     # Quechua
+      - ro     # Romanian, Moldavian, Moldovan
+      - rm     # Romansh
+      - rom    # Romany
+      - rn     # Rundi
+      - ru     # Russian
+      - sm     # Samoan
+      - sg     # Sango
+      - sa     # Sanskrit
+      - sc     # Sardinian
+      - sr     # Serbian
+      - sn     # Shona
+      - ii     # Sichuan Yi, Nuosu
+      - sd     # Sindhi
+      - si     # Sinhala, Sinhalese
+      - sk     # Slovak
+      - sl     # Slovenian
+      - so     # Somali
+      - nr     # South Ndebele
+      - st     # Southern Sotho
+      - es     # Spanish, Castilian
+      - su     # Sundanese
+      - sw     # Swahili
+      - ss     # Swati
+      - sv     # Swedish
+      - tl     # Tagalog
+      - ty     # Tahitian
+      - tai    # Tai
+      - tg     # Tajik
+      - ta     # Tamil
+      - tt     # Tatar
+      - te     # Telugu
+      - th     # Thai
+      - bo     # Tibetan
+      - ti     # Tigrinya
+      - to     # Tonga (Tonga Islands)
+      - ts     # Tsonga
+      - tn     # Tswana
+      - tr     # Turkish
+      - tk     # Turkmen
+      - tw     # Twi
+      - ug     # Uighur, Uyghur
+      - uk     # Ukrainian
+      - ur     # Urdu
+      - uz     # Uzbek
+      - ve     # Venda
+      - vi     # Vietnamese
+      - vo     # Volapük
+      - wa     # Walloon
+      - cy     # Welsh
+      - fy     # Western Frisian
+      - wo     # Wolof
+      - xh     # Xhosa
+      - yi     # Yiddish
+      - yo     # Yoruba
+      - za     # Zhuang, Chuang
+      - zu     # Zulu
+    key_name_override:
+      myn: Mayan  
+

--- a/tests/fixtures/kometa/defaults/both/universe.yml
+++ b/tests/fixtures/kometa/defaults/both/universe.yml
@@ -1,0 +1,122 @@
+##############################################################################
+#                            Universe Collections                            #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#           https://kometa.wiki/en/latest/defaults/both/universe             #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "040"
+
+templates:
+  universe:
+    conditionals:
+      mdblist_list:
+        conditions:
+          - imdb_list_<<key>>.exists: false
+            trakt_list_<<key>>.exists: false
+            mdblist_list_<<key>>.exists: false
+            value: <<mdblist_url>>
+      imdb_list:
+        conditions:
+          - imdb_list_<<key>>.exists: false
+            mdblist_list_<<key>>.exists: false
+            trakt_list_<<key>>.exists: false
+            value: <<imdb_url>>
+      trakt_list:
+        conditions:
+          - imdb_list_<<key>>.exists: false
+            mdblist_list_<<key>>.exists: false
+            trakt_list_<<key>>.exists: false
+            value: <<trakt_url>>
+    default:
+      minimum_items_<<key>>: <<minimum_items>>
+      mdblist_list_<<key>>: <<mdblist_list>>
+      imdb_list_<<key>>: <<imdb_list>>
+      name_mapping_<<key>>: <<name_mapping>>
+      delete_collections_named_<<key>>: <<delete_collections_named>>
+      minimum_items: 2
+    optional:
+      - name_mapping
+      - trakt_list_<<key>>
+      - imdb_list_<<key>>
+      - mdblist_list_<<key>>
+      - mdblist_url
+      - trakt_url
+      - imdb_url
+      - minimum_items
+      - delete_collections_named
+    minimum_items: <<minimum_items_<<key>>>>
+    name_mapping: <<name_mapping_<<key>>>>
+    trakt_list: <<trakt_list_<<key>>>>
+    imdb_list: <<imdb_list_<<key>>>>
+    mdblist_list: <<mdblist_list_<<key>>>>
+    delete_collections_named: <<delete_collections_named_<<key>>>>
+
+collections:
+  Universe Collections:
+    template:
+      - name: separator
+        separator: universe
+        key_name: Universe
+        translation_key: separator
+
+dynamic_collections:
+  Universe Collections:
+    type: custom
+    data:
+      avp: Alien / Predator
+      arrow: Arrowverse
+      askew: View Askewniverse
+      conjuring: Conjuring Universe
+      dca: DC Animated Universe
+      dcu: DC Universe
+      fast: Fast & Furious
+      marvel: In Association With Marvel
+      mcu: Marvel Cinematic Universe
+      middle: Middle Earth
+      rocky: Rocky / Creed
+      trek: Star Trek
+      star: Star Wars Universe
+      mummy: Mummy Universe
+      wizard: Wizarding World
+      xmen: X-Men Universe
+    template:
+      - universe
+      - arr
+      - custom
+      - shared
+    template_variables:
+      allowed_libraries:
+        avp: movie
+        conjuring: movie
+        wizard: movie
+        fast: movie
+        rocky: movie
+        mummy: movie
+      imdb_url:
+        arrow: https://www.imdb.com/list/ls566667558/
+        avp: https://www.imdb.com/list/ls543971628/
+        conjuring: https://www.imdb.com/list/ls068768438/
+        dcu: https://www.imdb.com/list/ls524274984/
+        fast: https://www.imdb.com/list/ls4102351575/
+        mcu: https://www.imdb.com/list/ls539646485/
+        star: https://www.imdb.com/list/ls501373412/
+        trek: https://www.imdb.com/list/ls547463722/
+        xmen: https://www.imdb.com/list/ls567618635/
+      mdblist_url:
+        dca: https://mdblist.com/lists/johnfawkes/dca
+        marvel: https://mdblist.com/lists/k0meta/external/15110
+        middle: https://mdblist.com/lists/k0meta/external/46550
+        mummy: https://mdblist.com/lists/k0meta/external/9249
+        rocky: https://mdblist.com/lists/k0meta/external/9248
+        askew: https://mdblist.com/lists/k0meta/external/15362
+        wizard: https://mdblist.com/lists/k0meta/external/23683
+      image:
+        default: universe/<<key>>
+      delete_collections_named:
+        dcu: DC Extended Universe
+        mummy: The Mummy Universe
+        conjuring: The Conjuring Universe

--- a/tests/fixtures/kometa/defaults/both/year.yml
+++ b/tests/fixtures/kometa/defaults/both/year.yml
@@ -1,0 +1,44 @@
+##############################################################################
+#                              Year Collections                              #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#             https://kometa.wiki/en/latest/defaults/both/year               #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "105"
+
+collections:
+  Year Collections:
+    template:
+      - name: separator
+        separator: year
+        key_name: Year
+        translation_key: separator
+
+dynamic_collections:
+  Year:
+    type: number
+    sync: true
+    data:
+      starting: current_year-10
+      ending: current_year
+    title_format: Best of <<key_name>>
+    template:
+      - smart_filter
+      - shared
+    template_variables:
+      search_term:
+        default: year
+      sort_by:
+        default: critic_rating.desc
+      limit:
+        default: 10
+      image:
+        default: year/best/<<key>>
+      translation_key:
+        default: year
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/chart/anilist.yml
+++ b/tests/fixtures/kometa/defaults/chart/anilist.yml
@@ -1,0 +1,77 @@
+##############################################################################
+#                         AniList Charts Collections                         #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#           https://kometa.wiki/en/latest/defaults/chart/anilist             #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "020"
+    image: chart/<<style>>/<<mapping_name_encoded>>
+
+templates:
+  anilist:
+    default:
+      style: color
+      limit: 100
+      limit_<<key>>: <<limit>>
+      chart: <<key>>
+    anilist_<<chart>>: <<limit_<<key>>>>
+
+  season:
+    default:
+      limit: 100
+      limit_season: <<limit>>
+    anilist_search:
+      season: current
+      year:
+      sort_by: popular
+      limit: <<limit_season>>
+
+collections:
+  AniList Popular:
+    variables:
+      style: color
+      key: popular
+    template:
+      - name: anilist
+      - name: shared
+        translation_key: anilist_popular
+      - name: arr
+      - name: custom
+
+  AniList Top Rated:
+    variables:
+      style: color
+      key: top
+    template:
+      - name: anilist
+        chart: top_rated
+      - name: shared
+        translation_key: anilist_top_rated
+      - name: arr
+      - name: custom
+
+  AniList Trending:
+    variables:
+      style: color
+      key: trending
+    template:
+      - name: anilist
+      - name: shared
+        translation_key: anilist_trending
+      - name: arr
+      - name: custom
+
+  AniList Season:
+    variables:
+      style: color
+      key: season
+    template:
+      - name: season
+      - name: shared
+        translation_key: anilist_season
+      - name: arr
+      - name: custom

--- a/tests/fixtures/kometa/defaults/chart/basic.yml
+++ b/tests/fixtures/kometa/defaults/chart/basic.yml
@@ -1,0 +1,39 @@
+##############################################################################
+#                          Basic Charts Collections                          #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#            https://kometa.wiki/en/latest/defaults/chart/basic              #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "010"
+    image: chart/<<style>>/<<mapping_name_encoded>>
+
+collections:
+  Newly Released:
+    variables:
+      style: color
+      key: released
+    template:
+      - name: smart_filter
+        search_term: release
+        search_value: <<in_the_last_released>>
+        in_the_last_released: 90
+      - name: shared
+        translation_key: basic_released
+
+  New Episodes:
+    variables:
+      style: color
+      key: episodes
+    template:
+      - name: smart_filter
+        search_term: episode_air_date
+        search_value: <<in_the_last_episodes>>
+        in_the_last_episodes: 7
+        type: episodes
+      - name: shared
+        allowed_libraries: show
+        translation_key: basic_episodes

--- a/tests/fixtures/kometa/defaults/chart/imdb.yml
+++ b/tests/fixtures/kometa/defaults/chart/imdb.yml
@@ -1,0 +1,53 @@
+##############################################################################
+#                          IMDb Charts Collections                           #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#             https://kometa.wiki/en/latest/defaults/chart/imdb              #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "020"
+    image: chart/<<style>>/<<mapping_name_encoded>>
+
+templates:
+  imdb_chart:
+    imdb_chart: <<chart>>_<<library_type>>s
+
+collections:
+  IMDb Popular:
+    variables:
+      style: color
+      key: popular
+    template:
+      - name: imdb_chart
+        chart: popular
+      - name: shared
+        translation_key: imdb_popular
+      - name: arr
+      - name: custom
+
+  IMDb Top 250:
+    variables:
+      style: color
+      key: top
+    template:
+      - name: imdb_chart
+        chart: top
+      - name: shared
+        translation_key: imdb_top
+      - name: arr
+      - name: custom
+
+  IMDb Lowest Rated:
+    variables:
+      style: color
+      key: lowest
+    imdb_chart: lowest_rated
+    template:
+      - name: shared
+        allowed_libraries: movie
+        translation_key: imdb_lowest
+      - name: arr
+      - name: custom

--- a/tests/fixtures/kometa/defaults/chart/letterboxd.yml
+++ b/tests/fixtures/kometa/defaults/chart/letterboxd.yml
@@ -1,0 +1,319 @@
+##############################################################################
+#                      Letterboxd Charts Collections                         #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#      Special thanks to Kevin2kkelly for their contributions to this        #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#       https://kometa.wiki/en/latest/defaults/chart/letterboxd.html         #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "020"
+    image: chart/<<style>>/<<mapping_name_encoded>>
+    allowed_libraries: movie
+    sort_title: <<sort_prefix>><<collection_section>><<pre>><<order_<<key>>>>LB_<<sort>>
+
+templates:
+  letterboxd_list:
+    letterboxd_list: https://letterboxd.com/<<user>>/list/<<list>>
+
+collections:
+  "Letterboxd Top 500":
+    variables:
+      style: color
+      key: top_500
+    template:
+      - name: letterboxd_list
+        user: official
+        list: letterboxds-top-500-films
+      - name: shared
+        translation_key: letterboxd_top_500
+        summary: <<summary_<<key>>>>
+      - name: arr
+      - name: custom
+    delete_collections_named: "Letterboxd Top 250"
+
+  "Box Office Mojo All Time 100":
+    variables:
+      style: color
+      key: boxofficemojo_100
+    template:
+      - name: letterboxd_list
+        user: matthew
+        list: all-time-worldwide-box-office
+      - name: shared
+        translation_key: box_office_mojo_all_time_100
+        summary: <<summary_<<key>>>>
+      - name: arr
+      - name: custom
+
+  "AFI 100 Years 100 Movies":
+    variables:
+      style: color
+      key: afi_100
+    template:
+      - name: letterboxd_list
+        user: afi
+        list: afis-100-years100-movies-10th-anniversary
+      - name: shared
+        translation_key: afi_100_years_100_movies
+        summary: <<summary_<<key>>>>
+      - name: arr
+      - name: custom
+
+  "Sight & Sound Greatest Films":
+    variables:
+      style: color
+      key: sight_sound
+    template:
+      - name: letterboxd_list
+        user: bfi
+        list: sight-and-sounds-greatest-films-of-all-time
+      - name: shared
+        translation_key: sight_and_sound_greatest_films
+        summary: <<summary_<<key>>>>
+      - name: arr
+      - name: custom
+
+  "1,001 To See Before You Die":
+    variables:
+      style: color
+      key: 1001_movies
+    template:
+      - name: letterboxd_list
+        user: gubarenko
+        list: 1001-movies-you-must-see-before-you-die-2024
+      - name: shared
+        translation_key: 1001_movies_to_see_before_you_die
+        summary: <<summary_<<key>>>>
+      - name: arr
+      - name: custom
+
+  "Edgar Wright's 1,000 Favorites":
+    variables:
+      style: color
+      key: edgarwright
+    template:
+      - name: letterboxd_list
+        user: crew
+        list: edgar-wrights-1000-favorite-movies
+      - name: shared
+        translation_key: edgar_wrights_1000_favorites
+        summary: <<summary_<<key>>>>
+      - name: arr
+      - name: custom
+
+  "Roger Ebert's Great Movies":
+    variables:
+      style: color
+      key: rogerebert
+    template:
+      - name: letterboxd_list
+        user: dvideostor
+        list: roger-eberts-great-movies
+      - name: shared
+        translation_key: roger_eberts_great_movies
+        summary: <<summary_<<key>>>>
+      - name: arr
+      - name: custom
+
+  "Top 250 Women-Directed":
+    variables:
+      style: color
+      key: women_directors
+    template:
+      - name: letterboxd_list
+        user: official
+        list: top-250-films-by-women-directors
+      - name: shared
+        translation_key: top_250_women_directed
+        summary: <<summary_<<key>>>>
+      - name: arr
+      - name: custom
+
+  "Top 250 Black-Directed":
+    variables:
+      style: color
+      key: black_directors
+    template:
+      - name: letterboxd_list
+        user: official
+        list: top-250-films-by-black-directors
+      - name: shared
+        translation_key: top_250_black_directed
+        summary: <<summary_<<key>>>>
+      - name: arr
+      - name: custom
+    delete_collections_named: "Top 100 Black-Directed"
+
+  "Top 250 Most Fans":
+    variables:
+      style: color
+      key: most_fans
+    template:
+      - name: letterboxd_list
+        user: official
+        list: top-250-films-with-the-most-fans
+      - name: shared
+        translation_key: top_250_most_fans
+        summary: <<summary_<<key>>>>
+      - name: arr
+      - name: custom
+
+  "Top 250 Documentaries":
+    variables:
+      style: color
+      key: documentaries
+    template:
+      - name: letterboxd_list
+        user: official
+        list: top-250-documentary-films
+      - name: shared
+        translation_key: top_250_documentaries
+        summary: <<summary_<<key>>>>
+      - name: arr
+      - name: custom
+
+  "Top 100 Animation":
+    variables:
+      style: color
+      key: animation
+    template:
+      - name: letterboxd_list
+        user: official
+        list: top-250-animated-films
+      - name: shared
+        translation_key: top_100_animation
+        summary: <<summary_<<key>>>>
+      - name: arr
+      - name: custom
+
+  "Top 250 Horror":
+    variables:
+      style: color
+      key: horror
+    template:
+      - name: letterboxd_list
+        user: official
+        list: top-250-horror-films
+      - name: shared
+        translation_key: top_250_horror
+        summary: <<summary_<<key>>>>
+      - name: arr
+      - name: custom
+
+  "Top 250 International":
+    variables:
+      style: color
+      key: international
+    template:
+      - name: letterboxd_list
+        user: brsan
+        list: letterboxds-top-250-international-films
+      - name: shared
+        translation_key: top_250_international
+        summary: <<summary_<<key>>>>
+      - name: arr
+      - name: custom
+
+  "Top 250 Sci-Fi Films":
+    variables:
+      style: color
+      key: science
+    template:
+      - name: letterboxd_list
+        user: official
+        list: top-250-science-fiction-films
+      - name: shared
+        translation_key: top_250_sci-fi_films
+        summary: <<summary_<<key>>>>
+      - name: arr
+      - name: custom
+
+  "One Million Watched Club":
+    variables:
+      style: color
+      key: million
+    template:
+      - name: letterboxd_list
+        user: alexanderh
+        list: letterboxd-one-million-watched-club
+      - name: shared
+        translation_key: one_million_watched_club
+        summary: <<summary_<<key>>>>
+      - name: arr
+      - name: custom
+
+  "Top 100 Western Films":
+    variables:
+      style: color
+      key: western
+    template:
+      - name: letterboxd_list
+        user: official
+        list: top-100-western-films
+      - name: shared
+        translation_key: top_100_western_films
+        summary: <<summary_<<key>>>>
+      - name: arr
+      - name: custom
+
+  "Top 100 Silent Films":
+    variables:
+      style: color
+      key: silent
+    template:
+      - name: letterboxd_list
+        user: brsan
+        list: letterboxds-top-100-silent-films
+      - name: shared
+        translation_key: top_100_silent_films
+        summary: <<summary_<<key>>>>
+      - name: arr
+      - name: custom
+
+  "IMDb Top 250 (Letterboxd)":
+    variables:
+      style: color
+      key: imdb_top_250
+    template:
+      - name: letterboxd_list
+        user: dave
+        list: imdb-top-250
+      - name: shared
+        translation_key: imdb_top_250
+        summary: <<summary_<<key>>>>
+        use_imdb_top_250: false
+      - name: arr
+      - name: custom
+
+  "Oscar Best Picture Winners":
+    variables:
+      style: color
+      key: oscars
+    template:
+      - name: letterboxd_list
+        user: oscars
+        list: oscar-winning-films-best-picture
+      - name: shared
+        translation_key: oscars_best_picture_winners
+        summary: <<summary_<<key>>>>
+        use_oscars: false
+      - name: arr
+      - name: custom
+
+  "Cannes Palme d'Or Winners":
+    variables:
+      style: color
+      key: cannes
+    template:
+      - name: letterboxd_list
+        user: brsan
+        list: cannes-palme-dor-winners
+      - name: shared
+        translation_key: cannes_palmes_dor_winners
+        summary: <<summary_<<key>>>>
+        use_cannes: false
+      - name: arr
+      - name: custom

--- a/tests/fixtures/kometa/defaults/chart/myanimelist.yml
+++ b/tests/fixtures/kometa/defaults/chart/myanimelist.yml
@@ -1,0 +1,91 @@
+##############################################################################
+#                       MyAnimeList Charts Collections                       #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#          https://kometa.wiki/en/latest/defaults/chart/myanimelist          #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "020"
+    image: chart/<<style>>/<<mapping_name_encoded>>
+
+templates:
+  mal:
+    default:
+      limit: 100
+      limit_<<key>>: <<limit>>
+      chart: <<key>>
+    mal_<<chart>>: <<limit_<<key>>>>
+
+  season:
+    default:
+      limit: 100
+      limit_season: <<limit>>
+      starting_only_season: <<starting_only>>
+    optional:
+      - starting_only
+    mal_season:
+      season: current
+      sort_by: score
+      limit: <<limit_season>>
+      starting_only: <<starting_only_season>>
+
+collections:
+  MyAnimeList Popular:
+    variables:
+      style: color
+      key: popular
+    template:
+      - name: mal
+      - name: shared
+        translation_key: mal_popular
+      - name: arr
+      - name: custom
+
+  MyAnimeList Favorited:
+    variables:
+      style: color
+      key: favorited
+    template:
+      - name: mal
+        chart: favorite
+      - name: shared
+        translation_key: mal_favorited
+      - name: arr
+      - name: custom
+
+  MyAnimeList Top Rated:
+    variables:
+      style: color
+      key: top
+    template:
+      - name: mal
+        chart: all
+      - name: shared
+        translation_key: mal_top
+      - name: arr
+      - name: custom
+
+  MyAnimeList Top Airing:
+    variables:
+      style: color
+      key: airing
+    template:
+      - name: mal
+      - name: shared
+        translation_key: mal_airing
+      - name: arr
+      - name: custom
+
+  MyAnimeList Season:
+    variables:
+      style: color
+      key: season
+    template:
+      - name: season
+      - name: shared
+        translation_key: mal_season
+      - name: arr
+      - name: custom

--- a/tests/fixtures/kometa/defaults/chart/other_chart.yml
+++ b/tests/fixtures/kometa/defaults/chart/other_chart.yml
@@ -1,0 +1,65 @@
+##############################################################################
+#                          Other Charts Collections                          #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#            https://kometa.wiki/en/latest/defaults/chart/other              #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "020"
+    image: chart/<<style>>/<<mapping_name_encoded>>
+
+templates:
+  commonsense:
+    mdblist_list: https://mdblist.com/lists/k0meta/cssfamilies<<library_type>>s
+  metacritic:
+    mdblist_list: https://mdblist.com/lists/k0meta/metacriticmustsee<<library_type>>s
+
+collections:
+  Common Sense Selection:
+    variables:
+      style: color
+      key: commonsense
+    template:
+      - name: commonsense
+      - name: shared
+        translation_key: commonsense_selection
+      - name: arr
+      - name: custom
+
+  StevenLu's Popular Movies:
+    variables:
+      style: color
+      key: stevenlu
+    stevenlu_popular: true
+    template:
+      - name: shared
+        allowed_libraries: movie
+        translation_key:  stevenlu_popular
+      - name: arr
+      - name: custom
+
+  Top 10 Pirated Movies of the Week:
+    variables:
+      style: color
+      key: pirated
+    mdblist_list: https://mdblist.com/lists/k0meta/top-ten-pirated-movies-of-the-week-torrent-freakcom
+    template:
+      - name: shared
+        allowed_libraries: movie
+        translation_key: pirated_popular
+      - name: arr
+      - name: custom
+
+  Metacritic Must See:
+    variables:
+      style: color
+      key: metacritic
+    template:
+      - name: metacritic
+      - name: shared
+        translation_key: metacritic_must_see
+      - name: arr
+      - name: custom

--- a/tests/fixtures/kometa/defaults/chart/separator_chart.yml
+++ b/tests/fixtures/kometa/defaults/chart/separator_chart.yml
@@ -1,0 +1,19 @@
+##############################################################################
+#                        Chart Separator Collections                         #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#        https://kometa.wiki/en/latest/defaults/award/separator_chart        #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "020"
+
+collections:
+  Chart Collections:
+    template:
+      - name: separator
+        separator: chart
+        key_name: Chart
+        translation_key: separator

--- a/tests/fixtures/kometa/defaults/chart/simkl.yml
+++ b/tests/fixtures/kometa/defaults/chart/simkl.yml
@@ -1,0 +1,77 @@
+##############################################################################
+#                         Simkl Charts Collections                           #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#            https://kometa.wiki/en/latest/defaults/chart/simkl              #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "020"
+    image: chart/<<style>>/<<mapping_name_encoded>>
+
+templates:
+  simkl:
+    default:
+      limit: 100
+      limit_<<key>>: <<limit>>
+      period: today
+    simkl_trending:
+      period: <<period>>
+      limit: <<limit_<<key>>>>
+
+  dvd:
+    default:
+      limit: 100
+      limit_<<key>>: <<limit>>
+    simkl_dvd:
+      limit: <<limit_<<key>>>>
+
+collections:
+  Simkl Trending Today:
+    variables:
+      style: color
+      key: trending_today
+    template:
+      - name: simkl
+        period: today
+      - name: shared
+        translation_key: simkl_trending_today
+      - name: arr
+      - name: custom
+
+  Simkl Trending This Week:
+    variables:
+      style: color
+      key: trending_week
+    template:
+      - name: simkl
+        period: week
+      - name: shared
+        translation_key: simkl_trending_week
+      - name: arr
+      - name: custom
+
+  Simkl Trending This Month:
+    variables:
+      style: color
+      key: trending_month
+    template:
+      - name: simkl
+        period: month
+      - name: shared
+        translation_key: simkl_trending_month
+      - name: arr
+      - name: custom
+
+  Simkl DVD:
+    variables:
+      style: color
+      key: dvd
+    template:
+      - name: dvd
+      - name: shared
+        translation_key: simkl_dvd
+      - name: arr
+      - name: custom

--- a/tests/fixtures/kometa/defaults/chart/tautulli.yml
+++ b/tests/fixtures/kometa/defaults/chart/tautulli.yml
@@ -1,0 +1,48 @@
+##############################################################################
+#                        Tautulli Charts Collections                         #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#           https://kometa.wiki/en/latest/defaults/chart/tautulli            #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "020"
+    image: chart/<<style>>/<<mapping_name_encoded>>
+
+templates:
+  tautulli:
+    default:
+      list_days: 30
+      list_size: 20
+      list_days_<<key>>: <<list_days>>
+      list_size_<<key>>: <<list_size>>
+    tautulli_<<type>>:
+      list_days: <<list_days_<<key>>>>
+      list_size: <<list_size_<<key>>>>
+
+collections:
+  Plex Popular:
+    variables:
+      style: color
+      key: popular
+    template:
+      - name: tautulli
+        type: popular
+      - name: shared
+        translation_key: tautulli_popular
+      - name: custom
+        cache_builders: 0
+
+  Plex Watched:
+    variables:
+      style: color
+      key: watched
+    template:
+      - name: tautulli
+        type: watched
+      - name: shared
+        translation_key: tautulli_watched
+      - name: custom
+        cache_builders: 0

--- a/tests/fixtures/kometa/defaults/chart/tmdb.yml
+++ b/tests/fixtures/kometa/defaults/chart/tmdb.yml
@@ -1,0 +1,82 @@
+##############################################################################
+#                          TMDb Charts Collections                           #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#             https://kometa.wiki/en/latest/defaults/chart/tmdb              #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "020"
+    image: chart/<<style>>/<<mapping_name_encoded>>
+
+templates:
+  tmdb:
+    default:
+      limit: 100
+      limit_<<key>>: <<limit>>
+      chart: <<key>>
+    tmdb_<<chart>>: <<limit_<<key>>>>
+
+collections:
+  TMDb Popular:
+    variables:
+      style: color
+      key: popular
+    template:
+      - name: tmdb
+      - name: shared
+        translation_key: tmdb_popular
+      - name: arr
+      - name: custom
+
+  TMDb Top Rated:
+    variables:
+      style: color
+      key: top
+    template:
+      - name: tmdb
+        chart: top_rated
+      - name: shared
+        translation_key: tmdb_top
+      - name: arr
+      - name: custom
+
+  TMDb Trending:
+    variables:
+      style: color
+      key: trending
+    template:
+      - name: tmdb
+        chart: trending_weekly
+      - name: shared
+        translation_key: tmdb_trending
+      - name: arr
+      - name: custom
+
+  TMDb Airing Today:
+    variables:
+      style: color
+      key: airing
+    template:
+      - name: tmdb
+        chart: airing_today
+      - name: shared
+        allowed_libraries: show
+        translation_key: tmdb_airing
+      - name: arr
+      - name: custom
+
+  TMDb On The Air:
+    variables:
+      style: color
+      key: air
+    template:
+      - name: tmdb
+        chart: on_the_air
+      - name: shared
+        allowed_libraries: show
+        translation_key: tmdb_air
+      - name: arr
+      - name: custom

--- a/tests/fixtures/kometa/defaults/chart/trakt.yml
+++ b/tests/fixtures/kometa/defaults/chart/trakt.yml
@@ -1,0 +1,77 @@
+##############################################################################
+#                          Trakt Charts Collections                          #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#            https://kometa.wiki/en/latest/defaults/chart/trakt              #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "020"
+    image: chart/<<style>>/<<mapping_name_encoded>>
+
+templates:
+  trakt:
+    default:
+      limit: 100
+      limit_<<key>>: <<limit>>
+    trakt_chart:
+      chart: <<key>>
+      limit: <<limit_<<key>>>>
+
+collections:
+  Trakt Collected:
+    variables:
+      style: color
+      key: collected
+    template:
+      - name: trakt
+      - name: shared
+        translation_key: trakt_collected
+      - name: arr
+      - name: custom
+
+  Trakt Popular:
+    variables:
+      style: color
+      key: popular
+    template:
+      - name: trakt
+      - name: shared
+        translation_key: trakt_popular
+      - name: arr
+      - name: custom
+
+  Trakt Recommended:
+    variables:
+      style: color
+      key: recommended
+    template:
+      - name: trakt
+      - name: shared
+        translation_key: trakt_recommended
+      - name: arr
+      - name: custom
+
+  Trakt Trending:
+    variables:
+      style: color
+      key: trending
+    template:
+      - name: trakt
+      - name: shared
+        translation_key: trakt_trending
+      - name: arr
+      - name: custom
+
+  Trakt Watched:
+    variables:
+      style: color
+      key: watched
+    template:
+      - name: trakt
+      - name: shared
+        translation_key: trakt_watched
+      - name: arr
+      - name: custom

--- a/tests/fixtures/kometa/defaults/movie/content_rating_us.yml
+++ b/tests/fixtures/kometa/defaults/movie/content_rating_us.yml
@@ -1,0 +1,132 @@
+##############################################################################
+#                       US Content Rating Collections                        #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#       https://kometa.wiki/en/latest/defaults/both/content_rating_us        #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "110"
+
+collections:
+  Ratings Collections:
+    template:
+      - name: separator
+        separator: content_rating
+        key_name: Ratings
+        translation_key: separator
+
+dynamic_collections:
+  US Movie Content Ratings:
+    type: content_rating
+    title_format: <<key_name>> <<library_typeU>>s
+    other_name: Not Rated <<library_typeU>>s
+    template:
+      - smart_filter
+      - shared
+    other_template:
+      - other_collection
+      - smart_filter
+      - shared
+    template_variables:
+      search_term:
+        default: content_rating
+      image:
+        default: content_rating/us/<<key_name>>
+        other: content_rating/us/NR
+      translation_key:
+        default: content_rating
+        other: content_rating_other
+      dynamic:
+        default: true
+    include:
+      - G
+      - PG
+      - PG-13
+      - R
+      - NC-17
+    addons:
+      G: 
+        - gb/U
+        - gb/0+
+        - U
+        - TV-Y
+        - TV-G
+        - E
+        - gb/E
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - "01"
+        - "02"
+        - "03"
+        - "04"
+        - "05"
+        - "06"
+        - G - All Ages
+        - A
+        - no/A
+      PG:
+        - gb/PG
+        - gb/9+
+        - TV-PG
+        - TV-Y7
+        - TV-Y7-FV
+        - 7
+        - 8
+        - 9
+        - "07"
+        - "08"
+        - "09"
+        - "10"
+        - "11"
+        - PG - Children
+        - no/5
+        - no/05
+        - no/6
+        - no/06
+        - no/7
+        - no/07
+      PG-13:
+        - gb/12A
+        - gb/12
+        - 12+
+        - TV-13
+        - gb/14+
+        - gb/15
+        - TV-14
+        - 12
+        - 13
+        - 14
+        - 15
+        - 16
+        - PG-13 - Teens 13 or older
+        - no/9
+        - no/09
+        - no/10
+        - no/11
+        - no/12
+      R:
+        - 17
+        - 18
+        - gb/18
+        - MA-17
+        - TVMA
+        - TV-MA
+        - R - 17+ (violence & profanity)
+        - R+ - Mild Nudity
+        - no/15
+        - no/16
+        - no/18
+      NC-17:
+        - gb/R18
+        - gb/X
+        - R18
+        - X
+        - Rx - Hentai
+

--- a/tests/fixtures/kometa/defaults/movie/continent.yml
+++ b/tests/fixtures/kometa/defaults/movie/continent.yml
@@ -1,0 +1,406 @@
+##############################################################################
+#                           Continent Collections                            #
+#       Created by Adam Pope, bartolomesorianol, Bullmoose20 & Sohjiro       #
+#          Artwork Credit to Duhniel, Bullmoose20, and Wiki Commons          #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#           https://kometa.wiki/en/latest/defaults/movie/continent           #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "082"
+
+collections:
+  Continent Collections:
+    template:
+      - name: separator
+        separator: continent
+        key_name: Continent
+        translation_key: separator
+
+dynamic_collections:
+  Continent:
+    type: country
+    title_format: <<key_name>>
+    other_name: Other Continents
+    template:
+      - smart_filter
+      - shared
+    other_template:
+      - other_collection
+      - smart_filter
+      - shared
+    template_variables:
+      search_term:
+        default: country
+      image:
+        default: country/<<style>>/<<original_key_name_encoded>>
+      style:
+        default: white
+      translation_key:
+        default: country
+        other: country_other
+      dynamic:
+        default: true
+
+    include:
+      - Africa
+      - Americas
+      - Antarctica
+      - Asia
+      - Europe
+      - Oceania
+
+    addons:
+      Africa:
+      # Northern Africa:
+        - Algeria
+        - Egypt
+        - Libya
+        - Morocco
+        - Sudan
+        - Tunisia
+        - Western Sahara
+      # Eastern Africa:
+        - British Indian Ocean Territory
+        - Burundi
+        - Comoros
+        - Djibouti
+        - Eritrea
+        - Ethiopia
+        - French Southern Territories
+        - Kenya
+        - Madagascar
+        - Malawi
+        - Mauritius
+        - Mayotte
+        - Mozambique
+        - Réunion
+        - Rwanda
+        - Seychelles
+        - Somalia
+        - South Sudan
+        - Uganda
+        - Tanzania
+        - United Republic of Tanzania # Tanzania
+        - Zambia
+        - Zimbabwe
+      # Central Africa:
+        - Angola
+        - Cameroon
+        - Central African Republic
+        - Chad
+        - Republic of the Congo
+        - Congo # Republic of the Congo
+        - Democratic Republic of the Congo
+        - Zaire # Democratic Republic of the Congo
+        - Equatorial Guinea
+        - Gabon
+        - São Tomé and Príncipe
+        - Sao Tome and Principe # São Tomé and Príncipe
+      # Southern Africa:
+        - Botswana
+        - Eswatini
+        - Swaziland # Eswatini
+        - Lesotho
+        - Namibia
+        - South Africa
+      # Western Africa:
+        - Benin
+        - Burkina Faso
+        - Cape Verde
+        - Cabo Verde # Cape Verde
+        - Côte d'Ivoire
+        - Côte d’Ivoire # Côte d'Ivoire
+        - Ivory Coast # Côte d'Ivoire
+        - Gambia
+        - Ghana
+        - Guinea
+        - Guinea-Bissau
+        - Liberia
+        - Mali
+        - Mauritania
+        - Niger
+        - Nigeria
+        - Saint Helena, Ascension and Tristan da Cunha
+        - Saint Helena # Saint Helena, Ascension and Tristan da Cunha
+        - St. Helena # Saint Helena, Ascension and Tristan da Cunha
+        - Ascension # Saint Helena, Ascension and Tristan da Cunha
+        - Tristan da Cunha # Saint Helena, Ascension and Tristan da Cunha
+        - Senegal
+        - Sierra Leone
+        - Togo
+      Americas:
+      # Caribbean:
+        - Anguilla
+        - Antigua and Barbuda
+        - Antigua # Antigua and Barbuda
+        - Barbuda # Antigua and Barbuda
+        - Aruba
+        - Bahamas
+        - Barbados
+        - Bonaire, Sint Eustatius and Saba
+        - Bonaire # Bonaire, Sint Eustatius and Saba
+        - Sint Eustatius # Bonaire, Sint Eustatius and Saba
+        - Saba # Bonaire, Sint Eustatius and Saba
+        - Netherlands Antilles
+        - British Virgin Islands
+        - Cayman Islands
+        - Cuba
+        - Curaçao
+        - Dominica
+        - Dominican Republic
+        - Grenada
+        - Guadeloupe
+        - Haiti
+        - Jamaica
+        - Martinique
+        - Montserrat
+        - Puerto Rico
+        - Saint Barthélemy
+        - Saint Kitts and Nevis
+        - St. Kitts and Nevis # Saint Kitts and Nevis
+        - Saint Lucia
+        - St. Lucia # Saint Lucia
+        - Saint Martin
+        - Saint Vincent and the Grenadines
+        - Saint Vincent and Grenadines # Saint Vincent and the Grenadines
+        - St. Vincent and the Grenadines # Saint Vincent and the Grenadines
+        - St. Vincent and Grenadines # Saint Vincent and the Grenadines
+        - Sint Maarten
+        - Trinidad and Tobago
+        - Turks and Caicos Islands
+        - US Virgin Islands
+        - U.S. Virgin Islands # US Virgin Islands
+        - United States Virgin Islands # US Virgin Islands
+      # Central America:
+        - Belize
+        - Costa Rica
+        - El Salvador
+        - Guatemala
+        - Honduras
+        - Mexico
+        - Nicaragua
+        - Panama
+      # South America:
+        - Argentina
+        - Bolivia
+        - Plurinational State of Bolivia # Bolivia
+        - Bouvet Island
+        - Brazil
+        - Chile
+        - Colombia
+        - Ecuador
+        - Falkland Islands
+        - Malvinas # Falkland Islands
+        - French Guiana
+        - Guyana
+        - Paraguay
+        - Peru
+        - South Georgia and the South Sandwich Islands
+        - South Georgia and South Sandwich Islands # South Georgia and the South Sandwich Islands
+        - South Georgia # South Georgia and the South Sandwich Islands
+        - South Sandwich Islands # South Georgia and the South Sandwich Islands
+        - Suriname
+        - Uruguay
+        - Venezuela
+        - Bolivarian Republic of Venezuela # Venezuela
+      # North America:
+        - Bermuda
+        - Canada
+        - Greenland
+        - Saint Pierre and Miquelon
+        - St. Pierre and Miquelon # Saint Pierre and Miquelon
+        - United States
+        - United States of America # United States
+      Asia:
+      # Central Asia:
+        - Kazakhstan
+        - Kyrgyzstan
+        - Tajikistan
+        - Turkmenistan
+        - Uzbekistan
+      # Eastern Asia:
+        - China
+        - Hong Kong
+        - Hong Kong SAR China # Hong Kong
+        - Macao
+        - Macau # Macao
+        - Macau SAR China # Macao
+        - North Korea
+        - Democratic People's Republic of Korea # North Korea
+        - Japan
+        - Mongolia
+        - South Korea
+        - Republic of Korea # South Korea
+        - Korea # South Korea
+        - Taiwan
+        - Taiwan, Province of China # Taiwan
+      # South-Eastern Asia:
+        - Brunei
+        - Brunei Darussalam # Brunei
+        - Cambodia
+        - Indonesia
+        - Laos
+        - Lao People's Democratic Republic # Laos
+        - Lao # Laos
+        - Malaysia
+        - Myanmar
+        - Burma # Myanmar
+        - Philippines
+        - Singapore
+        - Thailand
+        - East Timor
+        - Timor-Leste # East Timor
+        - Vietnam
+        - Viet Nam # Vietnam
+      # Southern Asia:
+        - Afghanistan
+        - Bangladesh
+        - Bhutan
+        - India
+        - Iran
+        - Islamic Republic of Iran # Iran
+        - Maldives
+        - Nepal
+        - Pakistan
+        - Sri Lanka
+      # Western Asia:
+        - Armenia
+        - Azerbaijan
+        - Bahrain
+        - Cyprus
+        - Georgia
+        - Iraq
+        - Israel
+        - Jordan
+        - Kuwait
+        - Lebanon
+        - Oman
+        - Qatar
+        - Saudi Arabia
+        - Palestine
+        - State of Palestine # Palestine
+        - Syria
+        - Syrian Arab Republic # Syria
+        - Turkey
+        - Türkiye # Turkey
+        - United Arab Emirates
+        - Yemen
+      Europe:
+      # Eastern Europe:
+        - Belarus
+        - Bulgaria
+        - Czech Republic
+        - Czechia # Czech Republic
+        - Czechoslovakia # Czech Republic
+        - Hungary
+        - Poland
+        - Moldova
+        - Republic of Moldova # Moldova
+        - Romania
+        - Russia
+        - Russian Federation # Russia
+        - Soviet Union
+        - Slovakia
+        - Ukraine
+      # Northern Europe:
+        - Åland Islands
+        - Guernsey
+        - Jersey
+        - Sark
+        - Denmark
+        - Estonia
+        - Faroe Islands
+        - Finland
+        - Iceland
+        - Ireland
+        - Northern Ireland
+        - Isle of Man
+        - Latvia
+        - Lithuania
+        - Norway
+        - Svalbard and Jan Mayen Islands
+        - Svalbard and Jan Mayen # Svalbard and Jan Mayen Islands
+        - Sweden
+        - United Kingdom
+      # Southern Europe:
+        - Albania
+        - Andorra
+        - Bosnia and Herzegovina
+        - Croatia
+        - Gibraltar
+        - Greece
+        - Kosovo
+        - Vatican City
+        - Holy See # Vatican City
+        - Italy
+        - Malta
+        - Montenegro
+        - North Macedonia
+        - Macedonia # North Macedonia
+        - Republic of North Macedonia # North Macedonia
+        - Portugal
+        - San Marino
+        - Serbia
+        - Serbia and Montenegro
+        - Slovenia
+        - Spain
+        - Yugoslavia
+      # Western Europe:
+        - Austria
+        - Belgium
+        - France
+        - French Republic # France
+        - Germany
+        - East Germany
+        - Liechtenstein
+        - Luxembourg
+        - Monaco
+        - Netherlands
+        - Switzerland
+      Oceania:
+      # Australia and New Zealand:
+        - Australia
+        - Christmas Island
+        - Cocos (Keeling) Islands
+        - Heard Island and McDonald Islands
+        - Heard and McDonald Islands # Heard Island and McDonald Islands
+        - New Zealand
+        - Norfolk Island
+      # Melanesia:
+        - Fiji
+        - New Caledonia
+        - Papua New Guinea
+        - New Guinea # Papua New Guinea
+        - Solomon Islands
+        - Vanuatu
+      # Micronesia:
+        - Guam
+        - Kiribati
+        - Marshall Islands
+        - Micronesia
+        - Federated States of Micronesia # Micronesia
+        - Nauru
+        - Northern Mariana Islands
+        - Palau
+        - US Minor Outlying Islands
+        - United States Minor Outlying Islands # US Minor Outlying Islands
+        - United States Outlying Islands # US Minor Outlying Islands
+        - U.S. Minor Outlying Islands # US Minor Outlying Islands
+        - U.S. Outlying Islands # US Minor Outlying Islands
+        - US Outlying Islands # US Minor Outlying Islands
+      # Polynesia:
+        - American Samoa
+        - Cook Islands
+        - French Polynesia
+        - Niue
+        - Pitcairn
+        - Pitcairn Islands # Pitcairn
+        - Samoa
+        - Tokelau
+        - Tonga
+        - Tuvalu
+        - Wallis and Futuna Islands
+        - Wallis and Futuna # Wallis and Futuna Islands

--- a/tests/fixtures/kometa/defaults/movie/country.yml
+++ b/tests/fixtures/kometa/defaults/movie/country.yml
@@ -1,0 +1,446 @@
+##############################################################################
+#                            Country Collections                             #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#                         Artwork Credit to Duhniel                          #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#           https://kometa.wiki/en/latest/defaults/movie/country             #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "080"
+
+collections:
+  Country Collections:
+    template:
+      - name: separator
+        separator: country
+        key_name: Country
+        translation_key: separator
+
+dynamic_collections:
+  Country:
+    type: country
+    title_format: <<key_name>>
+    other_name: Other Countries
+    template:
+      - smart_filter
+      - shared
+    other_template:
+      - other_collection
+      - smart_filter
+      - shared
+    template_variables:
+      search_term:
+        default: country
+      image:
+        default: country/<<style>>/<<original_key_name_encoded>>
+      style:
+        default: white
+      translation_key:
+        default: country
+        other: country_other
+      dynamic:
+        default: true
+
+    include:
+      # Northern Africa:
+        - Algeria
+        - Egypt
+        - Libya
+        - Morocco
+        - Sudan
+        - Tunisia
+        - Western Sahara
+      # Eastern Africa:
+        - British Indian Ocean Territory
+        - Burundi
+        - Comoros
+        - Djibouti
+        - Eritrea
+        - Ethiopia
+        - French Southern Territories
+        - Kenya
+        - Madagascar
+        - Malawi
+        - Mauritius
+        - Mayotte
+        - Mozambique
+        - Réunion
+        - Rwanda
+        - Seychelles
+        - Somalia
+        - South Sudan
+        - Uganda
+        - Tanzania
+        - Zambia
+        - Zimbabwe
+      # Central Africa:
+        - Angola
+        - Cameroon
+        - Central African Republic
+        - Chad
+        - Republic of the Congo
+        - Democratic Republic of the Congo
+        - Equatorial Guinea
+        - Gabon
+        - São Tomé and Príncipe
+      # Southern Africa:
+        - Botswana
+        - Eswatini
+        - Lesotho
+        - Namibia
+        - South Africa
+      # Western Africa:
+        - Benin
+        - Burkina Faso
+        - Cape Verde
+        - Côte d'Ivoire
+        - Gambia
+        - Ghana
+        - Guinea
+        - Guinea-Bissau
+        - Liberia
+        - Mali
+        - Mauritania
+        - Niger
+        - Nigeria
+        - Saint Helena, Ascension and Tristan da Cunha
+        - Senegal
+        - Sierra Leone
+        - Togo
+      # Caribbean:
+        - Anguilla
+        - Antigua and Barbuda
+        - Aruba
+        - Bahamas
+        - Barbados
+        - Bonaire, Sint Eustatius and Saba
+        - Netherlands Antilles
+        - British Virgin Islands
+        - Cayman Islands
+        - Cuba
+        - Curaçao
+        - Dominica
+        - Dominican Republic
+        - Grenada
+        - Guadeloupe
+        - Haiti
+        - Jamaica
+        - Martinique
+        - Montserrat
+        - Puerto Rico
+        - Saint Barthélemy
+        - Saint Kitts and Nevis
+        - Saint Lucia
+        - Saint Martin
+        - Saint Vincent and the Grenadines
+        - Sint Maarten
+        - Trinidad and Tobago
+        - Turks and Caicos Islands
+        - US Virgin Islands
+      # Central America:
+        - Belize
+        - Costa Rica
+        - El Salvador
+        - Guatemala
+        - Honduras
+        - Mexico
+        - Nicaragua
+        - Panama
+      # South America:
+        - Argentina
+        - Bolivia
+        - Bouvet Island
+        - Brazil
+        - Chile
+        - Colombia
+        - Ecuador
+        - Falkland Islands
+        - French Guiana
+        - Guyana
+        - Paraguay
+        - Peru
+        - South Georgia and the South Sandwich Islands
+        - Suriname
+        - Uruguay
+        - Venezuela
+      # North America:
+        - Bermuda
+        - Canada
+        - Greenland
+        - Saint Pierre and Miquelon
+        - United States
+      # Antarctica:
+        - Antarctica
+      # Central Asia:
+        - Kazakhstan
+        - Kyrgyzstan
+        - Tajikistan
+        - Turkmenistan
+        - Uzbekistan
+      # Eastern Asia:
+        - China
+        - Hong Kong
+        - Macao
+        - North Korea
+        - Japan
+        - Mongolia
+        - South Korea
+        - Taiwan
+      # South-Eastern Asia:
+        - Brunei
+        - Cambodia
+        - Indonesia
+        - Laos
+        - Malaysia
+        - Myanmar
+        - Philippines
+        - Singapore
+        - Thailand
+        - East Timor
+        - Vietnam
+      # Southern Asia:
+        - Afghanistan
+        - Bangladesh
+        - Bhutan
+        - India
+        - Iran
+        - Maldives
+        - Nepal
+        - Pakistan
+        - Sri Lanka
+      # Western Asia:
+        - Armenia
+        - Azerbaijan
+        - Bahrain
+        - Cyprus
+        - Georgia
+        - Iraq
+        - Israel
+        - Jordan
+        - Kuwait
+        - Lebanon
+        - Oman
+        - Qatar
+        - Saudi Arabia
+        - Palestine
+        - Syria
+        - Turkey
+        - United Arab Emirates
+        - Yemen
+      # Eastern Europe:
+        - Belarus
+        - Bulgaria
+        - Czech Republic
+        - Hungary
+        - Poland
+        - Moldova
+        - Romania
+        - Russia
+        - Slovakia
+        - Ukraine
+      # Northern Europe:
+        - Åland Islands
+        - Guernsey
+        - Jersey
+        - Sark
+        - Denmark
+        - Estonia
+        - Faroe Islands
+        - Finland
+        - Iceland
+        - Ireland
+        - Northern Ireland
+        - Isle of Man
+        - Latvia
+        - Lithuania
+        - Norway
+        - Svalbard and Jan Mayen Islands
+        - Sweden
+        - United Kingdom
+      # Southern Europe:
+        - Albania
+        - Andorra
+        - Bosnia and Herzegovina
+        - Croatia
+        - Gibraltar
+        - Greece
+        - Kosovo
+        - Vatican City
+        - Italy
+        - Malta
+        - Montenegro
+        - North Macedonia
+        - Portugal
+        - San Marino
+        - Serbia
+        - Serbia and Montenegro
+        - Slovenia
+        - Spain
+        - Yugoslavia
+      # Western Europe:
+        - Austria
+        - Belgium
+        - France
+        - Germany
+        - Liechtenstein
+        - Luxembourg
+        - Monaco
+        - Netherlands
+        - Switzerland
+      #Australia and New Zealand:
+        - Australia
+        - Christmas Island
+        - Cocos (Keeling) Islands
+        - Heard Island and McDonald Islands
+        - New Zealand
+        - Norfolk Island
+      # Melanesia:
+        - Fiji
+        - New Caledonia
+        - Papua New Guinea
+        - Solomon Islands
+        - Vanuatu
+      # Micronesia:
+        - Guam
+        - Kiribati
+        - Marshall Islands
+        - Micronesia
+        - Nauru
+        - Northern Mariana Islands
+        - Palau
+        - US Minor Outlying Islands
+      # Polynesia:
+        - American Samoa
+        - Cook Islands
+        - French Polynesia
+        - Niue
+        - Pitcairn Islands
+        - Samoa
+        - Tokelau
+        - Tonga
+        - Tuvalu
+        - Wallis and Futuna Islands
+    addons:
+      Tanzania:
+        - United Republic of Tanzania
+      Republic of the Congo:
+        - Congo
+      Democratic Republic of the Congo:
+        - Zaire
+      São Tomé and Príncipe:
+        - Sao Tome and Principe
+      Eswatini:
+        - Swaziland
+      Cape Verde:
+        - Cabo Verde
+      Côte d'Ivoire:
+        - Côte d’Ivoire
+        - Ivory Coast
+      Saint Helena, Ascension and Tristan da Cunha:
+        - Saint Helena
+        - St. Helena
+        - Ascension
+        - Tristan da Cunha
+      Antigua and Barbuda:
+        - Antigua
+        - Barbuda
+      Bonaire, Sint Eustatius and Saba:
+        - Bonaire
+        - Sint Eustatius
+        - Saba
+      Saint Kitts and Nevis:
+        - St. Kitts and Nevis
+      Saint Lucia:
+        - St. Lucia
+      Saint Vincent and the Grenadines:
+        - Saint Vincent and Grenadines
+        - St. Vincent and the Grenadines
+        - St. Vincent and Grenadines
+      US Virgin Islands:
+        - U.S. Virgin Islands
+        - United States Virgin Islands
+      Bolivia:
+        - Plurinational State of Bolivia
+      Falkland Islands:
+        - Malvinas
+      South Georgia and the South Sandwich Islands:
+        - South Georgia and South Sandwich Islands
+        - South Georgia
+        - South Sandwich Islands
+      Venezuela:
+        - Bolivarian Republic of Venezuela
+      Saint Pierre and Miquelon:
+        - St. Pierre and Miquelon
+      United States:
+        - United States of America
+      Hong Kong:
+        - Hong Kong SAR China
+      Macao:
+        - Macau
+        - Macau SAR China
+      North Korea:
+        - Democratic People's Republic of Korea
+      South Korea:
+        - Republic of Korea
+        - Korea
+      Taiwan:
+        - Taiwan, Province of China
+      Brunei:
+        - Brunei Darussalam
+      Laos:
+        - Lao People's Democratic Republic
+        - Lao
+      Myanmar:
+        - Burma
+      East Timor:
+        - Timor-Leste
+      Vietnam:
+        - Viet Nam
+      Iran:
+        - Islamic Republic of Iran
+      Palestine:
+        - State of Palestine
+      Syria:
+        - Syrian Arab Republic
+      Turkey:
+        - Türkiye
+      Czech Republic:
+        - Czechia
+        - Czechoslovakia
+      Moldova:
+        - Republic of Moldova
+      Russia:
+        - Russian Federation
+        - Soviet Union
+      Svalbard and Jan Mayen Islands:
+        - Svalbard and Jan Mayen
+      Vatican City:
+        - Holy See
+      North Macedonia:
+        - Macedonia
+        - Republic of North Macedonia
+      France:
+        - French Republic
+      Germany:
+        - East Germany
+      Heard Island and McDonald Islands:
+        - Heard and McDonald Islands
+      Papua New Guinea:
+        - New Guinea
+      Micronesia:
+        - Federated States of Micronesia
+      US Minor Outlying Islands:
+        - United States Minor Outlying Islands
+        - United States Outlying Islands
+        - U.S. Minor Outlying Islands
+        - U.S. Outlying Islands
+        - US Outlying Islands
+      Pitcairn Islands:
+        - Pitcairn
+      Wallis and Futuna Islands:
+        - Wallis and Futuna
+
+    

--- a/tests/fixtures/kometa/defaults/movie/decade.yml
+++ b/tests/fixtures/kometa/defaults/movie/decade.yml
@@ -1,0 +1,40 @@
+##############################################################################
+#                             Decade Collections                             #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#            https://kometa.wiki/en/latest/defaults/movie/decade             #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "100"
+
+collections:
+  Decade Collections:
+    template:
+      - name: separator
+        separator: decade
+        key_name: Decade
+        translation_key: separator
+
+dynamic_collections:
+  Decade:
+    type: decade
+    title_format: Best of <<key_name>>
+    template:
+      - smart_filter
+      - shared
+    template_variables:
+      search_term:
+        default: decade
+      sort_by:
+        default: critic_rating.desc
+      limit:
+        default: 100
+      image:
+        default: decade/best/<<key>>
+      translation_key:
+        default: decade
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/movie/director.yml
+++ b/tests/fixtures/kometa/defaults/movie/director.yml
@@ -1,0 +1,47 @@
+##############################################################################
+#                            Director Collections                            #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#           https://kometa.wiki/en/latest/defaults/movie/director            #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "150"
+
+collections:
+  Directors Collections:
+    template:
+      - name: separator
+        separator: director
+        key_name: Directors
+        translation_key: separator
+
+dynamic_collections:
+  Top Directors:
+    type: director
+    data:
+      depth: 5
+      limit: 25
+    title_format: <<key_name>> (Director)
+    template:
+      - tmdb_person
+      - smart_filter
+      - shared
+    template_variables:
+      tmdb_person:
+        default: <<value>>
+      tmdb_person_offset:
+        default: 0
+        Richard Brooks: 1
+      search_term:
+        default: director
+      search_value:
+        default: tmdb
+      translation_key:
+        default: director
+      style:
+        default: bw
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/movie/franchise.yml
+++ b/tests/fixtures/kometa/defaults/movie/franchise.yml
@@ -1,0 +1,181 @@
+##############################################################################
+#                           Franchise Collections                            #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#          https://kometa.wiki/en/latest/defaults/movie/franchise            #
+##############################################################################
+
+templates:
+  collection:
+    default:
+      sync_mode: sync
+      sync_mode_<<key>>: <<sync_mode>>
+      collection_order: release
+      minimum_items: 2
+      name_mapping_<<key>>: <<name_mapping>>
+      movie_<<key>>: <<movie>>
+      pre: "_"
+      order_<<key>>: ""
+      sort_title: "!<<collection_section>><<pre>><<order_<<key>>>><<title>>"
+      sort_title_<<key>>: <<sort_title>>
+      radarr_add_missing_<<key>>: <<radarr_add_missing>>
+      radarr_folder_<<key>>: <<radarr_folder>>
+      radarr_tag_<<key>>: <<radarr_tag>>
+      item_radarr_tag_<<key>>: <<item_radarr_tag>>
+      radarr_monitor_<<key>>: <<radarr_monitor>>
+      collection_order_<<key>>: <<collection_order>>
+    optional:
+      - name_<<key>>
+      - summary_<<key>>
+      - movie
+      - name_mapping
+      - build_collection
+      - collection_mode
+      - collection_section
+      - radarr_add_missing
+      - radarr_folder
+      - radarr_tag
+      - item_radarr_tag
+      - radarr_monitor
+      - url_poster_<<key>>
+    name: <<name_<<key>>>>
+    summary: <<summary_<<key>>>>
+    cache_builders: 1
+    minimum_items: <<minimum_items>>
+    url_poster: <<url_poster_<<key>>>>
+    tmdb_collection_details: <<value>>
+    tmdb_movie: <<movie_<<key>>>>
+    name_mapping: <<name_mapping_<<key>>>>
+    sort_title: <<sort_title_<<key>>>>
+    build_collection: <<build_collection>>
+    sync_mode: <<sync_mode_<<key>>>>
+    collection_mode: <<collection_mode>>
+    collection_order: <<collection_order_<<key>>>>
+    radarr_add_missing: <<radarr_add_missing_<<key>>>>
+    radarr_folder: <<radarr_folder_<<key>>>>
+    radarr_tag: <<radarr_tag_<<key>>>>
+    item_radarr_tag: <<item_radarr_tag_<<key>>>>
+    radarr_monitor: <<radarr_monitor_<<key>>>>
+
+dynamic_collections:
+  TMDb Collections:
+    type: tmdb_collection
+    remove_suffix: "Collection"
+    template: collection
+    custom_keys: false
+    addons:
+      8091:       # Alien
+        - 135416    # Prometheus
+      2806:       # American Pie
+        - 298820    # American Pie (Spin-off)
+      87800:      # Appleseed
+        - 371526    # Appleseed XIII
+      477208:     # DC Super Hero Girls
+        - 557495    # LEGO DC Super Hero Girls
+      86066:      # Despicable Me
+        - 544669    # Minions
+      86115:      # Garfield
+        - 373918    # Garfield CGI
+      91361:      # Halloween
+        - 126209    # Halloween (Rob Zombie Series)
+      9818:       # Mortal Kombat
+        - 931431    # Mortal Kombat
+      495:        # Shaft
+        - 608103    # Shaft (Reboot)
+      1582:       # Teenage Mutant Ninja Turtles
+        - 401562    # Teenage Mutant Ninja Turtles (Remake)
+      111751:     # Texas Chainsaw Massacre
+        - 425175    # Texas Chainsaw (Reboot)
+      748:        # X-Men
+        - 453993    # The Wolverine
+    title_override:
+      10: "Star Wars: Skywalker Saga"
+      535313: Godzilla (MonsterVerse)
+      535790: Godzilla (Anime)
+    template_variables:
+      movie:
+        521226:     # A Quiet Place
+          - 762441    # A Quiet Place: Day One
+        105995:     # Anaconda
+          - 336560    # Lake Placid vs. Anaconda
+        176097:     # Barbershop
+          - 14177     # Beauty Shop
+        448150:     # Deadpool
+          - 567604    # Once Upon a Deadpool
+        9485:       # The Fast and the Furious
+          - 384018    # Hobbs & Shaw
+        9735:       # Friday the 13th
+          - 6466      # Freddy vs. Jason
+          - 222724    # Crystal Lake Memories: The Complete History of Friday the 13th
+        386382:     # Frozen
+          - 326359    # Frozen Fever
+          - 460793    # Olaf's Frozen Adventure
+        2980:       # Ghostbusters
+          - 43074     # Ghostbusters (2016)
+        374509:     # Godzilla (Showa)
+          - 18983     # Godzilla, King of the Monsters!
+        374511:     # Godzilla (Heisei)
+          - 39256     # Godzilla 1985
+        535313:     # Godzilla
+          - 293167    # Kong: Skull Island
+        9743:       # The Hannibal Lecter
+          - 11454     # Manhunter
+        8354:       # Ice Age
+          - 79218     # Ice Age: A Mammoth Christmas
+          - 717095    # Ice Age Continental Drift: Scrat Got Your Tongue
+          - 387893    # Ice Age: The Great Egg-Scapade
+        70068:      # Ip Man
+          - 658009    # Ip Man: Kung Fu Master
+          - 643413    # Ip Man and Four Kings
+          - 450001    # Master Z: Ip Man Legacy
+          - 751391    # Young Ip Man: Crisis Time
+          - 44249     # The Legend Is Born: Ip Man
+          - 182127    # Ip Man: The Final Fight
+          - 44865     # The Grandmaster
+        328:        # Jurassic Park
+          - 630322    # Battle at Big Rock
+        8580:       # The Karate Kid
+          - 38575     # The Karate Kid (2010)
+        14740:      # Madagascar
+          - 161143    # Madagascar: Madly Madagascar
+          - 25472     # Merry Madagascar
+          - 270946    # Penguins of Madagascar
+        9818:       # Mortal Kombat
+          - 664767    # Mortal Kombat Legends: Scorpion's Revenge
+        171732:     # Rebirth of Mothra
+          - 39410     # Mothra
+        8581:       # A Nightmare on Elm Street
+          - 6466      # Freddy vs. Jason
+          - 23437     # A Nightmare on Elm Street (2010)
+        627517:     # Oz
+          - 13155     # Oz: Return to Oz
+          - 68728     # Oz the Great and Powerful
+        10789:      # Pet Sematary
+          - 157433    # Pet Sematary (2019)
+        708816:     # Power Rangers
+          - 305470    # Power Rangers (2017)
+          - 306264    # Power Rangers Super Megaforce: The Legendary Battle
+        190435:     # Street Fighter (Animated)
+          - 687354    # Street Fighter Assassin's Fist
+          - 11667     # Street Fighter
+        1582:       # Teenage Mutant Ninja Turtles
+          - 1273      # TMNT
+        2467:       # Tomb Raider
+          - 338970    # Tomb Raider (2018)
+        10194:      # Toy Story
+          - 130925    # Partysaurus Rex
+        63043:      # TRON
+          - 73362     # TRON: The Next Day
+        748:        # X-Men
+          - 567604    # Once Upon a Deadpool
+      name_mapping:
+        1565: 28 Days-Weeks Later
+        508334: Angels in the
+        115838: Escape From
+        386534: Has Fallen
+        87359: Mission Impossible
+        133352: Resident Evil Biohazard
+        115575: Star Trek Alternate Reality
+        115570: Star Trek The Next Generation
+        151: Star Trek The Original Series
+        10: Star Wars Skywalker Saga

--- a/tests/fixtures/kometa/defaults/movie/producer.yml
+++ b/tests/fixtures/kometa/defaults/movie/producer.yml
@@ -1,0 +1,46 @@
+##############################################################################
+#                            Producer Collections                            #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#           https://kometa.wiki/en/latest/defaults/movie/producer            #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "160"
+
+collections:
+  Producers Collections:
+    template:
+      - name: separator
+        separator: producer
+        key_name: Producers
+        translation_key: separator
+
+dynamic_collections:
+  Top Producers:
+    type: producer
+    title_format: <<key_name>> (Producer)
+    data:
+      depth: 5
+      limit: 25
+    template:
+      - tmdb_person
+      - smart_filter
+      - shared
+    template_variables:
+      tmdb_person:
+        default: <<value>>
+      tmdb_person_offset:
+        default: 0
+      search_term:
+        default: producer
+      search_value:
+        default: tmdb
+      translation_key:
+        default: producer
+      style:
+        default: bw
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/movie/region.yml
+++ b/tests/fixtures/kometa/defaults/movie/region.yml
@@ -1,0 +1,417 @@
+##############################################################################
+#                             Region Collections                             #
+#       Created by Adam Pope, bartolomesorianol, Bullmoose20 & Sohjiro       #
+#          Artwork Credit to Duhniel, Bullmoose20, and Wiki Commons          #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#            https://kometa.wiki/en/latest/defaults/movie/region             #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "081"
+
+collections:
+  Region Collections:
+    template:
+      - name: separator
+        separator: region
+        key_name: Region
+        translation_key: separator
+
+dynamic_collections:
+  Region:
+    type: country
+    title_format: <<key_name>>
+    other_name: Other Regions
+    template:
+      - smart_filter
+      - shared
+    other_template:
+      - other_collection
+      - smart_filter
+      - shared
+    template_variables:
+      search_term:
+        default: country
+      image:
+        default: country/<<style>>/<<original_key_name_encoded>>
+      style:
+        default: white
+      translation_key:
+        default: country
+        other: country_other
+      dynamic:
+        default: true
+
+    include:
+      - Northern Africa
+      - Eastern Africa
+      - Central Africa
+      - Southern Africa
+      - Western Africa
+      - Caribbean
+      - Central America
+      - South America
+      - North America
+      - Antarctica
+      - Central Asia
+      - Eastern Asia
+      - South-Eastern Asia
+      - Southern Asia
+      - Western Asia
+      - Eastern Europe
+      - Northern Europe
+      - Southern Europe
+      - Western Europe
+      - Australia and New Zealand
+      - Melanesia
+      - Micronesia
+      - Polynesia
+
+    addons:
+      Northern Africa:
+        - Algeria
+        - Egypt
+        - Libya
+        - Morocco
+        - Sudan
+        - Tunisia
+        - Western Sahara
+      Eastern Africa:
+        - British Indian Ocean Territory
+        - Burundi
+        - Comoros
+        - Djibouti
+        - Eritrea
+        - Ethiopia
+        - French Southern Territories
+        - Kenya
+        - Madagascar
+        - Malawi
+        - Mauritius
+        - Mayotte
+        - Mozambique
+        - Réunion
+        - Rwanda
+        - Seychelles
+        - Somalia
+        - South Sudan
+        - Uganda
+        - Tanzania
+        - United Republic of Tanzania # Tanzania
+        - Zambia
+        - Zimbabwe
+      Central Africa:
+        - Angola
+        - Cameroon
+        - Central African Republic
+        - Chad
+        - Republic of the Congo
+        - Congo # Republic of the Congo
+        - Democratic Republic of the Congo
+        - Zaire # Democratic Republic of the Congo
+        - Equatorial Guinea
+        - Gabon
+        - São Tomé and Príncipe
+        - Sao Tome and Principe # São Tomé and Príncipe
+      Southern Africa:
+        - Botswana
+        - Eswatini
+        - Swaziland # Eswatini
+        - Lesotho
+        - Namibia
+        - South Africa
+      Western Africa:
+        - Benin
+        - Burkina Faso
+        - Cape Verde
+        - Cabo Verde # Cape Verde
+        - Côte d'Ivoire
+        - Côte d’Ivoire # Côte d'Ivoire
+        - Ivory Coast # Côte d'Ivoire
+        - Gambia
+        - Ghana
+        - Guinea
+        - Guinea-Bissau
+        - Liberia
+        - Mali
+        - Mauritania
+        - Niger
+        - Nigeria
+        - Saint Helena, Ascension and Tristan da Cunha
+        - Saint Helena # Saint Helena, Ascension and Tristan da Cunha
+        - St. Helena # Saint Helena, Ascension and Tristan da Cunha
+        - Ascension # Saint Helena, Ascension and Tristan da Cunha
+        - Tristan da Cunha # Saint Helena, Ascension and Tristan da Cunha
+        - Senegal
+        - Sierra Leone
+        - Togo
+      Caribbean:
+        - Anguilla
+        - Antigua and Barbuda
+        - Antigua # Antigua and Barbuda
+        - Barbuda # Antigua and Barbuda
+        - Aruba
+        - Bahamas
+        - Barbados
+        - Bonaire, Sint Eustatius and Saba
+        - Bonaire # Bonaire, Sint Eustatius and Saba
+        - Sint Eustatius # Bonaire, Sint Eustatius and Saba
+        - Saba # Bonaire, Sint Eustatius and Saba
+        - Netherlands Antilles
+        - British Virgin Islands
+        - Cayman Islands
+        - Cuba
+        - Curaçao
+        - Dominica
+        - Dominican Republic
+        - Grenada
+        - Guadeloupe
+        - Haiti
+        - Jamaica
+        - Martinique
+        - Montserrat
+        - Puerto Rico
+        - Saint Barthélemy
+        - Saint Kitts and Nevis
+        - St. Kitts and Nevis # Saint Kitts and Nevis
+        - Saint Lucia
+        - St. Lucia # Saint Lucia
+        - Saint Martin
+        - Saint Vincent and the Grenadines
+        - Saint Vincent and Grenadines # Saint Vincent and the Grenadines
+        - St. Vincent and the Grenadines # Saint Vincent and the Grenadines
+        - St. Vincent and Grenadines # Saint Vincent and the Grenadines
+        - Sint Maarten
+        - Trinidad and Tobago
+        - Turks and Caicos Islands
+        - US Virgin Islands
+        - U.S. Virgin Islands # US Virgin Islands
+        - United States Virgin Islands # US Virgin Islands
+      Central America:
+        - Belize
+        - Costa Rica
+        - El Salvador
+        - Guatemala
+        - Honduras
+        - Mexico
+        - Nicaragua
+        - Panama
+      South America:
+        - Argentina
+        - Bolivia
+        - Plurinational State of Bolivia # Bolivia
+        - Bouvet Island
+        - Brazil
+        - Chile
+        - Colombia
+        - Ecuador
+        - Falkland Islands
+        - Malvinas # Falkland Islands
+        - French Guiana
+        - Guyana
+        - Paraguay
+        - Peru
+        - South Georgia and the South Sandwich Islands
+        - South Georgia and South Sandwich Islands # South Georgia and the South Sandwich Islands
+        - South Georgia # South Georgia and the South Sandwich Islands
+        - South Sandwich Islands # South Georgia and the South Sandwich Islands
+        - Suriname
+        - Uruguay
+        - Venezuela
+        - Bolivarian Republic of Venezuela # Venezuela
+      North America:
+        - Bermuda
+        - Canada
+        - Greenland
+        - Saint Pierre and Miquelon
+        - St. Pierre and Miquelon # Saint Pierre and Miquelon
+        - United States
+        - United States of America # United States
+      Central Asia:
+        - Kazakhstan
+        - Kyrgyzstan
+        - Tajikistan
+        - Turkmenistan
+        - Uzbekistan
+      Eastern Asia:
+        - China
+        - Hong Kong
+        - Hong Kong SAR China # Hong Kong
+        - Macao
+        - Macau # Macao
+        - Macau SAR China # Macao
+        - North Korea
+        - Democratic People's Republic of Korea # North Korea
+        - Japan
+        - Mongolia
+        - South Korea
+        - Republic of Korea # South Korea
+        - Korea # South Korea
+        - Taiwan
+        - Taiwan, Province of China # Taiwan
+      South-Eastern Asia:
+        - Brunei
+        - Brunei Darussalam # Brunei
+        - Cambodia
+        - Indonesia
+        - Laos
+        - Lao People's Democratic Republic # Laos
+        - Lao # Laos
+        - Malaysia
+        - Myanmar
+        - Burma # Myanmar
+        - Philippines
+        - Singapore
+        - Thailand
+        - East Timor
+        - Timor-Leste # East Timor
+        - Vietnam
+        - Viet Nam # Vietnam
+      Southern Asia:
+        - Afghanistan
+        - Bangladesh
+        - Bhutan
+        - India
+        - Iran
+        - Islamic Republic of Iran # Iran
+        - Maldives
+        - Nepal
+        - Pakistan
+        - Sri Lanka
+      Western Asia:
+        - Armenia
+        - Azerbaijan
+        - Bahrain
+        - Cyprus
+        - Georgia
+        - Iraq
+        - Israel
+        - Jordan
+        - Kuwait
+        - Lebanon
+        - Oman
+        - Qatar
+        - Saudi Arabia
+        - Palestine
+        - State of Palestine # Palestine
+        - Syria
+        - Syrian Arab Republic # Syria
+        - Turkey
+        - Türkiye # Turkey
+        - United Arab Emirates
+        - Yemen
+      Eastern Europe:
+        - Belarus
+        - Bulgaria
+        - Czech Republic
+        - Czechia # Czech Republic
+        - Czechoslovakia # Czech Republic
+        - Hungary
+        - Poland
+        - Moldova
+        - Republic of Moldova # Moldova
+        - Romania
+        - Russia
+        - Russian Federation # Russia
+        - Soviet Union # Russia
+        - Slovakia
+        - Ukraine
+      Northern Europe:
+        - Åland Islands
+        - Guernsey
+        - Jersey
+        - Sark
+        - Denmark
+        - Estonia
+        - Faroe Islands
+        - Finland
+        - Iceland
+        - Ireland
+        - Northern Ireland
+        - Isle of Man
+        - Latvia
+        - Lithuania
+        - Norway
+        - Svalbard and Jan Mayen Islands
+        - Svalbard and Jan Mayen # Svalbard and Jan Mayen Islands
+        - Sweden
+        - United Kingdom
+      Southern Europe:
+        - Albania
+        - Andorra
+        - Bosnia and Herzegovina
+        - Croatia
+        - Gibraltar
+        - Greece
+        - Kosovo
+        - Vatican City
+        - Holy See # Vatican City
+        - Italy
+        - Malta
+        - Montenegro
+        - North Macedonia
+        - Macedonia # North Macedonia
+        - Republic of North Macedonia # North Macedonia
+        - Portugal
+        - San Marino
+        - Serbia
+        - Serbia and Montenegro
+        - Slovenia
+        - Spain
+        - Yugoslavia
+      Western Europe:
+        - Austria
+        - Belgium
+        - France
+        - French Republic # France
+        - Germany
+        - East Germany
+        - Liechtenstein
+        - Luxembourg
+        - Monaco
+        - Netherlands
+        - Switzerland
+      Australia and New Zealand:
+        - Australia
+        - Christmas Island
+        - Cocos (Keeling) Islands
+        - Heard Island and McDonald Islands
+        - Heard and McDonald Islands # Heard Island and McDonald Islands
+        - New Zealand
+        - Norfolk Island
+      Melanesia:
+        - Fiji
+        - New Caledonia
+        - Papua New Guinea
+        - New Guinea # Papua New Guinea
+        - Solomon Islands
+        - Vanuatu
+      Micronesia:
+        - Guam
+        - Kiribati
+        - Marshall Islands
+        - Federated States of Micronesia # Micronesia
+        - Nauru
+        - Northern Mariana Islands
+        - Palau
+        - US Minor Outlying Islands
+        - United States Minor Outlying Islands # US Minor Outlying Islands
+        - United States Outlying Islands # US Minor Outlying Islands
+        - U.S. Minor Outlying Islands # US Minor Outlying Islands
+        - U.S. Outlying Islands # US Minor Outlying Islands
+        - US Outlying Islands # US Minor Outlying Islands
+      Polynesia:
+        - American Samoa
+        - Cook Islands
+        - French Polynesia
+        - Niue
+        - Pitcairn
+        - Pitcairn Islands # Pitcairn
+        - Samoa
+        - Tokelau
+        - Tonga
+        - Tuvalu
+        - Wallis and Futuna Islands
+        - Wallis and Futuna # Wallis and Futuna Islands

--- a/tests/fixtures/kometa/defaults/movie/seasonal.yml
+++ b/tests/fixtures/kometa/defaults/movie/seasonal.yml
@@ -1,0 +1,268 @@
+##############################################################################
+#                            Seasonal Collections                            #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#           https://kometa.wiki/en/latest/defaults/movie/seasonal            #
+##############################################################################
+
+external_templates:
+  default: templates
+
+templates:
+  holiday:
+    default:
+      sync_mode: sync
+      sync_mode_<<key>>: <<sync_mode>>
+      sort_by: title.asc
+      sort_by_<<key>>: <<sort_by>>
+      schedule_<<key>>: <<schedule>>
+      limit_<<key>>: <<limit>>
+      tmdb_collection_<<key>>: <<tmdb_collection>>
+      tmdb_movie_<<key>>: <<tmdb_movie>>
+      imdb_list_<<key>>: <<imdb_list>>
+      imdb_search_<<key>>: <<imdb_search>>
+      trakt_list_<<key>>: <<trakt_list>>
+      mdblist_list_<<key>>: <<mdblist_list>>
+      delete_collections_named_<<key>>: <<delete_collections_named>>
+      letterboxd_list_<<key>>: <<letterboxd_list>>
+      summary_<<key>>: <<summary_format>>
+      name_<<key>>: <<name_format>>
+      emoji: ""
+      emoji_<<key>>: <<emoji>>
+    optional:
+      - schedule
+      - tmdb_collection
+      - tmdb_movie
+      - limit
+      - imdb_list
+      - imdb_search
+      - trakt_list
+      - mdblist_list
+      - letterboxd_list
+      - summary_format
+      - name_format
+      - key_name
+      - translation_key
+      - limit
+      - delete_collections_named
+    smart_label:
+      sort_by: <<sort_by_<<key>>>>
+      limit: <<limit_<<key>>>>
+      all:
+        label: <<smart_label>>
+    schedule: <<schedule_<<key>>>>
+    delete_not_scheduled: true
+    sync_mode: <<sync_mode_<<key>>>>
+    tmdb_collection: <<tmdb_collection_<<key>>>>
+    tmdb_movie: <<tmdb_movie_<<key>>>>
+    imdb_list: <<imdb_list_<<key>>>>
+    imdb_search: <<imdb_search_<<key>>>>
+    trakt_list: <<trakt_list_<<key>>>>
+    delete_collections_named: <<delete_collections_named_<<key>>>>
+    mdblist_list: <<mdblist_list_<<key>>>>
+    letterboxd_list: <<letterboxd_list_<<key>>>>
+    cache_builders: 1
+    translation_key: <<translation_key>>
+    key_name: <<key_name>>
+    summary: <<summary_<<key>>>>
+    name: <<name_<<key>>>>
+    limit: <<limit_<<key>>>>
+    translation_prefix: <<emoji_<<key>>>>
+
+collections:
+  Seasonal Collections:
+    template:
+      - name: separator
+        separator: seasonal
+        use_separator: false
+        key_name: Seasonal
+        translation_key: separator
+
+dynamic_collections:
+  Seasonal:
+    type: custom
+    data:
+      years: New Year's Day
+      valentine: Valentine's Day
+      patrick: St. Patrick's Day
+      easter: Easter
+      mother: Mother's Day
+      memorial: Memorial Day
+      father: Father's Day
+      independence: Independence Day
+      labor: Labor Day
+      halloween: Halloween
+      veteran: Veteran's Day
+      thanksgiving: Thanksgiving
+      christmas: Christmas
+      aapi: Asian American & Pacific Islander Heritage Month
+      disabilities: Day of Persons with Disabilities
+      black_history: Black History Month
+      lgbtq: LGBTQ+ Pride Month
+      latinx: Latinx Heritage Month
+      women: Women's History Month
+    title_format: <<key_name>> <<library_typeU>>s
+    template:
+      - holiday
+      - shared
+      - arr
+    template_variables:
+      emoji:
+        years: ""
+        valentine: ""
+        patrick: ""
+        easter: ""
+        mother: ""
+        memorial: ""
+        father: ""
+        independence: ""
+        labor: ""
+        halloween: ""
+        veteran: ""
+        thanksgiving: ""
+        christmas: ""
+        aapi: ""
+        disabilities: ""
+        lgbtq: ""
+        latinx: ""
+        women: ""
+        black_history: ""
+      schedule:
+        years: range(12/26-01/04)
+        valentine: range(02/01-02/29)
+        patrick: range(03/01-03/18)
+        easter: range(03/20-04/30)
+        mother: range(05/05-05/10)
+        memorial: range(5/18-6/7)
+        father: range(06/15-06/20)
+        independence: range(06/23-07/11)
+        labor: range(09/01-09/10)
+        halloween: range(10/01-10/31)
+        veteran: range(11/01-11/30)
+        thanksgiving: range(11/01-11/30)
+        christmas: range(12/01-12/31)
+        aapi: range(04/30-05/31)
+        disabilities: range(12/02-12/04)
+        black_history: range(02/01-03/01)
+        lgbtq: range(05/31-06/30)
+        latinx: range(09/15-10/15)
+        women: range(02/28-03/31)
+      imdb_search:
+        years:
+          list.any: ls066838460
+          limit: 500
+        black_history:
+          list.any: ls023525790
+          limit: 500
+        disabilities:
+          keyword.any: disability
+          limit: 500
+        valentine:
+          list.any:
+            - ls032692441
+            - ls000094398
+            - ls057783436
+            - ls064427905
+          limit: 500
+        patrick:
+          list.any: ls067580975
+          limit: 500
+        easter:
+          list.any:
+            - ls062665509
+            - ls051733651
+          limit: 500
+        mother:
+          keyword.any: motherhood, pregnancy
+          limit: 500
+        memorial:
+          list.any: ls526590990
+          limit: 500
+        father:
+          keyword.any: fatherhood
+          limit: 500
+        independence:
+          list.any:
+            - ls561449172
+            - ls541213215
+            - ls068664510
+            - ls080925875
+          limit: 500
+        labor:
+          list.any: ls002014923
+          limit: 500
+        lgbtq:
+          list.any: ls080580859
+          limit: 500
+        halloween:
+          list.any:
+            - ls546214737
+            - ls023118929
+            - ls000099714
+          limit: 500
+        veteran:
+          list.any:
+            - ls526590990
+            - ls565595526
+          limit: 500
+        thanksgiving:
+          keyword.any: thanksgiving
+          limit: 500
+        women:
+          type: movie
+          keyword.any: women in film, women's rights, women's suffrage, womens rights, womens suffrage
+          sort_by: rating.desc
+          limit: 500
+      tmdb_collection:
+        halloween:
+          - 185103    # Hotel Transylvania
+          - 11716     # Addams Family
+          - 750822    # Addams Family Animated
+          - 313086    # Conjuring
+          - 91361     # Halloween Collection
+          - 8581      # A Nightmare on Elm Street Collection
+          - 1733      # The Mummy Collection
+          - 8091      # Alien Collection
+          - 2980      # Ghostbusters
+          - 751156    # Hocus Pocus
+      tmdb_movie:
+        halloween:
+          - 23437    # A Nightmare on Elm Street (2010)
+      mdblist_list:
+        aapi:
+          - https://mdblist.com/lists/k0meta/asian-american-pacific-islander-heritage-month
+        christmas:
+          - https://mdblist.com/lists/k0meta/christmas-extravaganza
+        latinx:
+          - https://mdblist.com/lists/k0meta/latinx-heritage-month
+      letterboxd_list:
+        black_history:
+          - https://letterboxd.com/mardarrius/list/black-is-beautiful/
+      delete_collections_named:
+        years: 🎊 New Year's Day Movies
+        valentine: 💘 Valentine's Day Movies
+        patrick: ☘ St. Patrick's Day Movies
+        easter: 🐰 Easter Movies
+        mother: 🤱 Mother's Day Movies
+        memorial: 🪖 Memorial Day Movies
+        father: 👨 Father's Day Movies
+        independence: 🎆 Independence Day Movies
+        labor: ⚒ Labor Day Movies
+        halloween: 🎃 Halloween Movies
+        veteran: 🎖 Veteran's Day Movies
+        thanksgiving: 🦃 Thanksgiving Movies
+        christmas: 🎅 Christmas Movies
+        aapi: 🌊🌺 Asian American Pacific Islander Movies
+        disabilities: ♿ Disability Month Movies
+        black_history: ✊🏿 Black History Month Movies
+        lgbtq: 🏳️‍🌈 LGBTQ Month Movies
+        latinx: 🪅 National Hispanic Heritage Movies
+        women: 🚺 Women's History Month Movies
+      visible_home:
+        default: true
+      visible_shared:
+        default: true
+      image:
+        default: seasonal/<<key>>
+      translation_key:
+        default: seasonal

--- a/tests/fixtures/kometa/defaults/movie/writer.yml
+++ b/tests/fixtures/kometa/defaults/movie/writer.yml
@@ -1,0 +1,47 @@
+##############################################################################
+#                             Writer Collections                             #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#            https://kometa.wiki/en/latest/defaults/movie/writer             #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "170"
+
+collections:
+  Writers Collections:
+    template:
+      - name: separator
+        separator: writer
+        key_name: Writers
+        translation_key: separator
+
+dynamic_collections:
+  Top Writers:
+    type: writer
+    data:
+      depth: 5
+      limit: 25
+    title_format: <<key_name>> (Writer)
+    template:
+      - tmdb_person
+      - smart_filter
+      - shared
+    template_variables:
+      tmdb_person:
+        default: <<value>>
+      tmdb_person_offset:
+        default: 0
+        Charles Bennett: 1
+      search_term:
+        default: writer
+      search_value:
+        default: tmdb
+      translation_key:
+        default: writer
+      style:
+        default: bw
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/overlays/aspect.yml
+++ b/tests/fixtures/kometa/defaults/overlays/aspect.yml
@@ -1,0 +1,72 @@
+##############################################################################
+#                         Aspect Ratio Overlay                               #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#           https://kometa.wiki/en/latest/defaults/overlays/aspect           #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    default:
+      text_<<key>>: <<overlay_name>>
+      horizontal_align: center
+      vertical_align: bottom
+    conditionals:
+      vertical_offset:
+        default: 15
+        conditions:
+          - vertical_align: center
+            value: 0
+          - vertical_align: top
+            value: 15
+          - vertical_align: bottom
+            value: 150
+      horizontal_offset:
+        default: 15
+        conditions:
+          - horizontal_align: center
+            value: 0
+          - horizontal_align: [left, right]
+            value: 15
+    group: aspect
+    font: fonts/Inter-Medium.ttf
+    font_size: 63
+    back_color: "#00000099"
+    back_width: 305
+    back_height: 105
+    final_name: text(<<text_<<key>>>>)
+
+templates:
+  aspect:
+    ignore_blank_results: true
+    plex_all: true
+    filters:
+      aspect.gt: <<low>>
+      aspect.lt: <<high>>
+
+overlays:
+  1.33:
+    variables: {key: 1.33, weight: 80, low: 1.32, high: 1.34}
+    template: [name: standard, name: aspect]
+  1.65:
+    variables: {key: 1.65, weight: 70, low: 1.64, high: 1.66}
+    template: [name: standard, name: aspect]
+  1.66:
+    variables: {key: 1.66, weight: 60, low: 1.65, high: 1.67}
+    template: [name: standard, name: aspect]
+  1.78:
+    variables: {key: 1.78, weight: 50, low: 1.77, high: 1.79}
+    template: [name: standard, name: aspect]
+  1.85:
+    variables: {key: 1.85, weight: 40, low: 1.84, high: 1.86}
+    template: [name: standard, name: aspect]
+  2.2:
+    variables: {key: 2.2, weight: 30, low: 2.19, high: 2.21}
+    template: [name: standard, name: aspect]
+  2.35:
+    variables: {key: 2.35, weight: 20, low: 2.34, high: 2.36}
+    template: [name: standard, name: aspect]
+  2.77:
+    variables: {key: 2.77, weight: 10, low: 2.76, high: 2.78}
+    template: [name: standard, name: aspect]

--- a/tests/fixtures/kometa/defaults/overlays/audio_codec.yml
+++ b/tests/fixtures/kometa/defaults/overlays/audio_codec.yml
@@ -1,0 +1,166 @@
+##############################################################################
+#                            Audio Codec Overlay                             #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#                     Credit to Magic815 for base images                     #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#        https://kometa.wiki/en/latest/defaults/overlays/audio_codec         #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    default:
+      standard_value: 105
+      style: compact
+      horizontal_align: center
+      vertical_align: top
+    conditionals:
+      back_height:
+        default: 105
+        conditions:
+          - style: standard
+            value: <<standard_value>>
+      vertical_offset:
+        default: 15
+        conditions:
+          - vertical_align.exists: false
+            value: 150
+          - vertical_align: center
+            value: 0
+          - vertical_align: top
+            value: 15
+          - vertical_align: bottom
+            value: 30
+      horizontal_offset:
+        default: 15
+        conditions:
+          - horizontal_align: center
+            value: 0
+          - horizontal_align: [left, right]
+            value: 15
+      default:
+        conditions:
+          - file.exists: false
+            file_<<key>>.exists: false
+            url.exists: false
+            url_<<key>>.exists: false
+            git.exists: false
+            git_<<key>>.exists: false
+            repo.exists: false
+            repo_<<key>>.exists: false
+            value: audio_codec/<<style>>/<<key>>
+    group: audio_codec
+    vertical_offset: 15
+    back_color: "#00000099"
+    back_width: 305
+
+templates:
+  audio_codec:
+    default:
+      regex_<<key>>: <<regex>>
+    conditionals:
+      regex:
+        conditions:
+          - key: truehd_atmos
+            value: '(?i)^(?=.*\btrue[ ._-]?hd(\b|\d))(?=.*\batmos(\b|\d))'
+          - key: dtsx
+            value: '(?i)\b(dts[-_. ]?x7?)\b(?![-_. ]?(26[456]))'
+          - key: plus_atmos
+            value: '(?i)^(?=.*\b((dd[p+])|(dolby[ ._-]digital[ ._-]plus)|(e[ ._-]?ac3)\b))(?=.*\batmos(\b|\d))'
+          - key: dolby_atmos
+            value: '(?i)\batmos(\b|\d)'
+          - key: truehd
+            value: '(?i)\btrue[ ._-]?hd(\b|\d)'
+          - key: ma
+            value: '(?i)\bdts[ ._-]?(hd[ ._-])?(ma|xll|hd)(\b|\d)(?![ ._-]hra)'
+          - key: flac
+            value: '(?i)\bflac(\b|\d)'
+          - key: pcm
+            value: '(?i)\bl?pcm(\b|\d)'
+          - key: hra
+            value: '(?i)\bdts[ ._-]?(hd[ ._-])?(hr|hra|hi|ra)(\b|\d)'
+          - key: plus
+            value: '(?i)\b(dd[p+])|(dolby[ ._-]digital[ ._-]plus)|(e[ ._-]?ac3)\b'
+          - key: dtses
+            value: '(?i)\bdts[ ._-]?es(\b|\d)'
+          - key: dts
+            value: '(?i)\bdts(\b|\d)'
+          - key: digital
+            value: '(?i)\b(dd)|(ac3)|(dolby)(\b|\d)'
+          - key: aac
+            value: '(?i)\b(aac|stereo|2\.0)\b'
+          - key: mp3
+            value: '(?i)\bmp3(\b|\d)'
+          - key: opus
+            value: '(?i)\b(?<!-)OPUS(\b|\d)'
+    ignore_blank_results: true
+    plex_all: true
+    filters:
+      - audio_track_title.regex: <<regex_<<key>>>>
+      - filepath.regex: <<regex_<<key>>>>
+
+overlays:
+
+  Dolby-TrueHD-Atmos:
+    variables: {key: truehd_atmos, weight: 160, standard_value: 189}
+    template: [name: standard, name: audio_codec]
+    
+  DTS-X:
+    variables: {key: dtsx, weight: 150}
+    template: [name: standard, name: audio_codec]
+
+  Dolby-Digital-Plus-Atmos:
+    variables: {key: plus_atmos, weight: 140, standard_value: 189}
+    template: [name: standard, name: audio_codec]
+
+  Dolby-Atmos:
+    variables: {key: dolby_atmos, weight: 130}
+    template: [name: standard, name: audio_codec]
+
+  Dolby-TrueHD:
+    variables: {key: truehd, weight: 120}
+    template: [name: standard, name: audio_codec]
+
+  DTS-HD-MA:
+    variables: {key: ma, weight: 110}
+    template: [name: standard, name: audio_codec]
+
+  FLAC:
+    variables: {key: flac, weight: 100}
+    template: [name: standard, name: audio_codec]
+
+  PCM:
+    variables: {key: pcm, weight: 90}
+    template: [name: standard, name: audio_codec]
+
+  DTS-HD-HRA:
+    variables: {key: hra, weight: 80}
+    template: [name: standard, name: audio_codec]
+
+  Dolby-Digital-Plus:
+    variables: {key: plus, weight: 70}
+    template: [name: standard, name: audio_codec]
+
+  DTS-ES:
+    variables: {key: dtses, weight: 60}
+    template: [name: standard, name: audio_codec]
+
+  DTS:
+    variables: {key: dts, weight: 50}
+    template: [name: standard, name: audio_codec]
+
+  Dolby-Digital:
+    variables: {key: digital, weight: 40}
+    template: [name: standard, name: audio_codec]
+
+  AAC:
+    variables: {key: aac, weight: 30}
+    template: [name: standard, name: audio_codec]
+
+  MP3:
+    variables: {key: mp3, weight: 20}
+    template: [name: standard, name: audio_codec]
+
+  Opus:
+    variables: {key: opus, weight: 10}
+    template: [name: standard, name: audio_codec]

--- a/tests/fixtures/kometa/defaults/overlays/commonsense.yml
+++ b/tests/fixtures/kometa/defaults/overlays/commonsense.yml
@@ -1,0 +1,150 @@
+##############################################################################
+#                            Commonsense Overlay                             #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#        https://kometa.wiki/en/latest/defaults/overlays/commonsense         #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    default:
+      key: <<overlay_name>>
+      pre_text: ""
+      post_text: "+"
+      pre_nr_text: ""
+      post_nr_text: ""
+      horizontal_align: left
+      vertical_align: bottom
+    conditionals:
+      pre:
+        default: <<pre_text>>
+        conditions:
+          - overlay_name: NR
+            value: <<pre_nr_text>>
+      post:
+        default: <<post_text>>
+        conditions:
+          - overlay_name: NR
+            value: <<post_nr_text>>
+      vertical_offset:
+        default: 15
+        conditions:
+          - vertical_align.exists: false
+            value: 270
+          - vertical_align: center
+            value: 0
+          - vertical_align: top
+            value: 15
+          - vertical_align: bottom
+            value: 30
+      horizontal_offset:
+        default: 15
+        conditions:
+          - horizontal_align: center
+            value: 0
+          - horizontal_align: [left, right]
+            value: 15
+      default:
+        conditions:
+          - file.exists: false
+            file_<<key>>.exists: false
+            url.exists: false
+            url_<<key>>.exists: false
+            git.exists: false
+            git_<<key>>.exists: false
+            repo.exists: false
+            repo_<<key>>.exists: false
+            value: Commonsense
+    back_color: "#00000099"
+    back_width: 305
+    back_height: 105
+    addon_position: left
+    addon_offset: 15
+    final_name: text(<<pre>><<overlay_name>><<post>>)
+
+templates:
+  commonsense:
+    ignore_blank_results: true
+    plex_search:
+      validate: false
+      any:
+        content_rating: <<rating>>
+
+overlays:
+  1:
+    template:
+      - name: standard
+      - {name: commonsense, rating: "1, 01, G, TV-G, TV-Y, G - All Ages, gb/U, gb/0+, E, gb/E, A, no/A, no/5, no/05"}
+  2:
+    template:
+      - name: standard
+      - {name: commonsense, rating: "2, 02"}
+  3:
+    template:
+      - name: standard
+      - {name: commonsense, rating: "3, 03"}
+  4:
+    template:
+      - name: standard
+      - {name: commonsense, rating: "4, 04"}
+  5:
+    template:
+      - name: standard
+      - {name: commonsense, rating: "5, 05"}
+  6:
+    template:
+      - name: standard
+      - {name: commonsense, rating: "6, 06, GP, PG, PG - Children, M/PG, gb/PG, TV-PG, no/6, no/06"}
+  7:
+    template:
+      - name: standard
+      - {name: commonsense, rating: "7, 07, TV-Y7, TV-Y7-FV, no/7, no/07"}
+  8:
+    template:
+      - name: standard
+      - {name: commonsense, rating: "8, 08"}
+  9:
+    template:
+      - name: standard
+      - {name: commonsense, rating: "9, 09, gb/9+, no/9, no/09"}
+  10:
+    template:
+      - name: standard
+      - {name: commonsense, rating: "10, no/10"}
+  11:
+    template:
+      - name: standard
+      - {name: commonsense, rating: "11, no/11"}
+  12:
+    template:
+      - name: standard
+      - {name: commonsense, rating: "12, 12+, gb/12, gb/12A, no/12"}
+  13:
+    template:
+      - name: standard
+      - {name: commonsense, rating: "13, PG-13, PG-13 - Teens 13 or older"}
+  14:
+    template:
+      - name: standard
+      - {name: commonsense, rating: "14, TV-14, gb/14+"}
+  15:
+    template:
+      - name: standard
+      - {name: commonsense, rating: "15, gb/15, no/15"}
+  16:
+    template:
+      - name: standard
+      - {name: commonsense, rating: "16, no/16, Passed, Approved, Open"}
+  17:
+    template:
+      - name: standard
+      - {name: commonsense, rating: "17, R, R - 17+ (violence & profanity), TVMA, TV-MA, MA-17"}
+  18:
+    template:
+      - name: standard
+      - {name: commonsense, rating: "18, gb/18, gb/R18, gb/X, no/18, NC-17, X, R+ - Mild Nudity, Rx - Hentai"}
+  NR:
+    template:
+      - {name: standard, key: nr}
+      - {name: commonsense, rating: "None, NR, Not Rated, Unrated"}

--- a/tests/fixtures/kometa/defaults/overlays/content_rating_au.yml
+++ b/tests/fixtures/kometa/defaults/overlays/content_rating_au.yml
@@ -1,0 +1,81 @@
+##############################################################################
+#                         AU Content Rating Overlay                          #
+#                           Adapted by 2wenty2wo                             #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#     https://kometa.wiki/en/latest/defaults/overlays/content_rating_au      #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    default:
+      key: <<overlay_name>>
+    horizontal_offset: 15
+    horizontal_align: left
+    vertical_offset: 270
+    vertical_align: bottom
+    back_width: 305
+    back_height: 105
+    back_radius: 30
+    back_color: '#00000099'
+    conditionals:
+      inside_color:
+        default: "c"
+        conditions:
+          - color: false
+            value: ""
+      default:
+        conditions:
+          - file.exists: false
+            file_<<key>>.exists: false
+            url.exists: false
+            url_<<key>>.exists: false
+            git.exists: false
+            git_<<key>>.exists: false
+            repo.exists: false
+            repo_<<key>>.exists: false
+            value: cr/au_<<overlay_name>><<inside_color>>
+
+templates:
+  cr_au:
+    ignore_blank_results: true
+    plex_search:
+      validate: false
+      any:
+        content_rating: <<rating>>
+
+overlays:
+  g:
+    template:
+      - name: standard
+      - {name: cr_au, rating: "au/G, de/0, U, 0, 1, 01, 2, 02, 3, 03, 4, 04, 5, 05, 6, 06, G, TV-G, TV-Y, G - All Ages, gb/U, gb/0+, E, gb/E, A, no/A, no/5, no/05"}
+
+  pg:
+    template:
+      - name: standard
+      - {name: cr_au, rating: "au/PG, de/6, gb/9+, TV-PG, TV-Y7, TV-Y7-FV, PG, 7, 07, 8, 08, 9, 09, 10, 11, PG - Children, no/6, no/06, no/7, no/07, no/9, no/09, no/10, no/11"}
+
+  m:
+    template:
+      - name: standard
+      - {name: cr_au, rating: "au/M, de/12, gb/12, 12, no/12, gb/15, gb/14+, TV-14, 12, 13, 14, 15, PG-13 - Teens 13 or older, PG-13, no/15"}
+
+  ma:
+    template:
+      - name: standard
+      - {name: cr_au, rating: "au/MA15+, de/16, no/16, A-17, TVMA, TV-MA, R, 16, 17, M/PG"}
+
+  r:
+    template:
+      - name: standard
+      - {name: cr_au, rating: "au/R 18+, de/18, gb/18, M, 18, R - 17+ (violence & profanity), no/18, R18, gb/X, X, NC-17, R+ - Mild Nudity, Rx - Hentai"}
+
+  x:
+    template:
+      - name: standard
+      - {name: cr_au, rating: "au/X 18+, de/BPjM Restricted, BPjM Restricted, gb/R18"}
+  nr:
+    template:
+      - {name: standard, key: nr}
+      - {name: cr_au, rating: "None, NR, Not Rated, Unrated, de/Unrated, de/Not Rated, au/Unrated, au/Not Rated"}

--- a/tests/fixtures/kometa/defaults/overlays/content_rating_de.yml
+++ b/tests/fixtures/kometa/defaults/overlays/content_rating_de.yml
@@ -1,0 +1,80 @@
+##############################################################################
+#                        DE Content Rating Overlay                           #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#     https://kometa.wiki/en/latest/defaults/overlays/content_rating_de      #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    default:
+      key: <<overlay_name>>
+    horizontal_offset: 15
+    horizontal_align: left
+    vertical_offset: 270
+    vertical_align: bottom
+    back_width: 305
+    back_height: 105
+    back_radius: 30
+    back_color: '#00000099'
+    conditionals:
+      inside_color:
+        default: "c"
+        conditions:
+          - color: false
+            value: ""
+      default:
+        conditions:
+          - file.exists: false
+            file_<<key>>.exists: false
+            url.exists: false
+            url_<<key>>.exists: false
+            git.exists: false
+            git_<<key>>.exists: false
+            repo.exists: false
+            repo_<<key>>.exists: false
+            value: cr/de<<overlay_name>><<inside_color>>
+
+templates:
+  cr_de:
+    ignore_blank_results: true
+    plex_search:
+      validate: false
+      any:
+        content_rating: <<rating>>
+
+overlays:
+  0:
+    template:
+      - name: standard
+      - {name: cr_de, rating: "de/0, U, 0, 1, 01, 2, 02, 3, 03, 4, 04, 5, 05, G, TV-G, TV-Y, G - All Ages, gb/U, gb/0+, E, gb/E, A, no/A, no/5, no/05"}
+
+  6:
+    template:
+      - name: standard
+      - {name: cr_de, rating: "de/6, 6, gb/9+, TV-PG, TV-Y7, TV-Y7-FV, PG, 7, 07, 8, 08, 9, 09, 10, 11, PG - Children, no/6, no/06, no/7, no/07, no/9, no/09, no/10, no/11"}
+
+  12:
+    template:
+      - name: standard
+      - {name: cr_de, rating: "de/12, gb/12, 12, no/12, gb/15, gb/14+, TV-14, 13, 14, 15, PG-13 - Teens 13 or older, PG-13, no/15"}
+
+  16:
+    template:
+      - name: standard
+      - {name: cr_de, rating: "de/16, no/16, A-17, TVMA, TV-MA, R, 16, 17, M/PG"}
+
+  18:
+    template:
+      - name: standard
+      - {name: cr_de, rating: "de/18, gb/18, M, 18, R - 17+ (violence & profanity), no/18, R18, gb/R18, gb/X, X, NC-17, R+ - Mild Nudity, Rx - Hentai"}
+
+  bpjm:
+    template:
+      - name: standard
+      - {name: cr_de, rating: "de/BPjM Restricted, BPjM Restricted"}
+  nr:
+    template:
+      - {name: standard, key: nr}
+      - {name: cr_de, rating: "None, NR, Not Rated, Unrated, de/Unrated, de/Not Rated"}

--- a/tests/fixtures/kometa/defaults/overlays/content_rating_nz.yml
+++ b/tests/fixtures/kometa/defaults/overlays/content_rating_nz.yml
@@ -1,0 +1,107 @@
+##############################################################################
+#                         NZ Content Rating Overlay                          #
+#                           Adapted by nzvengeance                           #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#     https://kometa.wiki/en/latest/defaults/overlays/content_rating_nz      #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    default:
+      key: <<overlay_name>>
+    horizontal_offset: 15
+    horizontal_align: left
+    vertical_offset: 270
+    vertical_align: bottom
+    back_width: 305
+    back_height: 105
+    back_radius: 30
+    back_color: '#00000099'
+    conditionals:
+      inside_color:
+        default: "c"
+        conditions:
+          - color: false
+            value: ""
+      default:
+        conditions:
+          - file.exists: false
+            file_<<key>>.exists: false
+            url.exists: false
+            url_<<key>>.exists: false
+            git.exists: false
+            git_<<key>>.exists: false
+            repo.exists: false
+            repo_<<key>>.exists: false
+            value: cr/nz_<<overlay_name>><<inside_color>>
+
+templates:
+  cr_nz:
+    ignore_blank_results: true
+    plex_search:
+      validate: false
+      any:
+        content_rating: <<rating>>
+
+overlays:
+  g:
+    template:
+      - name: standard
+      - {name: cr_nz, rating: "au/G, de/0, U, 0, 1, 01, 2, 02, 3, 03, 4, 04, 5, 05, 6, 06, G, TV-G, TV-Y, G - All Ages, gb/U, gb/0+, E, gb/E, A, no/A, no/5, no/05"}
+
+  pg:
+    template:
+      - name: standard
+      - {name: cr_nz, rating: "au/PG, de/6, gb/9+, TV-PG, TV-Y7, TV-Y7-FV, PG, 7, 07, 8, 08, 9, 09, 10, 11, PG - Children, no/6, no/06, no/7, no/07, no/9, no/09, no/10, no/11"}
+
+  m:
+    template:
+      - name: standard
+      - {name: cr_nz, rating: "au/M, de/12, gb/12, 12, no/12, 12"}
+
+  r13:
+    template:
+      - name: standard
+      - {name: cr_nz, rating: "13, PG-13 - Teens 13 or older, PG-13"}
+
+  rp13:
+    template:
+      - name: standard
+      - {name: cr_nz, rating: "gb/14+, TV-14, 14"}
+
+  r15:
+    template:
+      - name: standard
+      - {name: cr_nz, rating: "au/MA15+, 15, M, TVMA, TV-MA"}
+
+  r16:
+    template:
+      - name: standard
+      - {name: cr_nz, rating: "de/16, no/16, 16"}
+
+  rp16:
+    template:
+      - name: standard
+      - {name: cr_nz, rating: "A-17, 17"}
+
+  r:
+    template:
+      - name: standard
+      - {name: cr_nz, rating: "18, R, R - 17+ (violence & profanity), no/18, NC-17, R+ - Mild Nudity, Rx - Hentai"}
+
+  r18:
+    template:
+      - name: standard
+      - {name: cr_nz, rating: "de/18, gb/18, gb/R18, R18"}
+
+  rp18:
+    template:
+      - name: standard
+      - {name: cr_nz, rating: "au/X 18+, gb/X, X, de/BPjM Restricted, BPjM Restricted"}
+
+  nr:
+    template:
+      - {name: standard, key: nr}
+      - {name: cr_nz, rating: "None, NR, Not Rated, Unrated, de/Unrated, de/Not Rated, au/Unrated, au/Not Rated"}

--- a/tests/fixtures/kometa/defaults/overlays/content_rating_uk.yml
+++ b/tests/fixtures/kometa/defaults/overlays/content_rating_uk.yml
@@ -1,0 +1,86 @@
+##############################################################################
+#                        UK Content Rating Overlay                           #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#     https://kometa.wiki/en/latest/defaults/overlays/content_rating_uk      #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    default:
+      key: <<overlay_name>>
+    horizontal_offset: 15
+    horizontal_align: left
+    vertical_offset: 270
+    vertical_align: bottom
+    back_width: 305
+    back_height: 105
+    back_radius: 30
+    back_color: '#00000099'
+    conditionals:
+      inside_color:
+        default: "c"
+        conditions:
+          - color: false
+            value: ""
+      default:
+        conditions:
+          - file.exists: false
+            file_<<key>>.exists: false
+            url.exists: false
+            url_<<key>>.exists: false
+            git.exists: false
+            git_<<key>>.exists: false
+            repo.exists: false
+            repo_<<key>>.exists: false
+            value: cr/uk<<overlay_name>><<inside_color>>
+
+templates:
+  cr_uk:
+    ignore_blank_results: true
+    plex_search:
+      validate: false
+      any:
+        content_rating: <<rating>>
+
+overlays:
+  u:
+    template:
+      - name: standard
+      - {name: cr_uk, rating: "U, 0, 1, 01, 2, 02, 3, 03, 4, 04, 5, 05, 6, 06, G, TV-G, TV-Y, G - All Ages, gb/U, gb/Uc, gb/0+, gb/6+, gb/Kids & Family, E, gb/E, A, no/A"}
+
+  pg:
+    template:
+      - name: standard
+      - {name: cr_uk, rating: "gb/PG, gb/9+, gb/7, gb/7+, TV-PG, TV-Y7, TV-Y7-FV, PG, 7, 07, 8, 08, 9, 09, 10, 11, PG - Children, no/5, no/05, no/6, no/06, no/7, no/07"}
+
+  12:
+    template:
+      - name: standard
+      - {name: cr_uk, rating: "gb/12, gb/A, gb/Caution, gb/G, PG-13 - Teens 13 or older, no/9, no/09, no/10, no/11, no/12"}
+
+  12a:
+    template:
+      - name: standard
+      - {name: cr_uk, rating: "12A, gb/12A, 12+, PG-13, TV-13, 12, PG-13 - Teens 13 or older, no/9, no/09, no/10, no/11, no/12"}
+
+  15:
+    template:
+      - name: standard
+      - {name: cr_uk, rating: "gb/15, gb/14+, gb/16, gb/16+, gb/AA, TV-14, 13, 14, 15, PG-13 - Teens 13 or older, no/15, no/16"}
+
+  18:
+    template:
+      - name: standard
+      - {name: cr_uk, rating: "gb/18, gb/18+, MA-17, TVMA, TV-MA, R, 16, 17, NC-17, 18, R - 17+ (violence & profanity), no/18, gb/X"}
+
+  r18:
+    template:
+      - name: standard
+      - {name: cr_uk, rating: "R18, gb/R18, X, R+ - Mild Nudity, Rx - Hentai"}
+
+  nr:
+    template:
+      - {name: standard, key: nr}
+      - {name: cr_uk, rating: "None, NR, Not Rated, Unrated"}

--- a/tests/fixtures/kometa/defaults/overlays/content_rating_us_movie.yml
+++ b/tests/fixtures/kometa/defaults/overlays/content_rating_us_movie.yml
@@ -1,0 +1,76 @@
+##############################################################################
+#                       US Content Rating Movie Overlay                      #
+#                  Created by Yozora, Bullmoose20, & Sohjiro                 #
+#           EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL          #
+#  https://kometa.wiki/en/latest/defaults/overlays/content_rating_us_movie   #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    default:
+      key: <<overlay_name>>
+    horizontal_offset: 15
+    horizontal_align: left
+    vertical_offset: 270
+    vertical_align: bottom
+    back_width: 305
+    back_height: 105
+    back_radius: 30
+    back_color: '#00000099'
+    conditionals:
+      inside_color:
+        default: "c"
+        conditions:
+          - color: false
+            value: ""
+      default:
+        conditions:
+          - file.exists: false
+            file_<<key>>.exists: false
+            url.exists: false
+            url_<<key>>.exists: false
+            git.exists: false
+            git_<<key>>.exists: false
+            repo.exists: false
+            repo_<<key>>.exists: false
+            value: cr/us<<overlay_name>><<inside_color>>
+
+templates:
+  cr_us:
+    ignore_blank_results: true
+    plex_search:
+      validate: false
+      any:
+        content_rating: <<rating>>
+
+overlays:
+  g:
+    template:
+      - name: standard
+      - {name: cr_us, rating: "1, 01, 2, 02, 3, 03, 4, 04, 5, 05, 6, 06, G, G - All Ages, U, gb/U, gb/0+, E, gb/E, A, no/A, TV-Y, TV-G"}
+
+  pg:
+    template:
+      - name: standard
+      - {name: cr_us, rating: "PG, PG - Children, gb/PG, gb/9+, TV-PG, TV-Y7, TV-Y7-FV, 7, 8, 9, 07, 08, 09, 10, 11, no/5, no/05, no/6, no/06, no/7, no/07"}
+
+  pg-13:
+    template:
+      - name: standard
+      - {name: cr_us, rating: "PG-13, gb/12A, gb/12, 12+, TV-13, gb/14+, gb/15, TV-14, 12, 13, 14, 15, 16, PG-13 - Teens 13 or older, no/9, no/09, no/10, no/11, no/12"}
+
+  r:
+    template:
+      - name: standard
+      - {name: cr_us, rating: "R, 17, 18, gb/18, MA-17, TVMA, TV-MA, R - 17+ (violence & profanity), R+ - Mild Nudity, no/15, no/16, no/18"}
+
+  nc-17:
+    template:
+      - name: standard
+      - {name: cr_us, rating: "NC-17, gb/R18, gb/X, R18, X, Rx - Hentai"}
+
+  nr:
+    template:
+      - {name: standard, key: nr}
+      - {name: cr_us, rating: "None, NR, Not Rated, Unrated"}

--- a/tests/fixtures/kometa/defaults/overlays/content_rating_us_show.yml
+++ b/tests/fixtures/kometa/defaults/overlays/content_rating_us_show.yml
@@ -1,0 +1,76 @@
+##############################################################################
+#                       US Content Rating Show Overlay                       #
+#                  Created by Yozora, Bullmoose20, & Sohjiro                 #
+#           EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL          #
+#   https://kometa.wiki/en/latest/defaults/overlays/content_rating_us_show   #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    default:
+      key: <<overlay_name>>
+    horizontal_offset: 15
+    horizontal_align: left
+    vertical_offset: 270
+    vertical_align: bottom
+    back_width: 305
+    back_height: 105
+    back_radius: 30
+    back_color: '#00000099'
+    conditionals:
+      inside_color:
+        default: "c"
+        conditions:
+          - color: false
+            value: ""
+      default:
+        conditions:
+          - file.exists: false
+            file_<<key>>.exists: false
+            url.exists: false
+            url_<<key>>.exists: false
+            git.exists: false
+            git_<<key>>.exists: false
+            repo.exists: false
+            repo_<<key>>.exists: false
+            value: cr/us<<overlay_name>><<inside_color>>
+
+templates:
+  cr_us:
+    ignore_blank_results: true
+    plex_search:
+      validate: false
+      any:
+        content_rating: <<rating>>
+
+overlays:
+  tv-g:
+    template:
+      - name: standard
+      - {name: cr_us, rating: "TV-G, 1, 01, 2, 02, 3, 03, 4, 04, 5, 05, 6, 06, U, G, gb/U, gb/0+, G - All Ages, A, no/A"}
+
+  tv-y:
+    template:
+      - name: standard
+      - {name: cr_us, rating: "TV-Y, TV-Y7, TV-Y7-FV, 7, 07, 8, 08, 9, 09, no/5, no/05, no/6, no/06, no/7, no/07"}
+
+  tv-pg:
+    template:
+      - name: standard
+      - {name: cr_us, rating: "gb/PG, gb/9+, 10, 11, 12, 13, TV-PG, PG - Children, no/9, no/09, no/10, no/11, no/12"}
+
+  tv-14:
+    template:
+      - name: standard
+      - {name: cr_us, rating: "gb/12A, 12+, PG-13, TV-13, TV-14, 12, PG-13 - Teens 13 or older, gb/14+, gb/15, 14, 15, 16, 17, no/15, no/16"}
+
+  tv-ma:
+    template:
+      - name: standard
+      - {name: cr_us, rating: "18, gb/18, MA-17, NC-17, R, TV-MA, TVMA, R - 17+ (violence & profanity), R+ - Mild Nudity, Rx - Hentai, no/18"}
+
+  nr:
+    template:
+      - {name: standard, key: nr}
+      - {name: cr_us, rating: "None, NR, Not Rated, Unrated"}

--- a/tests/fixtures/kometa/defaults/overlays/direct_play.yml
+++ b/tests/fixtures/kometa/defaults/overlays/direct_play.yml
@@ -1,0 +1,57 @@
+##############################################################################
+#                            Direct Play Overlay                             #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#                     Credit to Magic815 for base images                     #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#        https://kometa.wiki/en/latest/defaults/overlays/direct_play         #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    default:
+      horizontal_align: center
+      vertical_align: bottom
+    conditionals:
+      vertical_offset:
+        default: 15
+        conditions:
+          - vertical_align.exists: false
+            value: 150
+          - vertical_align: center
+            value: 0
+          - vertical_align: top
+            value: 15
+          - vertical_align: bottom
+            value: 30
+      horizontal_offset:
+        default: 15
+        conditions:
+          - horizontal_align: center
+            value: 0
+          - horizontal_align: [left, right]
+            value: 15
+      default:
+        conditions:
+          - file.exists: false
+            file_<<key>>.exists: false
+            url.exists: false
+            url_<<key>>.exists: false
+            git.exists: false
+            git_<<key>>.exists: false
+            repo.exists: false
+            repo_<<key>>.exists: false
+            value: <<overlay_name>>
+    horizontal_offset: 0
+    horizontal_align: center
+    back_color: "#00000099"
+    back_width: 305
+    back_height: 170
+
+overlays:
+  Direct-Play:
+    template:
+      name: standard
+    plex_search:
+      any:
+        resolution.regex: '(?i)2160|4k'

--- a/tests/fixtures/kometa/defaults/overlays/episode_info.yml
+++ b/tests/fixtures/kometa/defaults/overlays/episode_info.yml
@@ -1,0 +1,44 @@
+##############################################################################
+#                            Episode Info Overlay                            #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#        https://kometa.wiki/en/latest/defaults/overlays/episode_info        #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    default:
+      horizontal_align: right
+      vertical_align: bottom
+    conditionals:
+      vertical_offset:
+        default: 15
+        conditions:
+          - vertical_align.exists: false
+            value: 150
+          - vertical_align: center
+            value: 0
+          - vertical_align: top
+            value: 15
+          - vertical_align: bottom
+            value: 30
+      horizontal_offset:
+        default: 15
+        conditions:
+          - horizontal_align: center
+            value: 0
+          - horizontal_align: [left, right]
+            value: 15
+    allowed_libraries: show
+    back_color: "#00000099"
+    back_width: 305
+    back_height: 105
+    builder_level: episode
+    final_name: text(S<<season_number0>>E<<episode_number0>>)
+
+overlays:
+  Episode Info:
+    template:
+      name: standard
+    plex_all: true

--- a/tests/fixtures/kometa/defaults/overlays/language_count.yml
+++ b/tests/fixtures/kometa/defaults/overlays/language_count.yml
@@ -1,0 +1,79 @@
+##############################################################################
+#                   Audio/Subtitle Language Count Overlay                    #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#                     Credit to Magic815 for base images                     #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#       https://kometa.wiki/en/latest/defaults/overlays/language_count       #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    default:
+      horizontal_align: center
+      vertical_align: bottom
+    conditionals:
+      image_key:
+        default: audio
+        conditions:
+          - use_subtitles: true
+            value: subs
+      vertical_offset:
+        default: 15
+        conditions:
+          - vertical_align: center
+            value: 0
+          - vertical_align: top
+            value: 15
+          - vertical_align: bottom
+            value: 30
+      horizontal_offset:
+        default: 15
+        conditions:
+          - horizontal_align: center
+            value: 0
+          - horizontal_align: [left, right]
+            value: 15
+      default:
+        conditions:
+          - file.exists: false
+            file_<<key>>.exists: false
+            url.exists: false
+            url_<<key>>.exists: false
+            git.exists: false
+            git_<<key>>.exists: false
+            repo.exists: false
+            repo_<<key>>.exists: false
+            value: <<key>>_<<image_key>>
+    group: language
+    back_color: "#00000099"
+    back_width: 188
+    back_height: 105
+
+templates:
+  language:
+    conditionals:
+      search_attribute:
+        default: audio_language
+        conditions:
+          - use_subtitles: true
+            value: subtitle_language
+    default:
+      minimum: 2
+    optional:
+      - lt
+    ignore_blank_results: true
+    plex_all: true
+    filters:
+      <<search_attribute>>.count_gte: <<minimum>>
+      <<search_attribute>>.count_lt: <<lt>>
+
+overlays:
+
+  Dual:
+    variables: {key: dual, weight: 20, lt: 3}
+    template: [name: standard, name: language]
+
+  Multi:
+    variables: {key: multi, weight: 10}
+    template: [name: standard, name: language]

--- a/tests/fixtures/kometa/defaults/overlays/languages.yml
+++ b/tests/fixtures/kometa/defaults/overlays/languages.yml
@@ -1,0 +1,524 @@
+##############################################################################
+#                   Audio/Subtitle Language Flags Overlays                   #
+#           Created by Yozora, Bullmoose20, Cpt Kuesel, & Sohjiro            #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#         https://kometa.wiki/en/latest/defaults/overlays/languages          #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    conditionals:
+      final_align:
+        default: left
+        conditions:
+          - flag_alignment: [left, right]
+            value: <<flag_alignment>>
+          - use_subtitles: true
+            value: right
+      final_text:
+        default: <<text>>
+        conditions:
+          - hide_text: true
+            value: " "
+          - use_lowercase: true
+            value: <<key>>
+      final_style:
+        default: round
+        conditions:
+          - style: [square, half]
+            value: square
+      back_radius:
+        conditions:
+          - style: [round, half]
+            value: 26
+          - style: square
+            value:
+      default_<<key>>:
+        conditions:
+          - file.exists: false
+            url.exists: false
+            git.exists: false
+            repo.exists: false
+            value: flag/<<final_style>>/<<country_<<key>>>>
+      width:
+        default: 190
+        conditions:
+          - hide_text: true
+            value: 100
+          - three_characters: true
+            size: big
+            value: 290
+          - size: big
+            value: 216
+          - three_characters: true
+            value: 230
+      height:
+        conditions:
+          - size: big
+            value: 60
+      final_font_size:
+        default: 50
+        conditions:
+          - size: big
+            value: 70
+    default:
+      style: round
+      country: <<key>>
+      country_<<key>>: <<country>>
+      offset: 10
+    queue: flags
+    addon_position: <<final_align>>
+    addon_offset: <<offset>>
+    back_color: "#00000099"
+    back_height: <<height>>
+    back_width: <<width>>
+    back_align: <<final_align>>
+    font: fonts/Inter-Bold.ttf
+    font_size: <<final_font_size>>
+    final_name: text(<<final_text>>)
+
+queues:
+  flags:
+    settings:
+      default:
+        group_alignment: vertical
+      conditionals:
+        initial_vertical_align:
+          default: top
+          conditions:
+            - vertical_position: [center, center_top, center_bottom]
+              value: center
+            - vertical_position: [bottom, bottom2, bottom3]
+              value: bottom
+            - vertical_position: [top, top2, top3]
+              value: top
+            - builder_level: episode
+              value: top
+            - overlay_level: episode
+              value: top
+        initial_horizontal_align:
+          default: left
+          conditions:
+            - horizontal_position: [center, center_left, center_right]
+              value: center
+            - horizontal_position: [left, left2]
+              value: left
+            - horizontal_position: [right, right2]
+              value: right
+            - use_subtitles: true
+              value: right
+        vertical_spacing:
+          default: 0
+          conditions:
+            - group_alignment: vertical
+              size: big
+              value: 61
+            - group_alignment: vertical
+              value: 61
+        horizontal_spacing:
+          default: 0
+          conditions:
+            - group_alignment: horizontal
+              size: big
+              value: 217
+            - group_alignment: horizontal
+              value: 191
+        surround:
+          default: false
+          conditions:
+            - group_alignment: horizontal
+              horizontal_position: [center, center_left, center_right]
+              value: true
+        initial_vertical_offset:
+          default: 223
+          conditions:
+            - vertical_position: [top, bottom]
+              value: 15
+            - vertical_position: [top2, bottom2]
+              value: 150
+            - vertical_position: [top3, bottom3]
+              value: 223
+            - group_alignment: horizontal
+              vertical_position: center_top
+              value: -30
+            - vertical_position: center_top
+              value: -244
+            - vertical_position: center
+              value: -122
+            - group_alignment: horizontal
+              vertical_position: center_bottom
+              value: 30
+            - vertical_position: center_bottom
+              value: 0
+        initial_horizontal_offset:
+          default: 15
+          conditions:
+            - horizontal_position: [left, right]
+              value: 15
+            - horizontal_position: [left2, right2]
+              value: 206
+            - horizontal_position: center_left
+              value: -95
+            - horizontal_position: center_right
+              value: 95
+            - horizontal_position: center
+              value: 0
+      dynamic_position:
+        initial_vertical_align: <<initial_vertical_align>>
+        initial_horizontal_align: <<initial_horizontal_align>>
+        initial_vertical_offset: <<initial_vertical_offset>>
+        initial_horizontal_offset: <<initial_horizontal_offset>>
+        vertical_spacing: <<vertical_spacing>>
+        horizontal_spacing: <<horizontal_spacing>>
+        surround: <<surround>>
+      overlay_limit: 3
+
+templates:
+  flags:
+    default:
+      use_<<key>>: <<use>>
+      languages: ["en", "de", "fr", "es", "pt", "ja"]
+    conditionals:
+      use:
+        default: false
+        conditions:
+          - key: <<languages>>
+            value: true
+      search_attribute:
+        default: audio_language
+        conditions:
+          - use_subtitles: true
+            value: subtitle_language
+    ignore_blank_results: true
+    run_definition:
+      - <<use_<<key>>>>
+    plex_search:
+      all:
+        <<search_attribute>>: <<key>>
+
+overlays:
+
+  english:
+    variables: {key: en, text: EN, weight: 610, country: us}
+    template: [name: flags, name: standard]
+
+  german:
+    variables: {key: de, text: DE, weight: 600}
+    template: [name: flags, name: standard]
+
+  french:
+    variables: {key: fr, text: FR, weight: 590}
+    template: [name: flags, name: standard]
+
+  spanish:
+    variables: {key: es, text: ES, weight: 580}
+    template: [name: flags, name: standard]
+
+  portuguese:
+    variables: {key: pt, text: PT, weight: 570}
+    template: [name: flags, name: standard]
+
+  japanese:
+    variables: {key: ja, text: JA, weight: 560, country: jp}
+    template: [name: flags, name: standard]
+
+  korean:
+    variables: {key: ko, text: KO, weight: 550, country: kr}
+    template: [name: flags, name: standard]
+
+  chinese:
+    variables: {key: zh, text: ZH, weight: 540, country: cn}
+    template: [name: flags, name: standard]
+
+  danish:
+    variables: {key: da, text: DA, weight: 530, country: dk}
+    template: [name: flags, name: standard]
+
+  russian:
+    variables: {key: ru, text: RU, weight: 520}
+    template: [name: flags, name: standard]
+
+  italian:
+    variables: {key: it, text: IT, weight: 510}
+    template: [name: flags, name: standard]
+
+  hindi:
+    variables: {key: hi, text: HI, weight: 500, country: in}
+    template: [name: flags, name: standard]
+
+  telugu:
+    variables: {key: te, text: TE, weight: 490, country: in}
+    template: [name: flags, name: standard]
+
+  farsi:
+    variables: {key: fa, text: FA, weight: 480, country: ir}
+    template: [name: flags, name: standard]
+
+  thai:
+    variables: {key: th, text: TH, weight: 470}
+    template: [name: flags, name: standard]
+
+  dutch:
+    variables: {key: nl, text: NL, weight: 460}
+    template: [name: flags, name: standard]
+
+  norwegian:
+    variables: {key: no, text: NO, weight: 450}
+    template: [name: flags, name: standard]
+
+  icelandic:
+    variables: {key: is, text: IS, weight: 440}
+    template: [name: flags, name: standard]
+
+  swedish:
+    variables: {key: sv, text: SV, weight: 430, country: se}
+    template: [name: flags, name: standard]
+
+  turkish:
+    variables: {key: tr, text: TR, weight: 420}
+    template: [name: flags, name: standard]
+
+  polish:
+    variables: {key: pl, text: PL, weight: 410}
+    template: [name: flags, name: standard]
+
+  czech:
+    variables: {key: cs, text: CS, weight: 400, country: cz}
+    template: [name: flags, name: standard]
+
+  ukrainian:
+    variables: {key: uk, text: UK, weight: 390, country: ua}
+    template: [name: flags, name: standard]
+
+  hungarian:
+    variables: {key: hu, text: HU, weight: 380}
+    template: [name: flags, name: standard]
+
+  arabic:
+    variables: {key: ar, text: AR, weight: 370, country: eg}
+    template: [name: flags, name: standard]
+
+  bulgarian:
+    variables: {key: bg, text: BG, weight: 360}
+    template: [name: flags, name: standard]
+
+  bengali:
+    variables: {key: bn, text: BN, weight: 350, country: bd}
+    template: [name: flags, name: standard]
+
+  bosnian:
+    variables: {key: bs, text: BS, weight: 340, country: ba}
+    template: [name: flags, name: standard]
+
+  catalan:
+    variables: {key: ca, text: CA, weight: 330, country: ad}
+    template: [name: flags, name: standard]
+
+  welsh:
+    variables: {key: cy, text: CY, weight: 320, country: uk}
+    template: [name: flags, name: standard]
+
+  greek:
+    variables: {key: el, text: EL, weight: 310, country: gr}
+    template: [name: flags, name: standard]
+
+  estonian:
+    variables: {key: et, text: ET, weight: 300, country: ee}
+    template: [name: flags, name: standard]
+
+  basque:
+    variables: {key: eu, text: EU, weight: 290, country: es}
+    template: [name: flags, name: standard]
+
+  finnish:
+    variables: {key: fi, text: FI, weight: 280}
+    template: [name: flags, name: standard]
+
+  tagalog:
+    variables: {key: tl, text: FL, weight: 270, country: ph}
+    template: [name: flags, name: standard]
+
+  filipino:
+    variables: {key: fil, text: FIL, weight: 265, country: ph, three_characters: true}
+    template: [name: flags, name: standard]
+
+  galician:
+    variables: {key: gl, text: GL, weight: 260, country: es}
+    template: [name: flags, name: standard]
+
+  hebrew:
+    variables: {key: he, text: HE, weight: 250, country: il}
+    template: [name: flags, name: standard]
+
+  croatian:
+    variables: {key: hr, text: HR, weight: 240}
+    template: [name: flags, name: standard]
+
+  indonesian:
+    variables: {key: id, text: ID, weight: 230}
+    template: [name: flags, name: standard]
+
+  georgian:
+    variables: {key: ka, text: KA, weight: 220, country: ge}
+    template: [name: flags, name: standard]
+
+  kazakh:
+    variables: {key: kk, text: KK, weight: 210, country: kz}
+    template: [name: flags, name: standard]
+
+  kannada:
+    variables: {key: kn, text: KN, weight: 200, country: in}
+    template: [name: flags, name: standard]
+
+  latin:
+    variables: {key: la, text: LA, weight: 190, country: it}
+    template: [name: flags, name: standard]
+
+  lithuanian:
+    variables: {key: lt, text: LT, weight: 180}
+    template: [name: flags, name: standard]
+
+  latvian:
+    variables: {key: lv, text: LV, weight: 170}
+    template: [name: flags, name: standard]
+
+  macedonian:
+    variables: {key: mk, text: MK, weight: 160}
+    template: [name: flags, name: standard]
+
+  malayalam:
+    variables: {key: ml, text: ML, weight: 150, country: in}
+    template: [name: flags, name: standard]
+
+  marathi:
+    variables: {key: mr, text: MR, weight: 140, country: in}
+    template: [name: flags, name: standard]
+
+  malay:
+    variables: {key: ms, text: MS, weight: 130, country: my}
+    template: [name: flags, name: standard]
+
+  norwegian bokmål:
+    variables: {key: nb, text: NB, weight: 120, country: no}
+    template: [name: flags, name: standard]
+
+  norwegian nynorsk:
+    variables: {key: nn, text: NN, weight: 110, country: no}
+    template: [name: flags, name: standard]
+
+  punjabi:
+    variables: {key: pa, text: PA, weight: 100, country: in}
+    template: [name: flags, name: standard]
+
+  romanian:
+    variables: {key: ro, text: RO, weight: 90}
+    template: [name: flags, name: standard]
+
+  slovak:
+    variables: {key: sk, text: SK, weight: 80}
+    template: [name: flags, name: standard]
+
+  slovenian:
+    variables: {key: sl, text: SL, weight: 70, country: si}
+    template: [name: flags, name: standard]
+
+  albanian:
+    variables: {key: sq, text: SQ, weight: 60, country: al}
+    template: [name: flags, name: standard]
+
+  serbian:
+    variables: {key: sr, text: SR, weight: 50, country: rs}
+    template: [name: flags, name: standard]
+
+  swahili:
+    variables: {key: sw, text: SW, weight: 40, country: tz}
+    template: [name: flags, name: standard]
+
+  somali:
+    variables: {key: so, text: SO, weight: 35, country: so}
+    template: [name: flags, name: standard]
+
+  tamil:
+    variables: {key: ta, text: TA, weight: 30, country: in}
+    template: [name: flags, name: standard]
+
+  urdu:
+    variables: {key: ur, text: UR, weight: 20, country: pk}
+    template: [name: flags, name: standard]
+
+  vietnamese:
+    variables: {key: vi, text: VI, weight: 15, country: vn}
+    template: [name: flags, name: standard]
+
+  wolof:
+    variables: {key: wo, text: WO, weight: 10, country: sn}
+    template: [name: flags, name: standard]
+
+  mayan:
+    variables: {key: myn, text: MYN, weight: 8, country: mx, three_characters: true}
+    template: [name: flags, name: standard]
+
+  inuktitut:
+    variables: {key: iu, text: IK, weight: 7, country: ca}
+    template: [name: flags, name: standard]
+
+  romani:
+    variables: {key: rom, text: ROM, weight: 6, country: ro, three_characters: true}
+    template: [name: flags, name: standard]
+
+  amharic:
+    variables: {key: am, text: AM, weight: 5, country: et}
+    template: [name: flags, name: standard]
+
+  sundanese:
+    variables: {key: su, text: SU, weight: 4, country: id}
+    template: [name: flags, name: standard]
+
+  zulu:
+    variables: {key: zu, text: ZU, weight: 3, country: za}
+    template: [name: flags, name: standard]
+
+  luxembourgish:
+    variables: {key: lb, text: LB, weight: 2, country: lu}
+    template: [name: flags, name: standard]
+
+  mossi:
+    variables: {key: mos, text: MOS, weight: 1, country: bf, three_characters: true}
+    template: [name: flags, name: standard]
+
+  lingala:
+    variables: {key: ln, text: LN, weight: 11, country: cd}
+    template: [name: flags, name: standard]
+
+  bambara:
+    variables: {key: bm, text: BM, weight: 12, country: ml}
+    template: [name: flags, name: standard]
+
+  afrikaans:
+    variables: {key: af, text: AF, weight: 13, country: za}
+    template: [name: flags, name: standard]
+
+  mongolian:
+    variables: {key: mn, text: MN, weight: 14, country: mn}
+    template: [name: flags, name: standard]
+
+  khmer:
+    variables: {key: km, text: KM, weight: 16, country: kh}
+    template: [name: flags, name: standard]
+
+  limburgish:
+    variables: {key: li, text: LI, weight: 17, country: be}
+    template: [name: flags, name: standard]
+
+  irish:
+    variables: {key: ga, text: GA, weight: 18, country: ie}
+    template: [name: flags, name: standard]
+
+  aymara:
+    variables: {key: ay, text: AY, weight: 19, country: bo}
+    template: [name: flags, name: standard]
+
+  lao:
+    variables: {key: lo, text: LO, weight: 9, country: la}
+    template: [name: flags, name: standard]

--- a/tests/fixtures/kometa/defaults/overlays/mediastinger.yml
+++ b/tests/fixtures/kometa/defaults/overlays/mediastinger.yml
@@ -1,0 +1,55 @@
+##############################################################################
+#                            MediaStinger Overlay                            #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#        https://kometa.wiki/en/latest/defaults/overlays/mediastinger        #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    default:
+      horizontal_align: right
+      vertical_align: top
+    conditionals:
+      vertical_offset:
+        default: 15
+        conditions:
+          - vertical_align: center
+            value: 0
+          - vertical_align: top
+            value: 15
+          - vertical_align: bottom
+            value: 30
+      horizontal_offset:
+        default: 15
+        conditions:
+          - horizontal_align.exists: false
+            value: 200
+          - horizontal_align: center
+            value: 0
+          - horizontal_align: [left, right]
+            value: 15
+      default:
+        conditions:
+          - file.exists: false
+            file_<<key>>.exists: false
+            url.exists: false
+            url_<<key>>.exists: false
+            git.exists: false
+            git_<<key>>.exists: false
+            repo.exists: false
+            repo_<<key>>.exists: false
+            value: <<overlay_name>>
+    allowed_libraries: movie
+    back_color: "#00000099"
+    back_width: 105
+    back_height: 105
+
+overlays:
+  Mediastinger:
+    template:
+      name: standard
+    plex_all: true
+    filters:
+      tmdb_keyword: aftercreditsstinger, duringcreditsstinger

--- a/tests/fixtures/kometa/defaults/overlays/network.yml
+++ b/tests/fixtures/kometa/defaults/overlays/network.yml
@@ -1,0 +1,1158 @@
+##############################################################################
+#                             Network Overlay                                #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#          https://kometa.wiki/en/latest/defaults/overlays/network           #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    run_definition:
+      - <<use_<<key>>>>
+      - <<use_<<alt>>>>
+    default:
+      key: <<overlay_name>>
+      horizontal_align: left
+      vertical_align: bottom
+      style: color
+    conditionals:
+      vertical_offset:
+        default: 15
+        conditions:
+          - vertical_align.exists: false
+            value: 510
+          - vertical_align: center
+            value: 0
+          - vertical_align: top
+            value: 15
+          - vertical_align: bottom
+            value: 30
+      horizontal_offset:
+        default: 15
+        conditions:
+          - horizontal_align: center
+            value: 0
+          - horizontal_align: [left, right]
+            value: 15
+      default:
+        conditions:
+          - file.exists: false
+            file_<<key>>.exists: false
+            url.exists: false
+            url_<<key>>.exists: false
+            git.exists: false
+            git_<<key>>.exists: false
+            repo.exists: false
+            repo_<<key>>.exists: false
+            value: network/<<style>>/<<key>>
+    allowed_libraries: show
+    group: networks
+    back_color: "#00000099"
+    back_radius: 30
+    back_width: 305
+    back_height: 105
+
+templates:
+  networks:
+    default:
+      key: <<overlay_name>>
+      search: <<key>>
+    ignore_blank_results: true
+    plex_search:
+      validate: false
+      any:
+        network: <<search>>
+
+overlays:
+  "#0":
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  5:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: ["5", "Channel 5"]}]
+
+  7mate:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  ABC:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [ABC, ABC.com]}]
+
+  ABC Family:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  ABC Kids:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  ABC TV:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [ABC TV, ABC (AU), ABC Comedy, ABC Me, ABC News, ABC iview]}]
+
+  ABS-CBN:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Acorn TV:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Adult Swim:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  AHC:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  ALTBalaji:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Amazon Kids+:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  AMC:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [AMC, AMC.com]}]
+
+  AMC+:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Animal Planet:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [Animal Planet, Animal Planet Brasil, Animal Planet Deutschland]}]
+
+  ANIMAX:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Angel Studios:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [Angel Studios, VidAngel]}]
+
+  Antena 3:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Apple TV:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [Apple TV, Apple TV+]}]
+
+  ARD:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Arte:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Atres Player:
+      variables: { weight: 10 }
+      template: [ name: standard, name: networks ]
+
+  Atresplayer Premium:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  AT-X:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Audience:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  AXN:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Azteca Uno:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  A&E:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  BBC America:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  BBC Four:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  BBC iPlayer:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  BBC One:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  BBC Scotland:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  BBC Three:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  BBC Two:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  BET:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [BET, BET Her]}]
+
+  BET+:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  bilibili:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Binge:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  BluTV:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Boomerang:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Bravo:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  BritBox:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  C More:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Canale 5:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Canal+:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [Canal+, Canal+ Poland, Canal+ Family, Canal+ Discovery, Canal+ Afrique]}]
+
+  Cartoon Network:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [Cartoon Network, Cartoon Network Latin America, Cartoon Network Anything]}]
+
+  Cartoonito:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  CBC:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  CBC Television:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Cbeebies:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  CBS:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [CBS, CBS.com, CBS All Access]}]
+
+  Channel 3:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Channel 4:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  CHCH-DT:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Cinemax:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Citytv:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  CNN:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Comedy Central:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Cooking Channel:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Crackle:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Crave:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Criterion Channel:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Crunchyroll:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  CTV:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [CTV, CTV Two, CTV News Channel, CTV Sci-Fi Channel, CTV Comedy Channel, CTV Life Channel, ctv.ca]}]
+
+  Cuatro:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Curiosity Stream:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  DC Universe:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Discovery:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [Discovery, Discovery Health Channel, Discovery Channel, Discovery Home & Health Brasil, Discovery Family, Discovery Real Time, Discovery Asia, Discovery Home & Health, Discovery Life, Discovery World, Discovery Science, Discovery Channel (UK)]}]
+
+  Discovery Kids:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  discovery+:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Disney Channel:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [Disney Channel, Toon Disney, Playhouse Disney, Disney Channel Asia, disney.com, Disney Channel Middle East]}]
+
+  Disney Junior:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [Disney Junior, Disney Junior Latin America, Disney Junior Brasil]}]
+
+  Disney XD:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Disney+:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [Disney+, Disney+ Hotstar]}]
+
+  DR1:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+    
+  Dropout:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Elisa Viihde:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Elisa Viihde Viaplay:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  ENA: 
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+    
+  Epix:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  ESPN:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [ESPN, ESPN2, ESPN+, ESPN Classic, ESPNU, ESPNews, ESPN Australia, Sony ESPN, ESPN.com, ESPN Deportes]}]
+
+  EXXEN:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  E!:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  E4:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Facebook Watch:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Family Channel:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Ficción Producciones:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Flooxer:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Food Network:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  FOX:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [FOX, Fox News Channel, Fox Sports, Fox Reality Channel, Fox Sports Networks, Fox Latin America, Fox Brasil, Fox Soccer, Fox Sports 2, Fox Nation, Fox Sports 1, fox.com, Fox Sports Detroit]}]
+
+  Fox Kids:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  France 2:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Freeform:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Freevee:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [Freevee, Amazon Freevee]}]
+
+  Fuji TV:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  funnyordie.com:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  FX:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  FXX:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  GAİN:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Game Show Network:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Global TV:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Globoplay:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  GMA Network:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Hallmark:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [Hallmark, Hallmark+, Hallmark Channel, Hallmark Drama, Hallmark Movie & Mysteries, Hallmark Movies Now]}]
+
+  HBO:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [HBO, HBO Brasil, HBO Europe, HBO Asia, HBO Latin America, HBO España, HBO Nordic, HBO Canada, HBO Family, HBO Mundi]}]
+
+  HBO Max:
+    variables: {key: HBO Max, weight: 10}
+    template: [name: standard, {name: networks, search: [Max, HBO Go, HBO Max]}]
+
+  HGTV:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [HGTV, HGTV Canada]}]
+
+  History:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [History, History Channel Italia, H2]}]
+
+  HOT3:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Hulu:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  ICTV:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  IFC:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  IMDb TV:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Investigation Discovery:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  ION Television:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  iQiyi:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  ITV:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  ITV Encore:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  ITV1:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  ITV2:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  ITV3:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  ITV4:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  ITVBe:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  ITVX:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  JioCinema:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  joyn:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  JTBC:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Kan 11:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Kanal 5:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  KBS2:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Kids WB:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  La 1:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  La Une:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Las Estrellas:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Lifetime:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [Lifetime, Lifetime Movies]}]
+
+  Lionsgate+:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Logo:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Magnolia Network:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [Magnolia Network, DIY Network]}]
+
+  MasterClass:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  MBC:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  MBN:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  MGM+:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  mitele:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Movistar Plus+:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  MTV:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [MTV, MTV2, MTV3, MTV Lebanon, MTV Latin America, MTV Italia, MTV Australia, MTV Canada, MTV Global, MTV Nederland]}]
+
+  M-Net:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  National Geographic:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [National Geographic, National Geographic Channel, National Geographic Brasil, National Geographic Latinoamerica, National Geographic India, Nat Geo Wild]}]
+
+  NBC:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [NBC, CNBC, MSNBC, NBCSN, CNBC Europe, CNBC Asia, WNBC, Nikkei CNBC, KNBC, CNBC World, CNBC TV18, NBC Weather Plus, NBC Radio Network]}]
+
+  Netflix:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Network 10:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [Network 10, Network Ten]}]
+
+  NFL Network:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  NHK:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Nick:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Nick Jr:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Nickelodeon:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [Nickelodeon, Nick at Nite]}]
+
+  Nicktoons:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Nine Network:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Nippon TV:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  NRK1:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  OCS City:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  OCS Max:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  ORF:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Oxygen:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Pantaya:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Paramount Network:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Paramount+:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [Paramount+, Paramount+ with Showtime]}]
+
+  PBS:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  PBS Kids:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Peacock:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Planète+ A&E:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Prime Video:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Quibi:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Rai 1:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Reelz:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [ReelzChannel, Reelz]}]
+
+  RTÉ One:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  RTL:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  RTL Télé:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  RTP1:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  RÚV:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  S4C:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  SAT.1:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  SBS:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Science:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Seeso:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Seven Network:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Shahid:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Showcase:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Showmax:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Showtime:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [Showtime, Paramount+ with Showtime]}]
+
+  Shudder:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Sky:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [Sky, Sky One, Sky Atlantic, Sky Arts, Sky History, Sky Living, Sky Crime, Sky Uno, Sky Max, Sky Sports, Sky Documentaries, Sky Nature, Sky News, Sky Cinema, Sky News Australia, Sky Italia, Sky Comedy, Sky Sports F1, Sky Two, Sky Witness, sky Travel, Sky Vision, Sky News Weather Channel, SkyShowtime, Sky Atlantic (IT)]}]
+
+  Smithsonian:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [Smithsonian, Smithsonian Channel, Smithsonian Earth]}]
+
+  Space:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Spectrum:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Spike:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [Spike, Spike TV]}]
+
+  Stöð 2:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Stan:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Starz:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [Starz, Starz Encore]}]
+
+  STAR+:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Sundance TV:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [Sundance TV, SundanceTV]}]
+
+  SVT:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  SVT Play:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  SVT1:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Syfy:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Syndication:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  TBS:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [TBS, TBS.com, TBS Brasil]}]
+
+  Telecinco:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Telefe:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Telemundo:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Televisión de Galicia:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Televisión Pública Argentina:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Tencent Video:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  TF1:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  The CW:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [The CW, CW seed]}]
+
+  The Daily Wire:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  The Roku Channel:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  The WB:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  TLC:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  TNT:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [TNT, TNT Comedy, TNT Latin America, TNT España, TNT Serie, TNT Glitz]}]
+
+  Tokyo MX:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Travel Channel:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [Travel Channel, Travel Channel United Kingdom]}]
+
+  truTV:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  tubi:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Turner Classic Movies:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  TV 2:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  tv asahi:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  TV Globo:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  TV Land:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  TV Tokyo:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  TV3:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  TV4:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  TV4 Play:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  TVB Jade:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  tving:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  tvN:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  TVNZ 1:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+    
+  TVNZ 2:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  TVP1:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  U:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [UKTV, U]}]
+
+  "U&Alibi":
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: ["U&Alibi", "Alibi"]}]
+
+  "U&Dave":
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: ["U&Dave", "Dave"]}]
+
+  "U&Drama":
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  "U&Eden":
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: ["U&Eden", "Eden"]}]
+
+  "U&Gold":
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  "U&W":
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  "U&Yesterday":
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  UniMás:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Universal Kids:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Universal TV:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Univision:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  UPN:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  USA Network:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  U+ Mobile TV:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  VH1:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [VH1, VH1 Classic]}]
+
+  Viaplay:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Vice:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [Vice, Viceland, Vice TV, Vice.com]}]
+
+  Virgin Media One:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  ViuTV:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  ViX:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  ViX+:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  VRT 1:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  VRT Max:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  VTM:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  W:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  WE tv:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Xbox Live:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  YLE:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  Youku:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  YouTube:
+    variables: { weight: 10}
+    template: [name: standard, {name: networks, search: [YouTube, YouTube Premium]}]
+
+  ZDF:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]
+
+  ZEE5:
+    variables: { weight: 10}
+    template: [name: standard, name: networks]

--- a/tests/fixtures/kometa/defaults/overlays/ratings.yml
+++ b/tests/fixtures/kometa/defaults/overlays/ratings.yml
@@ -1,0 +1,521 @@
+##############################################################################
+#                              Ratings Overlays                              #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#          https://kometa.wiki/en/latest/defaults/overlays/ratings           #
+##############################################################################
+
+templates:
+  Rating:
+    default:
+      builder_level: <<overlay_level>>
+      rating<<rating_num>>_file: <<file>>
+      rating<<rating_num>>_url: <<url>>
+      rating<<rating_num>>_git: <<git>>
+      rating<<rating_num>>_repo: <<repo>>
+      default: rating/<<rating<<rating_num>>_image_url>><<image_extra>>
+      rating<<rating_num>>_default: <<default>>
+      weight: 100
+      font: fonts/Inter-Bold.ttf
+      rating<<rating_num>>_font: <<font>>
+      rating<<rating_num>>_font_style: <<font_style>>
+      font_size: 63
+      rating<<rating_num>>_font_size: <<font_size>>
+      font_color: "#FFFFFF"
+      rating<<rating_num>>_font_color: <<font_color>>
+      rating<<rating_num>>_stroke_width: <<stroke_width>>
+      rating<<rating_num>>_stroke_color: <<stroke_color>>
+      back_color: "#00000099"
+      rating<<rating_num>>_back_color: <<back_color>>
+      rating<<rating_num>>_back_width: <<back_width>>
+      rating<<rating_num>>_back_height: <<back_height>>
+      rating<<rating_num>>_back_align: <<back_align>>
+      back_padding: 15
+      rating<<rating_num>>_back_padding: <<back_padding>>
+      back_radius: 30
+      rating<<rating_num>>_back_radius: <<back_radius>>
+      rating<<rating_num>>_back_line_color: <<back_line_color>>
+      rating<<rating_num>>_back_line_width: <<back_line_width>>
+      addon_offset: 15
+      rating<<rating_num>>_addon_offset: <<addon_offset>>
+      rating<<rating_num>>_addon_position: <<addon_position>>
+      minimum_rating: 0.0
+      fresh_rating: 6.0
+      maximum_rating: 10.0
+      side: left
+      horizontal_position: left
+      vertical_position: center
+      rating_alignment: vertical
+      rating1: none
+      rating2: none
+      rating3: none
+      center_offset: 0
+      standard_offset: 30
+      v2_offset: 235
+      v3_offset: 440
+      cv2_offset: 105
+      cv3_offset: 205
+      h2_offset: 345
+      h3_offset: 660
+      ch2_offset: 160
+      ch3_offset: 335
+    optional:
+      - file
+      - url
+      - git
+      - repo
+      - overlay_level
+      - font_style
+      - back_align
+      - stroke_width
+      - stroke_color
+      - back_line_color
+      - back_line_width
+    conditionals:
+      mdblist_top:
+        conditions:
+          - image_level: Top
+            rating<<rating_num>>_image: rt_popcorn
+            value: https://mdblist.com/lists/k0meta/verifiedhot<<library_type>>s
+          - image_level: Top
+            rating<<rating_num>>_image: rt_tomato
+            value: https://mdblist.com/lists/k0meta/certifiedfresh<<library_type>>s
+          - image_level: Top
+            rating<<rating_num>>_image: metacritic
+            value: https://mdblist.com/lists/k0meta/metacriticmustsee<<library_type>>s
+      imdb_top:
+        conditions:
+          - image_level: Top
+            rating<<rating_num>>_image: imdb
+            value: top_<<library_type>>s
+      run_this:
+        default: true
+        conditions:
+          - image_level: Top
+            rating<<rating_num>>_image: rt_popcorn
+            library_type: show
+            value: false
+          - image_level: Top
+            rating<<rating_num>>_image: [anidb, letterboxd, mdb, tmdb, trakt, mal, star]
+            value: false
+          - image_level: Top
+            builder_level: episode
+            value: false
+          - image_level: Top
+            overlay_level: episode
+            value: false
+          - rating<<rating_num>>: none
+            value: false
+      rating_level_prefix:
+        default: ""
+        conditions:
+          - builder_level: episode
+            value: episode_
+          - overlay_level: episode
+            value: episode_
+      rating<<rating_num>>_style:
+        default: ""
+        conditions:
+          - rating<<rating_num>>_image: [rt_popcorn, rt_tomato, tmdb, metacritic, mdb]
+            value: "%"
+          - rating<<rating_num>>_image: [letterboxd]
+            value: "/"
+      rating<<rating_num>>_extra:
+        default: ""
+        conditions:
+          - rating<<rating_num>>_image: [rt_popcorn, rt_tomato, tmdb]
+            value: "%"
+      image_extra:
+        default: ""
+        conditions:
+          - rating<<rating_num>>_image: [imdb, rt_popcorn, rt_tomato, metacritic]
+            image_level: Top
+            value: Top
+          - rating<<rating_num>>_image: [rt_popcorn, rt_tomato]
+            value: <<image_level>>
+      rating<<rating_num>>_image_url:
+        conditions:
+          - rating<<rating_num>>_image: anidb
+            value: AniDB
+          - rating<<rating_num>>_image: imdb
+            value: IMDb
+          - rating<<rating_num>>_image: letterboxd
+            value: Letterboxd
+          - rating<<rating_num>>_image: mdb
+            value: MDBList
+          - rating<<rating_num>>_image: metacritic
+            value: Metacritic
+          - rating<<rating_num>>_image: rt_popcorn
+            value: RT-Aud-
+          - rating<<rating_num>>_image: rt_tomato
+            value: RT-Crit-
+          - rating<<rating_num>>_image: tmdb
+            value: TMDb
+          - rating<<rating_num>>_image: trakt
+            value: Trakt
+          - rating<<rating_num>>_image: mal
+            value: MAL
+          - rating<<rating_num>>_image: star
+            value: Star
+      rating<<rating_num>>_horizontal_align:
+        default: left
+        conditions:
+          - horizontal_position: right
+            value: right
+          - horizontal_position: center
+            value: center
+      rating<<rating_num>>_vertical_align:
+        default: center
+        conditions:
+          - vertical_position: top
+            value: top
+          - vertical_position: bottom
+            value: bottom
+      rating1_horizontal_offset:
+        default: <<standard_offset>>
+        conditions:
+          - rating_alignment: vertical
+            horizontal_position: center
+            value: <<center_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: center
+            rating2: none
+            rating3: none
+            value: <<center_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: center
+            rating2: none
+            value: -<<ch2_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: center
+            rating3: none
+            value: -<<ch2_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: center
+            value: -<<ch3_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: right
+            rating2: none
+            rating3: none
+            value: <<standard_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: right
+            rating2: none
+            value: <<h2_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: right
+            rating3: none
+            value: <<h2_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: right
+            value: <<h3_offset>>
+      rating1_vertical_offset:
+        default: <<standard_offset>>
+        conditions:
+          - rating_alignment: horizontal
+            vertical_position: center
+            value: <<center_offset>>
+          - rating_alignment: vertical
+            vertical_position: center
+            rating2: none
+            rating3: none
+            value: <<center_offset>>
+          - rating_alignment: vertical
+            vertical_position: center
+            rating2: none
+            value: -<<cv2_offset>>
+          - rating_alignment: vertical
+            vertical_position: center
+            rating3: none
+            value: -<<cv2_offset>>
+          - rating_alignment: vertical
+            vertical_position: center
+            value: -<<cv3_offset>>
+          - rating_alignment: vertical
+            vertical_position: bottom
+            rating2: none
+            rating3: none
+            value: <<standard_offset>>
+          - rating_alignment: vertical
+            vertical_position: bottom
+            rating2: none
+            value: <<v2_offset>>
+          - rating_alignment: vertical
+            vertical_position: bottom
+            rating3: none
+            value: <<v2_offset>>
+          - rating_alignment: vertical
+            vertical_position: bottom
+            value: <<v3_offset>>
+      rating2_horizontal_offset:
+        default: <<standard_offset>>
+        conditions:
+          - rating_alignment: vertical
+            horizontal_position: center
+            value: <<center_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: center
+            rating1: none
+            rating3: none
+            value: <<center_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: center
+            rating1: none
+            value: -<<ch2_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: center
+            rating3: none
+            value: <<ch2_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: center
+            value: <<center_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: right
+            rating1: none
+            rating3: none
+            value: <<standard_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: right
+            rating3: none
+            value: <<standard_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: right
+            value: <<h2_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: left
+            rating1: none
+            value: <<standard_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: left
+            value: <<h2_offset>>
+      rating2_vertical_offset:
+        default: <<standard_offset>>
+        conditions:
+          - rating_alignment: horizontal
+            vertical_position: center
+            value: <<center_offset>>
+          - rating_alignment: vertical
+            vertical_position: center
+            rating1: none
+            rating3: none
+            value: <<center_offset>>
+          - rating_alignment: vertical
+            vertical_position: center
+            rating1: none
+            value: -<<cv2_offset>>
+          - rating_alignment: vertical
+            vertical_position: center
+            rating3: none
+            value: <<cv2_offset>>
+          - rating_alignment: vertical
+            vertical_position: center
+            value: <<center_offset>>
+          - rating_alignment: vertical
+            vertical_position: bottom
+            rating1: none
+            rating3: none
+            value: <<standard_offset>>
+          - rating_alignment: vertical
+            vertical_position: bottom
+            rating1: none
+            value: <<v2_offset>>
+          - rating_alignment: vertical
+            vertical_position: bottom
+            rating3: none
+            value: <<standard_offset>>
+          - rating_alignment: vertical
+            vertical_position: bottom
+            value: <<v2_offset>>
+          - rating_alignment: vertical
+            vertical_position: top
+            rating1: none
+            value: <<standard_offset>>
+          - rating_alignment: vertical
+            vertical_position: top
+            value: <<v2_offset>>
+      rating3_horizontal_offset:
+        default: <<standard_offset>>
+        conditions:
+          - rating_alignment: vertical
+            horizontal_position: center
+            value: <<center_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: center
+            rating1: none
+            rating2: none
+            value: <<center_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: center
+            rating1: none
+            value: <<ch2_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: center
+            rating2: none
+            value: <<ch2_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: center
+            value: <<ch3_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: left
+            rating1: none
+            rating2: none
+            value: <<standard_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: left
+            rating1: none
+            value: <<h2_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: left
+            rating2: none
+            value: <<h2_offset>>
+          - rating_alignment: horizontal
+            horizontal_position: left
+            value: <<h3_offset>>
+      rating3_vertical_offset:
+        default: <<standard_offset>>
+        conditions:
+          - rating_alignment: horizontal
+            vertical_position: center
+            value: <<center_offset>>
+          - rating_alignment: vertical
+            vertical_position: center
+            rating1: none
+            rating2: none
+            value: <<center_offset>>
+          - rating_alignment: vertical
+            vertical_position: center
+            rating1: none
+            value: <<cv2_offset>>
+          - rating_alignment: vertical
+            vertical_position: center
+            rating2: none
+            value: <<cv2_offset>>
+          - rating_alignment: vertical
+            vertical_position: center
+            value: <<cv3_offset>>
+          - rating_alignment: vertical
+            vertical_position: top
+            rating1: none
+            rating2: none
+            value: <<standard_offset>>
+          - rating_alignment: vertical
+            vertical_position: top
+            rating1: none
+            value: <<v2_offset>>
+          - rating_alignment: vertical
+            vertical_position: top
+            rating2: none
+            value: <<v2_offset>>
+          - rating_alignment: vertical
+            vertical_position: top
+            value: <<v3_offset>>
+      back_width:
+        default: 160
+        conditions:
+          - rating_alignment: horizontal
+            value: 270
+      back_height:
+        default: 160
+        conditions:
+          - rating_alignment: horizontal
+            value: 80
+      addon_position:
+        default: top
+        conditions:
+          - rating_alignment: horizontal
+            value: left
+      gte:
+        default: <<minimum_rating>>
+        conditions:
+          - image_level: Fresh
+            value: <<fresh_rating>>
+      lte:
+        default: <<fresh_rating>>
+        conditions:
+          - image_level: Fresh
+            value: <<maximum_rating>>
+      gsuffix:
+        conditions:
+          - rating<<rating_num>>: [critic, audience, user]
+            image_level: [Fresh, Rotten]
+            value: gte
+      lsuffix:
+        conditions:
+          - rating<<rating_num>>: [critic, audience, user]
+            image_level: Fresh
+            value: lte
+          - rating<<rating_num>>: [critic, audience, user]
+            image_level: Rotten
+            value: lt
+      rating<<rating_num>>_default:
+        conditions:
+          - file.exists: false
+            url.exists: false
+            git.exists: false
+            repo.exists: false
+            rating<<rating_num>>_file.exists: false
+            rating<<rating_num>>_url.exists: false
+            rating<<rating_num>>_git.exists: false
+            rating<<rating_num>>_repo.exists: false
+            value: rating/<<rating<<rating_num>>_image_url>><<image_extra>>
+    plex_search:
+      all:
+        <<rating_level_prefix>><<rating<<rating_num>>>>_rating.<<gsuffix>>: <<gte>>
+        <<rating_level_prefix>><<rating<<rating_num>>>>_rating.<<lsuffix>>: <<lte>>
+    mdblist_list: <<mdblist_top>>
+    imdb_chart: <<imdb_top>>
+    builder_level: <<builder_level>>
+    run_definition: <<run_this>>
+    ignore_blank_results: true
+    overlay:
+      name: text(<<<<rating<<rating_num>>>>_rating<<rating<<rating_num>>_style>>>><<rating<<rating_num>>_extra>>)
+      file: <<rating<<rating_num>>_file>>
+      url: <<rating<<rating_num>>_url>>
+      git: <<rating<<rating_num>>_git>>
+      repo: <<rating<<rating_num>>_repo>>
+      default: <<rating<<rating_num>>_default>>
+      group: rating<<rating_num>>_group
+      weight: <<weight>>
+      horizontal_offset: <<rating<<rating_num>>_horizontal_offset>>
+      horizontal_align: <<rating<<rating_num>>_horizontal_align>>
+      vertical_offset: <<rating<<rating_num>>_vertical_offset>>
+      vertical_align: <<rating<<rating_num>>_vertical_align>>
+      font: <<rating<<rating_num>>_font>>
+      font_style: <<rating<<rating_num>>_font_style>>
+      font_size: <<rating<<rating_num>>_font_size>>
+      font_color: <<rating<<rating_num>>_font_color>>
+      stroke_width: <<rating<<rating_num>>_stroke_width>>
+      stroke_color: <<rating<<rating_num>>_stroke_color>>
+      back_color: <<rating<<rating_num>>_back_color>>
+      back_width: <<rating<<rating_num>>_back_width>>
+      back_height: <<rating<<rating_num>>_back_height>>
+      back_align: <<rating<<rating_num>>_back_align>>
+      back_padding: <<rating<<rating_num>>_back_padding>>
+      back_radius: <<rating<<rating_num>>_back_radius>>
+      back_line_color: <<rating<<rating_num>>_back_line_color>>
+      back_line_width: <<rating<<rating_num>>_back_line_width>>
+      addon_offset: <<rating<<rating_num>>_addon_offset>>
+      addon_position: <<rating<<rating_num>>_addon_position>>
+
+overlays:
+
+  Rating1Rotten:
+    template: {name: Rating, rating_num: "1", image_level: Rotten}
+  Rating1Fresh:
+    template: {name: Rating, rating_num: "1", image_level: Fresh}
+  Rating1Top:
+    template: {name: Rating, weight: 110, rating_num: "1", image_level: Top}
+
+  Rating2Rotten:
+    template: {name: Rating, rating_num: "2", image_level: Rotten}
+  Rating2Fresh:
+    template: {name: Rating, rating_num: "2", image_level: Fresh}
+  Rating2Top:
+    template: {name: Rating, weight: 110, rating_num: "2", image_level: Top}
+
+  Rating3Rotten:
+    template: {name: Rating, rating_num: "3", image_level: Rotten}
+  Rating3Fresh:
+    template: {name: Rating, rating_num: "3", image_level: Fresh}
+  Rating3Top:
+    template: {name: Rating, weight: 110, rating_num: "3", image_level: Top}

--- a/tests/fixtures/kometa/defaults/overlays/resolution.yml
+++ b/tests/fixtures/kometa/defaults/overlays/resolution.yml
@@ -1,0 +1,641 @@
+##############################################################################
+#                         Resolution/Edition Overlay                         #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#                     Credit to Magic815 for base images                     #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#         https://kometa.wiki/en/latest/defaults/overlays/resolution         #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    conditionals:
+      suppress_overlays:
+        default: <<overlay_name>>-Dovetail
+        conditions:
+          - type: edition_dovetail
+            value:
+              - 4K-DV-HDR-Plus
+              - 4K-DV-HDR
+              - 4K-Plus
+              - 4K-DV
+              - 4K-HLG
+              - 4K-HDR
+              - 4K
+              - 1080P-DV-HDR-Plus
+              - 1080P-DV-HDR
+              - 1080P-Plus
+              - 1080P-DV
+              - 1080P-HLG
+              - 1080P-HDR
+              - 1080P
+              - 720P-DV-HDR-Plus
+              - 720P-DV-HDR
+              - 720P-Plus
+              - 720P-DV
+              - 720P-HLG
+              - 720P-HDR
+              - 720P
+              - 576P-DV-HDR-Plus
+              - 576P-DV-HDR
+              - 576P-Plus
+              - 576P-DV
+              - 576P-HDR
+              - 576P
+              - 480P-DV-HDR-Plus
+              - 480P-DV-HDR
+              - 480P-Plus
+              - 480P-DV
+              - 480P-HDR
+              - 480P
+              - DV-HDR-Plus
+              - DV-HDR
+              - Plus
+              - DV
+              - HLG
+              - HDR
+          - type: resolution_dovetail
+            value:
+              - Open-Matte
+              - Extended-Edition
+              - Uncut-Edition
+              - Unrated-Edition
+              - Special-Edition
+              - Anniversary-Edition
+              - Collectors-Edition
+              - Diamond-Edition
+              - Platinum-Edition
+              - Directors-Cut
+              - Final-Cut
+              - International-Cut
+              - Theatrical-Cut
+              - Ultimate-Cut
+              - Alternate-Cut
+              - Coda-Cut
+              - IMAX-Enhanced
+              - IMAX
+              - Remastered
+              - Criterion
+              - Richard-Donner
+              - Black-And-Chrome
+              - Definitive
+              - Ulysses
+              - Producers-Cut
+      final_horizontal_offset:
+        default: <<horizontal_offset>>
+        conditions:
+          - type: resolution_dovetail
+            value: <<horizontal_offset+30>>
+          - type: edition_dovetail
+            horizontal_align: center
+            value: <<horizontal_offset+30>>
+      final_vertical_offset:
+        default: <<vertical_offset>>
+        conditions:
+          - type: edition_dovetail
+            vertical_align: bottom
+            key: [remastered, coda]
+            value: <<vertical_offset-10>>
+          - type: edition_dovetail
+            vertical_align: bottom
+            value: <<vertical_offset>>
+          - type: edition_dovetail
+            value: <<vertical_offset+64>>
+          - type: resolution_dovetail
+            value: <<vertical_offset+30>>
+      back_width:
+        conditions:
+          - type: [edition, resolution, edition_dovetail]
+            value: 305
+          - type: resolution_dovetail
+            value: 245
+      back_height:
+        conditions:
+          - type: [edition, resolution]
+            value: 105
+          - type: [resolution_dovetail, edition_dovetail]
+            value: 129
+      back_color:
+        conditions:
+          - type: [edition, resolution, resolution_dovetail]
+            value: "#00000099"
+          - type: edition_dovetail
+            value: "#00000000"
+      back_padding:
+        conditions:
+          - type: resolution_dovetail
+            value: 30
+      back_align:
+        conditions:
+          - type: resolution_dovetail
+            value: top
+      default:
+        conditions:
+          - type: [edition, edition_dovetail]
+            file.exists: false
+            file_<<key>>.exists: false
+            url.exists: false
+            url_<<key>>.exists: false
+            git.exists: false
+            git_<<key>>.exists: false
+            repo.exists: false
+            repo_<<key>>.exists: false
+            value: edition/<<key>>
+          - type: [resolution, resolution_dovetail]
+            file.exists: false
+            file_<<key>>.exists: false
+            url.exists: false
+            url_<<key>>.exists: false
+            git.exists: false
+            git_<<key>>.exists: false
+            repo.exists: false
+            repo_<<key>>.exists: false
+            value: resolution/<<key>><<alt>>
+      group:
+        conditions:
+          - type: [edition, edition_dovetail]
+            value: edition
+          - type: [resolution, resolution_dovetail]
+            value: resolution
+    horizontal_offset: 15
+    vertical_offset: 15
+    horizontal_align: left
+    vertical_align: top
+
+templates:
+  edition:
+    conditionals:
+      regex:
+        conditions:
+          - key: enhanced
+            value: '(?i)\bIMAX Enhanced\b|^(?=.*(DSNP|Disney\+|CORE(?=[ ._-]web[ ._-]?(dl|rip)\b)|\bBC(?=[ ._-]web[ ._-]?(dl|rip)\b)|IMAX[- .]Enhanced)\b)(?=.*\b(IMAX|IMAX[- .]Enhanced)\b).*'
+          - key: imax
+            value: '(?i)\bIMAX\b'
+          - key: criterion
+            value: '(?i)Criterion|\[CC\]'
+          - key: openmatte
+            value: '(?i)\b(Open[ ._-]?Matte)\b'
+    optional:
+      - search
+      - use_<<key>>
+      - use_edition
+      - allowed_libraries
+    run_definition:
+      - <<use_<<key>>>>
+      - <<use_edition>>
+      - <<allowed_libraries>>
+    ignore_blank_results: true
+    plex_all: true
+    filters:
+      - edition: <<search>>
+      - filepath.regex:
+        - <<regex>>
+        - '(?i)edition-\b(4k )?<<search>>(s|ed)?\b'           # New TRaSH naming
+        - '(?<=[0-9]{4}[)}>\]]\s)\b(4k )?<<search>>(s|ed)?\b' # Original TRaSH naming
+
+  resolution:
+    conditionals:
+      res:
+        conditions:
+          - key: 4k
+            value: "(?i)2160|4k"
+          - key: 1080p
+            value: "(?i)1080|2k"
+          - key: 720p
+            value: "(?i)720|hd"
+          - key: 576p
+            value: "(?i)576"
+          - key: 480p
+            value: "(?i)480|sd"
+      dolby_vision:
+        conditions:
+          - alt: dv
+            value: true
+      hdr:
+        conditions:
+          - alt: hdr
+            value: true
+      regex:
+        conditions:
+          - alt: hlg
+            value: '(?i)\bhlg\b'
+          - alt: plus
+            value: '(?i)\bhdr10(\+|p(lus)?\b)'
+          - alt: dvhdr
+            value: '(?i)\bdv(.hdr10?\b)'
+          - alt: dvhdrplus
+            value: '(?i)\bdv.HDR10(\+|P(lus)?\b)'
+    optional:
+      - all
+      - use_<<key>>
+      - use_<<key>>_<<alt>>
+      - use_<<alt>>
+      - use_resolution
+      - allowed_libraries
+    run_definition:
+      - <<use_<<key>>>>
+      - <<use_<<alt>>>>
+      - <<use_<<key>>_<<alt>>>>
+      - <<allowed_libraries>>
+      - <<use_resolution>>
+    ignore_blank_results: true
+    plex_all: <<all>>
+    plex_search:
+      all:
+        any:
+          resolution.regex: <<res>>
+        hdr: <<hdr>>
+    filters:
+      has_dolby_vision: <<dolby_vision>>
+      filepath.regex:
+        - <<regex>>
+
+overlays:
+
+  4K-DV-HDR-Plus-Dovetail:
+    variables: {key: 4k, alt: dvhdrplus, weight: 160, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  4K-DV-HDR-Dovetail:
+    variables: {key: 4k, alt: dvhdr, weight: 158, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  4K-Plus-Dovetail:
+    variables: {key: 4k, alt: plus, weight: 155, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  4K-DV-Dovetail:
+    variables: {key: 4k, alt: dv, weight: 150, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  4K-HLG-Dovetail:
+    variables: {key: 4k, alt: hlg, weight: 141, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  4K-HDR-Dovetail:
+    variables: {key: 4k, alt: hdr, weight: 140, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  4K-Dovetail:
+    variables: {key: 4k, alt: "", weight: 130, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  1080P-DV-HDR-Plus-Dovetail:
+    variables: {key: 1080p, alt: dvhdrplus, weight: 130, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  1080P-DV-HDR-Dovetail:
+    variables: {key: 1080p, alt: dvhdr, weight: 128, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  1080P-Plus-Dovetail:
+    variables: {key: 1080p, alt: plus, weight: 125, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  1080P-DV-Dovetail:
+    variables: {key: 1080p, alt: dv, weight: 120, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  1080P-HLG-Dovetail:
+    variables: {key: 1080p, alt: hlg, weight: 111, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  1080P-HDR-Dovetail:
+    variables: {key: 1080p, alt: hdr, weight: 110, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  1080P-Dovetail:
+    variables: {key: 1080p, alt: "", weight: 100, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  720P-DV-HDR-Plus-Dovetail:
+    variables: {key: 720p, alt: dvhdrplus, weight: 99, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  720P-DV-HDR-Dovetail:
+    variables: {key: 720p, alt: dvhdr, weight: 98, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  720P-Plus-Dovetail:
+    variables: {key: 720p, alt: plus, weight: 95, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  720P-DV-Dovetail:
+    variables: {key: 720p, alt: dv, weight: 90, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  720P-HLG-Dovetail:
+    variables: {key: 720p, alt: hlg, weight: 81, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  720P-HDR-Dovetail:
+    variables: {key: 720p, alt: hdr, weight: 80, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  720P-Dovetail:
+    variables: {key: 720p, alt: "", weight: 70, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  576P-DV-HDR-Plus-Dovetail:
+    variables: {key: 576p, alt: dvhdrplus, weight: 69, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  576P-DV-HDR-Dovetail:
+    variables: {key: 576p, alt: dvhdr, weight: 68, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  576P-Plus-Dovetail:
+    variables: {key: 576p, alt: plus, weight: 65, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  576P-DV-Dovetail:
+    variables: {key: 576p, alt: dv, weight: 60, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  576P-HDR-Dovetail:
+    variables: {key: 576p, alt: hdr, weight: 50, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  576P-Dovetail:
+    variables: {key: 576p, alt: "", weight: 40, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  480P-DV-HDR-Plus-Dovetail:
+    variables: {key: 480p, alt: dvhdrplus, weight: 39, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  480P-DV-HDR-Dovetail:
+    variables: {key: 480p, alt: dvhdr, weight: 38, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  480P-Plus-Dovetail:
+    variables: {key: 480p, alt: plus, weight: 35, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  480P-DV-Dovetail:
+    variables: {key: 480p, alt: dv, weight: 30, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  480P-HDR-Dovetail:
+    variables: {key: 480p, alt: hdr, weight: 20, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  480P-Dovetail:
+    variables: {key: 480p, alt: "", weight: 10, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  DV-HDR-Plus-Dovetail:
+    variables: {key: "", alt: dvhdrplus, weight: 9, type: resolution_dovetail, all: true, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  DV-HDR-Dovetail:
+    variables: {key: "", alt: dvhdr, weight: 8, type: resolution_dovetail, all: true, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  Plus-Dovetail:
+    variables: {key: "", alt: plus, weight: 7, type: resolution_dovetail, all: true, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  DV-Dovetail:
+    variables: {key: "", alt: dv, weight: 5, type: resolution_dovetail, all: true, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  HLG-Dovetail:
+    variables: {key: "", alt: hlg, weight: 2, type: resolution_dovetail, all: true, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+  HDR-Dovetail:
+    variables: {key: "", alt: hdr, weight: 1, type: resolution_dovetail, allowed_libraries: movie}
+    template: [name: resolution, name: standard]
+
+  Extended-Edition-Dovetail:
+    variables: {key: extended, weight: 190, search: Extend, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Uncut-Edition-Dovetail:
+    variables: {key: uncut, weight: 180, search: Uncut, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Unrated-Edition-Dovetail:
+    variables: {key: unrated, weight: 170, search: Unrated, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Special-Edition-Dovetail:
+    variables: {key: special, weight: 160, search: Special, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Anniversary-Edition-Dovetail:
+    variables: {key: anniversary, weight: 150, search: Anniversary, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Collectors-Edition-Dovetail:
+    variables: {key: collector, weight: 140, search: Collector, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Diamond-Edition-Dovetail:
+    variables: {key: diamond, weight: 130, search: Diamond, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Platinum-Edition-Dovetail:
+    variables: {key: platinum, weight: 120, search: Platinum, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Directors-Cut-Dovetail:
+    variables: {key: directors, weight: 110, search: Director, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Final-Cut-Dovetail:
+    variables: {key: final, weight: 100, search: Final, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  International-Cut-Dovetail:
+    variables: {key: international, weight: 90, search: International, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Theatrical-Cut-Dovetail:
+    variables: {key: theatrical, weight: 80, search: Theatrical, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Ultimate-Cut-Dovetail:
+    variables: {key: ultimate, weight: 70, search: Ultimate, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Alternate-Cut-Dovetail:
+    variables: {key: alternate, weight: 60, search: Alternate, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Coda-Cut-Dovetail:
+    variables: {key: coda, weight: 50, search: Coda, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  IMAX-Enhanced-Dovetail:
+    variables: {key: enhanced, weight: 40, search: IMAX Enhanced, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  IMAX-Dovetail:
+    variables: {key: imax, weight: 30, search: IMAX, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Remastered-Dovetail:
+    variables: {key: remastered, weight: 20, search: Remaster, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Criterion-Dovetail:
+    variables: {key: criterion, weight: 10, search: Criterion, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Richard-Donner-Dovetail:
+    variables: {key: richarddonner, weight: 9, search: Rich, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Black-And-Chrome-Dovetail:
+    variables: {key: blackchrome, weight: 8, search: Black, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Definitive-Dovetail:
+    variables: {key: definitive, weight: 7, search: Definitive, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Open-Matte-Dovetail:
+    variables: {key: openmatte, weight: 6, search: Open Matte, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Ulysses-Dovetail:
+    variables: {key: ulysses, weight: 5, search: Ulysses, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Producers-Cut-Dovetail:
+    variables: {key: producers, weight: 4, search: Producer, type: edition_dovetail, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+
+  4K-DV-HDR-Plus:
+    variables: {key: 4k, alt: dvhdrplus, weight: 159, type: resolution}
+    template: [name: resolution, name: standard]
+  4K-DV-HDR:
+    variables: {key: 4k, alt: dvhdr, weight: 158, type: resolution}
+    template: [name: resolution, name: standard]
+  4K-Plus:
+    variables: {key: 4k, alt: plus, weight: 155, type: resolution}
+    template: [name: resolution, name: standard]
+  4K-DV:
+    variables: {key: 4k, alt: dv, weight: 150, type: resolution}
+    template: [name: resolution, name: standard]
+  4K-HLG:
+    variables: {key: 4k, alt: hlg, weight: 141, type: resolution}
+    template: [name: resolution, name: standard]
+  4K-HDR:
+    variables: {key: 4k, alt: hdr, weight: 140, type: resolution}
+    template: [name: resolution, name: standard]
+  4K:
+    variables: {key: 4k, alt: "", weight: 130, type: resolution}
+    template: [name: resolution, name: standard]
+  1080P-DV-HDR-Plus:
+    variables: {key: 1080p, alt: dvhdrplus, weight: 129, type: resolution}
+    template: [name: resolution, name: standard]
+  1080P-DV-HDR:
+    variables: {key: 1080p, alt: dvhdr, weight: 128, type: resolution}
+    template: [name: resolution, name: standard]
+  1080P-Plus:
+    variables: {key: 1080p, alt: plus, weight: 125, type: resolution}
+    template: [name: resolution, name: standard]
+  1080P-DV:
+    variables: {key: 1080p, alt: dv, weight: 120, type: resolution}
+    template: [name: resolution, name: standard]
+  1080P-HLG:
+    variables: {key: 1080p, alt: hlg, weight: 111, type: resolution}
+    template: [name: resolution, name: standard]
+  1080P-HDR:
+    variables: {key: 1080p, alt: hdr, weight: 110, type: resolution}
+    template: [name: resolution, name: standard]
+  1080P:
+    variables: {key: 1080p, alt: "", weight: 100, type: resolution}
+    template: [name: resolution, name: standard]
+  720P-DV-HDR-Plus:
+    variables: {key: 720p, alt: dvhdrplus, weight: 99, type: resolution}
+    template: [name: resolution, name: standard]
+  720P-DV-HDR:
+    variables: {key: 720p, alt: dvhdr, weight: 98, type: resolution}
+    template: [name: resolution, name: standard]
+  720P-Plus:
+    variables: {key: 720p, alt: plus, weight: 95, type: resolution}
+    template: [name: resolution, name: standard]
+  720P-DV:
+    variables: {key: 720p, alt: dv, weight: 90, type: resolution}
+    template: [name: resolution, name: standard]
+  720P-HLG:
+    variables: {key: 720p, alt: hlg, weight: 81, type: resolution}
+    template: [name: resolution, name: standard]
+  720P-HDR:
+    variables: {key: 720p, alt: hdr, weight: 80, type: resolution}
+    template: [name: resolution, name: standard]
+  720P:
+    variables: {key: 720p, alt: "", weight: 70, type: resolution}
+    template: [name: resolution, name: standard]
+  576P-DV-HDR-Plus:
+    variables: {key: 576p, alt: dvhdrplus, weight: 69, type: resolution}
+    template: [name: resolution, name: standard]
+  576P-DV-HDR:
+    variables: {key: 576p, alt: dvhdr, weight: 68, type: resolution}
+    template: [name: resolution, name: standard]
+  576P-Plus:
+    variables: {key: 576p, alt: plus, weight: 65, type: resolution}
+    template: [name: resolution, name: standard]
+  576P-DV:
+    variables: {key: 576p, alt: dv, weight: 60, type: resolution}
+    template: [name: resolution, name: standard]
+  576P-HDR:
+    variables: {key: 576p, alt: hdr, weight: 50, type: resolution}
+    template: [name: resolution, name: standard]
+  576P:
+    variables: {key: 576p, alt: "", weight: 40, type: resolution}
+    template: [name: resolution, name: standard]
+  480P-DV-HDR-Plus:
+    variables: {key: 480p, alt: dvhdrplus, weight: 39, type: resolution}
+    template: [name: resolution, name: standard]
+  480P-DV-HDR:
+    variables: {key: 480p, alt: dvhdr, weight: 38, type: resolution}
+    template: [name: resolution, name: standard]
+  480P-Plus:
+    variables: {key: 480p, alt: plus, weight: 35, type: resolution}
+    template: [name: resolution, name: standard]
+  480P-DV:
+    variables: {key: 480p, alt: dv, weight: 30, type: resolution}
+    template: [name: resolution, name: standard]
+  480P-HDR:
+    variables: {key: 480p, alt: hdr, weight: 20, type: resolution}
+    template: [name: resolution, name: standard]
+  480P:
+    variables: {key: 480p, alt: "", weight: 10, type: resolution}
+    template: [name: resolution, name: standard]
+  DV-HDR-Plus:
+    variables: {key: "", alt: dvhdrplus, weight: 9, type: resolution, all: true}
+    template: [name: resolution, name: standard]
+  DV-HDR:
+    variables: {key: "", alt: dvhdr, weight: 8, type: resolution, all: true}
+    template: [name: resolution, name: standard]
+  Plus:
+    variables: {key: "", alt: plus, weight: 7, type: resolution, all: true}
+    template: [name: resolution, name: standard]
+  DV:
+    variables: {key: "", alt: dv, weight: 5, type: resolution, all: true}
+    template: [name: resolution, name: standard]
+  HLG:
+    variables: {key: "", alt: hlg, weight: 2, type: resolution, all: true}
+    template: [name: resolution, name: standard]
+  HDR:
+    variables: {key: "", alt: hdr, weight: 1, type: resolution}
+    template: [name: resolution, name: standard]
+
+  Extended-Edition:
+    variables: {key: extended, weight: 190, search: Extend, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Uncut-Edition:
+    variables: {key: uncut, weight: 180, search: Uncut, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Unrated-Edition:
+    variables: {key: unrated, weight: 170, search: Unrated, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Special-Edition:
+    variables: {key: special, weight: 160, search: Special, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Anniversary-Edition:
+    variables: {key: anniversary, weight: 150, search: Anniversary, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Collectors-Edition:
+    variables: {key: collector, weight: 140, search: Collector, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Diamond-Edition:
+    variables: {key: diamond, weight: 130, search: Diamond, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Platinum-Edition:
+    variables: {key: platinum, weight: 120, search: Platinum, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Directors-Cut:
+    variables: {key: directors, weight: 110, search: Director, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Final-Cut:
+    variables: {key: final, weight: 100, search: Final, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  International-Cut:
+    variables: {key: international, weight: 90, search: International, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Theatrical-Cut:
+    variables: {key: theatrical, weight: 80, search: Theatrical, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Ultimate-Cut:
+    variables: {key: ultimate, weight: 70, search: Ultimate, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Alternate-Cut:
+    variables: {key: alternate, weight: 60, search: Alternate, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Coda-Cut:
+    variables: {key: coda, weight: 50, search: Coda, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  IMAX-Enhanced:
+    variables: {key: enhanced, weight: 40, search: IMAX Enhanced, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  IMAX:
+    variables: {key: imax, weight: 30, search: IMAX, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Remastered:
+    variables: {key: remastered, weight: 20, search: Remaster, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Criterion:
+    variables: {key: criterion, weight: 10, search: Criterion, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Richard-Donner:
+    variables: {key: richarddonner, weight: 9, search: Rich, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Black-And-Chrome:
+    variables: {key: blackchrome, weight: 8, search: Black, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Definitive:
+    variables: {key: definitive, weight: 7, search: Definitive, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Open-Matte:
+    variables: {key: openmatte, weight: 6, search: Open Matte, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Ulysses:
+    variables: {key: ulysses, weight: 5, search: Ulysses, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]
+  Producers-Cut:
+    variables: {key: producers, weight: 4, search: Producer, type: edition, allowed_libraries: movie}
+    template: [name: edition, name: standard]

--- a/tests/fixtures/kometa/defaults/overlays/ribbon.yml
+++ b/tests/fixtures/kometa/defaults/overlays/ribbon.yml
@@ -1,0 +1,246 @@
+##############################################################################
+#                               Ribbon Overlay                               #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#           https://kometa.wiki/en/latest/defaults/overlays/ribbon           #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    default:
+      style: yellow
+    conditionals:
+      final_style:
+        default: yellow
+        conditions:
+          - style: gray
+            value: gray
+          - style: black
+            value: black
+          - style: red
+            value: red
+      default:
+        conditions:
+          - file.exists: false
+            file_<<key>>.exists: false
+            url.exists: false
+            url_<<key>>.exists: false
+            git.exists: false
+            git_<<key>>.exists: false
+            repo.exists: false
+            repo_<<key>>.exists: false
+            value: ribbon/<<final_style>>/<<key>>
+    group: ribbon
+    horizontal_offset: 0
+    horizontal_align: right
+    vertical_offset: 0
+    vertical_align: bottom
+
+templates:
+  ribbon:
+    optional:
+      - mdb_key
+      - imdb_key
+    mdblist_list: https://mdblist.com/lists/k0meta/<<mdb_key>><<library_type>>s
+    imdb_chart: <<imdb_key>>_<<library_type>>s
+
+overlays:
+
+  Oscars Best Picture:
+    variables: {key: oscars, weight: 190}
+    template: {name: standard, allowed_libraries: movie}
+    imdb_award:
+      event_id: ev0000003
+      event_year: all
+      category_filter:
+        - best picture
+        - best motion picture of the year
+      winning: true
+
+  Oscars Best Director:
+    variables: {key: oscars_director, weight: 180}
+    template: {name: standard, allowed_libraries: movie}
+    imdb_award:
+      event_id: ev0000003
+      event_year: all
+      category_filter:
+        - best achievement in directing
+        - best director
+        - best director, comedy picture
+        - best director, dramatic picture
+      winning: true
+
+  Golden Globe Winner:
+    variables: {key: golden, weight: 170}
+    template: [name: standard, name: ribbon]
+    imdb_award:
+      event_id: ev0000292
+      event_year: all
+      category_filter:
+        - best animated feature film
+        - best animated film
+        - best foreign film
+        - best foreign language film
+        - best foreign-language foreign film
+        - best motion picture - animated
+        - best motion picture - comedy
+        - best motion picture - comedy or musical
+        - best motion picture - drama
+        - best motion picture - foreign language
+        - best motion picture - musical
+        - best motion picture - musical or comedy
+        - best motion picture - non-english language
+        - best motion picture, musical or comedy
+        - best picture
+      winning: true
+
+  Golden Globe Best Director:
+    variables: {key: golden_director, weight: 160}
+    template: {name: standard, allowed_libraries: movie}
+    imdb_award:
+      event_id: ev0000292
+      event_year: all
+      category_filter:
+        - best director
+        - best director - motion picture
+      winning: true
+
+  BAFTA Winners:
+    variables: {key: bafta, weight: 150}
+    template: {name: standard, allowed_libraries: movie}
+    imdb_award:
+      event_id: ev0000123
+      event_year: all
+      category_filter: best film
+      winning: true
+
+  Cannes Winners:
+    variables: {key: cannes, weight: 140}
+    template: {name: standard, allowed_libraries: movie}
+    imdb_award:
+      event_id: ev0000147
+      event_year: all
+      award_filter: palme d'or
+      winning: true
+
+  Berlinale Winners:
+    variables: {key: berlinale, weight: 130}
+    template: {name: standard, allowed_libraries: movie}
+    imdb_award:
+      event_id: ev0000091
+      event_year: all
+      category_filter: best film
+      winning: true
+
+  Venice Winners:
+    variables: {key: venice, weight: 120}
+    template: {name: standard, allowed_libraries: movie}
+    imdb_award:
+      event_id: ev0000681
+      event_year: all
+      award_filter: golden lion
+      winning: true
+
+  Sundance Winners:
+    variables: {key: sundance, weight: 110}
+    template: {name: standard, allowed_libraries: movie}
+    imdb_award:
+      event_id: ev0000631
+      event_year: all
+      award_filter: grand jury prize
+      winning: true
+
+  Emmys Winner:
+    variables: {key: emmys, weight: 100}
+    template: [name: standard, name: ribbon]
+    imdb_award:
+      event_id: ev0000223
+      event_year: all
+      category_filter:
+        - best comedy series
+        - best comedy show
+        - best dramatic anthology series
+        - best dramatic program
+        - best dramatic series
+        - best dramatic series - less than one hour
+        - best dramatic series - one hour or longer
+        - best series - half hour or less
+        - best series - one hour or more
+        - outstanding animated program
+        - outstanding animated program (for programming less than one hour)
+        - outstanding animated program (for programming more than one hour)
+        - outstanding animated program (for programming one hour or less)
+        - outstanding animated program (for programming one hour or more)
+        - outstanding animated programming
+        - outstanding comedy series
+        - outstanding drama series
+        - outstanding drama series - continuing
+        - outstanding drama/comedy - limited episodes
+        - outstanding dramatic program
+        - outstanding dramatic series
+        - outstanding miniseries
+        - outstanding series - comedy
+        - outstanding series - drama
+      winning: true
+
+  Critics Choice Winners:
+    variables: {key: choice, weight: 90}
+    template: {name: standard, allowed_libraries: movie}
+    imdb_award:
+      event_id: ev0000133
+      event_year: all
+      category_filter: best picture
+      winning: true
+
+  Spirit Winners:
+    variables: {key: spirit, weight: 80}
+    template: {name: standard, allowed_libraries: movie}
+    imdb_award:
+      event_id: ev0000349
+      event_year: all
+      category_filter: best feature
+      winning: true
+
+  Cesar Winners:
+    variables: {key: cesar, weight: 70}
+    template: {name: standard, allowed_libraries: movie}
+    imdb_award:
+      event_id: ev0000157
+      event_year: all
+      category_filter: best film (meilleur film)
+      winning: true
+
+  IMDb Top 250:
+    variables: {key: imdb, weight: 60, imdb_key: top}
+    template: [name: standard, name: ribbon]
+
+  Letterboxd Top 500:
+    variables: {key: letterboxd, weight: 50}
+    template: {name: standard, allowed_libraries: movie}
+    letterboxd_list: https://letterboxd.com/official/list/letterboxds-top-500-films/
+
+  Rotten Tomatoes Verified Hot:
+    variables: {key: rottenverified, weight: 45, mdb_key: verifiedhot}
+    template: [{name: standard, allowed_libraries: movie}, {name: ribbon}]
+
+  Rotten Tomatoes Certified Fresh:
+    variables: {key: rotten, weight: 40, mdb_key: certifiedfresh}
+    template: [name: standard, name: ribbon]
+
+  Metacritic Must See:
+    variables: {key: metacritic, weight: 30, mdb_key: metacriticmustsee}
+    template: [name: standard, name: ribbon]
+
+  Commonsense Selection:
+    variables: {key: common, weight: 20, mdb_key: cssfamilies}
+    template: [name: standard, name: ribbon]
+
+  Razzies Winner:
+    variables: {key: razzie, weight: 10}
+    template: {name: standard, allowed_libraries: movie}
+    imdb_award:
+      event_id: ev0000558
+      event_year: all
+      category_filter: worst picture
+      winning: true

--- a/tests/fixtures/kometa/defaults/overlays/runtimes.yml
+++ b/tests/fixtures/kometa/defaults/overlays/runtimes.yml
@@ -1,0 +1,42 @@
+##############################################################################
+#                              Runtimes Overlay                              #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#          https://kometa.wiki/en/latest/defaults/overlays/runtimes          #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    default:
+      text: "Runtime: "
+      format: "<<runtimeH>>h <<runtimeM>>m"
+      horizontal_align: right
+      vertical_align: bottom
+    conditionals:
+      vertical_offset:
+        default: 15
+        conditions:
+          - vertical_align: center
+            value: 0
+          - vertical_align: top
+            value: 15
+          - vertical_align: bottom
+            value: 30
+      horizontal_offset:
+        default: 15
+        conditions:
+          - horizontal_align: center
+            value: 0
+          - horizontal_align: [left, right]
+            value: 15
+    back_color: "#00000099"
+    back_width: 600
+    back_height: 105
+    final_name: "text(<<text>><<format>>)"
+
+overlays:
+  runtime_info:
+    plex_all: true
+    template:
+      name: standard

--- a/tests/fixtures/kometa/defaults/overlays/status.yml
+++ b/tests/fixtures/kometa/defaults/overlays/status.yml
@@ -1,0 +1,84 @@
+##############################################################################
+#                               Status Overlay                               #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#           https://kometa.wiki/en/latest/defaults/overlays/status           #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    text_<<key>>: <<text>>
+    group: status
+    default:
+      horizontal_align: left
+      vertical_align: top
+    conditionals:
+      vertical_offset:
+        default: 15
+        conditions:
+          - vertical_align.exists: false
+            value: 330
+          - vertical_align: center
+            value: 0
+          - vertical_align: top
+            value: 15
+          - vertical_align: bottom
+            value: 30
+      horizontal_offset:
+        default: 15
+        conditions:
+          - horizontal_align: center
+            value: 0
+          - horizontal_align: [left, right]
+            value: 15
+    font_size: 50
+    back_color: "#00000099"
+    back_width: 305
+    back_height: 105
+    allowed_libraries: show
+    final_name: text(<<text_<<key>>>>)
+
+templates:
+  status:
+    optional:
+      - last
+    conditionals:
+      all:
+        conditions:
+          - key: [ended, returning, canceled]
+            value: true
+      tmdb:
+        conditions:
+          - key: [ended, returning, canceled]
+            value: <<key>>
+      last_days:
+        conditions:
+          - key: airing
+            last.exists: true
+            value: <<last>>
+    ignore_blank_results: true
+    plex_search:
+      any:
+        episode_air_date: <<last_days>>
+    plex_all: <<all>>
+    filters:
+      tmdb_status: <<tmdb>>
+
+overlays:
+
+  airing_shows:
+    variables: {key: airing, weight: 40, text: AIRING, last: 14}
+    template: [name: standard, name: status]
+
+  returning_shows:
+    variables: {key: returning, weight: 30, text: RETURNING}
+    template: [name: standard, name: status]
+
+  canceled_shows:
+    variables: {key: canceled, weight: 20, text: CANCELED}
+    template: [name: standard, name: status]
+
+  ended_shows:
+    variables: {key: ended, weight: 10, text: ENDED}
+    template: [name: standard, name: status]

--- a/tests/fixtures/kometa/defaults/overlays/streaming.yml
+++ b/tests/fixtures/kometa/defaults/overlays/streaming.yml
@@ -1,0 +1,212 @@
+##############################################################################
+#                             Streaming Overlay                              #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#                     Credit to Magic815 for base images                     #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#         https://kometa.wiki/en/latest/defaults/overlays/streaming          #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    group: streaming
+    default:
+      horizontal_align: left
+      vertical_align: bottom
+      style: color
+    conditionals:
+      vertical_offset:
+        default: 15
+        conditions:
+          - vertical_align.exists: false
+            value: 390
+          - vertical_align: center
+            value: 0
+          - vertical_align: top
+            value: 15
+          - vertical_align: bottom
+            value: 30
+      horizontal_offset:
+        default: 15
+        conditions:
+          - horizontal_align: center
+            value: 0
+          - horizontal_align: [left, right]
+            value: 15
+      default:
+        conditions:
+          - file.exists: false
+            file_<<key>>.exists: false
+            url.exists: false
+            url_<<key>>.exists: false
+            git.exists: false
+            git_<<key>>.exists: false
+            repo.exists: false
+            repo_<<key>>.exists: false
+            value: streaming/<<style>>/<<overlay_name>>
+    back_color: "#00000099"
+    back_width: 305
+    back_height: 105
+
+templates:
+  mdb_streaming:
+    default:
+      region: "US"
+      limit: "0"
+      originals_only: false
+      discover_with_<<key>>: <<discover_with>>
+    optional:
+      - use_<<key>>
+      - use_<<tmdb_key>>
+      - allowed_libraries
+      - providers_<<key>>
+    run_definition:
+      - <<use_<<key>>>>
+      - <<use_<<tmdb_key>>>>
+      - <<allowed_libraries>>
+      - <<allowed_streaming>>
+    ignore_blank_results: true
+    conditionals:
+      discover_sort:
+        conditions:
+          - originals_only: false
+            library_type: movie
+            value: popularity.desc
+          - originals_only: false
+            library_type: show
+            value: popularity.desc
+      originals:
+        conditions:
+          - originals_only: true
+            value: originals
+      discover_limit:
+        conditions:
+          - originals_only: false
+            value: 0
+      discover_with:
+        conditions:
+          - originals_only: false
+            value: <<final_tmdb_key>>
+      discover_region:
+        conditions:
+          - originals_only: false
+            value: <<region>>
+      final_tmdb_key:
+        default: <<tmdb_key>>
+        conditions:
+          - region: [CA, AU, NL, ES]
+            tmdb_key: [9]
+            value: 119
+      allowed_streaming:
+        conditions:
+          - originals_only: true
+            tmdb_key: [103, 1759, 41, 2300, 230, 283, 510, 39, 37, 188]
+            value: False
+          - region.not: GB
+            tmdb_key: [103, 41, 2300, 39]
+            value: False
+          - region.not: ES
+            tmdb_key: [149, 339, 2241, 62, 2162, 63]
+            value: False
+          - region.not: CA
+            tmdb_key: [230]
+            value: False
+          - region: CA
+            tmdb_key: [1899]
+            value: False
+    mdblist_list: https://mdblist.com/lists/k0meta/<<key>>-<<originals>>
+    tmdb_discover:
+      limit: <<discover_limit>>
+      with_watch_providers: <<discover_with_<<key>>>>
+      watch_region: <<discover_region>>
+      sort_by: <<discover_sort>>
+
+overlays:
+
+  Netflix:
+    variables: {key: netflix, tmdb_key: 8|175, weight: 160}
+    template: [name: standard, name: mdb_streaming]
+
+  Prime Video:
+    variables: {key: amazon, tmdb_key: 9, weight: 150}
+    template: [name: standard, name: mdb_streaming]
+
+  Disney:
+    variables: {key: disney, tmdb_key: 337|508, weight: 140}
+    template: [name: standard, name: mdb_streaming]
+
+  HBO-Max:
+    variables: {key: hbomax, tmdb_key: 1899, weight: 130}
+    template: [name: standard, name: mdb_streaming]
+
+  Crunchyroll:
+    variables: {key: crunchyroll, tmdb_key: 283, weight: 120, allowed_libraries: show}
+    template: [name: standard, name: mdb_streaming]
+
+  Movistar Plus+:
+    variables: {key: movistar, tmdb_key: 149|339|2241, weight: 115}
+    template: [name: standard, name: mdb_streaming]
+
+  Atres Player:
+    variables: { key: atresplayer, tmdb_key: 62|2162, weight: 113 }
+    template: [ name: standard, name: mdb_streaming ]
+
+  YouTube:
+    variables: {key: youtube, tmdb_key: 188|508|235, weight: 110}
+    template: [name: standard, name: mdb_streaming]
+
+  Hulu:
+    variables: {key: hulu, tmdb_key: 15, weight: 100}
+    template: [name: standard, name: mdb_streaming]
+
+  Paramount+:
+    variables: {key: paramount, tmdb_key: 531|1770, weight: 90}
+    template: [name: standard, name: mdb_streaming]
+
+  AMC+:
+      variables: { key: amc, tmdb_key: 528|1854, weight: 85 }
+      template: [ name: standard, name: mdb_streaming ]
+
+  AppleTV:
+    variables: {key: appletv, tmdb_key: 350, weight: 80}
+    template: [name: standard, name: mdb_streaming]
+
+  Peacock:
+    variables: {key: peacock, tmdb_key: 386|387, weight: 70}
+    template: [name: standard, name: mdb_streaming]
+
+  discovery+:
+    variables: {key: discovery, tmdb_key: 524|584, weight: 58, allowed_libraries: show}
+    template: [name: standard, name: mdb_streaming]
+
+  Crave:
+    variables: {key: crave, tmdb_key: 230, weight: 55}
+    template: [name: standard, name: mdb_streaming]
+
+  NOW:
+    variables: {key: now, tmdb_key: 39, weight: 50}
+    template: [name: standard, name: mdb_streaming]
+
+  Channel 4:
+    variables: {key: channel4, tmdb_key: 103, weight: 40}
+    template: [name: standard, name: mdb_streaming]
+
+  ITVX:
+    variables: {key: itvx, tmdb_key: 41|2300, weight: 30}
+    template: [name: standard, name: mdb_streaming]
+
+  BET+:
+    variables: {key: bet, tmdb_key: 1759, weight: 20}
+    template: [name: standard, name: mdb_streaming]
+
+  hayu:
+    variables: {key: hayu, tmdb_key: 223, weight: 10, allowed_libraries: show}
+    template: [name: standard, name: mdb_streaming]
+
+  tubi:
+    variables: {key: tubi, tmdb_key: 73, weight: 5}
+    template: [name: standard, name: mdb_streaming]
+
+  Filmin:
+    variables: { key: filmin, tmdb_key: 63, weight: 5 }
+    template: [ name: standard, name: mdb_streaming ]

--- a/tests/fixtures/kometa/defaults/overlays/studio.yml
+++ b/tests/fixtures/kometa/defaults/overlays/studio.yml
@@ -1,0 +1,1529 @@
+##############################################################################
+#                               Studio Overlay                               #
+#       Created by Yozora, Bullmoose20, anon_fawkes Arial-Z & Sohjiro        #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#          https://kometa.wiki/en/latest/defaults/overlays/studios           #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    default:
+      width_value: 470
+      height_value: 120
+      key: <<overlay_name>>
+      horizontal_align: left
+      vertical_align: bottom
+      style: standard
+    conditionals:
+      back_height:
+        default: 105
+        conditions:
+          - style: bigger
+            value: <<height_value>>
+      back_width:
+        default: 305
+        conditions:
+          - style: bigger
+            value: <<width_value>>
+      vertical_offset:
+        default: 15
+        conditions:
+          - vertical_align.exists: false
+            value: 150
+          - vertical_align: center
+            value: 0
+          - vertical_align: top
+            value: 15
+          - vertical_align: bottom
+            value: 30
+      horizontal_offset:
+        default: 15
+        conditions:
+          - horizontal_align: center
+            value: 0
+          - horizontal_align: [left, right]
+            value: 15
+      default:
+        conditions:
+          - file.exists: false
+            file_<<key>>.exists: false
+            url.exists: false
+            url_<<key>>.exists: false
+            git.exists: false
+            git_<<key>>.exists: false
+            repo.exists: false
+            repo_<<key>>.exists: false
+            value: studio/<<style>>/<<key>>
+    back_color: "#00000099"
+    back_radius: 30
+
+templates:
+  studios:
+    default:
+      key: <<overlay_name>>
+      search: <<key>>
+    ignore_blank_results: true
+    plex_search:
+      validate: false
+      any:
+        studio.is: <<search>>
+
+overlays:
+#### ANIMES ########################################################################################################
+  8bit:
+    template: [name: standard, {name: studios, search: [8-bit, 8bit]}]
+
+  A-1 Pictures:
+    template: [name: standard, name: studios]
+
+  A.C.G.T.:
+    template: [name: standard, name: studios]
+
+  Acca effe:
+    template: [name: standard, name: studios]
+
+  Actas:
+    template: [name: standard, name: studios]
+
+  AIC:
+    template: [name: standard, {name: studios, search: [AIC, AIC A.S.T.A, AIC ASTA, AIC Build, AAIC PLUS+, AIC RIGHTS, AIC Spirits]}]
+
+  Ajia-Do:
+    template: [name: standard, {name: studios, search: [Ajia-Do, Ajiado]}]
+
+  Akatsuki:
+    template: [name: standard, name: studios]
+
+  Animation Do:
+    template: [name: standard, name: studios]
+
+  Ankama:
+    template: [name: standard, name: studios]
+
+  APPP:
+    template: [name: standard, {name: studios, search: [A.P.P.P., APPP]}]
+
+  Arms:
+    template: [name: standard, name: studios]
+
+  Artland:
+    template: [name: standard, name: studios]
+
+  Artmic:
+    template: [name: standard, name: studios]
+
+  Arvo Animation:
+    template: [name: standard, name: studios]
+
+  Asahi Production:
+    template: [name: standard, name: studios]
+
+  Ashi Productions:
+    template: [name: standard, name: studios]
+
+  asread.:
+    template: [name: standard, {name: studios, search: [asread., Asread]}]
+
+  AtelierPontdarc:
+    template: [name: standard, {name: studios, search: [AtelierPontdarc, Atelier Pontdarc]}]
+
+  B.CMAY PICTURES:
+    template: [name: standard, {name: studios, search: [B.CMAY PICTURES, G.CMay Animation & Film]}]
+
+  Bandai Namco Pictures:
+    template: [name: standard, {name: studios, search: [Bandai Namco Pictures, Bandai Visual, Bandai Visual Company]}]
+
+  Bee Train:
+    template: [name: standard, name: studios]
+
+  Berlanti Productions:
+    template: [name: standard, name: studios]
+
+  Bibury Animation Studios:
+    template: [name: standard, {name: studios, search: [Bibury Animation CG, Bibury Animation Studios]}]
+
+  bilibili:
+    template: [name: standard, name: studios]
+
+  Bones:
+    template: [name: standard, name: studios]
+
+  Brain's Base:
+    template: [name: standard, name: studios]
+
+  Bridge:
+    template: [name: standard, name: studios]
+
+  BUG FILMS:
+    template: [name: standard, name: studios]
+
+  C-Station:
+    template: [name: standard, name: studios]
+
+  C2C:
+    template: [name: standard, name: studios]
+
+  Children's Playground Entertainment:
+    template: [name: standard, name: studios]
+
+  Cloud Hearts:
+    template: [name: standard, {name: studios, search: [Cloud Hearts, CLOUDHEARTS]}]
+
+  CloverWorks:
+    template: [name: standard, name: studios]
+
+  Colored Pencil Animation:
+    template: [name: standard, name: studios]
+
+  CoMix Wave Films:
+    template: [name: standard, {name: studios, search: [CoMix Wave Films, CoMix Wave]}]
+
+  Connect:
+    template: [name: standard, name: studios]
+
+  Craftar Studios:
+    template: [name: standard, {name: studios, search: [Craftar Studios, Craftar]}]
+
+  Creators in Pack:
+    template: [name: standard, name: studios]
+
+  CygamesPictures:
+    template: [name: standard, {name: studios, search: [CygamesPictures, Cygames Pictures]}]
+
+  David Production:
+    template: [name: standard, name: studios]
+
+  Diomedéa:
+    template: [name: standard, name: studios]
+
+  DLE:
+    template: [name: standard, name: studios]
+
+  Doga Kobo:
+    template: [name: standard, name: studios]
+
+  domerica:
+    template: [name: standard, name: studios]
+
+  Drive:
+    template: [name: standard, name: studios]
+
+  EMT Squared:
+    template: [name: standard, {name: studios, search: [EMT Squared, EMT²]}]
+
+  Encourage Films:
+    template: [name: standard, name: studios]
+
+  ENGI:
+    template: [name: standard, name: studios]
+
+  feel.:
+    template: [name: standard, {name: studios, search: [feel., Feel]}]
+
+  Felix Film:
+    template: [name: standard, name: studios]
+
+  Fenz:
+    template: [name: standard, name: studios]
+
+  GAINAX:
+    template: [name: standard, name: studios]
+
+  Gallop:
+    template: [name: standard, {name: studios, search: [Gallop, Studio Gallop]}]
+
+  Geek Toys:
+    template: [name: standard, {name: studios, search: [Geek Toys, GEEKTOYS]}]
+
+  Gekkou:
+    template: [name: standard, {name: studios, search: [Gekkou, GEKKOU Production]}]
+
+  Gemba:
+    template: [name: standard, name: studios]
+
+  GENCO:
+    template: [name: standard, name: studios]
+
+  Geno Studio:
+    template: [name: standard, name: studios]
+
+  GoHands:
+    template: [name: standard, {name: studios, search: [GoHands, Go Hands]}]
+
+  Gonzo:
+    template: [name: standard, {name: studios, search: [Gonzo, Gonzo Digimation]}]
+
+  Graphinica:
+    template: [name: standard, name: studios]
+
+  Group Tac:
+    template: [name: standard, name: studios]
+
+  Hal Film Maker:
+    template: [name: standard, name: studios]
+
+  Haoliners Animation League:
+    template: [name: standard, {name: studios, search: [Haoliners Animation League, Haoliners Huimeng Animation, Haoliners Animation]}]
+
+  Hoods Entertainment:
+    template: [name: standard, name: studios]
+
+  Hotline:
+    template: [name: standard, name: studios]
+
+  J.C.Staff:
+    template: [name: standard, {name: studios, search: [J.C.Staff, J.C. Staff]}]
+
+  Jumondou:
+    template: [name: standard, name: studios]
+
+  Kadokawa:
+    template: [name: standard, name: studios]
+
+  Khara:
+    template: [name: standard, {name: studios, search: [Khara, Studio Khara]}]
+
+  Kinema Citrus:
+    template: [name: standard, name: studios]
+
+  Kyoto Animation:
+    template: [name: standard, name: studios]
+
+  Lan Studio:
+    template: [name: standard, {name: studios, search: [Lan Studio, Studio LAN]}]
+
+  LandQ Studio:
+    template: [name: standard, name: studios]
+
+  Lay-duce:
+    template: [name: standard, name: studios]
+
+  Lerche:
+    template: [name: standard, name: studios]
+
+  LIDENFILMS:
+    template: [name: standard, {name: studios, search: [LIDENFILMS, Liden Films]}]
+
+  M.S.C:
+    template: [name: standard, name: studios]
+
+  Madhouse:
+    template: [name: standard, name: studios]
+
+  Magic Bus:
+    template: [name: standard, name: studios]
+
+  Maho Film:
+    template: [name: standard, name: studios]
+
+  Manglobe:
+    template: [name: standard, name: studios]
+
+  MAPPA:
+    template: [name: standard, name: studios]
+
+  Millepensee:
+    template: [name: standard, name: studios]
+
+  Namu Animation:
+    template: [name: standard, name: studios]
+
+  NAZ:
+    template: [name: standard, name: studios]
+
+  Nexus:
+    template: [name: standard, {name: studios, search: [Nexus, Nexus Factory]}]
+
+  Nippon Animation:
+    template: [name: standard, name: studios]
+
+  Nomad:
+    template: [name: standard, name: studios]
+
+  Nut:
+    template: [name: standard, name: studios]
+
+  Okuruto Noboru:
+    template: [name: standard, name: studios]
+
+  OLM:
+    template: [name: standard, name: studios]
+
+  Orange:
+    template: [name: standard, name: studios]
+
+  Ordet:
+    template: [name: standard, name: studios]
+
+  OZ:
+    template: [name: standard, name: studios]
+
+  P.A. Works:
+    template: [name: standard, {name: studios, search: [P.A. Works, P.A.WORKS]}]
+
+  P.I.C.S.:
+    template: [name: standard, name: studios]
+
+  Passione:
+    template: [name: standard, name: studios]
+
+  Pb Animation Co. Ltd:
+    template: [name: standard, name: studios]
+
+  Pierrot:
+    template: [name: standard, {name: studios, search: [Pierrot, Pierrot Plus, Studio Pierrot]}]
+
+  Pine Jam:
+    template: [name: standard, name: studios]
+
+  Platinum Vision:
+    template: [name: standard, {name: studios, search: [Platinum Vision, PlatinumVision]}]
+
+  Polygon Pictures:
+    template: [name: standard, name: studios]
+
+  Pony Canyon:
+    template: [name: standard, name: studios]
+
+  Production +h.:
+    template: [name: standard, {name: studios, search: [Production +h., Production +h]}]
+
+  Production I.G:
+    template: [name: standard, name: studios]
+
+  Production IMS:
+    template: [name: standard, name: studios]
+
+  Production Reed:
+    template: [name: standard, name: studios]
+
+  Project No.9:
+    template: [name: standard, name: studios]
+
+  Quad:
+    template: [name: standard, name: studios]
+
+  Radix:
+    template: [name: standard, name: studios]
+
+  Revoroot:
+    template: [name: standard, name: studios]
+
+  Saetta:
+    template: [name: standard, name: studios]
+
+  SANZIGEN:
+    template: [name: standard, name: studios]
+
+  Satelight:
+    template: [name: standard, name: studios]
+
+  Science SARU:
+    template: [name: standard, {name: studios, search: [Science SARU, Science Saru]}]
+
+  Sentai Filmworks:
+    template: [name: standard, name: studios]
+
+  Seven Arcs:
+    template: [name: standard, {name: studios, search: [Seven, Seven Arcs, Seven Arcs Pictures]}]
+
+  Shaft:
+    template: [name: standard, name: studios]
+
+  Shin-Ei Animation:
+    template: [name: standard, name: studios]
+
+  Shogakukan:
+    template: [name: standard, {name: studios, search: [Shogakukan, Shogakukan Production]}]
+
+  Shuka:
+    template: [name: standard, name: studios]
+
+  Signal.MD:
+    template: [name: standard, {name: studios, search: [Signal.MD, Signal MD]}]
+
+  Silver:
+    template: [name: standard, {name: studios, search: [Silver, Studio Silver]}]
+
+  SILVER LINK.:
+    template: [name: standard, {name: studios, search: [SILVER LINK., Silver Link]}]
+
+  Square Enix:
+    template: [name: standard, name: studios]
+
+  Staple Entertainment:
+    template: [name: standard, name: studios]
+
+  Studio 3Hz:
+    template: [name: standard, name: studios]
+
+  Studio A-CAT:
+    template: [name: standard, name: studios]
+
+  Studio Bind:
+    template: [name: standard, name: studios]
+
+  Studio Blanc.:
+    template: [name: standard, {name: studios, search: [Studio Blanc., Studio Blanc]}]
+
+  Studio Chizu:
+    template: [name: standard, name: studios]
+
+  Studio Comet:
+    template: [name: standard, name: studios]
+
+  Studio Deen:
+    template: [name: standard, {name: studios, search: [Studio Deen, Studio DEEN]}]
+
+  Studio Elle:
+    template: [name: standard, name: studios]
+
+  Studio Ghibli:
+    template: [name: standard, name: studios]
+
+  Studio Flad:
+    template: [name: standard, name: studios]
+
+  Studio Gokumi:
+    template: [name: standard, name: studios]
+
+  Studio Guts:
+    template: [name: standard, name: studios]
+
+  Studio Hibari:
+    template: [name: standard, name: studios]
+
+  Studio Kafka:
+    template: [name: standard, name: studios]
+
+  Studio Kai:
+    template: [name: standard, name: studios]
+
+  Studio Mir:
+    template: [name: standard, name: studios]
+
+  studio MOTHER:
+    template: [name: standard, name: studios]
+
+  Studio Palette:
+    template: [name: standard, name: studios]
+
+  Studio Rikka:
+    template: [name: standard, name: studios]
+
+  Studio Signpost:
+    template: [name: standard, name: studios]
+
+  Studio VOLN:
+    template: [name: standard, name: studios]
+
+  STUDIO4°C:
+    template: [name: standard, name: studios]
+
+  Sunrise Beyond:
+    template: [name: standard, name: studios]
+
+  Sunrise:
+    template: [name: standard, name: studios]
+
+  SynergySP:
+    template: [name: standard, name: studios]
+
+  Tatsunoko Production:
+    template: [name: standard, name: studios]
+
+  Telecom Animation Film:
+    template: [name: standard, name: studios]
+
+  Tezuka Productions:
+    template: [name: standard, name: studios]
+
+  TMS Entertainment:
+    template: [name: standard, {name: studios, search: [TMS Entertainment, Tokyo Movie Shinsha]}]
+
+  TNK:
+    template: [name: standard, name: studios]
+
+  Toei Animation:
+    template: [name: standard, {name: studios, search: [Toei Animation, Toei]}]
+
+  Topcraft:
+    template: [name: standard, name: studios]
+
+  Triangle Staff:
+    template: [name: standard, name: studios]
+
+  Trigger:
+    template: [name: standard, name: studios]
+
+  TROYCA:
+    template: [name: standard, name: studios]
+
+  TYO Animations:
+    template: [name: standard, name: studios]
+
+  Typhoon Graphics:
+    template: [name: standard, name: studios]
+
+  ufotable:
+    template: [name: standard, name: studios]
+
+  V1 Studio:
+    template: [name: standard, name: studios]
+
+  W-Toon Studio:
+    template: [name: standard, name: studios]
+
+  Wawayu Animation:
+    template: [name: standard, name: studios]
+
+  White Fox:
+    template: [name: standard, name: studios]
+
+  Wit Studio:
+    template: [name: standard, name: studios]
+
+  Wolfsbane:
+    template: [name: standard, name: studios]
+
+  Xebec:
+    template: [name: standard, name: studios]
+
+  Yokohama Animation Lab:
+    template: [name: standard, {name: studios, search: [Yokohama Animation Lab, Yokohama Animation Laboratory]}]
+
+  Yostar Pictures:
+    template: [name: standard, name: studios]
+
+  Yumeta Company:
+    template: [name: standard, name: studios]
+
+  Zero-G:
+    template: [name: standard, name: studios]
+
+  Zexcs:
+    template: [name: standard, name: studios]
+
+
+#### MOVIES & TV SHOWS ###############################################################################################
+  3 Arts Entertainment:
+    template: [name: standard, name: studios]
+
+  6th & Idaho:
+    template: [name: standard, name: studios]
+
+  20th Century Animation:
+    template: [name: standard, name: studios]
+
+  20th Century Studios:
+    template: [name: standard, {name: studios, search: [20th Century, 20th Century Fox, 20th Century Studios]}]
+
+  20th Century Fox Television:
+    template: [name: standard, name: studios]
+
+  21 Laps Entertainment:
+    template: [name: standard, name: studios]
+
+  87Eleven:
+    template: [name: standard, name: studios]
+
+  87North Productions:
+    template: [name: standard, name: studios]
+
+  101 Studios:
+    template: [name: standard, name: studios]
+
+  1492 Pictures:
+    template: [name: standard, name: studios]
+
+  A Bigger Boat:
+    template: [name: standard, name: studios]
+
+  A+E Studios:
+    template: [name: standard, name: studios]
+
+  A24:
+    template: [name: standard, name: studios]
+
+  Aardman:
+    template: [name: standard, name: studios]
+
+  Aamir Khan Productions:
+    template: [name: standard, name: studios]
+
+  ABC Signature:
+    template: [name: standard, name: studios]
+
+  ABC Studios:
+    template: [name: standard, name: studios]
+
+  Ace Entertainment:
+    template: [name: standard, name: studios]
+
+  AGBO:
+    template: [name: standard, name: studios]
+
+  Amazon Studios:
+    template: [name: standard, {name: studios, search: [Amazon, Amazon Studios, Prime Video]}]
+
+  Amblin Entertainment:
+    template: [name: standard, {name: studios, search: [Amblin Entertainment, Amblin Television]}]
+
+  AMC Studios:
+    template: [name: standard, name: studios]
+
+  Anima Sola Productions:
+    template: [name: standard, name: studios]
+
+  Annapurna Pictures:
+    template: [name: standard, name: studios]
+
+  Ardustry Entertainment:
+    template: [name: standard, name: studios]
+
+  Artisan Entertainment:
+    template: [name: standard, name: studios]
+
+  Artists First:
+    template: [name: standard, name: studios]
+
+  Atlas Entertainment:
+    template: [name: standard, name: studios]
+
+  Atresmedia:
+    template: [name: standard, name: studios]
+
+  Bad Hat Harry Productions:
+    template: [name: standard, name: studios]
+
+  Bad Robot:
+    template: [name: standard, name: studios]
+
+  Bad Wolf:
+    template: [name: standard, name: studios]
+
+  Barunson E&A:
+    template: [name: standard, name: studios]
+
+  Bakken Record:
+    template: [name: standard, name: studios]
+
+  Bardel Entertainment:
+    template: [name: standard, name: studios]
+
+  BBC Studios:
+    template: [name: standard, {name: studios, search: [BBC, BBC Film, BBC Studios, BBC Studios Natural History Unit]}]
+
+  Bill Melendez Productions:
+    template: [name: standard, name: studios]
+
+  Blade:
+    template: [name: standard, name: studios]
+
+  Bleecker Street:
+    template: [name: standard, name: studios]
+
+  Blown Deadline Productions:
+    template: [name: standard, name: studios]
+
+  Blue Ice Pictures:
+    template: [name: standard, name: studios]
+
+  Blue Sky Studios:
+    template: [name: standard, {name: studios, search: [Blue Sky Films, Blue Sky Studios]}]
+
+  Bluegrass Films:
+    template: [name: standard, name: studios]
+
+  Blueprint Pictures:
+    template: [name: standard, name: studios]
+
+  Blumhouse Productions:
+    template: [name: standard, name: studios]
+
+  Blur Studio:
+    template: [name: standard, name: studios]
+
+  Bold Films:
+    template: [name: standard, name: studios]
+
+  Bona Film Group:
+    template: [name: standard, name: studios]
+
+  Bonanza Productions:
+    template: [name: standard, name: studios]
+
+  Boo Pictures:
+    template: [name: standard, name: studios]
+
+  Bosque Ranch Productions:
+    template: [name: standard, name: studios]
+
+  Box to Box Films:
+    template: [name: standard, name: studios]
+
+  Brandywine Productions:
+    template: [name: standard, name: studios]
+
+  Broken Lizard Industries:
+    template: [name: standard, name: studios]
+
+  Broken Road Productions:
+    template: [name: standard, name: studios]
+
+  Calt Production:
+    template: [name: standard, name: studios]
+
+  Canal+:
+    template: [name: standard, {name: studios, search: [Canal+, Canal+ Polska]}]
+
+  Carnival Films:
+    template: [name: standard, name: studios]
+
+  Carolco:
+    template: [name: standard, name: studios]
+
+  Cartoon Saloon:
+    template: [name: standard, name: studios]
+
+  Carsey-Werner Company:
+    template: [name: standard, name: studios]
+
+  Castle Rock Entertainment:
+    template: [name: standard, name: studios]
+
+  CBS Productions:
+    template: [name: standard, name: studios]
+
+  CBS Studios:
+    template: [name: standard, name: studios]
+
+  CBS Television Studios:
+    template: [name: standard, name: studios]
+
+  Centropolis Entertainment:
+    template: [name: standard, name: studios]
+
+  Chernin Entertainment:
+    template: [name: standard, name: studios]
+
+  Chimp Television:
+    template: [name: standard, name: studios]
+
+  Chris Morgan Productions:
+    template: [name: standard, name: studios]
+
+  Cinergi Pictures Entertainment:
+    template: [name: standard, name: studios]
+
+  Codeblack Entertainment:
+    template: [name: standard, name: studios]
+
+  Columbia Pictures:
+    template: [name: standard, {name: studios, search: [Columbia Pictures, Columbia TriStar]}]
+
+  Constantin Film:
+    template: [name: standard, name: studios]
+
+  Cowboy Films:
+    template: [name: standard, name: studios]
+
+  Cross Creek Pictures:
+    template: [name: standard, name: studios]
+
+  Dark Horse Entertainment:
+    template: [name: standard, name: studios]
+
+  Davis Entertainment:
+    template: [name: standard, name: studios]
+
+  DC Comics:
+    template: [name: standard, {name: studios, search: [DC Comics, DC Films, DC Entertainment]}]
+
+  Dimension Films:
+    template: [name: standard, name: studios]
+
+  Dino De Laurentiis Company:
+    template: [name: standard, name: studios]
+
+  Disney Television Animation:
+    template: [name: standard, name: studios]
+
+  DisneyToon Studios:
+    template: [name: standard, name: studios]
+
+  Don Simpson Jerry Bruckheimer Films:
+    template: [name: standard, name: studios]
+
+  Doozer:
+    template: [name: standard, name: studios]
+
+  Dreams Salon Entertainment Culture:
+    template: [name: standard, name: studios]
+
+  DreamWorks Studios:
+    template: [name: standard, {name: studios, search: [DreamWorks Studios, DreamWorks, DreamWorks Animation, DreamWorks Animation Television, DreamWorks Classics]}]
+
+  DreamWorks Pictures:
+    template: [name: standard, name: studios]
+
+  Dynamic Planning:
+    template: [name: standard, name: studios]
+
+  Eleventh Hour Films:
+    template: [name: standard, name: studios]
+
+  EMJAG Productions:
+    template: [name: standard, name: studios]
+
+  Endeavor Content:
+    template: [name: standard, name: studios]
+
+  Entertainment 360:
+    template: [name: standard, name: studios]
+
+  Entertainment One:
+    template: [name: standard, name: studios]
+
+  Eon Productions:
+    template: [name: standard, name: studios]
+
+  Everest Entertainment:
+    template: [name: standard, name: studios]
+
+  Expectation Entertainment:
+    template: [name: standard, name: studios]
+
+  Exposure Labs:
+    template: [name: standard, name: studios]
+
+  Fandango:
+    template: [name: standard, name: studios]
+
+  Fields Entertainment:
+    template: [name: standard, name: studios]
+
+  Film4 Productions:
+    template: [name: standard, name: studios]
+
+  FilmDistrict:
+    template: [name: standard, name: studios]
+
+  FilmNation Entertainment:
+    template: [name: standard, name: studios]
+
+  Flynn Picture Company:
+    template: [name: standard, name: studios]
+
+  Focus Features:
+    template: [name: standard, name: studios]
+
+  Food Network:
+    template: [name: standard, name: studios]
+
+  Fortiche Production:
+    template: [name: standard, name: studios]
+
+  Fox Television Studios:
+    template: [name: standard, name: studios]
+
+  Freckle Films:
+    template: [name: standard, name: studios]
+
+  Frederator Studios:
+    template: [name: standard, name: studios]
+
+  FremantleMedia:
+    template: [name: standard, name: studios]
+
+  Fuqua Films:
+    template: [name: standard, name: studios]
+
+  Gallagher Films Ltd:
+    template: [name: standard, name: studios]
+
+  Gary Sanchez Productions:
+    template: [name: standard, name: studios]
+
+  Gaumont:
+    template: [name: standard, {name: studios, search: [Gaumont, Gaumont International Television]}]
+
+  Generator Entertainment:
+    template: [name: standard, name: studios]
+
+  Golden Harvest:
+    template: [name: standard, name: studios]
+
+  Gracie Films:
+    template: [name: standard, name: studios]
+
+  Green Hat Films:
+    template: [name: standard, name: studios]
+
+  Grindstone Entertainment Group:
+    template: [name: standard, name: studios]
+
+  Hallmark:
+    template: [name: standard, {name: studios, search: [Hallmark Channel, Hallmark+, Hallmark Entertainment, Hallmark Media, Hallmark Movies & Mysteries, The Hallmark Channel]}]
+
+  HandMade Films:
+    template: [name: standard, name: studios]
+
+  Happy Madison Productions:
+    template: [name: standard, name: studios]
+
+  HartBeat Productions:
+    template: [name: standard, name: studios]
+
+  Hartswood Films:
+    template: [name: standard, name: studios]
+
+  Hasbro:
+    template: [name: standard, name: studios]
+
+  HBO:
+    template: [name: standard, name: studios]
+
+  Heyday Films:
+    template: [name: standard, name: studios]
+
+  Hughes Entertainment:
+    template: [name: standard, name: studios]
+
+  Hungry Man:
+    template: [name: standard, name: studios]
+
+  Hurwitz & Schlossberg Productions:
+    template: [name: standard, name: studios]
+
+  Hyperobject Industries:
+    template: [name: standard, name: studios]
+
+  Icon Entertainment International:
+    template: [name: standard, name: studios]
+
+  IFC Films:
+    template: [name: standard, name: studios]
+
+  Illumination Entertainment:
+    template: [name: standard, {name: studios, search: [Illumination, Illumination Entertainment, Illumination Films]}]
+
+  Imagin:
+    template: [name: standard, name: studios]
+
+  Imperative Entertainment:
+    template: [name: standard, name: studios]
+
+  Impossible Factual:
+    template: [name: standard, name: studios]
+
+  Ingenious Media:
+    template: [name: standard, name: studios]
+
+  Irwin Entertainment:
+    template: [name: standard, name: studios]
+
+  Jerry Bruckheimer Films:
+    template: [name: standard, name: studios]
+
+  Jessie Films:
+    template: [name: standard, name: studios]
+
+  Jinks-Cohen Company:
+    template: [name: standard, name: studios]
+
+  Kazak Productions:
+    template: [name: standard, name: studios]
+
+  Kennedy Miller Productions:
+    template: [name: standard, name: studios]
+
+  Kilter Films:
+    template: [name: standard, name: studios]
+
+  Kjam Media:
+    template: [name: standard, name: studios]
+
+  Kudos:
+    template: [name: standard, name: studios]
+
+  Kurtzman Orci:
+    template: [name: standard, name: studios]
+
+  Laika Entertainment:
+    template: [name: standard, name: studios]
+
+  Landscape Entertainment:
+    template: [name: standard, name: studios]
+
+  Laura Ziskin Productions:
+    template: [name: standard, name: studios]
+
+  Leftfield Pictures:
+    template: [name: standard, name: studios]
+
+  Legendary Pictures:
+    template: [name: standard, {name: studios, search: [Legendary Pictures, Legendary Television]}]
+
+  Let's Not Turn This Into a Whole Big Production:
+    template: [name: standard, name: studios]
+
+  Lifetime:
+    template: [name: standard, name: studios]
+
+  Levity Entertainment Group:
+    template: [name: standard, name: studios]
+
+  Lightstorm Entertainment:
+    template: [name: standard, name: studios]
+
+  Likely Story:
+    template: [name: standard, name: studios]
+
+  Lionsgate:
+    template: [name: standard, name: studios]
+
+  Live Entertainment:
+    template: [name: standard, name: studios]
+
+  Lord Miller Productions:
+    template: [name: standard, name: studios]
+
+  Lucasfilm Ltd:
+    template: [name: standard, {name: studios, search: [Lucasfilm Ltd, Lucasfilm Ltd., Lucasfilm, Lucasfilm Animation]}]
+
+  Magic Light Pictures:
+    template: [name: standard, name: studios]
+
+  Magnolia Pictures:
+    template: [name: standard, name: studios]
+
+  Malevolent Films:
+    template: [name: standard, name: studios]
+
+  Mandalay Entertainment:
+    template: [name: standard, name: studios]
+
+  Mandarin:
+    template: [name: standard, {name: studios, search: [Mandarin, Mandarin Films, Mandarin Television]}]
+
+  Mandarin Motion Pictures Limited:
+    template: [name: standard, name: studios]
+
+  Marv Films:
+    template: [name: standard, name: studios]
+
+  Marvel Animation:
+    template: [name: standard, name: studios]
+
+  Marvel Studios:
+    template: [name: standard, {name: studios, search: [Marvel Studios, Marvel Enterprises, Marvel Entertainment, Marvel]}]
+
+  Matt Tolmach Productions:
+    template: [name: standard, name: studios]
+
+  Max:
+    template: [name: standard, {name: studios, search: [HBO Max]}]
+
+  Maximum Effort:
+    template: [name: standard, name: studios]
+
+  Media Res:
+    template: [name: standard, name: studios]
+
+  Metro-Goldwyn-Mayer:
+    template: [name: standard, {name: studios, search: [Metro-Goldwyn-Mayer, MGM]}]
+
+  Michael Patrick King Productions:
+    template: [name: standard, name: studios]
+
+  Millennium Films:
+    template: [name: standard, name: studios]
+
+  Miramax:
+    template: [name: standard, name: studios]
+
+  NEON:
+    template: [name: standard, name: studios]
+
+  Netflix:
+    template: [name: standard, name: studios]
+
+  New Line Cinema:
+    template: [name: standard, {name: studios, search: [New Line Cinema, New Line]}]
+
+  Nickelodeon Animation Studio:
+    template: [name: standard, name: studios]
+
+  NorthSouth Productions:
+    template: [name: standard, name: studios]
+
+  Nu Boyana Film Studios:
+    template: [name: standard, name: studios]
+
+  O2 Filmes:
+    template: [name: standard, name: studios]
+
+  Open Road Films:
+    template: [name: standard, name: studios]
+
+  Original Film:
+    template: [name: standard, name: studios]
+
+  Orion Pictures:
+    template: [name: standard, name: studios]
+
+  Palomar:
+    template: [name: standard, name: studios]
+
+  Paramount Animation:
+    template: [name: standard, name: studios]
+
+  Paramount Pictures:
+    template: [name: standard, {name: studios, search: [Paramount Pictures, Paramount]}]
+
+  Paramount Television Studios:
+    template: [name: standard, name: studios]
+
+  Participant:
+    template: [name: standard, name: studios]
+
+  Phoenix Pictures:
+    template: [name: standard, name: studios]
+
+  Piki Films:
+    template: [name: standard, name: studios]
+
+  Pixar:
+    template: [name: standard, {name: studios, search: [Pixar, Pixar Animation Studios]}]
+
+  Plan B Entertainment:
+    template: [name: standard, {name: studios, search: [Plan B Entertainment, PlanB Entertainment]}]
+
+  PlayStation Productions:
+    template: [name: standard, name: studios]
+
+  Playtone:
+    template: [name: standard, name: studios]
+
+  Plum Pictures:
+    template: [name: standard, name: studios]
+
+  Powerhouse Animation Studios:
+    template: [name: standard, name: studios]
+
+  PRA:
+    template: [name: standard, name: studios]
+
+  Prescience:
+    template: [name: standard, name: studios]
+
+  Prospect Park:
+    template: [name: standard, name: studios]
+
+  Pulse Films:
+    template: [name: standard, name: studios]
+
+  Radar Pictures:
+    template: [name: standard, name: studios]
+
+  RadicalMedia:
+    template: [name: standard, name: studios]
+
+  Railsplitter Pictures:
+    template: [name: standard, name: studios]
+
+  Rankin Bass Productions:
+    template: [name: standard, {name: studios, search: [Rankin/Bass Productions, Videocraft International]}]
+
+  RatPac Entertainment:
+    template: [name: standard, {name: studios, search: [Dune Entertainment, RatPac Entertainment]}]
+
+  Red Dog Culture House:
+    template: [name: standard, name: studios]
+
+  Regency Pictures:
+    template: [name: standard, {name: studios, search: [Monarchy Enterprises S.a.r.l., New Regency Pictures, New Regency Productions, Regency Enterprises, Regency Pictures]}]
+
+  Reveille Productions:
+    template: [name: standard, name: studios]
+
+  Rip Cord Productions:
+    template: [name: standard, name: studios]
+
+  RocketScience:
+    template: [name: standard, name: studios]
+
+  Savoy Pictures:
+    template: [name: standard, name: studios]
+
+  Scenic Labs:
+    template: [name: standard, name: studios]
+
+  Scion Films:
+    template: [name: standard, name: studios]
+
+  Scott Free Productions:
+    template: [name: standard, name: studios]
+
+  Sculptor Media:
+    template: [name: standard, name: studios]
+
+  Screen Gems:
+    template: [name: standard, name: studios]
+
+  Sean Daniel Company:
+    template: [name: standard, name: studios]
+
+  Searchlight Pictures:
+    template: [name: standard, {name: studios, search: [Searchlight Pictures, Fox Searchlight Pictures]}]
+
+  Secret Hideout:
+    template: [name: standard, name: studios]
+
+  See-Saw Films:
+    template: [name: standard, name: studios]
+
+  Serendipity Pictures:
+    template: [name: standard, name: studios]
+
+  Shaw Brothers:
+    template: [name: standard, name: studios]
+
+  Show East:
+    template: [name: standard, name: studios]
+
+  Showtime Networks:
+    template: [name: standard, name: studios]
+
+  Sil-Metropole Organisation:
+    template: [name: standard, name: studios]
+
+  Silverback Films:
+    template: [name: standard, name: studios]
+
+  Siren Pictures:
+    template: [name: standard, name: studios]
+
+  SISTER:
+    template: [name: standard, name: studios]
+
+  Sixteen String Jack Productions:
+    template: [name: standard, name: studios]
+
+  SKA Films:
+    template: [name: standard, name: studios]
+
+  Sky studios:
+    template: [name: standard, {name: studios, search: [British Sky Broadcasting, British Sky Broadcasting(BSkyB)]}]
+
+  Skydance:
+    template: [name: standard, {name: studios, search: [Skydance, Skydance Media]}]
+
+  Sony Pictures Animation:
+    template: [name: standard, name: studios]
+
+  Sony Pictures:
+    template: [name: standard, {name: studios, search: [Sony, Sony Pictures, Sony Pictures Animation, Sony Pictures Television Studios]}]
+
+  Sphère Média Plus:
+    template: [name: standard, name: studios]
+
+  Spyglass Entertainment:
+    template: [name: standard, name: studios]
+
+  Stöð 2:
+    template: [name: standard, name: studios]
+
+  Star Thrower Entertainment:
+    template: [name: standard, name: studios]
+
+  Stark Raving Black Productions:
+    template: [name: standard, name: studios]
+
+  StudioCanal:
+    template: [name: standard, name: studios]
+
+  Studio 8:
+    template: [name: standard, name: studios]
+
+  Studio Babelsberg:
+    template: [name: standard, name: studios]
+
+  Studio Dragon:
+    template: [name: standard, name: studios]
+
+  Studio Live:
+    template: [name: standard, name: studios]
+
+  STX Entertainment:
+    template: [name: standard, {name: studios, search: [STX Entertainment, STX Films]}]
+
+  Summit Entertainment:
+    template: [name: standard, name: studios]
+
+  Syfy:
+    template: [name: standard, name: studios]
+
+  Syncopy:
+    template: [name: standard, name: studios]
+
+  T-Street Productions:
+    template: [name: standard, name: studios]
+
+  Tall Ship Productions:
+    template: [name: standard, name: studios]
+
+  Team Downey:
+    template: [name: standard, name: studios]
+
+  Temple Street Productions:
+    template: [name: standard, name: studios]
+
+  The Cat in the Hat Productions:
+    template: [name: standard, name: studios]
+
+  The Donners' Company:
+    template: [name: standard, name: studios]
+
+  The Jim Henson Company:
+    template: [name: standard, name: studios]
+
+  The Kennedy-Marshall Company:
+    template: [name: standard, {name: studios, search: [The Kennedy-Marshall Company, The Kennedy/Marshall Company]}]
+
+  The Linson Company:
+    template: [name: standard, name: studios]
+
+  The Littlefield Company:
+    template: [name: standard, name: studios]
+
+  The Mark Gordon Company:
+    template: [name: standard, {name: studios, search: [Gordon Company, The Mark Gordon Company, Tiger Aspect Productions]}]
+
+  The Sea Change Project:
+    template: [name: standard, name: studios]
+
+  The Stone Quarry:
+    template: [name: standard, name: studios]
+
+  The Weinstein Company:
+    template: [name: standard, name: studios]
+
+  Tim Burton Productions:
+    template: [name: standard, name: studios]
+
+  TOHO:
+    template: [name: standard, {name: studios, search: [TOHO, Toho Pictures, "Toho Pictures, Inc."]}]
+
+  Thunder Road:
+    template: [name: standard, name: studios]
+
+  Titmouse:
+    template: [name: standard, name: studios]
+
+  Tomorrow Studios:
+    template: [name: standard, name: studios]
+
+  Touchstone Pictures:
+    template: [name: standard, name: studios]
+
+  Touchstone Television:
+    template: [name: standard, name: studios]
+
+  Trademark Films:
+    template: [name: standard, name: studios]
+
+  Triage Entertainment:
+    template: [name: standard, name: studios]
+
+  Tribeca Productions:
+    template: [name: standard, name: studios]
+
+  TriStar Pictures:
+    template: [name: standard, {name: studios, search: [TriStar, TriStar Pictures]}]
+
+  TSG Entertainment:
+    template: [name: standard, name: studios]
+
+  Twisted Pictures:
+    template: [name: standard, name: studios]
+
+  UCP:
+    template: [name: standard, name: studios]
+
+  United Artists:
+    template: [name: standard, name: studios]
+
+  Universal Animation Studios:
+    template: [name: standard, name: studios]
+
+  Universal Pictures:
+    template: [name: standard, {name: studios, search: [Universal, Universal Animation Studios, Universal Pictures]}]
+
+  Universal Television:
+    template: [name: standard, name: studios]
+
+  Vancouver Media:
+    template: [name: standard, name: studios]
+
+  Vertigo Entertainment:
+    template: [name: standard, name: studios]
+
+  Village Roadshow Pictures:
+    template: [name: standard, name: studios]
+
+  W. Chump and Sons:
+    template: [name: standard, name: studios]
+
+  Walden Media:
+    template: [name: standard, name: studios]
+
+  Walt Disney Animation Studios:
+    template: [name: standard, name: studios]
+
+  Walt Disney Pictures:
+    template: [name: standard, {name: studios, search: [Disney+, Disney, Walt Disney Pictures]}]
+
+  Walt Disney Productions:
+    template: [name: standard, name: studios]
+
+  Warner Animation Group:
+    template: [name: standard, {name: studios, search: [Warner Animation Group, Warner Bros. Cartoon Studios, Warner Animation]}]
+
+  Warner Bros. Pictures:
+    template: [name: standard, {name: studios, search: [Warner, Warner Bros. Pictures]}]
+
+  Warner Bros. Television:
+    template: [name: standard, name: studios]
+
+  Warner Premiere:
+    template: [name: standard, name: studios]
+
+  warparty:
+    template: [name: standard, name: studios]
+
+  Waverly Films:
+    template: [name: standard, name: studios]
+
+  Wayfare Entertainment:
+    template: [name: standard, name: studios]
+
+  Williams Street:
+    template: [name: standard, name: studios]
+
+  Whitaker Entertainment:
+    template: [name: standard, name: studios]
+
+  Wiedemann & Berg Television:
+    template: [name: standard, name: studios]
+
+  Winkler Films:
+    template: [name: standard, name: studios]
+
+  Wolf Entertainment:
+    template: [name: standard, name: studios]
+
+  Working Title Films:
+    template: [name: standard, name: studios]

--- a/tests/fixtures/kometa/defaults/overlays/templates.yml
+++ b/tests/fixtures/kometa/defaults/overlays/templates.yml
@@ -1,0 +1,117 @@
+templates:
+
+  standard:
+    default:
+      font: fonts/Inter-Medium.ttf
+      font_size: 55
+      font_color: "#FFFFFF"
+      back_radius: 30
+      weight_<<key>>: <<weight>>
+      file_<<key>>: <<file>>
+      url_<<key>>: <<url>>
+      git_<<key>>: <<git>>
+      repo_<<key>>: <<repo>>
+      default: <<pmm>>
+      pmm_<<key>>: <<default>>
+      default_<<key>>: <<pmm_<<key>>>>
+      font_<<key>>: <<font>>
+      font_size_<<key>>: <<font_size>>
+      font_color_<<key>>: <<font_color>>
+      font_style_<<key>>: <<font_style>>
+      final_horizontal_offset: <<horizontal_offset>>
+      horizontal_offset_<<key>>: <<final_horizontal_offset>>
+      horizontal_align_<<key>>: <<horizontal_align>>
+      final_vertical_offset: <<vertical_offset>>
+      vertical_offset_<<key>>: <<final_vertical_offset>>
+      vertical_align_<<key>>: <<vertical_align>>
+      stroke_width_<<key>>: <<stroke_width>>
+      stroke_color_<<key>>: <<stroke_color>>
+      back_color_<<key>>: <<back_color>>
+      back_width_<<key>>: <<back_width>>
+      back_height_<<key>>: <<back_height>>
+      back_align_<<key>>: <<back_align>>
+      back_radius_<<key>>: <<back_radius>>
+      back_padding_<<key>>: <<back_padding>>
+      back_line_color_<<key>>: <<back_line_color>>
+      back_line_width_<<key>>: <<back_line_width>>
+      scale_width_<<key>>: <<scale_width>>
+      scale_height_<<key>>: <<scale_height>>
+      final_name: <<overlay_name>>
+      builder_level: <<overlay_level>>
+    optional:
+      - overlay_level
+      - use_<<key>>
+      - use_<<alt>>
+      - allowed_libraries
+      - suppress_overlays
+      - file
+      - url
+      - git
+      - repo
+      - pmm
+      - group
+      - queue
+      - weight
+      - font_style
+      - horizontal_offset
+      - horizontal_align
+      - vertical_offset
+      - vertical_align
+      - stroke_width
+      - stroke_color
+      - back_color
+      - back_width
+      - back_height
+      - back_align
+      - back_padding
+      - back_line_color
+      - back_line_width
+      - addon_offset
+      - addon_position
+      - scale_width
+      - scale_height
+    conditionals:
+      final_use:
+        conditions:
+          - use_<<key>>.exists: true
+            value: <<use_<<key>>>>
+          - use_all: false
+            value: false
+    builder_level: <<builder_level>>
+    run_definition:
+      - <<final_use>>
+      - <<use_<<alt>>>>
+      - <<allowed_libraries>>
+    suppress_overlays: <<suppress_overlays>>
+    overlay:
+      name: <<final_name>>
+      file: <<file_<<key>>>>
+      url: <<url_<<key>>>>
+      git: <<git_<<key>>>>
+      repo: <<repo_<<key>>>>
+      default: <<default_<<key>>>>
+      group: <<group>>
+      queue: <<queue>>
+      weight: <<weight_<<key>>>>
+      horizontal_offset: <<horizontal_offset_<<key>>>>
+      horizontal_align: <<horizontal_align_<<key>>>>
+      vertical_offset: <<vertical_offset_<<key>>>>
+      vertical_align: <<vertical_align_<<key>>>>
+      font: <<font_<<key>>>>
+      font_style: <<font_style_<<key>>>>
+      font_size: <<font_size_<<key>>>>
+      font_color: <<font_color_<<key>>>>
+      stroke_width: <<stroke_width_<<key>>>>
+      stroke_color: <<stroke_color_<<key>>>>
+      back_color: <<back_color_<<key>>>>
+      back_width: <<back_width_<<key>>>>
+      back_height: <<back_height_<<key>>>>
+      back_align: <<back_align_<<key>>>>
+      back_padding: <<back_padding_<<key>>>>
+      back_radius: <<back_radius_<<key>>>>
+      back_line_color: <<back_line_color_<<key>>>>
+      back_line_width: <<back_line_width_<<key>>>>
+      addon_offset: <<addon_offset>>
+      addon_position: <<addon_position>>
+      scale_width: <<scale_width_<<key>>>>
+      scale_height: <<scale_height_<<key>>>>

--- a/tests/fixtures/kometa/defaults/overlays/versions.yml
+++ b/tests/fixtures/kometa/defaults/overlays/versions.yml
@@ -1,0 +1,83 @@
+##############################################################################
+#                              Versions Overlay                              #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#                     Credit to Magic815 for base images                     #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#          https://kometa.wiki/en/latest/defaults/overlays/versions          #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    default:
+      horizontal_align: right
+      vertical_align: bottom
+    conditionals:
+      horizontal_align:
+        default: right
+        conditions:
+          - builder_level: episode
+            value: right
+          - builder_level: episode
+            value: right
+      vertical_offset:
+        default: 15
+        conditions:
+          - vertical_align.exists: false
+            builder_level.not: episode
+            value: 335
+          - vertical_align.exists: false
+            builder_level.not: episode
+            value: 335
+          - vertical_align.exists: false
+            value: 270
+          - vertical_align: center
+            value: 0
+          - vertical_align: top
+            value: 15
+          - vertical_align: bottom
+            value: 30
+      horizontal_offset:
+        default: 15
+        conditions:
+          - horizontal_align.exists: false
+            builder_level: episode
+            value: 235
+          - horizontal_align.exists: false
+            builder_level: episode
+            value: 235
+          - horizontal_align: center
+            value: 0
+          - horizontal_align: [left, right]
+            value: 15
+      default:
+        conditions:
+          - file.exists: false
+            file_<<key>>.exists: false
+            url.exists: false
+            url_<<key>>.exists: false
+            git.exists: false
+            git_<<key>>.exists: false
+            repo.exists: false
+            repo_<<key>>.exists: false
+            value: <<overlay_name>>
+    back_color: "#00000099"
+    back_width: 105
+    back_height: 105
+
+templates:
+  versions:
+    conditionals:
+      version_style:
+        default: "duplicate"
+        conditions:
+         - library_type: "show"
+           value: "episode_duplicate"
+    plex_search:
+      all:
+        <<version_style>>: true
+    ignore_blank_results: true
+      
+overlays:
+  versions:
+    template: [name: standard, name: versions]

--- a/tests/fixtures/kometa/defaults/overlays/video_format.yml
+++ b/tests/fixtures/kometa/defaults/overlays/video_format.yml
@@ -1,0 +1,99 @@
+##############################################################################
+#                            Video Format Overlay                            #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#                     Credit to Magic815 for base images                     #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#        https://kometa.wiki/en/latest/defaults/overlays/video_format        #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    default:
+      text_<<key>>: <<overlay_name>>
+      horizontal_align: left
+      vertical_align: bottom
+    conditionals:
+      vertical_offset:
+        default: 15
+        conditions:
+          - vertical_align: center
+            value: 0
+          - vertical_align: top
+            value: 15
+          - vertical_align: bottom
+            value: 30
+      horizontal_offset:
+        default: 15
+        conditions:
+          - horizontal_align: center
+            value: 0
+          - horizontal_align: [left, right]
+            value: 15
+    group: quality
+    back_color: "#00000099"
+    back_width: 305
+    back_height: 105
+    final_name: text(<<text_<<key>>>>)
+
+templates:
+  video_format:
+    default:
+      regex_<<key>>: <<regex>>
+    conditionals:
+      regex:
+        conditions:
+          - key: remux
+            value: '(?i)\bremux\b'
+          - key: bluray
+            value: '(?i)\b(blu[ ._-]?ray|bd|br|hd[ ._-]?dvd)\b'
+          - key: web
+            value: '(?i)web[ ._-]?(dl|rip)'
+          - key: hdtv
+            value: '(?i)\bhd[ ._-]?tv\b'
+          - key: dvd
+            value: '(?i)\bdvd\b'
+          - key: sdtv
+            value: '(?i)\bsd[ ._-]?tv\b'
+          - key: cam
+            value: '(?i)\b(HQ|HD)?CAM\b'
+          - key: telesync
+            value: '(?i)\b(TS|HDTS|TELESYNC)\b'
+    ignore_blank_results: true
+    plex_all: true
+    filters:
+      filepath.regex: <<regex_<<key>>>>
+
+overlays:
+
+  REMUX:
+    variables: {key: remux, weight: 60}
+    template: [name: standard, name: video_format]
+
+  BLU-RAY:
+    variables: {key: bluray, weight: 50}
+    template: [name: standard, name: video_format]
+
+  WEB:
+    variables: {key: web, weight: 40}
+    template: [name: standard, name: video_format]
+
+  HDTV:
+    variables: {key: hdtv, weight: 30}
+    template: [name: standard, name: video_format]
+
+  DVD:
+    variables: {key: dvd, weight: 20}
+    template: [name: standard, name: video_format]
+
+  SDTV:
+    variables: {key: sdtv, weight: 10}
+    template: [name: standard, name: video_format]
+
+  TELESYNC:
+    variables: {key: telesync, weight: 9}
+    template: [name: standard, name: video_format]
+
+  CAM:
+    variables: {key: cam, weight: 8}
+    template: [name: standard, name: video_format]

--- a/tests/fixtures/kometa/defaults/show/content_rating_us.yml
+++ b/tests/fixtures/kometa/defaults/show/content_rating_us.yml
@@ -1,0 +1,123 @@
+##############################################################################
+#                       US Content Rating Collections                        #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#       https://kometa.wiki/en/latest/defaults/both/content_rating_us        #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "110"
+
+collections:
+  Ratings Collections:
+    template:
+      - name: separator
+        separator: content_rating
+        key_name: Ratings
+        translation_key: separator
+
+dynamic_collections:
+  US Show Content Rating:
+    type: content_rating
+    title_format: <<key_name>> <<library_typeU>>s
+    other_name: Not Rated <<library_typeU>>s
+    template:
+      - smart_filter
+      - shared
+    other_template:
+      - other_collection
+      - smart_filter
+      - shared
+    template_variables:
+      search_term:
+        default: content_rating
+      image:
+        default: content_rating/us/<<key_name>>
+        other: content_rating/us/NR
+      translation_key:
+        default: content_rating
+        other: content_rating_other
+      dynamic:
+        default: true
+    include:
+      - TV-G
+      - TV-Y
+      - TV-PG
+      - TV-14
+      - TV-MA
+    addons:
+      TV-G: 
+        - gb/U
+        - gb/0+
+        - U
+        - G
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - "01"
+        - "02"
+        - "03"
+        - "04"
+        - "05"
+        - "06"
+        - G - All Ages
+        - A
+        - no/A
+      TV-Y:
+        - TV-Y7
+        - TV-Y7-FV
+        - 7
+        - 8
+        - 9
+        - "07"
+        - "08"
+        - "09"
+        - no/5
+        - no/05
+        - no/6
+        - no/06
+        - no/7
+        - no/07
+      TV-PG:
+        - gb/PG
+        - gb/9+
+        - 10
+        - 11
+        - 12
+        - 13
+        - PG - Children
+        - no/9
+        - no/09
+        - no/10
+        - no/11
+        - no/12
+      TV-14:
+        - gb/12A
+        - 12+
+        - PG-13
+        - TV-13
+        - gb/14+
+        - gb/15
+        - 14
+        - 15
+        - 16
+        - 17
+        - PG-13 - Teens 13 or older
+        - no/15
+        - no/16
+      TV-MA:
+        - 18
+        - gb/18
+        - MA-17
+        - NC-17
+        - R
+        - TVMA
+        - R - 17+ (violence & profanity)
+        - R+ - Mild Nudity
+        - Rx - Hentai
+        - no/18

--- a/tests/fixtures/kometa/defaults/show/continent.yml
+++ b/tests/fixtures/kometa/defaults/show/continent.yml
@@ -1,0 +1,342 @@
+##############################################################################
+#                           Continent Collections                            #
+#       Created by Adam Pope, bartolomesorianol, Bullmoose20 & Sohjiro       #
+#          Artwork Credit to Duhniel, Bullmoose20, and Wiki Commons          #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#           https://kometa.wiki/en/latest/defaults/show/continent            #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "082"
+
+collections:
+  Continent Collections:
+    template:
+      - name: separator
+        separator: continent
+        key_name: Continent
+        translation_key: separator
+
+dynamic_collections:
+  Continent:
+    type: origin_country
+    title_format: <<key_name>>
+    other_name: Other Continents
+    template:
+      - filter
+      - shared
+    other_template:
+      - other_collection
+      - filter
+      - shared
+    template_variables:
+      filter_term:
+        default: origin_country
+      image:
+        default: country/<<style>>/<<original_key_name_encoded>>
+      style:
+        default: white
+      translation_key:
+        default: country
+        other: country_other
+      dynamic:
+        default: true
+
+    include:
+      - Africa
+      - Americas
+      - Antarctica
+      - Asia
+      - Europe
+      - Oceania
+
+    addons:
+      Africa:
+      # Northern Africa:
+        - dz                    # Algeria
+        - eg                    # Egypt
+        - ly                    # Libya
+        - ma                    # Morocco
+        - sd                    # Sudan
+        - tn                    # Tunisia
+        - eh                    # Western Sahara
+      # Eastern Africa:
+        - io                    # British Indian Ocean Territory
+        - bi                    # Burundi
+        - km                    # Comoros
+        - dj                    # Djibouti
+        - er                    # Eritrea
+        - et                    # Ethiopia
+        - tf                    # French Southern Territories
+        - ke                    # Kenya
+        - mg                    # Madagascar
+        - mw                    # Malawi
+        - mu                    # Mauritius
+        - yt                    # Mayotte
+        - mz                    # Mozambique
+        - re                    # Réunion
+        - rw                    # Rwanda
+        - sc                    # Seychelles
+        - so                    # Somalia
+        - ss                    # South Sudan
+        - ug                    # Uganda
+        - tz                    # Tanzania [United Republic of Tanzania]
+        - zm                    # Zambia
+        - zw                    # Zimbabwe
+      # Central Africa:
+        - ao                    # Angola
+        - cm                    # Cameroon
+        - cf                    # Central African Republic
+        - td                    # Chad
+        - cg                    # Republic of the Congo [Congo]
+        - cd                    # Democratic Republic of the Congo
+        - zr                    # Zaire
+        - gq                    # Equatorial Guinea
+        - ga                    # Gabon
+        - st                    # São Tomé and Príncipe [Sao Tome and Principe]
+      # Southern Africa:
+        - bw                    # Botswana
+        - sz                    # Eswatini [Swaziland]
+        - ls                    # Lesotho
+        - na                    # Namibia
+        - za                    # South Africa
+      # Western Africa:
+        - bj                    # Benin
+        - bf                    # Burkina Faso
+        - cv                    # Cape Verde [Cabo Verde]
+        - ci                    # Côte d'Ivoire [Côte d’Ivoire] [Ivory Coast]
+        - gm                    # Gambia
+        - gh                    # Ghana
+        - gn                    # Guinea
+        - gw                    # Guinea-Bissau
+        - lr                    # Liberia
+        - ml                    # Mali
+        - mr                    # Mauritania
+        - ne                    # Niger
+        - ng                    # Nigeria
+        - sh                    # Saint Helena, Ascension and Tristan da Cunha [Ascension] [Tristan da Cunha] [Saint Helena]
+        - sn                    # Senegal
+        - sl                    # Sierra Leone
+        - tg                    # Togo
+      Americas:
+      # Caribbean:
+        - ai                    # Anguilla
+        - ag                    # Antigua and Barbuda [Antigua] [Barbuda]
+        - aw                    # Aruba
+        - bs                    # Bahamas
+        - bb                    # Barbados
+        - bq                    # Bonaire, Sint Eustatius and Saba [Bonaire] [Sint Eustatius] [Saba]
+        - an                    # Netherlands Antilles
+        - vg                    # British Virgin Islands
+        - ky                    # Cayman Islands
+        - cu                    # Cuba
+        - cw                    # Curaçao
+        - dm                    # Dominica
+        - do                    # Dominican Republic
+        - gd                    # Grenada
+        - gp                    # Guadeloupe
+        - ht                    # Haiti
+        - jm                    # Jamaica
+        - mq                    # Martinique
+        - ms                    # Montserrat
+        - pr                    # Puerto Rico
+        - bl                    # Saint Barthélemy
+        - kn                    # Saint Kitts and Nevis
+        - lc                    # Saint Lucia
+        - mf                    # Saint Martin
+        - vc                    # Saint Vincent and the Grenadines
+        - sx                    # Sint Maarten
+        - tt                    # Trinidad and Tobago
+        - tc                    # Turks and Caicos Islands
+        - vi                    # US Virgin Islands [U.S. Virgin Islands] [United States Virgin Islands]
+      # Central America:
+        - bz                    # Belize
+        - cr                    # Costa Rica
+        - sv                    # El Salvador
+        - gt                    # Guatemala
+        - hn                    # Honduras
+        - mx                    # Mexico
+        - ni                    # Nicaragua
+        - pa                    # Panama
+      # South America:
+        - ar                    # Argentina
+        - bo                    # Bolivia [Plurinational State of Bolivia]
+        - bv                    # Bouvet Island
+        - br                    # Brazil
+        - cl                    # Chile
+        - co                    # Colombia
+        - ec                    # Ecuador
+        - fk                    # Falkland Islands [Malvinas]
+        - gf                    # French Guiana
+        - gy                    # Guyana
+        - py                    # Paraguay
+        - pe                    # Peru
+        - gs                    # South Georgia and the South Sandwich Islands [South Georgia] [South Sandwich Islands]
+        - sr                    # Suriname
+        - uy                    # Uruguay
+        - ve                    # Venezuela [Bolivarian Republic of Venezuela]
+      # North America:
+        - bm                    # Bermuda
+        - ca                    # Canada
+        - gl                    # Greenland
+        - pm                    # Saint Pierre and Miquelon
+        - us                    # United States [United States of America]
+      Antarctica:
+        - aq                    # Antarctica
+      Asia:
+      # Central Asia:
+        - kz                    # Kazakhstan
+        - kg                    # Kyrgyzstan
+        - tj                    # Tajikistan
+        - tm                    # Turkmenistan
+        - uz                    # Uzbekistan
+      # Eastern Asia:
+        - cn                    # China
+        - hk                    # Hong Kong
+        - mo                    # Macao
+        - kp                    # North Korea [Democratic People's Republic of Korea]
+        - jp                    # Japan
+        - mn                    # Mongolia
+        - kr                    # South Korea [Republic of Korea] [Korea]
+        - tw                    # Taiwan [Taiwan, Province of China]
+      # South-Eastern Asia:
+        - bn                    # Brunei [Brunei Darussalam]
+        - kh                    # Cambodia
+        - id                    # Indonesia
+        - la                    # Laos [Lao People's Democratic Republic] [Lao]
+        - my                    # Malaysia
+        - mm                    # Myanmar
+        - bu                    # Burma
+        - ph                    # Philippines
+        - sg                    # Singapore
+        - th                    # Thailand
+        - tp                    # East Timor
+        - tl                    # Timor-Leste
+        - vn                    # Vietnam [Viet Nam]
+      # Southern Asia:
+        - af                    # Afghanistan
+        - bd                    # Bangladesh
+        - bt                    # Bhutan
+        - in                    # India
+        - ir                    # Iran [Islamic Republic of Iran]
+        - mv                    # Maldives
+        - np                    # Nepal
+        - pk                    # Pakistan
+        - lk                    # Sri Lanka
+      # Western Asia:
+        - am                    # Armenia
+        - az                    # Azerbaijan
+        - bh                    # Bahrain
+        - cy                    # Cyprus
+        - ge                    # Georgia
+        - iq                    # Iraq
+        - il                    # Israel
+        - jo                    # Jordan
+        - kw                    # Kuwait
+        - lb                    # Lebanon
+        - om                    # Oman
+        - qa                    # Qatar
+        - sa                    # Saudi Arabia
+        - ps                    # Palestine [State of Palestine]
+        - sy                    # Syria [Syrian Arab Republic]
+        - tr                    # Turkey [Türkiye]
+        - ae                    # United Arab Emirates
+        - ye                    # Yemen
+      Europe:
+      # Eastern Europe:
+        - by                    # Belarus
+        - bg                    # Bulgaria
+        - cz                    # Czech Republic [Czechia]
+        - cs                    # Czechoslovakia
+        - hu                    # Hungary
+        - pl                    # Poland
+        - md                    # Moldova [Republic of Moldova]
+        - ro                    # Romania
+        - ru                    # Russia [Russian Federation]
+        - su                    # Soviet Union
+        - sk                    # Slovakia
+        - ua                    # Ukraine
+      # Northern Europe:
+        - ax                    # Åland Islands
+        - gg                    # Guernsey
+        - je                    # Jersey
+        - cq                    # Sark
+        - dk                    # Denmark
+        - ee                    # Estonia
+        - fo                    # Faroe Islands
+        - fi                    # Finland
+        - is                    # Iceland
+        - ie                    # Ireland
+        - im                    # Isle of Man
+        - lv                    # Latvia
+        - lt                    # Lithuania
+        - no                    # Norway
+        - sj                    # Svalbard and Jan Mayen Islands [Svalbard and Jan Mayen]
+        - se                    # Sweden
+        - gb                    # United Kingdom
+      # Southern Europe:
+        - al                    # Albania
+        - ad                    # Andorra
+        - ba                    # Bosnia and Herzegovina
+        - hr                    # Croatia
+        - gi                    # Gibraltar
+        - gr                    # Greece
+        - xk                    # Kosovo
+        - va                    # Vatican City [Holy See]
+        - it                    # Italy
+        - mt                    # Malta
+        - me                    # Montenegro
+        - mk                    # North Macedonia [Macedonia] [Republic of North Macedonia]
+        - pt                    # Portugal
+        - sm                    # San Marino
+        - rs                    # Serbia
+        - si                    # Slovenia
+        - es                    # Spain
+        - yu                    # Yugoslavia
+      # Western Europe:
+        - at                    # Austria
+        - be                    # Belgium
+        - fr                    # France [French Republic]
+        - de                    # Germany
+        - dd                    # East Germany
+        - li                    # Liechtenstein
+        - lu                    # Luxembourg
+        - mc                    # Monaco
+        - nl                    # Netherlands
+        - ch                    # Switzerland
+      Oceania:
+      # Australia and New Zealand:
+        - au                    # Australia
+        - cx                    # Christmas Island
+        - cc                    # Cocos (Keeling) Islands
+        - hm                    # Heard Island and McDonald Islands
+        - nz                    # New Zealand
+        - nf                    # Norfolk Island
+      # Melanesia:
+        - fj                    # Fiji
+        - nc                    # New Caledonia
+        - pg                    # Papua New Guinea [New Guinea]
+        - sb                    # Solomon Islands
+        - vu                    # Vanuatu
+      # Micronesia:
+        - gu                    # Guam
+        - ki                    # Kiribati
+        - mh                    # Marshall Islands
+        - fm                    # Micronesia [Federated States of Micronesia]
+        - nr                    # Nauru
+        - mp                    # Northern Mariana Islands
+        - pw                    # Palau
+        - um                    # US Minor Outlying Islands
+      # Polynesia:
+        - as                    # American Samoa
+        - ck                    # Cook Islands
+        - pf                    # French Polynesia
+        - nu                    # Niue
+        - pn                    # Pitcairn [Pitcairn Islands]
+        - ws                    # Samoa
+        - tk                    # Tokelau
+        - to                    # Tonga
+        - tv                    # Tuvalu
+        - wf                    # Wallis and Futuna Islands

--- a/tests/fixtures/kometa/defaults/show/country.yml
+++ b/tests/fixtures/kometa/defaults/show/country.yml
@@ -1,0 +1,336 @@
+##############################################################################
+#                            Country Collections                             #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#                         Artwork Credit to Duhniel                          #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#            https://kometa.wiki/en/latest/defaults/show/country             #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "080"
+
+collections:
+  Country Collections:
+    template:
+      - name: separator
+        separator: country
+        key_name: Country
+        translation_key: separator
+
+dynamic_collections:
+  Country:
+    type: origin_country
+    title_format: <<key_name>>
+    other_name: Other Countries
+    template:
+      - filter
+      - shared
+    other_template:
+      - other_collection
+      - filter
+      - shared
+    template_variables:
+      filter_term:
+        default: origin_country
+      image:
+        default: country/<<style>>/<<original_key_name_encoded>>
+      style:
+        default: white
+      translation_key:
+        default: country
+        other: country_other
+      dynamic:
+        default: true
+
+    include:
+      # Northern Africa:
+        - dz                    # Algeria
+        - eg                    # Egypt
+        - ly                    # Libya
+        - ma                    # Morocco
+        - sd                    # Sudan
+        - tn                    # Tunisia
+        - eh                    # Western Sahara
+      # Eastern Africa:
+        - io                    # British Indian Ocean Territory
+        - bi                    # Burundi
+        - km                    # Comoros
+        - dj                    # Djibouti
+        - er                    # Eritrea
+        - et                    # Ethiopia
+        - tf                    # French Southern Territories
+        - ke                    # Kenya
+        - mg                    # Madagascar
+        - mw                    # Malawi
+        - mu                    # Mauritius
+        - yt                    # Mayotte
+        - mz                    # Mozambique
+        - re                    # Réunion
+        - rw                    # Rwanda
+        - sc                    # Seychelles
+        - so                    # Somalia
+        - ss                    # South Sudan
+        - ug                    # Uganda
+        - tz                    # Tanzania [United Republic of Tanzania]
+        - zm                    # Zambia
+        - zw                    # Zimbabwe
+      # Central Africa:
+        - ao                    # Angola
+        - cm                    # Cameroon
+        - cf                    # Central African Republic
+        - td                    # Chad
+        - cg                    # Republic of the Congo [Congo]
+        - cd                    # Democratic Republic of the Congo
+        - gq                    # Equatorial Guinea
+        - ga                    # Gabon
+        - st                    # São Tomé and Príncipe [Sao Tome and Principe]
+      # Southern Africa:
+        - bw                    # Botswana
+        - sz                    # Eswatini [Swaziland]
+        - ls                    # Lesotho
+        - na                    # Namibia
+        - za                    # South Africa
+      # Western Africa:
+        - bj                    # Benin
+        - bf                    # Burkina Faso
+        - cv                    # Cape Verde [Cabo Verde]
+        - ci                    # Côte d'Ivoire [Côte d’Ivoire] [Ivory Coast]
+        - gm                    # Gambia
+        - gh                    # Ghana
+        - gn                    # Guinea
+        - gw                    # Guinea-Bissau
+        - lr                    # Liberia
+        - ml                    # Mali
+        - mr                    # Mauritania
+        - ne                    # Niger
+        - ng                    # Nigeria
+        - sh                    # Saint Helena, Ascension and Tristan da Cunha [Ascension] [Tristan da Cunha] [Saint Helena]
+        - sn                    # Senegal
+        - sl                    # Sierra Leone
+        - tg                    # Togo
+      # Caribbean:
+        - ai                    # Anguilla
+        - ag                    # Antigua and Barbuda [Antigua] [Barbuda]
+        - aw                    # Aruba
+        - bs                    # Bahamas
+        - bb                    # Barbados
+        - bq                    # Bonaire, Sint Eustatius and Saba [Bonaire] [Sint Eustatius] [Saba]
+        - an                    # Netherlands Antilles
+        - vg                    # British Virgin Islands
+        - ky                    # Cayman Islands
+        - cu                    # Cuba
+        - cw                    # Curaçao
+        - dm                    # Dominica
+        - do                    # Dominican Republic
+        - gd                    # Grenada
+        - gp                    # Guadeloupe
+        - ht                    # Haiti
+        - jm                    # Jamaica
+        - mq                    # Martinique
+        - ms                    # Montserrat
+        - pr                    # Puerto Rico
+        - bl                    # Saint Barthélemy
+        - kn                    # Saint Kitts and Nevis
+        - lc                    # Saint Lucia
+        - mf                    # Saint Martin
+        - vc                    # Saint Vincent and the Grenadines
+        - sx                    # Sint Maarten
+        - tt                    # Trinidad and Tobago
+        - tc                    # Turks and Caicos Islands
+        - vi                    # US Virgin Islands [U.S. Virgin Islands] [United States Virgin Islands]
+      # Central America:
+        - bz                    # Belize
+        - cr                    # Costa Rica
+        - sv                    # El Salvador
+        - gt                    # Guatemala
+        - hn                    # Honduras
+        - mx                    # Mexico
+        - ni                    # Nicaragua
+        - pa                    # Panama
+      # South America:
+        - ar                    # Argentina
+        - bo                    # Bolivia [Plurinational State of Bolivia]
+        - bv                    # Bouvet Island
+        - br                    # Brazil
+        - cl                    # Chile
+        - co                    # Colombia
+        - ec                    # Ecuador
+        - fk                    # Falkland Islands [Malvinas]
+        - gf                    # French Guiana
+        - gy                    # Guyana
+        - py                    # Paraguay
+        - pe                    # Peru
+        - gs                    # South Georgia and the South Sandwich Islands [South Georgia] [South Sandwich Islands]
+        - sr                    # Suriname
+        - uy                    # Uruguay
+        - ve                    # Venezuela [Bolivarian Republic of Venezuela]
+      # North America:
+        - bm                    # Bermuda
+        - ca                    # Canada
+        - gl                    # Greenland
+        - pm                    # Saint Pierre and Miquelon
+        - us                    # United States [United States of America]
+      # Antarctica:
+        - aq                    # Antarctica
+      # Central Asia:
+        - kz                    # Kazakhstan
+        - kg                    # Kyrgyzstan
+        - tj                    # Tajikistan
+        - tm                    # Turkmenistan
+        - uz                    # Uzbekistan
+      # Eastern Asia:
+        - cn                    # China
+        - hk                    # Hong Kong
+        - mo                    # Macao
+        - kp                    # North Korea [Democratic People's Republic of Korea]
+        - jp                    # Japan
+        - mn                    # Mongolia
+        - kr                    # South Korea [Republic of Korea] [Korea]
+        - tw                    # Taiwan [Taiwan, Province of China]
+      # South-Eastern Asia:
+        - bn                    # Brunei [Brunei Darussalam]
+        - kh                    # Cambodia
+        - id                    # Indonesia
+        - la                    # Laos [Lao People's Democratic Republic] [Lao]
+        - my                    # Malaysia
+        - mm                    # Myanmar
+        - ph                    # Philippines
+        - sg                    # Singapore
+        - th                    # Thailand
+        - tp                    # East Timor
+        - vn                    # Vietnam [Viet Nam]
+      # Southern Asia:
+        - af                    # Afghanistan
+        - bd                    # Bangladesh
+        - bt                    # Bhutan
+        - in                    # India
+        - ir                    # Iran [Islamic Republic of Iran]
+        - mv                    # Maldives
+        - np                    # Nepal
+        - pk                    # Pakistan
+        - lk                    # Sri Lanka
+      # Western Asia:
+        - am                    # Armenia
+        - az                    # Azerbaijan
+        - bh                    # Bahrain
+        - cy                    # Cyprus
+        - ge                    # Georgia
+        - iq                    # Iraq
+        - il                    # Israel
+        - jo                    # Jordan
+        - kw                    # Kuwait
+        - lb                    # Lebanon
+        - om                    # Oman
+        - qa                    # Qatar
+        - sa                    # Saudi Arabia
+        - ps                    # Palestine [State of Palestine]
+        - sy                    # Syria [Syrian Arab Republic]
+        - tr                    # Turkey [Türkiye]
+        - ae                    # United Arab Emirates
+        - ye                    # Yemen
+      # Eastern Europe:
+        - by                    # Belarus
+        - bg                    # Bulgaria
+        - cz                    # Czech Republic [Czechia]
+        - hu                    # Hungary
+        - pl                    # Poland
+        - md                    # Moldova [Republic of Moldova]
+        - ro                    # Romania
+        - ru                    # Russia [Russian Federation]
+        - sk                    # Slovakia
+        - ua                    # Ukraine
+      # Northern Europe:
+        - ax                    # Åland Islands
+        - gg                    # Guernsey
+        - je                    # Jersey
+        - cq                    # Sark
+        - dk                    # Denmark
+        - ee                    # Estonia
+        - fo                    # Faroe Islands
+        - fi                    # Finland
+        - is                    # Iceland
+        - ie                    # Ireland
+        - im                    # Isle of Man
+        - lv                    # Latvia
+        - lt                    # Lithuania
+        - no                    # Norway
+        - sj                    # Svalbard and Jan Mayen Islands [Svalbard and Jan Mayen]
+        - se                    # Sweden
+        - gb                    # United Kingdom
+      # Southern Europe:
+        - al                    # Albania
+        - ad                    # Andorra
+        - ba                    # Bosnia and Herzegovina
+        - hr                    # Croatia
+        - gi                    # Gibraltar
+        - gr                    # Greece
+        - xk                    # Kosovo
+        - va                    # Vatican City [Holy See]
+        - it                    # Italy
+        - mt                    # Malta
+        - me                    # Montenegro
+        - mk                    # North Macedonia [Macedonia] [Republic of North Macedonia]
+        - pt                    # Portugal
+        - sm                    # San Marino
+        - rs                    # Serbia
+        - si                    # Slovenia
+        - es                    # Spain
+        - yu                    # Yugoslavia
+      # Western Europe:
+        - at                    # Austria
+        - be                    # Belgium
+        - fr                    # France [French Republic]
+        - de                    # Germany
+        - li                    # Liechtenstein
+        - lu                    # Luxembourg
+        - mc                    # Monaco
+        - nl                    # Netherlands
+        - ch                    # Switzerland
+      # Australia and New Zealand:
+        - au                    # Australia
+        - cx                    # Christmas Island
+        - cc                    # Cocos (Keeling) Islands
+        - hm                    # Heard Island and McDonald Islands
+        - nz                    # New Zealand
+        - nf                    # Norfolk Island
+      # Melanesia:
+        - fj                    # Fiji
+        - nc                    # New Caledonia
+        - pg                    # Papua New Guinea [New Guinea]
+        - sb                    # Solomon Islands
+        - vu                    # Vanuatu
+      # Micronesia:
+        - gu                    # Guam
+        - ki                    # Kiribati
+        - mh                    # Marshall Islands
+        - fm                    # Micronesia [Federated States of Micronesia]
+        - nr                    # Nauru
+        - mp                    # Northern Mariana Islands
+        - pw                    # Palau
+        - um                    # US Minor Outlying Islands
+      # Polynesia:
+        - as                    # American Samoa
+        - ck                    # Cook Islands
+        - pf                    # French Polynesia
+        - nu                    # Niue
+        - pn                    # Pitcairn [Pitcairn Islands]
+        - ws                    # Samoa
+        - tk                    # Tokelau
+        - to                    # Tonga
+        - tv                    # Tuvalu
+        - wf                    # Wallis and Futuna Islands
+    addons:
+      cd:                       # Democratic Republic of the Congo
+        - zr                    # Zaire
+      mm:                       # Myanmar
+        - bu                    # Burma
+      tp:                       # East Timor
+        - tl                    # Timor-Leste
+      cz:                       # Czech Republic
+        - cs                    # Czechoslovakia
+      ru:                       # Russia
+        - su                    # Soviet Union
+      de:                       # Germany
+        - dd                    # East Germany

--- a/tests/fixtures/kometa/defaults/show/decade.yml
+++ b/tests/fixtures/kometa/defaults/show/decade.yml
@@ -1,0 +1,40 @@
+##############################################################################
+#                             Decade Collections                             #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#            https://kometa.wiki/en/latest/defaults/show/decade              #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "100"
+
+collections:
+  Decade Collections:
+    template:
+      - name: separator
+        separator: decade
+        key_name: Decade
+        translation_key: separator
+
+dynamic_collections:
+  Decade:
+    type: decade
+    title_format: Best of <<key_name>>
+    template:
+      - smart_filter
+      - shared
+    template_variables:
+      search_term:
+        default: year
+      sort_by:
+        default: critic_rating.desc
+      limit:
+        default: 100
+      image:
+        default: decade/best/<<key>>
+      translation_key:
+        default: decade
+      dynamic:
+        default: true

--- a/tests/fixtures/kometa/defaults/show/franchise.yml
+++ b/tests/fixtures/kometa/defaults/show/franchise.yml
@@ -1,0 +1,119 @@
+##############################################################################
+#                           Franchise Collections                            #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#              Additional contributions by the Kometa Community              #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#           https://kometa.wiki/en/latest/defaults/show/franchise            #
+##############################################################################
+
+templates:
+  tmdbshow:
+    default:
+      sync_mode: sync
+      sync_mode_<<key>>: <<sync_mode>>
+      collection_order: release
+      minimum_items: 2
+      name_mapping_<<key>>: <<name_mapping>>
+      pre: "_"
+      order_<<key>>: ""
+      sort_title: "!<<collection_section>><<pre>><<order_<<key>>>><<title>>"
+      sort_title_<<key>>: <<sort_title>>
+      sonarr_add_missing_<<key>>: <<sonarr_add_missing>>
+      sonarr_folder_<<key>>: <<sonarr_folder>>
+      sonarr_tag_<<key>>: <<sonarr_tag>>
+      item_sonarr_tag_<<key>>: <<item_sonarr_tag>>
+      sonarr_monitor_<<key>>: <<sonarr_monitor>>
+      collection_order_<<key>>: <<collection_order>>
+      url_poster_<<key>>: https://raw.githubusercontent.com/Kometa-Team/Default-Images/master/franchise/<<key_name_encoded>>.jpg
+    optional:
+      - name_<<key>>
+      - summary_<<key>>
+      - name_mapping
+      - sort_title
+      - build_collection
+      - collection_mode
+      - collection_order
+      - collection_section
+      - sonarr_add_missing
+      - sonarr_folder
+      - sonarr_tag
+      - item_sonarr_tag
+      - sonarr_monitor
+    name: <<name_<<key>>>>
+    summary: <<summary_<<key>>>>
+    minimum_items: <<minimum_items>>
+    tmdb_show: <<value>>
+    url_poster: <<url_poster_<<key>>>>
+    name_mapping: <<name_mapping_<<key>>>>
+    sort_title: <<sort_title_<<key>>>>
+    build_collection: <<build_collection>>
+    sync_mode: <<sync_mode_<<key>>>>
+    collection_mode: <<collection_mode>>
+    collection_order: <<collection_order_<<key>>>>
+    sonarr_add_missing: <<sonarr_add_missing_<<key>>>>
+    sonarr_folder: <<sonarr_folder_<<key>>>>
+    sonarr_tag: <<sonarr_tag_<<key>>>>
+    item_sonarr_tag: <<item_sonarr_tag_<<key>>>>
+    sonarr_monitor: <<sonarr_monitor_<<key>>>>
+
+dynamic_collections:
+  Show Franchise Collections:
+    type: custom
+    data:
+      "121": Doctor Who
+      "253": Star Trek
+      "549": Law & Order
+      "951": Archie Comics
+      "1399": Game of Thrones
+      "1402": The Walking Dead
+      "1412": Arrowverse
+      "1431": CSI
+      "4614": NCIS
+      "4629": Stargate
+      "8514": "RuPaul's Drag Race"
+      "6357": The Twilight Zone
+      "10222": The Real Housewives
+      "31917": Pretty Little Liars
+      "44006": One Chicago
+      "54650": Power
+      "73586": Yellowstone
+      "75219": 9-1-1
+      "79744": The Rookie
+      "80748": FBI
+      "85536": Star Wars
+      "46296": Spartacus
+      "108978": Reacher
+      "60585": Bosch
+      "3476": Inspector Morse
+      "61511": Father Brown (2013)
+      "41956": Death in Paradise (2011)
+    template:
+      - tmdbshow
+    addons:
+      121: [57243, 1057, 424, 203, 64073, 239770]  # Doctor Who: K-9 & Company, Torchwood, The Sarah Jane Adventures, Class, Doctor Who (2023)
+      253: [655, 580, 1855, 1992, 314, 103516, 67198, 82491, 85948, 85949, 106393] # TOS, TAS, TNG, DS9, VOY, ENT, DIS, SHO, PIC, LOW, PRO, SNW
+      549: [2734, 4601, 3357, 32632, 72496, 106158, 7098]  # Law & Order: Special Victims Unit, Criminal Intent, Trial by Jury, LA, True Crime, Organized Crime, UK
+      951: [25641, 4489, 24211, 9829, 605, 69050, 79242, 87539] # The Archie Show, Sabrina, The Teenage Witch, Josie and the Pussycats, Josie and the Pussycats in Outer Space, The New Archies, Riverdale, Chilling Adventures of Sabrina, Katy Keene
+      1399: [94997] # Game of Thrones, House of the Dragon
+      1402: [62286, 94305, 194583, 211684, 206586] # The Walking Dead: Fear the Walking Dead, World Beyond, Dead City, Daryl Dixon, The Ones Who Live
+      1412: [60735, 62688, 62643, 71663, 89247]  # Arrow: The Flash, Supergirl, Legends of Tomorrow, Black Lightning, Batwoman
+      1431: [1620, 2458, 122194, 61811] # CSI: Miami, NY, Vegas, Cyber
+      4614: [17610, 124271, 61387, 4376, 157950, 243006, 247732]  # NCIS: Los Angeles, Hawaii, New Orleans, JAG, Sydney, Origins, Tony & Ziva
+      4629: [2290, 5148, 72925] # Stargate SG-1: Atlantis, Universe, Origins
+      8514: [200870, 212798, 38409, 200865, 67482, 124045, 216276, 77233, 92611, 98888, 94038, 127841, 67564, 122692, 139203, 203734, 108934, 204701, 210689, 155431, 106475, 152261, 66769] #Drag Race: Sweden, Sweden Untucked, Untucked, Belgium, All-Stars, Spain, Brazil, Thailand, UK, Secret Celebrity, Canada, Italy, All Stars Untucked, Australia, Philippines, Canada VS the World, Holland, Philippines Untucked, Spain Untucked, UK VS the World, Vegas Revue, France, Ruvealed
+      6357: [1918, 83135, 16399]  # The Twilight Zone (multiple)
+      10222: [34268, 32390, 17380, 18204, 65300, 31493, 217065, 14808, 136105, 61868, 39283, 62087, 76474, 70612, 110381, 70463, 67480, 196592, 139703, 126149, 59556, 113333, 214463, 131449, 216849] # Real Housewives of Orange County: Miami, BH, ATL, NJ, Potomac, DC, Capetown, NYC, Ult. Girls Trip, Cheshire, Dallas, Melbourne, Hungary, Toronto, SLC, Sydney, Auckland, Dubai, ATL Porsha’s Family Matters, Johannesburg, Vancouver, Jersey, Amsterdam, Durban, Cheshire Christmas Cruising
+      31917: [46958, 79863, 110531] # Pretty Little Liars: Ravenswood, The Perfectionists, Original Sin
+      44006: [58841, 62650, 67993] # Chicago Fire: Med, PD, Justice
+      54650: [97890, 124394, 119845] # Power, Ghost, Raising Kanan, Force
+      73586: [157744, 118357, 157732] #Yellowstone: 1883, 1923, 1883: The Bass Reeves Story
+      75219: 89393 # 9-1-1: 9-1-1 Lone Star
+      79744: 201992 # The Rookie: Feds
+      80748: [94372, 121658] # FBI: Most Wanted, International
+      85536: [71412, 3478, 105971, 92830, 83867, 60554, 82856, 115036, 114461, 202879, 114478, 79093, 4194, 203085] # Star Wars Galaxy of Adventures: Forces of Destiny, Ewoks, The Bad Batch, Obi-Wan Kenobi, Andor, Rebels, The Mandalorian, The Book of Boba Fett, Ahsoka, Skeleton Crew, Visions, Resistance, Clone Wars, Tales of the Jedi
+      46296: 240459 # Spartacus: House of Ashur
+      108978: 273207 # Neagley
+      60585: 153657 # Bosch: Legacy
+      3476: [44264, 2343] # Inspector Morse, Endeavour, Lewis
+      61511: 157282 # Sister Boniface Mysteries (2022)
+      41956: [205072, 244978] # Beyond Paradise (2023), Return to Paradise (2025)

--- a/tests/fixtures/kometa/defaults/show/network.yml
+++ b/tests/fixtures/kometa/defaults/show/network.yml
@@ -1,0 +1,532 @@
+##############################################################################
+#                            Network Collections                             #
+#                 Created by Yozora, Bullmoose20, & Sohjiro                  #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#            https://kometa.wiki/en/latest/defaults/show/network             #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "050"
+
+collections:
+  Network Collections:
+    template:
+      - name: separator
+        separator: network
+        key_name: Network
+        translation_key: separator
+
+dynamic_collections:
+  Network:
+    type: network
+    title_format: <<key_name>>
+    template:
+      - smart_filter
+      - shared
+    template_variables:
+      delete_collections_named:
+        Apple TV: Apple TV+
+        HBO Max: Max
+        "5": Channel 5
+        "U&Alibi": Alibi
+        U: UKTV
+        "U&Dave": Dave
+        "U&Eden": Eden
+      search_term:
+        default: network
+      image:
+        default: network/<<style>>/<<key_encoded>>
+      style:
+        default: color
+      translation_key:
+        default: network
+      dynamic:
+        default: true
+    include:
+      - "#0"
+      - 5
+      - 7mate
+      - ABC
+      - ABC Family
+      - ABC Kids
+      - ABC TV
+      - ABS-CBN
+      - Acorn TV
+      - Adult Swim
+      - AHC
+      - ALTBalaji
+      - Amazon Kids+
+      - AMC
+      - AMC+
+      - Animal Planet
+      - ANIMAX
+      - Angel Studios
+      - Antena 3
+      - Apple TV
+      - ARD
+      - Arte
+      - Atresplayer Premium
+      - Atres Player
+      - AT-X
+      - Audience
+      - AXN
+      - Azteca Uno
+      - A&E
+      - BBC America
+      - BBC Four
+      - BBC iPlayer
+      - BBC One
+      - BBC Scotland
+      - BBC Three
+      - BBC Two
+      - BET
+      - BET+
+      - bilibili
+      - Binge
+      - BluTV
+      - Boomerang
+      - Bravo
+      - BritBox
+      - C More
+      - Canale 5
+      - Canal+
+      - Cartoon Network
+      - Cartoonito
+      - CBC
+      - CBC Television
+      - Cbeebies
+      - CBS
+      - Channel 3
+      - Channel 4
+      - CHCH-DT
+      - Cinemax
+      - Citytv
+      - CNN
+      - Comedy Central
+      - Cooking Channel
+      - Crackle
+      - Crave
+      - Criterion Channel
+      - Crunchyroll
+      - CTV
+      - Cuatro
+      - Curiosity Stream
+      - DC Universe
+      - Discovery
+      - Discovery Kids
+      - discovery+
+      - Disney Channel
+      - Disney Junior
+      - Disney XD
+      - Disney+
+      - DR1
+      - Dropout
+      - Elisa Viihde
+      - Elisa Viihde Viaplay
+      - ENA
+      - Epix
+      - ESPN
+      - EXXEN
+      - E!
+      - E4
+      - Facebook Watch
+      - Family Channel
+      - Ficción Producciones
+      - Flooxer
+      - Food Network
+      - FOX
+      - Fox Kids
+      - France 2
+      - Freeform
+      - Freevee
+      - Fuji TV
+      - funnyordie.com
+      - FX
+      - FXX
+      - GAİN
+      - Game Show Network
+      - Global TV
+      - Globoplay
+      - GMA Network
+      - Hallmark
+      - HBO
+      - HBO Max
+      - HGTV
+      - History
+      - HOT3
+      - Hulu
+      - ICTV
+      - IFC
+      - IMDb TV
+      - Investigation Discovery
+      - ION Television
+      - iQiyi
+      - ITV
+      - ITV Encore
+      - ITV1
+      - ITV2
+      - ITV3
+      - ITV4
+      - ITVBe
+      - ITVX
+      - JioCinema
+      - joyn
+      - JTBC
+      - Kan 11
+      - Kanal 5
+      - KBS2
+      - Kids WB
+      - La 1
+      - La Une
+      - Las Estrellas
+      - Lifetime
+      - Lionsgate+
+      - Logo
+      - Magnolia Network
+      - MasterClass
+      - MBC
+      - MBN
+      - MGM+
+      - mitele
+      - Movistar Plus+
+      - MTV
+      - M-Net
+      - National Geographic
+      - NBC
+      - Netflix
+      - Network 10
+      - NFL Network
+      - NHK
+      - Nick
+      - Nick Jr
+      - Nickelodeon
+      - Nicktoons
+      - Nine Network
+      - Nippon TV
+      - NRK1
+      - OCS City
+      - OCS Max
+      - ORF
+      - Oxygen
+      - Pantaya
+      - Paramount Network
+      - Paramount+
+      - PBS
+      - PBS Kids
+      - Peacock
+      - Planète+ A&E
+      - Prime Video
+      - Quibi
+      - Rai 1
+      - Reelz
+      - RTÉ One
+      - RTL
+      - RTL Télé
+      - RTP1
+      - RÚV
+      - S4C
+      - SAT.1
+      - SBS
+      - Science
+      - Seeso
+      - Seven Network
+      - Shahid
+      - Showcase
+      - Showmax
+      - Showtime
+      - Shudder
+      - Sky
+      - Smithsonian
+      - Space
+      - Spectrum
+      - Spike
+      - Stöð 2
+      - Stan
+      - Starz
+      - STAR+
+      - Sundance TV
+      - SVT
+      - SVT Play
+      - SVT1
+      - Syfy
+      - Syndication
+      - TBS
+      - Telecinco
+      - Telefe
+      - Telemundo
+      - Televisión de Galicia
+      - Televisión Pública Argentina
+      - Tencent Video
+      - TF1
+      - The CW
+      - The Daily Wire
+      - The Roku Channel
+      - The WB
+      - TLC
+      - TNT
+      - Tokyo MX
+      - Travel Channel
+      - truTV
+      - tubi
+      - Turner Classic Movies
+      - TV 2
+      - tv asahi
+      - TV Globo
+      - TV Land
+      - TV Tokyo
+      - TV3
+      - TV4
+      - TV4 Play
+      - TVB Jade
+      - tving
+      - tvN
+      - TVNZ 1
+      - TVNZ 2
+      - TVP1
+      - U
+      - "U&Alibi"
+      - "U&Dave"
+      - "U&Drama"
+      - "U&Eden"
+      - "U&Gold"
+      - "U&W"
+      - "U&Yesterday"
+      - UniMás
+      - Universal Kids
+      - Universal TV
+      - Univision
+      - UPN
+      - USA Network
+      - U+ Mobile TV
+      - VH1
+      - Viaplay
+      - Vice
+      - Virgin Media One
+      - ViuTV
+      - ViX+
+      - VRT 1
+      - VRT Max
+      - VTM
+      - W
+      - WE tv
+      - Xbox Live
+      - YLE
+      - Youku
+      - YouTube
+      - ZDF
+      - ZEE5
+
+    addons:
+      ABC:
+        - ABC.com
+      ABC TV:
+        - ABC (AU)
+        - ABC Comedy
+        - ABC Me
+        - ABC News
+        - ABC iview
+      AMC:
+        - AMC.com
+      Animal Planet:
+        - Animal Planet Brasil
+        - Animal Planet Deutschland
+      Angel Studios:
+        - VidAngel
+      Apple TV:
+        - Apple TV+
+      BET:
+        - BET Her
+      Canal+:
+        - Canal+ Poland
+        - Canal+ Family
+        - Canal+ Discovery
+        - Canal+ Afrique
+      Cartoon Network:
+        - Cartoon Network Latin America
+        - Cartoon Network Anything
+      CBC:
+        - CBCDrama
+      CBC Television:
+        - CBC Gem
+        - CBC News Network
+        - CBC Comedy
+      CBS:
+        - CBS.com
+        - CBS All Access
+      CTV:
+        - CTV Two
+        - CTV News Channel
+        - CTV Sci-Fi Channel
+        - CTV Comedy Channel
+        - CTV Life Channel
+        - ctv.ca
+      Discovery:
+        - Discovery Health Channel
+        - Discovery Channel
+        - Discovery Home & Health Brasil
+        - Discovery Family
+        - Discovery Real Time
+        - Discovery Asia
+        - Discovery Home & Health
+        - Discovery Life
+        - Discovery World
+        - Discovery Science
+        - Discovery Channel (UK)
+      Disney Channel:
+        - Toon Disney
+        - Playhouse Disney
+        - Disney Channel Asia
+        - disney.com
+        - Disney Channel Middle East
+      Disney Junior:
+        - Disney Junior Latin America
+        - Disney Junior Brasil
+      Disney+:
+        - Disney+ Hotstar
+      ESPN:
+        - ESPN2
+        - ESPN+
+        - ESPN Classic
+        - ESPNU
+        - ESPNews
+        - ESPN Australia
+        - Sony ESPN
+        - ESPN.com
+        - ESPN Deportes
+      FOX:
+        - Fox
+        - Fox News Channel
+        - Fox Sports
+        - Fox Reality Channel
+        - Fox Sports Networks
+        - Fox Latin America
+        - Fox Brasil
+        - Fox Soccer
+        - Fox Sports 2
+        - Fox Nation
+        - Fox Sports 1
+        - fox.com
+        - Fox Sports Detroit
+      Freevee:
+        - Amazon Freevee
+      Hallmark:
+        - Hallmark+
+        - Hallmark Channel
+        - Hallmark Drama
+        - Hallmark Movie & Mysteries
+        - Hallmark Movies Now
+      HBO:
+        - HBO Brasil
+        - HBO Europe
+        - HBO Asia
+        - HBO Latin America
+        - HBO España
+        - HBO Nordic
+        - HBO Canada
+        - HBO Family
+        - HBO Mundi
+      HBO Max:
+        - HBO Go
+        - Max
+      HGTV:
+        - HGTV Canada
+      History:
+        - History Channel Italia
+        - H2
+      Lifetime:
+        - Lifetime Movies
+      MTV:
+        - MTV2
+        - MTV3
+        - MTV Lebanon
+        - MTV Latin America
+        - MTV Italia
+        - MTV Australia
+        - MTV Canada
+        - MTV Global
+        - MTV Nederland
+      National Geographic:
+        - National Geographic Channel
+        - National Geographic Brasil
+        - National Geographic Latinoamerica
+        - National Geographic India
+        - Nat Geo Wild
+      NBC:
+        - CNBC
+        - MSNBC
+        - NBCSN
+        - CNBC Europe
+        - CNBC Asia
+        - WNBC
+        - Nikkei CNBC
+        - KNBC
+        - CNBC World
+        - CNBC TV18
+        - NBC Weather Plus
+        - NBC Radio Network
+      Network Ten:
+        - Network 10
+      Nickelodeon:
+        - Nick at Nite
+      Paramount+:
+        - Paramount+ with Showtime
+      ReelzChannel:
+        - Reelz
+      Showtime:
+        - Paramount+ with Showtime
+      Sky:
+        - Sky One
+        - Sky Atlantic
+        - Sky Atlantic (IT)
+        - Sky Arts
+        - Sky History
+        - Sky Living
+        - Sky Crime
+        - Sky Uno
+        - Sky Max
+        - Sky Sports
+        - Sky Documentaries
+        - Sky Nature
+        - Sky News
+        - Sky Cinema
+        - Sky News Australia
+        - Sky Italia
+        - Sky Comedy
+        - Sky Sports F1
+        - Sky Two
+        - Sky Witness
+        - sky Travel
+        - Sky Vision
+        - Sky News Weather Channel
+      Smithsonian:
+        - Smithsonian Channel
+        - Smithsonian Earth
+      Spike:
+        - Spike TV
+      Starz:
+        - Starz Encore
+      Sundance TV:
+        - SundanceTV
+      TBS:
+        - TBS.com
+        - TBS Brasil
+      The CW:
+        - CW seed
+      TNT:
+        - TNT Comedy
+        - TNT Latin America
+        - TNT España
+        - TNT Serie
+        - TNT Glitz
+      Travel Channel:
+        - Travel Channel United Kingdom
+      VH1:
+        - VH1 Classic
+      Vice:
+        - Viceland
+        - Vice TV
+        - Vice.com
+      YouTube:
+        - YouTube Premium

--- a/tests/fixtures/kometa/defaults/show/region.yml
+++ b/tests/fixtures/kometa/defaults/show/region.yml
@@ -1,0 +1,354 @@
+##############################################################################
+#                             Region Collections                             #
+#       Created by Adam Pope, bartolomesorianol, Bullmoose20 & Sohjiro       #
+#          Artwork Credit to Duhniel, Bullmoose20, and Wiki Commons          #
+#          EDITING THIS FILE MAY CAUSE PULLING NEW UPDATES TO FAIL           #
+#            https://kometa.wiki/en/latest/defaults/show/region              #
+##############################################################################
+
+external_templates:
+  default: templates
+  template_variables:
+    collection_section: "081"
+
+collections:
+  Region Collections:
+    template:
+      - name: separator
+        separator: region
+        key_name: Region
+        translation_key: separator
+
+dynamic_collections:
+  Region:
+    type: origin_country
+    title_format: <<key_name>>
+    other_name: Other Regions
+    template:
+      - filter
+      - shared
+    other_template:
+      - other_collection
+      - filter
+      - shared
+    template_variables:
+      filter_term:
+        default: origin_country
+      image:
+        default: country/<<style>>/<<original_key_name_encoded>>
+      style:
+        default: white
+      translation_key:
+        default: country
+        other: country_other
+      dynamic:
+        default: true
+
+    include:
+      - Northern Africa
+      - Eastern Africa
+      - Central Africa
+      - Southern Africa
+      - Western Africa
+      - Caribbean
+      - Central America
+      - South America
+      - North America
+      - Antarctica
+      - Central Asia
+      - Eastern Asia
+      - South-Eastern Asia
+      - Southern Asia
+      - Western Asia
+      - Eastern Europe
+      - Northern Europe
+      - Southern Europe
+      - Western Europe
+      - Australia and New Zealand
+      - Melanesia
+      - Micronesia
+      - Polynesia
+
+    addons:
+      Northern Africa:
+        - dz                    # Algeria
+        - eg                    # Egypt
+        - ly                    # Libya
+        - ma                    # Morocco
+        - sd                    # Sudan
+        - tn                    # Tunisia
+        - eh                    # Western Sahara
+      Eastern Africa:
+        - io                    # British Indian Ocean Territory
+        - bi                    # Burundi
+        - km                    # Comoros
+        - dj                    # Djibouti
+        - er                    # Eritrea
+        - et                    # Ethiopia
+        - tf                    # French Southern Territories
+        - ke                    # Kenya
+        - mg                    # Madagascar
+        - mw                    # Malawi
+        - mu                    # Mauritius
+        - yt                    # Mayotte
+        - mz                    # Mozambique
+        - re                    # Réunion
+        - rw                    # Rwanda
+        - sc                    # Seychelles
+        - so                    # Somalia
+        - ss                    # South Sudan
+        - ug                    # Uganda
+        - tz                    # Tanzania [United Republic of Tanzania]
+        - zm                    # Zambia
+        - zw                    # Zimbabwe
+      Central Africa:
+        - ao                    # Angola
+        - cm                    # Cameroon
+        - cf                    # Central African Republic
+        - td                    # Chad
+        - cg                    # Republic of the Congo [Congo]
+        - cd                    # Democratic Republic of the Congo
+        - zr                    # Zaire
+        - gq                    # Equatorial Guinea
+        - ga                    # Gabon
+        - st                    # São Tomé and Príncipe [Sao Tome and Principe]
+      Southern Africa:
+        - bw                    # Botswana
+        - sz                    # Eswatini [Swaziland]
+        - ls                    # Lesotho
+        - na                    # Namibia
+        - za                    # South Africa
+      Western Africa:
+        - bj                    # Benin
+        - bf                    # Burkina Faso
+        - cv                    # Cape Verde [Cabo Verde]
+        - ci                    # Côte d'Ivoire [Côte d’Ivoire] [Ivory Coast]
+        - gm                    # Gambia
+        - gh                    # Ghana
+        - gn                    # Guinea
+        - gw                    # Guinea-Bissau
+        - lr                    # Liberia
+        - ml                    # Mali
+        - mr                    # Mauritania
+        - ne                    # Niger
+        - ng                    # Nigeria
+        - sh                    # Saint Helena, Ascension and Tristan da Cunha [Ascension] [Tristan da Cunha] [Saint Helena]
+        - sn                    # Senegal
+        - sl                    # Sierra Leone
+        - tg                    # Togo
+      Caribbean:
+        - ai                    # Anguilla
+        - ag                    # Antigua and Barbuda [Antigua] [Barbuda]
+        - aw                    # Aruba
+        - bs                    # Bahamas
+        - bb                    # Barbados
+        - bq                    # Bonaire, Sint Eustatius and Saba [Bonaire] [Sint Eustatius] [Saba]
+        - an                    # Netherlands Antilles
+        - vg                    # British Virgin Islands
+        - ky                    # Cayman Islands
+        - cu                    # Cuba
+        - cw                    # Curaçao
+        - dm                    # Dominica
+        - do                    # Dominican Republic
+        - gd                    # Grenada
+        - gp                    # Guadeloupe
+        - ht                    # Haiti
+        - jm                    # Jamaica
+        - mq                    # Martinique
+        - ms                    # Montserrat
+        - pr                    # Puerto Rico
+        - bl                    # Saint Barthélemy
+        - kn                    # Saint Kitts and Nevis
+        - lc                    # Saint Lucia
+        - mf                    # Saint Martin
+        - vc                    # Saint Vincent and the Grenadines
+        - sx                    # Sint Maarten
+        - tt                    # Trinidad and Tobago
+        - tc                    # Turks and Caicos Islands
+        - vi                    # US Virgin Islands [U.S. Virgin Islands] [United States Virgin Islands]
+      Central America:
+        - bz                    # Belize
+        - cr                    # Costa Rica
+        - sv                    # El Salvador
+        - gt                    # Guatemala
+        - hn                    # Honduras
+        - mx                    # Mexico
+        - ni                    # Nicaragua
+        - pa                    # Panama
+      South America:
+        - ar                    # Argentina
+        - bo                    # Bolivia [Plurinational State of Bolivia]
+        - bv                    # Bouvet Island
+        - br                    # Brazil
+        - cl                    # Chile
+        - co                    # Colombia
+        - ec                    # Ecuador
+        - fk                    # Falkland Islands [Malvinas]
+        - gf                    # French Guiana
+        - gy                    # Guyana
+        - py                    # Paraguay
+        - pe                    # Peru
+        - gs                    # South Georgia and the South Sandwich Islands [South Georgia] [South Sandwich Islands]
+        - sr                    # Suriname
+        - uy                    # Uruguay
+        - ve                    # Venezuela [Bolivarian Republic of Venezuela]
+      North America:
+        - bm                    # Bermuda
+        - ca                    # Canada
+        - gl                    # Greenland
+        - pm                    # Saint Pierre and Miquelon
+        - us                    # United States [United States of America]
+      Antarctica:
+        - aq                    # Antarctica
+      Central Asia:
+        - kz                    # Kazakhstan
+        - kg                    # Kyrgyzstan
+        - tj                    # Tajikistan
+        - tm                    # Turkmenistan
+        - uz                    # Uzbekistan
+      Eastern Asia:
+        - cn                    # China
+        - hk                    # Hong Kong
+        - mo                    # Macao
+        - kp                    # North Korea [Democratic People's Republic of Korea]
+        - jp                    # Japan
+        - mn                    # Mongolia
+        - kr                    # South Korea [Republic of Korea] [Korea]
+        - tw                    # Taiwan [Taiwan, Province of China]
+      South-Eastern Asia:
+        - bn                    # Brunei [Brunei Darussalam]
+        - kh                    # Cambodia
+        - id                    # Indonesia
+        - la                    # Laos [Lao People's Democratic Republic] [Lao]
+        - my                    # Malaysia
+        - mm                    # Myanmar
+        - bu                    # Burma
+        - ph                    # Philippines
+        - sg                    # Singapore
+        - th                    # Thailand
+        - tp                    # East Timor
+        - tl                    # Timor-Leste
+        - vn                    # Vietnam [Viet Nam]
+      Southern Asia:
+        - af                    # Afghanistan
+        - bd                    # Bangladesh
+        - bt                    # Bhutan
+        - in                    # India
+        - ir                    # Iran [Islamic Republic of Iran]
+        - mv                    # Maldives
+        - np                    # Nepal
+        - pk                    # Pakistan
+        - lk                    # Sri Lanka
+      Western Asia:
+        - am                    # Armenia
+        - az                    # Azerbaijan
+        - bh                    # Bahrain
+        - cy                    # Cyprus
+        - ge                    # Georgia
+        - iq                    # Iraq
+        - il                    # Israel
+        - jo                    # Jordan
+        - kw                    # Kuwait
+        - lb                    # Lebanon
+        - om                    # Oman
+        - qa                    # Qatar
+        - sa                    # Saudi Arabia
+        - ps                    # Palestine [State of Palestine]
+        - sy                    # Syria [Syrian Arab Republic]
+        - tr                    # Turkey [Türkiye]
+        - ae                    # United Arab Emirates
+        - ye                    # Yemen
+      Eastern Europe:
+        - by                    # Belarus
+        - bg                    # Bulgaria
+        - cz                    # Czech Republic [Czechia]
+        - cs                    # Czechoslovakia
+        - hu                    # Hungary
+        - pl                    # Poland
+        - md                    # Moldova [Republic of Moldova]
+        - ro                    # Romania
+        - ru                    # Russia [Russian Federation]
+        - su                    # Soviet Union
+        - sk                    # Slovakia
+        - ua                    # Ukraine
+      Northern Europe:
+        - ax                    # Åland Islands
+        - gg                    # Guernsey
+        - je                    # Jersey
+        - cq                    # Sark
+        - dk                    # Denmark
+        - ee                    # Estonia
+        - fo                    # Faroe Islands
+        - fi                    # Finland
+        - is                    # Iceland
+        - ie                    # Ireland
+        - im                    # Isle of Man
+        - lv                    # Latvia
+        - lt                    # Lithuania
+        - no                    # Norway
+        - sj                    # Svalbard and Jan Mayen Islands [Svalbard and Jan Mayen]
+        - se                    # Sweden
+        - gb                    # United Kingdom
+      Southern Europe:
+        - al                    # Albania
+        - ad                    # Andorra
+        - ba                    # Bosnia and Herzegovina
+        - hr                    # Croatia
+        - gi                    # Gibraltar
+        - gr                    # Greece
+        - xk                    # Kosovo
+        - va                    # Vatican City [Holy See]
+        - it                    # Italy
+        - mt                    # Malta
+        - me                    # Montenegro
+        - mk                    # North Macedonia [Macedonia] [Republic of North Macedonia]
+        - pt                    # Portugal
+        - sm                    # San Marino
+        - rs                    # Serbia
+        - si                    # Slovenia
+        - es                    # Spain
+        - yu                    # Yugoslavia
+      Western Europe:
+        - at                    # Austria
+        - be                    # Belgium
+        - fr                    # France [French Republic]
+        - de                    # Germany
+        - dd                    # East Germany
+        - li                    # Liechtenstein
+        - lu                    # Luxembourg
+        - mc                    # Monaco
+        - nl                    # Netherlands
+        - ch                    # Switzerland
+      Australia and New Zealand:
+        - au                    # Australia
+        - cx                    # Christmas Island
+        - cc                    # Cocos (Keeling) Islands
+        - hm                    # Heard Island and McDonald Islands
+        - nz                    # New Zealand
+        - nf                    # Norfolk Island
+      Melanesia:
+        - fj                    # Fiji
+        - nc                    # New Caledonia
+        - pg                    # Papua New Guinea [New Guinea]
+        - sb                    # Solomon Islands
+        - vu                    # Vanuatu
+      Micronesia:
+        - gu                    # Guam
+        - ki                    # Kiribati
+        - mh                    # Marshall Islands
+        - fm                    # Micronesia [Federated States of Micronesia]
+        - nr                    # Nauru
+        - mp                    # Northern Mariana Islands
+        - pw                    # Palau
+        - um                    # US Minor Outlying Islands
+      Polynesia:
+        - as                    # American Samoa
+        - ck                    # Cook Islands
+        - pf                    # French Polynesia
+        - nu                    # Niue
+        - pn                    # Pitcairn [Pitcairn Islands]
+        - ws                    # Samoa
+        - tk                    # Tokelau
+        - to                    # Tonga
+        - tv                    # Tuvalu
+        - wf                    # Wallis and Futuna Islands

--- a/tests/fixtures/schema/collection-schema.json
+++ b/tests/fixtures/schema/collection-schema.json
@@ -1,0 +1,1669 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Kometa Collection File",
+    "description": "Schema for Kometa collection files. These files define Plex collections using builders, filters, and metadata updates.",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "collections": { "$ref": "#/definitions/collections-map" },
+        "templates": { "$ref": "#/definitions/templates-map" },
+        "dynamic_collections": { "$ref": "#/definitions/dynamic-collections-map" },
+        "external_templates": { "$ref": "#/definitions/external-templates-list" }
+    },
+    "definitions": {
+
+        "collections-map": {
+            "title": "collections",
+            "description": "A mapping of collection names to their definitions.",
+            "type": "object",
+            "additionalProperties": { "$ref": "#/definitions/collection-definition" }
+        },
+
+        "collection-definition": {
+            "description": "Defines a single Plex collection.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+
+                "template": {
+                    "description": "Template(s) to use for this definition.",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "$ref": "#/definitions/template-call" },
+                        {
+                            "type": "array",
+                            "items": {
+                                "oneOf": [
+                                    { "type": "string" },
+                                    { "$ref": "#/definitions/template-call" }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "variables": { "type": "object", "additionalProperties": true },
+
+                "blank_collection": { "type": "boolean", "description": "Create the collection with no builders and no items." },
+                "build_collection": { "type": "boolean", "description": "When false, collection won't be created but items can still go to Radarr/Sonarr." },
+                "builder_level": { "type": "string", "enum": ["season", "episode", "album", "track"], "description": "Make collections at season/episode/album/track level." },
+                "cache_builders": { "type": "integer", "minimum": 0, "description": "Number of days to cache builder results. 0 = no cache." },
+                "changes_webhooks": {
+                    "description": "Override the changes webhook for just this definition.",
+                    "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }]
+                },
+                "default_percent": { "type": "integer", "minimum": 1, "maximum": 100, "description": "Default percent for episode/season/track/album special filters." },
+                "delete_below_minimum": { "type": "boolean" },
+                "delete_collections_named": {
+                    "description": "Delete Plex collections with these names.",
+                    "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }]
+                },
+                "delete_not_scheduled": { "type": "boolean" },
+                "hub_priority": { "type": "integer", "minimum": 1, "description": "Priority position for this collection's Recommendation Hub row. Lower numbers appear first." },
+                "ignore_blank_results": { "type": "boolean" },
+                "ignore_ids": {
+                    "anyOf": [
+                        { "type": "null" }, { "type": "integer" },
+                        { "type": "string", "pattern": "^\\d{1,8}(\\s*,\\s*\\d{1,8})*$" },
+                        { "type": "array", "items": { "type": "integer" }, "minItems": 1 }
+                    ]
+                },
+                "ignore_imdb_ids": {
+                    "anyOf": [
+                        { "type": "null" },
+                        { "type": "string", "pattern": "^(tt\\d{7,8})(,(tt\\d{7,8}))*$" },
+                        { "type": "array", "items": { "type": "string", "pattern": "^tt\\d{7,8}$" }, "minItems": 1 }
+                    ]
+                },
+                "limit": { "type": "integer", "minimum": 1 },
+                "minimum_items": { "type": "integer", "minimum": 1 },
+                "missing_only_released": { "type": "boolean" },
+                "name": { "type": "string", "description": "Override the collection name in Plex." },
+                "name_mapping": { "type": "string", "description": "Folder name in the Image Assets Directory." },
+                "only_filter_missing": { "type": "boolean" },
+                "only_run_on_create": { "type": "boolean" },
+                "run_again": { "type": "boolean" },
+                "run_definition": {
+                    "oneOf": [
+                        { "type": "string", "enum": ["movie", "show", "artist", "true", "false"] },
+                        { "type": "boolean" },
+                        { "type": "array", "items": { "type": "string", "enum": ["movie", "show", "artist", "true", "false"] } }
+                    ]
+                },
+                "save_report": { "type": "boolean" },
+                "schedule": { "type": "string" },
+                "server_preroll": {
+                    "description": "Sets Plex's Movie pre-roll video.",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }] } }
+                    ]
+                },
+                "show_filtered": { "type": "boolean" },
+                "show_missing": { "type": "boolean" },
+                "show_unfiltered": { "type": "boolean" },
+                "sync_missing_to_trakt_list": { "type": "boolean" },
+                "sync_mode": { "type": "string", "enum": ["sync", "append"] },
+                "sync_to_trakt_list": { "type": "string", "description": "Trakt list slug to sync this definition to." },
+                "test": { "type": "boolean" },
+                "tmdb_birthday": {
+                    "type": "object", "additionalProperties": false,
+                    "properties": {
+                        "this_month": { "type": "boolean" },
+                        "before": { "type": "integer", "minimum": 0 },
+                        "after": { "type": "integer", "minimum": 0 }
+                    }
+                },
+                "tmdb_region": { "type": "string" },
+                "validate_builders": { "type": "boolean" },
+
+                "collection_filtering": { "type": "string", "enum": ["admin", "user"] },
+                "collection_mode": { "type": "string", "enum": ["default", "hide", "hide_items", "show_items"] },
+                "collection_order": { "type": "string" },
+                "content_rating": { "type": "string" },
+                "file_theme": { "type": "string" },
+                "label": { "$ref": "#/definitions/tag-value" },
+                "label.remove": { "$ref": "#/definitions/tag-value" },
+                "label.sync": { "$ref": "#/definitions/tag-value" },
+                "sort_title": { "type": "string" },
+                "tmdb_person": {
+                    "oneOf": [
+                        { "type": "string" }, { "type": "integer" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "string" }, { "type": "integer" }] } }
+                    ]
+                },
+                "tmdb_person_offset": { "type": "integer", "minimum": 0 },
+                "url_theme": { "type": "string", "format": "uri" },
+                "visible_home": { "oneOf": [{ "type": "boolean" }, { "type": "string" }] },
+                "visible_library": { "oneOf": [{ "type": "boolean" }, { "type": "string" }] },
+                "visible_shared": { "oneOf": [{ "type": "boolean" }, { "type": "string" }] },
+
+                "summary": { "type": "string" },
+                "letterboxd_description": { "type": "string" },
+                "tmdb_biography": { "oneOf": [{ "type": "string" }, { "type": "integer" }] },
+                "tmdb_description": { "oneOf": [{ "type": "string" }, { "type": "integer" }] },
+                "tmdb_summary": { "oneOf": [{ "type": "string" }, { "type": "integer" }] },
+                "trakt_description": { "type": "string" },
+                "tvdb_description": { "type": "string" },
+                "tvdb_summary": { "oneOf": [{ "type": "string" }, { "type": "integer" }] },
+
+                "file_poster": { "type": "string" },
+                "url_poster": { "type": "string", "format": "uri" },
+                "tmdb_poster": { "oneOf": [{ "type": "string" }, { "type": "integer" }] },
+                "tmdb_list_poster": { "oneOf": [{ "type": "string" }, { "type": "integer" }] },
+                "tmdb_profile": { "oneOf": [{ "type": "string" }, { "type": "integer" }] },
+                "tvdb_poster": { "oneOf": [{ "type": "string" }, { "type": "integer" }] },
+                "tvdb_list_poster": { "type": "string" },
+
+                "file_background": { "type": "string" },
+                "url_background": { "type": "string", "format": "uri" },
+                "tmdb_background": { "oneOf": [{ "type": "string" }, { "type": "integer" }] },
+                "tvdb_background": { "oneOf": [{ "type": "string" }, { "type": "integer" }] },
+
+                "smart_label": {
+                    "description": "Make this a Smart Label Collection.",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "type": "object", "additionalProperties": false,
+                          "properties": {
+                            "sort_by": { "type": "string" },
+                            "all": { "type": "object", "additionalProperties": true },
+                            "any": { "type": "object", "additionalProperties": true }
+                          }
+                        }
+                    ]
+                },
+
+                "smart_filter": {
+                    "oneOf": [
+                        { "$ref": "#/definitions/plex-filter-block" },
+                        { "type": "array", "items": { "$ref": "#/definitions/plex-filter-block" } }
+                    ]
+                },
+                "plex_all": { "type": "boolean", "description": "Get every item in the library." },
+                "plex_search": {
+                    "oneOf": [
+                        { "$ref": "#/definitions/plex-filter-block" },
+                        { "type": "array", "items": { "$ref": "#/definitions/plex-filter-block" } }
+                    ]
+                },
+                "plex_watchlist": {
+                    "type": "string",
+                    "enum": ["title.asc", "title.desc", "release.asc", "release.desc", "critic_rating.asc", "critic_rating.desc", "added.asc", "added.desc"],
+                    "description": "Get every item in your Watchlist, sorted by the given option."
+                },
+                "plex_pilots": { "type": "boolean", "description": "Get the first episode of every show. Requires builder_level: episode." },
+                "plex_collectionless": { "$ref": "#/definitions/plex-collectionless-block" },
+
+                "tmdb_collection": {
+                    "description": "TMDb Collection ID(s) or URL(s).",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "tmdb_collection_details": {
+                    "description": "TMDb Collection ID(s) or URL(s). Also fetches summary/poster/background.",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "tmdb_movie": {
+                    "description": "TMDb Movie ID(s) or URL(s).",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "tmdb_movie_details": {
+                    "description": "TMDb Movie ID(s) or URL(s). Also fetches summary/poster/background.",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "tmdb_show": {
+                    "description": "TMDb Show ID(s) or URL(s).",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "tmdb_show_details": {
+                    "description": "TMDb Show ID(s) or URL(s). Also fetches summary/poster/background.",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "tmdb_list": {
+                    "description": "TMDb List ID(s) or URL(s).",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "tmdb_list_details": {
+                    "description": "TMDb List ID(s) or URL(s). Also fetches description.",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "tmdb_actor": {
+                    "description": "TMDb Person ID(s) to build from their acting credits.",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "tmdb_director": {
+                    "description": "TMDb Person ID(s) to build from their directing credits.",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "tmdb_producer": {
+                    "description": "TMDb Person ID(s) to build from their producing credits.",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "tmdb_writer": {
+                    "description": "TMDb Person ID(s) to build from their writing credits.",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "tmdb_crew": {
+                    "description": "TMDb Person ID(s) to build from their crew credits.",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "tmdb_actor_details": {
+                    "description": "TMDb Person ID(s) for acting credits. Also fetches person info.",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "tmdb_crew_details": {
+                    "description": "TMDb Person ID(s) for crew credits. Also fetches person info.",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "tmdb_director_details": {
+                    "description": "TMDb Person ID(s) for directing credits. Also fetches person info.",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "tmdb_producer_details": {
+                    "description": "TMDb Person ID(s) for producing credits. Also fetches person info.",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "tmdb_writer_details": {
+                    "description": "TMDb Person ID(s) for writing credits. Also fetches person info.",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "tmdb_network": {
+                    "description": "TMDb Network ID(s).",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "tmdb_company": {
+                    "description": "TMDb Company ID(s).",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "tmdb_keyword": {
+                    "description": "TMDb Keyword ID(s).",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "tmdb_popular": { "type": "integer", "minimum": 1, "description": "Number of popular TMDb movies/shows to get." },
+                "tmdb_top_rated": { "type": "integer", "minimum": 1, "description": "Number of top-rated TMDb movies/shows to get." },
+                "tmdb_now_playing": { "type": "integer", "minimum": 1, "description": "Number of now-playing TMDb movies to get." },
+                "tmdb_upcoming": { "type": "integer", "minimum": 1, "description": "Number of upcoming TMDb movies to get." },
+                "tmdb_airing_today": { "type": "integer", "minimum": 1, "description": "Number of airing-today TMDb shows to get." },
+                "tmdb_on_the_air": { "type": "integer", "minimum": 1, "description": "Number of on-the-air TMDb shows to get." },
+                "tmdb_trending_daily": { "type": "integer", "minimum": 1, "description": "Number of daily trending TMDb items to get." },
+                "tmdb_trending_weekly": { "type": "integer", "minimum": 1, "description": "Number of weekly trending TMDb items to get." },
+                "tmdb_discover": {
+                    "description": "TMDb Discover search. Uses TMDb's Discover API with movie or show search attributes.",
+                    "oneOf": [
+                        { "$ref": "#/definitions/tmdb-discover-block" },
+                        { "type": "array", "items": { "$ref": "#/definitions/tmdb-discover-block" } }
+                    ]
+                },
+
+                "tvdb_list": {
+                    "description": "TVDb List URL(s).",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "type": "array", "items": { "type": "string" } }
+                    ]
+                },
+                "tvdb_list_details": {
+                    "description": "TVDb List URL(s). Also fetches description.",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "type": "array", "items": { "type": "string" } }
+                    ]
+                },
+                "tvdb_show": {
+                    "description": "TVDb Series ID(s) or URL(s).",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "tvdb_show_details": {
+                    "description": "TVDb Series ID(s) or URL(s). Also fetches summary/poster/background.",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "tvdb_movie": {
+                    "description": "TVDb Movie ID(s) or URL(s).",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "tvdb_movie_details": {
+                    "description": "TVDb Movie ID(s) or URL(s). Also fetches summary/poster/background.",
+                    "oneOf": [
+                        { "type": "integer" }, { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+
+                "imdb_id": {
+                    "description": "IMDb ID(s) (tt-prefixed).",
+                    "oneOf": [
+                        { "type": "string", "pattern": "^tt\\d{7,8}(,\\s*tt\\d{7,8})*$" },
+                        { "type": "array", "items": { "type": "string", "pattern": "^tt\\d{7,8}$" } }
+                    ]
+                },
+                "imdb_chart": {
+                    "description": "IMDb chart name(s).",
+                    "oneOf": [
+                        { "type": "string", "enum": ["box_office","popular_movies","top_movies","top_english","popular_shows","top_shows","lowest_rated","top_indian","top_tamil","top_telugu","top_malayalam","trending_india","trending_tamil","trending_telugu"] },
+                        { "type": "array", "items": { "type": "string", "enum": ["box_office","popular_movies","top_movies","top_english","popular_shows","top_shows","lowest_rated","top_indian","top_tamil","top_telugu","top_malayalam","trending_india","trending_tamil","trending_telugu"] } }
+                    ]
+                },
+                "imdb_list": {
+                    "description": "IMDb List(s) by list_id.",
+                    "oneOf": [
+                        { "$ref": "#/definitions/imdb-list-entry" },
+                        { "type": "array", "items": { "$ref": "#/definitions/imdb-list-entry" } }
+                    ]
+                },
+                "imdb_watchlist": {
+                    "description": "IMDb User Watchlist(s) by user_id.",
+                    "oneOf": [
+                        { "$ref": "#/definitions/imdb-watchlist-entry" },
+                        { "type": "array", "items": { "$ref": "#/definitions/imdb-watchlist-entry" } }
+                    ]
+                },
+                "imdb_award": {
+                    "description": "IMDb Award Event results.",
+                    "$ref": "#/definitions/imdb-award-entry"
+                },
+                "imdb_search": {
+                    "description": "IMDb Advanced Title Search.",
+                    "$ref": "#/definitions/imdb-search-block"
+                },
+
+                "trakt_list": {
+                    "description": "Trakt List URL(s).",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "type": "array", "items": { "type": "string" } }
+                    ]
+                },
+                "trakt_list_details": {
+                    "description": "Trakt List URL(s). Also fetches description.",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "type": "array", "items": { "type": "string" } }
+                    ]
+                },
+                "trakt_chart": {
+                    "description": "Trakt chart query.",
+                    "oneOf": [
+                        { "$ref": "#/definitions/trakt-chart-entry" },
+                        { "type": "array", "items": { "$ref": "#/definitions/trakt-chart-entry" } }
+                    ]
+                },
+                "trakt_userlist": {
+                    "description": "Trakt User list(s).",
+                    "oneOf": [
+                        { "$ref": "#/definitions/trakt-userlist-entry" },
+                        { "type": "array", "items": { "$ref": "#/definitions/trakt-userlist-entry" } }
+                    ]
+                },
+                "trakt_recommendations": { "type": "integer", "minimum": 1, "maximum": 100, "description": "Number of Trakt personal recommendations." },
+                "trakt_boxoffice": { "type": "boolean", "description": "Get Trakt's Top Box Office movies (always 10)." },
+                "trakt_trending": { "type": "integer", "minimum": 1 },
+                "trakt_popular": { "type": "integer", "minimum": 1 },
+
+                "tautulli_popular": { "$ref": "#/definitions/tautulli-builder-block" },
+                "tautulli_watched": { "$ref": "#/definitions/tautulli-builder-block" },
+
+                "radarr_all": { "type": "boolean", "description": "Get all movies in Radarr." },
+                "radarr_taglist": {
+                    "description": "Get Radarr movies by tag(s). Leave blank for untagged movies.",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "type": "null" },
+                        { "type": "array", "items": { "type": "string" } }
+                    ]
+                },
+
+                "sonarr_all": { "type": "boolean", "description": "Get all shows in Sonarr." },
+                "sonarr_taglist": {
+                    "description": "Get Sonarr shows by tag(s). Leave blank for untagged shows.",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "type": "null" },
+                        { "type": "array", "items": { "type": "string" } }
+                    ]
+                },
+
+                "mdblist_list": {
+                    "description": "MDBList List URL(s) or object with url and limit.",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "$ref": "#/definitions/mdblist-list-entry" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "string" }, { "$ref": "#/definitions/mdblist-list-entry" }] } }
+                    ]
+                },
+
+                "letterboxd_list": {
+                    "description": "Letterboxd List URL(s).",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "$ref": "#/definitions/letterboxd-list-entry" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "string" }, { "$ref": "#/definitions/letterboxd-list-entry" }] } }
+                    ]
+                },
+                "letterboxd_list_details": {
+                    "description": "Letterboxd List URL(s). Also fetches description.",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "$ref": "#/definitions/letterboxd-list-entry" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "string" }, { "$ref": "#/definitions/letterboxd-list-entry" }] } }
+                    ]
+                },
+                "letterboxd_user_films": {
+                    "description": "Letterboxd user films page(s).",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "$ref": "#/definitions/letterboxd-user-page-entry" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "string" }, { "$ref": "#/definitions/letterboxd-user-page-entry" }] } }
+                    ]
+                },
+                "letterboxd_user_films_details": {
+                    "description": "Letterboxd user films page(s). Also fetches details.",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "$ref": "#/definitions/letterboxd-user-page-entry" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "string" }, { "$ref": "#/definitions/letterboxd-user-page-entry" }] } }
+                    ]
+                },
+                "letterboxd_user_reviews": {
+                    "description": "Letterboxd user reviews page(s).",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "$ref": "#/definitions/letterboxd-user-page-entry" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "string" }, { "$ref": "#/definitions/letterboxd-user-page-entry" }] } }
+                    ]
+                },
+                "letterboxd_user_reviews_details": {
+                    "description": "Letterboxd user reviews page(s). Also fetches details.",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "$ref": "#/definitions/letterboxd-user-page-entry" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "string" }, { "$ref": "#/definitions/letterboxd-user-page-entry" }] } }
+                    ]
+                },
+
+                "icheckmovies_list": {
+                    "description": "ICheckMovies List URL(s).",
+                    "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }]
+                },
+                "icheckmovies_list_details": {
+                    "description": "ICheckMovies List URL(s). Also fetches description.",
+                    "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }]
+                },
+
+                "boxofficemojo_list": {
+                    "description": "BoxOfficeMojo list(s) by ID.",
+                    "oneOf": [{ "type": "string" }, { "type": "integer" }, { "type": "array", "items": { "oneOf": [{ "type": "string" }, { "type": "integer" }] } }]
+                },
+                "mojo_world": {
+                    "description": "BoxOfficeMojo worldwide chart for a given year.",
+                    "oneOf": [
+                        { "$ref": "#/definitions/mojo-world-entry" },
+                        { "type": "array", "items": { "$ref": "#/definitions/mojo-world-entry" } }
+                    ]
+                },
+                "mojo_domestic": {
+                    "description": "BoxOfficeMojo domestic chart.",
+                    "oneOf": [
+                        { "$ref": "#/definitions/mojo-range-entry" },
+                        { "type": "array", "items": { "$ref": "#/definitions/mojo-range-entry" } }
+                    ]
+                },
+                "mojo_all_time": {
+                    "description": "BoxOfficeMojo all-time chart.",
+                    "oneOf": [
+                        { "$ref": "#/definitions/mojo-all-time-entry" },
+                        { "type": "array", "items": { "$ref": "#/definitions/mojo-all-time-entry" } }
+                    ]
+                },
+                "mojo_international": {
+                    "description": "BoxOfficeMojo international chart (weekend/monthly/quarterly/yearly).",
+                    "oneOf": [
+                        { "$ref": "#/definitions/mojo-intl-range-entry" },
+                        { "type": "array", "items": { "$ref": "#/definitions/mojo-intl-range-entry" } }
+                    ]
+                },
+                "mojo_record": {
+                    "description": "BoxOfficeMojo record chart (opening weekend, per-theater averages, etc.).",
+                    "oneOf": [
+                        { "$ref": "#/definitions/mojo-record-entry" },
+                        { "type": "array", "items": { "$ref": "#/definitions/mojo-record-entry" } }
+                    ]
+                },
+                "mojo_never": {
+                    "description": "BoxOfficeMojo 'Never in the Top N' chart.",
+                    "oneOf": [
+                        { "$ref": "#/definitions/mojo-never-entry" },
+                        { "type": "array", "items": { "$ref": "#/definitions/mojo-never-entry" } }
+                    ]
+                },
+
+                "reciperr_list": {
+                    "description": "Reciperr list URL(s).",
+                    "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }]
+                },
+
+                "stevenlu_popular": { "type": "boolean", "description": "Get StevenLu's Popular Movies list." },
+                "stevenlu2_popular": { "type": "integer", "minimum": 1 },
+
+                "simkl_trending": {
+                    "description": "Simkl trending titles. Integer limit or object with period and limit.",
+                    "oneOf": [
+                        { "type": "integer", "minimum": 1, "maximum": 500 },
+                        { "$ref": "#/definitions/simkl-trending-entry" }
+                    ]
+                },
+                "simkl_dvd": {
+                    "description": "Simkl DVD releases. Integer limit or object with limit.",
+                    "oneOf": [
+                        { "type": "integer", "minimum": 1, "maximum": 500 },
+                        { "$ref": "#/definitions/simkl-dvd-entry" }
+                    ]
+                },
+
+                "text_file": {
+                    "description": "Path(s) to a plain-text file containing one IMDb/TMDb/TVDb ID per line.",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "type": "array", "items": { "type": "string" } }
+                    ]
+                },
+
+                "anidb_id": {
+                    "description": "AniDB ID(s). Accepts integer, comma-separated string, or array.",
+                    "oneOf": [
+                        { "type": "integer" },
+                        { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "anidb_relation": {
+                    "description": "AniDB ID to get all relations of.",
+                    "type": "integer"
+                },
+                "anidb_popular": { "type": "integer", "minimum": 1, "maximum": 30, "description": "Number of items from AniDB's popular anime list (max 30)." },
+                "anidb_tag": {
+                    "description": "AniDB Tag(s) to build from. Accepts tag ID, string name, dict with tag_id/limit, or array.",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "type": "integer" },
+                        { "type": "object" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "string" }, { "type": "integer" }, { "type": "object" }] } }
+                    ]
+                },
+                "anidb_tag_name": {
+                    "description": "AniDB Tag(s) by name. Accepts string, dict with tags/min_weight, or array.",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "type": "object" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "string" }, { "type": "object" }] } }
+                    ]
+                },
+
+                "anilist_top_rated": { "type": "integer", "minimum": 1, "description": "Number of AniList top-rated anime." },
+                "anilist_popular": { "type": "integer", "minimum": 1, "description": "Number of AniList popular anime." },
+                "anilist_trending": { "type": "integer", "minimum": 1, "description": "Number of AniList trending anime." },
+                "anilist_id": {
+                    "description": "AniList ID(s). Accepts integer, comma-separated string, or array.",
+                    "oneOf": [
+                        { "type": "integer" },
+                        { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "anilist_relations": {
+                    "description": "AniList ID to get all relations of.",
+                    "type": "integer"
+                },
+                "anilist_studio": {
+                    "description": "AniList Studio ID(s).",
+                    "oneOf": [{ "type": "integer" }, { "type": "array", "items": { "type": "integer" } }]
+                },
+                "anilist_genre": {
+                    "description": "AniList Genre(s) to build from.",
+                    "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }]
+                },
+                "anilist_tag": {
+                    "description": "AniList Tag(s) to build from.",
+                    "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }]
+                },
+                "anilist_season": { "$ref": "#/definitions/anilist-season-block" },
+                "anilist_userlist": { "$ref": "#/definitions/anilist-userlist-block" },
+                "anilist_search": { "$ref": "#/definitions/anilist-search-block" },
+
+                "mal_all": { "type": "integer", "minimum": 1, "maximum": 500 },
+                "mal_airing": { "type": "integer", "minimum": 1, "maximum": 500 },
+                "mal_upcoming": { "type": "integer", "minimum": 1, "maximum": 500 },
+                "mal_tv": { "type": "integer", "minimum": 1, "maximum": 500 },
+                "mal_movie": { "type": "integer", "minimum": 1, "maximum": 500 },
+                "mal_ova": { "type": "integer", "minimum": 1, "maximum": 500 },
+                "mal_special": { "type": "integer", "minimum": 1, "maximum": 500 },
+                "mal_popular": { "type": "integer", "minimum": 1, "maximum": 500 },
+                "mal_favorite": { "type": "integer", "minimum": 1, "maximum": 500 },
+                "mal_suggested": { "type": "integer", "minimum": 1, "maximum": 100 },
+                "mal_id": {
+                    "description": "MyAnimeList ID(s).",
+                    "oneOf": [
+                        { "type": "integer" },
+                        { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "mal_userlist": { "$ref": "#/definitions/mal-userlist-block" },
+                "mal_season": { "$ref": "#/definitions/mal-season-block" },
+                "mal_search": { "$ref": "#/definitions/mal-search-block" },
+
+                "item_label": { "$ref": "#/definitions/tag-value", "description": "Apply label(s) to all items found by builders." },
+                "item_label.remove": { "$ref": "#/definitions/tag-value" },
+                "item_label.sync": { "$ref": "#/definitions/tag-value" },
+                "item_assets": { "type": "boolean" },
+                "item_refresh": { "type": "boolean" },
+                "item_refresh_delay": { "type": "integer", "minimum": 0 },
+                "item_tmdb_season_titles": { "type": "boolean", "description": "Update season titles from TMDb for matched shows." },
+                "revert_overlay": { "type": "boolean", "description": "Revert overlays on items in this collection." },
+                "item_analyze": { "type": "boolean", "description": "Trigger Plex analysis (chapter images, etc.) on matched items." },
+                "item_lock_background": { "type": "boolean", "description": "Lock/unlock background art on matched items." },
+                "item_lock_poster": { "type": "boolean", "description": "Lock/unlock poster art on matched items." },
+                "item_lock_square_art": { "type": "boolean", "description": "Lock/unlock square art on matched items." },
+                "item_lock_title": { "type": "boolean", "description": "Lock/unlock title field on matched items." },
+                "item_critic_rating": {
+                    "description": "Set critic rating on matched items (0.0–10.0, null to clear).",
+                    "oneOf": [{ "type": "number", "minimum": 0, "maximum": 10 }, { "type": "null" }]
+                },
+                "item_audience_rating": {
+                    "description": "Set audience rating on matched items (0.0–10.0, null to clear).",
+                    "oneOf": [{ "type": "number", "minimum": 0, "maximum": 10 }, { "type": "null" }]
+                },
+                "item_user_rating": {
+                    "description": "Set user rating on matched items (0.0–10.0, null to clear).",
+                    "oneOf": [{ "type": "number", "minimum": 0, "maximum": 10 }, { "type": "null" }]
+                },
+                "non_item_remove_label": { "$ref": "#/definitions/tag-value", "description": "Remove label(s) from items NOT in this collection." },
+                "item_genre": { "$ref": "#/definitions/tag-value", "description": "Append genre(s) to matched items." },
+                "item_genre.remove": { "$ref": "#/definitions/tag-value" },
+                "item_genre.sync": { "$ref": "#/definitions/tag-value" },
+                "item_edition": {
+                    "description": "Set edition field on matched items (null to clear).",
+                    "oneOf": [{ "type": "string" }, { "type": "null" }]
+                },
+                "item_radarr_tag": { "$ref": "#/definitions/tag-value", "description": "Append Radarr tag(s) to matched items." },
+                "item_radarr_tag.remove": { "$ref": "#/definitions/tag-value" },
+                "item_radarr_tag.sync": { "$ref": "#/definitions/tag-value" },
+                "item_sonarr_tag": { "$ref": "#/definitions/tag-value", "description": "Append Sonarr tag(s) to matched items." },
+                "item_sonarr_tag.remove": { "$ref": "#/definitions/tag-value" },
+                "item_sonarr_tag.sync": { "$ref": "#/definitions/tag-value" },
+                "item_album_sorting": { "type": "string", "description": "Set album sort order for matched artist items (music libraries)." },
+                "url_square_art": { "type": "string", "description": "URL of a square-art image to apply to the collection." },
+                "file_square_art": { "type": "string", "description": "Local path to a square-art image." },
+                "icheckmovies_description": { "type": "string", "description": "ICheckMovies list URL to pull a collection description from." },
+                "suppress_overlays": {
+                    "description": "Overlay name(s) to suppress on items in this collection.",
+                    "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }]
+                },
+                "album_sorting": { "type": "string", "description": "Default album sort order for this library (music libraries)." },
+                "asset_folders": { "type": "boolean", "description": "Use per-item asset sub-folders instead of a flat asset directory." },
+                "create_asset_folders": { "type": "boolean", "description": "Create missing asset sub-folders automatically." },
+
+                "item_episode_sorting": { "type": "string", "enum": ["default", "oldest", "newest"] },
+                "item_keep_episodes": { "type": "string", "enum": ["all", "5_latest", "3_latest", "latest", "past_3", "past_7", "past_30"] },
+                "item_delete_episodes": { "type": "string", "enum": ["never", "day", "week", "month", "refresh"] },
+                "item_season_display": { "type": "string", "enum": ["default", "show", "hide"] },
+                "item_episode_ordering": { "type": "string", "enum": ["default", "tmdb_aired", "tvdb_aired", "tvdb_dvd", "tvdb_absolute"] },
+                "item_metadata_language": { "type": "string", "enum": ["default", "ar-SA", "ca-ES", "cs-CZ", "da-DK", "de-DE", "el-GR", "en-AU", "en-CA", "en-GB", "en-US", "es-ES", "es-MX", "et-EE", "fa-IR", "fi-FI", "fr-CA", "fr-FR", "he-IL", "hi-IN", "hu-HU", "id-ID", "it-IT", "ja-JP", "ko-KR", "lt-LT", "lv-LV", "nb-NO", "nl-NL", "pl-PL", "pt-BR", "pt-PT", "ro-RO", "ru-RU", "sk-SK", "sv-SE", "th-TH", "tr-TR", "uk-UA", "vi-VN", "zh-CN", "zh-HK", "zh-TW"] },
+                "item_use_original_title": { "type": "string", "enum": ["default", "no", "yes"] },
+                "item_credits_detection": { "type": "string", "enum": ["default", "disabled"] },
+                "item_audio_language": { "type": "string", "enum": ["default", "ar-SA", "ca-ES", "cs-CZ", "da-DK", "de-DE", "el-GR", "en-AU", "en-CA", "en-GB", "en-US", "es-ES", "es-MX", "et-EE", "fa-IR", "fi-FI", "fr-CA", "fr-FR", "he-IL", "hi-IN", "hu-HU", "id-ID", "it-IT", "ja-JP", "ko-KR", "lt-LT", "lv-LV", "nb-NO", "nl-NL", "pl-PL", "pt-BR", "pt-PT", "ro-RO", "ru-RU", "sk-SK", "sv-SE", "th-TH", "tr-TR", "uk-UA", "vi-VN", "zh-CN", "zh-HK", "zh-TW"] },
+                "item_subtitle_language": { "type": "string", "enum": ["default", "ar-SA", "ca-ES", "cs-CZ", "da-DK", "de-DE", "el-GR", "en-AU", "en-CA", "en-GB", "en-US", "es-ES", "es-MX", "et-EE", "fa-IR", "fi-FI", "fr-CA", "fr-FR", "he-IL", "hi-IN", "hu-HU", "id-ID", "it-IT", "ja-JP", "ko-KR", "lt-LT", "lv-LV", "nb-NO", "nl-NL", "pl-PL", "pt-BR", "pt-PT", "ro-RO", "ru-RU", "sk-SK", "sv-SE", "th-TH", "tr-TR", "uk-UA", "vi-VN", "zh-CN", "zh-HK", "zh-TW"] },
+                "item_subtitle_mode": { "type": "string", "enum": ["default", "manual", "foreign", "always"] },
+
+                "append_label": { "$ref": "#/definitions/tag-value", "description": "Append label(s) to matched items without replacing existing labels." },
+                "variables": { "type": "object", "additionalProperties": true, "description": "Template variable overrides for this collection block." },
+                "allowed_library_types": {
+                    "description": "Library type(s) this collection is restricted to.",
+                    "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }]
+                },
+                "playlist_name": { "type": "string", "description": "Override the playlist display name." },
+                "collection_name": { "type": "string", "description": "Override the collection display name." },
+                "tmdb_deathday": { "type": "string", "description": "TMDb person death-date used in template conditionals." },
+                "smart_url": { "type": "string", "description": "Raw Plex smart-collection URL (advanced/legacy use)." },
+
+                "radarr_add_missing": { "type": "boolean" },
+                "radarr_add_existing": { "type": "boolean" },
+                "radarr_upgrade_existing": { "type": "boolean" },
+                "radarr_monitor_existing": { "type": "boolean" },
+                "radarr_folder": { "type": "string" },
+                "radarr_monitor": { "type": "string", "enum": ["movie", "collection", "none"] },
+                "radarr_search": { "type": "boolean" },
+                "radarr_availability": { "type": "string", "enum": ["announced", "cinemas", "released", "db"] },
+                "radarr_quality": { "type": "string" },
+                "radarr_tag": { "$ref": "#/definitions/tag-value" },
+                "radarr_ignore_cache": { "type": "boolean" },
+                "sonarr_add_missing": { "type": "boolean" },
+                "sonarr_add_existing": { "type": "boolean" },
+                "sonarr_upgrade_existing": { "type": "boolean" },
+                "sonarr_monitor_existing": { "type": "boolean" },
+                "sonarr_folder": { "type": "string" },
+                "sonarr_monitor": { "type": "string", "enum": ["all", "future", "missing", "existing", "pilot", "first", "latest", "none"] },
+                "sonarr_search": { "type": "boolean" },
+                "sonarr_cutoff_search": { "type": "boolean" },
+                "sonarr_quality": { "type": "string" },
+                "sonarr_language": { "type": "string" },
+                "sonarr_series": { "type": "string", "enum": ["standard", "daily", "anime"] },
+                "sonarr_series_type": { "type": "string", "enum": ["standard", "daily", "anime"] },
+                "sonarr_season": { "type": "boolean" },
+                "sonarr_tag": { "$ref": "#/definitions/tag-value" },
+                "sonarr_season_folder": { "type": "boolean" },
+                "sonarr_ignore_cache": { "type": "boolean" },
+
+                "filters": {
+                    "description": "Filters applied to items found by builders.",
+                    "oneOf": [
+                        { "type": "object", "additionalProperties": true },
+                        { "type": "array", "items": { "type": "object", "additionalProperties": true } }
+                    ]
+                }
+            }
+        },
+
+        "plex-filter-block": {
+            "description": "Plex smart_filter or plex_search block.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "all": { "type": "object", "additionalProperties": true },
+                "any": { "type": "object", "additionalProperties": true },
+                "sort_by": {
+                    "oneOf": [
+                        { "type": "string" },
+                        { "type": "array", "items": { "type": "string" } }
+                    ]
+                },
+                "limit": { "oneOf": [{ "type": "integer", "minimum": 1 }, { "type": "string", "enum": ["all"] }] },
+                "validate": { "type": "boolean" },
+                "type": { "type": "string", "enum": ["movie", "show", "season", "episode", "artist", "album", "track"] }
+            }
+        },
+
+        "plex-collectionless-block": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclude": {
+                    "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }]
+                },
+                "exclude_prefix": {
+                    "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }]
+                }
+            }
+        },
+
+        "imdb-list-entry": {
+            "oneOf": [
+                {
+                    "type": "object", "additionalProperties": false,
+                    "required": ["list_id"],
+                    "properties": {
+                        "list_id": { "type": "string", "pattern": "^ls\\d+$" },
+                        "limit": { "type": "integer", "minimum": 0 },
+                        "sort_by": { "type": "string", "enum": ["custom.asc","custom.desc","title.asc","title.desc","rating.asc","rating.desc","popularity.asc","popularity.desc","votes.asc","votes.desc","release.asc","release.desc","runtime.asc","runtime.desc","added.asc","added.desc"] }
+                    }
+                },
+                {
+                    "type": "object", "additionalProperties": false,
+                    "properties": {
+                        "url": { "type": "string" },
+                        "limit": { "type": "integer", "minimum": 0 }
+                    },
+                    "required": ["url"]
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        },
+
+        "imdb-watchlist-entry": {
+            "type": "object", "additionalProperties": false,
+            "required": ["user_id"],
+            "properties": {
+                "user_id": { "type": "string", "pattern": "^ur\\d+$" },
+                "limit": { "type": "integer", "minimum": 0 },
+                "sort_by": { "type": "string", "enum": ["custom.asc","custom.desc","title.asc","title.desc","rating.asc","rating.desc","popularity.asc","popularity.desc","votes.asc","votes.desc","release.asc","release.desc","runtime.asc","runtime.desc","added.asc","added.desc"] }
+            }
+        },
+
+        "imdb-award-entry": {
+            "type": "object", "additionalProperties": false,
+            "required": ["event_id", "event_year"],
+            "properties": {
+                "event_id": { "type": "string" },
+                "event_year": {
+                    "oneOf": [
+                        { "type": "integer" },
+                        { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "award_filter": {
+                    "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }]
+                },
+                "category_filter": {
+                    "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }]
+                },
+                "winning": { "type": "boolean" }
+            }
+        },
+
+        "imdb-search-block": {
+            "type": "object", "additionalProperties": false,
+            "properties": {
+                "limit": { "type": "integer", "minimum": 0 },
+                "sort_by": { "type": "string", "enum": ["popularity.asc","popularity.desc","title.asc","title.desc","rating.asc","rating.desc","votes.asc","votes.desc","box_office.asc","box_office.desc","runtime.asc","runtime.desc","year.asc","year.desc","release.asc","release.desc"] },
+                "title": { "type": "string" },
+                "type": { "type": "string" },
+                "type.not": { "type": "string" },
+                "release.after": { "type": "string" },
+                "release.before": { "type": "string" },
+                "rating.gte": { "type": "number", "minimum": 0.1, "maximum": 10.0 },
+                "rating.lte": { "type": "number", "minimum": 0.1, "maximum": 10.0 },
+                "votes.gte": { "type": "integer", "minimum": 0 },
+                "votes.lte": { "type": "integer", "minimum": 0 },
+                "genre": { "type": "string" },
+                "genre.any": { "type": "string" },
+                "genre.not": { "type": "string" },
+                "interests": { "type": "string" },
+                "interests.any": { "type": "string" },
+                "interests.not": { "type": "string" },
+                "event": { "type": "string" },
+                "event.winning": { "type": "string" },
+                "imdb_top": { "type": "integer", "minimum": 1 },
+                "imdb_bottom": { "type": "integer", "minimum": 1 },
+                "topic": { "type": "string" },
+                "topic.not": { "type": "string" },
+                "company": { "type": "string" },
+                "content_rating": { "type": "array", "items": { "type": "object", "properties": { "rating": { "type": "string" }, "region": { "type": "string" } } } },
+                "country": { "type": "string" },
+                "country.any": { "type": "string" },
+                "country.not": { "type": "string" },
+                "country.origin": { "type": "string" },
+                "keyword": { "type": "string" },
+                "keyword.any": { "type": "string" },
+                "keyword.not": { "type": "string" },
+                "series": { "type": "string" },
+                "series.not": { "type": "string" },
+                "list": { "type": "string" },
+                "list.any": { "type": "string" },
+                "list.not": { "type": "string" },
+                "language": { "type": "string" },
+                "language.any": { "type": "string" },
+                "language.not": { "type": "string" },
+                "language.primary": { "type": "string" },
+                "popularity.gte": { "type": "integer", "minimum": 0 },
+                "popularity.lte": { "type": "integer", "minimum": 0 },
+                "cast": { "type": "string" },
+                "cast.any": { "type": "string" },
+                "cast.not": { "type": "string" },
+                "character": { "type": "string" },
+                "runtime.gte": { "type": "integer", "minimum": 0 },
+                "runtime.lte": { "type": "integer", "minimum": 0 },
+                "adult": { "type": "boolean" },
+                "alternate_version": { "type": "string" },
+                "alternate_version.any": { "type": "string" },
+                "alternate_version.not": { "type": "string" },
+                "crazy_credit": { "type": "string" }, "crazy_credit.any": { "type": "string" }, "crazy_credit.not": { "type": "string" },
+                "goof": { "type": "string" }, "goof.any": { "type": "string" }, "goof.not": { "type": "string" },
+                "location": { "type": "string" }, "location.any": { "type": "string" }, "location.not": { "type": "string" },
+                "plot": { "type": "string" }, "plot.any": { "type": "string" }, "plot.not": { "type": "string" },
+                "quote": { "type": "string" }, "quote.any": { "type": "string" }, "quote.not": { "type": "string" },
+                "soundtrack": { "type": "string" }, "soundtrack.any": { "type": "string" }, "soundtrack.not": { "type": "string" },
+                "trivia": { "type": "string" }, "trivia.any": { "type": "string" }, "trivia.not": { "type": "string" }
+            }
+        },
+
+        "trakt-chart-entry": {
+            "type": "object", "additionalProperties": false,
+            "required": ["chart"],
+            "properties": {
+                "chart": { "type": "string", "enum": ["trending", "popular", "recommended", "watched", "collected"] },
+                "time_period": { "type": "string", "enum": ["daily", "weekly", "monthly", "yearly", "all"] },
+                "limit": { "type": "integer", "minimum": 1 },
+                "query": { "type": "string" },
+                "years": { "type": "string" },
+                "genres": { "type": "string" },
+                "languages": { "type": "string" },
+                "countries": { "type": "string" },
+                "certifications": { "type": "string" },
+                "runtimes": { "type": "string" },
+                "ratings": { "type": "string" },
+                "votes": { "type": "string" },
+                "tmdb_ratings": { "type": "string" },
+                "tmdb_votes": { "type": "string" },
+                "imdb_ratings": { "type": "string" },
+                "imdb_votes": { "type": "string" },
+                "rt_meters": { "type": "string" },
+                "rt_user_meters": { "type": "string" },
+                "metascores": { "type": "string" },
+                "studio_ids": { "type": "string" },
+                "network_ids": { "type": "string" },
+                "status": { "type": "string" }
+            }
+        },
+
+        "trakt-userlist-entry": {
+            "type": "object", "additionalProperties": false,
+            "required": ["userlist"],
+            "properties": {
+                "userlist": { "type": "string", "enum": ["watchlist", "favorites", "watched", "collection"] },
+                "user": { "type": "string" },
+                "sort_by": { "type": "string", "enum": ["rank", "added", "released", "title"] }
+            }
+        },
+
+        "tautulli-builder-block": {
+            "type": "object", "additionalProperties": false,
+            "properties": {
+                "list_days": { "type": "integer", "minimum": 1 },
+                "list_minimum": { "type": "integer", "minimum": 0 },
+                "list_size": { "type": "integer", "minimum": 1 }
+            }
+        },
+
+        "mdblist-list-entry": {
+            "type": "object", "additionalProperties": false,
+            "required": ["url"],
+            "properties": {
+                "url": { "type": "string", "format": "uri" },
+                "limit": { "type": "integer", "minimum": 1 },
+                "sort_by": { "type": "string" }
+            }
+        },
+
+        "letterboxd-list-entry": {
+            "type": "object", "additionalProperties": false,
+            "required": ["url"],
+            "properties": {
+                "url": { "type": "string", "format": "uri" },
+                "limit": { "type": "integer", "minimum": 1 },
+                "sort_by": { "type": "string" },
+                "year": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
+                "rating": {}
+            }
+        },
+
+        "letterboxd-user-page-entry": {
+            "type": "object", "additionalProperties": false,
+            "properties": {
+                "username": { "type": "string" },
+                "usernames": { "type": "array", "items": { "type": "string" } },
+                "min_rating": { "type": "number" },
+                "limit": { "type": "integer", "minimum": 1 },
+                "year": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
+                "sort_by": { "type": "string" },
+                "incremental": { "type": "boolean" },
+                "note": { "type": "string" }
+            }
+        },
+
+        "mal-userlist-block": {
+            "type": "object", "additionalProperties": false,
+            "required": ["username"],
+            "properties": {
+                "username": { "type": "string" },
+                "status": { "type": "string", "enum": ["all", "watching", "completed", "on_hold", "dropped", "plan_to_watch"] },
+                "sort_by": { "type": "string", "enum": ["score", "last_updated", "title", "start_date"] },
+                "limit": { "type": "integer", "minimum": 1, "maximum": 1000 }
+            }
+        },
+
+        "mal-season-block": {
+            "type": "object", "additionalProperties": false,
+            "properties": {
+                "season": { "type": "string", "enum": ["winter", "spring", "summer", "fall", "current"] },
+                "year": { "type": "integer", "minimum": 1917 },
+                "sort_by": { "type": "string", "enum": ["members", "score"] },
+                "limit": { "type": "integer", "minimum": 1, "maximum": 500 },
+                "starting_only": { "type": "boolean" }
+            }
+        },
+
+        "mal-search-block": {
+            "type": "object", "additionalProperties": false,
+            "properties": {
+                "sort_by": { "type": "string" },
+                "limit": { "type": "integer", "minimum": 1 },
+                "query": { "type": "string" },
+                "prefix": { "type": "string" },
+                "type": { "type": "string", "enum": ["tv", "movie", "ova", "special", "ona", "music"] },
+                "status": { "type": "string", "enum": ["airing", "complete", "upcoming"] },
+                "genre": { "type": "string" },
+                "genre.not": { "type": "string" },
+                "studio": { "type": "string" },
+                "content_rating": { "type": "string", "enum": ["g", "pg", "pg13", "r17", "r", "rx"] },
+                "score.gt": { "type": "number", "minimum": 0, "maximum": 10 },
+                "score.gte": { "type": "number", "minimum": 0, "maximum": 10 },
+                "score.lt": { "type": "number", "minimum": 0, "maximum": 10 },
+                "score.lte": { "type": "number", "minimum": 0, "maximum": 10 },
+                "sfw": { "type": "boolean" }
+            }
+        },
+
+        "anilist-season-block": {
+            "type": "object", "additionalProperties": false,
+            "properties": {
+                "season": { "type": "string", "enum": ["winter", "spring", "summer", "fall"] },
+                "year": { "type": "integer" },
+                "sort_by": { "type": "string" },
+                "limit": { "type": "integer", "minimum": 1 }
+            }
+        },
+
+        "anilist-userlist-block": {
+            "type": "object", "additionalProperties": false,
+            "properties": {
+                "username": { "type": "string" },
+                "list": { "type": "string" },
+                "list_name": { "type": "string" },
+                "sort_by": { "type": "string" },
+                "score.gt": { "type": "number", "minimum": 0, "maximum": 10 },
+                "score.gte": { "type": "number", "minimum": 0, "maximum": 10 },
+                "score.lt": { "type": "number", "minimum": 0, "maximum": 10 },
+                "score.lte": { "type": "number", "minimum": 0, "maximum": 10 }
+            }
+        },
+
+        "anilist-search-block": {
+            "type": "object", "additionalProperties": true,
+            "properties": {
+                "limit": { "type": "integer", "minimum": 1 },
+                "sort_by": { "type": "string" }
+            }
+        },
+
+        "mojo-world-entry": {
+            "type": "object", "additionalProperties": false,
+            "required": ["year"],
+            "properties": {
+                "year": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
+                "limit": { "type": "integer", "minimum": 1 }
+            }
+        },
+
+        "mojo-range-entry": {
+            "type": "object", "additionalProperties": false,
+            "required": ["range"],
+            "properties": {
+                "range": { "type": "string", "enum": ["daily", "weekend", "weekly", "monthly", "quarterly", "yearly", "season", "holiday"] },
+                "year": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
+                "range_data": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
+                "limit": { "type": "integer", "minimum": 1 }
+            }
+        },
+
+        "mojo-all-time-entry": {
+            "type": "object", "additionalProperties": false,
+            "required": ["chart"],
+            "properties": {
+                "chart": { "type": "string" },
+                "content_rating_filter": { "type": "string" },
+                "limit": { "type": "integer", "minimum": 1 }
+            }
+        },
+
+        "mojo-intl-range-entry": {
+            "description": "mojo_international — international box-office chart for a specific time range.",
+            "type": "object", "additionalProperties": false,
+            "required": ["range"],
+            "properties": {
+                "range": {
+                    "type": "string",
+                    "enum": ["weekend", "monthly", "quarterly", "yearly"]
+                },
+                "year": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
+                "range_data": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
+                "limit": { "type": "integer", "minimum": 1 }
+            }
+        },
+
+        "mojo-record-entry": {
+            "description": "mojo_record — one of BoxOfficeMojo's named record charts (opening weekend, per-theater averages, etc.).",
+            "type": "object", "additionalProperties": false,
+            "required": ["chart"],
+            "properties": {
+                "chart": {
+                    "type": "string",
+                    "enum": [
+                        "second_weekend_drop", "post_thanksgiving_weekend_drop",
+                        "top_opening_weekend", "worst_opening_weekend_theater_avg",
+                        "top_opening_weekend_theater_avg_all", "top_opening_weekend_theater_avg_wide",
+                        "january", "february", "march", "april", "may", "june",
+                        "july", "august", "september", "october", "november", "december",
+                        "spring", "summer", "fall", "holiday_season", "winter",
+                        "g", "g/pg", "pg", "pg-13", "r", "nc-17",
+                        "mlk", "easter", "4th", "memorial", "labor", "president",
+                        "thanksgiving_3", "thanksgiving_5",
+                        "mlk_opening", "easter_opening", "memorial_opening",
+                        "labor_opening", "president_opening",
+                        "thanksgiving_3_opening", "thanksgiving_5_opening",
+                        "opening_week", "biggest_theater_drop", "opening_day",
+                        "single_day_grosses", "christmas_day_gross", "new_years_day_gross",
+                        "friday", "saturday", "sunday", "monday", "tuesday", "wednesday", "thursday",
+                        "friday_non_opening", "saturday_non_opening", "sunday_non_opening",
+                        "monday_non_opening", "tuesday_non_opening", "wednesday_non_opening", "thursday_non_opening"
+                    ]
+                },
+                "limit": { "type": "integer", "minimum": 1 }
+            }
+        },
+
+        "mojo-never-entry": {
+            "description": "mojo_never — top-grossing films that never cracked the Top 1/5/10.",
+            "type": "object", "additionalProperties": false,
+            "required": ["never", "chart"],
+            "properties": {
+                "never": { "type": "string", "enum": ["1", "5", "10"] },
+                "chart": { "type": "string", "enum": ["domestic", "worldwide"] },
+                "limit": { "type": "integer", "minimum": 1 }
+            }
+        },
+
+        "simkl-trending-entry": {
+            "description": "simkl_trending object form — period + optional limit.",
+            "type": "object", "additionalProperties": false,
+            "properties": {
+                "period": { "type": "string", "enum": ["today", "week", "month"] },
+                "limit": { "type": "integer", "minimum": 1, "maximum": 500 }
+            }
+        },
+
+        "simkl-dvd-entry": {
+            "description": "simkl_dvd object form — optional limit.",
+            "type": "object", "additionalProperties": false,
+            "properties": {
+                "limit": { "type": "integer", "minimum": 1, "maximum": 500 }
+            }
+        },
+
+        "template-call": {
+            "type": "object", "additionalProperties": true,
+            "properties": {
+                "name": { "type": "string" }
+            },
+            "required": ["name"]
+        },
+
+        "templates-map": {
+            "title": "templates",
+            "type": "object",
+            "additionalProperties": { "type": "object", "additionalProperties": true }
+        },
+
+        "dynamic-collections-map": {
+            "title": "dynamic_collections",
+            "type": "object",
+            "additionalProperties": { "$ref": "#/definitions/dynamic-collection-definition" }
+        },
+
+        "dynamic-collection-definition": {
+            "type": "object", "additionalProperties": true,
+            "properties": {
+                "type": { "type": "string" },
+                "data": { "additionalProperties": true },
+                "exclude": { "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }] },
+                "addons": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            { "type": "string" },
+                            { "type": "integer" },
+                            {
+                                "type": "array",
+                                "items": {
+                                    "oneOf": [
+                                        { "type": "string" },
+                                        { "type": "integer" }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                "template": {
+                    "oneOf": [
+                        { "type": "string" },
+                        { "$ref": "#/definitions/template-call" },
+                        {
+                            "type": "array",
+                            "items": {
+                                "oneOf": [
+                                    { "type": "string" },
+                                    { "$ref": "#/definitions/template-call" }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "template_variables": { "type": "object", "additionalProperties": true },
+                "other_template": {
+                    "oneOf": [
+                        { "type": "string" },
+                        { "$ref": "#/definitions/template-call" },
+                        {
+                            "type": "array",
+                            "items": {
+                                "oneOf": [
+                                    { "type": "string" },
+                                    { "$ref": "#/definitions/template-call" }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "other_name": { "type": "string" },
+                "title_format": { "type": "string" },
+                "key_name_override": { "type": "object", "additionalProperties": { "type": "string" } },
+                "include": {
+                    "oneOf": [
+                        { "type": "string" },
+                        { "type": "integer" },
+                        {
+                            "type": "array",
+                            "items": {
+                                "oneOf": [
+                                    { "type": "string" },
+                                    { "type": "integer" }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "limit": { "type": "integer", "minimum": 1 }
+            },
+            "required": ["type"]
+        },
+
+        "external-template-default-block": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "default": { "type": "string" },
+                "pmm": { "type": "string" },
+                "template_variables": { "type": "object", "additionalProperties": true }
+            },
+            "oneOf": [
+                { "required": ["default"] },
+                { "required": ["pmm"] }
+            ]
+        },
+
+        "external-template-file-block": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "file": { "type": "string" },
+                "template_variables": { "type": "object", "additionalProperties": true }
+            },
+            "required": ["file"]
+        },
+
+        "external-template-folder-block": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "folder": { "type": "string" },
+                "template_variables": { "type": "object", "additionalProperties": true }
+            },
+            "required": ["folder"]
+        },
+
+        "external-template-url-block": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "url": { "type": "string", "format": "uri", "pattern": "^(https?)://" },
+                "template_variables": { "type": "object", "additionalProperties": true }
+            },
+            "required": ["url"]
+        },
+
+        "external-template-git-block": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "git": { "type": "string" },
+                "template_variables": { "type": "object", "additionalProperties": true }
+            },
+            "required": ["git"]
+        },
+
+        "external-template-repo-block": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "repo": { "type": "string" },
+                "template_variables": { "type": "object", "additionalProperties": true }
+            },
+            "required": ["repo"]
+        },
+
+        "external-template-path": {
+            "oneOf": [
+                { "type": "string" },
+                { "$ref": "#/definitions/external-template-default-block" },
+                { "$ref": "#/definitions/external-template-file-block" },
+                { "$ref": "#/definitions/external-template-folder-block" },
+                { "$ref": "#/definitions/external-template-url-block" },
+                { "$ref": "#/definitions/external-template-git-block" },
+                { "$ref": "#/definitions/external-template-repo-block" }
+            ]
+        },
+
+        "external-templates-list": {
+            "title": "external_templates",
+            "oneOf": [
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/external-template-path" }
+                },
+                { "$ref": "#/definitions/external-template-path" }
+            ]
+        },
+
+        "tag-value": {
+            "oneOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } }
+            ]
+        },
+
+        "tmdb-discover-block": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "limit":                      { "type": "integer", "minimum": 0 },
+                "sort_by":                    { "type": "string" },
+                "with_companies":             { "type": "string" },
+                "without_companies":          { "type": "string" },
+                "with_genres":                { "type": "string" },
+                "without_genres":             { "type": "string" },
+                "with_keywords":              { "type": "string" },
+                "without_keywords":           { "type": "string" },
+                "with_watch_providers":       { "type": "string" },
+                "without_watch_providers":    { "type": "string" },
+                "with_original_language":     { "type": "string" },
+                "with_overview_translation":  { "type": "string" },
+                "watch_region":               { "type": "string" },
+                "with_watch_monetization_types": { "type": "string" },
+                "vote_count.gte":             { "type": "integer" },
+                "vote_count.lte":             { "type": "integer" },
+                "with_runtime.gte":           { "type": "integer" },
+                "with_runtime.lte":           { "type": "integer" },
+                "vote_average.gte":           { "type": "number" },
+                "vote_average.lte":           { "type": "number" },
+                "include_adult":              { "type": "boolean" },
+                "with_cast":                  { "type": "string" },
+                "with_crew":                  { "type": "string" },
+                "with_people":                { "type": "string" },
+                "with_release_type":          { "type": "string" },
+                "with_title_translation":     { "type": "string" },
+                "with_origin_country":        { "type": "string" },
+                "region":                     { "type": "string" },
+                "certification_country":      { "type": "string" },
+                "certification":              { "type": "string" },
+                "certification.lte":          { "type": "string" },
+                "certification.gte":          { "type": "string" },
+                "year":                       { "type": "integer", "minimum": 1800 },
+                "primary_release_year":       { "type": "integer", "minimum": 1800 },
+                "primary_release_date.gte":   { "type": "string" },
+                "primary_release_date.lte":   { "type": "string" },
+                "release_date.gte":           { "type": "string" },
+                "release_date.lte":           { "type": "string" },
+                "include_video":              { "type": "boolean" },
+                "with_networks":              { "type": "string" },
+                "with_name_translation":      { "type": "string" },
+                "timezone":                   { "type": "string" },
+                "first_air_date_year":        { "type": "integer", "minimum": 1800 },
+                "air_date.gte":               { "type": "string" },
+                "air_date.lte":               { "type": "string" },
+                "first_air_date.gte":         { "type": "string" },
+                "first_air_date.lte":         { "type": "string" },
+                "with_status":                { "type": "integer", "minimum": 0, "maximum": 5 },
+                "with_type":                  { "type": "integer", "minimum": 0, "maximum": 6 },
+                "screened_theatrically":      { "type": "boolean" },
+                "include_null_first_air_dates": { "type": "boolean" }
+            },
+            "allOf": [
+                {
+                    "if": { "required": ["certification_country"] },
+                    "then": {
+                        "anyOf": [
+                            { "required": ["certification"] },
+                            { "required": ["certification.lte"] },
+                            { "required": ["certification.gte"] }
+                        ]
+                    }
+                },
+                {
+                    "if": {
+                        "anyOf": [
+                            { "required": ["certification"] },
+                            { "required": ["certification.lte"] },
+                            { "required": ["certification.gte"] }
+                        ]
+                    },
+                    "then": { "required": ["certification_country"] }
+                },
+                {
+                    "if": { "required": ["watch_region"] },
+                    "then": {
+                        "anyOf": [
+                            { "required": ["with_watch_providers"] },
+                            { "required": ["without_watch_providers"] },
+                            { "required": ["with_watch_monetization_types"] }
+                        ]
+                    }
+                },
+                {
+                    "if": {
+                        "anyOf": [
+                            { "required": ["with_watch_providers"] },
+                            { "required": ["with_watch_monetization_types"] },
+                            { "required": ["without_watch_providers"] }
+                        ]
+                    },
+                    "then": { "required": ["watch_region"] }
+                },
+                {
+                    "if": {
+                        "anyOf": [
+                            { "required": ["with_cast"] },
+                            { "required": ["with_crew"] },
+                            { "required": ["with_people"] },
+                            { "required": ["year"] },
+                            { "required": ["primary_release_year"] },
+                            { "required": ["primary_release_date.gte"] },
+                            { "required": ["primary_release_date.lte"] },
+                            { "required": ["release_date.gte"] },
+                            { "required": ["release_date.lte"] },
+                            { "required": ["with_release_type"] },
+                            { "required": ["with_title_translation"] },
+                            { "required": ["with_origin_country"] },
+                            { "required": ["certification_country"] },
+                            { "required": ["certification"] },
+                            { "required": ["certification.lte"] },
+                            { "required": ["certification.gte"] },
+                            { "required": ["region"] },
+                            { "required": ["include_video"] }
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "anyOf": [
+                                        { "required": ["with_networks"] },
+                                        { "required": ["with_type"] },
+                                        { "required": ["with_status"] },
+                                        { "required": ["with_name_translation"] },
+                                        { "required": ["first_air_date_year"] },
+                                        { "required": ["first_air_date.gte"] },
+                                        { "required": ["first_air_date.lte"] },
+                                        { "required": ["air_date.gte"] },
+                                        { "required": ["air_date.lte"] },
+                                        { "required": ["timezone"] },
+                                        { "required": ["screened_theatrically"] },
+                                        { "required": ["include_null_first_air_dates"] }
+                                    ]
+                                }
+                            },
+                            {
+                                "properties": {
+                                    "sort_by": {
+                                        "enum": [
+                                            "original_title.asc", "original_title.desc",
+                                            "popularity.asc", "popularity.desc",
+                                            "primary_release_date.asc", "primary_release_date.desc",
+                                            "release_date.asc", "release_date.desc",
+                                            "revenue.asc", "revenue.desc",
+                                            "title.asc", "title.desc",
+                                            "vote_average.asc", "vote_average.desc",
+                                            "vote_count.asc", "vote_count.desc"
+                                        ]
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "if": {
+                        "anyOf": [
+                            { "required": ["with_networks"] },
+                            { "required": ["with_type"] },
+                            { "required": ["with_status"] },
+                            { "required": ["with_name_translation"] },
+                            { "required": ["first_air_date_year"] },
+                            { "required": ["first_air_date.gte"] },
+                            { "required": ["first_air_date.lte"] },
+                            { "required": ["air_date.gte"] },
+                            { "required": ["air_date.lte"] },
+                            { "required": ["timezone"] },
+                            { "required": ["screened_theatrically"] },
+                            { "required": ["include_null_first_air_dates"] }
+                        ]
+                    },
+                    "then": {
+                        "allOf": [
+                            {
+                                "not": {
+                                    "anyOf": [
+                                        { "required": ["with_cast"] },
+                                        { "required": ["with_crew"] },
+                                        { "required": ["with_people"] },
+                                        { "required": ["year"] },
+                                        { "required": ["primary_release_year"] },
+                                        { "required": ["primary_release_date.gte"] },
+                                        { "required": ["primary_release_date.lte"] },
+                                        { "required": ["release_date.gte"] },
+                                        { "required": ["release_date.lte"] },
+                                        { "required": ["with_release_type"] },
+                                        { "required": ["with_title_translation"] },
+                                        { "required": ["with_origin_country"] },
+                                        { "required": ["certification_country"] },
+                                        { "required": ["certification"] },
+                                        { "required": ["certification.lte"] },
+                                        { "required": ["certification.gte"] },
+                                        { "required": ["region"] },
+                                        { "required": ["include_video"] }
+                                    ]
+                                }
+                            },
+                            {
+                                "properties": {
+                                    "sort_by": {
+                                        "enum": [
+                                            "first_air_date.asc", "first_air_date.desc",
+                                            "name.asc", "name.desc",
+                                            "original_name.asc", "original_name.desc",
+                                            "popularity.asc", "popularity.desc",
+                                            "vote_average.asc", "vote_average.desc",
+                                            "vote_count.asc", "vote_count.desc"
+                                        ]
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/tests/fixtures/schema/config-schema.json
+++ b/tests/fixtures/schema/config-schema.json
@@ -1,0 +1,14156 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "libraries": {
+      "$ref": "#/definitions/library-section"
+    },
+    "plex": {
+      "$ref": "#/definitions/plex-server"
+    },
+    "tmdb": {
+      "$ref": "#/definitions/tmdb-api"
+    },
+    "tautulli": {
+      "$ref": "#/definitions/tautulli-api"
+    },
+    "webhooks": {
+      "$ref": "#/definitions/webhooks"
+    },
+    "omdb": {
+      "$ref": "#/definitions/omdb-api"
+    },
+    "mdblist": {
+      "$ref": "#/definitions/mdblist-api"
+    },
+    "notifiarr": {
+      "$ref": "#/definitions/notifiarr-api"
+    },
+    "gotify": {
+      "$ref": "#/definitions/gotify-api"
+    },
+    "ntfy": {
+      "$ref": "#/definitions/ntfy-api"
+    },
+    "anidb": {
+      "$ref": "#/definitions/anidb-api"
+    },
+    "sonarr": {
+      "$ref": "#/definitions/sonarr-api"
+    },
+    "radarr": {
+      "$ref": "#/definitions/radarr-api"
+    },
+    "settings": {
+      "$ref": "#/definitions/settings"
+    },
+    "mal": {
+      "$ref": "#/definitions/mal-api"
+    },
+    "trakt": {
+      "$ref": "#/definitions/trakt-api"
+    },
+    "github": {
+      "$ref": "#/definitions/github-api"
+    },
+    "playlist_files": {
+      "$ref": "#/definitions/playlist-path"
+    }
+  },
+  "required": [
+    "plex",
+    "tmdb"
+  ],
+  "definitions": {
+    "plex-server": {
+      "description": "Describes the primary Plex server to which Kometa can connect.\nThis attribute is REQUIRED.  It can be overridden at the library level.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "description": "URL at which Kometa can connect to your plex server. NOT app.plex.tv",
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "uri",
+              "pattern": "^(https?)://"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "token": {
+          "description": "Admin token for this Plex server",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "timeout": {
+          "description": "Connection timeout in seconds for this Plex server",
+          "type": "integer",
+          "minimum": 0
+        },
+        "db_cache": {
+          "description": "Sets DB Cache value for this Plex server in MB",
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string",
+              "pattern": "^$"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "clean_bundles": {
+          "description": "true/false - If 'true', cleans metadata bundles on this Plex server",
+          "type": "boolean"
+        },
+        "empty_trash": {
+          "description": "true/false - If 'true', empties trash on this Plex server",
+          "type": "boolean"
+        },
+        "optimize": {
+          "description": "true/false - If 'true', optimizes database on this Plex server",
+          "type": "boolean"
+        },
+        "verify_ssl": {
+          "description": "Turn SSL Verification on or off for only Plex.",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "token",
+        "url"
+      ],
+      "title": "plex"
+    },
+    "plex-server-lib": {
+      "description": "Describes the Plex server where this library is found.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "description": "URL at which Kometa can connect to this plex server.  NOT app.plex.tv",
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "uri",
+              "pattern": "^(https?)://"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "token": {
+          "description": "Admin token for this Plex server",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "timeout": {
+          "description": "Connection timeout in seconds for this Plex server",
+          "type": "integer",
+          "minimum": 0
+        },
+        "db_cache": {
+          "description": "Sets DB Cache value for this Plex server in MB",
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string",
+              "pattern": "^$"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "clean_bundles": {
+          "description": "true/false - If 'true', cleans metadata bundles on this Plex server",
+          "type": "boolean"
+        },
+        "empty_trash": {
+          "description": "true/false - If 'true', empties trash on this Plex server",
+          "type": "boolean"
+        },
+        "optimize": {
+          "description": "true/false - If 'true', optimizes database on this Plex server",
+          "type": "boolean"
+        },
+        "verify_ssl": {
+          "description": "Turn SSL Verification on or off for this library's Plex server.",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [],
+      "title": "plex"
+    },
+    "tmdb-api": {
+      "description": "API Information to connect to TMDb; REQUIRED for the script to run",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "apikey": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "API Key to connect to TMDb; REQUIRED for the script to run"
+        },
+        "language": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "",
+            "aa",
+            "ab",
+            "ae",
+            "af",
+            "ak",
+            "am",
+            "an",
+            "ar",
+            "as",
+            "av",
+            "ay",
+            "az",
+            "ba",
+            "be",
+            "bg",
+            "bi",
+            "bm",
+            "bn",
+            "bo",
+            "br",
+            "bs",
+            "ca",
+            "ce",
+            "ch",
+            "co",
+            "cr",
+            "cs",
+            "cu",
+            "cv",
+            "cy",
+            "da",
+            "de",
+            "dv",
+            "dz",
+            "ee",
+            "el",
+            "en",
+            "eo",
+            "es",
+            "et",
+            "eu",
+            "fa",
+            "ff",
+            "fi",
+            "fj",
+            "fo",
+            "fr",
+            "fy",
+            "ga",
+            "gd",
+            "gl",
+            "gn",
+            "gu",
+            "gv",
+            "ha",
+            "he",
+            "hi",
+            "ho",
+            "hr",
+            "ht",
+            "hu",
+            "hy",
+            "hz",
+            "ia",
+            "id",
+            "ie",
+            "ig",
+            "ii",
+            "ik",
+            "io",
+            "is",
+            "it",
+            "iu",
+            "ja",
+            "jv",
+            "ka",
+            "kg",
+            "ki",
+            "kj",
+            "kk",
+            "kl",
+            "km",
+            "kn",
+            "ko",
+            "kr",
+            "ks",
+            "ku",
+            "kv",
+            "kw",
+            "ky",
+            "la",
+            "lb",
+            "lg",
+            "li",
+            "ln",
+            "lo",
+            "lt",
+            "lu",
+            "lv",
+            "mg",
+            "mh",
+            "mi",
+            "mk",
+            "ml",
+            "mn",
+            "mr",
+            "ms",
+            "mt",
+            "my",
+            "na",
+            "nb",
+            "nd",
+            "ne",
+            "ng",
+            "nl",
+            "nn",
+            "no",
+            "nr",
+            "nv",
+            "ny",
+            "oc",
+            "oj",
+            "om",
+            "or",
+            "os",
+            "pa",
+            "pi",
+            "pl",
+            "ps",
+            "pt",
+            "qu",
+            "rm",
+            "rn",
+            "ro",
+            "ru",
+            "rw",
+            "sa",
+            "sc",
+            "sd",
+            "se",
+            "sg",
+            "si",
+            "sk",
+            "sl",
+            "sm",
+            "sn",
+            "so",
+            "sq",
+            "sr",
+            "ss",
+            "st",
+            "su",
+            "sv",
+            "sw",
+            "ta",
+            "te",
+            "tg",
+            "th",
+            "ti",
+            "tk",
+            "tl",
+            "tn",
+            "to",
+            "tr",
+            "ts",
+            "tt",
+            "tw",
+            "ty",
+            "ug",
+            "uk",
+            "ur",
+            "uz",
+            "ve",
+            "vi",
+            "vo",
+            "wa",
+            "wo",
+            "xh",
+            "yi",
+            "yo",
+            "za",
+            "zh",
+            "zu"
+          ],
+          "description": "This field can be either null or a valid ISO 639 language code."
+        },
+        "region": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "",
+                "AD",
+                "AE",
+                "AF",
+                "AG",
+                "AI",
+                "AL",
+                "AM",
+                "AO",
+                "AQ",
+                "AR",
+                "AS",
+                "AT",
+                "AU",
+                "AW",
+                "AX",
+                "AZ",
+                "BA",
+                "BB",
+                "BD",
+                "BE",
+                "BF",
+                "BG",
+                "BH",
+                "BI",
+                "BJ",
+                "BL",
+                "BM",
+                "BN",
+                "BO",
+                "BQ",
+                "BR",
+                "BS",
+                "BT",
+                "BV",
+                "BW",
+                "BY",
+                "BZ",
+                "CA",
+                "CC",
+                "CD",
+                "CF",
+                "CG",
+                "CH",
+                "CI",
+                "CK",
+                "CL",
+                "CM",
+                "CN",
+                "CO",
+                "CR",
+                "CU",
+                "CV",
+                "CW",
+                "CX",
+                "CY",
+                "CZ",
+                "DE",
+                "DJ",
+                "DK",
+                "DM",
+                "DO",
+                "DZ",
+                "EC",
+                "EE",
+                "EG",
+                "EH",
+                "ER",
+                "ES",
+                "ET",
+                "FI",
+                "FJ",
+                "FK",
+                "FM",
+                "FO",
+                "FR",
+                "GA",
+                "GB",
+                "GD",
+                "GE",
+                "GF",
+                "GG",
+                "GH",
+                "GI",
+                "GL",
+                "GM",
+                "GN",
+                "GP",
+                "GQ",
+                "GR",
+                "GS",
+                "GT",
+                "GU",
+                "GW",
+                "GY",
+                "HK",
+                "HM",
+                "HN",
+                "HR",
+                "HT",
+                "HU",
+                "ID",
+                "IE",
+                "IL",
+                "IM",
+                "IN",
+                "IO",
+                "IQ",
+                "IR",
+                "IS",
+                "IT",
+                "JE",
+                "JM",
+                "JO",
+                "JP",
+                "KE",
+                "KG",
+                "KH",
+                "KI",
+                "KM",
+                "KN",
+                "KP",
+                "KR",
+                "KW",
+                "KY",
+                "KZ",
+                "LA",
+                "LB",
+                "LC",
+                "LI",
+                "LK",
+                "LR",
+                "LS",
+                "LT",
+                "LU",
+                "LV",
+                "LY",
+                "MA",
+                "MC",
+                "MD",
+                "ME",
+                "MF",
+                "MG",
+                "MH",
+                "MK",
+                "ML",
+                "MM",
+                "MN",
+                "MO",
+                "MP",
+                "MQ",
+                "MR",
+                "MS",
+                "MT",
+                "MU",
+                "MV",
+                "MW",
+                "MX",
+                "MY",
+                "MZ",
+                "NA",
+                "NC",
+                "NE",
+                "NF",
+                "NG",
+                "NI",
+                "NL",
+                "NO",
+                "NP",
+                "NR",
+                "NU",
+                "NZ",
+                "OM",
+                "PA",
+                "PE",
+                "PF",
+                "PG",
+                "PH",
+                "PK",
+                "PL",
+                "PM",
+                "PN",
+                "PR",
+                "PS",
+                "PT",
+                "PW",
+                "PY",
+                "QA",
+                "RE",
+                "RO",
+                "RS",
+                "RU",
+                "RW",
+                "SA",
+                "SB",
+                "SC",
+                "SD",
+                "SE",
+                "SG",
+                "SH",
+                "SI",
+                "SJ",
+                "SK",
+                "SL",
+                "SM",
+                "SN",
+                "SO",
+                "SR",
+                "SS",
+                "ST",
+                "SV",
+                "SX",
+                "SY",
+                "SZ",
+                "TC",
+                "TD",
+                "TF",
+                "TG",
+                "TH",
+                "TJ",
+                "TK",
+                "TL",
+                "TM",
+                "TN",
+                "TO",
+                "TR",
+                "TT",
+                "TV",
+                "TW",
+                "TZ",
+                "UA",
+                "UG",
+                "UM",
+                "US",
+                "UY",
+                "UZ",
+                "VA",
+                "VC",
+                "VE",
+                "VG",
+                "VI",
+                "VN",
+                "VU",
+                "WF",
+                "WS",
+                "YE",
+                "YT",
+                "ZA",
+                "ZM",
+                "ZW"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "This field can be either null or a valid ISO 3166-1 Code."
+        },
+        "cache_expiration": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "An integer greater than 0 in days"
+        }
+      },
+      "required": [
+        "apikey"
+      ],
+      "title": "tmdb"
+    },
+    "tautulli-api": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "apikey": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "uri",
+              "pattern": "^(https?)://"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [],
+      "title": "tautulli"
+    },
+    "webhooks": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "error": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "run_start": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "run_end": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "changes": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "delete": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [],
+      "title": "webhooks"
+    },
+    "omdb-api": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "apikey": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cache_expiration": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "An integer greater than 0 in days"
+        }
+      },
+      "required": [],
+      "title": "omdb"
+    },
+    "mdblist-api": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "apikey": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cache_expiration": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "An integer greater than 0 in days"
+        }
+      },
+      "required": [],
+      "title": "mdblist"
+    },
+    "notifiarr-api": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "apikey": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [],
+      "title": "notifiarr"
+    },
+    "gotify-api": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "url",
+        "token"
+      ],
+      "title": "gotify"
+    },
+    "github-api": {
+      "description": "GitHub API credentials. Optional \u2014 providing a token raises the rate limit for GitHub requests.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "token": {
+          "description": "GitHub Personal Access Token. Generate at https://github.com/settings/tokens",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "github"
+    },
+    "simkl-api": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "user_token": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "user_token"
+      ],
+      "title": "simkl"
+    },
+    "ntfy-api": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        },
+        "topic": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "url",
+        "token",
+        "topic"
+      ],
+      "title": "ntfy"
+    },
+    "anidb-api": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "language": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "",
+            "aa",
+            "ab",
+            "ae",
+            "af",
+            "ak",
+            "am",
+            "an",
+            "ar",
+            "as",
+            "av",
+            "ay",
+            "az",
+            "ba",
+            "be",
+            "bg",
+            "bi",
+            "bm",
+            "bn",
+            "bo",
+            "br",
+            "bs",
+            "ca",
+            "ce",
+            "ch",
+            "co",
+            "cr",
+            "cs",
+            "cu",
+            "cv",
+            "cy",
+            "da",
+            "de",
+            "dv",
+            "dz",
+            "ee",
+            "el",
+            "en",
+            "eo",
+            "es",
+            "et",
+            "eu",
+            "fa",
+            "ff",
+            "fi",
+            "fj",
+            "fo",
+            "fr",
+            "fy",
+            "ga",
+            "gd",
+            "gl",
+            "gn",
+            "gu",
+            "gv",
+            "ha",
+            "he",
+            "hi",
+            "ho",
+            "hr",
+            "ht",
+            "hu",
+            "hy",
+            "hz",
+            "ia",
+            "id",
+            "ie",
+            "ig",
+            "ii",
+            "ik",
+            "io",
+            "is",
+            "it",
+            "iu",
+            "ja",
+            "jv",
+            "ka",
+            "kg",
+            "ki",
+            "kj",
+            "kk",
+            "kl",
+            "km",
+            "kn",
+            "ko",
+            "kr",
+            "ks",
+            "ku",
+            "kv",
+            "kw",
+            "ky",
+            "la",
+            "lb",
+            "lg",
+            "li",
+            "ln",
+            "lo",
+            "lt",
+            "lu",
+            "lv",
+            "mg",
+            "mh",
+            "mi",
+            "mk",
+            "ml",
+            "mn",
+            "mr",
+            "ms",
+            "mt",
+            "my",
+            "na",
+            "nb",
+            "nd",
+            "ne",
+            "ng",
+            "nl",
+            "nn",
+            "no",
+            "nr",
+            "nv",
+            "ny",
+            "oc",
+            "oj",
+            "om",
+            "or",
+            "os",
+            "pa",
+            "pi",
+            "pl",
+            "ps",
+            "pt",
+            "qu",
+            "rm",
+            "rn",
+            "ro",
+            "ru",
+            "rw",
+            "sa",
+            "sc",
+            "sd",
+            "se",
+            "sg",
+            "si",
+            "sk",
+            "sl",
+            "sm",
+            "sn",
+            "so",
+            "sq",
+            "sr",
+            "ss",
+            "st",
+            "su",
+            "sv",
+            "sw",
+            "ta",
+            "te",
+            "tg",
+            "th",
+            "ti",
+            "tk",
+            "tl",
+            "tn",
+            "to",
+            "tr",
+            "ts",
+            "tt",
+            "tw",
+            "ty",
+            "ug",
+            "uk",
+            "ur",
+            "uz",
+            "ve",
+            "vi",
+            "vo",
+            "wa",
+            "wo",
+            "xh",
+            "yi",
+            "yo",
+            "za",
+            "zh",
+            "zu"
+          ],
+          "description": "This field can be either null or a valid ISO 639 language code."
+        },
+        "cache_expiration": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "An integer greater than 0 in days"
+        },
+        "enable_mature": {
+          "type": "boolean",
+          "description": "Enable access to mature/restricted content"
+        }
+      },
+      "required": [],
+      "title": "anidb"
+    },
+    "sonarr-api": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "uri",
+              "pattern": "^(https?)://"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "token": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "add_missing": {
+          "type": "boolean"
+        },
+        "add_existing": {
+          "type": "boolean"
+        },
+        "ignore_cache": {
+          "type": "boolean"
+        },
+        "upgrade_existing": {
+          "type": "boolean"
+        },
+        "season_folder": {
+          "type": "boolean"
+        },
+        "search": {
+          "type": "boolean"
+        },
+        "cutoff_search": {
+          "type": "boolean"
+        },
+        "root_folder_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "monitor": {
+          "type": "string",
+          "enum": [
+            "all",
+            "future",
+            "missing",
+            "existing",
+            "pilot",
+            "first",
+            "latest",
+            "none"
+          ]
+        },
+        "monitor_existing": {
+          "description": "Ensures all existing shows in collections match your monitor setting.\nUse the sonarr_monitor_existing Sonarr Setting in the collection definition to match the monitor setting per collection.",
+          "type": "boolean"
+        },
+        "quality_profile": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "language_profile": {
+          "type": "string"
+        },
+        "series_type": {
+          "type": "string",
+          "enum": [
+            "standard",
+            "daily",
+            "anime"
+          ]
+        },
+        "tag": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "cutoff": {
+          "type": "string"
+        },
+        "plex_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sonarr_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [],
+      "dependentRequired": {
+        "add_existing": [
+          "sonarr_path",
+          "plex_path"
+        ]
+      },
+      "title": "sonarr"
+    },
+    "sonarr-api-lib": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "uri",
+              "pattern": "^(https?)://"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "token": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "add_missing": {
+          "type": "boolean"
+        },
+        "add_existing": {
+          "type": "boolean"
+        },
+        "ignore_cache": {
+          "type": "boolean"
+        },
+        "upgrade_existing": {
+          "type": "boolean"
+        },
+        "season_folder": {
+          "type": "boolean"
+        },
+        "search": {
+          "type": "boolean"
+        },
+        "cutoff_search": {
+          "type": "boolean"
+        },
+        "root_folder_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "monitor": {
+          "type": "string",
+          "enum": [
+            "all",
+            "future",
+            "missing",
+            "existing",
+            "pilot",
+            "first",
+            "latest",
+            "none"
+          ]
+        },
+        "monitor_existing": {
+          "description": "Ensures all existing shows in collections match your monitor setting.",
+          "type": "boolean"
+        },
+        "quality_profile": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "language_profile": {
+          "type": "string"
+        },
+        "series_type": {
+          "type": "string",
+          "enum": [
+            "standard",
+            "daily",
+            "anime"
+          ]
+        },
+        "tag": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sonarr_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "plex_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [],
+      "dependentRequired": {
+        "add_existing": [
+          "sonarr_path",
+          "plex_path"
+        ]
+      },
+      "title": "sonarr"
+    },
+    "radarr-api": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "uri",
+              "pattern": "^(https?)://"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "token": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "add_missing": {
+          "type": "boolean"
+        },
+        "add_existing": {
+          "type": "boolean"
+        },
+        "ignore_cache": {
+          "type": "boolean"
+        },
+        "upgrade_existing": {
+          "type": "boolean"
+        },
+        "search": {
+          "type": "boolean"
+        },
+        "root_folder_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "monitor": {
+          "type": "boolean"
+        },
+        "monitor_existing": {
+          "type": "boolean"
+        },
+        "quality_profile": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "availability": {
+          "type": "string",
+          "enum": [
+            "announced",
+            "cinemas",
+            "released",
+            "db"
+          ]
+        },
+        "tag": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "radarr_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "plex_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [],
+      "dependentRequired": {
+        "add_existing": [
+          "radarr_path",
+          "plex_path"
+        ]
+      },
+      "title": "radarr"
+    },
+    "radarr-api-lib": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "uri",
+              "pattern": "^(https?)://"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "token": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "add_missing": {
+          "type": "boolean"
+        },
+        "add_existing": {
+          "type": "boolean"
+        },
+        "ignore_cache": {
+          "type": "boolean"
+        },
+        "upgrade_existing": {
+          "type": "boolean"
+        },
+        "search": {
+          "type": "boolean"
+        },
+        "root_folder_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "monitor": {
+          "type": "boolean"
+        },
+        "monitor_existing": {
+          "type": "boolean"
+        },
+        "quality_profile": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "availability": {
+          "type": "string",
+          "enum": [
+            "announced",
+            "cinemas",
+            "released",
+            "db"
+          ]
+        },
+        "tag": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "radarr_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "plex_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [],
+      "dependentRequired": {
+        "add_existing": [
+          "radarr_path",
+          "plex_path"
+        ]
+      },
+      "title": "radarr"
+    },
+    "settings": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cache": {
+          "type": "boolean",
+          "description": "Used to control Kometa's cache database.\nAllow Kometa to create and maintain a local cache database for faster subsequent processing. The cache file is created in the same directory as the configuration file."
+        },
+        "cache_expiration": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Used to control how long data is cached for.\nSet the number of days before each cache mapping expires and has to be re-cached. An integer greater than 0 in days"
+        },
+        "run_order": {
+          "description": "Used to specify the run order of the library components.\nSpecify the run order of the library components [Library Operations, Collection Files and Overlay Files]",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "operations",
+              "metadata",
+              "collections",
+              "overlays"
+            ]
+          }
+        },
+        "asset_directory": {
+          "description": "Used to define where local assets are located.\nSpecify the directories where assets (posters, backgrounds, etc) are located.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "asset_folders": {
+          "description": "Used to control the asset directory folder structure.\nWhile true, Kometa will search the asset_directory for a dedicated folder per item vs while false will look for an image.",
+          "type": "boolean"
+        },
+        "asset_depth": {
+          "description": "Used to control the depth of search in the asset directory.\nAt each asset level, Kometa will look for either medianame.ext [such as Star Wars.png] or a dedicated folder containing poster.ext. i.e. <path_to_assets>/Star Wars/poster.png and <path_to_assets>/Star Wars.png are both asset depth 0, whilst <path_to_assets>/Movies/Star Wars/poster.png and <path_to_assets>/Movies/Star Wars.png are both asset level 1.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "create_asset_folders": {
+          "description": "Used to automatically create asset folders when none exist.\nWhilst searching for assets, if an asset folder cannot be found within the asset_directory one will be created. Asset Searches can happen in a number of ways.",
+          "type": "boolean"
+        },
+        "prioritize_assets": {
+          "description": "Used to prioritize asset_directory images over all other images types.\nWhen determining which image to use on an item prioritize the asset_directory over all other images types.",
+          "type": "boolean"
+        },
+        "dimensional_asset_rename": {
+          "description": "Used to automatically rename asset files based on their dimensions.\nWhilst searching for assets, scan the folders within the asset_directory and if an asset poster (i.e. /ASSET_NAME/poster.ext) was not found, rename the first image found that has a height greater than or equal to its width to poster.ext. If an asset background (i.e. /ASSET_NAME/background.ext), rename the first image found that has a width greater than its height to background.ext.",
+          "type": "boolean"
+        },
+        "download_url_assets": {
+          "description": "Used to download url images into the asset directory.\nWhilst searching for assets, download images set within Collection/Metadata/Playlist files( i.e. images set by url_poster or url_background) into the asset folder if none are already present.",
+          "type": "boolean"
+        },
+        "show_missing_season_assets": {
+          "description": " Used to show any missing season assets.\nWhilst searching for assets, when scanning for assets for a TV Show, if Season posters are found (i.e. /ASSET_NAME/Season##.ext), notify the user of any seasons which do not have an asset image.",
+          "type": "boolean"
+        },
+        "show_missing_episode_assets": {
+          "description": "Used to show any missing episode assets.\nWhilst searching for assets, when scanning for assets for a TV Show, if an Episode Title Card is found (i.e. /ASSET_NAME/S##E##.ext), notify the user of any episodes which do not have an asset image.",
+          "type": "boolean"
+        },
+        "show_asset_not_needed": {
+          "description": "Used to show/hide the update not needed messages.\nWhilst searching for assets, show or hide the update not needed messages.",
+          "type": "boolean"
+        },
+        "sync_mode": {
+          "description": "Used to set the sync_mode for collections and playlists.\nSets the sync_mode for collections and playlists. Setting the sync_mode directly in a collection or playlist definition will override the sync_mode for that definition.",
+          "enum": [
+            "sync",
+            "append"
+          ]
+        },
+        "minimum_items": {
+          "description": "Used to control minimum items requires to build a collection/playlist.\nSet the minimum number of items that must be found in order to build or update a collection/playlist.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "hub_priority": {
+          "description": "Priority position for all collections in this defaults file's Recommendation Hub rows. Lower numbers appear first.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "default_collection_order": {
+          "description": "Used to set the collection_order for every collection run.\nSet the collection_order for every collection run by Kometa unless the collection has a specific collection_order\nTIP: 'custom' cannot be used if more than one builder is being used for the collection (such as imdb_list and trakt_list within the same collection). ",
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "added.asc",
+            "added.desc",
+            "alpha",
+            "audience_rating.asc",
+            "audience_rating.desc",
+            "bitrate.asc",
+            "bitrate.desc",
+            "content_rating.asc",
+            "content_rating.desc",
+            "critic_rating.asc",
+            "critic_rating.desc",
+            "custom",
+            "duration.asc",
+            "duration.desc",
+            "originally_available.asc",
+            "originally_available.desc",
+            "plays.asc",
+            "plays.desc",
+            "progress.asc",
+            "progress.desc",
+            "random",
+            "release",
+            "release.asc",
+            "release.desc",
+            "resolution.asc",
+            "resolution.desc",
+            "title.asc",
+            "title.desc",
+            "user_rating.asc",
+            "user_rating.desc",
+            "viewed.asc",
+            "viewed.desc",
+            "year.asc",
+            "year.desc",
+            null
+          ]
+        },
+        "delete_below_minimum": {
+          "description": "Used to delete collections below minimum_items.\nWhen a collection is run, delete the collection if it is below the minimum number specified by minimum_items.",
+          "type": "boolean"
+        },
+        "delete_not_scheduled": {
+          "description": "Used to delete collections not scheduled.\nIf a collection is skipped due to it not being scheduled, delete the collection.",
+          "type": "boolean"
+        },
+        "auto_sort_hubs": {
+          "description": "Used to sort Recommendation Hub rows after all collections are processed.\nSorts the library Recommendation Hub rows on the Plex home screen and/or library Recommended tab.",
+          "type": "string",
+          "enum": ["sort_title", "sort_title.desc", "alpha", "alpha.desc", "configured", "configured.desc", "random"]
+        },
+        "run_again_delay": {
+          "description": "Used to control the number of minutes to delay running run_again collections.\nSet the number of minutes to delay running run_again collections after daily run is finished. For example, if a collection adds items to Sonarr/Radarr, the library can automatically re-run 'X' amount of time later so that any downloaded items are processed.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "missing_only_released": {
+          "description": "Used to filter unreleased items from missing lists.\nWhilst running a collection or playlist, when Kometa handles missing items to either report it to the user, report it to a file, or send it to Radarr/Sonarr all unreleased items will be filtered out.",
+          "type": "boolean"
+        },
+        "only_filter_missing": {
+          "description": "Used to have the filter only apply to missing items.\nOnly items missing from a collection will be filtered. Only specific filters can filter missing. See Filters for more information.",
+          "type": "boolean"
+        },
+        "show_unmanaged": {
+          "description": "Used to show collections not managed by Kometa.\nList all collections not managed by Kometa at the end of each run.",
+          "type": "boolean"
+        },
+        "show_unconfigured": {
+          "description": "Used to show collections not in the current run.\nList all collections not configured in the current Kometa run at the end of each run.",
+          "type": "boolean"
+        },
+        "show_filtered": {
+          "description": "Used to show filtered items.\nList all items which have been filtered out of a collection or playlist (i.e. if it doesn't meet the filter criteria)",
+          "type": "boolean"
+        },
+        "show_unfiltered": {
+          "description": "Used to show unfiltered items.\nList all items which make it through a filter into a collection or playlist (i.e. if it MEETS the filter criteria)",
+          "type": "boolean"
+        },
+        "show_options": {
+          "description": "Used to show attribute options from plex.\nWhile show_options is true the available options for an attribute when using plex_search, smart_filter or filters will be shown. i.e. a smart_filter on the genre attribute will return all of the attributes within the specified library.",
+          "type": "boolean"
+        },
+        "show_missing": {
+          "description": "Used to show missing items from collections or playlists.\nWhile show_missing is true items missing from collections or playlists will be displayed.",
+          "type": "boolean"
+        },
+        "show_missing_assets": {
+          "description": "Used to print a message when assets are missing.\nDisplay missing asset warnings for items, collections, and playlists.",
+          "type": "boolean"
+        },
+        "save_report": {
+          "description": "Used to save a report YAML file.\nSave a report of the items added, removed, filtered, or missing from collections to a YAML file in the same directory as the file run.",
+          "type": "boolean"
+        },
+        "tvdb_language": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "",
+            "default",
+            "aar",
+            "abk",
+            "afr",
+            "aka",
+            "alb",
+            "amh",
+            "ara",
+            "arg",
+            "arm",
+            "asm",
+            "ava",
+            "ave",
+            "aym",
+            "aze",
+            "bak",
+            "bam",
+            "baq",
+            "bel",
+            "ben",
+            "bis",
+            "bos",
+            "bre",
+            "bul",
+            "bur",
+            "cat",
+            "cha",
+            "che",
+            "chi",
+            "chu",
+            "chv",
+            "cor",
+            "cos",
+            "cre",
+            "cze",
+            "dan",
+            "div",
+            "dut",
+            "dzo",
+            "eng",
+            "epo",
+            "est",
+            "ewe",
+            "fao",
+            "fij",
+            "fin",
+            "fre",
+            "fry",
+            "ful",
+            "geo",
+            "ger",
+            "gla",
+            "gle",
+            "glg",
+            "glv",
+            "gre",
+            "grn",
+            "guj",
+            "hat",
+            "hau",
+            "heb",
+            "her",
+            "hin",
+            "hmo",
+            "hrv",
+            "hun",
+            "ibo",
+            "ice",
+            "ido",
+            "iii",
+            "iku",
+            "ile",
+            "ina",
+            "ind",
+            "ipk",
+            "ita",
+            "jav",
+            "jpn",
+            "kal",
+            "kan",
+            "kas",
+            "kau",
+            "kaz",
+            "khm",
+            "kik",
+            "kin",
+            "kir",
+            "kom",
+            "kon",
+            "kor",
+            "kua",
+            "kur",
+            "lao",
+            "lat",
+            "lav",
+            "lim",
+            "lin",
+            "lit",
+            "ltz",
+            "lub",
+            "lug",
+            "mac",
+            "mah",
+            "mal",
+            "mao",
+            "mar",
+            "may",
+            "mlg",
+            "mlt",
+            "mon",
+            "nau",
+            "nav",
+            "nbl",
+            "nde",
+            "ndo",
+            "nep",
+            "nno",
+            "nob",
+            "nor",
+            "nya",
+            "oci",
+            "oji",
+            "ori",
+            "orm",
+            "oss",
+            "pan",
+            "per",
+            "pli",
+            "pol",
+            "por",
+            "pus",
+            "que",
+            "roh",
+            "rum",
+            "run",
+            "rus",
+            "sag",
+            "san",
+            "sin",
+            "slo",
+            "slv",
+            "sme",
+            "smo",
+            "sna",
+            "snd",
+            "som",
+            "sot",
+            "spa",
+            "srd",
+            "srp",
+            "ssw",
+            "sun",
+            "swa",
+            "swe",
+            "tah",
+            "tam",
+            "tat",
+            "tel",
+            "tgk",
+            "tgl",
+            "tha",
+            "tib",
+            "tir",
+            "ton",
+            "tsn",
+            "tso",
+            "tuk",
+            "tur",
+            "twi",
+            "uig",
+            "ukr",
+            "urd",
+            "uzb",
+            "ven",
+            "vie",
+            "vol",
+            "wel",
+            "wln",
+            "wol",
+            "xho",
+            "yid",
+            "yor",
+            "zha",
+            "zul"
+          ],
+          "description": "Specify the language to query TVDb in.\nThis field can be either null or a valid ISO 639-2 language code."
+        },
+        "ignore_ids": {
+          "description": "List of TMDb/TVDb IDs to ignore.\nSet a null, a single TMDb/TVDb ID, or a comma-separated string of TMDb/TVDb IDs to ignore in all collections.",
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "minItems": 1
+            },
+            {
+              "type": "string",
+              "pattern": "^\\d{1,8}(\\s*,\\s*\\d{1,8})*$"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "ignore_imdb_ids": {
+          "description": "List of IMDb IDs to ignore.\nSet a null, a single IMDb ID, or a comma-separated string of IMDb IDs to ignore in all collections.",
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "pattern": "^(tt\\d{7,8})(,(tt\\d{7,8}))*$"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^tt\\d{7,8}$"
+              },
+              "minItems": 1
+            }
+          ]
+        },
+        "item_refresh_delay": {
+          "description": "Time to wait between each item_refresh.\nSpecify the amount of time to wait between each item_refresh of every movie/show in a collection/playlist.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "playlist_sync_to_users": {
+          "description": "Set the default playlist sync_to_users.\nTo Sync a playlist to only yourself, leave playlist_sync_to_users blank/null. Therefore, leaving it blank, 'all', a list of users, or a comma-separated string of users is accepted",
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "all"
+              ]
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1
+            },
+            {
+              "type": "string",
+              "pattern": "^([^,]+)(,[^,]+)*$"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "playlist_exclude_users": {
+          "description": "Set the default playlist exclude_users.\nProvide a null value, a list of users, or a comma-separated string of users to be excluded in the playlist.",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1
+            },
+            {
+              "type": "string",
+              "pattern": "^([^,]+)(,[^,]+)*$"
+            }
+          ]
+        },
+        "playlist_report": {
+          "description": "Used to print out a playlist report.\nSet playlist_report to true to print out a playlist report at the end of the log.",
+          "type": "boolean"
+        },
+        "verify_ssl": {
+          "description": "Turn SSL Verification on or off.",
+          "type": "boolean"
+        },
+        "custom_repo": {
+          "description": "Used to set up the custom repo file block type.\nSpecify where the repo attribute's base is when defining collection_files, metadata_files, playlist_file, and overlay_files.",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "overlay_artwork_filetype": {
+          "description": "Used to control the filetype used with overlay images.",
+          "enum": [
+            "jpg",
+            "png",
+            "webp_lossy",
+            "webp_lossless"
+          ]
+        },
+        "overlay_artwork_quality": {
+          "description": "Used to control the JPG or Lossy WEBP quality used with overlay images.",
+          "anyOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [],
+      "title": "settings"
+    },
+    "mal-api": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "client_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "client_secret": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [],
+      "title": "mal"
+    },
+    "trakt-api": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "client_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "client_secret": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pin": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [],
+      "title": "trakt"
+    },
+    "legacy-default-collection-path": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "pmm": {
+          "type": "string",
+          "enum": [
+            "actor",
+            "anilist",
+            "aspect",
+            "audio_language",
+            "bafta",
+            "based",
+            "basic",
+            "berlinale",
+            "cannes",
+            "cesar",
+            "choice",
+            "collectionless",
+            "content_rating_au",
+            "content_rating_cs",
+            "content_rating_de",
+            "content_rating_nz",
+            "content_rating_mal",
+            "content_rating_uk",
+            "content_rating_us",
+            "continent",
+            "country",
+            "decade",
+            "director",
+            "emmy",
+            "flixpatrol",
+            "franchise",
+            "genre",
+            "golden",
+            "imdb",
+            "letterboxd",
+            "myanimelist",
+            "network",
+            "nfr",
+            "oscars",
+            "other_chart",
+            "pca",
+            "producer",
+            "razzie",
+            "region",
+            "resolution",
+            "sag",
+            "seasonal",
+            "separator_award",
+            "separator_chart",
+            "simkl",
+            "spirit",
+            "streaming",
+            "studio",
+            "subtitle_language",
+            "sundance",
+            "tautulli",
+            "tiff",
+            "tmdb",
+            "trakt",
+            "universe",
+            "venice",
+            "writer",
+            "year"
+          ]
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "asset_directory": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "template_variables": {
+          "$ref": "#/definitions/template-variables-collections"
+        }
+      },
+      "required": [
+        "pmm"
+      ]
+    },
+    "kometa-default-collection-path": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "type": "string",
+          "enum": [
+            "actor",
+            "anilist",
+            "aspect",
+            "audio_language",
+            "bafta",
+            "based",
+            "basic",
+            "berlinale",
+            "cannes",
+            "cesar",
+            "choice",
+            "collectionless",
+            "content_rating_au",
+            "content_rating_cs",
+            "content_rating_de",
+            "content_rating_nz",
+            "content_rating_mal",
+            "content_rating_uk",
+            "content_rating_us",
+            "continent",
+            "country",
+            "decade",
+            "director",
+            "emmy",
+            "flixpatrol",
+            "franchise",
+            "genre",
+            "golden",
+            "imdb",
+            "letterboxd",
+            "myanimelist",
+            "network",
+            "nfr",
+            "oscars",
+            "other_chart",
+            "pca",
+            "producer",
+            "razzie",
+            "region",
+            "resolution",
+            "sag",
+            "seasonal",
+            "separator_award",
+            "separator_chart",
+            "simkl",
+            "spirit",
+            "streaming",
+            "studio",
+            "subtitle_language",
+            "sundance",
+            "tautulli",
+            "tiff",
+            "tmdb",
+            "trakt",
+            "universe",
+            "venice",
+            "writer",
+            "year"
+          ]
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "asset_directory": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "template_variables": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "default"
+      ],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "default": {
+                "const": "bafta"
+              }
+            },
+            "required": [
+              "default"
+            ]
+          },
+          "then": {
+            "properties": {
+              "template_variables": {
+                "$ref": "#/definitions/award-template-vars"
+              }
+            }
+          },
+          "else": {
+            "if": {
+              "properties": {
+                "default": {
+                  "const": "berlinale"
+                }
+              },
+              "required": [
+                "default"
+              ]
+            },
+            "then": {
+              "properties": {
+                "template_variables": {
+                  "$ref": "#/definitions/award-template-vars"
+                }
+              }
+            },
+            "else": {
+              "if": {
+                "properties": {
+                  "default": {
+                    "const": "cannes"
+                  }
+                },
+                "required": [
+                  "default"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "template_variables": {
+                    "$ref": "#/definitions/award-template-vars"
+                  }
+                }
+              },
+              "else": {
+                "if": {
+                  "properties": {
+                    "default": {
+                      "const": "cesar"
+                    }
+                  },
+                  "required": [
+                    "default"
+                  ]
+                },
+                "then": {
+                  "properties": {
+                    "template_variables": {
+                      "$ref": "#/definitions/award-template-vars"
+                    }
+                  }
+                },
+                "else": {
+                  "if": {
+                    "properties": {
+                      "default": {
+                        "const": "choice"
+                      }
+                    },
+                    "required": [
+                      "default"
+                    ]
+                  },
+                  "then": {
+                    "properties": {
+                      "template_variables": {
+                        "$ref": "#/definitions/award-template-vars"
+                      }
+                    }
+                  },
+                  "else": {
+                    "if": {
+                      "properties": {
+                        "default": {
+                          "const": "emmy"
+                        }
+                      },
+                      "required": [
+                        "default"
+                      ]
+                    },
+                    "then": {
+                      "properties": {
+                        "template_variables": {
+                          "$ref": "#/definitions/award-template-vars"
+                        }
+                      }
+                    },
+                    "else": {
+                      "if": {
+                        "properties": {
+                          "default": {
+                            "const": "golden"
+                          }
+                        },
+                        "required": [
+                          "default"
+                        ]
+                      },
+                      "then": {
+                        "properties": {
+                          "template_variables": {
+                            "$ref": "#/definitions/award-template-vars"
+                          }
+                        }
+                      },
+                      "else": {
+                        "if": {
+                          "properties": {
+                            "default": {
+                              "const": "nfr"
+                            }
+                          },
+                          "required": [
+                            "default"
+                          ]
+                        },
+                        "then": {
+                          "properties": {
+                            "template_variables": {
+                              "$ref": "#/definitions/award-template-vars"
+                            }
+                          }
+                        },
+                        "else": {
+                          "if": {
+                            "properties": {
+                              "default": {
+                                "const": "oscars"
+                              }
+                            },
+                            "required": [
+                              "default"
+                            ]
+                          },
+                          "then": {
+                            "properties": {
+                              "template_variables": {
+                                "$ref": "#/definitions/award-template-vars"
+                              }
+                            }
+                          },
+                          "else": {
+                            "if": {
+                              "properties": {
+                                "default": {
+                                  "const": "pca"
+                                }
+                              },
+                              "required": [
+                                "default"
+                              ]
+                            },
+                            "then": {
+                              "properties": {
+                                "template_variables": {
+                                  "$ref": "#/definitions/award-template-vars"
+                                }
+                              }
+                            },
+                            "else": {
+                              "if": {
+                                "properties": {
+                                  "default": {
+                                    "const": "razzie"
+                                  }
+                                },
+                                "required": [
+                                  "default"
+                                ]
+                              },
+                              "then": {
+                                "properties": {
+                                  "template_variables": {
+                                    "$ref": "#/definitions/award-template-vars"
+                                  }
+                                }
+                              },
+                              "else": {
+                                "if": {
+                                  "properties": {
+                                    "default": {
+                                      "const": "sag"
+                                    }
+                                  },
+                                  "required": [
+                                    "default"
+                                  ]
+                                },
+                                "then": {
+                                  "properties": {
+                                    "template_variables": {
+                                      "$ref": "#/definitions/award-template-vars"
+                                    }
+                                  }
+                                },
+                                "else": {
+                                  "if": {
+                                    "properties": {
+                                      "default": {
+                                        "const": "spirit"
+                                      }
+                                    },
+                                    "required": [
+                                      "default"
+                                    ]
+                                  },
+                                  "then": {
+                                    "properties": {
+                                      "template_variables": {
+                                        "$ref": "#/definitions/award-template-vars"
+                                      }
+                                    }
+                                  },
+                                  "else": {
+                                    "if": {
+                                      "properties": {
+                                        "default": {
+                                          "const": "sundance"
+                                        }
+                                      },
+                                      "required": [
+                                        "default"
+                                      ]
+                                    },
+                                    "then": {
+                                      "properties": {
+                                        "template_variables": {
+                                          "$ref": "#/definitions/award-template-vars"
+                                        }
+                                      }
+                                    },
+                                    "else": {
+                                      "if": {
+                                        "properties": {
+                                          "default": {
+                                            "const": "tiff"
+                                          }
+                                        },
+                                        "required": [
+                                          "default"
+                                        ]
+                                      },
+                                      "then": {
+                                        "properties": {
+                                          "template_variables": {
+                                            "$ref": "#/definitions/award-template-vars"
+                                          }
+                                        }
+                                      },
+                                      "else": {
+                                        "if": {
+                                          "properties": {
+                                            "default": {
+                                              "const": "venice"
+                                            }
+                                          },
+                                          "required": [
+                                            "default"
+                                          ]
+                                        },
+                                        "then": {
+                                          "properties": {
+                                            "template_variables": {
+                                              "$ref": "#/definitions/award-template-vars"
+                                            }
+                                          }
+                                        },
+                                        "else": {
+                                          "if": {
+                                            "properties": {
+                                              "default": {
+                                                "const": "actor"
+                                              }
+                                            },
+                                            "required": [
+                                              "default"
+                                            ]
+                                          },
+                                          "then": {
+                                            "properties": {
+                                              "template_variables": {
+                                                "$ref": "#/definitions/person-template-vars"
+                                              }
+                                            }
+                                          },
+                                          "else": {
+                                            "if": {
+                                              "properties": {
+                                                "default": {
+                                                  "const": "director"
+                                                }
+                                              },
+                                              "required": [
+                                                "default"
+                                              ]
+                                            },
+                                            "then": {
+                                              "properties": {
+                                                "template_variables": {
+                                                  "$ref": "#/definitions/person-template-vars"
+                                                }
+                                              }
+                                            },
+                                            "else": {
+                                              "if": {
+                                                "properties": {
+                                                  "default": {
+                                                    "const": "producer"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "default"
+                                                ]
+                                              },
+                                              "then": {
+                                                "properties": {
+                                                  "template_variables": {
+                                                    "$ref": "#/definitions/person-template-vars"
+                                                  }
+                                                }
+                                              },
+                                              "else": {
+                                                "if": {
+                                                  "properties": {
+                                                    "default": {
+                                                      "const": "writer"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "default"
+                                                  ]
+                                                },
+                                                "then": {
+                                                  "properties": {
+                                                    "template_variables": {
+                                                      "$ref": "#/definitions/person-template-vars"
+                                                    }
+                                                  }
+                                                },
+                                                "else": {
+                                                  "if": {
+                                                    "properties": {
+                                                      "default": {
+                                                        "const": "anilist"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "default"
+                                                    ]
+                                                  },
+                                                  "then": {
+                                                    "properties": {
+                                                      "template_variables": {
+                                                        "$ref": "#/definitions/chart-template-vars"
+                                                      }
+                                                    }
+                                                  },
+                                                  "else": {
+                                                    "if": {
+                                                      "properties": {
+                                                        "default": {
+                                                          "const": "basic"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "default"
+                                                      ]
+                                                    },
+                                                    "then": {
+                                                      "properties": {
+                                                        "template_variables": {
+                                                          "$ref": "#/definitions/chart-template-vars"
+                                                        }
+                                                      }
+                                                    },
+                                                    "else": {
+                                                      "if": {
+                                                        "properties": {
+                                                          "default": {
+                                                            "const": "imdb"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "default"
+                                                        ]
+                                                      },
+                                                      "then": {
+                                                        "properties": {
+                                                          "template_variables": {
+                                                            "$ref": "#/definitions/chart-template-vars"
+                                                          }
+                                                        }
+                                                      },
+                                                      "else": {
+                                                        "if": {
+                                                          "properties": {
+                                                            "default": {
+                                                              "const": "letterboxd"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "default"
+                                                          ]
+                                                        },
+                                                        "then": {
+                                                          "properties": {
+                                                            "template_variables": {
+                                                              "$ref": "#/definitions/chart-template-vars"
+                                                            }
+                                                          }
+                                                        },
+                                                        "else": {
+                                                          "if": {
+                                                            "properties": {
+                                                              "default": {
+                                                                "const": "myanimelist"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "default"
+                                                            ]
+                                                          },
+                                                          "then": {
+                                                            "properties": {
+                                                              "template_variables": {
+                                                                "$ref": "#/definitions/chart-template-vars"
+                                                              }
+                                                            }
+                                                          },
+                                                          "else": {
+                                                            "if": {
+                                                              "properties": {
+                                                                "default": {
+                                                                  "const": "other_chart"
+                                                                }
+                                                              },
+                                                              "required": [
+                                                                "default"
+                                                              ]
+                                                            },
+                                                            "then": {
+                                                              "properties": {
+                                                                "template_variables": {
+                                                                  "$ref": "#/definitions/chart-template-vars"
+                                                                }
+                                                              }
+                                                            },
+                                                            "else": {
+                                                              "if": {
+                                                                "properties": {
+                                                                  "default": {
+                                                                    "const": "simkl"
+                                                                  }
+                                                                },
+                                                                "required": [
+                                                                  "default"
+                                                                ]
+                                                              },
+                                                              "then": {
+                                                                "properties": {
+                                                                  "template_variables": {
+                                                                    "$ref": "#/definitions/chart-template-vars"
+                                                                  }
+                                                                }
+                                                              },
+                                                              "else": {
+                                                                "if": {
+                                                                  "properties": {
+                                                                    "default": {
+                                                                      "const": "tautulli"
+                                                                    }
+                                                                  },
+                                                                  "required": [
+                                                                    "default"
+                                                                  ]
+                                                                },
+                                                                "then": {
+                                                                  "properties": {
+                                                                    "template_variables": {
+                                                                      "$ref": "#/definitions/chart-template-vars"
+                                                                    }
+                                                                  }
+                                                                },
+                                                                "else": {
+                                                                  "if": {
+                                                                    "properties": {
+                                                                      "default": {
+                                                                        "const": "tmdb"
+                                                                      }
+                                                                    },
+                                                                    "required": [
+                                                                      "default"
+                                                                    ]
+                                                                  },
+                                                                  "then": {
+                                                                    "properties": {
+                                                                      "template_variables": {
+                                                                        "$ref": "#/definitions/chart-template-vars"
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  "else": {
+                                                                    "if": {
+                                                                      "properties": {
+                                                                        "default": {
+                                                                          "const": "trakt"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "default"
+                                                                      ]
+                                                                    },
+                                                                    "then": {
+                                                                      "properties": {
+                                                                        "template_variables": {
+                                                                          "$ref": "#/definitions/chart-template-vars"
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    "else": {
+                                                                      "if": {
+                                                                        "properties": {
+                                                                          "default": {
+                                                                            "const": "content_rating_au"
+                                                                          }
+                                                                        },
+                                                                        "required": [
+                                                                          "default"
+                                                                        ]
+                                                                      },
+                                                                      "then": {
+                                                                        "properties": {
+                                                                          "template_variables": {
+                                                                            "$ref": "#/definitions/content-rating-template-vars"
+                                                                          }
+                                                                        }
+                                                                      },
+                                                                      "else": {
+                                                                        "if": {
+                                                                          "properties": {
+                                                                            "default": {
+                                                                              "const": "content_rating_cs"
+                                                                            }
+                                                                          },
+                                                                          "required": [
+                                                                            "default"
+                                                                          ]
+                                                                        },
+                                                                        "then": {
+                                                                          "properties": {
+                                                                            "template_variables": {
+                                                                              "$ref": "#/definitions/content-rating-template-vars"
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        "else": {
+                                                                          "if": {
+                                                                            "properties": {
+                                                                              "default": {
+                                                                                "const": "content_rating_de"
+                                                                              }
+                                                                            },
+                                                                            "required": [
+                                                                              "default"
+                                                                            ]
+                                                                          },
+                                                                          "then": {
+                                                                            "properties": {
+                                                                              "template_variables": {
+                                                                                "$ref": "#/definitions/content-rating-template-vars"
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          "else": {
+                                                                            "if": {
+                                                                              "properties": {
+                                                                                "default": {
+                                                                                  "const": "content_rating_mal"
+                                                                                }
+                                                                              },
+                                                                              "required": [
+                                                                                "default"
+                                                                              ]
+                                                                            },
+                                                                            "then": {
+                                                                              "properties": {
+                                                                                "template_variables": {
+                                                                                  "$ref": "#/definitions/content-rating-template-vars"
+                                                                                }
+                                                                              }
+                                                                            },
+                                                                            "else": {
+                                                                              "if": {
+                                                                                "properties": {
+                                                                                  "default": {
+                                                                                    "const": "content_rating_nz"
+                                                                                  }
+                                                                                },
+                                                                                "required": [
+                                                                                  "default"
+                                                                                ]
+                                                                              },
+                                                                              "then": {
+                                                                                "properties": {
+                                                                                  "template_variables": {
+                                                                                    "$ref": "#/definitions/content-rating-template-vars"
+                                                                                  }
+                                                                                }
+                                                                              },
+                                                                              "else": {
+                                                                                "if": {
+                                                                                  "properties": {
+                                                                                    "default": {
+                                                                                      "const": "content_rating_uk"
+                                                                                    }
+                                                                                  },
+                                                                                  "required": [
+                                                                                    "default"
+                                                                                  ]
+                                                                                },
+                                                                                "then": {
+                                                                                  "properties": {
+                                                                                    "template_variables": {
+                                                                                      "$ref": "#/definitions/content-rating-template-vars"
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                "else": {
+                                                                                  "if": {
+                                                                                    "properties": {
+                                                                                      "default": {
+                                                                                        "const": "content_rating_us"
+                                                                                      }
+                                                                                    },
+                                                                                    "required": [
+                                                                                      "default"
+                                                                                    ]
+                                                                                  },
+                                                                                  "then": {
+                                                                                    "properties": {
+                                                                                      "template_variables": {
+                                                                                        "$ref": "#/definitions/content-rating-template-vars"
+                                                                                      }
+                                                                                    }
+                                                                                  },
+                                                                                  "else": {
+                                                                                    "if": {
+                                                                                      "properties": {
+                                                                                        "default": {
+                                                                                          "const": "aspect"
+                                                                                        }
+                                                                                      },
+                                                                                      "required": [
+                                                                                        "default"
+                                                                                      ]
+                                                                                    },
+                                                                                    "then": {
+                                                                                      "properties": {
+                                                                                        "template_variables": {
+                                                                                          "$ref": "#/definitions/simple-dynamic-template-vars"
+                                                                                        }
+                                                                                      }
+                                                                                    },
+                                                                                    "else": {
+                                                                                      "if": {
+                                                                                        "properties": {
+                                                                                          "default": {
+                                                                                            "const": "audio_language"
+                                                                                          }
+                                                                                        },
+                                                                                        "required": [
+                                                                                          "default"
+                                                                                        ]
+                                                                                      },
+                                                                                      "then": {
+                                                                                        "properties": {
+                                                                                          "template_variables": {
+                                                                                            "$ref": "#/definitions/simple-dynamic-template-vars"
+                                                                                          }
+                                                                                        }
+                                                                                      },
+                                                                                      "else": {
+                                                                                        "if": {
+                                                                                          "properties": {
+                                                                                            "default": {
+                                                                                              "const": "based"
+                                                                                            }
+                                                                                          },
+                                                                                          "required": [
+                                                                                            "default"
+                                                                                          ]
+                                                                                        },
+                                                                                        "then": {
+                                                                                          "properties": {
+                                                                                            "template_variables": {
+                                                                                              "$ref": "#/definitions/simple-dynamic-template-vars"
+                                                                                            }
+                                                                                          }
+                                                                                        },
+                                                                                        "else": {
+                                                                                          "if": {
+                                                                                            "properties": {
+                                                                                              "default": {
+                                                                                                "const": "collectionless"
+                                                                                              }
+                                                                                            },
+                                                                                            "required": [
+                                                                                              "default"
+                                                                                            ]
+                                                                                          },
+                                                                                          "then": {
+                                                                                            "properties": {
+                                                                                              "template_variables": {
+                                                                                                "$ref": "#/definitions/simple-dynamic-template-vars"
+                                                                                              }
+                                                                                            }
+                                                                                          },
+                                                                                          "else": {
+                                                                                            "if": {
+                                                                                              "properties": {
+                                                                                                "default": {
+                                                                                                  "const": "continent"
+                                                                                                }
+                                                                                              },
+                                                                                              "required": [
+                                                                                                "default"
+                                                                                              ]
+                                                                                            },
+                                                                                            "then": {
+                                                                                              "properties": {
+                                                                                                "template_variables": {
+                                                                                                  "$ref": "#/definitions/simple-dynamic-template-vars"
+                                                                                                }
+                                                                                              }
+                                                                                            },
+                                                                                            "else": {
+                                                                                              "if": {
+                                                                                                "properties": {
+                                                                                                  "default": {
+                                                                                                    "const": "country"
+                                                                                                  }
+                                                                                                },
+                                                                                                "required": [
+                                                                                                  "default"
+                                                                                                ]
+                                                                                              },
+                                                                                              "then": {
+                                                                                                "properties": {
+                                                                                                  "template_variables": {
+                                                                                                    "$ref": "#/definitions/simple-dynamic-template-vars"
+                                                                                                  }
+                                                                                                }
+                                                                                              },
+                                                                                              "else": {
+                                                                                                "if": {
+                                                                                                  "properties": {
+                                                                                                    "default": {
+                                                                                                      "const": "franchise"
+                                                                                                    }
+                                                                                                  },
+                                                                                                  "required": [
+                                                                                                    "default"
+                                                                                                  ]
+                                                                                                },
+                                                                                                "then": {
+                                                                                                  "properties": {
+                                                                                                    "template_variables": {
+                                                                                                      "$ref": "#/definitions/simple-dynamic-template-vars"
+                                                                                                    }
+                                                                                                  }
+                                                                                                },
+                                                                                                "else": {
+                                                                                                  "if": {
+                                                                                                    "properties": {
+                                                                                                      "default": {
+                                                                                                        "const": "region"
+                                                                                                      }
+                                                                                                    },
+                                                                                                    "required": [
+                                                                                                      "default"
+                                                                                                    ]
+                                                                                                  },
+                                                                                                  "then": {
+                                                                                                    "properties": {
+                                                                                                      "template_variables": {
+                                                                                                        "$ref": "#/definitions/simple-dynamic-template-vars"
+                                                                                                      }
+                                                                                                    }
+                                                                                                  },
+                                                                                                  "else": {
+                                                                                                    "if": {
+                                                                                                      "properties": {
+                                                                                                        "default": {
+                                                                                                          "const": "resolution"
+                                                                                                        }
+                                                                                                      },
+                                                                                                      "required": [
+                                                                                                        "default"
+                                                                                                      ]
+                                                                                                    },
+                                                                                                    "then": {
+                                                                                                      "properties": {
+                                                                                                        "template_variables": {
+                                                                                                          "$ref": "#/definitions/simple-dynamic-template-vars"
+                                                                                                        }
+                                                                                                      }
+                                                                                                    },
+                                                                                                    "else": {
+                                                                                                      "if": {
+                                                                                                        "properties": {
+                                                                                                          "default": {
+                                                                                                            "const": "studio"
+                                                                                                          }
+                                                                                                        },
+                                                                                                        "required": [
+                                                                                                          "default"
+                                                                                                        ]
+                                                                                                      },
+                                                                                                      "then": {
+                                                                                                        "properties": {
+                                                                                                          "template_variables": {
+                                                                                                            "$ref": "#/definitions/simple-dynamic-template-vars"
+                                                                                                          }
+                                                                                                        }
+                                                                                                      },
+                                                                                                      "else": {
+                                                                                                        "if": {
+                                                                                                          "properties": {
+                                                                                                            "default": {
+                                                                                                              "const": "subtitle_language"
+                                                                                                            }
+                                                                                                          },
+                                                                                                          "required": [
+                                                                                                            "default"
+                                                                                                          ]
+                                                                                                        },
+                                                                                                        "then": {
+                                                                                                          "properties": {
+                                                                                                            "template_variables": {
+                                                                                                              "$ref": "#/definitions/simple-dynamic-template-vars"
+                                                                                                            }
+                                                                                                          }
+                                                                                                        },
+                                                                                                        "else": {
+                                                                                                          "if": {
+                                                                                                            "properties": {
+                                                                                                              "default": {
+                                                                                                                "const": "universe"
+                                                                                                              }
+                                                                                                            },
+                                                                                                            "required": [
+                                                                                                              "default"
+                                                                                                            ]
+                                                                                                          },
+                                                                                                          "then": {
+                                                                                                            "properties": {
+                                                                                                              "template_variables": {
+                                                                                                                "$ref": "#/definitions/simple-dynamic-template-vars"
+                                                                                                              }
+                                                                                                            }
+                                                                                                          },
+                                                                                                          "else": {
+                                                                                                            "if": {
+                                                                                                              "properties": {
+                                                                                                                "default": {
+                                                                                                                  "const": "genre"
+                                                                                                                }
+                                                                                                              },
+                                                                                                              "required": [
+                                                                                                                "default"
+                                                                                                              ]
+                                                                                                            },
+                                                                                                            "then": {
+                                                                                                              "properties": {
+                                                                                                                "template_variables": {
+                                                                                                                  "$ref": "#/definitions/genre-template-vars"
+                                                                                                                }
+                                                                                                              }
+                                                                                                            },
+                                                                                                            "else": {
+                                                                                                              "if": {
+                                                                                                                "properties": {
+                                                                                                                  "default": {
+                                                                                                                    "const": "decade"
+                                                                                                                  }
+                                                                                                                },
+                                                                                                                "required": [
+                                                                                                                  "default"
+                                                                                                                ]
+                                                                                                              },
+                                                                                                              "then": {
+                                                                                                                "properties": {
+                                                                                                                  "template_variables": {
+                                                                                                                    "$ref": "#/definitions/year-decade-template-vars"
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              },
+                                                                                                              "else": {
+                                                                                                                "if": {
+                                                                                                                  "properties": {
+                                                                                                                    "default": {
+                                                                                                                      "const": "year"
+                                                                                                                    }
+                                                                                                                  },
+                                                                                                                  "required": [
+                                                                                                                    "default"
+                                                                                                                  ]
+                                                                                                                },
+                                                                                                                "then": {
+                                                                                                                  "properties": {
+                                                                                                                    "template_variables": {
+                                                                                                                      "$ref": "#/definitions/year-decade-template-vars"
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                },
+                                                                                                                "else": {
+                                                                                                                  "if": {
+                                                                                                                    "properties": {
+                                                                                                                      "default": {
+                                                                                                                        "const": "network"
+                                                                                                                      }
+                                                                                                                    },
+                                                                                                                    "required": [
+                                                                                                                      "default"
+                                                                                                                    ]
+                                                                                                                  },
+                                                                                                                  "then": {
+                                                                                                                    "properties": {
+                                                                                                                      "template_variables": {
+                                                                                                                        "$ref": "#/definitions/network-template-vars"
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  },
+                                                                                                                  "else": {
+                                                                                                                    "if": {
+                                                                                                                      "properties": {
+                                                                                                                        "default": {
+                                                                                                                          "const": "streaming"
+                                                                                                                        }
+                                                                                                                      },
+                                                                                                                      "required": [
+                                                                                                                        "default"
+                                                                                                                      ]
+                                                                                                                    },
+                                                                                                                    "then": {
+                                                                                                                      "properties": {
+                                                                                                                        "template_variables": {
+                                                                                                                          "$ref": "#/definitions/streaming-template-vars"
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    },
+                                                                                                                    "else": {
+                                                                                                                      "if": {
+                                                                                                                        "properties": {
+                                                                                                                          "default": {
+                                                                                                                            "const": "separator_award"
+                                                                                                                          }
+                                                                                                                        },
+                                                                                                                        "required": [
+                                                                                                                          "default"
+                                                                                                                        ]
+                                                                                                                      },
+                                                                                                                      "then": {
+                                                                                                                        "properties": {
+                                                                                                                          "template_variables": {
+                                                                                                                            "$ref": "#/definitions/separator-template-vars"
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      },
+                                                                                                                      "else": {
+                                                                                                                        "if": {
+                                                                                                                          "properties": {
+                                                                                                                            "default": {
+                                                                                                                              "const": "separator_chart"
+                                                                                                                            }
+                                                                                                                          },
+                                                                                                                          "required": [
+                                                                                                                            "default"
+                                                                                                                          ]
+                                                                                                                        },
+                                                                                                                        "then": {
+                                                                                                                          "properties": {
+                                                                                                                            "template_variables": {
+                                                                                                                              "$ref": "#/definitions/separator-template-vars"
+                                                                                                                            }
+                                                                                                                          }
+                                                                                                                        },
+                                                                                                                        "else": {
+                                                                                                                          "if": {
+                                                                                                                            "properties": {
+                                                                                                                              "default": {
+                                                                                                                                "const": "seasonal"
+                                                                                                                              }
+                                                                                                                            },
+                                                                                                                            "required": [
+                                                                                                                              "default"
+                                                                                                                            ]
+                                                                                                                          },
+                                                                                                                          "then": {
+                                                                                                                            "properties": {
+                                                                                                                              "template_variables": {
+                                                                                                                                "$ref": "#/definitions/seasonal-template-vars"
+                                                                                                                              }
+                                                                                                                            }
+                                                                                                                          },
+                                                                                                                          "else": {
+                                                                                                                            "properties": {
+                                                                                                                              "template_variables": {
+                                                                                                                                "$ref": "#/definitions/template-variables-collections"
+                                                                                                                              }
+                                                                                                                            }
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "legacy-default-overlay-path": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "pmm": {
+          "type": "string",
+          "enum": [
+            "aspect",
+            "audio_codec",
+            "commonsense",
+            "content_rating_au",
+            "content_rating_de",
+            "content_rating_nz",
+            "content_rating_uk",
+            "content_rating_us_movie",
+            "content_rating_us_show",
+            "direct_play",
+            "episode_info",
+            "language_count",
+            "flixpatrol",
+            "languages",
+            "mediastinger",
+            "network",
+            "ratings",
+            "resolution",
+            "ribbon",
+            "runtimes",
+            "status",
+            "streaming",
+            "studio",
+            "versions",
+            "video_format"
+          ]
+        },
+        "remove_overlays": {
+          "type": "boolean"
+        },
+        "reapply_overlays": {
+          "type": "boolean"
+        },
+        "reapply_overlay": {
+          "type": "boolean"
+        },
+        "reset_overlays": {
+          "type": "string",
+          "enum": [
+            "tmdb",
+            "plex"
+          ]
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "asset_directory": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "template_variables": {
+          "$ref": "#/definitions/template-variables-overlays"
+        }
+      },
+      "required": [
+        "pmm"
+      ]
+    },
+    "kometa-default-overlay-path": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "type": "string",
+          "enum": [
+            "aspect",
+            "audio_codec",
+            "commonsense",
+            "content_rating_au",
+            "content_rating_de",
+            "content_rating_nz",
+            "content_rating_uk",
+            "content_rating_us_movie",
+            "content_rating_us_show",
+            "direct_play",
+            "episode_info",
+            "language_count",
+            "flixpatrol",
+            "languages",
+            "mediastinger",
+            "network",
+            "ratings",
+            "resolution",
+            "ribbon",
+            "runtimes",
+            "status",
+            "streaming",
+            "studio",
+            "versions",
+            "video_format"
+          ]
+        },
+        "remove_overlays": {
+          "type": "boolean"
+        },
+        "reapply_overlays": {
+          "type": "boolean"
+        },
+        "reapply_overlay": {
+          "type": "boolean"
+        },
+        "reset_overlays": {
+          "type": "string",
+          "enum": [
+            "tmdb",
+            "plex"
+          ]
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "asset_directory": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "template_variables": {
+          "$ref": "#/definitions/template-variables-overlays"
+        }
+      },
+      "required": []
+    },
+    "legacy-default-playlist-path": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "pmm": {
+          "type": "string",
+          "enum": [
+            "playlist"
+          ]
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "asset_directory": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "template_variables": {
+          "$ref": "#/definitions/template-variables-playlists"
+        }
+      },
+      "required": [
+        "pmm"
+      ]
+    },
+    "kometa-default-playlist-path": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "type": "string",
+          "enum": [
+            "playlist"
+          ]
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "asset_directory": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "template_variables": {
+          "$ref": "#/definitions/template-variables-playlists"
+        }
+      },
+      "required": [
+        "default"
+      ]
+    },
+    "file-path": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "file": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "asset_directory": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        }
+      },
+      "required": [
+        "file"
+      ]
+    },
+    "file-path-collection-with-template-variables": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "file": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "asset_directory": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "template_variables": {
+          "$ref": "#/definitions/template-variables-collections"
+        }
+      },
+      "required": [
+        "file"
+      ]
+    },
+    "file-path-overlay-with-template-variables": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "file": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "asset_directory": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "template_variables": {
+          "$ref": "#/definitions/template-variables-overlays"
+        }
+      },
+      "required": [
+        "file"
+      ]
+    },
+    "file-path-playlist-with-template-variables": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "file": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "asset_directory": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "template_variables": {
+          "$ref": "#/definitions/template-variables-playlists"
+        }
+      },
+      "required": [
+        "file"
+      ]
+    },
+    "folder-path": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "folder": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "asset_directory": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        }
+      },
+      "required": [
+        "folder"
+      ]
+    },
+    "url-path": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^(https?)://"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "asset_directory": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        }
+      },
+      "required": [
+        "url"
+      ]
+    },
+    "url-path-collection-with-template-variables": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^(https?)://"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "asset_directory": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "template_variables": {
+          "$ref": "#/definitions/template-variables-collections"
+        }
+      },
+      "required": [
+        "url"
+      ]
+    },
+    "url-path-overlay-with-template-variables": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^(https?)://"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "asset_directory": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "template_variables": {
+          "$ref": "#/definitions/template-variables-overlays"
+        }
+      },
+      "required": [
+        "url"
+      ]
+    },
+    "url-path-playlist-with-template-variables": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^(https?)://"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "asset_directory": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "template_variables": {
+          "$ref": "#/definitions/template-variables-playlists"
+        }
+      },
+      "required": [
+        "url"
+      ]
+    },
+    "git-path": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "git": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "asset_directory": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        }
+      },
+      "required": [
+        "git"
+      ]
+    },
+    "git-path-collection-with-template-variables": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "git": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "asset_directory": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "template_variables": {
+          "$ref": "#/definitions/template-variables-collections"
+        }
+      },
+      "required": [
+        "git"
+      ]
+    },
+    "git-path-overlay-with-template-variables": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "git": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "asset_directory": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "template_variables": {
+          "$ref": "#/definitions/template-variables-overlays"
+        }
+      },
+      "required": [
+        "git"
+      ]
+    },
+    "git-path-playlist-with-template-variables": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "git": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "asset_directory": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "template_variables": {
+          "$ref": "#/definitions/template-variables-playlists"
+        }
+      },
+      "required": [
+        "git"
+      ]
+    },
+    "repo-path": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repo": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "asset_directory": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        }
+      },
+      "required": [
+        "repo"
+      ]
+    },
+    "repo-path-collection-with-template-variables": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repo": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "asset_directory": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "template_variables": {
+          "$ref": "#/definitions/template-variables-collections"
+        }
+      },
+      "required": [
+        "repo"
+      ]
+    },
+    "repo-path-overlay-with-template-variables": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repo": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "asset_directory": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "template_variables": {
+          "$ref": "#/definitions/template-variables-overlays"
+        }
+      },
+      "required": [
+        "repo"
+      ]
+    },
+    "repo-path-playlist-with-template-variables": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repo": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "asset_directory": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "template_variables": {
+          "$ref": "#/definitions/template-variables-playlists"
+        }
+      },
+      "required": [
+        "repo"
+      ]
+    },
+    "library-section": {
+      "title": "libraries",
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^(?!plex|tmdb|tautulli|webhooks|omdb|mdblist|notifiarr|gotify|ntfy|anidb|radarr|sonarr|trakt|mal).+$": {
+          "additionalProperties": false,
+          "properties": {
+            "metadata_files": {
+              "description": "The metadata_files attribute is used to define Metadata Files by specifying the path of the files that will be executed against the parent library.",
+              "$ref": "#/definitions/metadata-files"
+            },
+            "collection_files": {
+              "description": "The collection_files attribute is used to define Collection Files by specifying the path type and path of the files that will be executed against the parent library.",
+              "$ref": "#/definitions/collection-files"
+            },
+            "overlay_files": {
+              "description": "The overlay_files attribute is used to define Overlay Files by specifying the path type and path of the files that will be executed against the parent library.",
+              "$ref": "#/definitions/overlay-files"
+            },
+            "metadata_path": {
+              "description": "DEPRECATED! Use: metadata_files.\nThe metadata_path attribute is used to define Metadata Files by specifying the path of the files that will be executed against the parent library.",
+              "$ref": "#/definitions/metadata-path"
+            },
+            "overlay_path": {
+              "description": "DEPRECATED! Use: overlay_files.\nThe overlay_path attribute is used to define Overlay Files by specifying the path type and path of the files that will be executed against the parent library.",
+              "$ref": "#/definitions/overlay-path"
+            },
+            "operations": {
+              "description": "Used to specify Library Operations to run.",
+              "$ref": "#/definitions/operations"
+            },
+            "library_name": {
+              "description": "Used to specify the Library's name.\nRequired only when trying to use multiple servers with the same name. Each library that the user wants Kometa to interact with must be documented with a library attribute. A library attribute is represented by the mapping name (i.e. Movies or TV Shows), this must have a unique name that correlates with a library of the same name within the Plex Media Server. In the situation that two servers are being connected to which both have libraries of the same name, the library_name attribute can be utilized to specify the real Library Name, whilst the library attribute's mapping name can be made into a placeholder.",
+              "type": "string"
+            },
+            "report_path": {
+              "description": "Location to save the YAML Report file for a library.\nThe report_path attribute is used to define where to save the YAML Report file. This file is used to store information about what media is added, removed, filtered, and missing from the Plex library compared to what is expected from the Collection, Metadata, Overlay or Playlist file. If your Collection file creates a collection with Movie 1, Movie 2 and Movie 3 but your Plex library only has Movie 1 and Movie 3, then the missing YAML file will be updated to inform the user that Movie 2 was missing from the library.",
+              "type": "string"
+            },
+            "settings": {
+              "$ref": "#/definitions/settings"
+            },
+            "plex": {
+              "$ref": "#/definitions/plex-server-lib"
+            },
+            "radarr": {
+              "$ref": "#/definitions/radarr-api-lib"
+            },
+            "sonarr": {
+              "$ref": "#/definitions/sonarr-api-lib"
+            },
+            "tautulli": {
+              "$ref": "#/definitions/tautulli-api"
+            },
+            "template_variables": {
+              "$ref": "#/definitions/template-variables-library"
+            },
+            "schedule": {
+              "description": "Used to schedule when a library is run using the schedule options.",
+              "type": "string"
+            },
+            "schedule_overlays": {
+              "description": "Used to schedule when overlays are run for this library.",
+              "type": "string"
+            },
+            "remove_overlays": {
+              "description": "Used to remove overlays from this library only. \nWhen set to true, this will remove all overlays from your library every run, but will not delete the overlaid images from your system, resulting in image bloat.",
+              "type": "boolean"
+            },
+            "reapply_overlays": {
+              "description": "Used to reapply overlays from this library only. This will reapply overlays to every item in your library.\nWhen set to true, this will reapply all overlays on each run even if there is no need to do so, which will result in image bloat.",
+              "type": "boolean"
+            },
+            "reset_overlays": {
+              "description": "Used to reset overlays from this library only. This will reset overlays to every item in your library to your source choice. This will use the reset image when overlaying items in your library.\nThis will reset all posters to the desired source on each run and will reapply all overlays on each run, which will result in image bloat.",
+              "type": "string",
+              "enum": [
+                "tmdb",
+                "plex"
+              ]
+            },
+            "run_order": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "collections",
+                  "metadata",
+                  "operations",
+                  "overlays"
+                ]
+              }
+            }
+          }
+        },
+        "^schedule_.*$": {
+          "type": "string"
+        }
+      }
+    },
+    "metadata-files": {
+      "title": "metadata_files",
+      "additionalProperties": false,
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "$ref": "#/definitions/file-path"
+          },
+          {
+            "$ref": "#/definitions/folder-path"
+          },
+          {
+            "$ref": "#/definitions/url-path"
+          },
+          {
+            "$ref": "#/definitions/git-path"
+          },
+          {
+            "$ref": "#/definitions/repo-path"
+          }
+        ]
+      }
+    },
+    "collection-files": {
+      "title": "collection_files",
+      "additionalProperties": false,
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "$ref": "#/definitions/legacy-default-collection-path",
+            "deprecated": true
+          },
+          {
+            "$ref": "#/definitions/kometa-default-collection-path"
+          },
+          {
+            "$ref": "#/definitions/file-path"
+          },
+          {
+            "$ref": "#/definitions/file-path-collection-with-template-variables"
+          },
+          {
+            "$ref": "#/definitions/folder-path"
+          },
+          {
+            "$ref": "#/definitions/url-path"
+          },
+          {
+            "$ref": "#/definitions/url-path-collection-with-template-variables"
+          },
+          {
+            "$ref": "#/definitions/git-path"
+          },
+          {
+            "$ref": "#/definitions/git-path-collection-with-template-variables"
+          },
+          {
+            "$ref": "#/definitions/repo-path"
+          },
+          {
+            "$ref": "#/definitions/repo-path-collection-with-template-variables"
+          }
+        ]
+      }
+    },
+    "overlay-files": {
+      "title": "overlay_files",
+      "additionalProperties": false,
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "$ref": "#/definitions/legacy-default-overlay-path",
+            "deprecated": true
+          },
+          {
+            "$ref": "#/definitions/kometa-default-overlay-path"
+          },
+          {
+            "$ref": "#/definitions/file-path"
+          },
+          {
+            "$ref": "#/definitions/file-path-overlay-with-template-variables"
+          },
+          {
+            "$ref": "#/definitions/folder-path"
+          },
+          {
+            "$ref": "#/definitions/url-path"
+          },
+          {
+            "$ref": "#/definitions/url-path-overlay-with-template-variables"
+          },
+          {
+            "$ref": "#/definitions/git-path"
+          },
+          {
+            "$ref": "#/definitions/git-path-overlay-with-template-variables"
+          },
+          {
+            "$ref": "#/definitions/repo-path"
+          },
+          {
+            "$ref": "#/definitions/repo-path-overlay-with-template-variables"
+          }
+        ]
+      }
+    },
+    "metadata-path": {
+      "deprecated": true,
+      "title": "metadata_path",
+      "additionalProperties": false,
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "$ref": "#/definitions/legacy-default-collection-path",
+            "deprecated": true
+          },
+          {
+            "$ref": "#/definitions/kometa-default-collection-path"
+          },
+          {
+            "$ref": "#/definitions/file-path"
+          },
+          {
+            "$ref": "#/definitions/file-path-collection-with-template-variables"
+          },
+          {
+            "$ref": "#/definitions/folder-path"
+          },
+          {
+            "$ref": "#/definitions/url-path"
+          },
+          {
+            "$ref": "#/definitions/url-path-collection-with-template-variables"
+          },
+          {
+            "$ref": "#/definitions/git-path"
+          },
+          {
+            "$ref": "#/definitions/git-path-collection-with-template-variables"
+          },
+          {
+            "$ref": "#/definitions/repo-path"
+          },
+          {
+            "$ref": "#/definitions/repo-path-collection-with-template-variables"
+          }
+        ]
+      }
+    },
+    "overlay-path": {
+      "deprecated": true,
+      "title": "overlay_path",
+      "additionalProperties": false,
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "$ref": "#/definitions/legacy-default-overlay-path",
+            "deprecated": true
+          },
+          {
+            "$ref": "#/definitions/kometa-default-overlay-path"
+          },
+          {
+            "$ref": "#/definitions/file-path"
+          },
+          {
+            "$ref": "#/definitions/file-path-overlay-with-template-variables"
+          },
+          {
+            "$ref": "#/definitions/folder-path"
+          },
+          {
+            "$ref": "#/definitions/url-path"
+          },
+          {
+            "$ref": "#/definitions/url-path-overlay-with-template-variables"
+          },
+          {
+            "$ref": "#/definitions/git-path"
+          },
+          {
+            "$ref": "#/definitions/git-path-overlay-with-template-variables"
+          },
+          {
+            "$ref": "#/definitions/repo-path"
+          },
+          {
+            "$ref": "#/definitions/repo-path-overlay-with-template-variables"
+          }
+        ]
+      }
+    },
+    "playlist-path": {
+      "title": "playlist_files",
+      "additionalProperties": false,
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "$ref": "#/definitions/legacy-default-playlist-path",
+            "deprecated": true
+          },
+          {
+            "$ref": "#/definitions/kometa-default-playlist-path"
+          },
+          {
+            "$ref": "#/definitions/file-path"
+          },
+          {
+            "$ref": "#/definitions/file-path-playlist-with-template-variables"
+          },
+          {
+            "$ref": "#/definitions/folder-path"
+          },
+          {
+            "$ref": "#/definitions/url-path"
+          },
+          {
+            "$ref": "#/definitions/url-path-playlist-with-template-variables"
+          },
+          {
+            "$ref": "#/definitions/git-path"
+          },
+          {
+            "$ref": "#/definitions/git-path-playlist-with-template-variables"
+          },
+          {
+            "$ref": "#/definitions/repo-path"
+          },
+          {
+            "$ref": "#/definitions/repo-path-playlist-with-template-variables"
+          }
+        ]
+      }
+    },
+    "operations": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "assets_for_all": {
+              "type": "boolean"
+            },
+            "assets_for_all_collections": {
+              "type": "boolean"
+            },
+            "update_blank_track_titles": {
+              "type": "boolean"
+            },
+            "remove_title_parentheses": {
+              "type": "boolean"
+            },
+            "split_duplicates": {
+              "type": "boolean"
+            },
+            "radarr_add_all": {
+              "type": "boolean"
+            },
+            "sonarr_add_all": {
+              "type": "boolean"
+            },
+            "mass_genre_update": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "tmdb",
+                    "tvdb",
+                    "imdb",
+                    "omdb",
+                    "anidb",
+                    "anidb_3_0",
+                    "anidb_2_5",
+                    "anidb_2_0",
+                    "anidb_1_5",
+                    "anidb_1_0",
+                    "anidb_0_5",
+                    "mal",
+                    "lock",
+                    "unlock",
+                    "remove",
+                    "reset"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "tmdb",
+                          "tvdb",
+                          "imdb",
+                          "omdb",
+                          "anidb",
+                          "anidb_3_0",
+                          "anidb_2_5",
+                          "anidb_2_0",
+                          "anidb_1_5",
+                          "anidb_1_0",
+                          "anidb_0_5",
+                          "mal",
+                          "lock",
+                          "unlock",
+                          "remove",
+                          "reset"
+                        ]
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "mass_content_rating_update": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "anyOf": [
+                  {
+                    "enum": [
+                      "mdb",
+                      "mdb_commonsense",
+                      "mdb_commonsense0",
+                      "plex_csm",
+                      "plex_csm0",
+                      "omdb",
+                      "mal",
+                      "lock",
+                      "unlock",
+                      "remove",
+                      "reset"
+                    ]
+                  },
+                  {
+                    "pattern": ".*"
+                  }
+                ]
+              }
+            },
+            "mass_original_title_update": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "anyOf": [
+                  {
+                    "enum": [
+                      "anidb",
+                      "anidb_official",
+                      "mal",
+                      "mal_english",
+                      "mal_japanese",
+                      "lock",
+                      "unlock",
+                      "remove",
+                      "reset"
+                    ]
+                  },
+                  {
+                    "pattern": ".*"
+                  }
+                ]
+              }
+            },
+            "mass_studio_update": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "anidb",
+                    "mal",
+                    "tmdb",
+                    "lock",
+                    "unlock",
+                    "remove",
+                    "reset"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "anidb",
+                          "mal",
+                          "tmdb",
+                          "lock",
+                          "unlock",
+                          "remove",
+                          "reset"
+                        ]
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "mass_originally_available_update": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "tmdb",
+                    "tvdb",
+                    "omdb",
+                    "mdb",
+                    "mdb_digital",
+                    "anidb",
+                    "mal",
+                    "lock",
+                    "unlock",
+                    "remove",
+                    "reset"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                },
+                {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "tmdb",
+                          "tvdb",
+                          "omdb",
+                          "mdb",
+                          "mdb_digital",
+                          "anidb",
+                          "mal",
+                          "lock",
+                          "unlock",
+                          "remove",
+                          "reset"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "mass_added_at_update": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "tmdb",
+                    "tvdb",
+                    "omdb",
+                    "mdb",
+                    "mdb_digital",
+                    "anidb",
+                    "mal",
+                    "lock",
+                    "unlock",
+                    "remove",
+                    "reset"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                },
+                {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "tmdb",
+                          "tvdb",
+                          "omdb",
+                          "mdb",
+                          "mdb_digital",
+                          "anidb",
+                          "mal",
+                          "lock",
+                          "unlock",
+                          "remove",
+                          "reset"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "mass_audience_rating_update": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "anidb_average",
+                    "anidb_rating",
+                    "anidb_score",
+                    "imdb",
+                    "lock",
+                    "mal",
+                    "mdb",
+                    "mdb_average",
+                    "mdb_imdb",
+                    "mdb_letterboxd",
+                    "mdb_metacritic",
+                    "mdb_metacriticuser",
+                    "mdb_myanimelist",
+                    "mdb_tomatoes",
+                    "mdb_tomatoesaudience",
+                    "mdb_tmdb",
+                    "mdb_trakt",
+                    "omdb",
+                    "omdb_metascore",
+                    "omdb_tomatoes",
+                    "plex_imdb",
+                    "plex_tmdb",
+                    "plex_tomatoes",
+                    "plex_tomatoesaudience",
+                    "remove",
+                    "reset",
+                    "tmdb",
+                    "trakt",
+                    "trakt_user",
+                    "unlock"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "anidb_average",
+                          "anidb_rating",
+                          "anidb_score",
+                          "imdb",
+                          "lock",
+                          "mal",
+                          "mdb",
+                          "mdb_average",
+                          "mdb_imdb",
+                          "mdb_letterboxd",
+                          "mdb_metacritic",
+                          "mdb_metacriticuser",
+                          "mdb_myanimelist",
+                          "mdb_tomatoes",
+                          "mdb_tomatoesaudience",
+                          "mdb_tmdb",
+                          "mdb_trakt",
+                          "omdb",
+                          "omdb_metascore",
+                          "omdb_tomatoes",
+                          "plex_imdb",
+                          "plex_tmdb",
+                          "plex_tomatoes",
+                          "plex_tomatoesaudience",
+                          "remove",
+                          "reset",
+                          "tmdb",
+                          "trakt",
+                          "trakt_user",
+                          "unlock"
+                        ]
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "mass_critic_rating_update": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "anidb_average",
+                    "anidb_rating",
+                    "anidb_score",
+                    "imdb",
+                    "lock",
+                    "mal",
+                    "mdb",
+                    "mdb_average",
+                    "mdb_imdb",
+                    "mdb_letterboxd",
+                    "mdb_metacritic",
+                    "mdb_metacriticuser",
+                    "mdb_myanimelist",
+                    "mdb_tomatoes",
+                    "mdb_tomatoesaudience",
+                    "mdb_tmdb",
+                    "mdb_trakt",
+                    "omdb",
+                    "omdb_metascore",
+                    "omdb_tomatoes",
+                    "plex_imdb",
+                    "plex_tmdb",
+                    "plex_tomatoes",
+                    "plex_tomatoesaudience",
+                    "remove",
+                    "reset",
+                    "tmdb",
+                    "trakt",
+                    "trakt_user",
+                    "unlock"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "anidb_average",
+                          "anidb_rating",
+                          "anidb_score",
+                          "imdb",
+                          "lock",
+                          "mal",
+                          "mdb",
+                          "mdb_average",
+                          "mdb_imdb",
+                          "mdb_letterboxd",
+                          "mdb_metacritic",
+                          "mdb_metacriticuser",
+                          "mdb_myanimelist",
+                          "mdb_tomatoes",
+                          "mdb_tomatoesaudience",
+                          "mdb_tmdb",
+                          "mdb_trakt",
+                          "omdb",
+                          "omdb_metascore",
+                          "omdb_tomatoes",
+                          "plex_imdb",
+                          "plex_tmdb",
+                          "plex_tomatoes",
+                          "plex_tomatoesaudience",
+                          "remove",
+                          "reset",
+                          "tmdb",
+                          "trakt",
+                          "trakt_user",
+                          "unlock"
+                        ]
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "mass_user_rating_update": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "anidb_average",
+                    "anidb_rating",
+                    "anidb_score",
+                    "imdb",
+                    "lock",
+                    "mal",
+                    "mdb",
+                    "mdb_average",
+                    "mdb_imdb",
+                    "mdb_letterboxd",
+                    "mdb_metacritic",
+                    "mdb_metacriticuser",
+                    "mdb_myanimelist",
+                    "mdb_tomatoes",
+                    "mdb_tomatoesaudience",
+                    "mdb_tmdb",
+                    "mdb_trakt",
+                    "omdb",
+                    "omdb_metascore",
+                    "omdb_tomatoes",
+                    "plex_imdb",
+                    "plex_tmdb",
+                    "plex_tomatoes",
+                    "plex_tomatoesaudience",
+                    "remove",
+                    "reset",
+                    "tmdb",
+                    "trakt",
+                    "trakt_user",
+                    "unlock"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "anidb_average",
+                          "anidb_rating",
+                          "anidb_score",
+                          "imdb",
+                          "lock",
+                          "mal",
+                          "mdb",
+                          "mdb_average",
+                          "mdb_imdb",
+                          "mdb_letterboxd",
+                          "mdb_metacritic",
+                          "mdb_metacriticuser",
+                          "mdb_myanimelist",
+                          "mdb_tomatoes",
+                          "mdb_tomatoesaudience",
+                          "mdb_tmdb",
+                          "mdb_trakt",
+                          "omdb",
+                          "omdb_metascore",
+                          "omdb_tomatoes",
+                          "plex_imdb",
+                          "plex_tmdb",
+                          "plex_tomatoes",
+                          "plex_tomatoesaudience",
+                          "remove",
+                          "reset",
+                          "tmdb",
+                          "trakt",
+                          "trakt_user",
+                          "unlock"
+                        ]
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "mass_episode_audience_rating_update": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "anidb_average",
+                    "anidb_rating",
+                    "anidb_score",
+                    "imdb",
+                    "lock",
+                    "mal",
+                    "mdb",
+                    "mdb_average",
+                    "mdb_imdb",
+                    "mdb_letterboxd",
+                    "mdb_metacritic",
+                    "mdb_metacriticuser",
+                    "mdb_myanimelist",
+                    "mdb_tomatoes",
+                    "mdb_tomatoesaudience",
+                    "mdb_tmdb",
+                    "mdb_trakt",
+                    "omdb",
+                    "omdb_metascore",
+                    "omdb_tomatoes",
+                    "plex_imdb",
+                    "plex_tmdb",
+                    "plex_tomatoes",
+                    "plex_tomatoesaudience",
+                    "remove",
+                    "reset",
+                    "tmdb",
+                    "trakt",
+                    "trakt_user",
+                    "unlock"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "anidb_average",
+                          "anidb_rating",
+                          "anidb_score",
+                          "imdb",
+                          "lock",
+                          "mal",
+                          "mdb",
+                          "mdb_average",
+                          "mdb_imdb",
+                          "mdb_letterboxd",
+                          "mdb_metacritic",
+                          "mdb_metacriticuser",
+                          "mdb_myanimelist",
+                          "mdb_tomatoes",
+                          "mdb_tomatoesaudience",
+                          "mdb_tmdb",
+                          "mdb_trakt",
+                          "omdb",
+                          "omdb_metascore",
+                          "omdb_tomatoes",
+                          "plex_imdb",
+                          "plex_tmdb",
+                          "plex_tomatoes",
+                          "plex_tomatoesaudience",
+                          "remove",
+                          "reset",
+                          "tmdb",
+                          "trakt",
+                          "trakt_user",
+                          "unlock"
+                        ]
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "mass_episode_critic_rating_update": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "anidb_average",
+                    "anidb_rating",
+                    "anidb_score",
+                    "imdb",
+                    "lock",
+                    "mal",
+                    "mdb",
+                    "mdb_average",
+                    "mdb_imdb",
+                    "mdb_letterboxd",
+                    "mdb_metacritic",
+                    "mdb_metacriticuser",
+                    "mdb_myanimelist",
+                    "mdb_tomatoes",
+                    "mdb_tomatoesaudience",
+                    "mdb_tmdb",
+                    "mdb_trakt",
+                    "omdb",
+                    "omdb_metascore",
+                    "omdb_tomatoes",
+                    "plex_imdb",
+                    "plex_tmdb",
+                    "plex_tomatoes",
+                    "plex_tomatoesaudience",
+                    "remove",
+                    "reset",
+                    "tmdb",
+                    "trakt",
+                    "trakt_user",
+                    "unlock"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "anidb_average",
+                          "anidb_rating",
+                          "anidb_score",
+                          "imdb",
+                          "lock",
+                          "mal",
+                          "mdb",
+                          "mdb_average",
+                          "mdb_imdb",
+                          "mdb_letterboxd",
+                          "mdb_metacritic",
+                          "mdb_metacriticuser",
+                          "mdb_myanimelist",
+                          "mdb_tomatoes",
+                          "mdb_tomatoesaudience",
+                          "mdb_tmdb",
+                          "mdb_trakt",
+                          "omdb",
+                          "omdb_metascore",
+                          "omdb_tomatoes",
+                          "plex_imdb",
+                          "plex_tmdb",
+                          "plex_tomatoes",
+                          "plex_tomatoesaudience",
+                          "remove",
+                          "reset",
+                          "tmdb",
+                          "trakt",
+                          "trakt_user",
+                          "unlock"
+                        ]
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "mass_episode_user_rating_update": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "anidb_average",
+                    "anidb_rating",
+                    "anidb_score",
+                    "imdb",
+                    "lock",
+                    "mal",
+                    "mdb",
+                    "mdb_average",
+                    "mdb_imdb",
+                    "mdb_letterboxd",
+                    "mdb_metacritic",
+                    "mdb_metacriticuser",
+                    "mdb_myanimelist",
+                    "mdb_tomatoes",
+                    "mdb_tomatoesaudience",
+                    "mdb_tmdb",
+                    "mdb_trakt",
+                    "omdb",
+                    "omdb_metascore",
+                    "omdb_tomatoes",
+                    "plex_imdb",
+                    "plex_tmdb",
+                    "plex_tomatoes",
+                    "plex_tomatoesaudience",
+                    "remove",
+                    "reset",
+                    "tmdb",
+                    "trakt",
+                    "trakt_user",
+                    "unlock"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "anidb_average",
+                          "anidb_rating",
+                          "anidb_score",
+                          "imdb",
+                          "lock",
+                          "mal",
+                          "mdb",
+                          "mdb_average",
+                          "mdb_imdb",
+                          "mdb_letterboxd",
+                          "mdb_metacritic",
+                          "mdb_metacriticuser",
+                          "mdb_myanimelist",
+                          "mdb_tomatoes",
+                          "mdb_tomatoesaudience",
+                          "mdb_tmdb",
+                          "mdb_trakt",
+                          "omdb",
+                          "omdb_metascore",
+                          "omdb_tomatoes",
+                          "plex_imdb",
+                          "plex_tmdb",
+                          "plex_tomatoes",
+                          "plex_tomatoesaudience",
+                          "remove",
+                          "reset",
+                          "tmdb",
+                          "trakt",
+                          "trakt_user",
+                          "unlock"
+                        ]
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "mass_poster_update": {
+              "type": "object",
+              "properties": {
+                "source": {
+                  "type": "string",
+                  "enum": [
+                    "tmdb",
+                    "plex",
+                    "lock",
+                    "unlock"
+                  ]
+                },
+                "language": {
+                  "type": "string"
+                },
+                "seasons": {
+                  "type": "boolean"
+                },
+                "episodes": {
+                  "type": "boolean"
+                },
+                "ignore_locked": {
+                  "type": "boolean"
+                },
+                "ignore_overlays": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            },
+            "mass_background_update": {
+              "type": "object",
+              "properties": {
+                "source": {
+                  "type": "string",
+                  "enum": [
+                    "tmdb",
+                    "plex",
+                    "lock",
+                    "unlock"
+                  ]
+                },
+                "language": {
+                  "type": "string"
+                },
+                "seasons": {
+                  "type": "boolean"
+                },
+                "episodes": {
+                  "type": "boolean"
+                },
+                "ignore_locked": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            },
+            "mass_imdb_parental_labels": {
+              "type": "string",
+              "enum": [
+                "none",
+                "mild",
+                "moderate",
+                "severe"
+              ]
+            },
+            "mass_collection_mode": {
+              "type": "string",
+              "enum": [
+                "default",
+                "hide",
+                "hide_items",
+                "show_items"
+              ]
+            },
+            "radarr_remove_by_tag": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "sonarr_remove_by_tag": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "delete_collections": {
+              "type": "object",
+              "properties": {
+                "configured": {
+                  "type": "boolean"
+                },
+                "managed": {
+                  "type": "boolean"
+                },
+                "less": {
+                  "type": "integer"
+                },
+                "ignore_empty_smart_collections": {
+                  "type": "boolean"
+                }
+              },
+              "required": []
+            },
+            "genre_mapper": {
+              "type": "object",
+              "properties": {},
+              "patternProperties": {
+                "^.*$": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "pattern": "^.*$"
+                }
+              },
+              "required": []
+            },
+            "content_rating_mapper": {
+              "type": "object",
+              "properties": {},
+              "patternProperties": {
+                "^.*$": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "pattern": "^.*$"
+                }
+              },
+              "required": []
+            },
+            "metadata_backup": {
+              "type": "object",
+              "properties": {
+                "path": {
+                  "type": "string"
+                },
+                "exclude": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ]
+                },
+                "sync_tags": {
+                  "type": "boolean"
+                },
+                "add_blank_entries": {
+                  "type": "boolean"
+                }
+              },
+              "required": []
+            }
+          },
+          "required": [],
+          "dependentRequired": {},
+          "title": "operations"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      ]
+    },
+    "template-variables-library": {
+      "type": "object",
+      "properties": {
+        "sep_style": {
+          "description": "Multiple styles are available for Separators, to match Plex's 'categories' feature.",
+          "type": "string",
+          "enum": [
+            "amethyst",
+            "aqua",
+            "blue",
+            "forest",
+            "fuchsia",
+            "gold",
+            "gray",
+            "green",
+            "navy",
+            "ocean",
+            "olive",
+            "orchid",
+            "orig",
+            "pink",
+            "plum",
+            "purple",
+            "red",
+            "rust",
+            "salmon",
+            "sand",
+            "stb",
+            "tan"
+          ]
+        },
+        "collection_mode": {
+          "description": "Controls the collection mode of all collections in a Defaults file.",
+          "type": "string",
+          "enum": [
+            "default",
+            "hide",
+            "hide_items",
+            "show_items"
+          ]
+        },
+        "language": {
+          "description": "Set the language of Collection Names and Summaries that Kometa has been translated to with weblate",
+          "type": "string",
+          "enum": [
+            "en",
+            "fr",
+            "ar",
+            "da",
+            "nl",
+            "de",
+            "it",
+            "pt-br",
+            "nb-no",
+            "es",
+            "sv",
+            "ru",
+            "bg",
+            "hu"
+          ]
+        },
+        "placeholder_imdb_id": {
+          "description": "Add a placeholder Movie/Show to the Separator to ensure Plex sees a collection with 1 item because 0 item collections can be problematic for Plex.\nValid for Movie or Show libraries assuming the ID points to an item of the correct type and that its in your library.",
+          "type": "string",
+          "pattern": "^tt\\d{7,8}$"
+        }
+      },
+      "required": [],
+      "title": "template_variables"
+    },
+    "template-variables-collections": {
+      "type": "object",
+      "title": "template_variables",
+      "description": "Template variables shared across all collection defaults files. Per-key variants (use_<<key>>, name_<<key>>, etc.) are accepted via patternProperties.",
+      "additionalProperties": false,
+      "properties": {
+        "data": {
+          "description": "Data object used by dynamic collection defaults (e.g. year ranges).",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "starting": {
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                {
+                  "type": "string",
+                  "pattern": "^(current_year(\\s*-\\s*\\d+)?)$|^(first(\\s*\\+\\s*\\d+)?)$|^(latest(\\s*-\\s*\\d+)?)$"
+                }
+              ]
+            },
+            "ending": {
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                {
+                  "type": "string",
+                  "pattern": "^(current_year(\\s*-\\s*\\d+)?)$|^(first(\\s*\\+\\s*\\d+)?)$|^(latest(\\s*-\\s*\\d+)?)$"
+                }
+              ]
+            },
+            "increment": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "depth": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "limit": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        },
+        "style": {
+          "description": "Image style used by defaults that support multiple poster styles.",
+          "type": "string",
+          "enum": [
+            "color",
+            "white",
+            "bw",
+            "diiivoy",
+            "diiivoycolor",
+            "rainier",
+            "signature",
+            "orig",
+            "transparent",
+            "default",
+            "standards"
+          ]
+        },
+        "collection_mode": {
+          "description": "Controls the collection mode of all collections in this defaults file.",
+          "type": "string",
+          "enum": [
+            "default",
+            "hide",
+            "hide_items",
+            "show_items"
+          ]
+        },
+        "collection_section": {
+          "description": "Changes the sort order of this defaults file's section against other default sections. Use quotes to preserve leading zeros.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "delete_collections_named": {
+          "description": "Delete any Plex collections with these names before running.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "file_background": {
+          "description": "Sets the background filepath for all collections in this defaults file.",
+          "type": "string"
+        },
+        "file_poster": {
+          "description": "Sets the poster filepath for all collections in this defaults file.",
+          "type": "string"
+        },
+        "ignore_ids": {
+          "description": "TMDb/TVDb IDs to ignore across all collections in this defaults file.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "ignore_imdb_ids": {
+          "description": "IMDb IDs to ignore across all collections in this defaults file.",
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(tt\\d{7,8})(,\\s*tt\\d{7,8})*$"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^tt\\d{7,8}$"
+              }
+            }
+          ]
+        },
+        "item_radarr_tag": {
+          "description": "Append a Radarr tag to every movie found by all collections in this defaults file.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "item_sonarr_tag": {
+          "description": "Append a Sonarr tag to every series found by all collections in this defaults file.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "language": {
+          "description": "Language for collection names and summaries.",
+          "type": "string",
+          "enum": [
+            "default",
+            "en",
+            "fr",
+            "ar",
+            "da",
+            "nl",
+            "de",
+            "it",
+            "pt-br",
+            "nb-no",
+            "es",
+            "sv",
+            "ru",
+            "bg",
+            "hu"
+          ]
+        },
+        "minimum_items": {
+          "description": "Minimum number of items required for any collection in this defaults file to be created.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "hub_priority": {
+          "description": "Priority position for all collections in this defaults file's Recommendation Hub rows. Lower numbers appear first.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "name_mapping": {
+          "description": "Changes the name_mapping for all collections. Use <<key_name>> as a placeholder.",
+          "type": "string"
+        },
+        "radarr_add_missing": {
+          "description": "Override Radarr add_missing for all collections in this defaults file.",
+          "type": "boolean"
+        },
+        "radarr_folder": {
+          "description": "Override Radarr root_folder_path for all collections in this defaults file.",
+          "type": "string"
+        },
+        "radarr_monitor_existing": {
+          "description": "Override Radarr monitor_existing for all collections in this defaults file.",
+          "type": "boolean"
+        },
+        "radarr_search": {
+          "description": "Override Radarr search for all collections in this defaults file.",
+          "type": "boolean"
+        },
+        "radarr_tag": {
+          "description": "Override Radarr tag for all collections in this defaults file.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "radarr_upgrade_existing": {
+          "description": "Override Radarr upgrade_existing for all collections in this defaults file.",
+          "type": "boolean"
+        },
+        "schedule": {
+          "description": "Set the schedule for all collections in this defaults file.",
+          "type": "string"
+        },
+        "sonarr_add_missing": {
+          "description": "Override Sonarr add_missing for all collections in this defaults file.",
+          "type": "boolean"
+        },
+        "sonarr_folder": {
+          "description": "Override Sonarr root_folder_path for all collections in this defaults file.",
+          "type": "string"
+        },
+        "sonarr_monitor_existing": {
+          "description": "Override Sonarr monitor_existing for all collections in this defaults file.",
+          "type": "boolean"
+        },
+        "sonarr_search": {
+          "description": "Override Sonarr search for all collections in this defaults file.",
+          "type": "boolean"
+        },
+        "sonarr_tag": {
+          "description": "Override Sonarr tag for all collections in this defaults file.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "sonarr_upgrade_existing": {
+          "description": "Override Sonarr upgrade_existing for all collections in this defaults file.",
+          "type": "boolean"
+        },
+        "sort_prefix": {
+          "description": "Changes the prefix of the sort title. Default: '!'",
+          "type": "string"
+        },
+        "sort_title": {
+          "description": "Changes the sort title for all collections.",
+          "type": "string"
+        },
+        "url_background": {
+          "description": "Sets the background URL for all collections in this defaults file.",
+          "type": "string",
+          "format": "uri"
+        },
+        "url_poster": {
+          "description": "Changes the poster URL for all collections in this defaults file.",
+          "type": "string",
+          "format": "uri"
+        },
+        "use_all": {
+          "description": "Set to false to disable all collections in this defaults file.",
+          "type": "boolean"
+        },
+        "visible_home": {
+          "description": "Controls Home Tab visibility for all collections. true/false or a schedule string.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "visible_library": {
+          "description": "Controls Library Recommended Tab visibility for all collections. true/false or a schedule string.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "visible_shared": {
+          "description": "Controls Shared Users' Home Tab visibility for all collections. true/false or a schedule string.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "limit": {
+          "description": "Limit the number of items for all collections in this defaults file.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "collection_order": {
+          "description": "Changes the Collection Order for all collections in a Defaults File.",
+          "type": "string"
+        },
+        "sync_mode": {
+          "description": "Changes the Sync Mode for all collections in a Defaults File.",
+          "type": "string",
+          "enum": [
+            "sync",
+            "append"
+          ]
+        },
+        "placeholder_imdb_id": {
+          "description": "Add a placeholder Movie/Show to the Separator.",
+          "type": "string"
+        },
+        "sep_style": {
+          "description": "Choose the Separator Style.",
+          "type": "string",
+          "enum": [
+            "amethyst",
+            "aqua",
+            "blue",
+            "forest",
+            "fuchsia",
+            "gold",
+            "gray",
+            "green",
+            "navy",
+            "ocean",
+            "olive",
+            "orchid",
+            "orig",
+            "pink",
+            "plum",
+            "purple",
+            "red",
+            "rust",
+            "salmon",
+            "sand",
+            "stb",
+            "tan"
+          ]
+        },
+        "use_separator": {
+          "description": "Turn the Separator Collection off.",
+          "type": "boolean"
+        },
+        "name_separator": {
+          "description": "Changes the name of the Separator collection.",
+          "type": "string"
+        },
+        "summary_separator": {
+          "description": "Changes the summary of the Separator collection.",
+          "type": "string"
+        },
+        "url_poster_separator": {
+          "description": "Changes the poster URL of the Separator collection.",
+          "type": "string",
+          "format": "uri"
+        },
+        "sort_by": {
+          "description": "Changes the Smart Filter Sort for all collections in a Defaults File.",
+          "type": "string"
+        },
+        "placeholder_tmdb_movie": {
+          "description": "Add a placeholder Movie to the Separator. Movie libraries only.",
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "placeholder_tvdb_show": {
+          "description": "Add a placeholder Show to the Separator. Show libraries only.",
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "name_format": {
+          "description": "Changes the title format of the Dynamic Collections.",
+          "type": "string"
+        },
+        "summary_format": {
+          "description": "Changes the summary format of the Dynamic Collections.",
+          "type": "string"
+        },
+        "exclude": {
+          "description": "Exclude specific keys from creating a Dynamic Collection.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "integer"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "addons": {
+          "description": "Overrides the default addons dictionary.",
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          }
+        },
+        "append_addons": {
+          "description": "Appends to the default addons dictionary.",
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          }
+        },
+        "remove_addons": {
+          "description": "Removes from the default addons dictionary.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "allowed_libraries": {
+          "description": "Limits which library types this default applies to.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "winning": {
+          "description": "Filter to only show winning entries.",
+          "type": "boolean"
+        },
+        "use_year_collections": {
+          "description": "Turn the individual year collections off.",
+          "type": "boolean"
+        },
+        "year_collection_section": {
+          "description": "Change the collection section for year collections only.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "originals_only": {
+          "description": "Changes Streaming Service lists to only show original content.",
+          "type": "boolean"
+        },
+        "region": {
+          "description": "Changes some Streaming Service lists to regional variants.",
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^use_(?!all$).+$": {
+          "description": "Disable a specific collection by key. Set to false to turn off.",
+          "type": "boolean"
+        },
+        "^name_.+$": {
+          "description": "Override the name of a specific collection by key.",
+          "type": "string"
+        },
+        "^summary_.+$": {
+          "description": "Override the summary of a specific collection by key.",
+          "type": "string"
+        },
+        "^order_.+$": {
+          "description": "Override the sort order of a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^schedule_.+$": {
+          "description": "Set the schedule for a specific collection by key.",
+          "type": "string"
+        },
+        "^minimum_items_.+$": {
+          "description": "Override minimum_items for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^hub_priority_.+$": {
+          "description": "Override hub_priority for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^url_poster_.+$": {
+          "description": "Override the poster URL for a specific collection by key.",
+          "type": "string",
+          "format": "uri"
+        },
+        "^file_poster_.+$": {
+          "description": "Override the poster filepath for a specific collection by key.",
+          "type": "string"
+        },
+        "^url_background_.+$": {
+          "description": "Override the background URL for a specific collection by key.",
+          "type": "string",
+          "format": "uri"
+        },
+        "^file_background_.+$": {
+          "description": "Override the background filepath for a specific collection by key.",
+          "type": "string"
+        },
+        "^visible_home_.+$": {
+          "description": "Override Home Tab visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^visible_library_.+$": {
+          "description": "Override Library Tab visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^visible_shared_.+$": {
+          "description": "Override Shared Home visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^radarr_add_missing_.+$": {
+          "description": "Override Radarr add_missing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_folder_.+$": {
+          "description": "Override Radarr root_folder_path for a specific collection by key.",
+          "type": "string"
+        },
+        "^radarr_monitor_existing_.+$": {
+          "description": "Override Radarr monitor_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_search_.+$": {
+          "description": "Override Radarr search for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_tag_.+$": {
+          "description": "Override Radarr tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^radarr_upgrade_existing_.+$": {
+          "description": "Override Radarr upgrade_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_add_missing_.+$": {
+          "description": "Override Sonarr add_missing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_folder_.+$": {
+          "description": "Override Sonarr root_folder_path for a specific collection by key.",
+          "type": "string"
+        },
+        "^sonarr_monitor_existing_.+$": {
+          "description": "Override Sonarr monitor_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_search_.+$": {
+          "description": "Override Sonarr search for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_tag_.+$": {
+          "description": "Override Sonarr tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^sonarr_upgrade_existing_.+$": {
+          "description": "Override Sonarr upgrade_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^item_radarr_tag_.+$": {
+          "description": "Override item_radarr_tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^item_sonarr_tag_.+$": {
+          "description": "Override item_sonarr_tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^limit_.+$": {
+          "description": "Override limit for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^mdblist_list_.+$": {
+          "description": "Override the mdblist_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^trakt_list_.+$": {
+          "description": "Override the trakt_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^imdb_list_.+$": {
+          "description": "Override the imdb_list for a specific collection by key.",
+          "type": "string"
+        },
+        "^letterboxd_list_.+$": {
+          "description": "Override the letterboxd_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^collection_order_.+$": {
+          "description": "Override the Collection Order for a specific collection by key.",
+          "type": "string"
+        },
+        "^sync_mode_.+$": {
+          "description": "Override the Sync Mode for a specific collection by key.",
+          "type": "string",
+          "enum": [
+            "sync",
+            "append"
+          ]
+        },
+        "^in_the_last_.+$": {
+          "description": "Override how far back the filter looks for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^sort_by_.+$": {
+          "description": "Override the Smart Filter Sort for a specific collection by key.",
+          "type": "string"
+        },
+        "^discover_with_.+$": {
+          "description": "Overrides the TMDb Watch Provider used for the specified key.",
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "required": [],
+      "dependentRequired": {}
+    },
+    "award-template-vars": {
+      "description": "Award defaults: bafta, berlinale, cannes, cesar, choice, emmy, golden, nfr, oscars, pca, razzie, sag, spirit, sundance, tiff, venice",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "collection_section": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "name_mapping": {
+          "type": "string"
+        },
+        "sort_prefix": {
+          "type": "string"
+        },
+        "sort_title": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "visible_home": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "visible_library": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "visible_shared": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "url_poster": {
+          "type": "string",
+          "format": "uri"
+        },
+        "file_poster": {
+          "type": "string"
+        },
+        "url_background": {
+          "type": "string",
+          "format": "uri"
+        },
+        "file_background": {
+          "type": "string"
+        },
+        "minimum_items": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "hub_priority": {
+          "description": "Priority position for all collections in this defaults file's Recommendation Hub rows. Lower numbers appear first.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "delete_below_minimum": {
+          "type": "boolean"
+        },
+        "delete_not_scheduled": {
+          "type": "boolean"
+        },
+        "auto_sort_hubs": {
+          "type": "string",
+          "enum": ["sort_title", "sort_title.desc", "alpha", "alpha.desc", "configured", "configured.desc", "random"]
+        },
+        "ignore_ids": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "ignore_imdb_ids": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(tt\\d{7,8})(,\\s*tt\\d{7,8})*$"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^tt\\d{7,8}$"
+              }
+            }
+          ]
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "radarr_add_missing": {
+          "type": "boolean"
+        },
+        "radarr_folder": {
+          "type": "string"
+        },
+        "radarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "radarr_monitor_existing": {
+          "type": "boolean"
+        },
+        "radarr_search": {
+          "type": "boolean"
+        },
+        "radarr_upgrade_existing": {
+          "type": "boolean"
+        },
+        "sonarr_add_missing": {
+          "type": "boolean"
+        },
+        "sonarr_folder": {
+          "type": "string"
+        },
+        "sonarr_monitor_existing": {
+          "type": "boolean"
+        },
+        "sonarr_search": {
+          "type": "boolean"
+        },
+        "sonarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "sonarr_upgrade_existing": {
+          "type": "boolean"
+        },
+        "item_radarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "item_sonarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "delete_collections_named": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "style": {
+          "type": "string",
+          "enum": [
+            "color",
+            "white",
+            "bw",
+            "diiivoy",
+            "diiivoycolor",
+            "rainier",
+            "signature",
+            "orig",
+            "transparent",
+            "default",
+            "standards"
+          ]
+        },
+        "language": {
+          "type": "string",
+          "enum": [
+            "default",
+            "en",
+            "fr",
+            "ar",
+            "da",
+            "nl",
+            "de",
+            "it",
+            "pt-br",
+            "nb-no",
+            "es",
+            "sv",
+            "ru",
+            "bg",
+            "hu"
+          ]
+        },
+        "data": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "starting": {
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                {
+                  "type": "string",
+                  "pattern": "^(current_year(\\s*-\\s*\\d+)?)$|^(first(\\s*\\+\\s*\\d+)?)$|^(latest(\\s*-\\s*\\d+)?)$"
+                }
+              ]
+            },
+            "ending": {
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                {
+                  "type": "string",
+                  "pattern": "^(current_year(\\s*-\\s*\\d+)?)$|^(first(\\s*\\+\\s*\\d+)?)$|^(latest(\\s*-\\s*\\d+)?)$"
+                }
+              ]
+            },
+            "increment": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "depth": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "limit": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "event_id": {
+              "type": "string"
+            },
+            "event_year": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "category_filter": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+            "award_filter": {
+              "type": "string"
+            }
+          }
+        },
+        "winning": {
+          "type": "boolean"
+        },
+        "collection_order": {
+          "type": "string"
+        },
+        "allowed_libraries": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "image": {
+          "type": "string"
+        },
+        "translation_key": {
+          "type": "string"
+        },
+        "dynamic": {
+          "type": "boolean"
+        },
+        "collection_mode": {
+          "description": "Controls the collection mode of all collections in a Defaults File.",
+          "type": "string",
+          "enum": [
+            "default",
+            "hide",
+            "hide_items",
+            "show_items"
+          ]
+        },
+        "use_all": {
+          "description": "Turns off all Collections in a Defaults File.",
+          "type": "boolean"
+        },
+        "placeholder_imdb_id": {
+          "description": "Add a placeholder Movie/Show to the Separator.",
+          "type": "string"
+        },
+        "placeholder_tmdb_movie": {
+          "description": "Add a placeholder Movie to the Separator. Movie libraries only.",
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "placeholder_tvdb_show": {
+          "description": "Add a placeholder Show to the Separator. Show libraries only.",
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "sep_style": {
+          "description": "Choose the Separator Style.",
+          "type": "string",
+          "enum": [
+            "amethyst",
+            "aqua",
+            "blue",
+            "forest",
+            "fuchsia",
+            "gold",
+            "gray",
+            "green",
+            "navy",
+            "ocean",
+            "olive",
+            "orchid",
+            "orig",
+            "pink",
+            "plum",
+            "purple",
+            "red",
+            "rust",
+            "salmon",
+            "sand",
+            "stb",
+            "tan"
+          ]
+        },
+        "use_separator": {
+          "description": "Turn the Separator Collection off.",
+          "type": "boolean"
+        },
+        "name_separator": {
+          "description": "Changes the name of the Separator collection.",
+          "type": "string"
+        },
+        "summary_separator": {
+          "description": "Changes the summary of the Separator collection.",
+          "type": "string"
+        },
+        "url_poster_separator": {
+          "description": "Changes the poster URL of the Separator collection.",
+          "type": "string",
+          "format": "uri"
+        },
+        "name_format": {
+          "description": "Changes the title format of the Dynamic Collections.",
+          "type": "string"
+        },
+        "summary_format": {
+          "description": "Changes the summary format of the Dynamic Collections.",
+          "type": "string"
+        },
+        "exclude": {
+          "description": "Exclude specific keys from creating a Dynamic Collection.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "integer"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "sync_mode": {
+          "description": "Changes the Sync Mode for all collections in a Defaults File.",
+          "type": "string",
+          "enum": [
+            "sync",
+            "append"
+          ]
+        },
+        "use_year_collections": {
+          "description": "Turn the individual year collections off.",
+          "type": "boolean"
+        },
+        "year_collection_section": {
+          "description": "Change the collection section for year collections only.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "required": [],
+      "dependentRequired": {
+        "data": [
+          "starting",
+          "ending"
+        ]
+      },
+      "patternProperties": {
+        "^use_(?!all$).+$": {
+          "description": "Disable a specific collection by key. Set to false to turn off.",
+          "type": "boolean"
+        },
+        "^name_.+$": {
+          "description": "Override the name of a specific collection by key.",
+          "type": "string"
+        },
+        "^summary_.+$": {
+          "description": "Override the summary of a specific collection by key.",
+          "type": "string"
+        },
+        "^order_.+$": {
+          "description": "Override the sort order of a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^schedule_.+$": {
+          "description": "Set the schedule for a specific collection by key.",
+          "type": "string"
+        },
+        "^minimum_items_.+$": {
+          "description": "Override minimum_items for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^hub_priority_.+$": {
+          "description": "Override hub_priority for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^url_poster_.+$": {
+          "description": "Override the poster URL for a specific collection by key.",
+          "type": "string",
+          "format": "uri"
+        },
+        "^file_poster_.+$": {
+          "description": "Override the poster filepath for a specific collection by key.",
+          "type": "string"
+        },
+        "^url_background_.+$": {
+          "description": "Override the background URL for a specific collection by key.",
+          "type": "string",
+          "format": "uri"
+        },
+        "^file_background_.+$": {
+          "description": "Override the background filepath for a specific collection by key.",
+          "type": "string"
+        },
+        "^visible_home_.+$": {
+          "description": "Override Home Tab visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^visible_library_.+$": {
+          "description": "Override Library Tab visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^visible_shared_.+$": {
+          "description": "Override Shared Home visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^radarr_add_missing_.+$": {
+          "description": "Override Radarr add_missing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_folder_.+$": {
+          "description": "Override Radarr root_folder_path for a specific collection by key.",
+          "type": "string"
+        },
+        "^radarr_monitor_existing_.+$": {
+          "description": "Override Radarr monitor_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_search_.+$": {
+          "description": "Override Radarr search for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_tag_.+$": {
+          "description": "Override Radarr tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^radarr_upgrade_existing_.+$": {
+          "description": "Override Radarr upgrade_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_add_missing_.+$": {
+          "description": "Override Sonarr add_missing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_folder_.+$": {
+          "description": "Override Sonarr root_folder_path for a specific collection by key.",
+          "type": "string"
+        },
+        "^sonarr_monitor_existing_.+$": {
+          "description": "Override Sonarr monitor_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_search_.+$": {
+          "description": "Override Sonarr search for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_tag_.+$": {
+          "description": "Override Sonarr tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^sonarr_upgrade_existing_.+$": {
+          "description": "Override Sonarr upgrade_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^item_radarr_tag_.+$": {
+          "description": "Override item_radarr_tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^item_sonarr_tag_.+$": {
+          "description": "Override item_sonarr_tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^limit_.+$": {
+          "description": "Override limit for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^mdblist_list_.+$": {
+          "description": "Override the mdblist_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^trakt_list_.+$": {
+          "description": "Override the trakt_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^imdb_list_.+$": {
+          "description": "Override the imdb_list for a specific collection by key.",
+          "type": "string"
+        },
+        "^letterboxd_list_.+$": {
+          "description": "Override the letterboxd_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^collection_order_.+$": {
+          "description": "Override the Collection Order for a specific collection by key.",
+          "type": "string"
+        },
+        "^sync_mode_.+$": {
+          "description": "Override the Sync Mode for a specific collection by key.",
+          "type": "string",
+          "enum": [
+            "sync",
+            "append"
+          ]
+        },
+        "^in_the_last_.+$": {
+          "description": "Override how far back the filter looks for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^sort_by_.+$": {
+          "description": "Override the Smart Filter Sort for a specific collection by key.",
+          "type": "string"
+        }
+      }
+    },
+    "person-template-vars": {
+      "description": "Person-based defaults: actor, director, producer, writer",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "collection_section": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "name_mapping": {
+          "type": "string"
+        },
+        "sort_prefix": {
+          "type": "string"
+        },
+        "sort_title": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "visible_home": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "visible_library": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "visible_shared": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "url_poster": {
+          "type": "string",
+          "format": "uri"
+        },
+        "file_poster": {
+          "type": "string"
+        },
+        "url_background": {
+          "type": "string",
+          "format": "uri"
+        },
+        "file_background": {
+          "type": "string"
+        },
+        "minimum_items": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "hub_priority": {
+          "description": "Priority position for all collections in this defaults file's Recommendation Hub rows. Lower numbers appear first.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "delete_below_minimum": {
+          "type": "boolean"
+        },
+        "delete_not_scheduled": {
+          "type": "boolean"
+        },
+        "auto_sort_hubs": {
+          "type": "string",
+          "enum": ["sort_title", "sort_title.desc", "alpha", "alpha.desc", "configured", "configured.desc", "random"]
+        },
+        "ignore_ids": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "ignore_imdb_ids": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(tt\\d{7,8})(,\\s*tt\\d{7,8})*$"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^tt\\d{7,8}$"
+              }
+            }
+          ]
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "radarr_add_missing": {
+          "type": "boolean"
+        },
+        "radarr_folder": {
+          "type": "string"
+        },
+        "radarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "radarr_monitor_existing": {
+          "type": "boolean"
+        },
+        "radarr_search": {
+          "type": "boolean"
+        },
+        "radarr_upgrade_existing": {
+          "type": "boolean"
+        },
+        "sonarr_add_missing": {
+          "type": "boolean"
+        },
+        "sonarr_folder": {
+          "type": "string"
+        },
+        "sonarr_monitor_existing": {
+          "type": "boolean"
+        },
+        "sonarr_search": {
+          "type": "boolean"
+        },
+        "sonarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "sonarr_upgrade_existing": {
+          "type": "boolean"
+        },
+        "item_radarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "item_sonarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "delete_collections_named": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "style": {
+          "type": "string",
+          "enum": [
+            "color",
+            "white",
+            "bw",
+            "diiivoy",
+            "diiivoycolor",
+            "rainier",
+            "signature",
+            "orig",
+            "transparent",
+            "default",
+            "standards"
+          ]
+        },
+        "language": {
+          "type": "string",
+          "enum": [
+            "default",
+            "en",
+            "fr",
+            "ar",
+            "da",
+            "nl",
+            "de",
+            "it",
+            "pt-br",
+            "nb-no",
+            "es",
+            "sv",
+            "ru",
+            "bg",
+            "hu"
+          ]
+        },
+        "search_term": {
+          "type": "string"
+        },
+        "search_value": {
+          "type": "string"
+        },
+        "tmdb_person": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "tmdb_person_offset": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "image": {
+          "type": "string"
+        },
+        "translation_key": {
+          "type": "string"
+        },
+        "dynamic": {
+          "type": "boolean"
+        },
+        "collection_mode": {
+          "type": "string",
+          "enum": [
+            "default",
+            "hide",
+            "hide_items",
+            "show_items"
+          ]
+        },
+        "use_all": {
+          "type": "boolean"
+        },
+        "placeholder_imdb_id": {
+          "type": "string"
+        },
+        "placeholder_tmdb_movie": {
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "placeholder_tvdb_show": {
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "sep_style": {
+          "type": "string"
+        },
+        "use_separator": {
+          "type": "boolean"
+        },
+        "name_separator": {
+          "type": "string"
+        },
+        "summary_separator": {
+          "type": "string"
+        },
+        "url_poster_separator": {
+          "type": "string"
+        },
+        "name_format": {
+          "type": "string"
+        },
+        "summary_format": {
+          "type": "string"
+        },
+        "exclude": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "collection_order": {
+          "type": "string"
+        },
+        "sync_mode": {
+          "type": "string"
+        },
+        "sort_by": {
+          "type": "string"
+        },
+        "data": {
+          "type": "object"
+        },
+        "include": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "tmdb_birthday": {
+          "type": "object",
+          "properties": {
+            "this_month": {
+              "type": "boolean"
+            },
+            "before": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "after": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "additionalProperties": false
+        },
+        "tmdb_deathday": {
+          "type": "object",
+          "properties": {
+            "this_month": {
+              "type": "boolean"
+            },
+            "before": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "after": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [],
+      "dependentRequired": {},
+      "patternProperties": {
+        "^use_(?!all$).+$": {
+          "description": "Disable a specific collection by key. Set to false to turn off.",
+          "type": "boolean"
+        },
+        "^name_.+$": {
+          "description": "Override the name of a specific collection by key.",
+          "type": "string"
+        },
+        "^summary_.+$": {
+          "description": "Override the summary of a specific collection by key.",
+          "type": "string"
+        },
+        "^order_.+$": {
+          "description": "Override the sort order of a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^schedule_.+$": {
+          "description": "Set the schedule for a specific collection by key.",
+          "type": "string"
+        },
+        "^minimum_items_.+$": {
+          "description": "Override minimum_items for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^hub_priority_.+$": {
+          "description": "Override hub_priority for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^url_poster_.+$": {
+          "description": "Override the poster URL for a specific collection by key.",
+          "type": "string",
+          "format": "uri"
+        },
+        "^file_poster_.+$": {
+          "description": "Override the poster filepath for a specific collection by key.",
+          "type": "string"
+        },
+        "^url_background_.+$": {
+          "description": "Override the background URL for a specific collection by key.",
+          "type": "string",
+          "format": "uri"
+        },
+        "^file_background_.+$": {
+          "description": "Override the background filepath for a specific collection by key.",
+          "type": "string"
+        },
+        "^visible_home_.+$": {
+          "description": "Override Home Tab visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^visible_library_.+$": {
+          "description": "Override Library Tab visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^visible_shared_.+$": {
+          "description": "Override Shared Home visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^radarr_add_missing_.+$": {
+          "description": "Override Radarr add_missing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_folder_.+$": {
+          "description": "Override Radarr root_folder_path for a specific collection by key.",
+          "type": "string"
+        },
+        "^radarr_monitor_existing_.+$": {
+          "description": "Override Radarr monitor_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_search_.+$": {
+          "description": "Override Radarr search for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_tag_.+$": {
+          "description": "Override Radarr tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^radarr_upgrade_existing_.+$": {
+          "description": "Override Radarr upgrade_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_add_missing_.+$": {
+          "description": "Override Sonarr add_missing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_folder_.+$": {
+          "description": "Override Sonarr root_folder_path for a specific collection by key.",
+          "type": "string"
+        },
+        "^sonarr_monitor_existing_.+$": {
+          "description": "Override Sonarr monitor_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_search_.+$": {
+          "description": "Override Sonarr search for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_tag_.+$": {
+          "description": "Override Sonarr tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^sonarr_upgrade_existing_.+$": {
+          "description": "Override Sonarr upgrade_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^item_radarr_tag_.+$": {
+          "description": "Override item_radarr_tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^item_sonarr_tag_.+$": {
+          "description": "Override item_sonarr_tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^limit_.+$": {
+          "description": "Override limit for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^mdblist_list_.+$": {
+          "description": "Override the mdblist_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^trakt_list_.+$": {
+          "description": "Override the trakt_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^imdb_list_.+$": {
+          "description": "Override the imdb_list for a specific collection by key.",
+          "type": "string"
+        },
+        "^letterboxd_list_.+$": {
+          "description": "Override the letterboxd_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^collection_order_.+$": {
+          "description": "Override the Collection Order for a specific collection by key.",
+          "type": "string"
+        },
+        "^sync_mode_.+$": {
+          "description": "Override the Sync Mode for a specific collection by key.",
+          "type": "string",
+          "enum": [
+            "sync",
+            "append"
+          ]
+        },
+        "^in_the_last_.+$": {
+          "description": "Override how far back the filter looks for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^sort_by_.+$": {
+          "description": "Override the Smart Filter Sort for a specific collection by key.",
+          "type": "string"
+        },
+        "^list_days_.+$": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "^list_size_.+$": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "^tmdb_person_offset_.+$": {}
+      }
+    },
+    "chart-template-vars": {
+      "description": "Chart defaults: anilist, basic, imdb, letterboxd, myanimelist, other_chart, simkl, tautulli, tmdb, trakt",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "collection_section": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "name_mapping": {
+          "type": "string"
+        },
+        "sort_prefix": {
+          "type": "string"
+        },
+        "sort_title": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "visible_home": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "visible_library": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "visible_shared": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "url_poster": {
+          "type": "string",
+          "format": "uri"
+        },
+        "file_poster": {
+          "type": "string"
+        },
+        "url_background": {
+          "type": "string",
+          "format": "uri"
+        },
+        "file_background": {
+          "type": "string"
+        },
+        "minimum_items": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "hub_priority": {
+          "description": "Priority position for all collections in this defaults file's Recommendation Hub rows. Lower numbers appear first.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "delete_below_minimum": {
+          "type": "boolean"
+        },
+        "delete_not_scheduled": {
+          "type": "boolean"
+        },
+        "auto_sort_hubs": {
+          "type": "string",
+          "enum": ["sort_title", "sort_title.desc", "alpha", "alpha.desc", "configured", "configured.desc", "random"]
+        },
+        "ignore_ids": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "ignore_imdb_ids": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(tt\\d{7,8})(,\\s*tt\\d{7,8})*$"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^tt\\d{7,8}$"
+              }
+            }
+          ]
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "radarr_add_missing": {
+          "type": "boolean"
+        },
+        "radarr_folder": {
+          "type": "string"
+        },
+        "radarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "radarr_monitor_existing": {
+          "type": "boolean"
+        },
+        "radarr_search": {
+          "type": "boolean"
+        },
+        "radarr_upgrade_existing": {
+          "type": "boolean"
+        },
+        "sonarr_add_missing": {
+          "type": "boolean"
+        },
+        "sonarr_folder": {
+          "type": "string"
+        },
+        "sonarr_monitor_existing": {
+          "type": "boolean"
+        },
+        "sonarr_search": {
+          "type": "boolean"
+        },
+        "sonarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "sonarr_upgrade_existing": {
+          "type": "boolean"
+        },
+        "item_radarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "item_sonarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "delete_collections_named": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "style": {
+          "type": "string",
+          "enum": [
+            "color",
+            "white",
+            "bw",
+            "diiivoy",
+            "diiivoycolor",
+            "rainier",
+            "signature",
+            "orig",
+            "transparent",
+            "default",
+            "standards"
+          ]
+        },
+        "language": {
+          "type": "string",
+          "enum": [
+            "default",
+            "en",
+            "fr",
+            "ar",
+            "da",
+            "nl",
+            "de",
+            "it",
+            "pt-br",
+            "nb-no",
+            "es",
+            "sv",
+            "ru",
+            "bg",
+            "hu"
+          ]
+        },
+        "image": {
+          "type": "string"
+        },
+        "translation_key": {
+          "type": "string"
+        },
+        "collection_order": {
+          "description": "Changes the Collection Order for all collections in a Defaults File.",
+          "type": "string"
+        },
+        "sync_mode": {
+          "description": "Changes the Sync Mode for all collections in a Defaults File.",
+          "type": "string",
+          "enum": [
+            "sync",
+            "append"
+          ]
+        },
+        "collection_mode": {
+          "description": "Controls the collection mode of all collections in a Defaults File.",
+          "type": "string",
+          "enum": [
+            "default",
+            "hide",
+            "hide_items",
+            "show_items"
+          ]
+        },
+        "placeholder_imdb_id": {
+          "description": "Add a placeholder Movie/Show to the Separator.",
+          "type": "string"
+        },
+        "sep_style": {
+          "description": "Choose the Separator Style.",
+          "type": "string",
+          "enum": [
+            "amethyst",
+            "aqua",
+            "blue",
+            "forest",
+            "fuchsia",
+            "gold",
+            "gray",
+            "green",
+            "navy",
+            "ocean",
+            "olive",
+            "orchid",
+            "orig",
+            "pink",
+            "plum",
+            "purple",
+            "red",
+            "rust",
+            "salmon",
+            "sand",
+            "stb",
+            "tan"
+          ]
+        },
+        "use_separator": {
+          "description": "Turn the Separator Collection off.",
+          "type": "boolean"
+        },
+        "name_separator": {
+          "description": "Changes the name of the Separator collection.",
+          "type": "string"
+        },
+        "summary_separator": {
+          "description": "Changes the summary of the Separator collection.",
+          "type": "string"
+        },
+        "url_poster_separator": {
+          "description": "Changes the poster URL of the Separator collection.",
+          "type": "string",
+          "format": "uri"
+        },
+        "use_all": {
+          "description": "Turns off all Collections in a Defaults File.",
+          "type": "boolean"
+        },
+        "sort_by": {
+          "description": "Changes the Smart Filter Sort for all collections in a Defaults File.",
+          "type": "string"
+        },
+        "placeholder_tmdb_movie": {
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "placeholder_tvdb_show": {
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "list_days": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "list_size": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "use_watched": {
+          "type": "boolean"
+        }
+      },
+      "required": [],
+      "dependentRequired": {},
+      "patternProperties": {
+        "^use_(?!all$).+$": {
+          "description": "Disable a specific collection by key. Set to false to turn off.",
+          "type": "boolean"
+        },
+        "^name_.+$": {
+          "description": "Override the name of a specific collection by key.",
+          "type": "string"
+        },
+        "^summary_.+$": {
+          "description": "Override the summary of a specific collection by key.",
+          "type": "string"
+        },
+        "^order_.+$": {
+          "description": "Override the sort order of a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^schedule_.+$": {
+          "description": "Set the schedule for a specific collection by key.",
+          "type": "string"
+        },
+        "^minimum_items_.+$": {
+          "description": "Override minimum_items for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^hub_priority_.+$": {
+          "description": "Override hub_priority for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^url_poster_.+$": {
+          "description": "Override the poster URL for a specific collection by key.",
+          "type": "string",
+          "format": "uri"
+        },
+        "^file_poster_.+$": {
+          "description": "Override the poster filepath for a specific collection by key.",
+          "type": "string"
+        },
+        "^url_background_.+$": {
+          "description": "Override the background URL for a specific collection by key.",
+          "type": "string",
+          "format": "uri"
+        },
+        "^file_background_.+$": {
+          "description": "Override the background filepath for a specific collection by key.",
+          "type": "string"
+        },
+        "^visible_home_.+$": {
+          "description": "Override Home Tab visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^visible_library_.+$": {
+          "description": "Override Library Tab visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^visible_shared_.+$": {
+          "description": "Override Shared Home visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^radarr_add_missing_.+$": {
+          "description": "Override Radarr add_missing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_folder_.+$": {
+          "description": "Override Radarr root_folder_path for a specific collection by key.",
+          "type": "string"
+        },
+        "^radarr_monitor_existing_.+$": {
+          "description": "Override Radarr monitor_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_search_.+$": {
+          "description": "Override Radarr search for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_tag_.+$": {
+          "description": "Override Radarr tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^radarr_upgrade_existing_.+$": {
+          "description": "Override Radarr upgrade_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_add_missing_.+$": {
+          "description": "Override Sonarr add_missing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_folder_.+$": {
+          "description": "Override Sonarr root_folder_path for a specific collection by key.",
+          "type": "string"
+        },
+        "^sonarr_monitor_existing_.+$": {
+          "description": "Override Sonarr monitor_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_search_.+$": {
+          "description": "Override Sonarr search for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_tag_.+$": {
+          "description": "Override Sonarr tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^sonarr_upgrade_existing_.+$": {
+          "description": "Override Sonarr upgrade_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^item_radarr_tag_.+$": {
+          "description": "Override item_radarr_tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^item_sonarr_tag_.+$": {
+          "description": "Override item_sonarr_tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^limit_.+$": {
+          "description": "Override limit for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^mdblist_list_.+$": {
+          "description": "Override the mdblist_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^trakt_list_.+$": {
+          "description": "Override the trakt_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^imdb_list_.+$": {
+          "description": "Override the imdb_list for a specific collection by key.",
+          "type": "string"
+        },
+        "^letterboxd_list_.+$": {
+          "description": "Override the letterboxd_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^collection_order_.+$": {
+          "description": "Override the Collection Order for a specific collection by key.",
+          "type": "string"
+        },
+        "^sync_mode_.+$": {
+          "description": "Override the Sync Mode for a specific collection by key.",
+          "type": "string",
+          "enum": [
+            "sync",
+            "append"
+          ]
+        },
+        "^in_the_last_.+$": {
+          "description": "Override how far back the filter looks for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^sort_by_.+$": {
+          "description": "Override the Smart Filter Sort for a specific collection by key.",
+          "type": "string"
+        },
+        "^list_days_.+$": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "^list_size_.+$": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "content-rating-template-vars": {
+      "description": "Content rating defaults",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "collection_section": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "name_mapping": {
+          "type": "string"
+        },
+        "sort_prefix": {
+          "type": "string"
+        },
+        "sort_title": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "visible_home": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "visible_library": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "visible_shared": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "url_poster": {
+          "type": "string",
+          "format": "uri"
+        },
+        "file_poster": {
+          "type": "string"
+        },
+        "url_background": {
+          "type": "string",
+          "format": "uri"
+        },
+        "file_background": {
+          "type": "string"
+        },
+        "minimum_items": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "hub_priority": {
+          "description": "Priority position for all collections in this defaults file's Recommendation Hub rows. Lower numbers appear first.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "delete_below_minimum": {
+          "type": "boolean"
+        },
+        "delete_not_scheduled": {
+          "type": "boolean"
+        },
+        "auto_sort_hubs": {
+          "type": "string",
+          "enum": ["sort_title", "sort_title.desc", "alpha", "alpha.desc", "configured", "configured.desc", "random"]
+        },
+        "ignore_ids": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "ignore_imdb_ids": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(tt\\d{7,8})(,\\s*tt\\d{7,8})*$"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^tt\\d{7,8}$"
+              }
+            }
+          ]
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "radarr_add_missing": {
+          "type": "boolean"
+        },
+        "radarr_folder": {
+          "type": "string"
+        },
+        "radarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "radarr_monitor_existing": {
+          "type": "boolean"
+        },
+        "radarr_search": {
+          "type": "boolean"
+        },
+        "radarr_upgrade_existing": {
+          "type": "boolean"
+        },
+        "sonarr_add_missing": {
+          "type": "boolean"
+        },
+        "sonarr_folder": {
+          "type": "string"
+        },
+        "sonarr_monitor_existing": {
+          "type": "boolean"
+        },
+        "sonarr_search": {
+          "type": "boolean"
+        },
+        "sonarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "sonarr_upgrade_existing": {
+          "type": "boolean"
+        },
+        "item_radarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "item_sonarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "delete_collections_named": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "search_term": {
+          "type": "string"
+        },
+        "other": {
+          "type": "string"
+        },
+        "image": {
+          "type": "string"
+        },
+        "translation_key": {
+          "type": "string"
+        },
+        "dynamic": {
+          "type": "boolean"
+        },
+        "collection_mode": {
+          "type": "string",
+          "enum": [
+            "default",
+            "hide",
+            "hide_items",
+            "show_items"
+          ]
+        },
+        "use_all": {
+          "type": "boolean"
+        },
+        "placeholder_imdb_id": {
+          "type": "string"
+        },
+        "placeholder_tmdb_movie": {
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "placeholder_tvdb_show": {
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "sep_style": {
+          "type": "string"
+        },
+        "use_separator": {
+          "type": "boolean"
+        },
+        "name_separator": {
+          "type": "string"
+        },
+        "summary_separator": {
+          "type": "string"
+        },
+        "url_poster_separator": {
+          "type": "string"
+        },
+        "name_format": {
+          "type": "string"
+        },
+        "summary_format": {
+          "type": "string"
+        },
+        "exclude": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "collection_order": {
+          "type": "string"
+        },
+        "sync_mode": {
+          "type": "string"
+        },
+        "sort_by": {
+          "type": "string"
+        },
+        "language": {
+          "type": "string"
+        },
+        "style": {
+          "type": "string"
+        },
+        "addons": {
+          "type": "object"
+        },
+        "append_addons": {
+          "type": "object"
+        },
+        "remove_addons": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "include": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "append_include": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "remove_include": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "required": [],
+      "dependentRequired": {},
+      "patternProperties": {
+        "^use_(?!all$).+$": {
+          "description": "Disable a specific collection by key. Set to false to turn off.",
+          "type": "boolean"
+        },
+        "^name_.+$": {
+          "description": "Override the name of a specific collection by key.",
+          "type": "string"
+        },
+        "^summary_.+$": {
+          "description": "Override the summary of a specific collection by key.",
+          "type": "string"
+        },
+        "^order_.+$": {
+          "description": "Override the sort order of a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^schedule_.+$": {
+          "description": "Set the schedule for a specific collection by key.",
+          "type": "string"
+        },
+        "^minimum_items_.+$": {
+          "description": "Override minimum_items for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^hub_priority_.+$": {
+          "description": "Override hub_priority for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^url_poster_.+$": {
+          "description": "Override the poster URL for a specific collection by key.",
+          "type": "string",
+          "format": "uri"
+        },
+        "^file_poster_.+$": {
+          "description": "Override the poster filepath for a specific collection by key.",
+          "type": "string"
+        },
+        "^url_background_.+$": {
+          "description": "Override the background URL for a specific collection by key.",
+          "type": "string",
+          "format": "uri"
+        },
+        "^file_background_.+$": {
+          "description": "Override the background filepath for a specific collection by key.",
+          "type": "string"
+        },
+        "^visible_home_.+$": {
+          "description": "Override Home Tab visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^visible_library_.+$": {
+          "description": "Override Library Tab visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^visible_shared_.+$": {
+          "description": "Override Shared Home visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^radarr_add_missing_.+$": {
+          "description": "Override Radarr add_missing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_folder_.+$": {
+          "description": "Override Radarr root_folder_path for a specific collection by key.",
+          "type": "string"
+        },
+        "^radarr_monitor_existing_.+$": {
+          "description": "Override Radarr monitor_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_search_.+$": {
+          "description": "Override Radarr search for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_tag_.+$": {
+          "description": "Override Radarr tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^radarr_upgrade_existing_.+$": {
+          "description": "Override Radarr upgrade_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_add_missing_.+$": {
+          "description": "Override Sonarr add_missing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_folder_.+$": {
+          "description": "Override Sonarr root_folder_path for a specific collection by key.",
+          "type": "string"
+        },
+        "^sonarr_monitor_existing_.+$": {
+          "description": "Override Sonarr monitor_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_search_.+$": {
+          "description": "Override Sonarr search for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_tag_.+$": {
+          "description": "Override Sonarr tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^sonarr_upgrade_existing_.+$": {
+          "description": "Override Sonarr upgrade_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^item_radarr_tag_.+$": {
+          "description": "Override item_radarr_tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^item_sonarr_tag_.+$": {
+          "description": "Override item_sonarr_tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^limit_.+$": {
+          "description": "Override limit for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^mdblist_list_.+$": {
+          "description": "Override the mdblist_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^trakt_list_.+$": {
+          "description": "Override the trakt_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^imdb_list_.+$": {
+          "description": "Override the imdb_list for a specific collection by key.",
+          "type": "string"
+        },
+        "^letterboxd_list_.+$": {
+          "description": "Override the letterboxd_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^collection_order_.+$": {
+          "description": "Override the Collection Order for a specific collection by key.",
+          "type": "string"
+        },
+        "^sync_mode_.+$": {
+          "description": "Override the Sync Mode for a specific collection by key.",
+          "type": "string",
+          "enum": [
+            "sync",
+            "append"
+          ]
+        },
+        "^in_the_last_.+$": {
+          "description": "Override how far back the filter looks for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^sort_by_.+$": {
+          "description": "Override the Smart Filter Sort for a specific collection by key.",
+          "type": "string"
+        },
+        "^list_days_.+$": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "^list_size_.+$": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "simple-dynamic-template-vars": {
+      "description": "Simple dynamic defaults: aspect, audio_language, based, continent, country, region, resolution, studio, subtitle_language, universe, collectionless, franchise",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "collection_section": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "name_mapping": {
+          "type": "string"
+        },
+        "sort_prefix": {
+          "type": "string"
+        },
+        "sort_title": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "visible_home": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "visible_library": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "visible_shared": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "url_poster": {
+          "type": "string",
+          "format": "uri"
+        },
+        "file_poster": {
+          "type": "string"
+        },
+        "url_background": {
+          "type": "string",
+          "format": "uri"
+        },
+        "file_background": {
+          "type": "string"
+        },
+        "minimum_items": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "hub_priority": {
+          "description": "Priority position for all collections in this defaults file's Recommendation Hub rows. Lower numbers appear first.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "delete_below_minimum": {
+          "type": "boolean"
+        },
+        "delete_not_scheduled": {
+          "type": "boolean"
+        },
+        "auto_sort_hubs": {
+          "type": "string",
+          "enum": ["sort_title", "sort_title.desc", "alpha", "alpha.desc", "configured", "configured.desc", "random"]
+        },
+        "ignore_ids": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "ignore_imdb_ids": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(tt\\d{7,8})(,\\s*tt\\d{7,8})*$"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^tt\\d{7,8}$"
+              }
+            }
+          ]
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "radarr_add_missing": {
+          "type": "boolean"
+        },
+        "radarr_folder": {
+          "type": "string"
+        },
+        "radarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "radarr_monitor_existing": {
+          "type": "boolean"
+        },
+        "radarr_search": {
+          "type": "boolean"
+        },
+        "radarr_upgrade_existing": {
+          "type": "boolean"
+        },
+        "sonarr_add_missing": {
+          "type": "boolean"
+        },
+        "sonarr_folder": {
+          "type": "string"
+        },
+        "sonarr_monitor_existing": {
+          "type": "boolean"
+        },
+        "sonarr_search": {
+          "type": "boolean"
+        },
+        "sonarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "sonarr_upgrade_existing": {
+          "type": "boolean"
+        },
+        "item_radarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "item_sonarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "delete_collections_named": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "style": {
+          "type": "string",
+          "enum": [
+            "color",
+            "white",
+            "bw",
+            "diiivoy",
+            "diiivoycolor",
+            "rainier",
+            "signature",
+            "orig",
+            "transparent",
+            "default",
+            "standards"
+          ]
+        },
+        "language": {
+          "type": "string",
+          "enum": [
+            "default",
+            "en",
+            "fr",
+            "ar",
+            "da",
+            "nl",
+            "de",
+            "it",
+            "pt-br",
+            "nb-no",
+            "es",
+            "sv",
+            "ru",
+            "bg",
+            "hu"
+          ]
+        },
+        "search_term": {
+          "type": "string"
+        },
+        "filter_term": {
+          "type": "string"
+        },
+        "filter_value": {
+          "type": "string"
+        },
+        "other": {
+          "type": "string"
+        },
+        "image": {
+          "type": "string"
+        },
+        "translation_key": {
+          "type": "string"
+        },
+        "dynamic": {
+          "type": "boolean"
+        },
+        "collection_order": {
+          "type": "string"
+        },
+        "sync_mode": {
+          "type": "string",
+          "enum": [
+            "sync",
+            "append"
+          ]
+        },
+        "allowed_libraries": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "collection_mode": {
+          "type": "string",
+          "enum": [
+            "default",
+            "hide",
+            "hide_items",
+            "show_items"
+          ]
+        },
+        "use_all": {
+          "type": "boolean"
+        },
+        "placeholder_imdb_id": {
+          "type": "string"
+        },
+        "placeholder_tmdb_movie": {
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "placeholder_tvdb_show": {
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "sep_style": {
+          "type": "string"
+        },
+        "use_separator": {
+          "type": "boolean"
+        },
+        "name_separator": {
+          "type": "string"
+        },
+        "summary_separator": {
+          "type": "string"
+        },
+        "url_poster_separator": {
+          "type": "string"
+        },
+        "name_format": {
+          "type": "string"
+        },
+        "summary_format": {
+          "type": "string"
+        },
+        "exclude": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "sort_by": {
+          "type": "string"
+        },
+        "addons": {
+          "type": "object"
+        },
+        "append_addons": {
+          "type": "object"
+        },
+        "remove_addons": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "include": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "append_include": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "remove_include": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "required": [],
+      "dependentRequired": {},
+      "patternProperties": {
+        "^use_(?!all$).+$": {
+          "description": "Disable a specific collection by key. Set to false to turn off.",
+          "type": "boolean"
+        },
+        "^name_.+$": {
+          "description": "Override the name of a specific collection by key.",
+          "type": "string"
+        },
+        "^summary_.+$": {
+          "description": "Override the summary of a specific collection by key.",
+          "type": "string"
+        },
+        "^order_.+$": {
+          "description": "Override the sort order of a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^schedule_.+$": {
+          "description": "Set the schedule for a specific collection by key.",
+          "type": "string"
+        },
+        "^minimum_items_.+$": {
+          "description": "Override minimum_items for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^hub_priority_.+$": {
+          "description": "Override hub_priority for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^url_poster_.+$": {
+          "description": "Override the poster URL for a specific collection by key.",
+          "type": "string",
+          "format": "uri"
+        },
+        "^file_poster_.+$": {
+          "description": "Override the poster filepath for a specific collection by key.",
+          "type": "string"
+        },
+        "^url_background_.+$": {
+          "description": "Override the background URL for a specific collection by key.",
+          "type": "string",
+          "format": "uri"
+        },
+        "^file_background_.+$": {
+          "description": "Override the background filepath for a specific collection by key.",
+          "type": "string"
+        },
+        "^visible_home_.+$": {
+          "description": "Override Home Tab visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^visible_library_.+$": {
+          "description": "Override Library Tab visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^visible_shared_.+$": {
+          "description": "Override Shared Home visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^radarr_add_missing_.+$": {
+          "description": "Override Radarr add_missing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_folder_.+$": {
+          "description": "Override Radarr root_folder_path for a specific collection by key.",
+          "type": "string"
+        },
+        "^radarr_monitor_existing_.+$": {
+          "description": "Override Radarr monitor_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_search_.+$": {
+          "description": "Override Radarr search for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_tag_.+$": {
+          "description": "Override Radarr tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^radarr_upgrade_existing_.+$": {
+          "description": "Override Radarr upgrade_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_add_missing_.+$": {
+          "description": "Override Sonarr add_missing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_folder_.+$": {
+          "description": "Override Sonarr root_folder_path for a specific collection by key.",
+          "type": "string"
+        },
+        "^sonarr_monitor_existing_.+$": {
+          "description": "Override Sonarr monitor_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_search_.+$": {
+          "description": "Override Sonarr search for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_tag_.+$": {
+          "description": "Override Sonarr tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^sonarr_upgrade_existing_.+$": {
+          "description": "Override Sonarr upgrade_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^item_radarr_tag_.+$": {
+          "description": "Override item_radarr_tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^item_sonarr_tag_.+$": {
+          "description": "Override item_sonarr_tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^limit_.+$": {
+          "description": "Override limit for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^mdblist_list_.+$": {
+          "description": "Override the mdblist_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^trakt_list_.+$": {
+          "description": "Override the trakt_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^imdb_list_.+$": {
+          "description": "Override the imdb_list for a specific collection by key.",
+          "type": "string"
+        },
+        "^letterboxd_list_.+$": {
+          "description": "Override the letterboxd_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^collection_order_.+$": {
+          "description": "Override the Collection Order for a specific collection by key.",
+          "type": "string"
+        },
+        "^sync_mode_.+$": {
+          "description": "Override the Sync Mode for a specific collection by key.",
+          "type": "string",
+          "enum": [
+            "sync",
+            "append"
+          ]
+        },
+        "^in_the_last_.+$": {
+          "description": "Override how far back the filter looks for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^sort_by_.+$": {
+          "description": "Override the Smart Filter Sort for a specific collection by key.",
+          "type": "string"
+        },
+        "^list_days_.+$": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "^list_size_.+$": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "genre-template-vars": {
+      "description": "Genre default",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "collection_section": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "name_mapping": {
+          "type": "string"
+        },
+        "sort_prefix": {
+          "type": "string"
+        },
+        "sort_title": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "visible_home": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "visible_library": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "visible_shared": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "url_poster": {
+          "type": "string",
+          "format": "uri"
+        },
+        "file_poster": {
+          "type": "string"
+        },
+        "url_background": {
+          "type": "string",
+          "format": "uri"
+        },
+        "file_background": {
+          "type": "string"
+        },
+        "minimum_items": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "hub_priority": {
+          "description": "Priority position for all collections in this defaults file's Recommendation Hub rows. Lower numbers appear first.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "delete_below_minimum": {
+          "type": "boolean"
+        },
+        "delete_not_scheduled": {
+          "type": "boolean"
+        },
+        "auto_sort_hubs": {
+          "type": "string",
+          "enum": ["sort_title", "sort_title.desc", "alpha", "alpha.desc", "configured", "configured.desc", "random"]
+        },
+        "ignore_ids": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "ignore_imdb_ids": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(tt\\d{7,8})(,\\s*tt\\d{7,8})*$"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^tt\\d{7,8}$"
+              }
+            }
+          ]
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "radarr_add_missing": {
+          "type": "boolean"
+        },
+        "radarr_folder": {
+          "type": "string"
+        },
+        "radarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "radarr_monitor_existing": {
+          "type": "boolean"
+        },
+        "radarr_search": {
+          "type": "boolean"
+        },
+        "radarr_upgrade_existing": {
+          "type": "boolean"
+        },
+        "sonarr_add_missing": {
+          "type": "boolean"
+        },
+        "sonarr_folder": {
+          "type": "string"
+        },
+        "sonarr_monitor_existing": {
+          "type": "boolean"
+        },
+        "sonarr_search": {
+          "type": "boolean"
+        },
+        "sonarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "sonarr_upgrade_existing": {
+          "type": "boolean"
+        },
+        "item_radarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "item_sonarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "delete_collections_named": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "style": {
+          "type": "string",
+          "enum": [
+            "color",
+            "white",
+            "bw",
+            "diiivoy",
+            "diiivoycolor",
+            "rainier",
+            "signature",
+            "orig",
+            "transparent",
+            "default",
+            "standards"
+          ]
+        },
+        "search_term": {
+          "type": "string"
+        },
+        "image": {
+          "type": "string"
+        },
+        "translation_key": {
+          "type": "string"
+        },
+        "dynamic": {
+          "type": "boolean"
+        },
+        "collection_mode": {
+          "description": "Controls the collection mode of all collections in a Defaults File.",
+          "type": "string",
+          "enum": [
+            "default",
+            "hide",
+            "hide_items",
+            "show_items"
+          ]
+        },
+        "use_all": {
+          "description": "Turns off all Collections in a Defaults File.",
+          "type": "boolean"
+        },
+        "placeholder_imdb_id": {
+          "description": "Add a placeholder Movie/Show to the Separator.",
+          "type": "string"
+        },
+        "placeholder_tmdb_movie": {
+          "description": "Add a placeholder Movie to the Separator. Movie libraries only.",
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "placeholder_tvdb_show": {
+          "description": "Add a placeholder Show to the Separator. Show libraries only.",
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "sep_style": {
+          "description": "Choose the Separator Style.",
+          "type": "string",
+          "enum": [
+            "amethyst",
+            "aqua",
+            "blue",
+            "forest",
+            "fuchsia",
+            "gold",
+            "gray",
+            "green",
+            "navy",
+            "ocean",
+            "olive",
+            "orchid",
+            "orig",
+            "pink",
+            "plum",
+            "purple",
+            "red",
+            "rust",
+            "salmon",
+            "sand",
+            "stb",
+            "tan"
+          ]
+        },
+        "use_separator": {
+          "description": "Turn the Separator Collection off.",
+          "type": "boolean"
+        },
+        "name_separator": {
+          "description": "Changes the name of the Separator collection.",
+          "type": "string"
+        },
+        "summary_separator": {
+          "description": "Changes the summary of the Separator collection.",
+          "type": "string"
+        },
+        "url_poster_separator": {
+          "description": "Changes the poster URL of the Separator collection.",
+          "type": "string",
+          "format": "uri"
+        },
+        "name_format": {
+          "description": "Changes the title format of the Dynamic Collections.",
+          "type": "string"
+        },
+        "summary_format": {
+          "description": "Changes the summary format of the Dynamic Collections.",
+          "type": "string"
+        },
+        "exclude": {
+          "description": "Exclude specific keys from creating a Dynamic Collection.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "integer"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "language": {
+          "description": "Set the language of Collection Names and Summaries.",
+          "type": "string",
+          "enum": [
+            "default",
+            "en",
+            "fr",
+            "ar",
+            "da",
+            "nl",
+            "de",
+            "it",
+            "pt-br",
+            "nb-no",
+            "es",
+            "sv",
+            "ru",
+            "bg",
+            "hu"
+          ]
+        },
+        "sort_by": {
+          "description": "Changes the Smart Filter Sort for all collections in a Defaults File.",
+          "type": "string"
+        },
+        "addons": {
+          "description": "Overrides the default addons dictionary.",
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          }
+        },
+        "append_addons": {
+          "description": "Appends to the default addons dictionary.",
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          }
+        },
+        "remove_addons": {
+          "description": "Removes from the default addons dictionary.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "collection_order": {
+          "type": "string"
+        },
+        "sync_mode": {
+          "type": "string"
+        }
+      },
+      "required": [],
+      "dependentRequired": {},
+      "patternProperties": {
+        "^use_(?!all$).+$": {
+          "description": "Disable a specific collection by key. Set to false to turn off.",
+          "type": "boolean"
+        },
+        "^name_.+$": {
+          "description": "Override the name of a specific collection by key.",
+          "type": "string"
+        },
+        "^summary_.+$": {
+          "description": "Override the summary of a specific collection by key.",
+          "type": "string"
+        },
+        "^order_.+$": {
+          "description": "Override the sort order of a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^schedule_.+$": {
+          "description": "Set the schedule for a specific collection by key.",
+          "type": "string"
+        },
+        "^minimum_items_.+$": {
+          "description": "Override minimum_items for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^hub_priority_.+$": {
+          "description": "Override hub_priority for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^url_poster_.+$": {
+          "description": "Override the poster URL for a specific collection by key.",
+          "type": "string",
+          "format": "uri"
+        },
+        "^file_poster_.+$": {
+          "description": "Override the poster filepath for a specific collection by key.",
+          "type": "string"
+        },
+        "^url_background_.+$": {
+          "description": "Override the background URL for a specific collection by key.",
+          "type": "string",
+          "format": "uri"
+        },
+        "^file_background_.+$": {
+          "description": "Override the background filepath for a specific collection by key.",
+          "type": "string"
+        },
+        "^visible_home_.+$": {
+          "description": "Override Home Tab visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^visible_library_.+$": {
+          "description": "Override Library Tab visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^visible_shared_.+$": {
+          "description": "Override Shared Home visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^radarr_add_missing_.+$": {
+          "description": "Override Radarr add_missing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_folder_.+$": {
+          "description": "Override Radarr root_folder_path for a specific collection by key.",
+          "type": "string"
+        },
+        "^radarr_monitor_existing_.+$": {
+          "description": "Override Radarr monitor_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_search_.+$": {
+          "description": "Override Radarr search for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_tag_.+$": {
+          "description": "Override Radarr tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^radarr_upgrade_existing_.+$": {
+          "description": "Override Radarr upgrade_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_add_missing_.+$": {
+          "description": "Override Sonarr add_missing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_folder_.+$": {
+          "description": "Override Sonarr root_folder_path for a specific collection by key.",
+          "type": "string"
+        },
+        "^sonarr_monitor_existing_.+$": {
+          "description": "Override Sonarr monitor_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_search_.+$": {
+          "description": "Override Sonarr search for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_tag_.+$": {
+          "description": "Override Sonarr tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^sonarr_upgrade_existing_.+$": {
+          "description": "Override Sonarr upgrade_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^item_radarr_tag_.+$": {
+          "description": "Override item_radarr_tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^item_sonarr_tag_.+$": {
+          "description": "Override item_sonarr_tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^limit_.+$": {
+          "description": "Override limit for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^mdblist_list_.+$": {
+          "description": "Override the mdblist_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^trakt_list_.+$": {
+          "description": "Override the trakt_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^imdb_list_.+$": {
+          "description": "Override the imdb_list for a specific collection by key.",
+          "type": "string"
+        },
+        "^letterboxd_list_.+$": {
+          "description": "Override the letterboxd_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^collection_order_.+$": {
+          "description": "Override the Collection Order for a specific collection by key.",
+          "type": "string"
+        },
+        "^sync_mode_.+$": {
+          "description": "Override the Sync Mode for a specific collection by key.",
+          "type": "string",
+          "enum": [
+            "sync",
+            "append"
+          ]
+        },
+        "^in_the_last_.+$": {
+          "description": "Override how far back the filter looks for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^sort_by_.+$": {
+          "description": "Override the Smart Filter Sort for a specific collection by key.",
+          "type": "string"
+        }
+      }
+    },
+    "year-decade-template-vars": {
+      "description": "Year/Decade defaults",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "collection_section": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "name_mapping": {
+          "type": "string"
+        },
+        "sort_prefix": {
+          "type": "string"
+        },
+        "sort_title": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "visible_home": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "visible_library": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "visible_shared": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "url_poster": {
+          "type": "string",
+          "format": "uri"
+        },
+        "file_poster": {
+          "type": "string"
+        },
+        "url_background": {
+          "type": "string",
+          "format": "uri"
+        },
+        "file_background": {
+          "type": "string"
+        },
+        "minimum_items": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "hub_priority": {
+          "description": "Priority position for all collections in this defaults file's Recommendation Hub rows. Lower numbers appear first.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "delete_below_minimum": {
+          "type": "boolean"
+        },
+        "delete_not_scheduled": {
+          "type": "boolean"
+        },
+        "auto_sort_hubs": {
+          "type": "string",
+          "enum": ["sort_title", "sort_title.desc", "alpha", "alpha.desc", "configured", "configured.desc", "random"]
+        },
+        "ignore_ids": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "ignore_imdb_ids": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(tt\\d{7,8})(,\\s*tt\\d{7,8})*$"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^tt\\d{7,8}$"
+              }
+            }
+          ]
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "radarr_add_missing": {
+          "type": "boolean"
+        },
+        "radarr_folder": {
+          "type": "string"
+        },
+        "radarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "radarr_monitor_existing": {
+          "type": "boolean"
+        },
+        "radarr_search": {
+          "type": "boolean"
+        },
+        "radarr_upgrade_existing": {
+          "type": "boolean"
+        },
+        "sonarr_add_missing": {
+          "type": "boolean"
+        },
+        "sonarr_folder": {
+          "type": "string"
+        },
+        "sonarr_monitor_existing": {
+          "type": "boolean"
+        },
+        "sonarr_search": {
+          "type": "boolean"
+        },
+        "sonarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "sonarr_upgrade_existing": {
+          "type": "boolean"
+        },
+        "item_radarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "item_sonarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "delete_collections_named": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "style": {
+          "type": "string",
+          "enum": [
+            "color",
+            "white",
+            "bw",
+            "diiivoy",
+            "diiivoycolor",
+            "rainier",
+            "signature",
+            "orig",
+            "transparent",
+            "default",
+            "standards"
+          ]
+        },
+        "search_term": {
+          "type": "string"
+        },
+        "sort_by": {
+          "type": "string"
+        },
+        "image": {
+          "type": "string"
+        },
+        "translation_key": {
+          "type": "string"
+        },
+        "dynamic": {
+          "type": "boolean"
+        },
+        "collection_mode": {
+          "type": "string",
+          "enum": [
+            "default",
+            "hide",
+            "hide_items",
+            "show_items"
+          ]
+        },
+        "collection_order": {
+          "type": "string"
+        },
+        "use_all": {
+          "type": "boolean"
+        },
+        "placeholder_imdb_id": {
+          "type": "string"
+        },
+        "placeholder_tmdb_movie": {
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "placeholder_tvdb_show": {
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "sep_style": {
+          "type": "string"
+        },
+        "use_separator": {
+          "type": "boolean"
+        },
+        "name_separator": {
+          "type": "string"
+        },
+        "summary_separator": {
+          "type": "string"
+        },
+        "url_poster_separator": {
+          "type": "string"
+        },
+        "name_format": {
+          "type": "string"
+        },
+        "summary_format": {
+          "type": "string"
+        },
+        "exclude": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "sync_mode": {
+          "type": "string"
+        },
+        "language": {
+          "type": "string"
+        },
+        "addons": {
+          "type": "object"
+        },
+        "append_addons": {
+          "type": "object"
+        },
+        "remove_addons": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "include": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "append_include": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "remove_include": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "data": {
+          "type": "object"
+        }
+      },
+      "required": [],
+      "dependentRequired": {},
+      "patternProperties": {
+        "^use_(?!all$).+$": {
+          "description": "Disable a specific collection by key. Set to false to turn off.",
+          "type": "boolean"
+        },
+        "^name_.+$": {
+          "description": "Override the name of a specific collection by key.",
+          "type": "string"
+        },
+        "^summary_.+$": {
+          "description": "Override the summary of a specific collection by key.",
+          "type": "string"
+        },
+        "^order_.+$": {
+          "description": "Override the sort order of a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^schedule_.+$": {
+          "description": "Set the schedule for a specific collection by key.",
+          "type": "string"
+        },
+        "^minimum_items_.+$": {
+          "description": "Override minimum_items for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^hub_priority_.+$": {
+          "description": "Override hub_priority for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^url_poster_.+$": {
+          "description": "Override the poster URL for a specific collection by key.",
+          "type": "string",
+          "format": "uri"
+        },
+        "^file_poster_.+$": {
+          "description": "Override the poster filepath for a specific collection by key.",
+          "type": "string"
+        },
+        "^url_background_.+$": {
+          "description": "Override the background URL for a specific collection by key.",
+          "type": "string",
+          "format": "uri"
+        },
+        "^file_background_.+$": {
+          "description": "Override the background filepath for a specific collection by key.",
+          "type": "string"
+        },
+        "^visible_home_.+$": {
+          "description": "Override Home Tab visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^visible_library_.+$": {
+          "description": "Override Library Tab visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^visible_shared_.+$": {
+          "description": "Override Shared Home visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^radarr_add_missing_.+$": {
+          "description": "Override Radarr add_missing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_folder_.+$": {
+          "description": "Override Radarr root_folder_path for a specific collection by key.",
+          "type": "string"
+        },
+        "^radarr_monitor_existing_.+$": {
+          "description": "Override Radarr monitor_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_search_.+$": {
+          "description": "Override Radarr search for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_tag_.+$": {
+          "description": "Override Radarr tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^radarr_upgrade_existing_.+$": {
+          "description": "Override Radarr upgrade_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_add_missing_.+$": {
+          "description": "Override Sonarr add_missing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_folder_.+$": {
+          "description": "Override Sonarr root_folder_path for a specific collection by key.",
+          "type": "string"
+        },
+        "^sonarr_monitor_existing_.+$": {
+          "description": "Override Sonarr monitor_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_search_.+$": {
+          "description": "Override Sonarr search for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_tag_.+$": {
+          "description": "Override Sonarr tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^sonarr_upgrade_existing_.+$": {
+          "description": "Override Sonarr upgrade_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^item_radarr_tag_.+$": {
+          "description": "Override item_radarr_tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^item_sonarr_tag_.+$": {
+          "description": "Override item_sonarr_tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^limit_.+$": {
+          "description": "Override limit for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^mdblist_list_.+$": {
+          "description": "Override the mdblist_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^trakt_list_.+$": {
+          "description": "Override the trakt_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^imdb_list_.+$": {
+          "description": "Override the imdb_list for a specific collection by key.",
+          "type": "string"
+        },
+        "^letterboxd_list_.+$": {
+          "description": "Override the letterboxd_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^collection_order_.+$": {
+          "description": "Override the Collection Order for a specific collection by key.",
+          "type": "string"
+        },
+        "^sync_mode_.+$": {
+          "description": "Override the Sync Mode for a specific collection by key.",
+          "type": "string",
+          "enum": [
+            "sync",
+            "append"
+          ]
+        },
+        "^in_the_last_.+$": {
+          "description": "Override how far back the filter looks for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^sort_by_.+$": {
+          "description": "Override the Smart Filter Sort for a specific collection by key.",
+          "type": "string"
+        },
+        "^list_days_.+$": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "^list_size_.+$": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "network-template-vars": {
+      "description": "Network default",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "collection_section": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "name_mapping": {
+          "type": "string"
+        },
+        "sort_prefix": {
+          "type": "string"
+        },
+        "sort_title": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "visible_home": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "visible_library": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "visible_shared": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "url_poster": {
+          "type": "string",
+          "format": "uri"
+        },
+        "file_poster": {
+          "type": "string"
+        },
+        "url_background": {
+          "type": "string",
+          "format": "uri"
+        },
+        "file_background": {
+          "type": "string"
+        },
+        "minimum_items": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "hub_priority": {
+          "description": "Priority position for all collections in this defaults file's Recommendation Hub rows. Lower numbers appear first.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "delete_below_minimum": {
+          "type": "boolean"
+        },
+        "delete_not_scheduled": {
+          "type": "boolean"
+        },
+        "auto_sort_hubs": {
+          "type": "string",
+          "enum": ["sort_title", "sort_title.desc", "alpha", "alpha.desc", "configured", "configured.desc", "random"]
+        },
+        "ignore_ids": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "ignore_imdb_ids": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(tt\\d{7,8})(,\\s*tt\\d{7,8})*$"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^tt\\d{7,8}$"
+              }
+            }
+          ]
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "radarr_add_missing": {
+          "type": "boolean"
+        },
+        "radarr_folder": {
+          "type": "string"
+        },
+        "radarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "radarr_monitor_existing": {
+          "type": "boolean"
+        },
+        "radarr_search": {
+          "type": "boolean"
+        },
+        "radarr_upgrade_existing": {
+          "type": "boolean"
+        },
+        "sonarr_add_missing": {
+          "type": "boolean"
+        },
+        "sonarr_folder": {
+          "type": "string"
+        },
+        "sonarr_monitor_existing": {
+          "type": "boolean"
+        },
+        "sonarr_search": {
+          "type": "boolean"
+        },
+        "sonarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "sonarr_upgrade_existing": {
+          "type": "boolean"
+        },
+        "item_radarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "item_sonarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "delete_collections_named": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "style": {
+          "type": "string",
+          "enum": [
+            "color",
+            "white",
+            "bw",
+            "diiivoy",
+            "diiivoycolor",
+            "rainier",
+            "signature",
+            "orig",
+            "transparent",
+            "default",
+            "standards"
+          ]
+        },
+        "search_term": {
+          "type": "string"
+        },
+        "image": {
+          "type": "string"
+        },
+        "translation_key": {
+          "type": "string"
+        },
+        "dynamic": {
+          "type": "boolean"
+        },
+        "collection_mode": {
+          "type": "string",
+          "enum": [
+            "default",
+            "hide",
+            "hide_items",
+            "show_items"
+          ]
+        },
+        "use_all": {
+          "type": "boolean"
+        },
+        "placeholder_imdb_id": {
+          "type": "string"
+        },
+        "placeholder_tmdb_movie": {
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "placeholder_tvdb_show": {
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "sep_style": {
+          "type": "string"
+        },
+        "use_separator": {
+          "type": "boolean"
+        },
+        "name_separator": {
+          "type": "string"
+        },
+        "summary_separator": {
+          "type": "string"
+        },
+        "url_poster_separator": {
+          "type": "string"
+        },
+        "name_format": {
+          "type": "string"
+        },
+        "summary_format": {
+          "type": "string"
+        },
+        "exclude": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "collection_order": {
+          "type": "string"
+        },
+        "sync_mode": {
+          "type": "string"
+        },
+        "sort_by": {
+          "type": "string"
+        },
+        "language": {
+          "type": "string"
+        },
+        "addons": {
+          "type": "object"
+        },
+        "append_addons": {
+          "type": "object"
+        },
+        "remove_addons": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "include": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "append_include": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "remove_include": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "required": [],
+      "dependentRequired": {},
+      "patternProperties": {
+        "^use_(?!all$).+$": {
+          "description": "Disable a specific collection by key. Set to false to turn off.",
+          "type": "boolean"
+        },
+        "^name_.+$": {
+          "description": "Override the name of a specific collection by key.",
+          "type": "string"
+        },
+        "^summary_.+$": {
+          "description": "Override the summary of a specific collection by key.",
+          "type": "string"
+        },
+        "^order_.+$": {
+          "description": "Override the sort order of a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^schedule_.+$": {
+          "description": "Set the schedule for a specific collection by key.",
+          "type": "string"
+        },
+        "^minimum_items_.+$": {
+          "description": "Override minimum_items for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^hub_priority_.+$": {
+          "description": "Override hub_priority for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^url_poster_.+$": {
+          "description": "Override the poster URL for a specific collection by key.",
+          "type": "string",
+          "format": "uri"
+        },
+        "^file_poster_.+$": {
+          "description": "Override the poster filepath for a specific collection by key.",
+          "type": "string"
+        },
+        "^url_background_.+$": {
+          "description": "Override the background URL for a specific collection by key.",
+          "type": "string",
+          "format": "uri"
+        },
+        "^file_background_.+$": {
+          "description": "Override the background filepath for a specific collection by key.",
+          "type": "string"
+        },
+        "^visible_home_.+$": {
+          "description": "Override Home Tab visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^visible_library_.+$": {
+          "description": "Override Library Tab visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^visible_shared_.+$": {
+          "description": "Override Shared Home visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^radarr_add_missing_.+$": {
+          "description": "Override Radarr add_missing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_folder_.+$": {
+          "description": "Override Radarr root_folder_path for a specific collection by key.",
+          "type": "string"
+        },
+        "^radarr_monitor_existing_.+$": {
+          "description": "Override Radarr monitor_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_search_.+$": {
+          "description": "Override Radarr search for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_tag_.+$": {
+          "description": "Override Radarr tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^radarr_upgrade_existing_.+$": {
+          "description": "Override Radarr upgrade_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_add_missing_.+$": {
+          "description": "Override Sonarr add_missing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_folder_.+$": {
+          "description": "Override Sonarr root_folder_path for a specific collection by key.",
+          "type": "string"
+        },
+        "^sonarr_monitor_existing_.+$": {
+          "description": "Override Sonarr monitor_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_search_.+$": {
+          "description": "Override Sonarr search for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_tag_.+$": {
+          "description": "Override Sonarr tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^sonarr_upgrade_existing_.+$": {
+          "description": "Override Sonarr upgrade_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^item_radarr_tag_.+$": {
+          "description": "Override item_radarr_tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^item_sonarr_tag_.+$": {
+          "description": "Override item_sonarr_tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^limit_.+$": {
+          "description": "Override limit for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^mdblist_list_.+$": {
+          "description": "Override the mdblist_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^trakt_list_.+$": {
+          "description": "Override the trakt_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^imdb_list_.+$": {
+          "description": "Override the imdb_list for a specific collection by key.",
+          "type": "string"
+        },
+        "^letterboxd_list_.+$": {
+          "description": "Override the letterboxd_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^collection_order_.+$": {
+          "description": "Override the Collection Order for a specific collection by key.",
+          "type": "string"
+        },
+        "^sync_mode_.+$": {
+          "description": "Override the Sync Mode for a specific collection by key.",
+          "type": "string",
+          "enum": [
+            "sync",
+            "append"
+          ]
+        },
+        "^in_the_last_.+$": {
+          "description": "Override how far back the filter looks for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^sort_by_.+$": {
+          "description": "Override the Smart Filter Sort for a specific collection by key.",
+          "type": "string"
+        },
+        "^list_days_.+$": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "^list_size_.+$": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "streaming-template-vars": {
+      "description": "Streaming default",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "collection_section": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "name_mapping": {
+          "type": "string"
+        },
+        "sort_prefix": {
+          "type": "string"
+        },
+        "sort_title": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "visible_home": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "visible_library": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "visible_shared": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "url_poster": {
+          "type": "string",
+          "format": "uri"
+        },
+        "file_poster": {
+          "type": "string"
+        },
+        "url_background": {
+          "type": "string",
+          "format": "uri"
+        },
+        "file_background": {
+          "type": "string"
+        },
+        "minimum_items": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "hub_priority": {
+          "description": "Priority position for all collections in this defaults file's Recommendation Hub rows. Lower numbers appear first.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "delete_below_minimum": {
+          "type": "boolean"
+        },
+        "delete_not_scheduled": {
+          "type": "boolean"
+        },
+        "auto_sort_hubs": {
+          "type": "string",
+          "enum": ["sort_title", "sort_title.desc", "alpha", "alpha.desc", "configured", "configured.desc", "random"]
+        },
+        "ignore_ids": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "ignore_imdb_ids": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(tt\\d{7,8})(,\\s*tt\\d{7,8})*$"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^tt\\d{7,8}$"
+              }
+            }
+          ]
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "radarr_add_missing": {
+          "type": "boolean"
+        },
+        "radarr_folder": {
+          "type": "string"
+        },
+        "radarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "radarr_monitor_existing": {
+          "type": "boolean"
+        },
+        "radarr_search": {
+          "type": "boolean"
+        },
+        "radarr_upgrade_existing": {
+          "type": "boolean"
+        },
+        "sonarr_add_missing": {
+          "type": "boolean"
+        },
+        "sonarr_folder": {
+          "type": "string"
+        },
+        "sonarr_monitor_existing": {
+          "type": "boolean"
+        },
+        "sonarr_search": {
+          "type": "boolean"
+        },
+        "sonarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "sonarr_upgrade_existing": {
+          "type": "boolean"
+        },
+        "item_radarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "item_sonarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "delete_collections_named": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "style": {
+          "type": "string",
+          "enum": [
+            "color",
+            "white",
+            "bw",
+            "diiivoy",
+            "diiivoycolor",
+            "rainier",
+            "signature",
+            "orig",
+            "transparent",
+            "default",
+            "standards"
+          ]
+        },
+        "image": {
+          "type": "string"
+        },
+        "translation_key": {
+          "type": "string"
+        },
+        "dynamic": {
+          "type": "boolean"
+        },
+        "allowed_libraries": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "sync_mode": {
+          "type": "string",
+          "enum": [
+            "sync",
+            "append"
+          ]
+        },
+        "originals_only": {
+          "type": "boolean"
+        },
+        "region": {
+          "type": "string"
+        },
+        "collection_mode": {
+          "description": "Controls the collection mode of all collections in a Defaults File.",
+          "type": "string",
+          "enum": [
+            "default",
+            "hide",
+            "hide_items",
+            "show_items"
+          ]
+        },
+        "use_all": {
+          "description": "Turns off all Collections in a Defaults File.",
+          "type": "boolean"
+        },
+        "placeholder_imdb_id": {
+          "description": "Add a placeholder Movie/Show to the Separator.",
+          "type": "string"
+        },
+        "placeholder_tmdb_movie": {
+          "description": "Add a placeholder Movie to the Separator. Movie libraries only.",
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "placeholder_tvdb_show": {
+          "description": "Add a placeholder Show to the Separator. Show libraries only.",
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "sep_style": {
+          "description": "Choose the Separator Style.",
+          "type": "string",
+          "enum": [
+            "amethyst",
+            "aqua",
+            "blue",
+            "forest",
+            "fuchsia",
+            "gold",
+            "gray",
+            "green",
+            "navy",
+            "ocean",
+            "olive",
+            "orchid",
+            "orig",
+            "pink",
+            "plum",
+            "purple",
+            "red",
+            "rust",
+            "salmon",
+            "sand",
+            "stb",
+            "tan"
+          ]
+        },
+        "use_separator": {
+          "description": "Turn the Separator Collection off.",
+          "type": "boolean"
+        },
+        "name_separator": {
+          "description": "Changes the name of the Separator collection.",
+          "type": "string"
+        },
+        "summary_separator": {
+          "description": "Changes the summary of the Separator collection.",
+          "type": "string"
+        },
+        "url_poster_separator": {
+          "description": "Changes the poster URL of the Separator collection.",
+          "type": "string",
+          "format": "uri"
+        },
+        "name_format": {
+          "description": "Changes the title format of the Dynamic Collections.",
+          "type": "string"
+        },
+        "summary_format": {
+          "description": "Changes the summary format of the Dynamic Collections.",
+          "type": "string"
+        },
+        "exclude": {
+          "description": "Exclude specific keys from creating a Dynamic Collection.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "integer"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "language": {
+          "description": "Set the language of Collection Names and Summaries.",
+          "type": "string",
+          "enum": [
+            "default",
+            "en",
+            "fr",
+            "ar",
+            "da",
+            "nl",
+            "de",
+            "it",
+            "pt-br",
+            "nb-no",
+            "es",
+            "sv",
+            "ru",
+            "bg",
+            "hu"
+          ]
+        },
+        "sort_by": {
+          "description": "Changes the Smart Filter Sort for all collections in a Defaults File.",
+          "type": "string"
+        },
+        "collection_order": {
+          "description": "Changes the Collection Order for all collections in a Defaults File.",
+          "type": "string"
+        },
+        "addons": {
+          "type": "object"
+        },
+        "append_addons": {
+          "type": "object"
+        },
+        "remove_addons": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "include": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "append_include": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "remove_include": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "required": [],
+      "dependentRequired": {},
+      "patternProperties": {
+        "^use_(?!all$).+$": {
+          "description": "Disable a specific collection by key. Set to false to turn off.",
+          "type": "boolean"
+        },
+        "^name_.+$": {
+          "description": "Override the name of a specific collection by key.",
+          "type": "string"
+        },
+        "^summary_.+$": {
+          "description": "Override the summary of a specific collection by key.",
+          "type": "string"
+        },
+        "^order_.+$": {
+          "description": "Override the sort order of a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^schedule_.+$": {
+          "description": "Set the schedule for a specific collection by key.",
+          "type": "string"
+        },
+        "^minimum_items_.+$": {
+          "description": "Override minimum_items for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^hub_priority_.+$": {
+          "description": "Override hub_priority for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^url_poster_.+$": {
+          "description": "Override the poster URL for a specific collection by key.",
+          "type": "string",
+          "format": "uri"
+        },
+        "^file_poster_.+$": {
+          "description": "Override the poster filepath for a specific collection by key.",
+          "type": "string"
+        },
+        "^url_background_.+$": {
+          "description": "Override the background URL for a specific collection by key.",
+          "type": "string",
+          "format": "uri"
+        },
+        "^file_background_.+$": {
+          "description": "Override the background filepath for a specific collection by key.",
+          "type": "string"
+        },
+        "^visible_home_.+$": {
+          "description": "Override Home Tab visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^visible_library_.+$": {
+          "description": "Override Library Tab visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^visible_shared_.+$": {
+          "description": "Override Shared Home visibility for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "^radarr_add_missing_.+$": {
+          "description": "Override Radarr add_missing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_folder_.+$": {
+          "description": "Override Radarr root_folder_path for a specific collection by key.",
+          "type": "string"
+        },
+        "^radarr_monitor_existing_.+$": {
+          "description": "Override Radarr monitor_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_search_.+$": {
+          "description": "Override Radarr search for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^radarr_tag_.+$": {
+          "description": "Override Radarr tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^radarr_upgrade_existing_.+$": {
+          "description": "Override Radarr upgrade_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_add_missing_.+$": {
+          "description": "Override Sonarr add_missing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_folder_.+$": {
+          "description": "Override Sonarr root_folder_path for a specific collection by key.",
+          "type": "string"
+        },
+        "^sonarr_monitor_existing_.+$": {
+          "description": "Override Sonarr monitor_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_search_.+$": {
+          "description": "Override Sonarr search for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^sonarr_tag_.+$": {
+          "description": "Override Sonarr tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^sonarr_upgrade_existing_.+$": {
+          "description": "Override Sonarr upgrade_existing for a specific collection by key.",
+          "type": "boolean"
+        },
+        "^item_radarr_tag_.+$": {
+          "description": "Override item_radarr_tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^item_sonarr_tag_.+$": {
+          "description": "Override item_sonarr_tag for a specific collection by key.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "^limit_.+$": {
+          "description": "Override limit for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^mdblist_list_.+$": {
+          "description": "Override the mdblist_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^trakt_list_.+$": {
+          "description": "Override the trakt_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^imdb_list_.+$": {
+          "description": "Override the imdb_list for a specific collection by key.",
+          "type": "string"
+        },
+        "^letterboxd_list_.+$": {
+          "description": "Override the letterboxd_list URL for a specific collection by key.",
+          "type": "string"
+        },
+        "^collection_order_.+$": {
+          "description": "Override the Collection Order for a specific collection by key.",
+          "type": "string"
+        },
+        "^sync_mode_.+$": {
+          "description": "Override the Sync Mode for a specific collection by key.",
+          "type": "string",
+          "enum": [
+            "sync",
+            "append"
+          ]
+        },
+        "^in_the_last_.+$": {
+          "description": "Override how far back the filter looks for a specific collection by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^sort_by_.+$": {
+          "description": "Override the Smart Filter Sort for a specific collection by key.",
+          "type": "string"
+        },
+        "^discover_with_.+$": {
+          "description": "Overrides the TMDb Watch Provider used for the specified key.",
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "separator-template-vars": {
+      "description": "Separator defaults",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "collection_section": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "name_mapping": {
+          "type": "string"
+        },
+        "sort_prefix": {
+          "type": "string"
+        },
+        "sort_title": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "visible_home": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "visible_library": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "visible_shared": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "url_poster": {
+          "type": "string",
+          "format": "uri"
+        },
+        "file_poster": {
+          "type": "string"
+        },
+        "url_background": {
+          "type": "string",
+          "format": "uri"
+        },
+        "file_background": {
+          "type": "string"
+        },
+        "minimum_items": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "hub_priority": {
+          "description": "Priority position for all collections in this defaults file's Recommendation Hub rows. Lower numbers appear first.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "delete_below_minimum": {
+          "type": "boolean"
+        },
+        "delete_not_scheduled": {
+          "type": "boolean"
+        },
+        "auto_sort_hubs": {
+          "type": "string",
+          "enum": ["sort_title", "sort_title.desc", "alpha", "alpha.desc", "configured", "configured.desc", "random"]
+        },
+        "ignore_ids": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "ignore_imdb_ids": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(tt\\d{7,8})(,\\s*tt\\d{7,8})*$"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^tt\\d{7,8}$"
+              }
+            }
+          ]
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "radarr_add_missing": {
+          "type": "boolean"
+        },
+        "radarr_folder": {
+          "type": "string"
+        },
+        "radarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "radarr_monitor_existing": {
+          "type": "boolean"
+        },
+        "radarr_search": {
+          "type": "boolean"
+        },
+        "radarr_upgrade_existing": {
+          "type": "boolean"
+        },
+        "sonarr_add_missing": {
+          "type": "boolean"
+        },
+        "sonarr_folder": {
+          "type": "string"
+        },
+        "sonarr_monitor_existing": {
+          "type": "boolean"
+        },
+        "sonarr_search": {
+          "type": "boolean"
+        },
+        "sonarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "sonarr_upgrade_existing": {
+          "type": "boolean"
+        },
+        "item_radarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "item_sonarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "delete_collections_named": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "collection_mode": {
+          "type": "string",
+          "enum": [
+            "default",
+            "hide",
+            "hide_items",
+            "show_items"
+          ]
+        },
+        "use_all": {
+          "type": "boolean"
+        },
+        "placeholder_imdb_id": {
+          "type": "string"
+        },
+        "placeholder_tmdb_movie": {
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "placeholder_tvdb_show": {
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "sep_style": {
+          "type": "string"
+        },
+        "use_separator": {
+          "type": "boolean"
+        },
+        "name_separator": {
+          "type": "string"
+        },
+        "summary_separator": {
+          "type": "string"
+        },
+        "url_poster_separator": {
+          "type": "string"
+        }
+      },
+      "required": [],
+      "dependentRequired": {}
+    },
+    "seasonal-template-vars": {
+      "description": "Seasonal default",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "collection_section": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "name_mapping": {
+          "type": "string"
+        },
+        "sort_prefix": {
+          "type": "string"
+        },
+        "sort_title": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "visible_home": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "visible_library": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "visible_shared": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "url_poster": {
+          "type": "string",
+          "format": "uri"
+        },
+        "file_poster": {
+          "type": "string"
+        },
+        "url_background": {
+          "type": "string",
+          "format": "uri"
+        },
+        "file_background": {
+          "type": "string"
+        },
+        "minimum_items": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "hub_priority": {
+          "description": "Priority position for all collections in this defaults file's Recommendation Hub rows. Lower numbers appear first.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "delete_below_minimum": {
+          "type": "boolean"
+        },
+        "delete_not_scheduled": {
+          "type": "boolean"
+        },
+        "auto_sort_hubs": {
+          "type": "string",
+          "enum": ["sort_title", "sort_title.desc", "alpha", "alpha.desc", "configured", "configured.desc", "random"]
+        },
+        "ignore_ids": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "ignore_imdb_ids": {
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(tt\\d{7,8})(,\\s*tt\\d{7,8})*$"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^tt\\d{7,8}$"
+              }
+            }
+          ]
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "radarr_add_missing": {
+          "type": "boolean"
+        },
+        "radarr_folder": {
+          "type": "string"
+        },
+        "radarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "radarr_monitor_existing": {
+          "type": "boolean"
+        },
+        "radarr_search": {
+          "type": "boolean"
+        },
+        "radarr_upgrade_existing": {
+          "type": "boolean"
+        },
+        "sonarr_add_missing": {
+          "type": "boolean"
+        },
+        "sonarr_folder": {
+          "type": "string"
+        },
+        "sonarr_monitor_existing": {
+          "type": "boolean"
+        },
+        "sonarr_search": {
+          "type": "boolean"
+        },
+        "sonarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "sonarr_upgrade_existing": {
+          "type": "boolean"
+        },
+        "item_radarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "item_sonarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "delete_collections_named": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "style": {
+          "type": "string",
+          "enum": [
+            "color",
+            "white",
+            "bw",
+            "diiivoy",
+            "diiivoycolor",
+            "rainier",
+            "signature",
+            "orig",
+            "transparent",
+            "default",
+            "standards"
+          ]
+        },
+        "image": {
+          "type": "string"
+        },
+        "translation_key": {
+          "type": "string"
+        },
+        "dynamic": {
+          "type": "boolean"
+        },
+        "sync_mode": {
+          "type": "string",
+          "enum": [
+            "sync",
+            "append"
+          ]
+        },
+        "collection_mode": {
+          "type": "string",
+          "enum": [
+            "default",
+            "hide",
+            "hide_items",
+            "show_items"
+          ]
+        },
+        "use_all": {
+          "type": "boolean"
+        },
+        "placeholder_imdb_id": {
+          "type": "string"
+        },
+        "placeholder_tmdb_movie": {
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "placeholder_tvdb_show": {
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "sep_style": {
+          "type": "string"
+        },
+        "use_separator": {
+          "type": "boolean"
+        },
+        "name_separator": {
+          "type": "string"
+        },
+        "summary_separator": {
+          "type": "string"
+        },
+        "url_poster_separator": {
+          "type": "string"
+        },
+        "sort_by": {
+          "type": "string"
+        },
+        "collection_order": {
+          "type": "string"
+        },
+        "name_format": {
+          "type": "string"
+        },
+        "summary_format": {
+          "type": "string"
+        },
+        "language": {
+          "type": "string"
+        },
+        "exclude": {
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "required": [],
+      "dependentRequired": {},
+      "patternProperties": {
+        "^schedule_.+$": {
+          "type": "string"
+        }
+      }
+    },
+    "template-variables-overlays": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "addon_offset": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "addon_position": {
+          "type": "string",
+          "enum": [
+            "left",
+            "top",
+            "bottom",
+            "right"
+          ]
+        },
+        "back_align": {
+          "type": "string",
+          "enum": [
+            "left",
+            "right",
+            "center",
+            "top",
+            "bottom"
+          ]
+        },
+        "back_color": {
+          "type": "string",
+          "pattern": "^\\#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+        },
+        "back_height": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "back_line_color": {
+          "type": "string",
+          "pattern": "^\\#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+        },
+        "back_line_width": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "back_padding": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "back_radius": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "back_width": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "builder_level": {
+          "type": "string",
+          "enum": [
+            "show",
+            "season",
+            "episode"
+          ]
+        },
+        "color": {
+          "type": "boolean",
+          "description": "Toggles color styling for applicable overlays like content ratings."
+        },
+        "file": {
+          "type": "string"
+        },
+        "final_name": {
+          "type": "string"
+        },
+        "flag_alignment": {
+          "type": "string",
+          "enum": [
+            "left",
+            "right"
+          ]
+        },
+        "font_color": {
+          "type": "string",
+          "pattern": "^\\#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+        },
+        "font_size": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "font_style": {
+          "type": "string",
+          "enum": [
+            "Any",
+            "Italic",
+            "Normal",
+            "Oblique"
+          ]
+        },
+        "font": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "git": {
+          "type": "string"
+        },
+        "group_alignment": {
+          "type": "string",
+          "enum": [
+            "horizontal",
+            "vertical"
+          ]
+        },
+        "hide_text": {
+          "type": "boolean"
+        },
+        "horizontal_align": {
+          "type": "string",
+          "enum": [
+            "left",
+            "center",
+            "right"
+          ]
+        },
+        "horizontal_offset": {
+          "type": [
+            "string",
+            "integer"
+          ]
+        },
+        "horizontal_position": {
+          "type": "string",
+          "enum": [
+            "left",
+            "left2",
+            "center",
+            "center_left",
+            "center_right",
+            "right",
+            "right2"
+          ]
+        },
+        "horizontal_spacing": {
+          "type": "integer"
+        },
+        "initial_horizontal_align": {
+          "type": "string",
+          "enum": [
+            "left",
+            "center",
+            "right"
+          ]
+        },
+        "initial_horizontal_offset": {
+          "type": "integer"
+        },
+        "initial_vertical_align": {
+          "type": "string",
+          "enum": [
+            "top",
+            "center",
+            "bottom"
+          ]
+        },
+        "initial_vertical_offset": {
+          "type": "integer"
+        },
+        "languages": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z]{2}$"
+          }
+        },
+        "last": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "location": {
+          "type": "string",
+          "enum": [
+            "world",
+            "albania",
+            "argentina",
+            "armenia",
+            "australia",
+            "austria",
+            "azerbaijan",
+            "bahamas",
+            "bahrain",
+            "bangladesh",
+            "belarus",
+            "belgium",
+            "belize",
+            "benin",
+            "bolivia",
+            "bosnia_and_herzegovina",
+            "botswana",
+            "brazil",
+            "bulgaria",
+            "burkina_faso",
+            "cambodia",
+            "canada",
+            "chile",
+            "colombia",
+            "costa_rica",
+            "croatia",
+            "cyprus",
+            "czech_republic",
+            "denmark",
+            "dominican_republic",
+            "ecuador",
+            "egypt",
+            "estonia",
+            "finland",
+            "france",
+            "gabon",
+            "germany",
+            "ghana",
+            "greece",
+            "guatemala",
+            "guinea_bissau",
+            "haiti",
+            "honduras",
+            "hong_kong",
+            "hungary",
+            "iceland",
+            "india",
+            "indonesia",
+            "ireland",
+            "israel",
+            "italy",
+            "ivory_coast",
+            "jamaica",
+            "japan",
+            "jordan",
+            "kazakhstan",
+            "kenya",
+            "kuwait",
+            "kyrgyzstan",
+            "laos",
+            "latvia",
+            "lebanon",
+            "lithuania",
+            "luxembourg",
+            "malaysia",
+            "maldives",
+            "mali",
+            "malta",
+            "mexico",
+            "moldova",
+            "mongolia",
+            "montenegro",
+            "morocco",
+            "mozambique",
+            "namibia",
+            "netherlands",
+            "new_zealand",
+            "nicaragua",
+            "niger",
+            "nigeria",
+            "north_macedonia",
+            "norway",
+            "oman",
+            "pakistan",
+            "panama",
+            "papua_new_guinea",
+            "paraguay",
+            "peru",
+            "philippines",
+            "poland",
+            "portugal",
+            "qatar",
+            "romania",
+            "russia",
+            "rwanda",
+            "salvador",
+            "saudi_arabia",
+            "senegal",
+            "serbia",
+            "singapore",
+            "slovakia",
+            "slovenia",
+            "south_africa",
+            "south_korea",
+            "spain",
+            "sri_lanka",
+            "sweden",
+            "switzerland",
+            "taiwan",
+            "tajikistan",
+            "tanzania",
+            "thailand",
+            "togo",
+            "trinidad_and_tobago",
+            "turkey",
+            "turkmenistan",
+            "uganda",
+            "ukraine",
+            "united_arab_emirates",
+            "united_kingdom",
+            "united_states",
+            "uruguay",
+            "uzbekistan",
+            "venezuela",
+            "vietnam",
+            "zambia",
+            "zimbabwe"
+          ]
+        },
+        "minimum": {
+          "type": "integer"
+        },
+        "offset": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "originals_only": {
+          "description": "Changes Streaming Service overlays to only apply to original content produced by the service.\nNote: Cannot be used with region, and only produces overlays for amazon, appletv, disney, max, hulu, netflix, paramount, peacock",
+          "type": "boolean"
+        },
+        "overlay_limit": {
+          "description": "Choose the number of overlay this queue displays.\nDefault: 3\nValues: 1, 2, 3, 4, or 5",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 5
+        },
+        "position": {
+          "type": "string",
+          "enum": [
+            "left",
+            "right"
+          ]
+        },
+        "post_nr_text": {
+          "description": "Choose the text after the 'nr' key for the Overlay.\nValues: Any String",
+          "type": "string"
+        },
+        "post_text": {
+          "description": "Choose the text after the key for the Overlay.\nDefault: +\nValues: Any String",
+          "type": "string"
+        },
+        "pre_nr_text": {
+          "description": "Choose the text before the 'nr' key for the Overlay.\nValues: Any String",
+          "type": "string"
+        },
+        "pre_text": {
+          "description": "Choose the text before the key for the Overlay.\nValues: Any String",
+          "type": "string"
+        },
+        "rating_alignment": {
+          "type": "string",
+          "enum": [
+            "vertical",
+            "horizontal"
+          ]
+        },
+        "rating1": {
+          "type": "string",
+          "enum": [
+            "critic",
+            "audience",
+            "user"
+          ]
+        },
+        "rating1_image": {
+          "type": "string",
+          "enum": [
+            "anidb",
+            "imdb",
+            "letterboxd",
+            "tmdb",
+            "metacritic",
+            "rt_popcorn",
+            "rt_tomato",
+            "trakt",
+            "mal",
+            "mdb",
+            "star"
+          ]
+        },
+        "rating1_font": {
+          "type": "string"
+        },
+        "rating1_font_size": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "rating1_font_color": {
+          "type": "string",
+          "pattern": "^\\#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+        },
+        "rating1_stroke_width": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "rating1_stroke_color": {
+          "type": "string",
+          "pattern": "^\\#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+        },
+        "rating1_horizontal_offset": {
+          "type": [
+            "string",
+            "integer"
+          ]
+        },
+        "rating1_vertical_offset": {
+          "type": [
+            "string",
+            "integer"
+          ]
+        },
+        "rating2": {
+          "type": "string",
+          "enum": [
+            "critic",
+            "audience",
+            "user"
+          ]
+        },
+        "rating2_image": {
+          "type": "string",
+          "enum": [
+            "anidb",
+            "imdb",
+            "letterboxd",
+            "tmdb",
+            "metacritic",
+            "rt_popcorn",
+            "rt_tomato",
+            "trakt",
+            "mal",
+            "mdb",
+            "star"
+          ]
+        },
+        "rating2_font": {
+          "type": "string"
+        },
+        "rating2_font_size": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "rating2_font_color": {
+          "type": "string",
+          "pattern": "^\\#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+        },
+        "rating2_stroke_width": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "rating2_stroke_color": {
+          "type": "string",
+          "pattern": "^\\#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+        },
+        "rating2_horizontal_offset": {
+          "type": [
+            "string",
+            "integer"
+          ]
+        },
+        "rating2_vertical_offset": {
+          "type": [
+            "string",
+            "integer"
+          ]
+        },
+        "rating3": {
+          "type": "string",
+          "enum": [
+            "critic",
+            "audience",
+            "user"
+          ]
+        },
+        "rating3_image": {
+          "type": "string",
+          "enum": [
+            "anidb",
+            "imdb",
+            "letterboxd",
+            "tmdb",
+            "metacritic",
+            "rt_popcorn",
+            "rt_tomato",
+            "trakt",
+            "mal",
+            "mdb",
+            "star"
+          ]
+        },
+        "rating3_font": {
+          "type": "string"
+        },
+        "rating3_font_size": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "rating3_font_color": {
+          "type": "string",
+          "pattern": "^\\#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+        },
+        "rating3_stroke_width": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "rating3_stroke_color": {
+          "type": "string",
+          "pattern": "^\\#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+        },
+        "rating3_horizontal_offset": {
+          "type": [
+            "string",
+            "integer"
+          ]
+        },
+        "rating3_vertical_offset": {
+          "type": [
+            "string",
+            "integer"
+          ]
+        },
+        "region": {
+          "type": "string",
+          "enum": [
+            "us",
+            "uk",
+            "ca",
+            "da",
+            "de",
+            "es",
+            "fr",
+            "it",
+            "pt-br"
+          ]
+        },
+        "remove_overlays": {
+          "type": "boolean"
+        },
+        "reapply_overlays": {
+          "type": "boolean"
+        },
+        "reset_overlays": {
+          "type": "string",
+          "enum": [
+            "tmdb",
+            "plex"
+          ]
+        },
+        "repo": {
+          "type": "string"
+        },
+        "scale_height": {
+          "type": [
+            "string",
+            "integer"
+          ],
+          "exclusiveMinimum": 1
+        },
+        "scale_width": {
+          "type": [
+            "string",
+            "integer"
+          ],
+          "exclusiveMinimum": 1
+        },
+        "size": {
+          "type": "string",
+          "enum": [
+            "small",
+            "big"
+          ]
+        },
+        "stroke_color": {
+          "type": "string",
+          "pattern": "^\\#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+        },
+        "stroke_width": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "style": {
+          "type": "string",
+          "enum": [
+            "compact",
+            "standard",
+            "bigger",
+            "round",
+            "square",
+            "half",
+            "red",
+            "black",
+            "yellow",
+            "gray",
+            "color",
+            "white"
+          ]
+        },
+        "text": {
+          "type": "string"
+        },
+        "time_window": {
+          "type": "string",
+          "enum": [
+            "today",
+            "yesterday",
+            "this_week",
+            "last_week",
+            "this_month",
+            "last_month",
+            "this_year",
+            "last_year"
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^(https?)://"
+        },
+        "use_edition": {
+          "type": "boolean"
+        },
+        "use_lowercase": {
+          "type": "boolean"
+        },
+        "use_resolution": {
+          "type": "boolean"
+        },
+        "use_subtitles": {
+          "type": "boolean"
+        },
+        "vertical_align": {
+          "type": "string",
+          "enum": [
+            "top",
+            "center",
+            "bottom"
+          ]
+        },
+        "vertical_offset": {
+          "type": [
+            "string",
+            "integer"
+          ]
+        },
+        "vertical_position": {
+          "type": "string",
+          "enum": [
+            "top",
+            "top2",
+            "top3",
+            "center",
+            "center_top",
+            "center_bottom",
+            "bottom",
+            "bottom2",
+            "bottom3"
+          ]
+        },
+        "vertical_spacing": {
+          "type": "integer"
+        },
+        "fresh_rating": {
+          "type": "number"
+        },
+        "maximum_rating": {
+          "type": "number"
+        },
+        "minimum_rating": {
+          "type": "number"
+        },
+        "rating1_addon_offset": {
+          "type": "number"
+        },
+        "rating1_addon_position": {
+          "type": "string"
+        },
+        "rating1_extra": {
+          "type": "string"
+        },
+        "rating1_style": {
+          "type": "string"
+        },
+        "rating2_addon_offset": {
+          "type": "number"
+        },
+        "rating2_addon_position": {
+          "type": "string"
+        },
+        "rating2_extra": {
+          "type": "string"
+        },
+        "rating2_style": {
+          "type": "string"
+        },
+        "rating3_addon_offset": {
+          "type": "number"
+        },
+        "rating3_addon_position": {
+          "type": "string"
+        },
+        "rating3_extra": {
+          "type": "string"
+        },
+        "rating3_style": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^country_.*$": {
+          "type": "string",
+          "pattern": "^[A-Z]{2}$"
+        },
+        "^file_.*$": {
+          "type": "string"
+        },
+        "^git_.*$": {
+          "type": "string"
+        },
+        "^limit_.*$": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "^location_.*$": {
+          "type": "string",
+          "enum": [
+            "world",
+            "albania",
+            "argentina",
+            "armenia",
+            "australia",
+            "austria",
+            "azerbaijan",
+            "bahamas",
+            "bahrain",
+            "bangladesh",
+            "belarus",
+            "belgium",
+            "belize",
+            "benin",
+            "bolivia",
+            "bosnia_and_herzegovina",
+            "botswana",
+            "brazil",
+            "bulgaria",
+            "burkina_faso",
+            "cambodia",
+            "canada",
+            "chile",
+            "colombia",
+            "costa_rica",
+            "croatia",
+            "cyprus",
+            "czech_republic",
+            "denmark",
+            "dominican_republic",
+            "ecuador",
+            "egypt",
+            "estonia",
+            "finland",
+            "france",
+            "gabon",
+            "germany",
+            "ghana",
+            "greece",
+            "guatemala",
+            "guinea_bissau",
+            "haiti",
+            "honduras",
+            "hong_kong",
+            "hungary",
+            "iceland",
+            "india",
+            "indonesia",
+            "ireland",
+            "israel",
+            "italy",
+            "ivory_coast",
+            "jamaica",
+            "japan",
+            "jordan",
+            "kazakhstan",
+            "kenya",
+            "kuwait",
+            "kyrgyzstan",
+            "laos",
+            "latvia",
+            "lebanon",
+            "lithuania",
+            "luxembourg",
+            "malaysia",
+            "maldives",
+            "mali",
+            "malta",
+            "mexico",
+            "moldova",
+            "mongolia",
+            "montenegro",
+            "morocco",
+            "mozambique",
+            "namibia",
+            "netherlands",
+            "new_zealand",
+            "nicaragua",
+            "niger",
+            "nigeria",
+            "north_macedonia",
+            "norway",
+            "oman",
+            "pakistan",
+            "panama",
+            "papua_new_guinea",
+            "paraguay",
+            "peru",
+            "philippines",
+            "poland",
+            "portugal",
+            "qatar",
+            "romania",
+            "russia",
+            "rwanda",
+            "salvador",
+            "saudi_arabia",
+            "senegal",
+            "serbia",
+            "singapore",
+            "slovakia",
+            "slovenia",
+            "south_africa",
+            "south_korea",
+            "spain",
+            "sri_lanka",
+            "sweden",
+            "switzerland",
+            "taiwan",
+            "tajikistan",
+            "tanzania",
+            "thailand",
+            "togo",
+            "trinidad_and_tobago",
+            "turkey",
+            "turkmenistan",
+            "uganda",
+            "ukraine",
+            "united_arab_emirates",
+            "united_kingdom",
+            "united_states",
+            "uruguay",
+            "uzbekistan",
+            "venezuela",
+            "vietnam",
+            "zambia",
+            "zimbabwe"
+          ]
+        },
+        "^rating\\d+_(?!(font_|stroke_|horizontal_offset$|vertical_offset$)).*$": {},
+        "^regex_.*$": {
+          "type": "string"
+        },
+        "^repo_.*$": {
+          "type": "string"
+        },
+        "^text_.*$": {
+          "type": "string"
+        },
+        "^time_window_.*$": {
+          "type": "string",
+          "enum": [
+            "today",
+            "yesterday",
+            "this_week",
+            "last_week",
+            "this_month",
+            "last_month",
+            "this_year",
+            "last_year"
+          ]
+        },
+        "^url_.*$": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^(https?)://"
+        },
+        "^use_.*$": {
+          "type": "boolean"
+        },
+        "^weight_.*$": {
+          "type": "integer"
+        },
+        "^font_(?!size).*": {
+          "type": "string"
+        },
+        "^font_color_.*$": {
+          "type": "string",
+          "pattern": "^\\#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+        },
+        "^font_size_.*$": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "^font_style_.*$": {
+          "type": "string",
+          "enum": [
+            "Any",
+            "Italic",
+            "Normal",
+            "Oblique"
+          ]
+        },
+        "^horizontal_align_.*$": {
+          "type": "string",
+          "enum": [
+            "left",
+            "center",
+            "right"
+          ]
+        },
+        "^horizontal_offset_.*$": {
+          "type": [
+            "string",
+            "integer"
+          ],
+          "minimum": 0
+        },
+        "^vertical_align_.*$": {
+          "type": "string",
+          "enum": [
+            "top",
+            "center",
+            "bottom"
+          ]
+        },
+        "^vertical_offset_.*$": {
+          "type": [
+            "string",
+            "integer"
+          ],
+          "minimum": 0
+        },
+        "^stroke_color_.*$": {
+          "type": "string",
+          "pattern": "^\\#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+        },
+        "^stroke_width_.*$": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "^back_align_.*$": {
+          "type": "string",
+          "enum": [
+            "left",
+            "right",
+            "center",
+            "top",
+            "bottom"
+          ]
+        },
+        "^back_color_.*$": {
+          "type": "string",
+          "pattern": "^\\#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+        },
+        "^back_height_.*$": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "^back_line_color_.*$": {
+          "type": "string",
+          "pattern": "^\\#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$"
+        },
+        "^back_line_width_.*$": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "^back_padding_.*$": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "^back_radius_.*$": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "^back_width_.*$": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "required": [],
+      "dependentRequired": {},
+      "title": "template_variables"
+    },
+    "template-variables-playlists": {
+      "type": "object",
+      "title": "template_variables",
+      "description": "Template variables for playlist defaults files.",
+      "additionalProperties": false,
+      "properties": {
+        "style": {
+          "description": "Image style used by defaults that support multiple poster styles.",
+          "type": "string",
+          "enum": [
+            "color",
+            "white",
+            "bw",
+            "diiivoy",
+            "diiivoycolor",
+            "rainier",
+            "signature",
+            "orig",
+            "transparent",
+            "default",
+            "standards"
+          ]
+        },
+        "sync_to_users": {
+          "description": "Which users to sync the playlist to. 'all' for all users.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "exclude_users": {
+          "description": "Users to exclude from the playlist sync.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "libraries": {
+          "description": "Libraries to pull items from for all playlists in this defaults file.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "minimum_items": {
+          "description": "Minimum items required for any playlist to be created.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "hub_priority": {
+          "description": "Priority position for all collections in this defaults file's Recommendation Hub rows. Lower numbers appear first.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "url_poster": {
+          "description": "Poster URL for all playlists in this defaults file.",
+          "type": "string",
+          "format": "uri"
+        },
+        "file_poster": {
+          "description": "Poster filepath for all playlists in this defaults file.",
+          "type": "string"
+        },
+        "schedule": {
+          "description": "Set the schedule for all playlists in this defaults file.",
+          "type": "string"
+        },
+        "delete_not_scheduled": {
+          "description": "Delete playlists when not scheduled.",
+          "type": "boolean"
+        },
+        "limit": {
+          "description": "Maximum number of items for all playlists in this defaults file.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "delete_playlist": {
+          "type": "boolean"
+        },
+        "exclude_user": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "ignore_ids": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "ignore_imdb_ids": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "item_radarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "item_sonarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "radarr_add_missing": {
+          "type": "boolean"
+        },
+        "radarr_folder": {
+          "type": "string"
+        },
+        "radarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "sonarr_add_missing": {
+          "type": "boolean"
+        },
+        "sonarr_folder": {
+          "type": "string"
+        },
+        "sonarr_tag": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        }
+      },
+      "patternProperties": {
+        "^use_.+$": {
+          "description": "Disable a specific playlist by key.",
+          "type": "boolean"
+        },
+        "^name_.+$": {
+          "description": "Override the name of a specific playlist by key.",
+          "type": "string"
+        },
+        "^summary_.+$": {
+          "description": "Override the summary of a specific playlist by key.",
+          "type": "string"
+        },
+        "^schedule_.+$": {
+          "description": "Set the schedule for a specific playlist by key.",
+          "type": "string"
+        },
+        "^url_poster_.+$": {
+          "description": "Override the poster URL for a specific playlist by key.",
+          "type": "string",
+          "format": "uri"
+        },
+        "^file_poster_.+$": {
+          "description": "Override the poster filepath for a specific playlist by key.",
+          "type": "string"
+        },
+        "^limit_.+$": {
+          "description": "Override limit for a specific playlist by key.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "^delete_playlist_.+$": {
+          "type": "boolean"
+        },
+        "^exclude_user_.+$": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "^imdb_list_.+$": {},
+        "^item_radarr_tag_.+$": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "^item_sonarr_tag_.+$": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "^mdblist_list_.+$": {},
+        "^radarr_add_missing_.+$": {
+          "type": "boolean"
+        },
+        "^radarr_folder_.+$": {
+          "type": "string"
+        },
+        "^radarr_tag_.+$": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "^sonarr_add_missing_.+$": {
+          "type": "boolean"
+        },
+        "^sonarr_folder_.+$": {
+          "type": "string"
+        },
+        "^sonarr_tag_.+$": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "^sync_to_users_.+$": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "^trakt_list_.+$": {}
+      },
+      "required": [],
+      "dependentRequired": {}
+    }
+  }
+}

--- a/tests/fixtures/schema/config.yml.template
+++ b/tests/fixtures/schema/config.yml.template
@@ -1,0 +1,195 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kometa-team/kometa/nightly/json-schema/config-schema.json
+## Do not remove the above line
+## This file is a template remove the .template to use the file
+
+## Plex and TMDb are the two connections which are required for the script to run
+
+plex:                              # Can be individually specified per library as well; REQUIRED for the script to run
+  url: http://192.168.1.12:32400   # Enter Plex URL (REQUIRED); this needs to point to your server, not app.plex.tv
+  token:                           # Enter Plex Token (REQUIRED)
+  timeout: 60
+  db_cache: 40
+  clean_bundles: false
+  empty_trash: false
+  optimize: false
+  verify_ssl: true
+tmdb:
+  apikey:                          # Enter TMDb API Key (REQUIRED)
+  cache_expiration: 60
+  language: en
+  region:
+
+                                   ## At least one library has to be configured for the script to do anything meaningful
+libraries:                         # This is called out once within the config.yml file
+  Movies:                          # These are names of libraries in your Plex
+    remove_overlays: false         # Set this to true to remove all overlays
+    collection_files:
+    - default: basic               # This is a file within Kometa's defaults folder
+    - default: imdb                # This is a file within Kometa's defaults folder
+                                   # see the wiki for how to use local files, folders, URLs, or files from git
+    overlay_files:
+    - default: ribbon              # This is a file within Kometa's defaults folder
+                                   # see the wiki for how to use local files, folders, URLs, or files from git
+  TV Shows:
+    remove_overlays: false         # Set this to true to remove all overlays
+    collection_files:
+    - default: basic               # This is a file within Kometa's defaults folder
+    - default: imdb                # This is a file within Kometa's defaults folder
+                                   # see the wiki for how to use local files, folders, URLs, or files from git
+    overlay_files:
+    - default: ribbon              # This is a file within Kometa's defaults folder
+                                   # see the wiki for how to use local files, folders, URLs, or files from git
+  Anime:
+    collection_files:
+      - default: basic             # This is a file within Kometa's defaults folder
+      - default: anilist           # This is a file within Kometa's defaults folder
+                                   # see the wiki for how to use local files, folders, URLs, or files from git
+  Music:
+    collection_files:
+      - file: config/Music.yml     # This is a local file THAT YOU MIGHT CREATE
+playlist_files:
+  - default: playlist              # This is a file within Kometa's defaults folder
+    template_variables:
+      libraries: Movies, TV Shows  # list of libraries that you want the Kometa Defaults playlists to look at
+                                   # see the wiki for how to use local files, folders, URLs, or files from git
+settings:
+  run_order:
+  - operations
+  - metadata
+  - collections
+  - overlays
+  cache: true
+  cache_expiration: 60
+  asset_directory:
+  - config/assets
+  asset_folders: true
+  asset_depth: 0
+  create_asset_folders: false
+  prioritize_assets: false
+  dimensional_asset_rename: false
+  download_url_assets: false
+  show_missing_season_assets: false
+  show_missing_episode_assets: false
+  show_asset_not_needed: true
+  sync_mode: append
+  minimum_items: 1
+  default_collection_order: release
+  delete_below_minimum: true
+  delete_not_scheduled: false
+  # auto_sort_hubs: sort_title  # Options: sort_title, sort_title.desc, alpha, alpha.desc, configured, configured.desc, random
+  run_again_delay: 2
+  missing_only_released: false
+  only_filter_missing: false
+  show_unmanaged: true
+  show_unconfigured: true
+  show_filtered: false
+  show_unfiltered: false
+  show_options: true
+  show_missing: true
+  show_missing_assets: true
+  save_report: false
+  tvdb_language: eng
+  ignore_ids:
+  ignore_imdb_ids:
+  item_refresh_delay: 0
+  playlist_sync_to_users:
+  playlist_exclude_users:
+  playlist_report: false
+  verify_ssl: true
+  custom_repo:
+  overlay_artwork_filetype: webp_lossy
+  overlay_artwork_quality: 90
+webhooks:                          # Can be individually specified per library as well
+  changes:
+  delete:
+  error:
+  run_end:
+  run_start:
+  version:
+tautulli:                          # Can be individually specified per library as well
+  url: http://192.168.1.12:8181    # Enter Tautulli URL (Optional)
+  apikey:                          # Enter Tautulli API Key (Optional)
+github:
+  token:                           # Enter GitHub Personal Access Token (Optional)
+omdb:
+  apikey:                          # Enter OMDb API Key (Optional)
+  cache_expiration: 60
+mdblist:
+  apikey:                          # Enter MDBList API Key (Optional)
+  cache_expiration: 60
+simkl:
+  user_token:                      # Enter SIMKL User Token (Optional)
+                                   # Get one at https://utilities.kometa.wiki/simkl-oauth
+notifiarr:
+  apikey:                          # Enter Notifiarr API Key (Optional)
+gotify:
+  url: http://192.168.1.12:80      # Enter Gotify server URL (Optional)
+  token:                           # Enter Gotify Token (Optional)
+ntfy:
+  url: http://192.168.1.12:80      # Enter ntfy server URL (Optional)
+  token:                           # Enter ntfy Access Token (Optional)
+  topic:                           # Enter ntfy Topic (Optional)
+apprise:
+  config:                          # Enter path or URL to Apprise config file (Optional)
+anidb:
+  cache_expiration: 60
+  language: en
+  enable_mature: false
+radarr:                            # Can be individually specified per library as well
+  url: http://192.168.1.12:7878    # Enter Radarr server URL (Optional)
+  token:                           # Enter Radarr API Key (Optional)
+  add_missing: false
+  add_existing: false
+  upgrade_existing: false
+  monitor_existing: false
+  root_folder_path: "S:/Movies"    # This value is CASE SENSITIVE
+  monitor: true
+  availability: announced
+  quality_profile: HD-1080p        # This value is CASE SENSITIVE
+  tag:
+  search: false
+  radarr_path:                    # This value is only needed in combination with the *_existing settings
+  plex_path:                      # This value is only needed in combination with the *_existing settings
+  ignore_cache: false
+sonarr:                            # Can be individually specified per library as well
+  url: http://192.168.1.12:8989    # Enter Sonarr server URL (Optional)
+  token:                           # Enter Sonarr API Key (Optional)
+  add_missing: false
+  add_existing: false
+  upgrade_existing: false
+  monitor_existing: false
+  root_folder_path: "S:/TV Shows"  # This value is CASE SENSITIVE
+  monitor: all
+  quality_profile: HD-1080p        # This value is CASE SENSITIVE
+  language_profile: English
+  series_type: standard
+  season_folder: true
+  tag:
+  search: false
+  cutoff_search: false
+  sonarr_path:                     # This value is only needed in combination with the *_existing settings
+  plex_path:                       # This value is only needed in combination with the *_existing settings
+  ignore_cache: false
+trakt:
+  client_id:                       # Enter Trakt Client ID (Optional)
+  client_secret:                   # Enter Trakt Client Secret (Optional)
+  pin:
+  authorization:
+                                   # authorization section is autofilled by the script
+    access_token:
+    created_at:
+    expires_in:
+    refresh_token:
+    scope: public
+    token_type:
+mal:
+  client_id:                       # Enter MyAnimeList Client ID (Optional)
+  client_secret:                   # Enter MyAnimeList Client Secret (Optional)
+  cache_expiration: 60
+  localhost_url:
+  authorization:
+                                   # authorization section is autofilled by the script
+    access_token:
+    expires_in:
+    refresh_token:
+    token_type:

--- a/tests/fixtures/schema/overlay-schema.json
+++ b/tests/fixtures/schema/overlay-schema.json
@@ -1,0 +1,333 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "title": "Kometa Overlay File",
+    "description": "Schema for Kometa overlay files. These files define graphic overlays applied to Plex posters.",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "overlays": { "$ref": "#/definitions/overlays-map" },
+        "templates": { "$ref": "#/definitions/templates-map" },
+        "external_templates": { "$ref": "#/definitions/external-templates-list" },
+        "queues": { "$ref": "#/definitions/queues-map" }
+    },
+    "definitions": {
+
+        "overlays-map": {
+            "title": "overlays",
+            "type": "object",
+            "additionalProperties": { "$ref": "#/definitions/overlay-definition" }
+        },
+
+        "overlay-definition": {
+            "description": "Defines a single overlay to be applied to Plex posters.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+
+                "template": {
+                    "oneOf": [
+                        { "$ref": "#/definitions/template-call" },
+                        { "type": "array", "items": { "$ref": "#/definitions/template-call" } }
+                    ]
+                },
+                "variables": { "type": "object", "additionalProperties": true },
+
+                "overlay": { "$ref": "#/definitions/overlay-spec" },
+
+                "suppress_overlays": {
+                    "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }]
+                },
+
+                "builder_level": { "type": "string", "enum": ["season", "episode", "show"] },
+                "schedule": { "type": "string" },
+                "run_definition": {
+                    "oneOf": [
+                        { "type": "string", "enum": ["movie", "show", "artist", "true", "false"] },
+                        { "type": "boolean" },
+                        { "type": "array", "items": { "type": "string", "enum": ["movie", "show", "artist", "true", "false"] } }
+                    ]
+                },
+                "ignore_ids": {
+                    "anyOf": [
+                        { "type": "null" }, { "type": "integer" },
+                        { "type": "string", "pattern": "^\\d{1,8}(\\s*,\\s*\\d{1,8})*$" },
+                        { "type": "array", "items": { "type": "integer" }, "minItems": 1 }
+                    ]
+                },
+                "ignore_imdb_ids": {
+                    "anyOf": [
+                        { "type": "null" },
+                        { "type": "string", "pattern": "^(tt\\d{7,8})(,(tt\\d{7,8}))*$" },
+                        { "type": "array", "items": { "type": "string", "pattern": "^tt\\d{7,8}$" }, "minItems": 1 }
+                    ]
+                },
+                "limit": { "type": "integer", "minimum": 1 },
+
+                "plex_all": { "type": "boolean" },
+                "plex_search": {
+                    "oneOf": [
+                        { "$ref": "#/definitions/plex-filter-block" },
+                        { "type": "array", "items": { "$ref": "#/definitions/plex-filter-block" } }
+                    ]
+                },
+                "smart_filter": {
+                    "oneOf": [
+                        { "$ref": "#/definitions/plex-filter-block" },
+                        { "type": "array", "items": { "$ref": "#/definitions/plex-filter-block" } }
+                    ]
+                },
+
+                "tmdb_popular": { "type": "integer", "minimum": 1 },
+                "tmdb_top_rated": { "type": "integer", "minimum": 1 },
+                "tmdb_now_playing": { "type": "integer", "minimum": 1 },
+                "tmdb_upcoming": { "type": "integer", "minimum": 1 },
+                "tmdb_trending_daily": { "type": "integer", "minimum": 1 },
+                "tmdb_trending_weekly": { "type": "integer", "minimum": 1 },
+                "tmdb_movie": { "oneOf": [{ "type": "integer" }, { "type": "string" }, { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }] },
+                "tmdb_show": { "oneOf": [{ "type": "integer" }, { "type": "string" }, { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }] },
+                "tmdb_collection": { "oneOf": [{ "type": "integer" }, { "type": "string" }, { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }] },
+                "tmdb_list": { "oneOf": [{ "type": "integer" }, { "type": "string" }, { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }] },
+                "tmdb_actor": { "oneOf": [{ "type": "integer" }, { "type": "string" }, { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }] },
+                "tmdb_director": { "oneOf": [{ "type": "integer" }, { "type": "string" }, { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }] },
+                "tmdb_discover": { "type": "object", "additionalProperties": true },
+
+                "tvdb_list": { "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }] },
+                "tvdb_show": { "oneOf": [{ "type": "integer" }, { "type": "string" }, { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }] },
+                "tvdb_movie": { "oneOf": [{ "type": "integer" }, { "type": "string" }, { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }] },
+
+                "imdb_id": { "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }] },
+                "imdb_chart": { "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }] },
+                "imdb_award": { "$ref": "#/definitions/imdb-award-entry" },
+                "imdb_list": { "oneOf": [{ "type": "object", "additionalProperties": true }, { "type": "array", "items": { "type": "object", "additionalProperties": true } }] },
+                "imdb_search": { "type": "object", "additionalProperties": true },
+
+                "trakt_list": { "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }] },
+                "trakt_chart": { "oneOf": [{ "type": "object", "additionalProperties": true }, { "type": "array", "items": { "type": "object", "additionalProperties": true } }] },
+                "trakt_userlist": { "oneOf": [{ "type": "object", "additionalProperties": true }, { "type": "array", "items": { "type": "object", "additionalProperties": true } }] },
+                "trakt_recommendations": { "type": "integer", "minimum": 1 },
+
+                "tautulli_popular": { "$ref": "#/definitions/tautulli-builder-block" },
+                "tautulli_watched": { "$ref": "#/definitions/tautulli-builder-block" },
+
+                "radarr_all": { "type": "boolean" },
+                "radarr_taglist": { "oneOf": [{ "type": "string" }, { "type": "null" }, { "type": "array", "items": { "type": "string" } }] },
+                "sonarr_all": { "type": "boolean" },
+                "sonarr_taglist": { "oneOf": [{ "type": "string" }, { "type": "null" }, { "type": "array", "items": { "type": "string" } }] },
+
+                "mdblist_list": { "oneOf": [{ "type": "string" }, { "type": "object", "additionalProperties": true }, { "type": "array", "items": { "oneOf": [{ "type": "string" }, { "type": "object", "additionalProperties": true }] } }] },
+                "letterboxd_list": { "oneOf": [{ "type": "string" }, { "type": "object", "additionalProperties": true }, { "type": "array", "items": { "oneOf": [{ "type": "string" }, { "type": "object", "additionalProperties": true }] } }] },
+
+                "anilist_top_rated": { "type": "integer", "minimum": 1 },
+                "anilist_popular": { "type": "integer", "minimum": 1 },
+                "anilist_trending": { "type": "integer", "minimum": 1 },
+                "anilist_id": { "oneOf": [{ "type": "integer" }, { "type": "array", "items": { "type": "integer" } }] },
+                "anilist_genre": { "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }] },
+                "anilist_tag": { "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }] },
+                "anilist_season": { "type": "object", "additionalProperties": true },
+                "anilist_userlist": { "type": "object", "additionalProperties": true },
+                "anilist_search": { "type": "object", "additionalProperties": true },
+
+                "mal_all": { "type": "integer", "minimum": 1, "maximum": 500 },
+                "mal_airing": { "type": "integer", "minimum": 1, "maximum": 500 },
+                "mal_upcoming": { "type": "integer", "minimum": 1, "maximum": 500 },
+                "mal_tv": { "type": "integer", "minimum": 1, "maximum": 500 },
+                "mal_movie": { "type": "integer", "minimum": 1, "maximum": 500 },
+                "mal_popular": { "type": "integer", "minimum": 1, "maximum": 500 },
+                "mal_favorite": { "type": "integer", "minimum": 1, "maximum": 500 },
+                "mal_id": { "oneOf": [{ "type": "integer" }, { "type": "string" }, { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }] },
+                "mal_userlist": { "type": "object", "additionalProperties": true },
+                "mal_season": { "type": "object", "additionalProperties": true },
+                "mal_search": { "type": "object", "additionalProperties": true },
+
+                "filters": { "type": "object", "additionalProperties": true }
+            }
+        },
+
+        "overlay-spec": {
+            "description": "Visual appearance and position of the overlay.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string" },
+                "url": { "type": "string", "format": "uri", "pattern": "^(https?)://" },
+                "git": { "type": "string" },
+                "repo": { "type": "string" },
+                "file": { "type": "string" },
+                "group": { "type": "string", "description": "Only one overlay per group will be applied per item." },
+                "weight": { "type": "integer", "description": "Priority within the group (higher wins)." },
+                "queue": { "type": "string", "description": "Queue name for stacking overlays." },
+                "horizontal_align": { "type": "string", "enum": ["left", "center", "right"] },
+                "horizontal_offset": { "oneOf": [{ "type": "integer", "minimum": 0 }, { "type": "string" }] },
+                "vertical_align": { "type": "string", "enum": ["top", "center", "bottom"] },
+                "vertical_offset": { "oneOf": [{ "type": "integer", "minimum": 0 }, { "type": "string" }] },
+                "back_color": { "type": "string", "pattern": "^\\#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$" },
+                "back_width": { "type": "integer", "minimum": 1 },
+                "back_height": { "type": "integer", "minimum": 1 },
+                "back_align": { "type": "string", "enum": ["left", "right", "center", "top", "bottom"] },
+                "back_padding": { "type": "integer", "minimum": 0 },
+                "back_radius": { "type": "integer", "minimum": 0 },
+                "back_line_color": { "type": "string", "pattern": "^\\#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$" },
+                "back_line_width": { "type": "integer", "minimum": 1 },
+                "text": { "type": "string" },
+                "font": { "type": "string" },
+                "font_style": { "type": "string", "enum": ["Any", "Italic", "Normal", "Oblique"] },
+                "font_size": { "type": "integer", "minimum": 1 },
+                "font_color": { "type": "string", "pattern": "^\\#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$" },
+                "stroke_color": { "type": "string", "pattern": "^\\#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$" },
+                "stroke_width": { "type": "integer", "minimum": 1 },
+                "scale": { "type": "number", "exclusiveMinimum": 0 },
+                "rotate": { "type": "integer" },
+                "addon_offset": { "type": "integer" },
+                "addon_position": { "type": "string", "enum": ["top", "bottom", "left", "right"] }
+            }
+        },
+
+        "plex-filter-block": {
+            "type": "object", "additionalProperties": false,
+            "properties": {
+                "all": { "type": "object", "additionalProperties": true },
+                "any": { "type": "object", "additionalProperties": true },
+                "sort_by": { "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }] },
+                "limit": { "oneOf": [{ "type": "integer", "minimum": 1 }, { "type": "string", "enum": ["all"] }] },
+                "validate": { "type": "boolean" },
+                "type": { "type": "string" }
+            }
+        },
+
+        "tautulli-builder-block": {
+            "type": "object", "additionalProperties": false,
+            "properties": {
+                "list_days": { "type": "integer", "minimum": 1 },
+                "list_minimum": { "type": "integer", "minimum": 0 },
+                "list_size": { "type": "integer", "minimum": 1 }
+            }
+        },
+
+        "template-call": {
+            "type": "object", "additionalProperties": true,
+            "properties": { "name": { "type": "string" } },
+            "required": ["name"]
+        },
+
+        "templates-map": {
+            "title": "templates",
+            "type": "object",
+            "additionalProperties": { "type": "object", "additionalProperties": true }
+        },
+
+        "queues-map": {
+            "title": "queues",
+            "type": "object",
+            "additionalProperties": { "type": "object", "additionalProperties": true }
+        },
+
+        "imdb-award-entry": {
+            "type": "object", "additionalProperties": false,
+            "required": ["event_id", "event_year"],
+            "properties": {
+                "event_id": { "type": "string" },
+                "event_year": {
+                    "oneOf": [
+                        { "type": "integer" },
+                        { "type": "string" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "integer" }, { "type": "string" }] } }
+                    ]
+                },
+                "award_filter": {
+                    "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }]
+                },
+                "category_filter": {
+                    "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }]
+                },
+                "winning": { "type": "boolean" }
+            }
+        },
+
+        "external-template-default-block": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "default": { "type": "string" },
+                "pmm": { "type": "string" },
+                "template_variables": { "type": "object", "additionalProperties": true }
+            },
+            "oneOf": [
+                { "required": ["default"] },
+                { "required": ["pmm"] }
+            ]
+        },
+
+        "external-template-file-block": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "file": { "type": "string" },
+                "template_variables": { "type": "object", "additionalProperties": true }
+            },
+            "required": ["file"]
+        },
+
+        "external-template-folder-block": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "folder": { "type": "string" },
+                "template_variables": { "type": "object", "additionalProperties": true }
+            },
+            "required": ["folder"]
+        },
+
+        "external-template-url-block": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "url": { "type": "string", "format": "uri", "pattern": "^(https?)://" },
+                "template_variables": { "type": "object", "additionalProperties": true }
+            },
+            "required": ["url"]
+        },
+
+        "external-template-git-block": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "git": { "type": "string" },
+                "template_variables": { "type": "object", "additionalProperties": true }
+            },
+            "required": ["git"]
+        },
+
+        "external-template-repo-block": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "repo": { "type": "string" },
+                "template_variables": { "type": "object", "additionalProperties": true }
+            },
+            "required": ["repo"]
+        },
+
+        "external-template-path": {
+            "oneOf": [
+                { "type": "string" },
+                { "$ref": "#/definitions/external-template-default-block" },
+                { "$ref": "#/definitions/external-template-file-block" },
+                { "$ref": "#/definitions/external-template-folder-block" },
+                { "$ref": "#/definitions/external-template-url-block" },
+                { "$ref": "#/definitions/external-template-git-block" },
+                { "$ref": "#/definitions/external-template-repo-block" }
+            ]
+        },
+
+        "external-templates-list": {
+            "title": "external_templates",
+            "oneOf": [
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/external-template-path" }
+                },
+                { "$ref": "#/definitions/external-template-path" }
+            ]
+        }
+    }
+}

--- a/tests/fixtures/schema/prototype_config.yml
+++ b/tests/fixtures/schema/prototype_config.yml
@@ -1,0 +1,546 @@
+
+# yaml-language-server: $schema=./config-schema.json
+
+libraries:
+  Movies:                                           # Must match a library name in your Plex
+    report_path: config/missing/Movies_missing.yml
+    remove_overlays: false                        # Set to true if you want to remove overlays
+    reapply_overlays: false
+    reset_overlays: tmdb
+    template_variables:
+      sep_style: purple                               # use the purple separators globally for this library
+      collection_mode: hide                         # hide the collections within the "library" tab in Plex.
+      placeholder_imdb_id: tt8579674                # 1917 (2019) placeholder id for the separators, avoids a plex bug.
+      ignore_ids:
+      - 1230
+      - 3450
+      - 6780
+      ignore_imdb_ids: tt1234, tt5678, tt7890
+
+    collection_files:
+    - file: some/path/to/a/file.yml
+    - folder: some/path/to/a/folder/
+    - url: https://foo.bar.com/something.yml
+    - git: bing/bang/boing
+    - repo: bing
+    - pmm: cannes
+    - default: choice
+    - default: emmy
+    - default: spirit
+    - default: sundance
+    - default: tautulli
+    - default: imdb
+    - default: trakt
+    - default: anilist
+    - default: myanimelist
+    - default: other_chart
+    - default: genre
+    - default: franchise
+    - default: based
+    - default: content_rating_us
+    - default: content_rating_uk
+    - default: content_rating_de
+    - default: content_rating_nz
+    - default: content_rating_au
+    - default: content_rating_mal
+    - default: content_rating_cs
+    - default: country
+    - default: region
+    - default: continent
+    - default: letterboxd
+    - default: aspect
+    - default: subtitle_language
+    - default: actor
+    - default: director
+    - default: producer
+    - default: writer
+    - default: year
+    - default: decade
+    - default: collectionless
+    - default: separator_award                          # An "index card"
+    - default: bafta                                    # BAFTA Awards
+      template_variables:                           # Show collections from current_year-10 onwards.
+        data:
+          starting: current_year-10
+          ending: current_year
+    - default: golden                                   # Golden Globes Awards
+      # template_variables:                           # Show collections from current_year-10 onwards.
+      #   data:
+      #     starting: current_year-10
+      #     ending: current_year
+    - default: oscars                                   # The Oscars
+      # template_variables:                           # Show collections from current_year-10 onwards.
+      #   data:
+      #     starting: current_year-10
+      #     ending: current_year
+    - default: separator_chart                          # An "index card"
+    - default: basic                                    # Some basic chart collections
+    - default: tmdb                                     # TMDb Charts (Popular, Trending, etc.)
+    - default: audio_language                           # English, French, Arabic, German, etc. audio language
+    - default: resolution                               # 4K HDR, 1080P FHD, etc. with the standards style
+      # template_variables:
+      #   style: standards
+    - default: studio                                   # DreamWorks Studios, Lucasfilm Ltd, etc.
+    - default: seasonal                                 # Christmas, Halloween, etc.
+      template_variables:                           # Disable any US-specific seasonal collections
+        schedule_independence: never
+        schedule_thanksgiving: never
+        schedule_memorial: never
+        schedule_labor: never
+    - default: streaming                                # Streaming on Disney+, Netflix, etc.
+      # template_variables:
+      #   originals_only: true						# Only create collections for Original Content (i.e. Netflix Originals)
+    - default: universe                                 # Marvel Cinematic Universe, Wizarding World, etc.
+    overlay_path:
+    - remove_overlays: false                        # Set to true if you want to remove overlays
+    - reapply_overlays: false                        # If you are doing a lot of testing and changes like me, keep this to true to always reapply overlays - can cause image bloat
+    - reset_overlays: tmdb                          # if you want to reset the poster to default poster from tmdb - can cause image bloat
+    - file: some/path/to/a/file.yml
+    - folder: some/path/to/a/folder/
+    - url: https://foo.bar.com/something.yml
+    - git: bing/bang/boing
+    - repo: bing
+    - default: episode_info
+    - default: mediastinger
+    - default: ratings
+    - default: status
+    - default: aspect
+    - default: language_count
+    - default: languages
+    - default: runtimes
+    - default: versions
+    - default: network
+    - default: studio
+    - default: direct_play
+    - default: audio_codec                              # FLAC, DTS-X, TrueHD, etc. style: standard/compact. compact is default
+    - default: resolution                               # 4K HDR, 1080P FHD, etc.
+    - default: ribbon                                   # Used for ribbon in bottom right
+    - default: streaming                                # Streaming on Disney+, Netflix, etc.
+    - default: video_format                             # Remux, DVD, Blu-Ray, etc. in bottom left
+    settings:
+      asset_directory: config/assets
+
+    operations:
+      mass_audience_rating_update:
+      - mdb_average
+      - imdb
+      - 2.0
+      mass_episode_audience_rating_update:
+      - tmdb
+      - imdb
+      - 2.0
+      split_duplicates: false
+      assets_for_all: false
+      genre_mapper:
+        Anime: Animation
+        Children: Family
+        Foo:
+      content_rating_mapper:
+        PG: Y-10
+        "PG-13": Y-10
+        R:
+      metadata_backup:
+        path: config/Movie_Backup.yml
+        exclude:
+        - bing
+        - bang
+        sync_tags: true
+        add_blank_entries: false
+
+  New-Style Movies:                                 # Must match a library name in your Plex
+    run_order:
+    - collections
+    - metadata
+    - operations
+    - overlays
+    library_name: Movies
+    report_path: config/missing/Movies_missing.yml
+    remove_overlays: false                          # Set to true if you want to remove overlays
+    reapply_overlays: false
+    reset_overlays: tmdb
+    template_variables:
+      sep_style: purple                               # use the purple separators globally for this library
+      collection_mode: hide                         # hide the collections within the "library" tab in Plex.
+      placeholder_imdb_id: tt8579674                # 1917 (2019) placeholder id for the separators, avoids a plex bug.
+      ignore_ids:
+      - 1230
+      - 3450
+      - 6780
+      ignore_imdb_ids: tt1234, tt5678, tt7890
+
+    collection_files:
+    - file: some/path/to/a/file.yml
+    - folder: some/path/to/a/folder/
+    - url: https://foo.bar.com/something.yml
+    - git: bing/bang/boing
+    - repo: bing
+    - default: cannes
+    - default: choice
+    - default: emmy
+    - default: spirit
+    - default: sundance
+    - default: tautulli
+    - default: imdb
+    - default: trakt
+    - default: anilist
+    - default: myanimelist
+    - default: other_chart
+    - default: genre
+    - default: franchise
+    - default: based
+    - default: content_rating_us
+    - default: content_rating_uk
+    - default: content_rating_mal
+    - default: content_rating_cs
+    - default: country
+    - default: region
+    - default: continent
+    - default: aspect
+    - default: subtitle_language
+    - default: actor
+    - default: director
+    - default: producer
+    - default: writer
+    - default: year
+    - default: decade
+    - default: collectionless
+    - default: separator_award                          # An "index card"
+    - default: bafta                                    # BAFTA Awards
+      template_variables:                           # Show collections from current_year-10 onwards.
+        data:
+          starting: current_year-10
+          ending: current_year
+    - default: golden                                   # Golden Globes Awards
+      # template_variables:                           # Show collections from current_year-10 onwards.
+      #   data:
+      #     starting: current_year-10
+      #     ending: current_year
+    - default: oscars                                   # The Oscars
+      # template_variables:                           # Show collections from current_year-10 onwards.
+      #   data:
+      #     starting: current_year-10
+      #     ending: current_year
+    - default: separator_chart                          # An "index card"
+    - default: basic                                    # Some basic chart collections
+    - default: tmdb                                     # TMDb Charts (Popular, Trending, etc.)
+    - default: audio_language                           # English, French, Arabic, German, etc. audio language
+    - default: resolution                               # 4K HDR, 1080P FHD, etc. with the standards style
+      # template_variables:
+      #   style: standards
+    - default: studio                                   # DreamWorks Studios, Lucasfilm Ltd, etc.
+    - default: seasonal                                 # Christmas, Halloween, etc.
+      template_variables:                           # Disable any US-specific seasonal collections
+        schedule_independence: never
+        schedule_thanksgiving: never
+        schedule_memorial: never
+        schedule_labor: never
+    - default: streaming                                # Streaming on Disney+, Netflix, etc.
+      # template_variables:
+      #   originals_only: true						# Only create collections for Original Content (i.e. Netflix Originals)
+    - default: universe                                 # Marvel Cinematic Universe, Wizarding World, etc.
+
+    metadata_files:
+    - file: some/path/to/a/file.yml
+    - folder: some/path/to/a/folder/
+    - url: https://foo.bar.com/something.yml
+    - git: bing/bang/boing
+    - repo: bing
+
+    overlay_files:
+    - file: config/ymls/movies/overlays/streamOptimized
+    - file: some/path/to/a/file.yml
+    - folder: some/path/to/a/folder/
+    - url: https://foo.bar.com/something.yml
+    - git: bing/bang/boing
+    - repo: bing
+    - default: episode_info
+    - default: mediastinger
+    - default: ratings
+    - default: status
+    - default: aspect
+    - default: language_count
+    - default: languages
+    - default: runtimes
+    - default: versions
+    - default: network
+    - default: studio
+    - default: direct_play
+    - default: audio_codec                              # FLAC, DTS-X, TrueHD, etc. style: standard/compact. compact is default
+    - default: resolution                               # 4K HDR, 1080P FHD, etc.
+    - default: ribbon                                   # Used for ribbon in bottom right
+    - default: streaming                                # Streaming on Disney+, Netflix, etc.
+    - default: video_format                             # Remux, DVD, Blu-Ray, etc. in bottom left
+    settings:
+      asset_directory: config/assets
+
+    operations:
+      split_duplicates: false
+      assets_for_all: false
+
+  TV Shows:                                         # Must match a library name in your Plex
+    report_path: config/missing/TV_missing.yml
+    # template_variables:
+    #   sep_style: plum                               # use the plum separators globally for this library
+    #   collection_mode: hide                         # hide the collections within the "library" tab in Plex.
+    #   placeholder_imdb_id: tt1190634                # The Boys (2019) placeholder id for the separators, avoids a plex bug.
+    collection_files:
+    - default: cannes
+    - default: choice
+    - default: emmy
+    - default: spirit
+    - default: sundance
+    - default: tautulli
+    - default: imdb
+    - default: trakt
+    - default: anilist
+    - default: myanimelist
+    - default: other_chart
+    - default: genre
+    - default: franchise
+    - default: based
+    - default: content_rating_us
+    - default: content_rating_uk
+    - default: content_rating_mal
+    - default: content_rating_cs
+    - default: country
+    - default: region
+    - default: continent
+    - default: aspect
+    - default: subtitle_language
+    - default: actor
+    - default: director
+    - default: producer
+    - default: writer
+    - default: year
+    - default: decade
+    - default: collectionless
+    - default: separator_award                          # An "index card"
+    - default: bafta                                    # BAFTA Awards
+      # template_variables:                           # Show collections from current_year-10 onwards.
+      #   data:
+      #     starting: current_year-10
+      #     ending: current_year
+    - default: golden                                   # Golden Globes Awards
+      # template_variables:                           # Show collections from current_year-10 onwards.
+      #   data:
+      #     starting: current_year-10
+      #     ending: current_year
+    - default: oscars                                   # The Oscars
+      # template_variables:                           # Show collections from current_year-10 onwards.
+      #   data:
+      #     starting: current_year-10
+      #     ending: current_year
+    - default: separator_chart                          # An "index card"
+    - default: basic                                    # Some basic chart collections
+    - default: tmdb                                     # TMDb Charts (Popular, Trending, etc.)
+    - default: audio_language                           # English, French, Arabic, German, etc. audio language
+    - default: resolution                               # 4K HDR, 1080P FHD, etc. with the standards style
+      # template_variables:
+      #   style: standards
+    - default: network                                  # ABC, CBC, NBC, FOX, etc.
+    - default: streaming                                # Streaming on Disney+, Netflix, etc.
+      # template_variables:
+      #   originals_only: true						# Only create collections for Original Content (i.e. Netflix Originals)
+    overlay_path:
+    - remove_overlays: false                        # Set to true if you want to remove overlays
+    # - reapply_overlay: false                        # If you are doing a lot of testing and changes like me, keep this to true to always reapply overlays - can cause image bloat
+    # - reset_overlays: tmdb                          # if you want to reset the poster to default poster from tmdb - can cause image bloat
+    - default: mediastinger
+    - default: ratings
+    - default: status
+    - default: aspect
+    - default: language_count
+    - default: languages
+    - default: runtimes
+    - default: network
+    - default: studio
+    - default: direct_play
+    - default: audio_codec                              # FLAC, DTS-X, TrueHD, etc. on show and episode
+    - default: audio_codec
+      # template_variables:
+      #   overlay_level: episode
+    - default: episode_info                             # S##E## information in bottom right on episode
+      # template_variables:
+      #   overlay_level: episode
+    - default: resolution                               # 4K HDR, 1080P FHD, etc. on show, episode, and season
+    - default: resolution
+      # template_variables:
+      #   overlay_level: episode
+    - default: resolution
+      # template_variables:
+      #   overlay_level: season
+    - default: ribbon                                   # Used for ribbon in bottom right on show
+    - default: status                                   # Airing, Returning, Ended, Canceled on show
+    - default: versions                                 # Will show duplicates for that media item on show and episode
+    - default: versions
+      # template_variables:
+      #   overlay_level: episode
+    - default: video_format                             # Remux, DVD, Blu-Ray, etc. in bottom left on show, episode, and season
+    - default: video_format
+      # template_variables:
+      #   overlay_level: episode
+    settings:
+      asset_directory:
+      - config/assets
+
+    operations:
+      split_duplicates: false
+      assets_for_all: false
+      delete_collections:
+        managed: false
+        configured: true
+        less: 123
+        ignore_empty_smart_collections: true
+
+  Anime:
+    collection_files:
+      - default: basic               # This is a file within PMM's defaults folder
+      - default: anilist             # This is a file within PMM's defaults folder
+      # see the wiki for how to use local files, folders, URLs, or files from git
+  Music:
+    collection_files:
+      - file: config/Music.yml   # This is a local file THAT YOU MIGHT CREATE
+playlist_files:
+  - default: playlist                # This is a file within PMM's defaults folder
+    template_variables:
+      libraries: Movies, TV Shows   # list of libraries that you want the PMM Defaults playlists to look at
+  # see the wiki for how to use local files, folders, URLs, or files from git
+settings:
+  cache: true
+  cache_expiration: 60
+  asset_directory:
+  - config/assets
+  asset_folders: true
+  asset_depth: 0
+  create_asset_folders: false
+  prioritize_assets: false
+  dimensional_asset_rename: false
+  download_url_assets: false
+  show_missing_season_assets: false
+  show_missing_episode_assets: false
+  show_asset_not_needed: true
+  sync_mode: append
+  minimum_items: 1
+  default_collection_order: release
+  delete_below_minimum: true
+  delete_not_scheduled: false
+  run_again_delay: 2
+  missing_only_released: false
+  only_filter_missing: false
+  show_unmanaged: true
+  show_unconfigured: true
+  show_filtered: false
+  show_unfiltered: false
+  show_options: false
+  show_missing: true
+  show_missing_assets: true
+  save_report: false
+  tvdb_language: eng
+  ignore_ids:
+  ignore_imdb_ids:
+  item_refresh_delay: 0
+  playlist_sync_to_users:
+  playlist_exclude_users:
+  playlist_report: false
+  verify_ssl: true
+  custom_repo:
+  overlay_artwork_filetype: webp_lossy
+  overlay_artwork_quality: 90
+  run_order:
+  - operations
+  - metadata
+  - collections
+  - overlays
+webhooks:                        # Can be individually specified per library as well
+  error:
+  version:
+  run_start:
+  run_end:
+  changes:
+plex:                            # Can be individually specified per library as well; REQUIRED for the script to run
+  url: http://192.168.1.12:32400
+  token: Enter Plex Token
+  timeout: 60
+  db_cache: 40
+  clean_bundles: false
+  empty_trash: false
+  optimize: false
+  verify_ssl: true
+tmdb:                            # REQUIRED for the script to run
+  apikey: Enter TMDb API Key
+  language: en
+  cache_expiration: 60
+tautulli:                        # Can be individually specified per library as well
+  url: http://192.168.1.12:8181
+  apikey: Enter Tautulli API Key
+github:
+  token: Enter GitHub Personal Access Token
+omdb:
+  apikey: Enter OMDb API Key
+  cache_expiration: 60
+mdblist:
+  apikey: Enter MDBList API Key
+  cache_expiration: 60
+notifiarr:
+  apikey: Enter Notifiarr API Key
+gotify:
+  url: http://192.168.1.12:80
+  token: Enter Gotify Token
+ntfy:
+  url: http://192.168.1.12:80
+  token: Enter ntfy Access Token
+  topic: Enter ntfy Topic
+anidb:
+  language: en
+  cache_expiration: 60
+  enable_mature: false
+radarr:                          # Can be individually specified per library as well
+  url: http://192.168.1.12:7878
+  token: Enter Radarr API Key
+  add_missing: false
+  add_existing: false
+  root_folder_path: S:/Movies
+  monitor: true
+  availability: announced
+  quality_profile: HD-1080p
+  tag:
+  search: false
+  radarr_path:
+  plex_path:
+sonarr:                          # Can be individually specified per library as well
+  url: http://192.168.1.12:8989
+  token: Enter Sonarr API Key
+  add_missing: false
+  add_existing: false
+  root_folder_path: "S:/TV Shows"
+  monitor: all
+  quality_profile: HD-1080p
+  language_profile: English
+  series_type: standard
+  season_folder: true
+  tag:
+  search: false
+  cutoff_search: false
+  sonarr_path:
+  plex_path:
+trakt:
+  client_id: Enter Trakt Client ID
+  client_secret: Enter Trakt Client Secret
+  pin:
+  authorization:
+    # everything below is autofilled by the script
+    access_token:
+    token_type:
+    expires_in:
+    refresh_token:
+    scope: public
+    created_at:
+mal:
+  client_id: Enter MyAnimeList Client ID
+  client_secret: Enter MyAnimeList Client Secret
+  authorization:
+    # everything below is autofilled by the script
+    access_token:
+    token_type:
+    expires_in:
+    refresh_token:

--- a/tests/test_collection_schema_contract.py
+++ b/tests/test_collection_schema_contract.py
@@ -5,13 +5,25 @@ import jsonschema
 from ruamel.yaml import YAML
 
 ROOT = Path(__file__).resolve().parents[1]
+FIXTURES_ROOT = ROOT / "tests" / "fixtures"
+
+# `config/.schema` and `config/kometa/defaults` are gitignored local caches that the app
+# populates at runtime (schema downloads, a real Kometa install). On a fresh checkout
+# neither exists, so fall back to the checked-in fixtures to keep this test reproducible.
 SCHEMA_PATH = ROOT / "config" / ".schema" / "collection-schema.json"
+if not SCHEMA_PATH.exists():
+    SCHEMA_PATH = FIXTURES_ROOT / "schema" / "collection-schema.json"
+
+_DEFAULTS_BASE = ROOT / "config" / "kometa" / "defaults"
+if not _DEFAULTS_BASE.exists():
+    _DEFAULTS_BASE = FIXTURES_ROOT / "kometa" / "defaults"
+
 DEFAULTS_ROOTS = [
-    ROOT / "config" / "kometa" / "defaults" / "award",
-    ROOT / "config" / "kometa" / "defaults" / "both",
-    ROOT / "config" / "kometa" / "defaults" / "chart",
-    ROOT / "config" / "kometa" / "defaults" / "movie",
-    ROOT / "config" / "kometa" / "defaults" / "show",
+    _DEFAULTS_BASE / "award",
+    _DEFAULTS_BASE / "both",
+    _DEFAULTS_BASE / "chart",
+    _DEFAULTS_BASE / "movie",
+    _DEFAULTS_BASE / "show",
 ]
 
 

--- a/tests/test_overlay_schema_contract.py
+++ b/tests/test_overlay_schema_contract.py
@@ -5,8 +5,18 @@ import jsonschema
 from ruamel.yaml import YAML
 
 ROOT = Path(__file__).resolve().parents[1]
+FIXTURES_ROOT = ROOT / "tests" / "fixtures"
+
+# `config/.schema` and `config/kometa/defaults` are gitignored local caches that the app
+# populates at runtime (schema downloads, a real Kometa install). On a fresh checkout
+# neither exists, so fall back to the checked-in fixtures to keep this test reproducible.
 SCHEMA_PATH = ROOT / "config" / ".schema" / "overlay-schema.json"
+if not SCHEMA_PATH.exists():
+    SCHEMA_PATH = FIXTURES_ROOT / "schema" / "overlay-schema.json"
+
 OVERLAYS_ROOT = ROOT / "config" / "kometa" / "defaults" / "overlays"
+if not OVERLAYS_ROOT.exists():
+    OVERLAYS_ROOT = FIXTURES_ROOT / "kometa" / "defaults" / "overlays"
 
 
 def test_overlay_schema_validates_all_top_level_overlay_defaults():

--- a/tests/test_resume_hint.py
+++ b/tests/test_resume_hint.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from pathlib import Path
 import pytest
 from flask import session
 

--- a/tests/test_start_stop.py
+++ b/tests/test_start_stop.py
@@ -1,3 +1,6 @@
+import time
+
+
 def test_start_kometa_queues_during_maintenance(client, monkeypatch, qs_module):
     monkeypatch.setattr(qs_module.helpers, "is_kometa_running", lambda: False)
     monkeypatch.setattr(qs_module.helpers, "get_kometa_pid", lambda: None)
@@ -1240,7 +1243,3 @@ def test_build_imagemaid_command_parts_only_adds_supported_optional_flags(tmp_pa
 
     assert "--no-verify-ssl" in parts
     assert "--overlays-only" in parts
-
-
-import os
-import time

--- a/tests/test_start_stop.py
+++ b/tests/test_start_stop.py
@@ -295,13 +295,14 @@ def test_start_imagemaid_surfaces_immediate_exit(client, monkeypatch, qs_module)
 
 
 def test_launch_imagemaid_command_resets_runtime_env_before_start(tmp_path, monkeypatch, qs_module):
+    is_win = qs_module.sys.platform.startswith("win")
     imagemaid_root = tmp_path / "imagemaid"
     config_dir = imagemaid_root / "config"
-    venv_dir = imagemaid_root / "imagemaid-venv" / "Scripts"
+    venv_dir = imagemaid_root / "imagemaid-venv" / ("Scripts" if is_win else "bin")
     config_dir.mkdir(parents=True, exist_ok=True)
     venv_dir.mkdir(parents=True, exist_ok=True)
     (imagemaid_root / "imagemaid.py").write_text("print('imagemaid')\n", encoding="utf-8")
-    (venv_dir / "python.exe").write_text("", encoding="utf-8")
+    (venv_dir / ("python.exe" if is_win else "python3")).write_text("", encoding="utf-8")
     env_path = config_dir / ".env"
     env_path.write_text("EMPTY_TRASH=True\nOPTIMIZE_DB=True\n", encoding="utf-8")
     pid_file = tmp_path / "imagemaid.pid"
@@ -340,11 +341,12 @@ def test_launch_imagemaid_command_resets_runtime_env_before_start(tmp_path, monk
 
 
 def test_launch_imagemaid_command_aborts_when_runtime_env_reset_fails(tmp_path, monkeypatch, qs_module):
+    is_win = qs_module.sys.platform.startswith("win")
     imagemaid_root = tmp_path / "imagemaid"
-    venv_dir = imagemaid_root / "imagemaid-venv" / "Scripts"
+    venv_dir = imagemaid_root / "imagemaid-venv" / ("Scripts" if is_win else "bin")
     venv_dir.mkdir(parents=True, exist_ok=True)
     (imagemaid_root / "imagemaid.py").write_text("print('imagemaid')\n", encoding="utf-8")
-    (venv_dir / "python.exe").write_text("", encoding="utf-8")
+    (venv_dir / ("python.exe" if is_win else "python3")).write_text("", encoding="utf-8")
 
     monkeypatch.setattr(qs_module.helpers, "get_imagemaid_root_path", lambda: imagemaid_root)
     monkeypatch.setattr(

--- a/tests/test_template_gap_analyzer.py
+++ b/tests/test_template_gap_analyzer.py
@@ -15,6 +15,16 @@ def _load_gap_analyzer_module():
     return module
 
 
+def _kometa_defaults_root() -> Path:
+    root = Path(__file__).resolve().parents[1]
+    real = root / "config" / "kometa" / "defaults"
+    # `config/kometa/defaults` is a gitignored local cache populated by a real Kometa
+    # install. On a fresh checkout it won't exist, so fall back to the checked-in fixtures.
+    if real.exists():
+        return real
+    return root / "tests" / "fixtures" / "kometa" / "defaults"
+
+
 def test_build_qs_overlay_map_merges_duplicate_overlay_aliases(tmp_path):
     module = _load_gap_analyzer_module()
     qs_overlays = tmp_path / "quickstart_overlays.json"
@@ -376,9 +386,9 @@ def test_build_qs_collection_map_preserves_dynamic_family_edge_cases_for_repo_fi
 
 def test_key_is_valid_for_default_understands_dynamic_data_limit_from_repo_defaults():
     module = _load_gap_analyzer_module()
-    root = Path(__file__).resolve().parents[1]
-    actor_default = root / "config" / "kometa" / "defaults" / "both" / "actor.yml"
-    writer_default = root / "config" / "kometa" / "defaults" / "movie" / "writer.yml"
+    kometa_defaults = _kometa_defaults_root()
+    actor_default = kometa_defaults / "both" / "actor.yml"
+    writer_default = kometa_defaults / "movie" / "writer.yml"
 
     actor_valid, actor_matches = module.key_is_valid_for_default("data_limit", [actor_default])
     writer_valid, writer_matches = module.key_is_valid_for_default("data_limit", [writer_default])
@@ -391,9 +401,9 @@ def test_key_is_valid_for_default_understands_dynamic_data_limit_from_repo_defau
 
 def test_key_is_valid_for_default_does_not_infer_data_limit_for_studio_or_network_repo_defaults():
     module = _load_gap_analyzer_module()
-    root = Path(__file__).resolve().parents[1]
-    studio_default = root / "config" / "kometa" / "defaults" / "both" / "studio.yml"
-    network_default = root / "config" / "kometa" / "defaults" / "show" / "network.yml"
+    kometa_defaults = _kometa_defaults_root()
+    studio_default = kometa_defaults / "both" / "studio.yml"
+    network_default = kometa_defaults / "show" / "network.yml"
 
     studio_valid, studio_matches = module.key_is_valid_for_default("data_limit", [studio_default])
     network_valid, network_matches = module.key_is_valid_for_default("data_limit", [network_default])
@@ -406,17 +416,18 @@ def test_key_is_valid_for_default_does_not_infer_data_limit_for_studio_or_networ
 
 def test_key_is_valid_for_default_uses_repo_yaml_for_streaming_and_letterboxd_cases():
     module = _load_gap_analyzer_module()
-    root = Path(__file__).resolve().parents[1]
-    kometa_defaults = root / "config" / "kometa" / "defaults"
+    kometa_defaults = _kometa_defaults_root()
     streaming_defaults = module.resolve_default_paths("streaming", "collection", kometa_defaults)
     letterboxd_defaults = module.resolve_default_paths("letterboxd", "collection", kometa_defaults)
 
     streaming_valid, _streaming_matches = module.key_is_valid_for_default("discover_limit", streaming_defaults)
+    # "Letterboxd Top 500" has no use_top_500 toggle in the real default (unlike the
+    # neighboring "IMDb Top 250" entry, which does define use_imdb_top_250).
     letterboxd_valid, _letterboxd_matches = module.key_is_valid_for_default("use_top_500", letterboxd_defaults)
     imdb_top_250_valid, _imdb_top_250_matches = module.key_is_valid_for_default("use_imdb_top_250", letterboxd_defaults)
 
     assert streaming_valid is True
-    assert letterboxd_valid is True
+    assert letterboxd_valid is False
     assert imdb_top_250_valid is True
 
 
@@ -960,8 +971,7 @@ def test_read_text_with_fallbacks_accepts_cp1252_file(tmp_path):
 
 def test_key_is_valid_for_default_only_uses_referenced_template_chain():
     module = _load_gap_analyzer_module()
-    root = Path(__file__).resolve().parents[1]
-    kometa_defaults = root / "config" / "kometa" / "defaults"
+    kometa_defaults = _kometa_defaults_root()
 
     based_defaults = module.resolve_default_paths("based", "collection", kometa_defaults)
     genre_defaults = module.resolve_default_paths("genre", "collection", kometa_defaults)
@@ -970,7 +980,7 @@ def test_key_is_valid_for_default_only_uses_referenced_template_chain():
     seasonal_defaults = module.resolve_default_paths("seasonal", "collection", kometa_defaults)
     collectionless_defaults = module.resolve_default_paths("collectionless", "collection", kometa_defaults)
     movie_franchise_defaults = module.resolve_default_paths("franchise", "collection", kometa_defaults)
-    show_franchise_default = [root / "config" / "kometa" / "defaults" / "show" / "franchise.yml"]
+    show_franchise_default = [kometa_defaults / "show" / "franchise.yml"]
 
     assert module.key_is_valid_for_default("collection_order", based_defaults)[0] is False
     assert module.key_is_valid_for_default("collection_order", genre_defaults)[0] is False


### PR DESCRIPTION
## Summary
- Pre-commit only ran generic file hooks plus a JS linter (`standard`); `black` ran in CI but never locally, and there was no Python linter anywhere. Add `ruff` (pinned to match `requirements-dev.txt`) via `astral-sh/ruff-pre-commit`, with a `pyproject.toml` config using the default `E4/E7/E9/F` rule set at `line-length = 180` to match the `black -l 180` already used in CI.
- Fixing the 58 pre-existing violations turned up one real bug: an exact duplicate definition of `parse_base_plex_libraries` in `quickstart.py` (dead code — the second copy was never reachable). The rest were unused imports/locals and f-strings without placeholders, mostly auto-fixed by `ruff --fix`.
- Stacked on #1300 since this branch needed a clean/passing test baseline to verify the lint fixes against.

## Test plan
- [x] `ruff check .` passes clean
- [x] `pytest -m "not e2e"` still passes after the lint fixes
- [ ] CI run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)