### PR TITLE
Serialize increment-build.yml runs to stop them racing on shared state

### DIFF
--- a/.github/workflows/increment-build.yml
+++ b/.github/workflows/increment-build.yml
@@ -5,6 +5,10 @@ on:
     branches: [ develop ]
     types: [ closed ]
 
+concurrency:
+  group: increment-build-develop
+  cancel-in-progress: false
+
 jobs:
 
   verify-changes:


### PR DESCRIPTION
## Summary
Merging #1300 and #1301 into `develop` within seconds of each other triggered two concurrent `Increment Build` runs that raced on shared, non-branch-scoped external state and both partially failed:

- Both runs delete-then-recreate the single shared `prerelease` GitHub release. Whichever run's `gh release create` lands second hits `Release.tag_name already exists`.
- Both runs push the same `develop-amd64`/`develop-arm64`/`develop-armv7` Docker Hub tags concurrently, so one run's `docker manifest create` can read the registry mid-write from the other and fail with `no such manifest: ...:develop-amd64`.

`validate-pull.yml` already serializes via `concurrency: { group: ${{ github.workflow }}-${{ github.ref }} }`; `increment-build.yml` had no concurrency control at all. Added one with a constant group name (every run targets the same `develop` release and Docker tags regardless of source branch) and `cancel-in-progress: false`, since cancelling a run mid-Docker-push or mid-release-creation would leave Docker Hub or the GitHub release in a half-finished state — these should queue, not get killed.

## Test plan
- [x] YAML validated
- [ ] Verify on the next two PRs merged close together that the second run queues instead of racing

🤖 Generated with [Claude Code](https://claude.com/claude-code)