### PR TITLE
Extract TMDb lookup helpers into modules/tmdb_lookup.py (PR H of quickstart.py refactor)

### DIFF
--- a/modules/tmdb_lookup.py
+++ b/modules/tmdb_lookup.py
@@ -1,0 +1,238 @@
+"""TMDb (The Movie Database) lookup helpers for the YAML validation flow.
+
+These six small utilities used to live inline at module scope in
+``quickstart.py`` (lines 3020-3195 on develop).  They are pure helpers --
+no Flask app coupling, no global state -- so they belong in a focused
+module instead of in the 7,000-line monolith.
+
+The lone caller in ``quickstart.py`` is the
+``/lookup_template_string_value`` route (``lookup_template_string_value``),
+which uses these to verify TMDb IDs and IMDb IDs entered into YAML
+config templates.  ``quickstart.py`` re-exports each helper under the
+``_leading_underscore`` name it had before, so the route body and any
+tests that reach in through ``qs_module._lookup_tmdb_*`` keep working
+without changes.
+
+External dependencies (kept):
+    * ``requests`` -- HTTPS calls to the TMDb v3 API
+    * ``modules.database`` -- read TMDb API key from the active config
+    * ``flask.session`` -- pick the active config_name
+
+This module is intentionally test-friendly: every TMDb HTTP call goes
+through ``requests.get`` so callers can monkey-patch
+``modules.tmdb_lookup.requests`` (or use ``responses`` / ``httpx-mock``)
+without having to plumb through quickstart.
+"""
+
+from flask import session
+
+import requests
+
+from modules import database
+
+
+def get_active_tmdb_api_key():
+    """Return the TMDb API key for the currently-active config, or "" if none.
+
+    Reads ``config_name`` from the Flask session, looks up the persisted
+    ``tmdb`` section in the SQLite database, and digs out the API key
+    under any of the keys we historically accept (``apikey``,
+    ``api_key``, ``tmdb_apikey``, ``token``).
+    """
+    config_name = session.get("config_name")
+    if not config_name:
+        return ""
+    try:
+        _validated, _user_entered, stored = database.retrieve_section_data(config_name, "tmdb")
+    except Exception:
+        return ""
+    if not isinstance(stored, dict):
+        return ""
+    tmdb_block = stored.get("tmdb", stored)
+    if not isinstance(tmdb_block, dict):
+        return ""
+    api_key = tmdb_block.get("apikey") or tmdb_block.get("api_key") or tmdb_block.get("tmdb_apikey") or tmdb_block.get("token") or ""
+    return str(api_key).strip()
+
+
+def lookup_tmdb_by_imdb_id(imdb_id, media_type=""):
+    """Resolve an IMDb ID to a TMDb movie or show via the ``/find`` endpoint.
+
+    ``media_type`` is an optional hint (``"movie"`` or ``"show"``) used to
+    pick the preferred result when TMDb returns matches in both buckets.
+    """
+    api_key = get_active_tmdb_api_key()
+    if not api_key:
+        return {"valid": False, "verified": False, "message": "TMDb is not configured for the active config."}
+
+    try:
+        response = requests.get(
+            f"https://api.themoviedb.org/3/find/{imdb_id}",
+            params={"api_key": api_key, "external_source": "imdb_id"},
+            timeout=10,
+        )
+    except requests.RequestException as exc:
+        return {"valid": False, "verified": False, "message": f"TMDb lookup failed: {exc}."}
+
+    if response.status_code in {401, 403}:
+        return {"valid": False, "verified": False, "message": "TMDb lookup could not be verified with the configured API key."}
+
+    if response.status_code == 404:
+        return {"valid": False, "verified": True, "message": "TMDb did not find a matching IMDb ID."}
+
+    if response.status_code != 200:
+        return {"valid": False, "verified": False, "message": f"TMDb lookup failed with status {response.status_code}."}
+
+    payload = response.json() if response.content else {}
+    movie_results = payload.get("movie_results") if isinstance(payload.get("movie_results"), list) else []
+    tv_results = payload.get("tv_results") if isinstance(payload.get("tv_results"), list) else []
+
+    preferred_media_type = str(media_type or "").strip().lower()
+    ordered_results = []
+    if preferred_media_type == "movie":
+        ordered_results.extend(("movie", item) for item in movie_results)
+        ordered_results.extend(("show", item) for item in tv_results)
+    elif preferred_media_type == "show":
+        ordered_results.extend(("show", item) for item in tv_results)
+        ordered_results.extend(("movie", item) for item in movie_results)
+    else:
+        ordered_results.extend(("movie", item) for item in movie_results)
+        ordered_results.extend(("show", item) for item in tv_results)
+
+    for result_type, item in ordered_results:
+        if not isinstance(item, dict):
+            continue
+        label = str(item.get("title") or item.get("name") or "").strip()
+        if not label:
+            continue
+        tmdb_id = item.get("id")
+        tmdb_suffix = f" (TMDb {tmdb_id})" if tmdb_id not in [None, ""] else ""
+        media_label = "movie" if result_type == "movie" else "show"
+        return {
+            "valid": True,
+            "verified": True,
+            "label": label,
+            "result_type": result_type,
+            "message": f"TMDb {media_label}: {label}{tmdb_suffix}",
+        }
+
+    return {"valid": False, "verified": True, "message": "TMDb did not find a matching IMDb ID."}
+
+
+def lookup_tmdb_external_ids(endpoint, tmdb_id, api_key):
+    """Fetch the ``external_ids`` (IMDb, TVDb, etc.) for a given TMDb entry.
+
+    Returns an empty dict on any failure -- callers are expected to treat
+    the result as best-effort enrichment.
+    """
+    if endpoint not in {"movie", "tv"} or not tmdb_id or not api_key:
+        return {}
+
+    try:
+        response = requests.get(
+            f"https://api.themoviedb.org/3/{endpoint}/{tmdb_id}/external_ids",
+            params={"api_key": api_key},
+            timeout=10,
+        )
+    except requests.RequestException:
+        return {}
+
+    if response.status_code != 200:
+        return {}
+
+    payload = response.json() if response.content else {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def lookup_tmdb_numeric_id(tmdb_id, media_type=""):
+    """Resolve a numeric TMDb ID by trying movie / tv / collection / person endpoints.
+
+    ``media_type`` is an optional hint to reorder the endpoint probe so a
+    user-declared media type is tried first.
+    """
+    api_key = get_active_tmdb_api_key()
+    if not api_key:
+        return {"valid": False, "verified": False, "message": "TMDb is not configured for the active config."}
+
+    preferred_media_type = str(media_type or "").strip().lower()
+    endpoint_order = []
+    if preferred_media_type == "movie":
+        endpoint_order = [("movie", "movie"), ("tv", "show"), ("collection", "collection"), ("person", "person")]
+    elif preferred_media_type == "show":
+        endpoint_order = [("tv", "show"), ("movie", "movie"), ("collection", "collection"), ("person", "person")]
+    else:
+        endpoint_order = [("movie", "movie"), ("tv", "show"), ("collection", "collection"), ("person", "person")]
+
+    for endpoint, result_type in endpoint_order:
+        try:
+            response = requests.get(
+                f"https://api.themoviedb.org/3/{endpoint}/{tmdb_id}",
+                params={"api_key": api_key},
+                timeout=10,
+            )
+        except requests.RequestException as exc:
+            return {"valid": False, "verified": False, "message": f"TMDb lookup failed: {exc}."}
+
+        if response.status_code in {401, 403}:
+            return {"valid": False, "verified": False, "message": "TMDb lookup could not be verified with the configured API key."}
+
+        if response.status_code == 404:
+            continue
+
+        if response.status_code != 200:
+            return {"valid": False, "verified": False, "message": f"TMDb lookup failed with status {response.status_code}."}
+
+        payload = response.json() if response.content else {}
+        label = str(payload.get("title") or payload.get("name") or "").strip()
+        if not label:
+            label = f"TMDb {result_type} {tmdb_id}"
+        external_ids = lookup_tmdb_external_ids(endpoint, tmdb_id, api_key) if endpoint in {"movie", "tv"} else {}
+        tvdb_id = external_ids.get("tvdb_id")
+        id_suffix = f" (TMDb {tmdb_id})"
+        if tvdb_id not in [None, "", 0, "0"]:
+            id_suffix = f" (TMDb {tmdb_id}, TVDb {tvdb_id})"
+
+        return {
+            "valid": True,
+            "verified": True,
+            "label": label,
+            "result_type": result_type,
+            "tvdb_id": tvdb_id,
+            "message": f"TMDb {result_type}: {label}{id_suffix}",
+        }
+
+    return {"valid": False, "verified": True, "message": "TMDb did not find a matching numeric ID."}
+
+
+def normalize_tmdb_library_media_type(value):
+    """Collapse Plex-style library media types into ``"movie"`` / ``"show"`` / pass-through."""
+    normalized = str(value or "").strip().lower()
+    if normalized in {"movie", "movies", "mov"}:
+        return "movie"
+    if normalized in {"show", "shows", "sho", "tv", "season", "seasons", "episode", "episodes"}:
+        return "show"
+    return normalized
+
+
+def build_tmdb_library_type_warning(tmdb_message, tmdb_result_type, expected_media_type, value_label="ID"):
+    """Compose a friendly warning when a TMDb result's media type clashes with the active library.
+
+    Returns the empty string when the types agree or when either side is
+    not a recognizable movie/show -- the caller can drop falsy returns
+    without further checks.
+    """
+    resolved_type = normalize_tmdb_library_media_type(tmdb_result_type)
+    expected_type = normalize_tmdb_library_media_type(expected_media_type)
+    if not resolved_type or expected_type not in {"movie", "show"}:
+        return ""
+    if resolved_type == expected_type:
+        return ""
+
+    library_label = "movie library" if expected_type == "movie" else "show/season/episode library"
+    readable_type = {
+        "movie": "movie",
+        "show": "show",
+        "collection": "collection",
+        "person": "person",
+    }.get(resolved_type, resolved_type)
+    return f"{tmdb_message}. This {value_label} resolves to a {readable_type}, but the active library is a {library_label}."

--- a/quickstart.py
+++ b/quickstart.py
@@ -205,6 +205,12 @@ from blueprints.import_config_routes import (  # noqa: F401 (re-exports for test
     import_config_report,
 )
 from modules.assets import build_preview_image_data as _build_preview_image_data, list_overlay_fonts
+from modules.tmdb_lookup import (
+    get_active_tmdb_api_key as _get_active_tmdb_api_key,
+    lookup_tmdb_by_imdb_id as _lookup_tmdb_by_imdb_id,
+    lookup_tmdb_numeric_id as _lookup_tmdb_numeric_id,
+    build_tmdb_library_type_warning as _build_tmdb_library_type_warning,
+)
 from modules.test_libraries import (
     resolve_test_libraries_paths as _resolve_test_libraries_paths,  # noqa: F401 (used directly by tests as qs_module._resolve_test_libraries_paths)
     paths_overlap as _paths_overlap,  # noqa: F401 (used directly by tests as qs_module._paths_overlap)
@@ -3015,184 +3021,6 @@ def validate_library_service_overrides(library_id):
     result = _validate_library_service_overrides(library_id, libraries_data, force_validate=True)
     status_code = 200 if result.get("valid") else 400
     return jsonify(result), status_code
-
-
-def _get_active_tmdb_api_key():
-    config_name = session.get("config_name")
-    if not config_name:
-        return ""
-    try:
-        _validated, _user_entered, stored = database.retrieve_section_data(config_name, "tmdb")
-    except Exception:
-        return ""
-    if not isinstance(stored, dict):
-        return ""
-    tmdb_block = stored.get("tmdb", stored)
-    if not isinstance(tmdb_block, dict):
-        return ""
-    api_key = tmdb_block.get("apikey") or tmdb_block.get("api_key") or tmdb_block.get("tmdb_apikey") or tmdb_block.get("token") or ""
-    return str(api_key).strip()
-
-
-def _lookup_tmdb_by_imdb_id(imdb_id, media_type=""):
-    api_key = _get_active_tmdb_api_key()
-    if not api_key:
-        return {"valid": False, "verified": False, "message": "TMDb is not configured for the active config."}
-
-    try:
-        response = requests.get(
-            f"https://api.themoviedb.org/3/find/{imdb_id}",
-            params={"api_key": api_key, "external_source": "imdb_id"},
-            timeout=10,
-        )
-    except requests.RequestException as exc:
-        return {"valid": False, "verified": False, "message": f"TMDb lookup failed: {exc}."}
-
-    if response.status_code in {401, 403}:
-        return {"valid": False, "verified": False, "message": "TMDb lookup could not be verified with the configured API key."}
-
-    if response.status_code == 404:
-        return {"valid": False, "verified": True, "message": "TMDb did not find a matching IMDb ID."}
-
-    if response.status_code != 200:
-        return {"valid": False, "verified": False, "message": f"TMDb lookup failed with status {response.status_code}."}
-
-    payload = response.json() if response.content else {}
-    movie_results = payload.get("movie_results") if isinstance(payload.get("movie_results"), list) else []
-    tv_results = payload.get("tv_results") if isinstance(payload.get("tv_results"), list) else []
-
-    preferred_media_type = str(media_type or "").strip().lower()
-    ordered_results = []
-    if preferred_media_type == "movie":
-        ordered_results.extend(("movie", item) for item in movie_results)
-        ordered_results.extend(("show", item) for item in tv_results)
-    elif preferred_media_type == "show":
-        ordered_results.extend(("show", item) for item in tv_results)
-        ordered_results.extend(("movie", item) for item in movie_results)
-    else:
-        ordered_results.extend(("movie", item) for item in movie_results)
-        ordered_results.extend(("show", item) for item in tv_results)
-
-    for result_type, item in ordered_results:
-        if not isinstance(item, dict):
-            continue
-        label = str(item.get("title") or item.get("name") or "").strip()
-        if not label:
-            continue
-        tmdb_id = item.get("id")
-        tmdb_suffix = f" (TMDb {tmdb_id})" if tmdb_id not in [None, ""] else ""
-        media_label = "movie" if result_type == "movie" else "show"
-        return {
-            "valid": True,
-            "verified": True,
-            "label": label,
-            "result_type": result_type,
-            "message": f"TMDb {media_label}: {label}{tmdb_suffix}",
-        }
-
-    return {"valid": False, "verified": True, "message": "TMDb did not find a matching IMDb ID."}
-
-
-def _lookup_tmdb_external_ids(endpoint, tmdb_id, api_key):
-    if endpoint not in {"movie", "tv"} or not tmdb_id or not api_key:
-        return {}
-
-    try:
-        response = requests.get(
-            f"https://api.themoviedb.org/3/{endpoint}/{tmdb_id}/external_ids",
-            params={"api_key": api_key},
-            timeout=10,
-        )
-    except requests.RequestException:
-        return {}
-
-    if response.status_code != 200:
-        return {}
-
-    payload = response.json() if response.content else {}
-    return payload if isinstance(payload, dict) else {}
-
-
-def _lookup_tmdb_numeric_id(tmdb_id, media_type=""):
-    api_key = _get_active_tmdb_api_key()
-    if not api_key:
-        return {"valid": False, "verified": False, "message": "TMDb is not configured for the active config."}
-
-    preferred_media_type = str(media_type or "").strip().lower()
-    endpoint_order = []
-    if preferred_media_type == "movie":
-        endpoint_order = [("movie", "movie"), ("tv", "show"), ("collection", "collection"), ("person", "person")]
-    elif preferred_media_type == "show":
-        endpoint_order = [("tv", "show"), ("movie", "movie"), ("collection", "collection"), ("person", "person")]
-    else:
-        endpoint_order = [("movie", "movie"), ("tv", "show"), ("collection", "collection"), ("person", "person")]
-
-    for endpoint, result_type in endpoint_order:
-        try:
-            response = requests.get(
-                f"https://api.themoviedb.org/3/{endpoint}/{tmdb_id}",
-                params={"api_key": api_key},
-                timeout=10,
-            )
-        except requests.RequestException as exc:
-            return {"valid": False, "verified": False, "message": f"TMDb lookup failed: {exc}."}
-
-        if response.status_code in {401, 403}:
-            return {"valid": False, "verified": False, "message": "TMDb lookup could not be verified with the configured API key."}
-
-        if response.status_code == 404:
-            continue
-
-        if response.status_code != 200:
-            return {"valid": False, "verified": False, "message": f"TMDb lookup failed with status {response.status_code}."}
-
-        payload = response.json() if response.content else {}
-        label = str(payload.get("title") or payload.get("name") or "").strip()
-        if not label:
-            label = f"TMDb {result_type} {tmdb_id}"
-        external_ids = _lookup_tmdb_external_ids(endpoint, tmdb_id, api_key) if endpoint in {"movie", "tv"} else {}
-        tvdb_id = external_ids.get("tvdb_id")
-        id_suffix = f" (TMDb {tmdb_id})"
-        if tvdb_id not in [None, "", 0, "0"]:
-            id_suffix = f" (TMDb {tmdb_id}, TVDb {tvdb_id})"
-
-        return {
-            "valid": True,
-            "verified": True,
-            "label": label,
-            "result_type": result_type,
-            "tvdb_id": tvdb_id,
-            "message": f"TMDb {result_type}: {label}{id_suffix}",
-        }
-
-    return {"valid": False, "verified": True, "message": "TMDb did not find a matching numeric ID."}
-
-
-def _normalize_tmdb_library_media_type(value):
-    normalized = str(value or "").strip().lower()
-    if normalized in {"movie", "movies", "mov"}:
-        return "movie"
-    if normalized in {"show", "shows", "sho", "tv", "season", "seasons", "episode", "episodes"}:
-        return "show"
-    return normalized
-
-
-def _build_tmdb_library_type_warning(tmdb_message, tmdb_result_type, expected_media_type, value_label="ID"):
-    resolved_type = _normalize_tmdb_library_media_type(tmdb_result_type)
-    expected_type = _normalize_tmdb_library_media_type(expected_media_type)
-    if not resolved_type or expected_type not in {"movie", "show"}:
-        return ""
-    if resolved_type == expected_type:
-        return ""
-
-    library_label = "movie library" if expected_type == "movie" else "show/season/episode library"
-    readable_type = {
-        "movie": "movie",
-        "show": "show",
-        "collection": "collection",
-        "person": "person",
-    }.get(resolved_type, resolved_type)
-    return f"{tmdb_message}. This {value_label} resolves to a {readable_type}, but the active library is a {library_label}."
 
 
 def _parse_optional_id_list(value):


### PR DESCRIPTION
## Summary

PR H from the quickstart.py refactor sprint -- the **smallest and lowest-risk** of the remaining work.  Moves the six TMDb (The Movie Database) lookup utilities out of `quickstart.py` into a focused module.

These are pure HTTP helpers with no Flask app coupling and no global state -- textbook candidates for extraction.

Builds on the merged stack [#1321](https://github.com/Kometa-Team/Quickstart/pull/1321) (PR A), [#1322](https://github.com/Kometa-Team/Quickstart/pull/1322) (PR C), [#1323](https://github.com/Kometa-Team/Quickstart/pull/1323) (PR D), [#1324](https://github.com/Kometa-Team/Quickstart/pull/1324) (PR E), and is **independent** of [#1325](https://github.com/Kometa-Team/Quickstart/pull/1325) (PR F, still open) -- they touch different parts of the file and will merge cleanly in either order.

## What moved

Six small functions (166 lines on develop):

| Function (in new module) | Originally on develop | Lines |
|---|---:|---:|
| `get_active_tmdb_api_key` | `quickstart.py:3020` | 15 |
| `lookup_tmdb_by_imdb_id` | `quickstart.py:3037` | 57 |
| `lookup_tmdb_external_ids` | `quickstart.py:3096` | 18 |
| `lookup_tmdb_numeric_id` | `quickstart.py:3116` | 53 |
| `normalize_tmdb_library_media_type` | `quickstart.py:3171` | 7 |
| `build_tmdb_library_type_warning` | `quickstart.py:3180` | 16 |

Names lose their leading underscore in the new module (the module is the namespace now), but `quickstart.py` re-imports each one under its old `_leading_underscore` alias so the lone caller (`lookup_template_string_value`, the `/lookup_template_string_value` POST route) and any future tests keep working unchanged.

## Why this PR is cheap

- **No tests patch any of these helpers** via `qs_module._foo` today -- verified by grep across `tests/`.  So no test-patch boundary concerns like PR F had.
- **Only one caller** (`lookup_template_string_value`) inside `quickstart.py`.
- All six functions are pure utilities with a tiny, well-defined external API: `requests`, `modules.database`, `flask.session`.
- AST-verified verbatim extraction (modulo the leading-underscore rename and the added module docstrings).

## Re-export hygiene

Two of the six functions were only ever called by the *other* TMDb helpers in this cluster:

- `lookup_tmdb_external_ids` -- only called by `lookup_tmdb_numeric_id`
- `normalize_tmdb_library_media_type` -- only called by `build_tmdb_library_type_warning`

Both are now internal to `modules/tmdb_lookup.py` and **dropped from the `quickstart.py` re-export list**.  If a future caller needs them, a one-line import is all it takes.

## Verbatim extraction discipline

AST-verified -- all 6 functions byte-for-byte identical to develop after reverse-applying the leading-underscore rename and stripping the new module docstrings:

```
OK verbatim  get_active_tmdb_api_key
OK verbatim  lookup_tmdb_by_imdb_id
OK verbatim  lookup_tmdb_external_ids
OK verbatim  lookup_tmdb_numeric_id
OK verbatim  normalize_tmdb_library_media_type
OK verbatim  build_tmdb_library_type_warning
```

## Tests

- **801 tests pass** (zero regressions).
- `ruff check` clean on both touched files.
- No `conftest.py` fixture needed -- the helpers have no test surface that would benefit from one.

## Size impact

| File | Before | After | Δ |
|---|---:|---:|---:|
| `quickstart.py` | 7,397 | **7,225** | **−172** |
| `modules/tmdb_lookup.py` | — | 238 | new (under 600) |

The new module is larger than the moved code (166 → 238) because of the added module docstring and per-function docstrings explaining intent, semantics, and what each return shape means.  Worth the bytes for files that didn't have any inline documentation before.

## Cumulative refactor progress (relative to develop)

| PR | quickstart.py | Δ from baseline | % reduction |
|---|---:|---:|---:|
| Baseline (post #1320) | 11,087 | — | — |
| After PR A (#1321) | 9,831 | −1,256 | 11.3% |
| After PR C (#1322) | 9,227 | −1,860 | 16.8% |
| After PR D (#1323) | 8,709 | −2,378 | 21.4% |
| After PR E (#1324) | 7,397 | −3,690 | 33.3% |
| **After PR H (this)** | **7,225** | **−3,862** | **34.8%** |
| After PR F (#1325, also open) | 6,976 | −4,111 | 37.1% |

When PR F and PR H both land, `quickstart.py` will be at **~6,800 lines (−39% from baseline)**.

## What this unlocks

Just one PR left from the audit sprint:

- **PR G** -- `blueprints/download_routes.py` + `modules/bundle_artifacts.py` (~800 lines, **medium risk**).  Once landed, removes the 6 lazy `_qs` imports added in PR E for bundle/overlay-image helpers and brings `quickstart.py` close to the audit target (~5,000 lines).

## Linked

- Builds on [#1321](https://github.com/Kometa-Team/Quickstart/pull/1321) (PR A, merged)
- Builds on [#1322](https://github.com/Kometa-Team/Quickstart/pull/1322) (PR C, merged)
- Builds on [#1323](https://github.com/Kometa-Team/Quickstart/pull/1323) (PR D, merged)
- Builds on [#1324](https://github.com/Kometa-Team/Quickstart/pull/1324) (PR E, merged)
- Independent of [#1325](https://github.com/Kometa-Team/Quickstart/pull/1325) (PR F, open) -- can land in either order
- Next: PR G (`download_routes` + `bundle_artifacts`, the final piece)