### PR TITLE
Enhance gap analyzer

### DIFF
--- a/modules/importer.py
+++ b/modules/importer.py
@@ -385,6 +385,42 @@ def _collect_dynamic_child_field_specs(template_vars: Any) -> list[dict[str, str
     return specs
 
 
+def _collect_overlay_source_override_keys(overlay_meta: Any) -> set[str]:
+    if not isinstance(overlay_meta, dict):
+        return set()
+
+    config = overlay_meta.get("source_overrides")
+    if not isinstance(config, dict):
+        return set()
+
+    raw_types = config.get("source_types")
+    if isinstance(raw_types, list):
+        source_types = [str(item).strip() for item in raw_types if str(item).strip()]
+    else:
+        source_types = ["file", "url", "git", "repo"]
+
+    allowed = set(source_types)
+    if str(config.get("key_mode") or "").strip().lower() != "from_use_toggles":
+        return allowed
+
+    excluded_toggle_keys = {
+        str(item).strip()
+        for item in (config.get("exclude_toggle_keys") or [])
+        if str(item).strip()
+    }
+    template_keys = _collect_template_keys(overlay_meta.get("template_variables"))
+    for template_key in template_keys:
+        if not template_key.startswith("use_") or template_key in excluded_toggle_keys:
+            continue
+        child_key = template_key[4:]
+        if not child_key:
+            continue
+        for source_type in source_types:
+            allowed.add(f"{source_type}_{child_key}")
+
+    return allowed
+
+
 def _coerce_import_bool_text(value: Any) -> str:
     if isinstance(value, bool):
         return "true" if value else "false"
@@ -1557,6 +1593,7 @@ def prepare_import_payload(
 
                     if isinstance(template_values, dict):
                         allowed = _collect_template_keys(overlay_meta.get("template_variables"))
+                        allowed.update(_collect_overlay_source_override_keys(overlay_meta))
                         if overlay_id in {"overlay_languages", "overlay_languages_subtitles"}:
                             allowed = set(allowed)
                             allowed.update(language_weight_template_keys)

--- a/modules/importer.py
+++ b/modules/importer.py
@@ -403,11 +403,7 @@ def _collect_overlay_source_override_keys(overlay_meta: Any) -> set[str]:
     if str(config.get("key_mode") or "").strip().lower() != "from_use_toggles":
         return allowed
 
-    excluded_toggle_keys = {
-        str(item).strip()
-        for item in (config.get("exclude_toggle_keys") or [])
-        if str(item).strip()
-    }
+    excluded_toggle_keys = {str(item).strip() for item in (config.get("exclude_toggle_keys") or []) if str(item).strip()}
     template_keys = _collect_template_keys(overlay_meta.get("template_variables"))
     for template_key in template_keys:
         if not template_key.startswith("use_") or template_key in excluded_toggle_keys:

--- a/modules/url_validation.py
+++ b/modules/url_validation.py
@@ -1,4 +1,5 @@
 import ipaddress
+import json
 import re
 from urllib.parse import urlparse
 
@@ -111,6 +112,21 @@ def validate_payload(payload):
     if payload is None:
         return errors
 
+    def append_structured_url_errors(base_key, parsed_value):
+        if isinstance(parsed_value, dict):
+            for child_key, child_value in parsed_value.items():
+                valid, message = validate_url(child_value)
+                if not valid:
+                    errors.append(f"{base_key}[{child_key}]: {message}")
+            return True
+        if isinstance(parsed_value, list):
+            for index, child_value in enumerate(parsed_value):
+                valid, message = validate_url(child_value)
+                if not valid:
+                    errors.append(f"{base_key}[{index}]: {message}")
+            return True
+        return False
+
     items = payload.items() if isinstance(payload, dict) else []
     if hasattr(payload, "getlist"):
         items = []
@@ -129,6 +145,15 @@ def validate_payload(payload):
             continue
         if is_boolean_value(value):
             continue
+        if isinstance(value, str):
+            raw_text = value.strip()
+            if raw_text.startswith("{") or raw_text.startswith("["):
+                try:
+                    parsed = json.loads(raw_text)
+                except Exception:
+                    parsed = None
+                if append_structured_url_errors(key, parsed):
+                    continue
         valid, message = validate_url(value)
         if not valid:
             errors.append(f"{key}: {message}")

--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -678,8 +678,15 @@ def resolve_default_paths(alias: str, kind: str, kometa_defaults: Path) -> list[
         if path.exists():
             support_files.append(path)
         return support_files
-    matches = sorted(kometa_defaults.rglob(f"{alias}.yml"))
-    support_files.extend([p for p in matches if p.is_file()])
+    if kind == "collection":
+        collection_dirs = ("award", "both", "chart", "movie", "show")
+        for dirname in collection_dirs:
+            path = kometa_defaults / dirname / f"{alias}.yml"
+            if path.exists():
+                support_files.append(path)
+    else:
+        matches = sorted(kometa_defaults.rglob(f"{alias}.yml"))
+        support_files.extend([p for p in matches if p.is_file()])
     deduped: list[Path] = []
     seen: set[Path] = set()
     for path in support_files:

--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -74,6 +74,7 @@ DEFAULT_EXCLUDED_DIR_NAMES = {
     "obj",
     "output",
     "packages",
+    "parsed_configs",
     "photos",
     "pictures",
     "site-packages",
@@ -1785,9 +1786,16 @@ def prefilter_yaml_files(
             continue
         if encoding_used not in {"utf-8", "utf-8-sig"}:
             stats["decode_fallbacks"] += 1
-        contains_relevant_yaml = (
-            "template_variables" in raw_text or looks_like_kometa_config_text(raw_text) or any(f"{marker}:" in raw_text for marker in EXTERNAL_TOP_LEVEL_MARKERS)
-        )
+        has_config_markers = looks_like_kometa_config_text(raw_text)
+        has_external_markers = any(f"{marker}:" in raw_text for marker in EXTERNAL_TOP_LEVEL_MARKERS)
+        has_template_variables = "template_variables" in raw_text
+
+        if yaml_type_focus == "config":
+            contains_relevant_yaml = has_config_markers
+        elif yaml_type_focus == "all":
+            contains_relevant_yaml = has_template_variables or has_config_markers or has_external_markers
+        else:
+            contains_relevant_yaml = has_template_variables or has_external_markers
         if not contains_relevant_yaml:
             if is_probable_non_config_artifact(path):
                 skip_record = {
@@ -1980,7 +1988,7 @@ def scan_uploaded_configs(
                 checkpoint_callback(idx, total_files)
             continue
         file_findings = extract_findings_from_data(data, path)
-        file_importer_findings = extract_importer_findings_from_data(data, path)
+        file_importer_findings = extract_importer_findings_from_data(data, path) if document_type == "config" else []
         findings.extend(file_findings)
         importer_findings.extend(file_importer_findings)
         parsed_count += 1
@@ -2144,7 +2152,7 @@ def get_merged_fix_queue_exclusion(row: dict[str, Any]) -> str | None:
 
 
 def accumulate_quickstart_recommendation_summary(summary: dict[tuple[str, str | None, str], dict[str, Any]], row: dict[str, Any]) -> None:
-    if not row.get("name_verified") or row.get("quickstart_declared"):
+    if not row.get("name_verified") or row.get("supported_in_quickstart"):
         return
     if get_quickstart_recommendation_exclusion(row):
         return
@@ -2161,7 +2169,7 @@ def build_quickstart_recommendation_summary(rows: list[dict[str, Any]]) -> dict[
 def build_quickstart_recommendation_exclusion_summary(rows: list[dict[str, Any]]) -> dict[tuple[str, str | None, str], dict[str, Any]]:
     summary: dict[tuple[str, str | None, str], dict[str, Any]] = {}
     for row in rows:
-        if not row.get("name_verified") or row.get("quickstart_declared"):
+        if not row.get("name_verified") or row.get("supported_in_quickstart"):
             continue
         exclusion_reason = get_quickstart_recommendation_exclusion(row)
         if not exclusion_reason:
@@ -2298,7 +2306,7 @@ def build_merged_fix_queue(
             bucket["validation_levels"].add(str(item.get("validation_level")))
         if item.get("kometa_declared") and not item.get("schema_declared"):
             bucket["needs_schema_support"] = True
-        if item.get("kometa_declared") and not item.get("quickstart_declared") and not bucket["quickstart_exclusion_reason"]:
+        if item.get("kometa_declared") and not item.get("supported_in_quickstart") and not bucket["quickstart_exclusion_reason"]:
             bucket["needs_quickstart_support"] = True
 
     for item in importer_rows:

--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -2138,6 +2138,8 @@ QUICKSTART_RECOMMENDATION_EXCLUSIONS: dict[tuple[str, str], str] = {
     ("library", "overlay_path"): "legacy_library_path_key_not_recommended",
     ("library", "reapply_overlays"): "valid_but_not_recommended_for_quickstart",
     ("library", "library_type"): "internal_importer_or_analyzer_metadata",
+    ("library", "sort_by"): "library_template_variable_not_documented_for_quickstart",
+    ("library", "exclude"): "library_template_variable_not_documented_for_quickstart",
 }
 
 
@@ -2149,6 +2151,8 @@ def get_quickstart_recommendation_exclusion(row: dict[str, Any]) -> str | None:
 
 MERGED_FIX_QUEUE_EXCLUSIONS: dict[tuple[str, str], str] = {
     ("library", "library_type"): "internal_importer_or_analyzer_metadata",
+    ("library", "sort_by"): "library_template_variable_not_documented_for_quickstart",
+    ("library", "exclude"): "library_template_variable_not_documented_for_quickstart",
 }
 
 

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -25624,6 +25624,7 @@
             "tooltip": "Map a franchise child key to a custom poster URL. Quickstart exports these as <code>url_poster_&lt;&lt;key&gt;&gt;</code> template variables.",
             "key_placeholder": "Franchise key (e.g. 10)",
             "value_placeholder": "https://example.com/poster.jpg",
+            "validation_preset": "url",
             "dynamic_child_prefix": "url_poster_",
             "dynamic_child_value_kind": "string"
           },
@@ -26282,6 +26283,7 @@
             "tooltip": "Map a franchise child key to a custom poster URL. Quickstart exports these as <code>url_poster_&lt;&lt;key&gt;&gt;</code> template variables.",
             "key_placeholder": "Franchise key (e.g. 1399)",
             "value_placeholder": "https://example.com/poster.jpg",
+            "validation_preset": "url",
             "dynamic_child_prefix": "url_poster_",
             "dynamic_child_value_kind": "string"
           },

--- a/static/json/quickstart_overlays.json
+++ b/static/json/quickstart_overlays.json
@@ -4421,6 +4421,23 @@
         "image_url": "https://kometa.wiki/en/nightly/assets/images/defaults/overlays/resolution.png",
         "overlay_url": "https://raw.githubusercontent.com/Kometa-Team/Kometa/refs/heads/nightly/defaults/overlays/images/resolution/4kdvhdrplus.png",
         "edition_overlay_url": "https://raw.githubusercontent.com/Kometa-Team/Kometa/refs/heads/nightly/defaults/overlays/images/edition/enhanced.png",
+        "source_overrides": {
+          "title": "Image Source Overrides",
+          "description": "Advanced: override the built-in badge image for all badges or for a specific badge key using a local file, URL, Community-Configs git path, or custom_repo repo path.",
+          "source_types": [
+            "file",
+            "url",
+            "git",
+            "repo"
+          ],
+          "key_mode": "from_use_toggles",
+          "exclude_toggle_keys": [
+            "use_resolution",
+            "use_edition"
+          ],
+          "base_label": "All badges",
+          "add_label": "Add override"
+        },
         "default_offsets": {
           "horizontal": 15,
           "vertical": 15,

--- a/static/json/quickstart_overlays.json
+++ b/static/json/quickstart_overlays.json
@@ -4423,7 +4423,7 @@
         "edition_overlay_url": "https://raw.githubusercontent.com/Kometa-Team/Kometa/refs/heads/nightly/defaults/overlays/images/edition/enhanced.png",
         "source_overrides": {
           "title": "Image Source Overrides",
-          "description": "Advanced: override the built-in badge image for all badges or for a specific badge key using a local file, URL, Community-Configs git path, or custom_repo repo path.",
+          "description": "Advanced: override the built-in badge image for a specific badge key using a local file, URL, Community-Configs git path, or custom_repo repo path.",
           "source_types": [
             "file",
             "url",
@@ -4435,7 +4435,6 @@
             "use_resolution",
             "use_edition"
           ],
-          "base_label": "All badges",
           "add_label": "Add override"
         },
         "default_offsets": {

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -1,4 +1,4 @@
-/* global EventHandler, ValidationHandler, OverlayHandler, Sortable, showToast, setupParentChildToggleSync, bootstrap, FontFace, PathValidation, DOMParser, MutationObserver, jumpTo, showNavigationLoadingOverlay, hideNavigationLoadingOverlay, requestAnimationFrame */
+/* global EventHandler, ValidationHandler, OverlayHandler, Sortable, showToast, setupParentChildToggleSync, bootstrap, FontFace, PathValidation, URLValidation, DOMParser, MutationObserver, jumpTo, showNavigationLoadingOverlay, hideNavigationLoadingOverlay, requestAnimationFrame */
 
 document.addEventListener('DOMContentLoaded', function () {
   console.log('[DEBUG] Initializing Libraries...')
@@ -2326,15 +2326,25 @@ document.addEventListener('DOMContentLoaded', function () {
     function bindDependencyRequirementHintLiveRefresh (card) {
       if (!card || card.dataset.dependencyHintWatcherBound === 'true') return
 
-      const shouldTrack = (name) => {
-        const fieldName = String(name || '')
+      const shouldTrack = (target) => {
+        if (!target || target.nodeType !== 1) return false
+        if (
+          target.dataset.skipLibraryInputBubble === 'true' ||
+          target.closest('[data-overlay-source-editor="true"]') ||
+          target.closest('[data-overlay-source-hidden]') ||
+          (target.matches('input') && target.type === 'hidden')
+        ) {
+          return false
+        }
+
+        const fieldName = String(target.name || '')
         if (!fieldName) return false
         return /-library$|-collection_|-template_collection_|-attribute_|-overlay_|-template_overlay_/i.test(fieldName)
       }
 
       const onFieldInteraction = (event) => {
         const target = event && event.target
-        if (!target || !shouldTrack(target.name)) return
+        if (!shouldTrack(target)) return
         scheduleDependencyRequirementHintRefresh(160)
       }
 
@@ -3318,6 +3328,8 @@ document.addEventListener('DOMContentLoaded', function () {
         const addBtn = wrapper.querySelector('[data-template-mapping-add]')
         const list = wrapper.querySelector('[data-template-mapping-items]')
         const feedback = wrapper.querySelector('[data-template-mapping-feedback]')
+        const validationPreset = String(wrapper.dataset.validationPreset || '').trim().toLowerCase()
+        const valueKind = String(wrapper.dataset.mappingValueKind || 'string_list').trim().toLowerCase()
 
         if (!hidden || !keyInput || !valueInput || !addBtn || !list) return
 
@@ -3328,6 +3340,13 @@ document.addEventListener('DOMContentLoaded', function () {
           const text = String(rawValue || '').trim()
           if (!text) return []
           return text.split(',').map(item => item.trim()).filter(Boolean)
+        }
+
+        function parseScalarValue (rawValue) {
+          if (Array.isArray(rawValue)) {
+            return String(rawValue[0] || '').trim()
+          }
+          return String(rawValue || '').trim()
         }
 
         function parseStoredMapping (rawValue) {
@@ -3351,21 +3370,39 @@ document.addEventListener('DOMContentLoaded', function () {
           feedback.classList.toggle('d-block', Boolean(message))
         }
 
+        function setValueInputValidity (result) {
+          if (!valueInput) return
+          if (!result || result.valid) {
+            valueInput.classList.remove('is-invalid')
+            return
+          }
+          valueInput.classList.add('is-invalid')
+        }
+
+        function normalizeMappingValue (rawValue) {
+          if (valueKind === 'string_list') {
+            const values = parseValuesList(rawValue)
+            return values.length ? values : null
+          }
+          const value = parseScalarValue(rawValue)
+          return value || null
+        }
+
         function normalizeMapping (mapping) {
           const normalized = {}
           Object.entries(mapping || {}).forEach(([rawKey, rawValues]) => {
             const key = String(rawKey || '').trim()
             if (!key) return
-            const values = parseValuesList(rawValues)
-            if (!values.length) return
-            normalized[key] = values
+            const value = normalizeMappingValue(rawValues)
+            if (value == null) return
+            normalized[key] = value
           })
           return normalized
         }
 
         function renderList (mapping) {
           list.replaceChildren()
-          Object.entries(mapping).forEach(([key, values]) => {
+          Object.entries(mapping).forEach(([key, value]) => {
             const li = document.createElement('li')
             li.className = 'list-group-item d-flex justify-content-between align-items-center'
 
@@ -3378,7 +3415,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
             const details = document.createElement('div')
             details.className = 'small text-muted'
-            details.textContent = values.join(', ')
+            details.textContent = Array.isArray(value) ? value.join(', ') : String(value || '')
             textWrap.appendChild(details)
 
             const button = document.createElement('button')
@@ -3407,6 +3444,7 @@ document.addEventListener('DOMContentLoaded', function () {
           hidden.value = JSON.stringify(normalized)
           renderList(normalized)
           setFeedback(message)
+          setValueInputValidity({ valid: true })
           return normalized
         }
 
@@ -3416,13 +3454,21 @@ document.addEventListener('DOMContentLoaded', function () {
             setFeedback('Enter a key before adding it.')
             return
           }
-          const values = parseValuesList(valueInput.value)
-          if (!values.length) {
+          const normalizedValue = normalizeMappingValue(valueInput.value)
+          if (normalizedValue == null) {
             setFeedback('Enter at least one value before adding it.')
             return
           }
+          if (validationPreset === 'url' && typeof URLValidation !== 'undefined' && typeof URLValidation.validateValue === 'function') {
+            const validationResult = URLValidation.validateValue(normalizedValue)
+            if (!validationResult.valid) {
+              setValueInputValidity(validationResult)
+              setFeedback(validationResult.message || 'Enter a valid URL before adding it.')
+              return
+            }
+          }
           const current = normalizeMapping(parseStoredMapping(hidden.value))
-          current[key] = values
+          current[key] = normalizedValue
           syncState(current)
           keyInput.value = ''
           valueInput.value = ''
@@ -3439,6 +3485,7 @@ document.addEventListener('DOMContentLoaded', function () {
         })
         valueInput.addEventListener('input', () => {
           setFeedback('')
+          setValueInputValidity({ valid: true })
         })
         keyInput.addEventListener('keydown', (event) => {
           if (event.key === 'Enter') {
@@ -4121,6 +4168,9 @@ document.addEventListener('DOMContentLoaded', function () {
       if (typeof PathValidation !== 'undefined' && PathValidation.attach) {
         PathValidation.attach(card)
       }
+      if (typeof URLValidation !== 'undefined' && URLValidation.attach) {
+        URLValidation.attach(card)
+      }
       if (typeof ValidationHandler !== 'undefined' && ValidationHandler.updateValidationState) {
         ValidationHandler.updateValidationState()
       }
@@ -4255,10 +4305,26 @@ document.addEventListener('DOMContentLoaded', function () {
       if (typeof PathValidation !== 'undefined' && PathValidation.validateAll) {
         const pathValid = PathValidation.validateAll(card)
         if (!pathValid) {
+          if (typeof ValidationHandler !== 'undefined' && typeof ValidationHandler.focusFirstInvalidField === 'function') {
+            ValidationHandler.focusFirstInvalidField(card)
+          }
           if (typeof showToast === 'function') {
             showToast('error', 'Please fix invalid path fields before saving.')
           }
           return Promise.reject(new Error('Invalid path fields'))
+        }
+      }
+
+      if (typeof URLValidation !== 'undefined' && URLValidation.validateAll) {
+        const urlValid = URLValidation.validateAll(card)
+        if (!urlValid) {
+          if (typeof ValidationHandler !== 'undefined' && typeof ValidationHandler.focusFirstInvalidField === 'function') {
+            ValidationHandler.focusFirstInvalidField(card)
+          }
+          if (typeof showToast === 'function') {
+            showToast('error', 'Please fix invalid URL fields before saving.')
+          }
+          return Promise.reject(new Error('Invalid URL fields'))
         }
       }
 

--- a/static/local-js/eventHandler.js
+++ b/static/local-js/eventHandler.js
@@ -5,13 +5,16 @@ const EventHandler = {
     document.querySelectorAll('.library-checkbox').forEach((checkbox) => {
       const libraryId = checkbox.id.replace(/-(library|card-container)$/, '')
 
-      console.log(`[DEBUG] Attaching toggle listener for Library: ${libraryId}`)
+      if (checkbox.dataset.listenerAdded !== 'true') {
+        console.log(`[DEBUG] Attaching toggle listener for Library: ${libraryId}`)
 
-      // Attach event listener to each checkbox
-      checkbox.addEventListener('change', () => {
-        EventHandler.toggleLibraryVisibility(libraryId, checkbox.checked)
-        ValidationHandler.updateValidationState()
-      })
+        // Attach event listener to each checkbox
+        checkbox.addEventListener('change', () => {
+          EventHandler.toggleLibraryVisibility(libraryId, checkbox.checked)
+          ValidationHandler.updateValidationState()
+        })
+        checkbox.dataset.listenerAdded = 'true'
+      }
 
       // Ensure libraries are HIDDEN by default on first entry
       if (!checkbox.checked) {
@@ -201,12 +204,14 @@ const EventHandler = {
 
       // Automatically trigger preview updates when overlays are toggled or content rating changes
       library.querySelectorAll('input[type="checkbox"].overlay-toggle, input[type="radio"].overlay-toggle').forEach(input => {
+        if (input.dataset.previewListenerAdded === 'true') return
         input.addEventListener('change', () => {
           console.log(`[DEBUG] Overlay toggle changed: ${input.id}`)
           const match = input.id.match(/-(movie|show|season|episode)-overlay_/)
           const inputType = match ? match[1] : (isMovie ? 'movie' : 'show')
           ImageHandler.generateSinglePreview(libraryId, inputType)
         })
+        input.dataset.previewListenerAdded = 'true'
       })
 
       // Attach separator preview logic (Now handled by OverlayHandler)
@@ -345,7 +350,17 @@ const EventHandler = {
       })
 
       // Any change/input inside this library should update highlights/validation (not just toggles)
-      const bubbleHandler = () => {
+      const bubbleHandler = (event) => {
+        const target = event?.target
+        if (
+          target && target.nodeType === 1 &&
+          (
+            target.dataset.skipLibraryInputBubble === 'true' ||
+            target.closest('[data-overlay-source-editor="true"]')
+          )
+        ) {
+          return
+        }
         if (typeof EventHandler.updateAccordionHighlights === 'function') {
           EventHandler.updateAccordionHighlights()
         }
@@ -354,6 +369,7 @@ const EventHandler = {
         }
       }
       library.querySelectorAll('input:not([type="hidden"]), select, textarea').forEach(el => {
+        if (el.dataset.highlightListener === 'true') return
         el.addEventListener('change', bubbleHandler, true)
         el.addEventListener('input', bubbleHandler, true)
         el.dataset.highlightListener = 'true'
@@ -620,13 +636,27 @@ const EventHandler = {
 }
 
 // MutationObserver for dynamically added elements
+const shouldReattachForNode = (node) => {
+  if (!node || node.nodeType !== 1) return false
+  if (node.closest('[data-overlay-source-editor="true"]') || node.closest('[data-overlay-source-hidden]')) return false
+  if (node.matches("[id$='-card-container']")) return true
+  if (node.matches('input[type="hidden"]')) return false
+  if (node.matches('.accordion input:not([type="hidden"]), .accordion select, .accordion textarea')) return true
+
+  const descendants = node.querySelectorAll?.('.accordion input:not([type="hidden"]), .accordion select, .accordion textarea')
+  return Array.from(descendants || []).some(descendant => {
+    return !descendant.closest('[data-overlay-source-editor="true"]') &&
+      !descendant.closest('[data-overlay-source-hidden]')
+  })
+}
+
 const observer = new MutationObserver((mutations) => {
   let needsReattachment = false
 
   mutations.forEach((mutation) => {
     if (mutation.addedNodes.length > 0) {
       mutation.addedNodes.forEach((node) => {
-        if (node.nodeType === 1 && node.matches("[id$='-card-container'], .accordion input")) {
+        if (shouldReattachForNode(node)) {
           console.log(`[DEBUG] New element detected: ${node.id || node.className}, triggering re-attachment.`)
           needsReattachment = true
         }

--- a/static/local-js/overlayHandler.js
+++ b/static/local-js/overlayHandler.js
@@ -900,7 +900,6 @@ const OverlayHandler = {
           title: String(parsed.title || 'Image Source Overrides').trim(),
           description: String(parsed.description || 'Advanced source overrides for this overlay.').trim(),
           addLabel: String(parsed.add_label || 'Add override').trim(),
-          baseLabel: String(parsed.base_label || 'All badges').trim(),
           keyMode: String(parsed.key_mode || '').trim().toLowerCase(),
           sourceTypes,
           excludeToggleKeys: Array.isArray(parsed.exclude_toggle_keys)
@@ -935,18 +934,13 @@ const OverlayHandler = {
     }
 
     const getOverlaySourceOverrideKeyOptions = (cfg, config) => {
-      const options = [
-        {
-          value: '',
-          label: config.baseLabel || 'All badges'
-        }
-      ]
+      const options = []
       if (!cfg.container || config.keyMode !== 'from_use_toggles') return options
 
       const templateName = cfg.container.dataset.overlayTemplate
       if (!templateName) return options
 
-      const seen = new Set([''])
+      const seen = new Set()
       const excludedToggleKeys = new Set(config.excludeToggleKeys || [])
       const toggleInputs = Array.from(cfg.container.querySelectorAll(`[name^="${templateName}[use_"]`))
 
@@ -1016,6 +1010,7 @@ const OverlayHandler = {
         const decoded = decodeOverlaySourceOverrideVarName(config.sourceTypes, varName)
         const value = String(input.value || '').trim()
         if (!decoded || !value) return
+        if (config.keyMode === 'from_use_toggles' && !decoded.badgeKey) return
         state.push({
           sourceType: decoded.sourceType,
           badgeKey: decoded.badgeKey,
@@ -1077,6 +1072,7 @@ const OverlayHandler = {
       valueInput.type = 'text'
       valueInput.className = 'form-control form-control-sm'
       valueInput.dataset.overlaySourceValue = 'true'
+      valueInput.dataset.skipLibraryInputBubble = 'true'
       valueInput.value = String(entry.value || '').trim()
       valueCol.appendChild(valueInput)
       layout.appendChild(valueCol)
@@ -1101,21 +1097,21 @@ const OverlayHandler = {
         const sourceType = String(sourceSelect.value || '').trim()
         if (sourceType === 'url') {
           valueInput.placeholder = 'https://example.com/badge.png'
-          help.textContent = 'Use a direct URL to a badge image.'
+          help.textContent = 'Use a direct URL to a badge image. Quickstart stores this value as-is and does not live-check the target.'
           return
         }
         if (sourceType === 'git') {
           valueInput.placeholder = 'defaults/overlays/images/resolution/custom.png'
-          help.textContent = 'Use a Community-Configs git path.'
+          help.textContent = 'Use a Community-Configs git path. Quickstart stores this value as-is and does not live-check the target.'
           return
         }
         if (sourceType === 'repo') {
           valueInput.placeholder = 'overlays/resolution/custom.png'
-          help.textContent = 'Use a custom_repo-backed repo path.'
+          help.textContent = 'Use a custom_repo-backed repo path. Quickstart stores this value as-is and does not live-check the target.'
           return
         }
         valueInput.placeholder = 'config/overlays/resolution/custom.png'
-        help.textContent = 'Use a local file path that Kometa can read.'
+        help.textContent = 'Use a local file path that Kometa can read. Quickstart stores this value as-is and does not verify the file exists yet.'
       }
 
       updatePlaceholder()
@@ -1149,6 +1145,14 @@ const OverlayHandler = {
         const value = String(valueInput.value || '').trim()
         if (!value) return
 
+        if (!badgeKey) {
+          if (!warningText) {
+            warningText = 'Each source override needs a specific badge key.'
+          }
+          keySelect.classList.add('is-invalid')
+          return
+        }
+
         if (!sourceType) {
           if (!warningText) {
             warningText = 'Each source override needs a source type and a value.'
@@ -1171,11 +1175,15 @@ const OverlayHandler = {
         nextState.push({ badgeKey, sourceType, value })
       })
 
-      hiddenHost.innerHTML = ''
-      nextState.forEach(entry => {
-        const varName = encodeOverlaySourceOverrideVarName(entry.sourceType, entry.badgeKey)
-        createOverlaySourceOverrideHiddenInput(cfg, hiddenHost, varName, entry.value)
-      })
+      const serializedState = JSON.stringify(nextState)
+      if (hiddenHost.dataset.overlaySourceSerialized !== serializedState) {
+        hiddenHost.replaceChildren()
+        nextState.forEach(entry => {
+          const varName = encodeOverlaySourceOverrideVarName(entry.sourceType, entry.badgeKey)
+          createOverlaySourceOverrideHiddenInput(cfg, hiddenHost, varName, entry.value)
+        })
+        hiddenHost.dataset.overlaySourceSerialized = serializedState
+      }
 
       warning.textContent = warningText
       warning.classList.toggle('d-none', !warningText)
@@ -1218,8 +1226,14 @@ const OverlayHandler = {
         })
       })
 
-      rowsHost.querySelectorAll('[data-overlay-source-key="true"], [data-overlay-source-type="true"], [data-overlay-source-value="true"]').forEach(input => {
-        input.addEventListener('input', () => syncOverlaySourceOverrideRows(cfg, config, section))
+      rowsHost.querySelectorAll('[data-overlay-source-key="true"], [data-overlay-source-type="true"]').forEach(input => {
+        input.addEventListener('change', () => syncOverlaySourceOverrideRows(cfg, config, section))
+      })
+
+      rowsHost.querySelectorAll('[data-overlay-source-value="true"]').forEach(input => {
+        input.addEventListener('input', () => {
+          input.classList.remove('is-invalid')
+        })
         input.addEventListener('change', () => syncOverlaySourceOverrideRows(cfg, config, section))
       })
     }
@@ -1269,7 +1283,7 @@ const OverlayHandler = {
           const keyOptions = getOverlaySourceOverrideKeyOptions(cfg, config)
           rowsHost.appendChild(buildOverlaySourceOverrideRow(cfg, config, keyOptions, {
             sourceType: config.sourceTypes[0] || 'file',
-            badgeKey: '',
+            badgeKey: keyOptions[0]?.value || '',
             value: ''
           }))
           renderOverlaySourceOverrideRows(cfg, config, section, Array.from(rowsHost.querySelectorAll('[data-overlay-source-row="true"]')).map(row => ({

--- a/static/local-js/overlayHandler.js
+++ b/static/local-js/overlayHandler.js
@@ -1,4 +1,4 @@
-/* global EventHandler, toggleOverlayTemplateSection, FontFace, Image, requestAnimationFrame, boardState, ResizeObserver, DOMParser */
+/* global EventHandler, ValidationHandler, toggleOverlayTemplateSection, FontFace, Image, requestAnimationFrame, boardState, ResizeObserver, DOMParser */
 
 const OverlayHandler = {
   baseDimensions: {
@@ -884,6 +884,414 @@ const OverlayHandler = {
         }
       }
       warning.classList.toggle('d-none', useResolution || useEdition)
+    }
+
+    const getOverlaySourceOverrideConfig = (cfg) => {
+      if (!cfg.container) return null
+      const raw = String(cfg.container.dataset.overlaySourceOverrides || '').trim()
+      if (!raw) return null
+      try {
+        const parsed = JSON.parse(raw)
+        if (!parsed || parsed.enabled === false) return null
+        const sourceTypes = Array.isArray(parsed.source_types) && parsed.source_types.length
+          ? parsed.source_types.map(item => String(item || '').trim()).filter(Boolean)
+          : ['file', 'url', 'git', 'repo']
+        return {
+          title: String(parsed.title || 'Image Source Overrides').trim(),
+          description: String(parsed.description || 'Advanced source overrides for this overlay.').trim(),
+          addLabel: String(parsed.add_label || 'Add override').trim(),
+          baseLabel: String(parsed.base_label || 'All badges').trim(),
+          keyMode: String(parsed.key_mode || '').trim().toLowerCase(),
+          sourceTypes,
+          excludeToggleKeys: Array.isArray(parsed.exclude_toggle_keys)
+            ? parsed.exclude_toggle_keys.map(item => String(item || '').trim()).filter(Boolean)
+            : []
+        }
+      } catch (error) {
+        console.warn('[OverlaySourceOverrides] Failed to parse config', { overlayId: cfg.id, error })
+        return null
+      }
+    }
+
+    const decodeOverlaySourceOverrideVarName = (sourceTypes, varName) => {
+      const normalizedVarName = String(varName || '').trim()
+      if (!normalizedVarName) return null
+      for (const sourceType of sourceTypes) {
+        if (normalizedVarName === sourceType) {
+          return { sourceType, badgeKey: '' }
+        }
+        const prefix = `${sourceType}_`
+        if (normalizedVarName.startsWith(prefix)) {
+          return { sourceType, badgeKey: normalizedVarName.slice(prefix.length) }
+        }
+      }
+      return null
+    }
+
+    const encodeOverlaySourceOverrideVarName = (sourceType, badgeKey) => {
+      const normalizedType = String(sourceType || '').trim()
+      const normalizedKey = String(badgeKey || '').trim()
+      return normalizedKey ? `${normalizedType}_${normalizedKey}` : normalizedType
+    }
+
+    const getOverlaySourceOverrideKeyOptions = (cfg, config) => {
+      const options = [
+        {
+          value: '',
+          label: config.baseLabel || 'All badges'
+        }
+      ]
+      if (!cfg.container || config.keyMode !== 'from_use_toggles') return options
+
+      const templateName = cfg.container.dataset.overlayTemplate
+      if (!templateName) return options
+
+      const seen = new Set([''])
+      const excludedToggleKeys = new Set(config.excludeToggleKeys || [])
+      const toggleInputs = Array.from(cfg.container.querySelectorAll(`[name^="${templateName}[use_"]`))
+
+      toggleInputs.forEach(input => {
+        const keyMatch = /\[([^\]]+)\]$/.exec(String(input.name || ''))
+        const toggleKey = String(keyMatch?.[1] || '').trim()
+        if (!toggleKey.startsWith('use_') || excludedToggleKeys.has(toggleKey)) return
+        const badgeKey = toggleKey.slice(4)
+        if (!badgeKey || seen.has(badgeKey)) return
+
+        const labelEl = input.closest('.form-check')?.querySelector('.form-check-label')
+        let label = String(labelEl?.textContent || badgeKey).replace(/\s+/g, ' ').trim()
+        if (label.toLowerCase().startsWith('use ')) {
+          label = label.slice(4).trim()
+        }
+        seen.add(badgeKey)
+        options.push({ value: badgeKey, label })
+      })
+
+      return options
+    }
+
+    const createOverlaySourceOverrideHiddenInput = (cfg, hiddenHost, varName, value) => {
+      const templateName = cfg.container?.dataset?.overlayTemplate
+      if (!hiddenHost || !templateName) return null
+      const input = document.createElement('input')
+      input.type = 'hidden'
+      input.name = `${templateName}[${varName}]`
+      input.value = String(value || '').trim()
+      input.dataset.default = ''
+      input.dataset.overlaySourceOverride = 'true'
+      hiddenHost.appendChild(input)
+      return input
+    }
+
+    const materializeOverlaySourceOverrideSeed = (cfg, config, hiddenHost) => {
+      if (!cfg.container || !hiddenHost || cfg.container.dataset.overlaySourceSeedApplied === 'true') return
+      const rawSeed = String(cfg.container.dataset.overlaySourceSeed || '').trim()
+      if (!rawSeed) {
+        cfg.container.dataset.overlaySourceSeedApplied = 'true'
+        return
+      }
+      try {
+        const parsed = JSON.parse(rawSeed)
+        if (Array.isArray(parsed)) {
+          parsed.forEach(entry => {
+            if (!entry || typeof entry !== 'object') return
+            const varName = String(entry.key || '').trim()
+            const value = String(entry.value || '').trim()
+            if (!value) return
+            if (!decodeOverlaySourceOverrideVarName(config.sourceTypes, varName)) return
+            createOverlaySourceOverrideHiddenInput(cfg, hiddenHost, varName, value)
+          })
+        }
+      } catch (error) {
+        console.warn('[OverlaySourceOverrides] Failed to parse seed', { overlayId: cfg.id, error })
+      }
+      cfg.container.dataset.overlaySourceSeedApplied = 'true'
+    }
+
+    const readOverlaySourceOverrideState = (cfg, config, hiddenHost) => {
+      materializeOverlaySourceOverrideSeed(cfg, config, hiddenHost)
+      const state = []
+      hiddenHost.querySelectorAll('input[data-overlay-source-override="true"]').forEach(input => {
+        const varMatch = /\[([^\]]+)\]$/.exec(String(input.name || ''))
+        const varName = String(varMatch?.[1] || '').trim()
+        const decoded = decodeOverlaySourceOverrideVarName(config.sourceTypes, varName)
+        const value = String(input.value || '').trim()
+        if (!decoded || !value) return
+        state.push({
+          sourceType: decoded.sourceType,
+          badgeKey: decoded.badgeKey,
+          value
+        })
+      })
+      return state
+    }
+
+    const buildOverlaySourceOverrideRow = (cfg, config, keyOptions, entry = {}) => {
+      const row = document.createElement('div')
+      row.className = 'border rounded-3 p-2'
+      row.dataset.overlaySourceRow = 'true'
+
+      const layout = document.createElement('div')
+      layout.className = 'row g-2 align-items-start'
+      row.appendChild(layout)
+
+      const keyCol = document.createElement('div')
+      keyCol.className = 'col-lg-4'
+      const keySelect = document.createElement('select')
+      keySelect.className = 'form-select form-select-sm'
+      keySelect.dataset.overlaySourceKey = 'true'
+      keyOptions.forEach(option => {
+        const opt = document.createElement('option')
+        opt.value = option.value
+        opt.textContent = option.label
+        keySelect.appendChild(opt)
+      })
+      const requestedKey = String(entry.badgeKey || '').trim()
+      if (requestedKey && !keyOptions.some(option => option.value === requestedKey)) {
+        const opt = document.createElement('option')
+        opt.value = requestedKey
+        opt.textContent = requestedKey
+        keySelect.appendChild(opt)
+      }
+      keySelect.value = requestedKey
+      keyCol.appendChild(keySelect)
+      layout.appendChild(keyCol)
+
+      const sourceCol = document.createElement('div')
+      sourceCol.className = 'col-lg-2'
+      const sourceSelect = document.createElement('select')
+      sourceSelect.className = 'form-select form-select-sm'
+      sourceSelect.dataset.overlaySourceType = 'true'
+      config.sourceTypes.forEach(sourceType => {
+        const opt = document.createElement('option')
+        opt.value = sourceType
+        opt.textContent = sourceType
+        sourceSelect.appendChild(opt)
+      })
+      sourceSelect.value = String(entry.sourceType || config.sourceTypes[0] || 'file').trim()
+      sourceCol.appendChild(sourceSelect)
+      layout.appendChild(sourceCol)
+
+      const valueCol = document.createElement('div')
+      valueCol.className = 'col-lg-5'
+      const valueInput = document.createElement('input')
+      valueInput.type = 'text'
+      valueInput.className = 'form-control form-control-sm'
+      valueInput.dataset.overlaySourceValue = 'true'
+      valueInput.value = String(entry.value || '').trim()
+      valueCol.appendChild(valueInput)
+      layout.appendChild(valueCol)
+
+      const removeCol = document.createElement('div')
+      removeCol.className = 'col-lg-1 d-grid'
+      const removeBtn = document.createElement('button')
+      removeBtn.type = 'button'
+      removeBtn.className = 'btn btn-outline-danger btn-sm'
+      removeBtn.dataset.overlaySourceRemove = 'true'
+      removeBtn.innerHTML = '<i class="bi bi-x-lg"></i>'
+      removeBtn.setAttribute('aria-label', 'Remove source override')
+      removeCol.appendChild(removeBtn)
+      layout.appendChild(removeCol)
+
+      const help = document.createElement('div')
+      help.className = 'small text-muted mt-2'
+      help.dataset.overlaySourceHelp = 'true'
+      row.appendChild(help)
+
+      const updatePlaceholder = () => {
+        const sourceType = String(sourceSelect.value || '').trim()
+        if (sourceType === 'url') {
+          valueInput.placeholder = 'https://example.com/badge.png'
+          help.textContent = 'Use a direct URL to a badge image.'
+          return
+        }
+        if (sourceType === 'git') {
+          valueInput.placeholder = 'defaults/overlays/images/resolution/custom.png'
+          help.textContent = 'Use a Community-Configs git path.'
+          return
+        }
+        if (sourceType === 'repo') {
+          valueInput.placeholder = 'overlays/resolution/custom.png'
+          help.textContent = 'Use a custom_repo-backed repo path.'
+          return
+        }
+        valueInput.placeholder = 'config/overlays/resolution/custom.png'
+        help.textContent = 'Use a local file path that Kometa can read.'
+      }
+
+      updatePlaceholder()
+      sourceSelect.addEventListener('change', updatePlaceholder)
+      return row
+    }
+
+    const syncOverlaySourceOverrideRows = (cfg, config, section) => {
+      if (!cfg.container || !section) return
+      const hiddenHost = section.querySelector('[data-overlay-source-hidden]')
+      const rows = Array.from(section.querySelectorAll('[data-overlay-source-row="true"]'))
+      const warning = section.querySelector('[data-overlay-source-warning]')
+      if (!hiddenHost || !warning) return
+
+      const seen = new Set()
+      const nextState = []
+      let warningText = ''
+
+      rows.forEach(row => {
+        const keySelect = row.querySelector('[data-overlay-source-key="true"]')
+        const sourceSelect = row.querySelector('[data-overlay-source-type="true"]')
+        const valueInput = row.querySelector('[data-overlay-source-value="true"]')
+        if (!keySelect || !sourceSelect || !valueInput) return
+
+        keySelect.classList.remove('is-invalid')
+        sourceSelect.classList.remove('is-invalid')
+        valueInput.classList.remove('is-invalid')
+
+        const badgeKey = String(keySelect.value || '').trim()
+        const sourceType = String(sourceSelect.value || '').trim()
+        const value = String(valueInput.value || '').trim()
+        if (!value) return
+
+        if (!sourceType) {
+          if (!warningText) {
+            warningText = 'Each source override needs a source type and a value.'
+          }
+          sourceSelect.classList.toggle('is-invalid', !sourceType)
+          return
+        }
+
+        const combo = `${sourceType}:${badgeKey}`
+        if (seen.has(combo)) {
+          if (!warningText) {
+            warningText = 'Duplicate source overrides for the same badge and source type are ignored.'
+          }
+          keySelect.classList.add('is-invalid')
+          sourceSelect.classList.add('is-invalid')
+          return
+        }
+
+        seen.add(combo)
+        nextState.push({ badgeKey, sourceType, value })
+      })
+
+      hiddenHost.innerHTML = ''
+      nextState.forEach(entry => {
+        const varName = encodeOverlaySourceOverrideVarName(entry.sourceType, entry.badgeKey)
+        createOverlaySourceOverrideHiddenInput(cfg, hiddenHost, varName, entry.value)
+      })
+
+      warning.textContent = warningText
+      warning.classList.toggle('d-none', !warningText)
+
+      const emptyState = section.querySelector('[data-overlay-source-empty]')
+      if (emptyState) {
+        emptyState.classList.toggle('d-none', rows.length > 0)
+      }
+
+      if (typeof EventHandler !== 'undefined' && typeof EventHandler.updateAccordionHighlights === 'function') {
+        EventHandler.updateAccordionHighlights()
+      }
+      if (typeof ValidationHandler !== 'undefined' && typeof ValidationHandler.updateValidationState === 'function') {
+        ValidationHandler.updateValidationState()
+      }
+    }
+
+    const renderOverlaySourceOverrideRows = (cfg, config, section, state) => {
+      const rowsHost = section.querySelector('[data-overlay-source-rows]')
+      const hiddenHost = section.querySelector('[data-overlay-source-hidden]')
+      const emptyState = section.querySelector('[data-overlay-source-empty]')
+      if (!rowsHost || !hiddenHost) return
+
+      const keyOptions = getOverlaySourceOverrideKeyOptions(cfg, config)
+      rowsHost.innerHTML = ''
+      const entries = Array.isArray(state) && state.length ? state : []
+      entries.forEach(entry => {
+        const row = buildOverlaySourceOverrideRow(cfg, config, keyOptions, entry)
+        rowsHost.appendChild(row)
+      })
+
+      if (emptyState) {
+        emptyState.classList.toggle('d-none', rowsHost.children.length > 0)
+      }
+
+      rowsHost.querySelectorAll('[data-overlay-source-remove="true"]').forEach(btn => {
+        btn.addEventListener('click', () => {
+          btn.closest('[data-overlay-source-row="true"]')?.remove()
+          syncOverlaySourceOverrideRows(cfg, config, section)
+        })
+      })
+
+      rowsHost.querySelectorAll('[data-overlay-source-key="true"], [data-overlay-source-type="true"], [data-overlay-source-value="true"]').forEach(input => {
+        input.addEventListener('input', () => syncOverlaySourceOverrideRows(cfg, config, section))
+        input.addEventListener('change', () => syncOverlaySourceOverrideRows(cfg, config, section))
+      })
+    }
+
+    const ensureOverlaySourceOverrideEditor = (cfg) => {
+      if (!cfg.container) return
+      const config = getOverlaySourceOverrideConfig(cfg)
+      if (!config) return
+
+      const details = cfg.container.querySelector('.overlay-template-section')
+      if (!details) return
+
+      let section = cfg.container.querySelector('[data-overlay-source-editor="true"]')
+      if (!section) {
+        section = document.createElement('section')
+        section.className = 'border rounded-3 px-3 pt-3 pb-2 mb-3 bg-body-tertiary'
+        section.dataset.overlaySourceEditor = 'true'
+        section.innerHTML = `
+          <div class="d-flex align-items-start justify-content-between gap-2 flex-wrap mb-2">
+            <div>
+              <div class="small text-uppercase fw-semibold text-secondary">${config.title}</div>
+              <div class="form-text">${config.description}</div>
+            </div>
+            <button type="button" class="btn btn-outline-secondary btn-sm" data-overlay-source-add="true">${config.addLabel}</button>
+          </div>
+          <div class="alert alert-warning py-2 px-3 small d-none mb-2" data-overlay-source-warning></div>
+          <div class="d-flex flex-column gap-2" data-overlay-source-rows></div>
+          <div class="small text-muted fst-italic" data-overlay-source-empty>No source overrides configured.</div>
+          <div data-overlay-source-hidden class="d-none"></div>
+        `
+        details.prepend(section)
+      }
+
+      const hiddenHost = section.querySelector('[data-overlay-source-hidden]')
+      if (!hiddenHost) return
+
+      const state = readOverlaySourceOverrideState(cfg, config, hiddenHost)
+      renderOverlaySourceOverrideRows(cfg, config, section, state)
+      syncOverlaySourceOverrideRows(cfg, config, section)
+
+      const addBtn = section.querySelector('[data-overlay-source-add="true"]')
+      if (addBtn && addBtn.dataset.listenerAdded !== 'true') {
+        addBtn.dataset.listenerAdded = 'true'
+        addBtn.addEventListener('click', () => {
+          const rowsHost = section.querySelector('[data-overlay-source-rows]')
+          if (!rowsHost) return
+          const keyOptions = getOverlaySourceOverrideKeyOptions(cfg, config)
+          rowsHost.appendChild(buildOverlaySourceOverrideRow(cfg, config, keyOptions, {
+            sourceType: config.sourceTypes[0] || 'file',
+            badgeKey: '',
+            value: ''
+          }))
+          renderOverlaySourceOverrideRows(cfg, config, section, Array.from(rowsHost.querySelectorAll('[data-overlay-source-row="true"]')).map(row => ({
+            badgeKey: String(row.querySelector('[data-overlay-source-key="true"]')?.value || '').trim(),
+            sourceType: String(row.querySelector('[data-overlay-source-type="true"]')?.value || '').trim(),
+            value: String(row.querySelector('[data-overlay-source-value="true"]')?.value || '').trim()
+          })))
+          syncOverlaySourceOverrideRows(cfg, config, section)
+        })
+      }
+
+      const resetBtn = cfg.container.querySelector('.reset-offset-btn')
+      if (resetBtn && resetBtn.dataset.sourceOverrideResetBound !== 'true') {
+        resetBtn.dataset.sourceOverrideResetBound = 'true'
+        resetBtn.addEventListener('click', () => {
+          setTimeout(() => {
+            const nextState = readOverlaySourceOverrideState(cfg, config, hiddenHost)
+            renderOverlaySourceOverrideRows(cfg, config, section, nextState)
+            syncOverlaySourceOverrideRows(cfg, config, section)
+          }, 0)
+        })
+      }
     }
 
     const syncFlagSizeDefaults = (cfg, emit = true) => {
@@ -4418,6 +4826,7 @@ const OverlayHandler = {
           }
         }
         ensureResolutionToggleFamilyGroups(cfg)
+        ensureOverlaySourceOverrideEditor(cfg)
         syncAudioCodecBackdropHeight(cfg, false)
         syncResolutionBackdropHeight(cfg, false)
         syncResolutionEditionVisibility(cfg, false)

--- a/static/local-js/urlValidation.js
+++ b/static/local-js/urlValidation.js
@@ -104,6 +104,12 @@ const URLValidation = (() => {
 
   function validateAll (container = document) {
     let allValid = true
+    const candidates = Array.from(container.querySelectorAll('input[type="text"], input[type="url"], input[type="search"], textarea'))
+    candidates.forEach(input => {
+      if (isUrlField(input) && input.dataset.urlValidationBound !== 'true') {
+        bindInput(input)
+      }
+    })
     const inputs = Array.from(container.querySelectorAll('[data-url-validation-bound="true"]'))
     inputs.forEach(input => {
       const result = validateValue(input.value)
@@ -115,7 +121,8 @@ const URLValidation = (() => {
 
   return {
     attach,
-    validateAll
+    validateAll,
+    validateValue
   }
 })()
 

--- a/static/local-js/validationHandler.js
+++ b/static/local-js/validationHandler.js
@@ -1,4 +1,4 @@
-/* global $, PathValidation */
+/* global $, PathValidation, URLValidation */
 
 const librariesValidatedAtInput = document.getElementById('libraries_validated_at')
 let librariesTouched = false
@@ -67,6 +67,35 @@ const ValidationHandler = {
     }
 
     return true
+  },
+
+  showAccordionForField: function (field) {
+    if (!field) return
+    let collapse = field.closest('.accordion-collapse')
+    while (collapse) {
+      if (!collapse.classList.contains('show')) {
+        const button = collapse.previousElementSibling?.querySelector('button.accordion-button')
+        if (button) {
+          button.click()
+        } else {
+          collapse.classList.add('show')
+        }
+      }
+      collapse = collapse.parentElement?.closest('.accordion-collapse')
+    }
+  },
+
+  focusFirstInvalidField: function (scope = document) {
+    if (!scope) return
+    const first = scope.querySelector('.is-invalid')
+    if (!first) return
+    ValidationHandler.showAccordionForField(first)
+    window.setTimeout(() => {
+      first.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      if (typeof first.focus === 'function') {
+        first.focus({ preventScroll: true })
+      }
+    }, 180)
   },
 
   validateForm: function () {
@@ -204,12 +233,16 @@ const ValidationHandler = {
     const pathValid = (typeof PathValidation !== 'undefined' && PathValidation.validateAll)
       ? PathValidation.validateAll()
       : true
+    const urlValid = (typeof URLValidation !== 'undefined' && URLValidation.validateAll)
+      ? URLValidation.validateAll()
+      : true
 
     console.log(`[DEBUG] Libraries Valid: ${allLibrariesValid}`)
     console.log(`[DEBUG] Placeholders Valid: ${allPlaceholdersValid}`)
     console.log(`[DEBUG] Paths Valid: ${pathValid}`)
+    console.log(`[DEBUG] URLs Valid: ${urlValid}`)
 
-    if (allLibrariesValid && allPlaceholdersValid && pathValid) {
+    if (allLibrariesValid && allPlaceholdersValid && pathValid && urlValid) {
       console.log('[DEBUG] Validation Passed! Enabling navigation.')
       ValidationHandler.showValidationMessage('Validation successful! You may proceed.', 'success')
       ValidationHandler.enableNavigation()
@@ -217,7 +250,7 @@ const ValidationHandler = {
     } else {
       console.log('[DEBUG] Some validations failed! Disabling navigation.')
       ValidationHandler.showValidationMessage(
-        'Each selected library must have at least one highlighted item, a valid separator placeholder must be selected if a separator is enabled, and any path fields must be valid.',
+        'Each selected library must have at least one highlighted item, a valid separator placeholder must be selected if a separator is enabled, and any path or URL fields must be valid.',
         'danger'
       )
       ValidationHandler.disableNavigation(false)

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -1754,6 +1754,24 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                         current_radio_value == input_value if input_type == "radio"
                                         else data.libraries[input_name]|string|lower == "true"
                                         ) %}
+                                        {% set source_override_seed = [] %}
+                                        {% if overlay.source_overrides is defined %}
+                                            {% for raw_key, raw_val in data.libraries.items() %}
+                                                {% if raw_key.startswith(template_name ~ '[') and raw_key.endswith(']') and raw_val not in [none, '', 'None', 'none', '[]'] %}
+                                                    {% set source_var = raw_key | replace(template_name ~ '[', '') | replace(']', '') %}
+                                                    {% set is_source_override =
+                                                        source_var in ['file', 'url', 'git', 'repo']
+                                                        or source_var.startswith('file_')
+                                                        or source_var.startswith('url_')
+                                                        or source_var.startswith('git_')
+                                                        or source_var.startswith('repo_')
+                                                    %}
+                                                    {% if is_source_override %}
+                                                        {% set _ = source_override_seed.append({'key': source_var, 'value': raw_val}) %}
+                                                    {% endif %}
+                                                {% endif %}
+                                            {% endfor %}
+                                        {% endif %}
 
                                         <div class="template-toggle-group ms-3 mb-2 overlay-config-target"
                                             id="{{ base_id }}-overlay-config"
@@ -1768,6 +1786,8 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                             data-library-id="{{ library.id }}"
                                             data-base-width="{{ base_width }}"
                                             data-base-height="{{ base_height }}"
+                                            {% if overlay.source_overrides is defined %}data-overlay-source-overrides='{{ overlay.source_overrides | tojson | e }}'{% endif %}
+                                            {% if source_override_seed %}data-overlay-source-seed='{{ source_override_seed | tojson | e }}'{% endif %}
                                             {% if effective_offsets and effective_offsets.origin %}data-overlay-origin="{{ effective_offsets.origin }}"{% endif %}>
                                             <div class="form-check form-switch">
                                                 <input

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -1416,9 +1416,13 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                         {% else %}
                         {% set map_default_json = '{}' %}
                         {% endif %}
-                        <div class="mb-2" data-template-mapping-list data-hidden-input="{{ input_name }}">
+                        {% set label_width = item.label_width if item.label_width is defined else (320 if item.label|length > 24 else 170) %}
+                        <div class="mb-2" data-template-mapping-list data-hidden-input="{{ input_name }}"
+                            data-validation-preset="{{ item.validation_preset | default('') }}"
+                            data-mapping-value-kind="{{ item.dynamic_child_value_kind | default('string_list') }}">
                             <div class="input-group">
-                                <span class="input-group-text" id="{{ input_name }}_text" style="width: 170px;">
+                                <span class="input-group-text qs-template-variable-label" id="{{ input_name }}_text"
+                                    style="width: {{ label_width }}px;">
                                     {{ item.label }}
                                     {% if item.tooltip %}
                                     <span class="text-{{ item.tooltip_variant or 'info' }} ms-2" data-bs-toggle="tooltip"

--- a/tests/test_importer_overlay_files.py
+++ b/tests/test_importer_overlay_files.py
@@ -91,6 +91,42 @@ def test_prepare_import_payload_accepts_resolution_template_variables():
     assert any("libraries.Movies.overlay_files[0].template_variables.use_extended" in line for line in report.lines)
 
 
+def test_prepare_import_payload_accepts_resolution_source_override_template_variables():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Movies": {
+                    "overlay_files": [
+                        {
+                            "default": "resolution",
+                            "template_variables": {
+                                "file_4k": "config/overlays/resolution/4k.png",
+                                "url_1080p_dv": "https://example.com/1080p-dv.png",
+                                "git_extended": "defaults/overlays/images/edition/extended.png",
+                                "repo_openmatte": "overlays/resolution/open-matte.png",
+                            },
+                        }
+                    ]
+                }
+            }
+        },
+        {"Movies"},
+        set(),
+        set(),
+    )
+
+    libraries_payload = payload["libraries"]["libraries"]
+    assert libraries_payload["mov-library_movies-movie-overlay_resolution"] is True
+    assert libraries_payload["mov-library_movies-movie-template_overlay_resolution[file_4k]"] == "config/overlays/resolution/4k.png"
+    assert libraries_payload["mov-library_movies-movie-template_overlay_resolution[url_1080p_dv]"] == "https://example.com/1080p-dv.png"
+    assert libraries_payload["mov-library_movies-movie-template_overlay_resolution[git_extended]"] == "defaults/overlays/images/edition/extended.png"
+    assert libraries_payload["mov-library_movies-movie-template_overlay_resolution[repo_openmatte]"] == "overlays/resolution/open-matte.png"
+    assert any("libraries.Movies.overlay_files[0].template_variables.file_4k" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[0].template_variables.url_1080p_dv" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[0].template_variables.git_extended" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[0].template_variables.repo_openmatte" in line for line in report.lines)
+
+
 def test_prepare_import_payload_accepts_audio_codec_template_variables():
     payload, report = importer.prepare_import_payload(
         {

--- a/tests/test_template_gap_analyzer.py
+++ b/tests/test_template_gap_analyzer.py
@@ -428,6 +428,18 @@ def test_key_is_valid_for_default_uses_repo_yaml_for_streaming_and_letterboxd_ca
     assert imdb_top_250_valid is True
 
 
+def test_resolve_default_paths_for_collection_does_not_cross_into_overlay_defaults():
+    module = _load_gap_analyzer_module()
+    kometa_defaults = _kometa_defaults_root()
+
+    network_defaults = module.resolve_default_paths("network", "collection", kometa_defaults)
+
+    assert all("overlays" not in str(path).lower() for path in network_defaults)
+    assert any(str(path).lower().endswith("show\\network.yml") for path in network_defaults)
+    assert module.key_is_valid_for_default("horizontal_align", network_defaults)[0] is False
+    assert module.key_is_valid_for_default("vertical_align", network_defaults)[0] is False
+
+
 def test_classify_yaml_document_type_distinguishes_config_and_external_yaml():
     module = _load_gap_analyzer_module()
 

--- a/tests/test_template_gap_analyzer.py
+++ b/tests/test_template_gap_analyzer.py
@@ -184,7 +184,7 @@ def test_overlay_key_supported_in_quickstart_uses_direct_alias_match_when_availa
     assert module.overlay_key_supported_in_quickstart("ratings", "rating3_image", qs_overlays) is True
 
 
-def test_quickstart_recommendation_summary_includes_runtime_supported_overlay_keys():
+def test_quickstart_recommendation_summary_skips_runtime_supported_overlay_keys():
     module = _load_gap_analyzer_module()
 
     rows = [
@@ -209,10 +209,7 @@ def test_quickstart_recommendation_summary_includes_runtime_supported_overlay_ke
     summary = module.build_quickstart_recommendation_summary(rows)
     ranked = module.serialize_ranked_summary(summary)
 
-    assert len(ranked) == 1
-    assert ranked[0]["key"] == "back_width"
-    assert ranked[0]["supported_in_quickstart"] is True
-    assert ranked[0]["quickstart_declared"] is False
+    assert ranked == []
 
 
 def test_quickstart_recommendation_summary_excludes_legacy_or_not_recommended_library_keys():
@@ -288,7 +285,7 @@ def test_quickstart_recommendation_summary_excludes_legacy_or_not_recommended_li
     summary = module.build_quickstart_recommendation_summary(rows)
     ranked = module.serialize_ranked_summary(summary)
 
-    assert [item["key"] for item in ranked] == ["library_name", "horizontal_align"]
+    assert [item["key"] for item in ranked] == ["library_name"]
 
 
 def test_quickstart_recommendation_exclusion_summary_tracks_legacy_library_keys():
@@ -444,7 +441,7 @@ def test_classify_yaml_document_type_distinguishes_config_and_external_yaml():
     assert module.classify_yaml_document_type(["not", "a", "mapping"]) == "unknown"
 
 
-def test_prefilter_yaml_files_keeps_external_yaml_for_later_type_classification(tmp_path):
+def test_prefilter_yaml_files_skips_external_yaml_early_when_focus_is_config(tmp_path):
     module = _load_gap_analyzer_module()
     overlay_file = tmp_path / "overlay.yml"
     overlay_file.write_text(
@@ -459,9 +456,10 @@ overlays:
 
     candidates, skipped, stats = module.prefilter_yaml_files([overlay_file], yaml_type_focus="config")
 
-    assert candidates == [overlay_file]
-    assert skipped == []
-    assert stats["non_kometa_skips"] == 0
+    assert candidates == []
+    assert len(skipped) == 1
+    assert skipped[0]["error_type"] == "NotKometaConfig"
+    assert stats["non_kometa_skips"] == 1
 
 
 def test_prefilter_yaml_files_does_not_skip_real_config_just_because_filename_looks_like_artifact(tmp_path):
@@ -511,6 +509,29 @@ overlays:
     assert skipped[0]["error_type"] == "YamlTypeExcluded"
     assert skipped[0]["yaml_document_type"] == "external_overlay"
     assert skipped[0]["noise_reason"] == "yaml_type_excluded"
+
+
+def test_prefilter_yaml_files_skips_template_variable_only_external_yaml_when_focus_is_config(tmp_path):
+    module = _load_gap_analyzer_module()
+    external_file = tmp_path / "collection.yml"
+    external_file.write_text(
+        """
+collections:
+  Test:
+    template:
+      name: test
+    template_variables:
+      visible_home: true
+""".strip(),
+        encoding="utf-8",
+    )
+
+    candidates, skipped, stats = module.prefilter_yaml_files([external_file], yaml_type_focus="config")
+
+    assert candidates == []
+    assert len(skipped) == 1
+    assert skipped[0]["error_type"] == "NotKometaConfig"
+    assert stats["non_kometa_skips"] == 1
 
 
 def test_collect_yaml_files_recurses_into_nested_zip_archives(tmp_path):
@@ -855,7 +876,7 @@ def test_build_merged_fix_queue_suppresses_excluded_quickstart_only_keys():
 
     assert len(ranked) == 1
     assert ranked[0]["key"] == "horizontal_align"
-    assert ranked[0]["action_targets"] == ["quickstart", "importer"]
+    assert ranked[0]["action_targets"] == ["importer"]
 
 
 def test_build_merged_fix_queue_excludes_internal_library_type_metadata():

--- a/tests/test_template_gap_analyzer.py
+++ b/tests/test_template_gap_analyzer.py
@@ -265,6 +265,38 @@ def test_quickstart_recommendation_summary_excludes_legacy_or_not_recommended_li
             "value_shape_rule": "string",
         },
         {
+            "kind": "library",
+            "default": None,
+            "key": "sort_by",
+            "file": "config.yml",
+            "library": "Movies",
+            "matched_default_files": ["config/config.yml"],
+            "supported_in_quickstart": False,
+            "quickstart_declared": False,
+            "schema_declared": True,
+            "kometa_declared": True,
+            "validation_level": "works_in_kometa_missing_from_quickstart",
+            "name_verified": True,
+            "value_shape_verified": True,
+            "value_shape_rule": "string",
+        },
+        {
+            "kind": "library",
+            "default": None,
+            "key": "exclude",
+            "file": "config.yml",
+            "library": "Movies",
+            "matched_default_files": ["config/config.yml"],
+            "supported_in_quickstart": False,
+            "quickstart_declared": False,
+            "schema_declared": True,
+            "kometa_declared": True,
+            "validation_level": "works_in_kometa_missing_from_quickstart",
+            "name_verified": True,
+            "value_shape_verified": True,
+            "value_shape_rule": "list",
+        },
+        {
             "kind": "overlay",
             "default": "status",
             "key": "horizontal_align",
@@ -341,6 +373,38 @@ def test_quickstart_recommendation_exclusion_summary_tracks_legacy_library_keys(
             "value_shape_rule": "string",
         },
         {
+            "kind": "library",
+            "default": None,
+            "key": "sort_by",
+            "file": "config.yml",
+            "library": "Movies",
+            "matched_default_files": ["config/config.yml"],
+            "supported_in_quickstart": False,
+            "quickstart_declared": False,
+            "schema_declared": True,
+            "kometa_declared": True,
+            "validation_level": "works_in_kometa_missing_from_quickstart",
+            "name_verified": True,
+            "value_shape_verified": True,
+            "value_shape_rule": "string",
+        },
+        {
+            "kind": "library",
+            "default": None,
+            "key": "exclude",
+            "file": "config.yml",
+            "library": "Movies",
+            "matched_default_files": ["config/config.yml"],
+            "supported_in_quickstart": False,
+            "quickstart_declared": False,
+            "schema_declared": True,
+            "kometa_declared": True,
+            "validation_level": "works_in_kometa_missing_from_quickstart",
+            "name_verified": True,
+            "value_shape_verified": True,
+            "value_shape_rule": "list",
+        },
+        {
             "kind": "overlay",
             "default": "status",
             "key": "vertical_align",
@@ -363,10 +427,13 @@ def test_quickstart_recommendation_exclusion_summary_tracks_legacy_library_keys(
         key=lambda item: str(item["key"]),
     )
 
-    assert [item["key"] for item in excluded] == ["library_type", "metadata_path", "reapply_overlays"]
-    assert excluded[0]["reason"] == "internal_importer_or_analyzer_metadata"
-    assert excluded[1]["reason"] == "legacy_library_path_key_not_recommended"
-    assert excluded[2]["reason"] == "valid_but_not_recommended_for_quickstart"
+    assert [item["key"] for item in excluded] == ["exclude", "library_type", "metadata_path", "reapply_overlays", "sort_by"]
+    reasons = {item["key"]: item["reason"] for item in excluded}
+    assert reasons["library_type"] == "internal_importer_or_analyzer_metadata"
+    assert reasons["metadata_path"] == "legacy_library_path_key_not_recommended"
+    assert reasons["reapply_overlays"] == "valid_but_not_recommended_for_quickstart"
+    assert reasons["sort_by"] == "library_template_variable_not_documented_for_quickstart"
+    assert reasons["exclude"] == "library_template_variable_not_documented_for_quickstart"
 
 
 def test_build_qs_collection_map_preserves_dynamic_family_edge_cases_for_repo_file():
@@ -940,6 +1007,69 @@ def test_build_merged_fix_queue_excludes_internal_library_type_metadata():
     assert len(ranked) == 1
     assert ranked[0]["key"] == "library_name"
     assert ranked[0]["action_targets"] == ["quickstart", "importer"]
+
+
+def test_build_merged_fix_queue_excludes_undocumented_library_template_variables():
+    module = _load_gap_analyzer_module()
+
+    verified_rows = [
+        {
+            "kind": "library",
+            "default": None,
+            "key": "sort_by",
+            "occurrences": 4,
+            "files": ["config.yml"],
+            "libraries": ["Movies"],
+            "matched_default_files": ["config/config.yml"],
+            "supported_in_quickstart": False,
+            "quickstart_declared": False,
+            "schema_declared": True,
+            "kometa_declared": True,
+            "validation_level": "works_in_kometa_missing_from_quickstart",
+        },
+        {
+            "kind": "library",
+            "default": None,
+            "key": "exclude",
+            "occurrences": 4,
+            "files": ["config.yml"],
+            "libraries": ["Movies"],
+            "matched_default_files": ["config/config.yml"],
+            "supported_in_quickstart": False,
+            "quickstart_declared": False,
+            "schema_declared": True,
+            "kometa_declared": True,
+            "validation_level": "works_in_kometa_missing_from_quickstart",
+        },
+    ]
+    importer_rows = [
+        {
+            "kind": "library",
+            "default": None,
+            "key": "sort_by",
+            "import_status": "unmapped",
+            "reason_class": "missing_template_variable_support",
+            "occurrences": 1,
+            "files": ["config.yml"],
+            "libraries": ["Movies"],
+            "reasons": ["Template variable not available in Quickstart."],
+        },
+        {
+            "kind": "library",
+            "default": None,
+            "key": "exclude",
+            "import_status": "unmapped",
+            "reason_class": "missing_template_variable_support",
+            "occurrences": 1,
+            "files": ["config.yml"],
+            "libraries": ["Movies"],
+            "reasons": ["Template variable not available in Quickstart."],
+        },
+    ]
+
+    ranked = module.build_merged_fix_queue(verified_rows, importer_rows)
+
+    assert ranked == []
 
 
 def test_extract_importer_findings_from_data_ignores_bare_library_container_status():


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

The main Quickstart additions in this branch are:
Added support for auto_sort_hubs at both the global Settings level and the library level, including Plex Pass aware handling in the UI.
Added library placeholder ID support for separators:placeholder_imdb_id
placeholder_tmdb_movie
placeholder_tvdb_show
with media-aware behavior so movie/show placeholder usage is clearer and less error-prone.

Added award collection support for winning.
Added use_year_collections support across the award defaults sweep.
Added library_name support in Quickstart where it belongs, while treating library_type as analyzer/importer metadata instead of a missing documented Quickstart feature.
Added shared collection support for hub_priority, including child-key handling such as hub_priority_<key>.
Added franchise dynamic child-key support in Quickstart so franchise defaults can express per-key overrides without manual YAML editing.
This branch also improves the gap-analysis side so recommendations are closer to real Kometa support instead of wiki-only assumptions or importer noise:
Reduced false-positive “missing in Quickstart” recommendations by aligning more closely with the local Kometa YAML/defaults source of truth.
Reclassified or excluded keys that should not be surfaced as Quickstart backlog items, such as legacy or importer-only metadata cases.
Improved handling around documented-vs-runtime mismatches so the report is more useful for deciding whether something belongs in Quickstart, schema support, or neither.
Net effect: this branch adds real Kometa-backed support in Quickstart for a meaningful set of collection and library variables, and makes the gap report more trustworthy for deciding the next sweep of missing features.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
