### PR TITLE
Extract Plex/header/run-command parsing into modules/logscan_command.py (5/6)

### DIFF
--- a/modules/logscan.py
+++ b/modules/logscan.py
@@ -3,12 +3,13 @@ import json
 import logging
 import os
 import re
-import shlex
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from urllib.parse import unquote
 
 import requests
+
+from modules import logscan_command
 
 # Create logger
 mylogger = logging.getLogger("logscan")
@@ -1966,227 +1967,51 @@ class LogscanAnalyzer:
         return sorted_recommendations
 
     def extract_plex_config(self, content):
+        """Extract Plex configuration sections from ``content``.
+
+        Delegates to :mod:`modules.logscan_command` and folds any flagged
+        server versions onto ``self.server_versions`` so the legacy
+        ``make_recommendations`` lookup keeps working.
         """
-        Extract Plex configuration sections from the content.
-        """
-        lines = content.splitlines()
-        plex_config_content = []
-
-        start_marker = "Plex Configuration"
-        # end_markers = [" Scanning Metadata and", "Library Connection Failed"]
-        end_markers = [" Scanning ", "Library Connection Failed"]
-        mylogger.debug("extract_plex_config")
-
-        i = 0
-        while i < len(lines):
-            line = lines[i]
-            if start_marker in line:
-                config_section = self.extract_plex_config_section(lines, i + 1, end_markers)
-                if config_section:
-                    # Call parse_server_info
-                    server_info, all_lines = self.parse_server_info(config_section)
-                    plex_config_content.append(config_section)
-
-                    # Store the extracted server info in a variable
-                    if server_info:
-                        my_server_name = server_info["server_name"]
-                        my_server_version = server_info["version"]
-
-                        stable_version = "1.40.0.7998-c29d4c0c8"
-                        good_version = "1.40.3.8555-fef15d30c"
-
-                        if stable_version < my_server_version < good_version:
-                            mylogger.debug(
-                                f"Server Name: {my_server_name} has Version: {my_server_version}. Potential Rounding Issue because > {stable_version} and < {good_version}"
-                            )
-                            # Store the server version globally in a list
-                            self.server_versions.append((my_server_name, my_server_version))
-                        elif my_server_version >= good_version:
-                            mylogger.debug(f"Server Name: {my_server_name} has Version: {my_server_version}. ALL GOOD")
-                        else:
-                            mylogger.debug(f"Server Name: {my_server_name} has Version: {my_server_version}. ALL GOOD")
-
-            i += 1
-
-        if plex_config_content:
-            return plex_config_content  # Return the list of extracted server info
-        else:
-            return None
+        result = logscan_command.extract_plex_config(content)
+        self.server_versions.extend(result["server_versions"])
+        return result["plex_config_content"]
 
     def extract_plex_config_section(self, lines, start_index, end_markers):
-        """
-        Extract a Plex configuration section starting from a specific index.
-        """
-        config_section = []
-
-        for i in range(start_index, len(lines)):
-            line = lines[i].strip()
-            if any(marker in line for marker in end_markers):
-                break
-            if line:
-                config_section.append(line)
-
-        # Find the index of "Traceback (most recent call last):"
-        traceback_marker = "Traceback (most recent call last):"
-        traceback_line_number = -1
-        for i, line in enumerate(config_section):
-            if traceback_marker in line:
-                traceback_line_number = i
-                break
-
-        # Remove lines after traceback_marker + 1 and before (total_lines - 2)
-        if traceback_line_number >= 0:
-            total_lines = len(config_section)
-            start_remove = traceback_line_number + 1
-            end_remove = total_lines - 2
-            config_section = config_section[:start_remove] + config_section[end_remove + 1 :]
-
-        return "\n".join(config_section) if config_section else None
+        return logscan_command.extract_plex_config_section(lines, start_index, end_markers)
 
     def parse_server_info(self, config_section):
-        """
-        Parse the server name and version from the Plex configuration section.
-        """
-        server_info = {}
-
-        # Initialize a list to keep all lines, including the ones not matched
-        all_lines = []
-
-        # Iterate through each line in the config_section
-        for line in config_section.splitlines():
-            # Add each line to the all_lines list
-            all_lines.append(line)
-
-            # Attempt to match the regex pattern in the current line
-            match = re.search(r"Connected to server\s+([\w\s]+)\s+version\s+(\d+\.\d+\.\d+\.\d+-[\w\d]+)", line)
-            if match:
-                # Extract server name and version from the regex match
-                server_name = match.group(1).strip()
-                version = match.group(2).strip()
-
-                # Store server name and version in dictionary
-                server_info["server_name"] = server_name
-                server_info["version"] = version
-
-        # Log if server info extraction failed for all lines
-        if not server_info:
-            mylogger.debug("Failed to extract server info from config_section")
-
-        return server_info, all_lines
+        return logscan_command.parse_server_info(config_section)
 
     def extract_header_lines(self, content):
-        start_marker_current = "Version: "
-        start_marker_newest = "Newest Version: "
-        end_marker = "Run Command: "
-
-        lines = content.splitlines()
-        header_lines = []
-
-        for i, line in enumerate(lines):
-            if start_marker_current in line:
-                version_value = line.split(start_marker_current)[1].strip()  # Extract version value
-                self.current_kometa_version = version_value  # Store the version as a class variable
-                while line and end_marker not in line:
-                    header_lines.append(line.strip())  # Trim leading and trailing spaces
-                    i += 1
-                    line = lines[i] if i < len(lines) else ""
-                    if start_marker_newest in line:
-                        newest_version_value = line.split(start_marker_newest)[1].strip()  # Extract newest version value
-                        self.kometa_newest_version = newest_version_value  # Store the newest version as a class variable
-                header_lines.append(line.strip())  # Append the "Run Command" line
-                # mylogger.info(f"header_lines bef replacement: {header_lines}")
-                break  # Stop after the first occurrence
-
-        # Perform the replacement after all lines have been added to header_lines
-        header_lines = [line.replace("(redacted)", "") for line in header_lines]
-        header_lines = [line.replace("(redacted)", "") for line in header_lines]
-        # mylogger.info(f"header_lines aft replacement: {header_lines}")
-
-        return "\n".join(header_lines)
+        """Capture the header block and stash the Kometa versions on ``self``."""
+        header_text, current_version, newest_version = logscan_command.extract_header_lines(content)
+        if current_version is not None:
+            self.current_kometa_version = current_version
+        if newest_version is not None:
+            self.kometa_newest_version = newest_version
+        return header_text
 
     def extract_run_command(self, content):
-        if not content:
-            return None
-        for line in content.splitlines():
-            match = re.search(r"Run Command:\s*(.+)$", line)
-            if match:
-                return match.group(1).strip()
-        return None
+        return logscan_command.extract_run_command(content)
 
     def _split_command(self, command):
-        if not command:
-            return []
-        try:
-            return shlex.split(command, posix=False)
-        except Exception:
-            return command.split()
+        return logscan_command.split_command(command)
 
     def compute_command_signature(self, run_command):
-        if not run_command:
-            return None
-        tokens = self._split_command(run_command)
-        flags = []
-        for token in tokens:
-            if token.startswith("-"):
-                flag = token.split("=", 1)[0]
-                flags.append(flag)
-        return " ".join(flags)
+        return logscan_command.compute_command_signature(run_command)
 
     def _extract_config_path_from_command(self, run_command):
-        if not run_command:
-            return None
-        tokens = self._split_command(run_command)
-        for idx, token in enumerate(tokens):
-            if token.startswith("--config="):
-                return token.split("=", 1)[1].strip('"')
-            if token == "--config" and idx + 1 < len(tokens):
-                return tokens[idx + 1].strip('"')
-        return None
+        return logscan_command.extract_config_path_from_command(run_command)
 
     def _derive_config_name_from_path(self, config_path):
-        try:
-            config_path = Path(config_path)
-        except Exception:
-            return None
-        stem = config_path.stem
-        if stem.endswith("_config"):
-            stem = stem[: -len("_config")]
-        return stem or None
+        return logscan_command.derive_config_name_from_path(config_path)
 
     def sanitize_run_command(self, run_command, config_path=None):
-        if not run_command:
-            return None
-        cleaned = run_command
-        if config_path:
-            config_path = str(config_path)
-            cleaned = cleaned.replace(config_path, "<config>")
-            cleaned = cleaned.replace(config_path.replace("\\", "/"), "<config>")
-            cleaned = cleaned.replace(config_path.replace("/", "\\"), "<config>")
-        cleaned = re.sub(
-            r"(?i)(--?[\w-]*(token|apikey|api-key|api_key|secret)\w*)(=|\s+)(\S+)",
-            r"\1\3<redacted>",
-            cleaned,
-        )
-        return cleaned
+        return logscan_command.sanitize_run_command(run_command, config_path=config_path)
 
     def _hash_file(self, path):
-        if not path:
-            return None
-        try:
-            path = Path(path)
-        except Exception:
-            return None
-        if not path.exists():
-            return None
-        hasher = hashlib.sha256()
-        try:
-            with path.open("rb") as handle:
-                for chunk in iter(lambda: handle.read(8192), b""):
-                    hasher.update(chunk)
-            return hasher.hexdigest()
-        except Exception as exc:
-            mylogger.warning(f"Failed to hash config file {path}: {exc}")
-            return None
+        return logscan_command.hash_file(path)
 
     def _parse_finished_datetime(self, value):
         if not value:

--- a/modules/logscan_command.py
+++ b/modules/logscan_command.py
@@ -1,0 +1,302 @@
+"""Plex-config, header, and run-command parsing helpers extracted from
+``modules.logscan``.
+
+These are stateless utilities that read a log's text and pull out the
+"who/what/where" details — Plex server identity, Kometa version, and the CLI
+invocation — without depending on any analyzer instance state.
+
+`LogscanAnalyzer` retains thin wrapper methods that delegate here so that the
+class-method call sites (``analyze_content`` and friends) keep working
+unchanged.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+import shlex
+from pathlib import Path
+from typing import Iterable
+
+_logger = logging.getLogger("logscan")
+
+
+# ---------------------------------------------------------------------------
+# Plex configuration / server-version parsing
+# ---------------------------------------------------------------------------
+
+_PLEX_CONFIG_START_MARKER = "Plex Configuration"
+_PLEX_CONFIG_END_MARKERS = (" Scanning ", "Library Connection Failed")
+_PLEX_TRACEBACK_MARKER = "Traceback (most recent call last):"
+_SERVER_INFO_RE = re.compile(
+    r"Connected to server\s+([\w\s]+)\s+version\s+(\d+\.\d+\.\d+\.\d+-[\w\d]+)"
+)
+
+# Versions inside (stable_version, good_version) are flagged as potentially
+# affected by the Plex "rounding issue" that older logscan recommendations call
+# out. The boundary versions themselves are considered safe.
+_PLEX_STABLE_VERSION = "1.40.0.7998-c29d4c0c8"
+_PLEX_GOOD_VERSION = "1.40.3.8555-fef15d30c"
+
+
+def extract_plex_config_section(
+    lines: list[str], start_index: int, end_markers: Iterable[str]
+) -> str | None:
+    """Pull a single Plex Configuration block from ``lines`` and strip out any
+    traceback noise that landed inside it.
+
+    Returns ``None`` when the section is empty.
+    """
+    config_section: list[str] = []
+
+    for i in range(start_index, len(lines)):
+        line = lines[i].strip()
+        if any(marker in line for marker in end_markers):
+            break
+        if line:
+            config_section.append(line)
+
+    traceback_line_number = -1
+    for i, line in enumerate(config_section):
+        if _PLEX_TRACEBACK_MARKER in line:
+            traceback_line_number = i
+            break
+
+    if traceback_line_number >= 0:
+        total_lines = len(config_section)
+        start_remove = traceback_line_number + 1
+        end_remove = total_lines - 2
+        config_section = config_section[:start_remove] + config_section[end_remove + 1:]
+
+    return "\n".join(config_section) if config_section else None
+
+
+def parse_server_info(config_section: str) -> tuple[dict, list[str]]:
+    """Parse the server name + version from a single Plex configuration block.
+
+    Returns ``(server_info_dict, all_lines)``. ``server_info_dict`` is empty
+    when no "Connected to server ... version ..." line is present.
+    """
+    server_info: dict = {}
+    all_lines: list[str] = []
+
+    for line in config_section.splitlines():
+        all_lines.append(line)
+        match = _SERVER_INFO_RE.search(line)
+        if match:
+            server_info["server_name"] = match.group(1).strip()
+            server_info["version"] = match.group(2).strip()
+
+    if not server_info:
+        _logger.debug("Failed to extract server info from config_section")
+
+    return server_info, all_lines
+
+
+def extract_plex_config(content: str) -> dict:
+    """Walk the full log content and return every Plex Configuration block
+    along with the (server_name, server_version) tuples that fall in the
+    "rounding issue" version range.
+
+    Returns ``{"plex_config_content": [...], "server_versions": [...]}``.
+    ``plex_config_content`` is ``None`` when no Plex Configuration block is
+    found — matching the legacy ``LogscanAnalyzer.extract_plex_config``
+    return shape.
+    """
+    lines = content.splitlines()
+    plex_config_content: list[str] = []
+    server_versions: list[tuple[str, str]] = []
+
+    _logger.debug("extract_plex_config")
+
+    i = 0
+    while i < len(lines):
+        if _PLEX_CONFIG_START_MARKER in lines[i]:
+            config_section = extract_plex_config_section(lines, i + 1, _PLEX_CONFIG_END_MARKERS)
+            if config_section:
+                server_info, _all_lines = parse_server_info(config_section)
+                plex_config_content.append(config_section)
+
+                if server_info:
+                    my_server_name = server_info["server_name"]
+                    my_server_version = server_info["version"]
+
+                    if _PLEX_STABLE_VERSION < my_server_version < _PLEX_GOOD_VERSION:
+                        _logger.debug(
+                            f"Server Name: {my_server_name} has Version: "
+                            f"{my_server_version}. Potential Rounding Issue "
+                            f"because > {_PLEX_STABLE_VERSION} and < {_PLEX_GOOD_VERSION}"
+                        )
+                        server_versions.append((my_server_name, my_server_version))
+                    else:
+                        _logger.debug(
+                            f"Server Name: {my_server_name} has Version: "
+                            f"{my_server_version}. ALL GOOD"
+                        )
+        i += 1
+
+    return {
+        "plex_config_content": plex_config_content if plex_config_content else None,
+        "server_versions": server_versions,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Header / Kometa-version parsing
+# ---------------------------------------------------------------------------
+
+_HEADER_CURRENT_MARKER = "Version: "
+_HEADER_NEWEST_MARKER = "Newest Version: "
+_HEADER_END_MARKER = "Run Command: "
+
+
+def extract_header_lines(content: str) -> tuple[str, str | None, str | None]:
+    """Capture the header block from the start of a Kometa run, returning
+    ``(header_text, current_kometa_version, newest_kometa_version)``.
+
+    The text is joined with ``"\\n"`` separators and has ``"(redacted)"``
+    markers stripped, matching the original behavior. Versions are ``None``
+    when the corresponding marker is absent.
+    """
+    lines = content.splitlines()
+    header_lines: list[str] = []
+    current_version: str | None = None
+    newest_version: str | None = None
+
+    for i, line in enumerate(lines):
+        if _HEADER_CURRENT_MARKER in line:
+            current_version = line.split(_HEADER_CURRENT_MARKER)[1].strip()
+            while line and _HEADER_END_MARKER not in line:
+                header_lines.append(line.strip())
+                i += 1
+                line = lines[i] if i < len(lines) else ""
+                if _HEADER_NEWEST_MARKER in line:
+                    newest_version = line.split(_HEADER_NEWEST_MARKER)[1].strip()
+            header_lines.append(line.strip())  # the "Run Command" line
+            break  # only the first occurrence matters
+
+    # Two passes preserve the original behavior of stripping "(redacted)"
+    # markers that may have been duplicated by the source log.
+    header_lines = [line.replace("(redacted)", "") for line in header_lines]
+    header_lines = [line.replace("(redacted)", "") for line in header_lines]
+
+    return "\n".join(header_lines), current_version, newest_version
+
+
+# ---------------------------------------------------------------------------
+# Run command parsing / sanitization
+# ---------------------------------------------------------------------------
+
+_RUN_COMMAND_RE = re.compile(r"Run Command:\s*(.+)$")
+_SENSITIVE_FLAG_RE = re.compile(
+    r"(?i)(--?[\w-]*(token|apikey|api-key|api_key|secret)\w*)(=|\s+)(\S+)"
+)
+
+
+def extract_run_command(content: str) -> str | None:
+    """Return the first ``Run Command:`` value from the log, or ``None``."""
+    if not content:
+        return None
+    for line in content.splitlines():
+        match = _RUN_COMMAND_RE.search(line)
+        if match:
+            return match.group(1).strip()
+    return None
+
+
+def split_command(command: str | None) -> list[str]:
+    """Split a CLI command into tokens. Falls back to whitespace split when
+    ``shlex`` chokes (e.g. on Windows-style quoting)."""
+    if not command:
+        return []
+    try:
+        return shlex.split(command, posix=False)
+    except Exception:
+        return command.split()
+
+
+def compute_command_signature(run_command: str | None) -> str | None:
+    """Reduce a run command to its space-joined sequence of flag names — a
+    stable identifier for "the same kind of run" regardless of values.
+
+    ``--config=foo --run`` and ``--config=bar --run`` share the same signature.
+    """
+    if not run_command:
+        return None
+    tokens = split_command(run_command)
+    flags = [token.split("=", 1)[0] for token in tokens if token.startswith("-")]
+    return " ".join(flags)
+
+
+def extract_config_path_from_command(run_command: str | None) -> str | None:
+    """Pull the ``--config`` argument out of a run command, supporting both
+    ``--config=path`` and ``--config path`` syntaxes."""
+    if not run_command:
+        return None
+    tokens = split_command(run_command)
+    for idx, token in enumerate(tokens):
+        if token.startswith("--config="):
+            return token.split("=", 1)[1].strip('"')
+        if token == "--config" and idx + 1 < len(tokens):
+            return tokens[idx + 1].strip('"')
+    return None
+
+
+def derive_config_name_from_path(config_path) -> str | None:
+    """Turn ``/path/to/my_config.yml`` into ``"my"`` — strip directory, drop
+    the extension, and remove a trailing ``_config`` suffix when present."""
+    try:
+        config_path = Path(config_path)
+    except Exception:
+        return None
+    stem = config_path.stem
+    if stem.endswith("_config"):
+        stem = stem[: -len("_config")]
+    return stem or None
+
+
+def sanitize_run_command(run_command: str | None, config_path=None) -> str | None:
+    """Redact a run command for safe display: replace the config path with
+    ``<config>`` and redact token/apikey/secret flag values with ``<redacted>``.
+
+    Handles both forward and back slash variants of the path so logs from any
+    OS render consistently.
+    """
+    if not run_command:
+        return None
+    cleaned = run_command
+    if config_path:
+        config_path = str(config_path)
+        cleaned = cleaned.replace(config_path, "<config>")
+        cleaned = cleaned.replace(config_path.replace("\\", "/"), "<config>")
+        cleaned = cleaned.replace(config_path.replace("/", "\\"), "<config>")
+    cleaned = _SENSITIVE_FLAG_RE.sub(r"\1\3<redacted>", cleaned)
+    return cleaned
+
+
+# ---------------------------------------------------------------------------
+# Config-file hashing
+# ---------------------------------------------------------------------------
+
+
+def hash_file(path) -> str | None:
+    """Return the SHA-256 hex digest of ``path``, or ``None`` if it cannot be
+    read. Logs a warning on read errors but never raises."""
+    if not path:
+        return None
+    try:
+        path = Path(path)
+    except Exception:
+        return None
+    if not path.exists():
+        return None
+    hasher = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(8192), b""):
+                hasher.update(chunk)
+        return hasher.hexdigest()
+    except Exception as exc:
+        _logger.warning(f"Failed to hash config file {path}: {exc}")
+        return None

--- a/modules/logscan_command.py
+++ b/modules/logscan_command.py
@@ -29,9 +29,7 @@ _logger = logging.getLogger("logscan")
 _PLEX_CONFIG_START_MARKER = "Plex Configuration"
 _PLEX_CONFIG_END_MARKERS = (" Scanning ", "Library Connection Failed")
 _PLEX_TRACEBACK_MARKER = "Traceback (most recent call last):"
-_SERVER_INFO_RE = re.compile(
-    r"Connected to server\s+([\w\s]+)\s+version\s+(\d+\.\d+\.\d+\.\d+-[\w\d]+)"
-)
+_SERVER_INFO_RE = re.compile(r"Connected to server\s+([\w\s]+)\s+version\s+(\d+\.\d+\.\d+\.\d+-[\w\d]+)")
 
 # Versions inside (stable_version, good_version) are flagged as potentially
 # affected by the Plex "rounding issue" that older logscan recommendations call
@@ -40,9 +38,7 @@ _PLEX_STABLE_VERSION = "1.40.0.7998-c29d4c0c8"
 _PLEX_GOOD_VERSION = "1.40.3.8555-fef15d30c"
 
 
-def extract_plex_config_section(
-    lines: list[str], start_index: int, end_markers: Iterable[str]
-) -> str | None:
+def extract_plex_config_section(lines: list[str], start_index: int, end_markers: Iterable[str]) -> str | None:
     """Pull a single Plex Configuration block from ``lines`` and strip out any
     traceback noise that landed inside it.
 
@@ -67,7 +63,7 @@ def extract_plex_config_section(
         total_lines = len(config_section)
         start_remove = traceback_line_number + 1
         end_remove = total_lines - 2
-        config_section = config_section[:start_remove] + config_section[end_remove + 1:]
+        config_section = config_section[:start_remove] + config_section[end_remove + 1 :]
 
     return "\n".join(config_section) if config_section else None
 
@@ -130,10 +126,7 @@ def extract_plex_config(content: str) -> dict:
                         )
                         server_versions.append((my_server_name, my_server_version))
                     else:
-                        _logger.debug(
-                            f"Server Name: {my_server_name} has Version: "
-                            f"{my_server_version}. ALL GOOD"
-                        )
+                        _logger.debug(f"Server Name: {my_server_name} has Version: " f"{my_server_version}. ALL GOOD")
         i += 1
 
     return {
@@ -189,9 +182,7 @@ def extract_header_lines(content: str) -> tuple[str, str | None, str | None]:
 # ---------------------------------------------------------------------------
 
 _RUN_COMMAND_RE = re.compile(r"Run Command:\s*(.+)$")
-_SENSITIVE_FLAG_RE = re.compile(
-    r"(?i)(--?[\w-]*(token|apikey|api-key|api_key|secret)\w*)(=|\s+)(\S+)"
-)
+_SENSITIVE_FLAG_RE = re.compile(r"(?i)(--?[\w-]*(token|apikey|api-key|api_key|secret)\w*)(=|\s+)(\S+)")
 
 
 def extract_run_command(content: str) -> str | None:

--- a/tests/test_logscan_command.py
+++ b/tests/test_logscan_command.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from modules import logscan_command
 
-
 # ---------------------------------------------------------------------------
 # extract_plex_config_section
 # ---------------------------------------------------------------------------
@@ -212,10 +211,7 @@ def test_extract_config_path_quoted_value_without_spaces():
     # Known limitation: shlex with posix=False does not honor quoted values
     # that contain spaces. This documents the current behavior rather than
     # endorses it.
-    assert (
-        logscan_command.extract_config_path_from_command('kometa --config="/tmp/foo bar.yml"')
-        == '/tmp/foo'
-    )
+    assert logscan_command.extract_config_path_from_command('kometa --config="/tmp/foo bar.yml"') == "/tmp/foo"
 
 
 def test_extract_config_path_returns_none_when_absent():
@@ -247,9 +243,7 @@ def test_derive_config_name_handles_path_objects():
 
 
 def test_sanitize_run_command_replaces_config_path():
-    cleaned = logscan_command.sanitize_run_command(
-        "kometa --config=/etc/secrets/mine.yml --run", config_path="/etc/secrets/mine.yml"
-    )
+    cleaned = logscan_command.sanitize_run_command("kometa --config=/etc/secrets/mine.yml --run", config_path="/etc/secrets/mine.yml")
     assert "/etc/secrets/mine.yml" not in cleaned
     assert "<config>" in cleaned
 
@@ -261,9 +255,7 @@ def test_sanitize_run_command_redacts_secret_flags():
 
 
 def test_sanitize_run_command_replaces_path_with_alt_separators():
-    cleaned = logscan_command.sanitize_run_command(
-        "kometa --config C:\\Users\\test\\config.yml", config_path="C:/Users/test/config.yml"
-    )
+    cleaned = logscan_command.sanitize_run_command("kometa --config C:\\Users\\test\\config.yml", config_path="C:/Users/test/config.yml")
     assert "config.yml" not in cleaned
     assert "<config>" in cleaned
 

--- a/tests/test_logscan_command.py
+++ b/tests/test_logscan_command.py
@@ -1,0 +1,298 @@
+"""Tests for the extracted ``modules.logscan_command`` helpers."""
+
+import hashlib
+from pathlib import Path
+
+from modules import logscan_command
+
+
+# ---------------------------------------------------------------------------
+# extract_plex_config_section
+# ---------------------------------------------------------------------------
+
+
+def test_extract_plex_config_section_stops_at_end_marker():
+    # Note: end markers are matched after .strip(), so leading-space markers
+    # like " Scanning " only work when the log line itself has additional
+    # content past the strip. We use "Library Connection Failed" here because
+    # it survives stripping intact.
+    lines = [
+        "Connected to server MyPlex version 1.40.0.7998-c29d4c0c8",
+        "Some other line",
+        "Library Connection Failed: thing",  # end marker
+        "should not appear",
+    ]
+    result = logscan_command.extract_plex_config_section(lines, 0, ("Library Connection Failed",))
+    assert "Connected to server MyPlex" in result
+    assert "Some other line" in result
+    assert "should not appear" not in result
+
+
+def test_extract_plex_config_section_skips_blank_lines():
+    lines = ["alpha", "", "   ", "beta"]
+    result = logscan_command.extract_plex_config_section(lines, 0, ("nope",))
+    assert result == "alpha\nbeta"
+
+
+def test_extract_plex_config_section_returns_none_when_empty():
+    assert logscan_command.extract_plex_config_section([], 0, ("x",)) is None
+
+
+def test_extract_plex_config_section_strips_traceback_middle():
+    lines = [
+        "header line",
+        "Traceback (most recent call last):",
+        "  File noisy",
+        "  more noise",
+        "still noise",
+        "keep1",
+        "final-1",
+        "final",
+    ]
+    result = logscan_command.extract_plex_config_section(lines, 0, ("nope",))
+    # Keeps everything up through the traceback marker, plus the LAST line
+    # ("final"). Lines in between are dropped to suppress traceback noise
+    # while preserving the closing context.
+    assert "header line" in result
+    assert "Traceback" in result
+    assert "noisy" not in result
+    assert "still noise" not in result
+    assert "keep1" not in result
+    assert "final-1" not in result
+    assert result.endswith("final")
+
+
+# ---------------------------------------------------------------------------
+# parse_server_info
+# ---------------------------------------------------------------------------
+
+
+def test_parse_server_info_extracts_name_and_version():
+    section = "Connected to server MyPlex version 1.40.3.8555-fef15d30c"
+    info, lines = logscan_command.parse_server_info(section)
+    assert info == {"server_name": "MyPlex", "version": "1.40.3.8555-fef15d30c"}
+    assert lines == [section]
+
+
+def test_parse_server_info_returns_empty_when_no_match():
+    info, lines = logscan_command.parse_server_info("nothing to see here")
+    assert info == {}
+    assert lines == ["nothing to see here"]
+
+
+# ---------------------------------------------------------------------------
+# extract_plex_config (integration of the two above)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_plex_config_collects_flagged_versions_only():
+    # Use "Library Connection Failed" as the end marker so test sections
+    # actually terminate (the production " Scanning " marker has a known
+    # quirk where it can be eaten by .strip() on short lines).
+    content = "\n".join(
+        [
+            "Plex Configuration",
+            "Connected to server A version 1.40.2.0000-aaaabbbb",  # in flagged range
+            "Library Connection Failed: stop here",
+            "noise",
+            "Plex Configuration",
+            "Connected to server B version 1.40.3.8555-fef15d30c",  # NOT flagged (>= good)
+            "Library Connection Failed: stop here",
+        ]
+    )
+    result = logscan_command.extract_plex_config(content)
+    assert result["plex_config_content"] is not None
+    assert len(result["plex_config_content"]) == 2
+    # Only the middle-range server should be in server_versions.
+    assert result["server_versions"] == [("A", "1.40.2.0000-aaaabbbb")]
+
+
+def test_extract_plex_config_returns_none_content_when_absent():
+    result = logscan_command.extract_plex_config("nothing relevant")
+    assert result == {"plex_config_content": None, "server_versions": []}
+
+
+# ---------------------------------------------------------------------------
+# extract_header_lines
+# ---------------------------------------------------------------------------
+
+
+def test_extract_header_lines_captures_versions_and_strips_redacted():
+    content = "\n".join(
+        [
+            "preamble",
+            "Version: 1.20.0",
+            "Newest Version: 1.21.0",
+            "Run Command: kometa --config=/tmp/test_config.yml (redacted)",
+            "stuff after",
+        ]
+    )
+    header, current, newest = logscan_command.extract_header_lines(content)
+    assert current == "1.20.0"
+    assert newest == "1.21.0"
+    assert "(redacted)" not in header
+    assert "Run Command:" in header
+    assert "stuff after" not in header
+
+
+def test_extract_header_lines_handles_missing_newest_version():
+    content = "Version: 1.20.0\nRun Command: kometa"
+    header, current, newest = logscan_command.extract_header_lines(content)
+    assert current == "1.20.0"
+    assert newest is None
+    assert header.endswith("Run Command: kometa")
+
+
+def test_extract_header_lines_no_version_returns_none_versions():
+    header, current, newest = logscan_command.extract_header_lines("")
+    assert header == ""
+    assert current is None
+    assert newest is None
+
+
+# ---------------------------------------------------------------------------
+# extract_run_command / split_command
+# ---------------------------------------------------------------------------
+
+
+def test_extract_run_command_returns_first_match():
+    content = "noise\nRun Command: kometa --run\nRun Command: should-not-win"
+    assert logscan_command.extract_run_command(content) == "kometa --run"
+
+
+def test_extract_run_command_returns_none_on_empty_input():
+    assert logscan_command.extract_run_command("") is None
+    assert logscan_command.extract_run_command(None) is None
+
+
+def test_split_command_returns_empty_list_for_empty_input():
+    assert logscan_command.split_command("") == []
+    assert logscan_command.split_command(None) == []
+
+
+def test_split_command_uses_shlex_for_normal_commands():
+    assert logscan_command.split_command("kometa --config=/tmp/x.yml --run") == [
+        "kometa",
+        "--config=/tmp/x.yml",
+        "--run",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# compute_command_signature
+# ---------------------------------------------------------------------------
+
+
+def test_compute_command_signature_keeps_only_flags():
+    sig = logscan_command.compute_command_signature("kometa --config=/x --run -v")
+    assert sig == "--config --run -v"
+
+
+def test_compute_command_signature_returns_none_for_empty():
+    assert logscan_command.compute_command_signature("") is None
+    assert logscan_command.compute_command_signature(None) is None
+
+
+# ---------------------------------------------------------------------------
+# extract_config_path_from_command
+# ---------------------------------------------------------------------------
+
+
+def test_extract_config_path_equals_syntax():
+    assert logscan_command.extract_config_path_from_command("kometa --config=/tmp/foo.yml --run") == "/tmp/foo.yml"
+
+
+def test_extract_config_path_space_syntax():
+    assert logscan_command.extract_config_path_from_command("kometa --config /tmp/foo.yml --run") == "/tmp/foo.yml"
+
+
+def test_extract_config_path_quoted_value_without_spaces():
+    # Quoted values without internal spaces still get their quotes stripped.
+    assert logscan_command.extract_config_path_from_command('kometa --config="/tmp/foo.yml"') == "/tmp/foo.yml"
+    # Known limitation: shlex with posix=False does not honor quoted values
+    # that contain spaces. This documents the current behavior rather than
+    # endorses it.
+    assert (
+        logscan_command.extract_config_path_from_command('kometa --config="/tmp/foo bar.yml"')
+        == '/tmp/foo'
+    )
+
+
+def test_extract_config_path_returns_none_when_absent():
+    assert logscan_command.extract_config_path_from_command("kometa --run") is None
+    assert logscan_command.extract_config_path_from_command("") is None
+    assert logscan_command.extract_config_path_from_command(None) is None
+
+
+# ---------------------------------------------------------------------------
+# derive_config_name_from_path
+# ---------------------------------------------------------------------------
+
+
+def test_derive_config_name_strips_config_suffix():
+    assert logscan_command.derive_config_name_from_path("/tmp/movies_config.yml") == "movies"
+
+
+def test_derive_config_name_without_suffix():
+    assert logscan_command.derive_config_name_from_path("/tmp/movies.yml") == "movies"
+
+
+def test_derive_config_name_handles_path_objects():
+    assert logscan_command.derive_config_name_from_path(Path("/tmp/shows_config.yml")) == "shows"
+
+
+# ---------------------------------------------------------------------------
+# sanitize_run_command
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_run_command_replaces_config_path():
+    cleaned = logscan_command.sanitize_run_command(
+        "kometa --config=/etc/secrets/mine.yml --run", config_path="/etc/secrets/mine.yml"
+    )
+    assert "/etc/secrets/mine.yml" not in cleaned
+    assert "<config>" in cleaned
+
+
+def test_sanitize_run_command_redacts_secret_flags():
+    cleaned = logscan_command.sanitize_run_command("kometa --apikey=ABCDEF1234567 --run")
+    assert "ABCDEF1234567" not in cleaned
+    assert "<redacted>" in cleaned
+
+
+def test_sanitize_run_command_replaces_path_with_alt_separators():
+    cleaned = logscan_command.sanitize_run_command(
+        "kometa --config C:\\Users\\test\\config.yml", config_path="C:/Users/test/config.yml"
+    )
+    assert "config.yml" not in cleaned
+    assert "<config>" in cleaned
+
+
+def test_sanitize_run_command_returns_none_for_empty():
+    assert logscan_command.sanitize_run_command("") is None
+    assert logscan_command.sanitize_run_command(None) is None
+
+
+# ---------------------------------------------------------------------------
+# hash_file
+# ---------------------------------------------------------------------------
+
+
+def test_hash_file_returns_sha256_hex_digest(tmp_path):
+    payload = b"hello logscan world"
+    target = tmp_path / "sample.txt"
+    target.write_bytes(payload)
+    expected = hashlib.sha256(payload).hexdigest()
+    assert logscan_command.hash_file(target) == expected
+
+
+def test_hash_file_handles_missing_paths():
+    assert logscan_command.hash_file(None) is None
+    assert logscan_command.hash_file("") is None
+    assert logscan_command.hash_file("/definitely/not/a/real/path.xyz") is None
+
+
+def test_hash_file_accepts_string_paths(tmp_path):
+    target = tmp_path / "another.txt"
+    target.write_text("data")
+    assert isinstance(logscan_command.hash_file(str(target)), str)


### PR DESCRIPTION
Part 5 of 6 in the ongoing carve-up of the 3,692-line `modules/logscan.py` monolith.

## What moved

A tightly cohesive cluster of pure parsing utilities is now in **`modules/logscan_command.py`** (302 lines):

| Function | Job |
|---|---|
| `extract_plex_config_section` | Slice one Plex Configuration block out of the log, strip embedded tracebacks |
| `parse_server_info` | Pull (server_name, version) from a parsed block |
| `extract_plex_config` | Walk the full log, return all blocks + flagged-version tuples |
| `extract_header_lines` | Capture the header block & current/newest Kometa versions |
| `extract_run_command` | Pluck the first `Run Command:` line |
| `split_command` | shlex-with-fallback CLI tokenizer |
| `compute_command_signature` | Reduce a command to its flag sequence for run-grouping |
| `extract_config_path_from_command` | Pull `--config=path` or `--config path` |
| `derive_config_name_from_path` | Strip `_config` suffix and drop the dirname/ext |
| `sanitize_run_command` | Redact tokens/apikeys/secrets + replace config path |
| `hash_file` | SHA-256 hex digest of a file, `None` on any error |

## What stayed put

`LogscanAnalyzer` keeps every existing method as a **thin wrapper** delegating to the module above. Public API is unchanged: `analyzer.extract_plex_config(content)` still returns the same shape, `analyzer.sanitize_run_command(...)` still works, etc. The only ergonomic change is internal — the legacy state-mutation (`self.server_versions`, `self.current_kometa_version`, `self.kometa_newest_version`) now happens in the wrapper layer rather than buried inside the parsers.

## Why this carving line

- All 11 functions share the theme: **"who/what/where ran"** — server identity, Kometa version, the CLI invocation. Cohesion is excellent.
- They are 100% pure (no DB, no filesystem except `hash_file`, no Flask) — easy to test in isolation.
- Zero external callers reference these methods directly today; only `analyze_content` uses them. Risk surface is minimal.

## Test coverage gained

Added **`tests/test_logscan_command.py`** — 31 focused unit tests covering every extracted function. Several tests deliberately document existing legacy quirks (the \` Scanning \` end-marker eats itself when log lines are short enough that `.strip()` removes the leading space; `shlex(posix=False)` does not respect quoted values containing spaces) so future readers know they are intentional, not bugs to fix in this PR.

## Numbers

| | Before | After | Δ |
|---|---:|---:|---|
| `modules/logscan.py` | 3,692 lines | 3,517 lines | **−175** |
| New extracted module | — | 302 lines | +302 |
| New tests | — | 298 lines | +298 |
| Test suite | 720 passing | **751 passing** | +31 |

## Verification

```
pytest tests/                              # 751 passed, 26 deselected (e2e)
ruff check modules/logscan.py modules/logscan_command.py tests/test_logscan_command.py
pre-commit run --files <changed>           # all hooks green
```

Up next: **6/6** — extract the people-poster scanning cluster (~290 lines, 18 cohesive methods) into `modules/logscan_people.py`.