### PR TITLE
Extract background-jobs CRUD into modules/background_jobs.py

### DIFF
--- a/modules/background_jobs.py
+++ b/modules/background_jobs.py
@@ -1,0 +1,148 @@
+import threading
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+BACKGROUND_JOBS: Dict[str, Dict[str, Any]] = {}
+ACTIVE_BACKGROUND_JOBS: Dict[str, str] = {}
+BACKGROUND_JOBS_LOCK = threading.Lock()
+JOB_TARGET_PAGES = {
+    "logscan_reingest": "/logscan-trends",
+    "kometa_update": "/step/900-kometa",
+    "test_library_install": "/step/001-start",
+    "imagemaid_update": "/step/915-imagemaid",
+}
+
+
+def copy_background_job(job):
+    if not isinstance(job, dict):
+        return None
+    copied = dict(job)
+    if isinstance(copied.get("summary"), dict):
+        copied["summary"] = dict(copied["summary"])
+    if isinstance(copied.get("meta"), dict):
+        copied["meta"] = dict(copied["meta"])
+    if isinstance(copied.get("logs"), list):
+        copied["logs"] = list(copied["logs"])
+    return copied
+
+
+def create_background_job(job_type, job_id=None, trigger="manual", phase="queued", status="running", target_page=None, **extra):
+    normalized_type = str(job_type or "").strip()
+    if not normalized_type:
+        raise ValueError("job_type is required")
+    normalized_job_id = str(job_id or uuid.uuid4()).strip()
+    payload = {
+        "job_id": normalized_job_id,
+        "job_type": normalized_type,
+        "trigger": str(trigger or "manual").strip() or "manual",
+        "status": str(status or "running").strip() or "running",
+        "phase": str(phase or "").strip() or None,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "finished_at": None,
+        "target_page": target_page or JOB_TARGET_PAGES.get(normalized_type),
+        "summary": {},
+        "meta": {},
+    }
+    payload.update(extra)
+    with BACKGROUND_JOBS_LOCK:
+        BACKGROUND_JOBS[normalized_job_id] = payload
+        if payload["status"] in {"queued", "running"}:
+            ACTIVE_BACKGROUND_JOBS[normalized_type] = normalized_job_id
+    return copy_background_job(payload)
+
+
+def get_background_job(job_id):
+    normalized_job_id = str(job_id or "").strip()
+    if not normalized_job_id:
+        return None
+    with BACKGROUND_JOBS_LOCK:
+        payload = BACKGROUND_JOBS.get(normalized_job_id)
+        return copy_background_job(payload)
+
+
+def get_active_background_job(job_type):
+    normalized_type = str(job_type or "").strip()
+    if not normalized_type:
+        return None
+    with BACKGROUND_JOBS_LOCK:
+        job_id = ACTIVE_BACKGROUND_JOBS.get(normalized_type)
+        payload = BACKGROUND_JOBS.get(job_id) if job_id else None
+        return copy_background_job(payload)
+
+
+def get_active_background_jobs():
+    with BACKGROUND_JOBS_LOCK:
+        jobs = []
+        for job_id in ACTIVE_BACKGROUND_JOBS.values():
+            payload = BACKGROUND_JOBS.get(job_id)
+            if payload:
+                jobs.append(copy_background_job(payload))
+        return jobs
+
+
+def update_background_job(job_id, **updates):
+    normalized_job_id = str(job_id or "").strip()
+    if not normalized_job_id:
+        return None
+    with BACKGROUND_JOBS_LOCK:
+        payload = BACKGROUND_JOBS.get(normalized_job_id)
+        if not payload:
+            return None
+        payload.update(updates)
+        job_type = payload.get("job_type")
+        status = str(payload.get("status") or "").strip().lower()
+        if job_type:
+            if status in {"queued", "running"}:
+                ACTIVE_BACKGROUND_JOBS[job_type] = normalized_job_id
+            elif ACTIVE_BACKGROUND_JOBS.get(job_type) == normalized_job_id:
+                ACTIVE_BACKGROUND_JOBS.pop(job_type, None)
+        return copy_background_job(payload)
+
+
+def clear_active_background_job(job_type, job_id=None):
+    normalized_type = str(job_type or "").strip()
+    normalized_job_id = str(job_id or "").strip() or None
+    if not normalized_type:
+        return
+    with BACKGROUND_JOBS_LOCK:
+        active_job_id = ACTIVE_BACKGROUND_JOBS.get(normalized_type)
+        if normalized_job_id and active_job_id != normalized_job_id:
+            return
+        ACTIVE_BACKGROUND_JOBS.pop(normalized_type, None)
+
+
+def ensure_background_job(job_type, job_id=None, create_if_missing=False, **defaults):
+    normalized_type = str(job_type or "").strip()
+    if not normalized_type:
+        return None
+    candidate_id = str(job_id or "").strip() or None
+    if candidate_id:
+        existing = get_background_job(candidate_id)
+        if existing:
+            return existing
+    active = get_active_background_job(normalized_type)
+    if active:
+        return active
+    if not create_if_missing:
+        return None
+    return create_background_job(normalized_type, job_id=candidate_id, **defaults)
+
+
+def complete_background_job(job_id, phase="done", summary=None, **updates):
+    payload = {"status": "complete", "phase": phase, "finished_at": datetime.now(timezone.utc).isoformat()}
+    if summary is not None:
+        payload["summary"] = summary
+    payload.update(updates)
+    return update_background_job(job_id, **payload)
+
+
+def fail_background_job(job_id, error, phase="error", **updates):
+    payload = {
+        "status": "error",
+        "phase": phase,
+        "error": str(error or "Unknown error"),
+        "finished_at": datetime.now(timezone.utc).isoformat(),
+    }
+    payload.update(updates)
+    return update_background_job(job_id, **payload)

--- a/quickstart.py
+++ b/quickstart.py
@@ -54,20 +54,21 @@ from werkzeug.utils import secure_filename
 from werkzeug.wrappers import Request
 from flask_session import Session
 from modules import validations, output, persistence, helpers, database, logscan, importer, path_validation, url_validation
-from typing import Dict, Any
+from modules.background_jobs import (
+    JOB_TARGET_PAGES,
+    create_background_job as _create_background_job,
+    get_background_job as _get_background_job,
+    get_active_background_job as _get_active_background_job,
+    get_active_background_jobs as _get_active_background_jobs,
+    update_background_job as _update_background_job,
+    clear_active_background_job as _clear_active_background_job,
+    ensure_background_job as _ensure_background_job,
+    complete_background_job as _complete_background_job,
+    fail_background_job as _fail_background_job,
+)
 
 Request.max_form_parts = 100000  # Allow more form fields if needed
 
-# Shared in-memory background job store
-BACKGROUND_JOBS: Dict[str, Dict[str, Any]] = {}
-ACTIVE_BACKGROUND_JOBS: Dict[str, str] = {}
-BACKGROUND_JOBS_LOCK = threading.Lock()
-JOB_TARGET_PAGES = {
-    "logscan_reingest": "/logscan-trends",
-    "kometa_update": "/step/900-kometa",
-    "test_library_install": "/step/001-start",
-    "imagemaid_update": "/step/915-imagemaid",
-}
 ACTIVE_WORK_POLICIES = {
     "kometa_run": [
         {
@@ -192,140 +193,6 @@ SETTINGS_AUTO_SORT_HUBS_VALUES = {
     "configured.desc",
     "random",
 }
-
-
-def _copy_background_job(job):
-    if not isinstance(job, dict):
-        return None
-    copied = dict(job)
-    if isinstance(copied.get("summary"), dict):
-        copied["summary"] = dict(copied["summary"])
-    if isinstance(copied.get("meta"), dict):
-        copied["meta"] = dict(copied["meta"])
-    if isinstance(copied.get("logs"), list):
-        copied["logs"] = list(copied["logs"])
-    return copied
-
-
-def _create_background_job(job_type, job_id=None, trigger="manual", phase="queued", status="running", target_page=None, **extra):
-    normalized_type = str(job_type or "").strip()
-    if not normalized_type:
-        raise ValueError("job_type is required")
-    normalized_job_id = str(job_id or uuid.uuid4()).strip()
-    payload = {
-        "job_id": normalized_job_id,
-        "job_type": normalized_type,
-        "trigger": str(trigger or "manual").strip() or "manual",
-        "status": str(status or "running").strip() or "running",
-        "phase": str(phase or "").strip() or None,
-        "started_at": datetime.now(timezone.utc).isoformat(),
-        "finished_at": None,
-        "target_page": target_page or JOB_TARGET_PAGES.get(normalized_type),
-        "summary": {},
-        "meta": {},
-    }
-    payload.update(extra)
-    with BACKGROUND_JOBS_LOCK:
-        BACKGROUND_JOBS[normalized_job_id] = payload
-        if payload["status"] in {"queued", "running"}:
-            ACTIVE_BACKGROUND_JOBS[normalized_type] = normalized_job_id
-    return _copy_background_job(payload)
-
-
-def _get_background_job(job_id):
-    normalized_job_id = str(job_id or "").strip()
-    if not normalized_job_id:
-        return None
-    with BACKGROUND_JOBS_LOCK:
-        payload = BACKGROUND_JOBS.get(normalized_job_id)
-        return _copy_background_job(payload)
-
-
-def _get_active_background_job(job_type):
-    normalized_type = str(job_type or "").strip()
-    if not normalized_type:
-        return None
-    with BACKGROUND_JOBS_LOCK:
-        job_id = ACTIVE_BACKGROUND_JOBS.get(normalized_type)
-        payload = BACKGROUND_JOBS.get(job_id) if job_id else None
-        return _copy_background_job(payload)
-
-
-def _get_active_background_jobs():
-    with BACKGROUND_JOBS_LOCK:
-        jobs = []
-        for job_id in ACTIVE_BACKGROUND_JOBS.values():
-            payload = BACKGROUND_JOBS.get(job_id)
-            if payload:
-                jobs.append(_copy_background_job(payload))
-        return jobs
-
-
-def _update_background_job(job_id, **updates):
-    normalized_job_id = str(job_id or "").strip()
-    if not normalized_job_id:
-        return None
-    with BACKGROUND_JOBS_LOCK:
-        payload = BACKGROUND_JOBS.get(normalized_job_id)
-        if not payload:
-            return None
-        payload.update(updates)
-        job_type = payload.get("job_type")
-        status = str(payload.get("status") or "").strip().lower()
-        if job_type:
-            if status in {"queued", "running"}:
-                ACTIVE_BACKGROUND_JOBS[job_type] = normalized_job_id
-            elif ACTIVE_BACKGROUND_JOBS.get(job_type) == normalized_job_id:
-                ACTIVE_BACKGROUND_JOBS.pop(job_type, None)
-        return _copy_background_job(payload)
-
-
-def _clear_active_background_job(job_type, job_id=None):
-    normalized_type = str(job_type or "").strip()
-    normalized_job_id = str(job_id or "").strip() or None
-    if not normalized_type:
-        return
-    with BACKGROUND_JOBS_LOCK:
-        active_job_id = ACTIVE_BACKGROUND_JOBS.get(normalized_type)
-        if normalized_job_id and active_job_id != normalized_job_id:
-            return
-        ACTIVE_BACKGROUND_JOBS.pop(normalized_type, None)
-
-
-def _ensure_background_job(job_type, job_id=None, create_if_missing=False, **defaults):
-    normalized_type = str(job_type or "").strip()
-    if not normalized_type:
-        return None
-    candidate_id = str(job_id or "").strip() or None
-    if candidate_id:
-        existing = _get_background_job(candidate_id)
-        if existing:
-            return existing
-    active = _get_active_background_job(normalized_type)
-    if active:
-        return active
-    if not create_if_missing:
-        return None
-    return _create_background_job(normalized_type, job_id=candidate_id, **defaults)
-
-
-def _complete_background_job(job_id, phase="done", summary=None, **updates):
-    payload = {"status": "complete", "phase": phase, "finished_at": datetime.now(timezone.utc).isoformat()}
-    if summary is not None:
-        payload["summary"] = summary
-    payload.update(updates)
-    return _update_background_job(job_id, **payload)
-
-
-def _fail_background_job(job_id, error, phase="error", **updates):
-    payload = {
-        "status": "error",
-        "phase": phase,
-        "error": str(error or "Unknown error"),
-        "finished_at": datetime.now(timezone.utc).isoformat(),
-    }
-    payload.update(updates)
-    return _update_background_job(job_id, **payload)
 
 
 def _get_active_work_blocker(subject):


### PR DESCRIPTION
## Summary
Phase 1 of breaking up the `quickstart.py` monolith (16.5k lines, 120+ routes, ~75 module-level globals all in one file — see scoping discussion). Background-jobs state tracking is small, self-contained, and used by almost every long-running action (kometa/imagemaid start, logscan reingest, test-library clone), so it's a natural first extraction: later blueprint work will need to import it without circular imports back to `quickstart.py`.

- Moved `BACKGROUND_JOBS`, `ACTIVE_BACKGROUND_JOBS`, `BACKGROUND_JOBS_LOCK`, `JOB_TARGET_PAGES`, and the 9 CRUD functions (`create_background_job`, `get_background_job`, etc.) into `modules/background_jobs.py`.
- `_get_active_work_blocker` and `ACTIVE_WORK_POLICIES` stay in `quickstart.py` — they're the integration point between job state and process state, and a test monkeypatches `qs_module._get_active_background_job` as a dependency of `_get_active_work_blocker`. Moving that composition function too would mean the patched name and the call site resolve through different module globals, silently breaking the patch.
- `quickstart.py` re-imports the moved functions under their original leading-underscore names (`create_background_job as _create_background_job`, etc.) so existing call sites and test monkeypatches keep working unchanged.

Net: `quickstart.py` shrinks by 133 lines.

## Test plan
- [x] Full test suite passes (`pytest -m "not e2e"`), including the monkeypatch-sensitive `test_start_kometa_blocked_when_kometa_update_running` and all of `test_update_flows.py`
- [x] `ruff check .` clean
- [x] Manual smoke test: import `quickstart`, create/complete a background job end-to-end through the re-exported names
- [ ] CI run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)