### PR TITLE
Extract people-poster scanning into modules/logscan_people.py (6/6)

### DIFF
--- a/modules/logscan.py
+++ b/modules/logscan.py
@@ -1,15 +1,20 @@
 import hashlib
-import json
 import logging
-import os
 import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from urllib.parse import unquote
 
-import requests
+from modules import logscan_command, logscan_people
 
-from modules import logscan_command
+# Re-exported for back-compat with tests / quickstart imports.
+from modules.logscan_people import (  # noqa: F401
+    PEOPLE_MISSING_WARNING_RE,
+    PEOPLE_MISSING_WARNING_REGEX,
+    PEOPLE_README_URLS,
+    PEOPLE_SECTION_END_PATTERNS,
+    PEOPLE_SECTION_START_STRONG,
+    PEOPLE_SECTION_START_WEAK,
+)
 
 # Create logger
 mylogger = logging.getLogger("logscan")
@@ -40,29 +45,6 @@ def _version_in_inclusive_range(ver: str, low: tuple, high: tuple) -> bool:
 # Vulnerable range you want to flag (adjust as needed)
 _PMS_VULN_LOW = (1, 41, 7, 0)  # 1.41.7.x
 _PMS_VULN_HIGH = (1, 42, 0, 99999)  # through 1.42.0.x
-
-PEOPLE_README_URLS = [
-    "https://raw.githubusercontent.com/Kometa-Team/People-Images/refs/heads/master/README.md",
-]
-PEOPLE_MISSING_WARNING_REGEX = (
-    r"Collection Warning: No Poster Found at "
-    r"(https://raw\.githubusercontent\.com/"
-    r"(?:Kometa-Team/People-Images(?:-[^/]+)?|meisnate12/Plex-Meta-Manager-People(?:-[^/]+)?)"
-    r"/[^\s\]]+)"
-)
-PEOPLE_MISSING_WARNING_RE = re.compile(PEOPLE_MISSING_WARNING_REGEX, re.IGNORECASE)
-PEOPLE_SECTION_START_STRONG = [
-    r"^(.+?) Collection in .+$",
-    r"^Running .+ Collection$",
-]
-PEOPLE_SECTION_START_WEAK = [
-    r"^Updating Details of .+ Collection$",
-    r"^Validating .+ Attributes$",
-]
-PEOPLE_SECTION_END_PATTERNS = [
-    r"^Finished .+ Collection$",
-]
-
 
 class LogscanAnalyzer:
     def __init__(self):
@@ -403,91 +385,27 @@ class LogscanAnalyzer:
         return cleaned_content
 
     def extract_filename_from_url(self, url):
-        return unquote(os.path.splitext(os.path.basename(url))[0])
+        return logscan_people.extract_filename_from_url(url)
 
     def _get_people_cache_path(self, log_path):
-        cache_dir = Path(__file__).resolve().parent.parent / "config" / "cache" / "logscan"
-        try:
-            cache_dir.mkdir(parents=True, exist_ok=True)
-            return cache_dir / "logscan_people_readme.json"
-        except Exception:
-            pass
-        if log_path:
-            try:
-                log_path = Path(log_path)
-                if log_path.is_file():
-                    return log_path.parent / ".logscan_people_cache.json"
-            except Exception:
-                pass
-        return Path.cwd() / ".logscan_people_cache.json"
+        return logscan_people.get_people_cache_path(log_path)
 
     def _load_people_cache(self, cache_path):
-        try:
-            if not cache_path or not Path(cache_path).exists():
-                return {}
-            with open(cache_path, "r", encoding="utf-8") as handle:
-                return json.load(handle) or {}
-        except Exception:
-            return {}
+        return logscan_people.load_people_cache(cache_path)
 
     def _save_people_cache(self, cache_path, payload):
-        try:
-            if not cache_path:
-                return
-            with open(cache_path, "w", encoding="utf-8") as handle:
-                json.dump(payload, handle, ensure_ascii=True, indent=2)
-        except Exception:
-            return
+        return logscan_people.save_people_cache(cache_path, payload)
 
     def _fetch_people_readme(self, cache_path):
-        cache = self._load_people_cache(cache_path)
-        cached_content = cache.get("content")
-
-        for url in PEOPLE_README_URLS:
-            headers = {"User-Agent": "Quickstart-Logscan"}
-            if cache.get("url") == url:
-                if cache.get("etag"):
-                    headers["If-None-Match"] = cache["etag"]
-                if cache.get("last_modified"):
-                    headers["If-Modified-Since"] = cache["last_modified"]
-            try:
-                response = requests.get(url, headers=headers, timeout=5)
-            except Exception as exc:
-                mylogger.debug(f"People-Images README fetch failed for {url}: {exc}")
-                continue
-
-            if response.status_code == 304 and cached_content:
-                return cached_content, True
-            if response.status_code == 200 and response.text:
-                payload = {
-                    "url": url,
-                    "etag": response.headers.get("ETag"),
-                    "last_modified": response.headers.get("Last-Modified"),
-                    "fetched_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-                    "content": response.text,
-                }
-                self._save_people_cache(cache_path, payload)
-                return response.text, False
-            if response.status_code in (404, 410):
-                continue
-
-        return cached_content, True if cached_content else False
+        return logscan_people.fetch_people_readme(cache_path)
 
     def _build_people_index(self, readme_text):
-        if not readme_text:
-            return set()
-        filenames = re.findall(r"([A-Za-z0-9_./%\-]+\.(?:jpg|jpeg|png|webp))", readme_text, flags=re.IGNORECASE)
-        names = set()
-        for name in filenames:
-            cleaned = self.extract_filename_from_url(name)
-            if cleaned:
-                names.add(cleaned.lower())
-        return names
+        return logscan_people.build_people_index(readme_text)
 
     def preload_people_index(self, log_path=None):
-        cache_path = self._get_people_cache_path(log_path)
-        readme_text, _used_cache = self._fetch_people_readme(cache_path)
-        self._people_index = self._build_people_index(readme_text)
+        cache_path = logscan_people.get_people_cache_path(log_path)
+        readme_text, _used_cache = logscan_people.fetch_people_readme(cache_path)
+        self._people_index = logscan_people.build_people_index(readme_text)
         self.people_index_available = bool(self._people_index)
         return self._people_index
 
@@ -498,189 +416,44 @@ class LogscanAnalyzer:
         if self._people_index is not None:
             self.people_index_available = bool(self._people_index)
             return self._people_index
-        cache_path = self._get_people_cache_path(log_path)
-        readme_text, _used_cache = self._fetch_people_readme(cache_path)
-        self._people_index = self._build_people_index(readme_text)
-        self.people_index_available = bool(self._people_index)
-        return self._people_index
+        return self.preload_people_index(log_path=log_path)
 
     def _is_blank_log_line(self, line):
-        return not line.strip()
+        return logscan_people.is_blank_log_line(line)
 
     def _is_divider_log_line(self, line):
-        stripped = line.strip()
-        if not stripped:
-            return False
-        compact = stripped.replace(" ", "")
-        if len(compact) < 8:
-            return False
-        return len(set(compact)) == 1
+        return logscan_people.is_divider_log_line(line)
 
     def _is_section_break(self, line):
-        return self._is_blank_log_line(line) or self._is_divider_log_line(line)
+        return logscan_people.is_section_break(line)
 
     def _matches_any_pattern(self, normalized, patterns):
-        for pattern in patterns:
-            if re.match(pattern, normalized):
-                return True
-        return False
+        return logscan_people.matches_any_pattern(normalized, patterns)
 
     def _find_log_section_bounds(self, cleaned_lines, index, max_span=300):
-        start = None
-        end = None
-
-        min_index = max(0, index - max_span)
-        for idx in range(index, min_index - 1, -1):
-            normalized = self._normalize_name_line(cleaned_lines[idx])
-            if not normalized:
-                continue
-            if self._matches_any_pattern(normalized, PEOPLE_SECTION_START_STRONG):
-                start = idx
-                break
-
-        if start is None:
-            for idx in range(index, min_index - 1, -1):
-                normalized = self._normalize_name_line(cleaned_lines[idx])
-                if not normalized:
-                    continue
-                if self._matches_any_pattern(normalized, PEOPLE_SECTION_START_WEAK):
-                    start = idx
-                    break
-
-        if start is not None:
-            while start > 0 and self._is_divider_log_line(cleaned_lines[start - 1]):
-                start -= 1
-
-        max_index = len(cleaned_lines) - 1
-        max_end = min(max_index, index + max_span)
-        for idx in range(index, max_end + 1):
-            normalized = self._normalize_name_line(cleaned_lines[idx])
-            if not normalized:
-                continue
-            if self._matches_any_pattern(normalized, PEOPLE_SECTION_END_PATTERNS):
-                end = idx
-                break
-
-        if end is not None:
-            while end < max_index and self._is_divider_log_line(cleaned_lines[end + 1]):
-                end += 1
-
-        if start is None or end is None:
-            fallback_start = index
-            while fallback_start > 0 and (index - fallback_start) < max_span:
-                if self._is_section_break(cleaned_lines[fallback_start - 1]):
-                    if self._is_divider_log_line(cleaned_lines[fallback_start - 1]):
-                        fallback_start -= 1
-                    break
-                fallback_start -= 1
-
-            fallback_end = index
-            while fallback_end < max_index and (fallback_end - index) < max_span:
-                if self._is_section_break(cleaned_lines[fallback_end + 1]):
-                    if self._is_divider_log_line(cleaned_lines[fallback_end + 1]):
-                        fallback_end += 1
-                    break
-                fallback_end += 1
-
-            start = fallback_start if start is None else start
-            end = fallback_end if end is None else end
-
-        return start, end
+        return logscan_people.find_log_section_bounds(cleaned_lines, index, max_span=max_span)
 
     def _normalize_name_line(self, line):
-        if not line:
-            return ""
-        return line.strip().strip("= ").strip()
+        return logscan_people.normalize_name_line(line)
 
     def _extract_key_name_from_block(self, cleaned_lines, start, end):
-        block = cleaned_lines[start : end + 1]
-        for idx, line in enumerate(block):
-            if "Validating Method: key_name" in line:
-                for offset in range(1, 6):
-                    if idx + offset >= len(block):
-                        break
-                    candidate = block[idx + offset].strip()
-                    if not candidate:
-                        continue
-                    if "Value:" in candidate:
-                        value = candidate.split("Value:", 1)[1].strip()
-                        if value:
-                            return value
-                break
-
-        patterns = [
-            r"^Validating\s+(.+?)\s+Attributes$",
-            r"^Running\s+(.+?)\s+Collection$",
-            r"^Finished\s+(.+?)\s+Collection$",
-            r"^(.+?)\s+Collection\s+in\s+.+$",
-        ]
-        for line in block:
-            normalized = self._normalize_name_line(line)
-            if not normalized:
-                continue
-            for pattern in patterns:
-                match = re.match(pattern, normalized)
-                if match:
-                    return match.group(1).strip()
-        return None
+        return logscan_people.extract_key_name_from_block(cleaned_lines, start, end)
 
     def _extract_missing_people_names(self, lines, available, name_hint=None):
-        names = set()
-        for line in lines:
-            match = PEOPLE_MISSING_WARNING_RE.search(line)
-            if not match:
-                continue
-            name = name_hint
-            if not name:
-                url = match.group(1)
-                name = self.extract_filename_from_url(url)
-            if not name:
-                continue
-            key = name.lower()
-            if available and key in available:
-                continue
-            names.add(key)
-        return names
+        return logscan_people.extract_missing_people_names(lines, available, name_hint=name_hint)
 
     def collect_missing_people_lines(self, content, available_index=None, max_block_lines=300, log_path=None):
+        """Resolve the people index (caching it on ``self``) then delegate to
+        :func:`modules.logscan_people.collect_missing_people_lines`."""
         if not content:
             return []
         available = self._ensure_people_index(log_path=log_path, available_index=available_index)
-        raw_lines = content.splitlines()
-        cleaned_lines = self.cleanup_content(content).splitlines()
-        items = []
-        seen_blocks = set()
-
-        for idx, line in enumerate(raw_lines):
-            if not PEOPLE_MISSING_WARNING_RE.search(line):
-                continue
-
-            if idx < len(cleaned_lines):
-                start, end = self._find_log_section_bounds(cleaned_lines, idx, max_span=max_block_lines)
-            else:
-                start = max(0, idx - 2)
-                end = min(len(raw_lines) - 1, idx + 2)
-
-            block_lines = raw_lines[start : end + 1]
-            name_hint = None
-            if idx < len(cleaned_lines):
-                name_hint = self._extract_key_name_from_block(cleaned_lines, start, end)
-            names = self._extract_missing_people_names(block_lines, available, name_hint=name_hint)
-            if not names:
-                continue
-
-            block_text = "\n".join(block_lines)
-            if block_text in seen_blocks:
-                continue
-            seen_blocks.add(block_text)
-            items.append(
-                {
-                    "names": names,
-                    "block": block_text,
-                }
-            )
-
-        return items
+        return logscan_people.collect_missing_people_lines(
+            content,
+            available_index=available,
+            max_block_lines=max_block_lines,
+            cleanup_fn=self.cleanup_content,
+        )
 
     def scan_file_for_people_posters(self, content, log_path=None):
         if not content:

--- a/modules/logscan.py
+++ b/modules/logscan.py
@@ -46,6 +46,7 @@ def _version_in_inclusive_range(ver: str, low: tuple, high: tuple) -> bool:
 _PMS_VULN_LOW = (1, 41, 7, 0)  # 1.41.7.x
 _PMS_VULN_HIGH = (1, 42, 0, 99999)  # through 1.42.0.x
 
+
 class LogscanAnalyzer:
     def __init__(self):
         self._raw_content = None

--- a/modules/logscan_people.py
+++ b/modules/logscan_people.py
@@ -30,9 +30,7 @@ _logger = logging.getLogger("logscan")
 # Module-level constants
 # ---------------------------------------------------------------------------
 
-PEOPLE_README_URLS = (
-    "https://raw.githubusercontent.com/Kometa-Team/People-Images/refs/heads/master/README.md",
-)
+PEOPLE_README_URLS = ("https://raw.githubusercontent.com/Kometa-Team/People-Images/refs/heads/master/README.md",)
 
 PEOPLE_MISSING_WARNING_REGEX = (
     r"Collection Warning: No Poster Found at "
@@ -52,9 +50,7 @@ PEOPLE_SECTION_START_WEAK = (
 )
 PEOPLE_SECTION_END_PATTERNS = (r"^Finished .+ Collection$",)
 
-_PEOPLE_README_FILENAME_RE = re.compile(
-    r"([A-Za-z0-9_./%\-]+\.(?:jpg|jpeg|png|webp))", re.IGNORECASE
-)
+_PEOPLE_README_FILENAME_RE = re.compile(r"([A-Za-z0-9_./%\-]+\.(?:jpg|jpeg|png|webp))", re.IGNORECASE)
 _KEY_NAME_PATTERNS = (
     r"^Validating\s+(.+?)\s+Attributes$",
     r"^Running\s+(.+?)\s+Collection$",
@@ -216,9 +212,7 @@ def normalize_name_line(line: str) -> str:
     return line.strip().strip("= ").strip()
 
 
-def find_log_section_bounds(
-    cleaned_lines: list[str], index: int, max_span: int = 300
-) -> tuple[int, int]:
+def find_log_section_bounds(cleaned_lines: list[str], index: int, max_span: int = 300) -> tuple[int, int]:
     """Locate the start/end indices of the collection block containing
     ``cleaned_lines[index]``.
 
@@ -318,9 +312,7 @@ def extract_key_name_from_block(cleaned_lines: list[str], start: int, end: int) 
     return None
 
 
-def extract_missing_people_names(
-    lines: Iterable[str], available: set[str] | None, name_hint: str | None = None
-) -> set[str]:
+def extract_missing_people_names(lines: Iterable[str], available: set[str] | None, name_hint: str | None = None) -> set[str]:
     """For each log line that matches the People-Images missing-poster warning,
     add the (lowercased) person name to the result set — unless the name is
     already present in ``available``.

--- a/modules/logscan_people.py
+++ b/modules/logscan_people.py
@@ -1,0 +1,400 @@
+"""People-poster detection helpers extracted from ``modules.logscan``.
+
+These functions scan a Kometa log for ``Collection Warning: No Poster Found
+at <people-images-url>`` lines, look up the names against a cached copy of the
+People-Images repo README, and surface the genuinely-missing people for the
+recommendation panel.
+
+The functions are pure (no analyzer state); ``LogscanAnalyzer`` retains thin
+wrapper methods that delegate here and manage the cached people index on the
+analyzer instance so callers like ``quickstart.py`` keep working unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Iterable
+from urllib.parse import unquote
+
+import requests
+
+_logger = logging.getLogger("logscan")
+
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+PEOPLE_README_URLS = (
+    "https://raw.githubusercontent.com/Kometa-Team/People-Images/refs/heads/master/README.md",
+)
+
+PEOPLE_MISSING_WARNING_REGEX = (
+    r"Collection Warning: No Poster Found at "
+    r"(https://raw\.githubusercontent\.com/"
+    r"(?:Kometa-Team/People-Images(?:-[^/]+)?|meisnate12/Plex-Meta-Manager-People(?:-[^/]+)?)"
+    r"/[^\s\]]+)"
+)
+PEOPLE_MISSING_WARNING_RE = re.compile(PEOPLE_MISSING_WARNING_REGEX, re.IGNORECASE)
+
+PEOPLE_SECTION_START_STRONG = (
+    r"^(.+?) Collection in .+$",
+    r"^Running .+ Collection$",
+)
+PEOPLE_SECTION_START_WEAK = (
+    r"^Updating Details of .+ Collection$",
+    r"^Validating .+ Attributes$",
+)
+PEOPLE_SECTION_END_PATTERNS = (r"^Finished .+ Collection$",)
+
+_PEOPLE_README_FILENAME_RE = re.compile(
+    r"([A-Za-z0-9_./%\-]+\.(?:jpg|jpeg|png|webp))", re.IGNORECASE
+)
+_KEY_NAME_PATTERNS = (
+    r"^Validating\s+(.+?)\s+Attributes$",
+    r"^Running\s+(.+?)\s+Collection$",
+    r"^Finished\s+(.+?)\s+Collection$",
+    r"^(.+?)\s+Collection\s+in\s+.+$",
+)
+
+
+# ---------------------------------------------------------------------------
+# URL / filename helpers
+# ---------------------------------------------------------------------------
+
+
+def extract_filename_from_url(url: str) -> str:
+    """Return the URL-decoded basename of ``url`` with its extension stripped."""
+    return unquote(os.path.splitext(os.path.basename(url))[0])
+
+
+# ---------------------------------------------------------------------------
+# People cache (README mirror) management
+# ---------------------------------------------------------------------------
+
+
+def get_people_cache_path(log_path=None) -> Path:
+    """Return the on-disk path used to cache the People-Images README.
+
+    Prefers the project-wide ``config/cache/logscan/`` directory; falls back to
+    a sidecar in the log's directory, and finally to the current working
+    directory.
+    """
+    cache_dir = Path(__file__).resolve().parent.parent / "config" / "cache" / "logscan"
+    try:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        return cache_dir / "logscan_people_readme.json"
+    except Exception:
+        pass
+    if log_path:
+        try:
+            log_path = Path(log_path)
+            if log_path.is_file():
+                return log_path.parent / ".logscan_people_cache.json"
+        except Exception:
+            pass
+    return Path.cwd() / ".logscan_people_cache.json"
+
+
+def load_people_cache(cache_path) -> dict:
+    """Load and return the cached README payload, or ``{}`` on any failure."""
+    try:
+        if not cache_path or not Path(cache_path).exists():
+            return {}
+        with open(cache_path, "r", encoding="utf-8") as handle:
+            return json.load(handle) or {}
+    except Exception:
+        return {}
+
+
+def save_people_cache(cache_path, payload: dict) -> None:
+    """Write ``payload`` to ``cache_path``. Silently swallows any I/O error."""
+    try:
+        if not cache_path:
+            return
+        with open(cache_path, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=True, indent=2)
+    except Exception:
+        return
+
+
+def fetch_people_readme(cache_path) -> tuple[str | None, bool]:
+    """Fetch the People-Images README, honoring HTTP cache headers stored in
+    ``cache_path``. Returns ``(text, used_cache)``.
+
+    When the network is unavailable the cached text is returned with
+    ``used_cache=True``. When neither network nor cache yield content the
+    return is ``(None, False)``.
+    """
+    cache = load_people_cache(cache_path)
+    cached_content = cache.get("content")
+
+    for url in PEOPLE_README_URLS:
+        headers = {"User-Agent": "Quickstart-Logscan"}
+        if cache.get("url") == url:
+            if cache.get("etag"):
+                headers["If-None-Match"] = cache["etag"]
+            if cache.get("last_modified"):
+                headers["If-Modified-Since"] = cache["last_modified"]
+        try:
+            response = requests.get(url, headers=headers, timeout=5)
+        except Exception as exc:
+            _logger.debug(f"People-Images README fetch failed for {url}: {exc}")
+            continue
+
+        if response.status_code == 304 and cached_content:
+            return cached_content, True
+        if response.status_code == 200 and response.text:
+            payload = {
+                "url": url,
+                "etag": response.headers.get("ETag"),
+                "last_modified": response.headers.get("Last-Modified"),
+                "fetched_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                "content": response.text,
+            }
+            save_people_cache(cache_path, payload)
+            return response.text, False
+        if response.status_code in (404, 410):
+            continue
+
+    return cached_content, True if cached_content else False
+
+
+def build_people_index(readme_text: str | None) -> set[str]:
+    """Parse the README text and return a lowercased set of image basenames
+    (the keys we match log warnings against)."""
+    if not readme_text:
+        return set()
+    filenames = _PEOPLE_README_FILENAME_RE.findall(readme_text)
+    names: set[str] = set()
+    for name in filenames:
+        cleaned = extract_filename_from_url(name)
+        if cleaned:
+            names.add(cleaned.lower())
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Log-line structural helpers
+# ---------------------------------------------------------------------------
+
+
+def is_blank_log_line(line: str) -> bool:
+    return not line.strip()
+
+
+def is_divider_log_line(line: str) -> bool:
+    """Return True when ``line`` is a Kometa divider (all same character,
+    ignoring spaces, at least 8 chars long)."""
+    stripped = line.strip()
+    if not stripped:
+        return False
+    compact = stripped.replace(" ", "")
+    if len(compact) < 8:
+        return False
+    return len(set(compact)) == 1
+
+
+def is_section_break(line: str) -> bool:
+    return is_blank_log_line(line) or is_divider_log_line(line)
+
+
+def matches_any_pattern(normalized: str, patterns: Iterable[str]) -> bool:
+    return any(re.match(pattern, normalized) for pattern in patterns)
+
+
+def normalize_name_line(line: str) -> str:
+    """Strip whitespace and divider-edge characters from a log line so its
+    semantic content is easier to pattern-match."""
+    if not line:
+        return ""
+    return line.strip().strip("= ").strip()
+
+
+def find_log_section_bounds(
+    cleaned_lines: list[str], index: int, max_span: int = 300
+) -> tuple[int, int]:
+    """Locate the start/end indices of the collection block containing
+    ``cleaned_lines[index]``.
+
+    First tries strong section-start markers, then weak ones, then end markers.
+    Falls back to scanning for surrounding blank/divider lines when no marker
+    matches within ``max_span`` lines.
+    """
+    start = None
+    end = None
+
+    min_index = max(0, index - max_span)
+    for idx in range(index, min_index - 1, -1):
+        normalized = normalize_name_line(cleaned_lines[idx])
+        if not normalized:
+            continue
+        if matches_any_pattern(normalized, PEOPLE_SECTION_START_STRONG):
+            start = idx
+            break
+
+    if start is None:
+        for idx in range(index, min_index - 1, -1):
+            normalized = normalize_name_line(cleaned_lines[idx])
+            if not normalized:
+                continue
+            if matches_any_pattern(normalized, PEOPLE_SECTION_START_WEAK):
+                start = idx
+                break
+
+    if start is not None:
+        while start > 0 and is_divider_log_line(cleaned_lines[start - 1]):
+            start -= 1
+
+    max_index = len(cleaned_lines) - 1
+    max_end = min(max_index, index + max_span)
+    for idx in range(index, max_end + 1):
+        normalized = normalize_name_line(cleaned_lines[idx])
+        if not normalized:
+            continue
+        if matches_any_pattern(normalized, PEOPLE_SECTION_END_PATTERNS):
+            end = idx
+            break
+
+    if end is not None:
+        while end < max_index and is_divider_log_line(cleaned_lines[end + 1]):
+            end += 1
+
+    if start is None or end is None:
+        fallback_start = index
+        while fallback_start > 0 and (index - fallback_start) < max_span:
+            if is_section_break(cleaned_lines[fallback_start - 1]):
+                if is_divider_log_line(cleaned_lines[fallback_start - 1]):
+                    fallback_start -= 1
+                break
+            fallback_start -= 1
+
+        fallback_end = index
+        while fallback_end < max_index and (fallback_end - index) < max_span:
+            if is_section_break(cleaned_lines[fallback_end + 1]):
+                if is_divider_log_line(cleaned_lines[fallback_end + 1]):
+                    fallback_end += 1
+                break
+            fallback_end += 1
+
+        start = fallback_start if start is None else start
+        end = fallback_end if end is None else end
+
+    return start, end
+
+
+def extract_key_name_from_block(cleaned_lines: list[str], start: int, end: int) -> str | None:
+    """Pull the collection's logical name from a section block, preferring an
+    explicit ``Validating Method: key_name`` / ``Value: <name>`` pair, then
+    falling back to the Collection-named markers."""
+    block = cleaned_lines[start : end + 1]
+    for idx, line in enumerate(block):
+        if "Validating Method: key_name" in line:
+            for offset in range(1, 6):
+                if idx + offset >= len(block):
+                    break
+                candidate = block[idx + offset].strip()
+                if not candidate:
+                    continue
+                if "Value:" in candidate:
+                    value = candidate.split("Value:", 1)[1].strip()
+                    if value:
+                        return value
+            break
+
+    for line in block:
+        normalized = normalize_name_line(line)
+        if not normalized:
+            continue
+        for pattern in _KEY_NAME_PATTERNS:
+            match = re.match(pattern, normalized)
+            if match:
+                return match.group(1).strip()
+    return None
+
+
+def extract_missing_people_names(
+    lines: Iterable[str], available: set[str] | None, name_hint: str | None = None
+) -> set[str]:
+    """For each log line that matches the People-Images missing-poster warning,
+    add the (lowercased) person name to the result set — unless the name is
+    already present in ``available``.
+
+    When ``name_hint`` is provided it overrides the URL-derived name (used when
+    the surrounding block reveals the canonical collection key)."""
+    names: set[str] = set()
+    for line in lines:
+        match = PEOPLE_MISSING_WARNING_RE.search(line)
+        if not match:
+            continue
+        name = name_hint
+        if not name:
+            url = match.group(1)
+            name = extract_filename_from_url(url)
+        if not name:
+            continue
+        key = name.lower()
+        if available and key in available:
+            continue
+        names.add(key)
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry point
+# ---------------------------------------------------------------------------
+
+
+def collect_missing_people_lines(
+    content: str,
+    available_index: set[str] | None = None,
+    max_block_lines: int = 300,
+    cleanup_fn: Callable[[str], str] | None = None,
+) -> list[dict]:
+    """Walk the full log content and return a list of
+    ``{"names": set[str], "block": str}`` entries — one per distinct
+    collection block that mentions a genuinely-missing People-Images poster.
+
+    ``cleanup_fn`` is the analyzer's ``cleanup_content`` method; it is injected
+    rather than imported so this module stays free of the broader analyzer.
+    Defaults to a passthrough when not provided.
+    """
+    if not content:
+        return []
+    available = available_index if available_index is not None else set()
+    raw_lines = content.splitlines()
+    cleaned_source = cleanup_fn(content) if cleanup_fn else content
+    cleaned_lines = cleaned_source.splitlines()
+    items: list[dict] = []
+    seen_blocks: set[str] = set()
+
+    for idx, line in enumerate(raw_lines):
+        if not PEOPLE_MISSING_WARNING_RE.search(line):
+            continue
+
+        if idx < len(cleaned_lines):
+            start, end = find_log_section_bounds(cleaned_lines, idx, max_span=max_block_lines)
+        else:
+            start = max(0, idx - 2)
+            end = min(len(raw_lines) - 1, idx + 2)
+
+        block_lines = raw_lines[start : end + 1]
+        name_hint = None
+        if idx < len(cleaned_lines):
+            name_hint = extract_key_name_from_block(cleaned_lines, start, end)
+        names = extract_missing_people_names(block_lines, available, name_hint=name_hint)
+        if not names:
+            continue
+
+        block_text = "\n".join(block_lines)
+        if block_text in seen_blocks:
+            continue
+        seen_blocks.add(block_text)
+        items.append({"names": names, "block": block_text})
+
+    return items

--- a/tests/test_logscan_people.py
+++ b/tests/test_logscan_people.py
@@ -1,0 +1,321 @@
+"""Tests for the extracted ``modules.logscan_people`` helpers."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from modules import logscan_people
+
+
+# ---------------------------------------------------------------------------
+# extract_filename_from_url
+# ---------------------------------------------------------------------------
+
+
+def test_extract_filename_url_decodes_and_drops_extension():
+    url = "https://example.com/path/to/Foo%20Bar.jpg"
+    assert logscan_people.extract_filename_from_url(url) == "Foo Bar"
+
+
+def test_extract_filename_handles_basename_with_no_ext():
+    assert logscan_people.extract_filename_from_url("https://example.com/just-a-name") == "just-a-name"
+
+
+# ---------------------------------------------------------------------------
+# get_people_cache_path / load_people_cache / save_people_cache
+# ---------------------------------------------------------------------------
+
+
+def test_load_people_cache_returns_empty_when_path_missing(tmp_path):
+    missing = tmp_path / "definitely_not_here.json"
+    assert logscan_people.load_people_cache(missing) == {}
+
+
+def test_load_people_cache_returns_empty_on_none():
+    assert logscan_people.load_people_cache(None) == {}
+
+
+def test_load_people_cache_returns_empty_on_bad_json(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("not valid json {")
+    assert logscan_people.load_people_cache(bad) == {}
+
+
+def test_save_then_load_people_cache_roundtrip(tmp_path):
+    path = tmp_path / "cache.json"
+    payload = {"url": "https://x", "content": "hi", "etag": "abc"}
+    logscan_people.save_people_cache(path, payload)
+    loaded = logscan_people.load_people_cache(path)
+    assert loaded == payload
+
+
+def test_save_people_cache_with_none_path_is_a_noop():
+    # Should not raise; nothing to assert other than \"does not crash\".
+    logscan_people.save_people_cache(None, {"x": 1})
+
+
+# ---------------------------------------------------------------------------
+# build_people_index
+# ---------------------------------------------------------------------------
+
+
+def test_build_people_index_extracts_lowercased_names():
+    readme = """
+    Some preamble.
+    ![image](https://x/people/Pamela%20Anderson.jpg)
+    ![other](https://x/people/Bob_Marley.png)
+    not an image link: https://x/people/file.gif
+    """
+    index = logscan_people.build_people_index(readme)
+    # Note: extract_filename_from_url does NOT url-decode the regex output
+    # because the regex captures the raw URL substring. Match the actual
+    # behavior: the regex picks up the raw \"Pamela%20Anderson\" filename.
+    assert "pamela anderson" in index
+    assert "bob_marley" in index
+
+
+def test_build_people_index_returns_empty_on_blank_input():
+    assert logscan_people.build_people_index("") == set()
+    assert logscan_people.build_people_index(None) == set()
+
+
+# ---------------------------------------------------------------------------
+# is_blank_log_line / is_divider_log_line / is_section_break
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("line, expected", [
+    ("", True),
+    ("   ", True),
+    ("\t\n", True),
+    ("non-blank", False),
+])
+def test_is_blank_log_line(line, expected):
+    assert logscan_people.is_blank_log_line(line) is expected
+
+
+@pytest.mark.parametrize("line, expected", [
+    ("========", True),
+    ("============", True),
+    ("= = = = = = = =", True),
+    ("=", False),  # too short (compact length < 8)
+    ("=======", False),  # 7 chars, just under the threshold
+    ("==!==!==", False),  # mixed chars
+    ("", False),
+    ("real text", False),
+])
+def test_is_divider_log_line(line, expected):
+    assert logscan_people.is_divider_log_line(line) is expected
+
+
+def test_is_section_break_combines_blank_and_divider():
+    assert logscan_people.is_section_break("")
+    assert logscan_people.is_section_break("============")
+    assert not logscan_people.is_section_break("Validating Foo Attributes")
+
+
+# ---------------------------------------------------------------------------
+# matches_any_pattern
+# ---------------------------------------------------------------------------
+
+
+def test_matches_any_pattern_returns_true_on_first_hit():
+    patterns = (r"^foo", r"^bar")
+    assert logscan_people.matches_any_pattern("bar baz", patterns)
+
+
+def test_matches_any_pattern_returns_false_on_no_hit():
+    patterns = (r"^foo", r"^bar")
+    assert not logscan_people.matches_any_pattern("baz", patterns)
+
+
+# ---------------------------------------------------------------------------
+# normalize_name_line
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_name_line_strips_dividers_and_whitespace():
+    assert logscan_people.normalize_name_line("==  Foo Bar  ==") == "Foo Bar"
+    assert logscan_people.normalize_name_line("") == ""
+    assert logscan_people.normalize_name_line(None) == ""
+
+
+# ---------------------------------------------------------------------------
+# extract_key_name_from_block
+# ---------------------------------------------------------------------------
+
+
+def test_extract_key_name_prefers_validating_method_key_name():
+    block = [
+        "Some unrelated line",
+        "Validating Method: key_name",
+        "Value: Pamela Anderson",
+        "more noise",
+    ]
+    assert logscan_people.extract_key_name_from_block(block, 0, len(block) - 1) == "Pamela Anderson"
+
+
+def test_extract_key_name_falls_back_to_collection_pattern():
+    block = [
+        "noise",
+        "Running Tom Hanks Collection",
+        "more",
+    ]
+    assert logscan_people.extract_key_name_from_block(block, 0, len(block) - 1) == "Tom Hanks"
+
+
+def test_extract_key_name_returns_none_when_no_match():
+    block = ["nothing", "useful", "here"]
+    assert logscan_people.extract_key_name_from_block(block, 0, len(block) - 1) is None
+
+
+# ---------------------------------------------------------------------------
+# extract_missing_people_names
+# ---------------------------------------------------------------------------
+
+
+def test_extract_missing_people_names_basic():
+    lines = [
+        "Collection Warning: No Poster Found at https://raw.githubusercontent.com/Kometa-Team/People-Images/master/P/Pamela%20Anderson.jpg",
+        "unrelated line",
+    ]
+    names = logscan_people.extract_missing_people_names(lines, available=set())
+    assert names == {"pamela anderson"}
+
+
+def test_extract_missing_people_names_respects_available():
+    lines = [
+        "Collection Warning: No Poster Found at https://raw.githubusercontent.com/Kometa-Team/People-Images/master/P/Pamela%20Anderson.jpg",
+    ]
+    # If the name is already in the available index, it is NOT considered missing.
+    names = logscan_people.extract_missing_people_names(lines, available={"pamela anderson"})
+    assert names == set()
+
+
+def test_extract_missing_people_names_uses_name_hint_when_provided():
+    lines = [
+        "Collection Warning: No Poster Found at https://raw.githubusercontent.com/Kometa-Team/People-Images/master/P/some-random-filename.jpg",
+    ]
+    names = logscan_people.extract_missing_people_names(lines, available=set(), name_hint="Tom Hanks")
+    # Hint overrides the URL-derived name; it gets lowercased.
+    assert names == {"tom hanks"}
+
+
+def test_extract_missing_people_names_ignores_unrelated_warnings():
+    lines = [
+        "Collection Warning: No Poster Found at https://example.com/not-people/foo.jpg",
+        "Some other line",
+    ]
+    assert logscan_people.extract_missing_people_names(lines, available=set()) == set()
+
+
+# ---------------------------------------------------------------------------
+# collect_missing_people_lines (integration)
+# ---------------------------------------------------------------------------
+
+
+def test_collect_missing_people_lines_handles_empty_input():
+    assert logscan_people.collect_missing_people_lines("") == []
+
+
+def test_collect_missing_people_lines_returns_block_per_match():
+    content = "\n".join([
+        "Running Pamela Anderson Collection",
+        "stuff",
+        "Collection Warning: No Poster Found at https://raw.githubusercontent.com/Kometa-Team/People-Images/master/P/Pamela%20Anderson.jpg",
+        "Finished Pamela Anderson Collection",
+    ])
+    items = logscan_people.collect_missing_people_lines(content, available_index=set())
+    assert len(items) == 1
+    assert "pamela anderson" in items[0]["names"]
+    assert "Pamela Anderson Collection" in items[0]["block"]
+
+
+def test_collect_missing_people_lines_dedupes_identical_blocks():
+    # Same exact block appearing twice should only produce one entry.
+    block = "\n".join([
+        "Running Pamela Anderson Collection",
+        "Collection Warning: No Poster Found at https://raw.githubusercontent.com/Kometa-Team/People-Images/master/P/Pamela%20Anderson.jpg",
+        "Finished Pamela Anderson Collection",
+    ])
+    content = block + "\n" + block
+    items = logscan_people.collect_missing_people_lines(content, available_index=set())
+    # Both occurrences map to identical blocks => dedupe.
+    assert len(items) == 1
+
+
+def test_collect_missing_people_lines_invokes_cleanup_fn():
+    # When a cleanup_fn is provided, it should be called with the content.
+    cleanup = MagicMock(return_value="\n".join([
+        "Running Bob Collection",
+        "Collection Warning: No Poster Found at https://raw.githubusercontent.com/Kometa-Team/People-Images/master/B/Bob.jpg",
+        "Finished Bob Collection",
+    ]))
+    content = "\n".join([
+        "Running Bob Collection",
+        "Collection Warning: No Poster Found at https://raw.githubusercontent.com/Kometa-Team/People-Images/master/B/Bob.jpg",
+        "Finished Bob Collection",
+    ])
+    items = logscan_people.collect_missing_people_lines(content, available_index=set(), cleanup_fn=cleanup)
+    cleanup.assert_called_once_with(content)
+    assert len(items) == 1
+
+
+# ---------------------------------------------------------------------------
+# fetch_people_readme (network mocked)
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(status_code, text="", headers=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    resp.headers = headers or {}
+    return resp
+
+
+def test_fetch_people_readme_uses_cache_on_304(tmp_path):
+    cache_path = tmp_path / "cache.json"
+    cache_path.write_text(json.dumps({
+        "url": logscan_people.PEOPLE_README_URLS[0],
+        "content": "cached body",
+        "etag": "etag-1",
+    }))
+    with patch("modules.logscan_people.requests.get", return_value=_mock_response(304)):
+        text, used_cache = logscan_people.fetch_people_readme(cache_path)
+    assert text == "cached body"
+    assert used_cache is True
+
+
+def test_fetch_people_readme_writes_cache_on_200(tmp_path):
+    cache_path = tmp_path / "cache.json"
+    fresh = _mock_response(200, "fresh body", {"ETag": "etag-2"})
+    with patch("modules.logscan_people.requests.get", return_value=fresh):
+        text, used_cache = logscan_people.fetch_people_readme(cache_path)
+    assert text == "fresh body"
+    assert used_cache is False
+    # Verify the cache file got written with the fresh payload.
+    written = json.loads(cache_path.read_text())
+    assert written["content"] == "fresh body"
+    assert written["etag"] == "etag-2"
+
+
+def test_fetch_people_readme_falls_back_to_cache_on_network_error(tmp_path):
+    cache_path = tmp_path / "cache.json"
+    cache_path.write_text(json.dumps({
+        "url": logscan_people.PEOPLE_README_URLS[0],
+        "content": "stale body",
+    }))
+    with patch("modules.logscan_people.requests.get", side_effect=ConnectionError("offline")):
+        text, used_cache = logscan_people.fetch_people_readme(cache_path)
+    assert text == "stale body"
+    assert used_cache is True
+
+
+def test_fetch_people_readme_returns_none_when_no_cache_and_network_dead(tmp_path):
+    cache_path = tmp_path / "nothing.json"
+    with patch("modules.logscan_people.requests.get", side_effect=ConnectionError("offline")):
+        text, used_cache = logscan_people.fetch_people_readme(cache_path)
+    assert text is None
+    assert used_cache is False

--- a/tests/test_logscan_people.py
+++ b/tests/test_logscan_people.py
@@ -7,7 +7,6 @@ import pytest
 
 from modules import logscan_people
 
-
 # ---------------------------------------------------------------------------
 # extract_filename_from_url
 # ---------------------------------------------------------------------------
@@ -85,26 +84,32 @@ def test_build_people_index_returns_empty_on_blank_input():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("line, expected", [
-    ("", True),
-    ("   ", True),
-    ("\t\n", True),
-    ("non-blank", False),
-])
+@pytest.mark.parametrize(
+    "line, expected",
+    [
+        ("", True),
+        ("   ", True),
+        ("\t\n", True),
+        ("non-blank", False),
+    ],
+)
 def test_is_blank_log_line(line, expected):
     assert logscan_people.is_blank_log_line(line) is expected
 
 
-@pytest.mark.parametrize("line, expected", [
-    ("========", True),
-    ("============", True),
-    ("= = = = = = = =", True),
-    ("=", False),  # too short (compact length < 8)
-    ("=======", False),  # 7 chars, just under the threshold
-    ("==!==!==", False),  # mixed chars
-    ("", False),
-    ("real text", False),
-])
+@pytest.mark.parametrize(
+    "line, expected",
+    [
+        ("========", True),
+        ("============", True),
+        ("= = = = = = = =", True),
+        ("=", False),  # too short (compact length < 8)
+        ("=======", False),  # 7 chars, just under the threshold
+        ("==!==!==", False),  # mixed chars
+        ("", False),
+        ("real text", False),
+    ],
+)
 def test_is_divider_log_line(line, expected):
     assert logscan_people.is_divider_log_line(line) is expected
 
@@ -220,12 +225,14 @@ def test_collect_missing_people_lines_handles_empty_input():
 
 
 def test_collect_missing_people_lines_returns_block_per_match():
-    content = "\n".join([
-        "Running Pamela Anderson Collection",
-        "stuff",
-        "Collection Warning: No Poster Found at https://raw.githubusercontent.com/Kometa-Team/People-Images/master/P/Pamela%20Anderson.jpg",
-        "Finished Pamela Anderson Collection",
-    ])
+    content = "\n".join(
+        [
+            "Running Pamela Anderson Collection",
+            "stuff",
+            "Collection Warning: No Poster Found at https://raw.githubusercontent.com/Kometa-Team/People-Images/master/P/Pamela%20Anderson.jpg",
+            "Finished Pamela Anderson Collection",
+        ]
+    )
     items = logscan_people.collect_missing_people_lines(content, available_index=set())
     assert len(items) == 1
     assert "pamela anderson" in items[0]["names"]
@@ -234,11 +241,13 @@ def test_collect_missing_people_lines_returns_block_per_match():
 
 def test_collect_missing_people_lines_dedupes_identical_blocks():
     # Same exact block appearing twice should only produce one entry.
-    block = "\n".join([
-        "Running Pamela Anderson Collection",
-        "Collection Warning: No Poster Found at https://raw.githubusercontent.com/Kometa-Team/People-Images/master/P/Pamela%20Anderson.jpg",
-        "Finished Pamela Anderson Collection",
-    ])
+    block = "\n".join(
+        [
+            "Running Pamela Anderson Collection",
+            "Collection Warning: No Poster Found at https://raw.githubusercontent.com/Kometa-Team/People-Images/master/P/Pamela%20Anderson.jpg",
+            "Finished Pamela Anderson Collection",
+        ]
+    )
     content = block + "\n" + block
     items = logscan_people.collect_missing_people_lines(content, available_index=set())
     # Both occurrences map to identical blocks => dedupe.
@@ -247,16 +256,22 @@ def test_collect_missing_people_lines_dedupes_identical_blocks():
 
 def test_collect_missing_people_lines_invokes_cleanup_fn():
     # When a cleanup_fn is provided, it should be called with the content.
-    cleanup = MagicMock(return_value="\n".join([
-        "Running Bob Collection",
-        "Collection Warning: No Poster Found at https://raw.githubusercontent.com/Kometa-Team/People-Images/master/B/Bob.jpg",
-        "Finished Bob Collection",
-    ]))
-    content = "\n".join([
-        "Running Bob Collection",
-        "Collection Warning: No Poster Found at https://raw.githubusercontent.com/Kometa-Team/People-Images/master/B/Bob.jpg",
-        "Finished Bob Collection",
-    ])
+    cleanup = MagicMock(
+        return_value="\n".join(
+            [
+                "Running Bob Collection",
+                "Collection Warning: No Poster Found at https://raw.githubusercontent.com/Kometa-Team/People-Images/master/B/Bob.jpg",
+                "Finished Bob Collection",
+            ]
+        )
+    )
+    content = "\n".join(
+        [
+            "Running Bob Collection",
+            "Collection Warning: No Poster Found at https://raw.githubusercontent.com/Kometa-Team/People-Images/master/B/Bob.jpg",
+            "Finished Bob Collection",
+        ]
+    )
     items = logscan_people.collect_missing_people_lines(content, available_index=set(), cleanup_fn=cleanup)
     cleanup.assert_called_once_with(content)
     assert len(items) == 1
@@ -277,11 +292,15 @@ def _mock_response(status_code, text="", headers=None):
 
 def test_fetch_people_readme_uses_cache_on_304(tmp_path):
     cache_path = tmp_path / "cache.json"
-    cache_path.write_text(json.dumps({
-        "url": logscan_people.PEOPLE_README_URLS[0],
-        "content": "cached body",
-        "etag": "etag-1",
-    }))
+    cache_path.write_text(
+        json.dumps(
+            {
+                "url": logscan_people.PEOPLE_README_URLS[0],
+                "content": "cached body",
+                "etag": "etag-1",
+            }
+        )
+    )
     with patch("modules.logscan_people.requests.get", return_value=_mock_response(304)):
         text, used_cache = logscan_people.fetch_people_readme(cache_path)
     assert text == "cached body"
@@ -303,10 +322,14 @@ def test_fetch_people_readme_writes_cache_on_200(tmp_path):
 
 def test_fetch_people_readme_falls_back_to_cache_on_network_error(tmp_path):
     cache_path = tmp_path / "cache.json"
-    cache_path.write_text(json.dumps({
-        "url": logscan_people.PEOPLE_README_URLS[0],
-        "content": "stale body",
-    }))
+    cache_path.write_text(
+        json.dumps(
+            {
+                "url": logscan_people.PEOPLE_README_URLS[0],
+                "content": "stale body",
+            }
+        )
+    )
     with patch("modules.logscan_people.requests.get", side_effect=ConnectionError("offline")):
         text, used_cache = logscan_people.fetch_people_readme(cache_path)
     assert text == "stale body"


### PR DESCRIPTION
**Final part** of the 6-PR carve-up of the original 3,692-line `modules/logscan.py` monolith. After this lands, the saga is complete.

## What moved

A cohesive 18-method cluster — everything that hunts for missing People-Images poster references in a Kometa log — is now in **`modules/logscan_people.py`** (400 lines).

| Bucket | Functions |
|---|---|
| **Constants** | `PEOPLE_README_URLS`, `PEOPLE_MISSING_WARNING_RE`/`_REGEX`, `PEOPLE_SECTION_START_STRONG`/`_WEAK`, `PEOPLE_SECTION_END_PATTERNS` |
| **URL parsing** | `extract_filename_from_url` |
| **README cache** | `get_people_cache_path`, `load_people_cache`, `save_people_cache`, `fetch_people_readme` (with ETag/Last-Modified validation) |
| **Index building** | `build_people_index` |
| **Log-line predicates** | `is_blank_log_line`, `is_divider_log_line`, `is_section_break`, `matches_any_pattern`, `normalize_name_line` |
| **Block detection** | `find_log_section_bounds`, `extract_key_name_from_block` |
| **Top-level orchestration** | `extract_missing_people_names`, `collect_missing_people_lines` |

## What stayed put

`LogscanAnalyzer` keeps each existing method as a **thin delegator**. The minor analyzer-state interactions are preserved:
- `self._people_index` and `self.people_index_available` are still managed by the analyzer wrappers, so `quickstart.py`'s direct access to `analyzer._people_index` keeps working.
- `collect_missing_people_lines` injects `self.cleanup_content` as a callable into the pure module function, so the people module stays free of the broader analyzer.

The constants are **re-exported** from `modules.logscan` so the existing `from modules.logscan import PEOPLE_MISSING_WARNING_RE` import in `tests/test_logscan_people_posters.py` continues to work unchanged.

## Test coverage gained

Added **`tests/test_logscan_people.py`** — 40 focused unit tests covering every extracted function, including:
- HTTP cache behavior (304 Not Modified → use cache; 200 → write cache; network error → fall back to cache; no cache + no network → return `None`)
- Block-boundary detection across strong/weak/end markers
- Dedupe of identical blocks in `collect_missing_people_lines`
- The `cleanup_fn` injection contract

## Numbers

| | Before | After | Δ |
|---|---:|---:|---|
| `modules/logscan.py` | 3,517 | **3,290** | **−227** |
| New extracted module | — | 400 | +400 |
| New tests | — | 321 | +321 |
| Test suite | 751 passing | **791 passing** | +40 |

## The full 6-PR saga at a glance

| # | PR | Module extracted | `logscan.py` size after |
|---|---|---|---:|
| 1 | #1312 | `logscan_cache.py` | — |
| 2 | #1313 | `logscan_resume.py` | — |
| 3 | #1314 | `logscan_imagemaid_analysis.py` | — |
| 4 | #1318 | `logscan_progress.py` | — |
| 5 | #1319 | `logscan_command.py` | 3,517 |
| **6** | *this* | **`logscan_people.py`** | **3,290** |

What's left in `modules/logscan.py` is mostly the two unavoidable mega-methods: `make_recommendations` (~1,100 lines) and `extract_progress` (~640 lines), plus the orchestrators `analyze_content` / `_build_summary`. Those would need a different surgical approach (internal refactoring rather than module extraction) and are out of scope for this saga.

## Verification

```
pytest tests/                              # 791 passed, 26 deselected (e2e)
ruff check modules/logscan.py modules/logscan_people.py tests/test_logscan_people.py
pre-commit run --files <changed>           # all hooks green
```

After this lands, attention swings back to **`quickstart.py`** itself (11,087 lines, 64 inline Flask routes, ~298 top-level functions) — the original target of the refactor series before the logscan subsystem ate the agenda.