### PR TITLE
Extract third-party service validation routes into blueprints/validation_routes.py

### DIFF
--- a/blueprints/validation_routes.py
+++ b/blueprints/validation_routes.py
@@ -1,0 +1,473 @@
+import requests
+from flask import Blueprint, Flask, current_app as app, jsonify, request, session
+
+from modules import database, helpers, persistence, url_validation, validations
+
+bp = Blueprint("validation_routes", __name__)
+
+
+@bp.route("/validate_gotify", methods=["POST"])
+def validate_gotify():
+    data = request.get_json(silent=True) or {}
+    valid, message = url_validation.validate_url(data.get("gotify_url"), allow_local=True)
+    if not valid:
+        return jsonify({"valid": False, "error": f"Gotify URL: {message}"}), 400
+    return validations.validate_gotify_server(data)
+
+
+@bp.route("/validate_ntfy", methods=["POST"])
+def validate_ntfy():
+    data = request.get_json(silent=True) or {}
+    valid, message = url_validation.validate_url(data.get("ntfy_url"), allow_local=True)
+    if not valid:
+        return jsonify({"valid": False, "error": f"ntfy URL: {message}"}), 400
+    return validations.validate_ntfy_server(data)
+
+
+@bp.route("/validate_apprise", methods=["POST"])
+def validate_apprise():
+    data = request.get_json(silent=True) or {}
+    return validations.validate_apprise_server(data)
+
+
+@bp.route("/validate_plex", methods=["POST"])
+def validate_plex():
+    data = request.get_json(silent=True) or {}
+    valid, message = url_validation.validate_url(data.get("plex_url"), allow_local=True)
+    if not valid:
+        return jsonify({"valid": False, "error": f"Plex URL: {message}"}), 400
+    plex_response = validations.validate_plex_server(data)
+    plex_data = plex_response.get_json() if isinstance(plex_response, Flask.response_class) else plex_response
+    if not isinstance(plex_data, dict) or not plex_data.get("validated"):
+        return plex_response
+
+    config_name = persistence.resolve_request_config_name(data)
+    telemetry = {}
+    try:
+        telemetry = helpers.get_plex_metadata(plex_url=data.get("plex_url"), plex_token=data.get("plex_token")) or {}
+        if telemetry:
+            persistence.save_settings("plex_telemetry", telemetry)
+            if config_name:
+                try:
+                    database.save_section_data(
+                        name=config_name,
+                        section="plex_telemetry",
+                        validated=True,
+                        user_entered=False,
+                        data={"plex_telemetry": telemetry},
+                    )
+                except Exception as e:
+                    helpers.ts_log(f"Failed to persist Plex telemetry during validation for {config_name}: {e}", level="WARNING")
+    except Exception as e:
+        helpers.ts_log(f"Failed to fetch Plex telemetry during validation: {e}", level="WARNING")
+
+    merged = {**plex_data, **telemetry}
+    return jsonify(merged)
+
+
+@bp.route("/refresh_plex_libraries", methods=["POST"])
+def refresh_plex_libraries():
+    try:
+        config_name = session.get("config_name")
+        if not config_name:
+            return jsonify({"valid": False, "error": "Missing config_name"}), 400
+
+        # Get stored Plex credentials
+        plex_url, plex_token = persistence.get_stored_plex_credentials("010-plex")
+        dummy = persistence.get_dummy_data("plex")
+        default_plex_url = dummy.get("url", "")
+        default_plex_token = dummy.get("token", "")
+
+        # Validate credentials
+        if not plex_url or not plex_token or plex_url == default_plex_url or plex_token == default_plex_token:
+            return (
+                jsonify(
+                    {
+                        "valid": False,
+                        "error": "Plex credentials are using default placeholder values",
+                    }
+                ),
+                400,
+            )
+
+        cached_refresh = helpers.get_cached_plex_refresh(plex_url, plex_token)
+        if cached_refresh:
+            helpers.ts_log("Using cached Plex library refresh payload.", level="DEBUG")
+            persistence.update_stored_plex_libraries(
+                "010-plex",
+                cached_refresh.get("movie_libraries", []),
+                cached_refresh.get("show_libraries", []),
+                cached_refresh.get("music_libraries", []),
+                cached_refresh.get("user_list", []),
+            )
+            cached_telemetry = {
+                key: value
+                for key, value in cached_refresh.items()
+                if key
+                not in {
+                    "validated",
+                    "user_list",
+                    "music_libraries",
+                    "movie_libraries",
+                    "show_libraries",
+                    "has_plex_pass",
+                }
+            }
+            persistence.save_settings("plex_telemetry", cached_telemetry)
+            try:
+                database.save_section_data(
+                    name=config_name,
+                    section="plex_telemetry",
+                    validated=True,
+                    user_entered=False,
+                    data={"plex_telemetry": cached_telemetry},
+                )
+            except Exception as e:
+                helpers.ts_log(f"Failed to persist cached Plex telemetry for {config_name}: {e}", level="WARNING")
+            return jsonify(cached_refresh)
+
+        # Validate Plex server and get updated libraries
+        plex_response = validations.validate_plex_server({"plex_url": plex_url, "plex_token": plex_token})
+        plex_data = plex_response.get_json() if isinstance(plex_response, Flask.response_class) else plex_response
+
+        if not plex_data.get("validated"):
+            return jsonify({"valid": False, "error": "Plex validation failed"}), 500
+
+        # Update stored libraries
+        persistence.update_stored_plex_libraries(
+            "010-plex",
+            plex_data.get("movie_libraries", []),
+            plex_data.get("show_libraries", []),
+            plex_data.get("music_libraries", []),
+            plex_data.get("user_list", []),
+        )
+
+        # Get fresh telemetry using helpers and store it
+        telemetry = helpers.get_plex_metadata(plex_url=plex_url, plex_token=plex_token)
+        persistence.save_settings("plex_telemetry", telemetry)
+        try:
+            database.save_section_data(
+                name=config_name,
+                section="plex_telemetry",
+                validated=True,
+                user_entered=False,
+                data={"plex_telemetry": telemetry},
+            )
+        except Exception as e:
+            helpers.ts_log(f"Failed to persist Plex telemetry for {config_name}: {e}", level="WARNING")
+
+        # Merge both plex_data and telemetry for response
+        merged_response = {**plex_data, **telemetry}
+        helpers.set_cached_plex_refresh(plex_url, plex_token, merged_response)
+
+        return jsonify(merged_response)
+
+    except Exception as e:
+        helpers.ts_log(f"Plex validation failed: {e}", level="ERROR")
+        return jsonify({"valid": False, "error": "Server error."}), 500
+
+
+@bp.route("/validate_tautulli", methods=["POST"])
+def validate_tautulli():
+    data = request.json
+    return validations.validate_tautulli_server(data)
+
+
+@bp.route("/validate_trakt", methods=["POST"])
+def validate_trakt():
+    data = request.json
+    return validations.validate_trakt_server(data)
+
+
+@bp.route("/validate_trakt_token", methods=["POST"])
+def validate_trakt_token():
+    data = request.get_json(silent=True) or {}
+    access_token = data.get("access_token")
+    client_id = data.get("client_id")
+    client_secret = data.get("client_secret")
+    refresh_token = data.get("refresh_token")
+    debug_enabled = helpers.booler(app.config.get("QS_DEBUG", False)) or helpers.booler(data.get("debug", False))
+
+    def is_blank(value):
+        if value is None:
+            return True
+        if isinstance(value, str):
+            trimmed = value.strip()
+            if trimmed == "" or trimmed.lower() in ("none", "null"):
+                return True
+        return False
+
+    if is_blank(access_token) or is_blank(client_id) or is_blank(client_secret) or is_blank(refresh_token):
+        settings = persistence.retrieve_settings("130-trakt") or {}
+        trakt_data = settings.get("trakt", {}) if isinstance(settings, dict) else {}
+        auth = trakt_data.get("authorization", {}) if isinstance(trakt_data, dict) else {}
+        if is_blank(access_token):
+            access_token = auth.get("access_token")
+        if is_blank(client_id):
+            client_id = trakt_data.get("client_id") or auth.get("client_id")
+        if is_blank(client_secret):
+            client_secret = trakt_data.get("client_secret") or auth.get("client_secret")
+        if is_blank(refresh_token):
+            refresh_token = auth.get("refresh_token")
+
+    if is_blank(access_token) or is_blank(client_id):
+        debug_payload = None
+        if debug_enabled:
+            settings = persistence.retrieve_settings("130-trakt") or {}
+            trakt_data = settings.get("trakt", {}) if isinstance(settings, dict) else {}
+            auth = trakt_data.get("authorization", {}) if isinstance(trakt_data, dict) else {}
+            debug_payload = {
+                "config_name": session.get("config_name"),
+                "request": {
+                    "access_token": not is_blank(data.get("access_token")),
+                    "client_id": not is_blank(data.get("client_id")),
+                    "client_secret": not is_blank(data.get("client_secret")),
+                    "refresh_token": not is_blank(data.get("refresh_token")),
+                },
+                "stored": {
+                    "access_token": not is_blank(auth.get("access_token")),
+                    "client_id": not is_blank(trakt_data.get("client_id") or auth.get("client_id")),
+                    "client_secret": not is_blank(trakt_data.get("client_secret") or auth.get("client_secret")),
+                    "refresh_token": not is_blank(auth.get("refresh_token")),
+                },
+            }
+        response = {"valid": False, "error": "Missing Trakt access token or client ID."}
+        if debug_payload:
+            response["debug"] = debug_payload
+        return jsonify(response), 400
+    try:
+        response = requests.get(
+            "https://api.trakt.tv/users/settings",
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {access_token}",
+                "trakt-api-version": "2",
+                "trakt-api-key": client_id,
+            },
+            timeout=10,
+        )
+        if debug_enabled:
+            helpers.ts_log(f"Trakt token check status={response.status_code}", level="DEBUG")
+        if response.status_code == 200:
+            return jsonify({"valid": True})
+        if response.status_code == 423:
+            return jsonify({"valid": False, "error": "Account is locked; please contact Trakt Support."}), 400
+        if response.status_code in (401, 403):
+            if is_blank(refresh_token) or is_blank(client_secret):
+                return jsonify({"valid": False, "error": "Access token is invalid or expired."}), 400
+
+            refresh_response = requests.post(
+                "https://api.trakt.tv/oauth/token",
+                json={
+                    "refresh_token": refresh_token,
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                    "redirect_uri": "urn:ietf:wg:oauth:2.0:oob",
+                    "grant_type": "refresh_token",
+                },
+                headers={"Content-Type": "application/json"},
+                timeout=10,
+            )
+            if refresh_response.status_code != 200:
+                debug_payload = None
+                if debug_enabled:
+                    debug_payload = {
+                        "status": response.status_code,
+                        "refresh_status": refresh_response.status_code,
+                    }
+                response_body = {"valid": False, "error": "Access token is invalid or expired."}
+                if debug_payload:
+                    response_body["debug"] = debug_payload
+                return jsonify(response_body), 400
+
+            refreshed = refresh_response.json()
+            new_access = refreshed.get("access_token")
+            if is_blank(new_access):
+                return jsonify({"valid": False, "error": "Access token refresh failed."}), 400
+
+            config_name = session.get("config_name") or persistence.ensure_session_config_name()
+            stored_validated, user_entered, stored_data = database.retrieve_section_data(config_name, "trakt")
+            if not isinstance(stored_data, dict):
+                stored_data = {}
+            trakt_data = stored_data.get("trakt", {}) if isinstance(stored_data.get("trakt"), dict) else {}
+            auth = trakt_data.get("authorization", {}) if isinstance(trakt_data.get("authorization"), dict) else {}
+            auth["access_token"] = new_access
+            if refreshed.get("refresh_token"):
+                auth["refresh_token"] = refreshed.get("refresh_token")
+            if refreshed.get("token_type"):
+                auth["token_type"] = refreshed.get("token_type")
+            if refreshed.get("expires_in"):
+                auth["expires_in"] = refreshed.get("expires_in")
+            if refreshed.get("scope"):
+                auth["scope"] = refreshed.get("scope")
+            if refreshed.get("created_at"):
+                auth["created_at"] = refreshed.get("created_at")
+            trakt_data["authorization"] = auth
+            stored_data["trakt"] = trakt_data
+            stored_data["validated"] = True
+            stored_data["validated_at"] = helpers.utc_now_iso()
+            database.save_section_data(
+                name=config_name,
+                section="trakt",
+                validated=True,
+                user_entered=user_entered,
+                data=stored_data,
+            )
+            return jsonify({"valid": True, "refreshed": True, "authorization": auth})
+        response_body = {"valid": False, "error": f"Trakt validation failed ({response.status_code})."}
+        if debug_enabled:
+            response_body["debug"] = {"status": response.status_code}
+        return jsonify(response_body), 400
+    except requests.exceptions.RequestException as exc:
+        helpers.ts_log(f"Trakt validation error: {exc}", level="ERROR")
+        response_body = {"valid": False, "error": "Trakt validation error."}
+        if debug_enabled:
+            response_body["debug"] = {"status": "request_exception"}
+        return jsonify(response_body), 400
+
+
+@bp.route("/validate_mal", methods=["POST"])
+def validate_mal():
+    data = request.json
+    return validations.validate_mal_server(data)
+
+
+@bp.route("/validate_mal_token", methods=["POST"])
+def validate_mal_token():
+    data = request.get_json(silent=True) or {}
+    access_token = data.get("access_token")
+    debug_enabled = helpers.booler(app.config.get("QS_DEBUG", False)) or helpers.booler(data.get("debug", False))
+
+    def is_blank(value):
+        if value is None:
+            return True
+        if isinstance(value, str):
+            trimmed = value.strip()
+            if trimmed == "" or trimmed.lower() in ("none", "null"):
+                return True
+        return False
+
+    if is_blank(access_token):
+        settings = persistence.retrieve_settings("140-mal") or {}
+        mal_data = settings.get("mal", {}) if isinstance(settings, dict) else {}
+        auth = mal_data.get("authorization", {}) if isinstance(mal_data, dict) else {}
+        access_token = auth.get("access_token")
+
+    if is_blank(access_token):
+        debug_payload = None
+        if debug_enabled:
+            settings = persistence.retrieve_settings("140-mal") or {}
+            mal_data = settings.get("mal", {}) if isinstance(settings, dict) else {}
+            auth = mal_data.get("authorization", {}) if isinstance(mal_data.get("authorization"), dict) else {}
+            debug_payload = {
+                "config_name": session.get("config_name"),
+                "request": {"access_token": not is_blank(data.get("access_token"))},
+                "stored": {"access_token": not is_blank(auth.get("access_token"))},
+            }
+        response = {"valid": False, "error": "Missing MyAnimeList access token."}
+        if debug_payload:
+            response["debug"] = debug_payload
+        return jsonify(response), 400
+    try:
+        response = requests.get(
+            "https://api.myanimelist.net/v2/users/@me",
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=10,
+        )
+        if response.status_code == 200:
+            return jsonify({"valid": True})
+        if response.status_code in (401, 403):
+            return jsonify({"valid": False, "error": "Access token is invalid or expired."}), 400
+        return jsonify({"valid": False, "error": f"MyAnimeList validation failed ({response.status_code})."}), 400
+    except requests.exceptions.RequestException as exc:
+        helpers.ts_log(f"MyAnimeList validation error: {exc}", level="ERROR")
+        return jsonify({"valid": False, "error": "MyAnimeList validation error."}), 400
+
+
+@bp.route("/validate_webhook", methods=["POST"])
+def validate_webhook():
+    data = request.json
+    return validations.validate_webhook_server(data)
+
+
+@bp.route("/validate_radarr", methods=["POST"])
+def validate_radarr():
+    data = request.json
+    result = validations.validate_radarr_server(data)
+    status_code = 200
+    if isinstance(result, tuple):
+        result, status_code = result
+
+    if result.get_json().get("valid"):
+        return jsonify(result.get_json())
+    else:
+        return jsonify(result.get_json()), status_code or 400
+
+
+@bp.route("/validate_sonarr", methods=["POST"])
+def validate_sonarr():
+    data = request.json
+    result = validations.validate_sonarr_server(data)
+    status_code = 200
+    if isinstance(result, tuple):
+        result, status_code = result
+
+    if result.get_json().get("valid"):
+        return jsonify(result.get_json())
+    else:
+        return jsonify(result.get_json()), status_code or 400
+
+
+@bp.route("/validate_omdb", methods=["POST"])
+def validate_omdb():
+    data = request.json
+    result = validations.validate_omdb_server(data)
+
+    if result.get_json().get("valid"):
+        return jsonify(result.get_json())
+    else:
+        return jsonify(result.get_json()), 400
+
+
+@bp.route("/validate_github", methods=["POST"])
+def validate_github():
+    data = request.json
+    result = validations.validate_github_server(data)
+
+    if result.get_json().get("valid"):
+        return jsonify(result.get_json())
+    else:
+        return jsonify(result.get_json()), 400
+
+
+@bp.route("/validate_tmdb", methods=["POST"])
+def validate_tmdb():
+    data = request.json
+    result = validations.validate_tmdb_server(data)
+
+    if result.get_json().get("valid"):
+        return jsonify(result.get_json())
+    else:
+        return jsonify(result.get_json()), 400
+
+
+@bp.route("/validate_mdblist", methods=["POST"])
+def validate_mdblist():
+    data = request.json
+    result = validations.validate_mdblist_server(data)
+
+    if result.get_json().get("valid"):
+        return jsonify(result.get_json())
+    else:
+        return jsonify(result.get_json()), 400
+
+
+@bp.route("/validate_notifiarr", methods=["POST"])
+def validate_notifiarr():
+    data = request.json
+    result = validations.validate_notifiarr_server(data)
+
+    if result.get_json().get("valid"):
+        return jsonify(result.get_json())
+    else:
+        return jsonify(result.get_json()), 400

--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -107,6 +107,10 @@ JSON_SCHEMA_SYNC_FILES = (
 )
 
 
+def utc_now_iso():
+    return datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
+
+
 def detect_git_branch(repo_root=None, default="develop"):
     root = Path(repo_root or get_app_root()).resolve()
 

--- a/modules/persistence.py
+++ b/modules/persistence.py
@@ -6,7 +6,7 @@ import datetime
 import copy
 
 from flask import current_app as app
-from flask import session
+from flask import has_request_context, session
 from ruamel.yaml import YAML
 from ruamel.yaml.constructor import DuplicateKeyError  # noqa
 from urllib.parse import urlparse
@@ -72,6 +72,19 @@ def ensure_session_config_name():
     if app.config["QS_DEBUG"]:
         helpers.ts_log(f"Initialized missing session config_name: {session['config_name']}", level="DEBUG")
     return session["config_name"]
+
+
+def resolve_request_config_name(payload=None):
+    raw_config_name = str((payload or {}).get("config_name") or "").strip() if isinstance(payload, dict) else ""
+    normalized = helpers.normalize_config_name_for_storage(raw_config_name) if raw_config_name else ""
+    if normalized:
+        if has_request_context():
+            session["config_name"] = normalized
+        return normalized
+    resolved = session.get("config_name") or ensure_session_config_name()
+    if has_request_context() and resolved:
+        session["config_name"] = resolved
+    return resolved
 
 
 def clean_form_data(form_data):

--- a/quickstart.py
+++ b/quickstart.py
@@ -66,8 +66,12 @@ from modules.background_jobs import (
     complete_background_job as _complete_background_job,
     fail_background_job as _fail_background_job,
 )
+from blueprints.validation_routes import bp as validation_routes_bp, refresh_plex_libraries
 
 Request.max_form_parts = 100000  # Allow more form fields if needed
+
+_resolve_request_config_name = persistence.resolve_request_config_name
+utc_now_iso = helpers.utc_now_iso
 
 ACTIVE_WORK_POLICIES = {
     "kometa_run": [
@@ -380,10 +384,6 @@ QS_MAL_DEP_ATTRIBUTE_OPERATIONS = {
 }
 QS_MAL_DEP_ATTRIBUTE_VALUES = {"mal", "mal_english", "mal_japanese"}
 QS_FINAL_VALIDATION_TTL_HOURS = 12
-
-
-def utc_now_iso():
-    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def _normalize_auto_sort_hubs_value(value):
@@ -4217,6 +4217,8 @@ basedir = os.path.abspath
 kometa_process = None
 
 app = Flask(__name__)
+
+app.register_blueprint(validation_routes_bp)
 
 # Run version check at startup
 app.config["VERSION_CHECK"] = helpers.check_for_update()
@@ -9151,65 +9153,6 @@ def download_redacted():
     return redirect(url_for("step", name="900-kometa"))
 
 
-@app.route("/validate_gotify", methods=["POST"])
-def validate_gotify():
-    data = request.get_json(silent=True) or {}
-    valid, message = url_validation.validate_url(data.get("gotify_url"), allow_local=True)
-    if not valid:
-        return jsonify({"valid": False, "error": f"Gotify URL: {message}"}), 400
-    return validations.validate_gotify_server(data)
-
-
-@app.route("/validate_ntfy", methods=["POST"])
-def validate_ntfy():
-    data = request.get_json(silent=True) or {}
-    valid, message = url_validation.validate_url(data.get("ntfy_url"), allow_local=True)
-    if not valid:
-        return jsonify({"valid": False, "error": f"ntfy URL: {message}"}), 400
-    return validations.validate_ntfy_server(data)
-
-
-@app.route("/validate_apprise", methods=["POST"])
-def validate_apprise():
-    data = request.get_json(silent=True) or {}
-    return validations.validate_apprise_server(data)
-
-
-@app.route("/validate_plex", methods=["POST"])
-def validate_plex():
-    data = request.get_json(silent=True) or {}
-    valid, message = url_validation.validate_url(data.get("plex_url"), allow_local=True)
-    if not valid:
-        return jsonify({"valid": False, "error": f"Plex URL: {message}"}), 400
-    plex_response = validations.validate_plex_server(data)
-    plex_data = plex_response.get_json() if isinstance(plex_response, Flask.response_class) else plex_response
-    if not isinstance(plex_data, dict) or not plex_data.get("validated"):
-        return plex_response
-
-    config_name = _resolve_request_config_name(data)
-    telemetry = {}
-    try:
-        telemetry = helpers.get_plex_metadata(plex_url=data.get("plex_url"), plex_token=data.get("plex_token")) or {}
-        if telemetry:
-            persistence.save_settings("plex_telemetry", telemetry)
-            if config_name:
-                try:
-                    database.save_section_data(
-                        name=config_name,
-                        section="plex_telemetry",
-                        validated=True,
-                        user_entered=False,
-                        data={"plex_telemetry": telemetry},
-                    )
-                except Exception as e:
-                    helpers.ts_log(f"Failed to persist Plex telemetry during validation for {config_name}: {e}", level="WARNING")
-    except Exception as e:
-        helpers.ts_log(f"Failed to fetch Plex telemetry during validation: {e}", level="WARNING")
-
-    merged = {**plex_data, **telemetry}
-    return jsonify(merged)
-
-
 @app.route("/path-validation-rules", methods=["GET"])
 def path_validation_rules():
     rules = path_validation.load_rules()
@@ -9222,359 +9165,6 @@ def path_validation_rules():
     )
 
 
-@app.route("/refresh_plex_libraries", methods=["POST"])
-def refresh_plex_libraries():
-    try:
-        config_name = session.get("config_name")
-        if not config_name:
-            return jsonify({"valid": False, "error": "Missing config_name"}), 400
-
-        # Get stored Plex credentials
-        plex_url, plex_token = persistence.get_stored_plex_credentials("010-plex")
-        dummy = persistence.get_dummy_data("plex")
-        default_plex_url = dummy.get("url", "")
-        default_plex_token = dummy.get("token", "")
-
-        # Validate credentials
-        if not plex_url or not plex_token or plex_url == default_plex_url or plex_token == default_plex_token:
-            return (
-                jsonify(
-                    {
-                        "valid": False,
-                        "error": "Plex credentials are using default placeholder values",
-                    }
-                ),
-                400,
-            )
-
-        cached_refresh = helpers.get_cached_plex_refresh(plex_url, plex_token)
-        if cached_refresh:
-            helpers.ts_log("Using cached Plex library refresh payload.", level="DEBUG")
-            persistence.update_stored_plex_libraries(
-                "010-plex",
-                cached_refresh.get("movie_libraries", []),
-                cached_refresh.get("show_libraries", []),
-                cached_refresh.get("music_libraries", []),
-                cached_refresh.get("user_list", []),
-            )
-            cached_telemetry = {
-                key: value
-                for key, value in cached_refresh.items()
-                if key
-                not in {
-                    "validated",
-                    "user_list",
-                    "music_libraries",
-                    "movie_libraries",
-                    "show_libraries",
-                    "has_plex_pass",
-                }
-            }
-            persistence.save_settings("plex_telemetry", cached_telemetry)
-            try:
-                database.save_section_data(
-                    name=config_name,
-                    section="plex_telemetry",
-                    validated=True,
-                    user_entered=False,
-                    data={"plex_telemetry": cached_telemetry},
-                )
-            except Exception as e:
-                helpers.ts_log(f"Failed to persist cached Plex telemetry for {config_name}: {e}", level="WARNING")
-            return jsonify(cached_refresh)
-
-        # Validate Plex server and get updated libraries
-        plex_response = validations.validate_plex_server({"plex_url": plex_url, "plex_token": plex_token})
-        plex_data = plex_response.get_json() if isinstance(plex_response, Flask.response_class) else plex_response
-
-        if not plex_data.get("validated"):
-            return jsonify({"valid": False, "error": "Plex validation failed"}), 500
-
-        # Update stored libraries
-        persistence.update_stored_plex_libraries(
-            "010-plex",
-            plex_data.get("movie_libraries", []),
-            plex_data.get("show_libraries", []),
-            plex_data.get("music_libraries", []),
-            plex_data.get("user_list", []),
-        )
-
-        # Get fresh telemetry using helpers and store it
-        telemetry = helpers.get_plex_metadata(plex_url=plex_url, plex_token=plex_token)
-        persistence.save_settings("plex_telemetry", telemetry)
-        try:
-            database.save_section_data(
-                name=config_name,
-                section="plex_telemetry",
-                validated=True,
-                user_entered=False,
-                data={"plex_telemetry": telemetry},
-            )
-        except Exception as e:
-            helpers.ts_log(f"Failed to persist Plex telemetry for {config_name}: {e}", level="WARNING")
-
-        # Merge both plex_data and telemetry for response
-        merged_response = {**plex_data, **telemetry}
-        helpers.set_cached_plex_refresh(plex_url, plex_token, merged_response)
-
-        return jsonify(merged_response)
-
-    except Exception as e:
-        helpers.ts_log(f"Plex validation failed: {e}", level="ERROR")
-        return jsonify({"valid": False, "error": "Server error."}), 500
-
-
-@app.route("/validate_tautulli", methods=["POST"])
-def validate_tautulli():
-    data = request.json
-    return validations.validate_tautulli_server(data)
-
-
-@app.route("/validate_trakt", methods=["POST"])
-def validate_trakt():
-    data = request.json
-    return validations.validate_trakt_server(data)
-
-
-@app.route("/validate_trakt_token", methods=["POST"])
-def validate_trakt_token():
-    data = request.get_json(silent=True) or {}
-    access_token = data.get("access_token")
-    client_id = data.get("client_id")
-    client_secret = data.get("client_secret")
-    refresh_token = data.get("refresh_token")
-    debug_enabled = helpers.booler(app.config.get("QS_DEBUG", False)) or helpers.booler(data.get("debug", False))
-
-    def is_blank(value):
-        if value is None:
-            return True
-        if isinstance(value, str):
-            trimmed = value.strip()
-            if trimmed == "" or trimmed.lower() in ("none", "null"):
-                return True
-        return False
-
-    if is_blank(access_token) or is_blank(client_id) or is_blank(client_secret) or is_blank(refresh_token):
-        settings = persistence.retrieve_settings("130-trakt") or {}
-        trakt_data = settings.get("trakt", {}) if isinstance(settings, dict) else {}
-        auth = trakt_data.get("authorization", {}) if isinstance(trakt_data, dict) else {}
-        if is_blank(access_token):
-            access_token = auth.get("access_token")
-        if is_blank(client_id):
-            client_id = trakt_data.get("client_id") or auth.get("client_id")
-        if is_blank(client_secret):
-            client_secret = trakt_data.get("client_secret") or auth.get("client_secret")
-        if is_blank(refresh_token):
-            refresh_token = auth.get("refresh_token")
-
-    if is_blank(access_token) or is_blank(client_id):
-        debug_payload = None
-        if debug_enabled:
-            settings = persistence.retrieve_settings("130-trakt") or {}
-            trakt_data = settings.get("trakt", {}) if isinstance(settings, dict) else {}
-            auth = trakt_data.get("authorization", {}) if isinstance(trakt_data, dict) else {}
-            debug_payload = {
-                "config_name": session.get("config_name"),
-                "request": {
-                    "access_token": not is_blank(data.get("access_token")),
-                    "client_id": not is_blank(data.get("client_id")),
-                    "client_secret": not is_blank(data.get("client_secret")),
-                    "refresh_token": not is_blank(data.get("refresh_token")),
-                },
-                "stored": {
-                    "access_token": not is_blank(auth.get("access_token")),
-                    "client_id": not is_blank(trakt_data.get("client_id") or auth.get("client_id")),
-                    "client_secret": not is_blank(trakt_data.get("client_secret") or auth.get("client_secret")),
-                    "refresh_token": not is_blank(auth.get("refresh_token")),
-                },
-            }
-        response = {"valid": False, "error": "Missing Trakt access token or client ID."}
-        if debug_payload:
-            response["debug"] = debug_payload
-        return jsonify(response), 400
-    try:
-        response = requests.get(
-            "https://api.trakt.tv/users/settings",
-            headers={
-                "Content-Type": "application/json",
-                "Authorization": f"Bearer {access_token}",
-                "trakt-api-version": "2",
-                "trakt-api-key": client_id,
-            },
-            timeout=10,
-        )
-        if debug_enabled:
-            helpers.ts_log(f"Trakt token check status={response.status_code}", level="DEBUG")
-        if response.status_code == 200:
-            return jsonify({"valid": True})
-        if response.status_code == 423:
-            return jsonify({"valid": False, "error": "Account is locked; please contact Trakt Support."}), 400
-        if response.status_code in (401, 403):
-            if is_blank(refresh_token) or is_blank(client_secret):
-                return jsonify({"valid": False, "error": "Access token is invalid or expired."}), 400
-
-            refresh_response = requests.post(
-                "https://api.trakt.tv/oauth/token",
-                json={
-                    "refresh_token": refresh_token,
-                    "client_id": client_id,
-                    "client_secret": client_secret,
-                    "redirect_uri": "urn:ietf:wg:oauth:2.0:oob",
-                    "grant_type": "refresh_token",
-                },
-                headers={"Content-Type": "application/json"},
-                timeout=10,
-            )
-            if refresh_response.status_code != 200:
-                debug_payload = None
-                if debug_enabled:
-                    debug_payload = {
-                        "status": response.status_code,
-                        "refresh_status": refresh_response.status_code,
-                    }
-                response_body = {"valid": False, "error": "Access token is invalid or expired."}
-                if debug_payload:
-                    response_body["debug"] = debug_payload
-                return jsonify(response_body), 400
-
-            refreshed = refresh_response.json()
-            new_access = refreshed.get("access_token")
-            if is_blank(new_access):
-                return jsonify({"valid": False, "error": "Access token refresh failed."}), 400
-
-            config_name = session.get("config_name") or persistence.ensure_session_config_name()
-            stored_validated, user_entered, stored_data = database.retrieve_section_data(config_name, "trakt")
-            if not isinstance(stored_data, dict):
-                stored_data = {}
-            trakt_data = stored_data.get("trakt", {}) if isinstance(stored_data.get("trakt"), dict) else {}
-            auth = trakt_data.get("authorization", {}) if isinstance(trakt_data.get("authorization"), dict) else {}
-            auth["access_token"] = new_access
-            if refreshed.get("refresh_token"):
-                auth["refresh_token"] = refreshed.get("refresh_token")
-            if refreshed.get("token_type"):
-                auth["token_type"] = refreshed.get("token_type")
-            if refreshed.get("expires_in"):
-                auth["expires_in"] = refreshed.get("expires_in")
-            if refreshed.get("scope"):
-                auth["scope"] = refreshed.get("scope")
-            if refreshed.get("created_at"):
-                auth["created_at"] = refreshed.get("created_at")
-            trakt_data["authorization"] = auth
-            stored_data["trakt"] = trakt_data
-            stored_data["validated"] = True
-            stored_data["validated_at"] = utc_now_iso()
-            database.save_section_data(
-                name=config_name,
-                section="trakt",
-                validated=True,
-                user_entered=user_entered,
-                data=stored_data,
-            )
-            return jsonify({"valid": True, "refreshed": True, "authorization": auth})
-        response_body = {"valid": False, "error": f"Trakt validation failed ({response.status_code})."}
-        if debug_enabled:
-            response_body["debug"] = {"status": response.status_code}
-        return jsonify(response_body), 400
-    except requests.exceptions.RequestException as exc:
-        helpers.ts_log(f"Trakt validation error: {exc}", level="ERROR")
-        response_body = {"valid": False, "error": "Trakt validation error."}
-        if debug_enabled:
-            response_body["debug"] = {"status": "request_exception"}
-        return jsonify(response_body), 400
-
-
-@app.route("/validate_mal", methods=["POST"])
-def validate_mal():
-    data = request.json
-    return validations.validate_mal_server(data)
-
-
-@app.route("/validate_mal_token", methods=["POST"])
-def validate_mal_token():
-    data = request.get_json(silent=True) or {}
-    access_token = data.get("access_token")
-    debug_enabled = helpers.booler(app.config.get("QS_DEBUG", False)) or helpers.booler(data.get("debug", False))
-
-    def is_blank(value):
-        if value is None:
-            return True
-        if isinstance(value, str):
-            trimmed = value.strip()
-            if trimmed == "" or trimmed.lower() in ("none", "null"):
-                return True
-        return False
-
-    if is_blank(access_token):
-        settings = persistence.retrieve_settings("140-mal") or {}
-        mal_data = settings.get("mal", {}) if isinstance(settings, dict) else {}
-        auth = mal_data.get("authorization", {}) if isinstance(mal_data, dict) else {}
-        access_token = auth.get("access_token")
-
-    if is_blank(access_token):
-        debug_payload = None
-        if debug_enabled:
-            settings = persistence.retrieve_settings("140-mal") or {}
-            mal_data = settings.get("mal", {}) if isinstance(settings, dict) else {}
-            auth = mal_data.get("authorization", {}) if isinstance(mal_data.get("authorization"), dict) else {}
-            debug_payload = {
-                "config_name": session.get("config_name"),
-                "request": {"access_token": not is_blank(data.get("access_token"))},
-                "stored": {"access_token": not is_blank(auth.get("access_token"))},
-            }
-        response = {"valid": False, "error": "Missing MyAnimeList access token."}
-        if debug_payload:
-            response["debug"] = debug_payload
-        return jsonify(response), 400
-    try:
-        response = requests.get(
-            "https://api.myanimelist.net/v2/users/@me",
-            headers={"Authorization": f"Bearer {access_token}"},
-            timeout=10,
-        )
-        if response.status_code == 200:
-            return jsonify({"valid": True})
-        if response.status_code in (401, 403):
-            return jsonify({"valid": False, "error": "Access token is invalid or expired."}), 400
-        return jsonify({"valid": False, "error": f"MyAnimeList validation failed ({response.status_code})."}), 400
-    except requests.exceptions.RequestException as exc:
-        helpers.ts_log(f"MyAnimeList validation error: {exc}", level="ERROR")
-        return jsonify({"valid": False, "error": "MyAnimeList validation error."}), 400
-
-
-@app.route("/validate_webhook", methods=["POST"])
-def validate_webhook():
-    data = request.json
-    return validations.validate_webhook_server(data)
-
-
-@app.route("/validate_radarr", methods=["POST"])
-def validate_radarr():
-    data = request.json
-    result = validations.validate_radarr_server(data)
-    status_code = 200
-    if isinstance(result, tuple):
-        result, status_code = result
-
-    if result.get_json().get("valid"):
-        return jsonify(result.get_json())
-    else:
-        return jsonify(result.get_json()), status_code or 400
-
-
-@app.route("/validate_sonarr", methods=["POST"])
-def validate_sonarr():
-    data = request.json
-    result = validations.validate_sonarr_server(data)
-    status_code = 200
-    if isinstance(result, tuple):
-        result, status_code = result
-
-    if result.get_json().get("valid"):
-        return jsonify(result.get_json())
-    else:
-        return jsonify(result.get_json()), status_code or 400
-
-
 @app.route("/validate_library_service_overrides/<library_id>", methods=["POST"])
 def validate_library_service_overrides(library_id):
     payload = request.get_json(silent=True) or request.form or {}
@@ -9585,39 +9175,6 @@ def validate_library_service_overrides(library_id):
     result = _validate_library_service_overrides(library_id, libraries_data, force_validate=True)
     status_code = 200 if result.get("valid") else 400
     return jsonify(result), status_code
-
-
-@app.route("/validate_omdb", methods=["POST"])
-def validate_omdb():
-    data = request.json
-    result = validations.validate_omdb_server(data)
-
-    if result.get_json().get("valid"):
-        return jsonify(result.get_json())
-    else:
-        return jsonify(result.get_json()), 400
-
-
-@app.route("/validate_github", methods=["POST"])
-def validate_github():
-    data = request.json
-    result = validations.validate_github_server(data)
-
-    if result.get_json().get("valid"):
-        return jsonify(result.get_json())
-    else:
-        return jsonify(result.get_json()), 400
-
-
-@app.route("/validate_tmdb", methods=["POST"])
-def validate_tmdb():
-    data = request.json
-    result = validations.validate_tmdb_server(data)
-
-    if result.get_json().get("valid"):
-        return jsonify(result.get_json())
-    else:
-        return jsonify(result.get_json()), 400
 
 
 def _get_active_tmdb_api_key():
@@ -9974,28 +9531,6 @@ def lookup_template_string_value():
         )
 
     return jsonify({"error": f"Unsupported lookup preset: {preset}"}), 400
-
-
-@app.route("/validate_mdblist", methods=["POST"])
-def validate_mdblist():
-    data = request.json
-    result = validations.validate_mdblist_server(data)
-
-    if result.get_json().get("valid"):
-        return jsonify(result.get_json())
-    else:
-        return jsonify(result.get_json()), 400
-
-
-@app.route("/validate_notifiarr", methods=["POST"])
-def validate_notifiarr():
-    data = request.json
-    result = validations.validate_notifiarr_server(data)
-
-    if result.get_json().get("valid"):
-        return jsonify(result.get_json())
-    else:
-        return jsonify(result.get_json()), 400
 
 
 @app.route("/validate_all_services", methods=["POST"])
@@ -16917,19 +16452,6 @@ def _imagemaid_settings_to_form_payload(payload):
         if key in payload:
             form_payload[f"imagemaid_{key}"] = payload.get(key)
     return form_payload
-
-
-def _resolve_request_config_name(payload=None):
-    raw_config_name = str((payload or {}).get("config_name") or "").strip() if isinstance(payload, dict) else ""
-    normalized = helpers.normalize_config_name_for_storage(raw_config_name) if raw_config_name else ""
-    if normalized:
-        if has_request_context():
-            session["config_name"] = normalized
-        return normalized
-    resolved = session.get("config_name") or persistence.ensure_session_config_name()
-    if has_request_context() and resolved:
-        session["config_name"] = resolved
-    return resolved
 
 
 def _retrieve_settings_for_config(config_name, target):


### PR DESCRIPTION
## Summary
Phase 2 of breaking up the `quickstart.py` monolith (see the scoping discussion / #1302). Moved the 18 routes that validate connectivity/credentials for a single third-party service (Plex, Trakt, MyAnimeList, Radarr/Sonarr, notification services, etc.) into a new `blueprints/` package, registered via Flask's `Blueprint` mechanism.

Left in `quickstart.py` (different concerns, future phases):
- `path_validation_rules`, `validate_library_service_overrides` — tied to the core library/attribute dependency engine.
- The TMDb/IMDb template-string lookup cluster (`_get_active_tmdb_api_key`, `_lookup_tmdb_*`, `lookup_template_string_value`) — a distinct "resolve a display label" feature, not credential checking.
- `validate_all_services` — a 590-line orchestrator deeply coupled to the core wizard's dependency/validation-summary engine, not a thin wrapper. Explicitly scoped for the final, highest-risk phase of this refactor.

Two small shared utilities the moved routes depended on (`_resolve_request_config_name`, `utc_now_iso`) had no `quickstart.py`-specific state, so they moved to `modules/persistence.py` and `modules/helpers.py` respectively, with `quickstart.py` re-importing them under their original names — both have other call sites elsewhere in `quickstart.py` untouched by this phase, and neither is monkeypatched by tests.

`refresh_plex_libraries` is also called directly (not just as a route) from the `/step` handler, so it's re-imported into `quickstart.py`'s namespace rather than only registered on the blueprint.

Net: `quickstart.py` shrinks by 461 lines.

## Test plan
- [x] Full test suite passes (`pytest -m "not e2e"`)
- [x] `ruff check .` clean
- [x] Manual smoke test: posted to `/validate_gotify` and `/validate_apprise` through `app.test_client()`, confirmed `refresh_plex_libraries`/`_resolve_request_config_name`/`utc_now_iso` are still reachable as `quickstart.<name>`
- [ ] CI run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)