### PR TITLE
Fix platform-specific path separator bug in gap-analyzer test

### DIFF
--- a/tests/test_template_gap_analyzer.py
+++ b/tests/test_template_gap_analyzer.py
@@ -502,7 +502,7 @@ def test_resolve_default_paths_for_collection_does_not_cross_into_overlay_defaul
     network_defaults = module.resolve_default_paths("network", "collection", kometa_defaults)
 
     assert all("overlays" not in str(path).lower() for path in network_defaults)
-    assert any(str(path).lower().endswith("show\\network.yml") for path in network_defaults)
+    assert any(path.parts[-2:] == ("show", "network.yml") for path in network_defaults)
     assert module.key_is_valid_for_default("horizontal_align", network_defaults)[0] is False
     assert module.key_is_valid_for_default("vertical_align", network_defaults)[0] is False
 


### PR DESCRIPTION
## Summary
`test_resolve_default_paths_for_collection_does_not_cross_into_overlay_defaults` (added in #1308) hardcoded a Windows-style backslash separator: `str(path).lower().endswith("show\\network.yml")`. On POSIX, `str(Path(...))` uses forward slashes, so this assertion never matches and the test fails on Linux/macOS dev environments and CI runners.

Fixed by comparing `Path.parts` directly instead of stringifying with an assumed separator — works regardless of platform.

Verified this is unrelated to the in-flight monolith-breakup work (#1309): confirmed via `git diff origin/develop` that this branch touches nothing else, and the fix is scoped to this one line.

## Test plan
- [x] `pytest tests/test_template_gap_analyzer.py` passes
- [x] `ruff check .` clean
- [ ] CI run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)