### PR TITLE
Fix two bugs found during test-matrix expansion

### DIFF
--- a/blueprints/download_routes.py
+++ b/blueprints/download_routes.py
@@ -1,0 +1,92 @@
+"""Download routes for serving generated Kometa config bundles.
+
+This blueprint owns:
+
+* ``GET /download`` -- serve the current session's YAML config (or a ZIP
+  bundle when there are custom fonts or referenced library/overlay-image
+  files to ship alongside it).
+* ``GET /download_redacted`` -- same, but with secrets redacted via
+  ``helpers.redact_sensitive_data`` so the output is safe to share.
+
+Both routes are thin orchestrators over ``modules.bundle_artifacts``.
+The actual bundle-building logic lives there.
+"""
+
+import io
+
+from flask import Blueprint, flash, redirect, send_file, session, url_for
+
+from modules import bundle_artifacts, helpers
+
+bp = Blueprint("download_routes", __name__)
+
+
+@bp.route("/download")
+def download():
+    yaml_content = session.get("yaml_content", "")
+    if yaml_content:
+        config_name = session.get("config_name")
+        custom_fonts = bundle_artifacts.get_custom_font_files(config_name)
+        artifact_files, bundle_yaml = bundle_artifacts.bundle_artifacts_from_yaml(yaml_content, config_name=config_name)
+        if custom_fonts or artifact_files:
+            bundle = bundle_artifacts.build_config_bundle(
+                bundle_yaml,
+                "config.yml",
+                custom_fonts,
+                artifact_files=artifact_files,
+                config_name=config_name,
+            )
+            if bundle:
+                bundle_name = f"{bundle_artifacts.safe_bundle_name(config_name)}_config_bundle.zip"
+                return send_file(
+                    bundle,
+                    mimetype="application/zip",
+                    as_attachment=True,
+                    download_name=bundle_name,
+                )
+        return send_file(
+            io.BytesIO(yaml_content.encode("utf-8")),
+            mimetype="text/yaml",
+            as_attachment=True,
+            download_name="config.yml",
+        )
+    flash("No configuration to download", "danger")
+    return redirect(url_for("step", name="900-kometa"))
+
+
+@bp.route("/download_redacted")
+def download_redacted():
+    yaml_content = session.get("yaml_content", "")
+    if yaml_content:
+        # Redact sensitive information
+        redacted_content = helpers.redact_sensitive_data(yaml_content)
+
+        # Serve the redacted YAML as a file download
+        config_name = session.get("config_name")
+        custom_fonts = bundle_artifacts.get_custom_font_files(config_name)
+        artifact_files, bundle_yaml = bundle_artifacts.bundle_artifacts_from_yaml(redacted_content, config_name=config_name)
+        if custom_fonts or artifact_files:
+            bundle = bundle_artifacts.build_config_bundle(
+                bundle_yaml,
+                "config_redacted.yml",
+                custom_fonts,
+                artifact_files=artifact_files,
+                config_name=config_name,
+                redacted=True,
+            )
+            if bundle:
+                bundle_name = f"{bundle_artifacts.safe_bundle_name(config_name)}_config_bundle_redacted.zip"
+                return send_file(
+                    bundle,
+                    mimetype="application/zip",
+                    as_attachment=True,
+                    download_name=bundle_name,
+                )
+        return send_file(
+            io.BytesIO(redacted_content.encode("utf-8")),
+            mimetype="text/yaml",
+            as_attachment=True,
+            download_name="config_redacted.yml",
+        )
+    flash("No configuration to download", "danger")
+    return redirect(url_for("step", name="900-kometa"))

--- a/blueprints/import_config_routes.py
+++ b/blueprints/import_config_routes.py
@@ -34,15 +34,11 @@ from pathlib import Path
 
 from flask import Blueprint, Flask, current_app, jsonify, request, session
 
-from modules import assets, database, helpers, importer, persistence, validations
+from modules import assets, bundle_artifacts, database, helpers, importer, persistence, validations
 from modules.library_file_entries import (
     _is_bundled_library_archive_member,
     _normalize_imported_libraries_payload,
 )
-
-# A handful of bundle / overlay-image helpers (PR G territory) still live in
-# quickstart.py and are imported lazily inside the route bodies to avoid a
-# load-order cycle: see route bodies for the `import quickstart as _qs` calls.
 
 bp = Blueprint("import_config_routes", __name__)
 
@@ -185,17 +181,6 @@ def _map_playlist_libraries(payload, library_mapping, plex_names):
 
 @bp.route("/import-config/preview", methods=["POST"])
 def import_config_preview():
-    # Bundle/overlay-image helpers still live in quickstart.py (PR G territory);
-    # lazy-import to avoid a load-order cycle.
-    import quickstart as _qs
-
-    _is_allowed_bundle_member = _qs._is_allowed_bundle_member
-    _is_bundled_overlay_image_archive_member = _qs._is_bundled_overlay_image_archive_member
-    _normalize_bundle_member_name = _qs._normalize_bundle_member_name
-    _yaml_path_suffix = _qs._yaml_path_suffix
-    _rewrite_bundle_library_paths = _qs._rewrite_bundle_library_paths
-    _rewrite_bundle_overlay_image_paths = _qs._rewrite_bundle_overlay_image_paths
-
     def count_comment_lines(text: str) -> int:
         if not isinstance(text, str):
             return 0
@@ -244,17 +229,17 @@ def import_config_preview():
                 font_files = []
 
                 for member_name in archive_members:
-                    normalized_member = _normalize_bundle_member_name(member_name)
+                    normalized_member = bundle_artifacts.normalize_bundle_member_name(member_name)
                     if not normalized_member:
                         continue
-                    if not _is_allowed_bundle_member(normalized_member):
+                    if not bundle_artifacts.is_allowed_bundle_member(normalized_member):
                         unexpected_members.append(normalized_member)
                         continue
                     if _is_bundled_library_archive_member(normalized_member):
                         bundled_library_files.append(member_name)
-                    elif _is_bundled_overlay_image_archive_member(normalized_member):
+                    elif bundle_artifacts.is_bundled_overlay_image_archive_member(normalized_member):
                         bundled_overlay_images.append(member_name)
-                    elif _yaml_path_suffix(normalized_member):
+                    elif bundle_artifacts.yaml_path_suffix(normalized_member):
                         config_files.append(member_name)
                     elif normalized_member.lower().endswith((".ttf", ".otf")):
                         font_files.append(member_name)
@@ -350,8 +335,8 @@ def import_config_preview():
                 pass
         return jsonify(success=False, message="Unable to parse config file."), 400
     if extracted_dir:
-        parsed = _rewrite_bundle_library_paths(parsed, extracted_dir)
-        parsed = _rewrite_bundle_overlay_image_paths(parsed, extracted_dir)
+        parsed = bundle_artifacts.rewrite_bundle_library_paths(parsed, extracted_dir)
+        parsed = bundle_artifacts.rewrite_bundle_overlay_image_paths(parsed, extracted_dir)
 
     def parse_plex_credentials(config_data):
         plex_block = config_data.get("plex", {}) if isinstance(config_data, dict) else {}

--- a/blueprints/validation_routes.py
+++ b/blueprints/validation_routes.py
@@ -6,6 +6,30 @@ from modules import database, helpers, persistence, url_validation, validations
 bp = Blueprint("validation_routes", __name__)
 
 
+def _unpack_validation_result(result):
+    """Normalise a validator return value into ``(flask_response, status_code)``.
+
+    Validator functions in ``modules.validations`` may return either:
+
+    * ``jsonify(payload)`` -- a plain Flask ``Response`` (the common case).
+    * ``(jsonify(payload), status_code)`` -- a tuple (used when the validator
+      wants to signal a specific HTTP status, e.g. 400 for a bad URL).
+
+    Both are valid Flask view-return values when returned *directly*, but when
+    a route needs to *inspect* the payload first (to decide whether to re-emit
+    the body with a different status code), it must unpack consistently.
+    Without this helper, routes that call ``result.get_json()`` crash with
+    ``AttributeError: 'tuple' object has no attribute 'get_json'`` whenever
+    the underlying validator returns a tuple.
+
+    ``status_code`` defaults to 200 for plain responses so callers can always
+    use ``status_code or 400`` as the fallback error status.
+    """
+    if isinstance(result, tuple):
+        return result[0], int(result[1])
+    return result, None  # caller uses ``status_code or 400`` -- None keeps the fallback working
+
+
 @bp.route("/validate_gotify", methods=["POST"])
 def validate_gotify():
     data = request.get_json(silent=True) or {}
@@ -411,81 +435,61 @@ def validate_webhook():
 @bp.route("/validate_radarr", methods=["POST"])
 def validate_radarr():
     data = request.json
-    result = validations.validate_radarr_server(data)
-    status_code = 200
-    if isinstance(result, tuple):
-        result, status_code = result
-
+    result, status_code = _unpack_validation_result(validations.validate_radarr_server(data))
     if result.get_json().get("valid"):
         return jsonify(result.get_json())
-    else:
-        return jsonify(result.get_json()), status_code or 400
+    return jsonify(result.get_json()), status_code or 400
 
 
 @bp.route("/validate_sonarr", methods=["POST"])
 def validate_sonarr():
     data = request.json
-    result = validations.validate_sonarr_server(data)
-    status_code = 200
-    if isinstance(result, tuple):
-        result, status_code = result
-
+    result, status_code = _unpack_validation_result(validations.validate_sonarr_server(data))
     if result.get_json().get("valid"):
         return jsonify(result.get_json())
-    else:
-        return jsonify(result.get_json()), status_code or 400
+    return jsonify(result.get_json()), status_code or 400
 
 
 @bp.route("/validate_omdb", methods=["POST"])
 def validate_omdb():
     data = request.json
-    result = validations.validate_omdb_server(data)
-
+    result, status_code = _unpack_validation_result(validations.validate_omdb_server(data))
     if result.get_json().get("valid"):
         return jsonify(result.get_json())
-    else:
-        return jsonify(result.get_json()), 400
+    return jsonify(result.get_json()), status_code or 400
 
 
 @bp.route("/validate_github", methods=["POST"])
 def validate_github():
     data = request.json
-    result = validations.validate_github_server(data)
-
+    result, status_code = _unpack_validation_result(validations.validate_github_server(data))
     if result.get_json().get("valid"):
         return jsonify(result.get_json())
-    else:
-        return jsonify(result.get_json()), 400
+    return jsonify(result.get_json()), status_code or 400
 
 
 @bp.route("/validate_tmdb", methods=["POST"])
 def validate_tmdb():
     data = request.json
-    result = validations.validate_tmdb_server(data)
-
+    result, status_code = _unpack_validation_result(validations.validate_tmdb_server(data))
     if result.get_json().get("valid"):
         return jsonify(result.get_json())
-    else:
-        return jsonify(result.get_json()), 400
+    return jsonify(result.get_json()), status_code or 400
 
 
 @bp.route("/validate_mdblist", methods=["POST"])
 def validate_mdblist():
     data = request.json
-    result = validations.validate_mdblist_server(data)
-
+    result, status_code = _unpack_validation_result(validations.validate_mdblist_server(data))
     if result.get_json().get("valid"):
         return jsonify(result.get_json())
-    else:
-        return jsonify(result.get_json()), 400
+    return jsonify(result.get_json()), status_code or 400
 
 
 @bp.route("/validate_notifiarr", methods=["POST"])
 def validate_notifiarr():
     data = request.json
-    result = validations.validate_notifiarr_server(data)
-
+    result, status_code = _unpack_validation_result(validations.validate_notifiarr_server(data))
     if result.get_json().get("valid"):
         return jsonify(result.get_json())
-    else:
-        return jsonify(result.get_json()), 400
+    return jsonify(result.get_json()), status_code or 400

--- a/modules/bundle_artifacts.py
+++ b/modules/bundle_artifacts.py
@@ -1,0 +1,545 @@
+"""Bundle / overlay-image asset helpers extracted from ``quickstart.py``.
+
+This module owns the logic for:
+
+* **Bundle inspection** -- decide which paths inside an uploaded config
+  ZIP are safe to extract (``is_allowed_bundle_member``,
+  ``normalize_bundle_member_name``, ``yaml_path_suffix``,
+  ``is_bundled_overlay_image_archive_member``).
+* **Path rewriting on import** -- after a bundle is extracted into a
+  temp directory, rewrite YAML library/overlay-image references so they
+  point at the extracted on-disk files
+  (``rewrite_bundle_library_paths``, ``rewrite_bundle_overlay_image_paths``).
+* **Managed-location resolution** -- map between on-disk paths under
+  ``CONFIG_DIR`` and the canonical "config-relative" archive paths used
+  inside bundles and in YAML
+  (``managed_bundle_location_for_path``, the overlay-image variants,
+  ``display_managed_overlay_image_location``).
+* **Bundle build** -- collect referenced library files + overlay-image
+  source files + custom fonts and pack them into a ZIP for the
+  ``/download`` and ``/download_redacted`` routes
+  (``iter_bundle_artifacts``, ``iter_overlay_source_bundle_artifacts``,
+  ``bundle_write_path``, ``bundle_write_artifact``,
+  ``bundle_artifacts_from_yaml``, ``build_config_bundle``,
+  ``get_custom_font_files``, ``safe_bundle_name``,
+  ``normalize_config_name``).
+
+These functions lost their leading ``_`` when moved here -- the module
+*is* the namespace now.  ``quickstart.py`` and the routes that still
+live there re-import each one under its original ``_leading_underscore``
+alias so callers (and the YAML preview blueprint introduced in PR E)
+work without modification.
+
+External dependencies (intentionally narrow):
+
+* ``modules.helpers`` -- ``CONFIG_DIR``, ``ALLOWED_EXTENSIONS``,
+  ``FONT_EXTENSIONS``, ``MANAGED_OVERLAY_IMAGE_DIR``,
+  ``redact_sensitive_data``, custom-fonts helpers
+* ``modules.importer`` -- ``load_yaml_config``
+* ``modules.validations`` -- ``normalize_overlay_source_override_file_location``
+* ``modules.library_file_entries`` -- the four already-modular library
+  path helpers (``_is_bundled_library_archive_member``,
+  ``_normalized_managed_library_relative_path``,
+  ``_parse_managed_library_relative_path``,
+  ``_resolve_local_library_source``).
+"""
+
+import hashlib
+import io
+import os
+import re
+import zipfile
+from io import BytesIO
+from pathlib import Path
+
+from ruamel.yaml import YAML
+from werkzeug.utils import secure_filename
+
+from modules import helpers, importer, validations
+from modules.library_file_entries import (
+    LIBRARY_FILE_KINDS,
+    LOCAL_LIBRARY_FILE_TYPES,
+    _is_bundled_library_archive_member,
+    _normalized_managed_library_relative_path,
+    _parse_managed_library_relative_path,
+    _resolve_local_library_source,
+)
+
+
+def yaml_path_suffix(path_value):
+    return str(path_value or "").strip().lower().endswith((".yml", ".yaml"))
+
+
+def normalize_bundle_member_name(path_value):
+    normalized = str(path_value or "").replace("\\", "/").lstrip("/")
+    return "/".join(part for part in normalized.split("/") if part)
+
+
+def is_allowed_bundle_member(path_value):
+    normalized = normalize_bundle_member_name(path_value)
+    if not normalized:
+        return True
+    lowered = normalized.lower()
+    if _is_bundled_library_archive_member(normalized):
+        return yaml_path_suffix(normalized)
+    if is_bundled_overlay_image_archive_member(normalized):
+        return lowered.endswith(tuple(f".{ext}" for ext in helpers.ALLOWED_EXTENSIONS))
+    if yaml_path_suffix(normalized):
+        return True
+    if lowered.endswith((".ttf", ".otf")):
+        return True
+    if lowered == "readme.txt":
+        return True
+    return False
+
+
+def dump_yaml_text(data):
+    buffer = io.StringIO()
+    YAML().dump(data, buffer)
+    return buffer.getvalue()
+
+
+def managed_bundle_location_for_path(path):
+    config_root = Path(helpers.CONFIG_DIR).resolve()
+    try:
+        relative = Path(path).resolve().relative_to(config_root)
+    except Exception:
+        return None
+    normalized_relative = _normalized_managed_library_relative_path(Path(*relative.parts).as_posix())
+    if not normalized_relative:
+        return None
+    info = _parse_managed_library_relative_path(normalized_relative)
+    if not info or info["layout"] != "config_first":
+        return None
+    return normalized_relative
+
+
+def is_overlay_source_override_file_key(key):
+    normalized = str(key or "").strip()
+    return normalized == "file" or normalized.startswith("file_")
+
+
+def parse_managed_overlay_image_relative_path(path_value):
+    normalized = str(path_value or "").replace("\\", "/").lstrip("/")
+    if not normalized:
+        return None
+    parts = [part for part in normalized.split("/") if part]
+    if len(parts) >= 3 and parts[1] == helpers.MANAGED_OVERLAY_IMAGE_DIR:
+        return {"config_name": parts[0], "remainder": parts[2:], "layout": "config_root"}
+    if len(parts) >= 4 and parts[0] == "config" and parts[2] == helpers.MANAGED_OVERLAY_IMAGE_DIR:
+        return {"config_name": parts[1], "remainder": parts[3:], "layout": "display"}
+    return None
+
+
+def normalized_managed_overlay_image_relative_path(path_value):
+    info = parse_managed_overlay_image_relative_path(path_value)
+    if not info:
+        return None
+    return Path(info["config_name"], helpers.MANAGED_OVERLAY_IMAGE_DIR, *info["remainder"]).as_posix()
+
+
+def is_bundled_overlay_image_archive_member(path_value):
+    return normalized_managed_overlay_image_relative_path(str(path_value or "").replace("\\", "/").lstrip("/")) is not None
+
+
+def resolve_local_overlay_image_source(location):
+    raw = str(location or "").strip()
+    if not raw:
+        return None
+    expanded = Path(os.path.expandvars(os.path.expanduser(raw)))
+    if expanded.is_absolute():
+        try:
+            return expanded.resolve()
+        except OSError:
+            return expanded
+    managed_relative = normalized_managed_overlay_image_relative_path(expanded)
+    if managed_relative:
+        try:
+            return (Path(helpers.CONFIG_DIR) / managed_relative).resolve()
+        except OSError:
+            return Path(helpers.CONFIG_DIR) / managed_relative
+    normalized_parts = [part for part in str(expanded).replace("\\", "/").split("/") if part]
+    if normalized_parts and normalized_parts[0] == helpers.MANAGED_OVERLAY_IMAGE_DIR:
+        try:
+            return (Path(helpers.CONFIG_DIR) / expanded).resolve()
+        except OSError:
+            return Path(helpers.CONFIG_DIR) / expanded
+    try:
+        return (Path.cwd() / expanded).resolve()
+    except OSError:
+        return Path.cwd() / expanded
+
+
+def managed_overlay_image_bundle_location_for_path(path):
+    config_root = Path(helpers.CONFIG_DIR).resolve()
+    try:
+        relative = Path(path).resolve().relative_to(config_root)
+    except Exception:
+        return None
+    normalized_relative = normalized_managed_overlay_image_relative_path(Path(*relative.parts).as_posix())
+    if not normalized_relative:
+        return None
+    return normalized_relative
+
+
+def safe_overlay_bundle_slug(value, fallback):
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "_", str(value or "").strip())
+    slug = slug.strip("._-")
+    return slug or fallback
+
+
+def display_managed_overlay_image_location(location):
+    raw = str(location or "").strip().replace("\\", "/")
+    if not raw:
+        return raw
+    normalized_relative = normalized_managed_overlay_image_relative_path(raw)
+    if normalized_relative:
+        return Path("config", *normalized_relative.split("/")).as_posix()
+    return raw
+
+
+def normalize_overlay_source_override_entries_payload(libraries_data, config_name):
+    if not isinstance(libraries_data, dict):
+        return {}, [], False
+
+    normalized = dict(libraries_data)
+    errors = []
+    changed = False
+    pattern = re.compile(r"^(?P<library_id>(?:mov|sho)-library_.+?)-(?P<builder>movie|show|season|episode)-template_(?P<overlay_id>[^\[]+)\[(?P<template_key>[^\]]+)\]$")
+
+    for key, raw_value in list(normalized.items()):
+        if not isinstance(key, str) or "-template_overlay_" not in key or not key.endswith("]"):
+            continue
+        match = pattern.match(key)
+        if not match:
+            continue
+        template_key = str(match.group("template_key") or "").strip()
+        if not is_overlay_source_override_file_key(template_key):
+            continue
+        location = str(raw_value or "").strip()
+        if not location:
+            continue
+        try:
+            normalized_location, entry_changed = validations.normalize_overlay_source_override_file_location(
+                location,
+                config_name=config_name,
+                library_id=match.group("library_id"),
+                overlay_id=match.group("overlay_id"),
+                template_key=template_key,
+            )
+        except ValueError as exc:
+            errors.append(f"{match.group('library_id')}: {match.group('overlay_id')}[{template_key}] {exc}")
+            continue
+        normalized[key] = normalized_location
+        changed = changed or bool(entry_changed) or normalized_location != location
+
+    return normalized, errors, changed
+
+
+def rewrite_bundle_library_paths(config_data, bundle_root):
+    if not isinstance(config_data, dict):
+        return config_data
+    libraries = config_data.get("libraries")
+    if not isinstance(libraries, dict):
+        return config_data
+    root = Path(bundle_root).resolve()
+    for lib_cfg in libraries.values():
+        if not isinstance(lib_cfg, dict):
+            continue
+        for kind in LIBRARY_FILE_KINDS:
+            entries = lib_cfg.get(kind)
+            if not isinstance(entries, list):
+                continue
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                for entry_type in LOCAL_LIBRARY_FILE_TYPES:
+                    location = entry.get(entry_type)
+                    if not location:
+                        continue
+                    raw_location = str(location).strip()
+                    candidate = root / Path(raw_location)
+                    if not candidate.exists():
+                        normalized_relative = _normalized_managed_library_relative_path(raw_location)
+                        if normalized_relative:
+                            candidate = root / Path(normalized_relative)
+                    if not candidate.exists():
+                        continue
+                    entry[entry_type] = str(candidate.resolve())
+                    break
+    return config_data
+
+
+def rewrite_bundle_overlay_image_paths(config_data, bundle_root):
+    if not isinstance(config_data, dict):
+        return config_data
+    libraries = config_data.get("libraries")
+    if not isinstance(libraries, dict):
+        return config_data
+    root = Path(bundle_root).resolve()
+    for lib_cfg in libraries.values():
+        if not isinstance(lib_cfg, dict):
+            continue
+        overlay_entries = lib_cfg.get("overlay_files")
+        if not isinstance(overlay_entries, list):
+            continue
+        for entry in overlay_entries:
+            if not isinstance(entry, dict):
+                continue
+            template_vars = entry.get("template_variables")
+            if not isinstance(template_vars, dict):
+                continue
+            for key, value in list(template_vars.items()):
+                if not is_overlay_source_override_file_key(key) or not value:
+                    continue
+                raw_location = str(value).strip()
+                candidate = root / Path(raw_location)
+                if not candidate.exists():
+                    normalized_relative = normalized_managed_overlay_image_relative_path(raw_location)
+                    if normalized_relative:
+                        candidate = root / Path(normalized_relative)
+                if not candidate.exists():
+                    continue
+                template_vars[key] = str(candidate.resolve())
+    return config_data
+
+
+def iter_bundle_artifacts(config_data):
+    seen = set()
+    if not isinstance(config_data, dict):
+        return []
+    libraries = config_data.get("libraries")
+    if not isinstance(libraries, dict):
+        return []
+    artifacts = []
+    for lib_cfg in libraries.values():
+        if not isinstance(lib_cfg, dict):
+            continue
+        for kind in LIBRARY_FILE_KINDS:
+            entries = lib_cfg.get(kind)
+            if not isinstance(entries, list):
+                continue
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                for entry_type in LOCAL_LIBRARY_FILE_TYPES:
+                    location = entry.get(entry_type)
+                    if not location:
+                        continue
+                    raw_location = str(location).strip()
+                    if not raw_location:
+                        continue
+                    source_path = _resolve_local_library_source(raw_location)
+                    if source_path is None:
+                        continue
+                    if not source_path.exists():
+                        continue
+                    archive_path = managed_bundle_location_for_path(source_path)
+                    if not archive_path:
+                        archive_path = _normalized_managed_library_relative_path(raw_location) or Path(raw_location).as_posix()
+                    dedupe_key = (str(source_path), archive_path)
+                    if dedupe_key in seen:
+                        break
+                    seen.add(dedupe_key)
+                    artifacts.append(
+                        {
+                            "source": source_path,
+                            "archive": archive_path,
+                            "type": entry_type,
+                        }
+                    )
+                    break
+    return artifacts
+
+
+def iter_overlay_source_bundle_artifacts(config_data, config_name):
+    seen = set()
+    changed = False
+    if not isinstance(config_data, dict):
+        return [], changed
+    libraries = config_data.get("libraries")
+    if not isinstance(libraries, dict):
+        return [], changed
+
+    config_slug = normalize_config_name(config_name)
+    artifacts = []
+    for library_name, lib_cfg in libraries.items():
+        if not isinstance(lib_cfg, dict):
+            continue
+        overlay_entries = lib_cfg.get("overlay_files")
+        if not isinstance(overlay_entries, list):
+            continue
+        for entry in overlay_entries:
+            if not isinstance(entry, dict):
+                continue
+            template_vars = entry.get("template_variables")
+            if not isinstance(template_vars, dict):
+                continue
+            overlay_name = str(entry.get("default") or "overlay").strip()
+            for template_key, raw_value in list(template_vars.items()):
+                if not is_overlay_source_override_file_key(template_key):
+                    continue
+                raw_location = str(raw_value or "").strip()
+                if not raw_location:
+                    continue
+                source_path = resolve_local_overlay_image_source(raw_location)
+                if source_path is None or not source_path.exists() or not source_path.is_file():
+                    continue
+
+                archive_path = managed_overlay_image_bundle_location_for_path(source_path)
+                if not archive_path:
+                    library_slug = safe_overlay_bundle_slug(library_name, "library")
+                    overlay_slug = safe_overlay_bundle_slug(overlay_name, "overlay")
+                    template_slug = safe_overlay_bundle_slug(template_key, "image")
+                    stem_slug = safe_overlay_bundle_slug(source_path.stem, "image")
+                    digest_source = f"{str(source_path).replace('\\', '/').lower()}|{library_slug}|{overlay_slug}|{template_slug}"
+                    digest = hashlib.sha1(digest_source.encode("utf-8", errors="ignore")).hexdigest()[:10]
+                    suffix = source_path.suffix or ".png"
+                    archive_path = Path(
+                        config_slug,
+                        helpers.MANAGED_OVERLAY_IMAGE_DIR,
+                        library_slug,
+                        overlay_slug,
+                        f"{template_slug}_{stem_slug}_{digest}{suffix}",
+                    ).as_posix()
+
+                display_location = display_managed_overlay_image_location(archive_path)
+                if raw_location != display_location:
+                    template_vars[template_key] = display_location
+                    changed = True
+
+                dedupe_key = (str(source_path), archive_path)
+                if dedupe_key in seen:
+                    continue
+                seen.add(dedupe_key)
+                artifacts.append({"source": source_path, "archive": archive_path, "type": "overlay_image"})
+
+    return artifacts, changed
+
+
+def bundle_write_path(zf, archive_name, source_path, redacted=False):
+    source_path = Path(source_path)
+    archive_name = Path(archive_name).as_posix()
+    if redacted and source_path.is_file() and yaml_path_suffix(source_path.name):
+        text = source_path.read_text(encoding="utf-8", errors="replace")
+        zf.writestr(archive_name, helpers.redact_sensitive_data(text))
+        return
+    zf.write(source_path, archive_name)
+
+
+def bundle_write_artifact(zf, artifact, redacted=False):
+    source_path = Path((artifact or {}).get("source", ""))
+    archive_path = Path(str((artifact or {}).get("archive", "")).replace("\\", "/"))
+    if not source_path.exists() or not str(archive_path):
+        return
+    if source_path.is_dir():
+        for child in sorted(source_path.rglob("*"), key=lambda item: item.as_posix().lower()):
+            if not child.is_file():
+                continue
+            relative_child = child.relative_to(source_path)
+            bundle_write_path(zf, (archive_path / relative_child).as_posix(), child, redacted=redacted)
+        return
+    bundle_write_path(zf, archive_path.as_posix(), source_path, redacted=redacted)
+
+
+def normalize_config_name(raw_name: str | None) -> str:
+    name = (raw_name or "").strip().lower().replace(" ", "_")
+    return name or "default"
+
+
+def safe_bundle_name(raw_name: str | None) -> str:
+    safe = secure_filename(normalize_config_name(raw_name))
+    return safe or "default"
+
+
+def get_custom_font_files(config_name: str | None = None) -> list[Path]:
+    font_files: list[Path] = []
+    seen: set[str] = set()
+    candidate_dirs: list[Path] = []
+    if config_name:
+        helpers.migrate_legacy_custom_fonts_to_config(config_name)
+        candidate_dirs.append(helpers.get_custom_fonts_dir(config_name))
+    candidate_dirs.append(helpers.get_legacy_custom_fonts_dir())
+    for custom_dir in candidate_dirs:
+        if not custom_dir.is_dir():
+            continue
+        for entry in sorted(custom_dir.iterdir(), key=lambda p: p.name.lower()):
+            if not entry.is_file() or entry.suffix.lower() not in helpers.FONT_EXTENSIONS:
+                continue
+            if entry.name in seen:
+                continue
+            font_files.append(entry)
+            seen.add(entry.name)
+    return font_files
+
+
+def bundle_artifacts_from_yaml(yaml_text, config_name=None):
+    parsed = importer.load_yaml_config(yaml_text)
+    if not parsed:
+        return [], yaml_text
+    artifact_files = list(iter_bundle_artifacts(parsed))
+    overlay_artifacts, overlay_changed = iter_overlay_source_bundle_artifacts(parsed, config_name)
+    artifact_files.extend(overlay_artifacts)
+    if overlay_changed:
+        return artifact_files, dump_yaml_text(parsed)
+    return artifact_files, yaml_text
+
+
+def build_config_bundle(
+    config_text: str,
+    config_filename: str,
+    font_files: list[Path],
+    artifact_files: list[dict] | None = None,
+    config_name: str | None = None,
+    redacted: bool = False,
+) -> BytesIO | None:
+    artifact_files = artifact_files or []
+    if not config_text or (not font_files and not artifact_files):
+        return None
+    name = normalize_config_name(config_name)
+    font_names = [font.name for font in font_files]
+    has_artifacts = bool(artifact_files)
+    readme_lines = [
+        "Quickstart config bundle",
+        f"Config name: {name}",
+        "",
+        "This bundle includes:",
+        f"- {config_filename}",
+    ]
+    if font_names:
+        readme_lines.append(f"- {name}/fonts/ (custom fonts uploaded in Quickstart)")
+        readme_lines.append(f"- Fonts included: {', '.join(font_names)}")
+    if has_artifacts:
+        readme_lines.append(f"- {name}/metadata_files/, {name}/collection_files/, {name}/overlay_files/, {name}/overlay_images/ (config-owned library files and overlay images)")
+    readme_lines += [
+        "",
+        "Install steps:",
+        "1) Copy the config file into your Kometa config folder (config/).",
+    ]
+    if font_names:
+        readme_lines.append(f"2) Copy the font files from {name}/fonts/ into your Kometa config/fonts/ folder.")
+    if has_artifacts:
+        readme_lines.append(f"3) Copy {name}/ into your Kometa config/ folder.")
+    readme_lines += [
+        "",
+        "Note: Validate Kometa and Run Now both sync config-owned library files automatically.",
+        "Note: The Quickstart Run Now button also syncs referenced fonts automatically.",
+        "This bundle is for manual installs.",
+    ]
+    if redacted:
+        readme_lines += [
+            "",
+            "This bundle uses a redacted config and is safe to share.",
+            "Review before sharing in case you manually added sensitive data.",
+        ]
+    readme_lines.append("")
+    bundle = BytesIO()
+    with zipfile.ZipFile(bundle, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(config_filename, config_text)
+        for font_path in font_files:
+            zf.write(font_path, f"{name}/fonts/{font_path.name}")
+        for artifact in artifact_files:
+            bundle_write_artifact(zf, artifact, redacted=redacted)
+        zf.writestr("README.txt", "\n".join(readme_lines))
+    bundle.seek(0)
+    return bundle

--- a/modules/database.py
+++ b/modules/database.py
@@ -191,6 +191,7 @@ def reset_data(name, section=None):
     with sqlite3.connect(get_database_path(), detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES) as connection:
         connection.row_factory = sqlite3.Row
         with closing(connection.cursor()) as cursor:
+            cursor.execute(persisted_section_table_create())  # ensure table exists before DELETE
             sql = "DELETE from section_data where name == ?"
             if section:
                 cursor.execute(f"{sql} AND section == ?", (name, section))

--- a/modules/library_file_entries.py
+++ b/modules/library_file_entries.py
@@ -294,15 +294,13 @@ def _remove_managed_path(path, root):
 
 
 def _copy_library_artifact_to_managed_store(kind, entry_type, location, config_name, library_scope, force_clone_managed=False):
-    # _managed_bundle_location_for_path still lives in quickstart.py until PR G; lazy-import
-    # to avoid a load-order cycle.
-    import quickstart as _qs
+    from modules import bundle_artifacts
 
     source_path = _resolve_local_library_source(location)
     if source_path is None:
         raise RuntimeError("Path is required.")
 
-    managed_location = _qs._managed_bundle_location_for_path(source_path)
+    managed_location = bundle_artifacts.managed_bundle_location_for_path(source_path)
     if managed_location and not force_clone_managed:
         return managed_location
 
@@ -440,9 +438,7 @@ def _normalize_library_file_entries_payload(libraries_data, config_name, validat
 
 
 def _normalize_imported_libraries_payload(payload_section, config_name):
-    # _normalize_overlay_source_override_entries_payload stays in quickstart.py
-    # until PR G (overlay-image bundle cluster); lazy-import.
-    import quickstart as _qs
+    from modules import bundle_artifacts
 
     if not isinstance(payload_section, dict):
         return payload_section, []
@@ -450,7 +446,7 @@ def _normalize_imported_libraries_payload(payload_section, config_name):
     if not isinstance(libraries_data, dict):
         return payload_section, []
     normalized, errors, _changed = _normalize_library_file_entries_payload(libraries_data, config_name, validate_local=True)
-    normalized, overlay_errors, _overlay_changed = _qs._normalize_overlay_source_override_entries_payload(normalized, config_name)
+    normalized, overlay_errors, _overlay_changed = bundle_artifacts.normalize_overlay_source_override_entries_payload(normalized, config_name)
     errors.extend(overlay_errors)
     if errors:
         return None, errors

--- a/quickstart.py
+++ b/quickstart.py
@@ -4,7 +4,6 @@ import inspect
 import io
 import json
 import os
-import hashlib
 import platform
 import psutil
 import re
@@ -16,9 +15,7 @@ import threading
 import time
 import uuid
 import webbrowser
-import zipfile
 import secrets
-from io import BytesIO
 from threading import Thread
 from pathlib import Path
 from collections import deque
@@ -35,20 +32,18 @@ from flask import (
     request,
     redirect,
     url_for,
-    flash,
     session,
     send_file,
     abort,
     has_request_context,
 )
 from waitress import serve
-from ruamel.yaml import YAML
 from werkzeug.datastructures import MultiDict
-from werkzeug.utils import secure_filename
 
 from werkzeug.wrappers import Request
 from flask_session import Session
-from modules import validations, output, persistence, helpers, database, logscan, importer, path_validation, url_validation
+from modules import validations, output, persistence, helpers, database, logscan, path_validation, url_validation
+from modules import importer  # noqa: F401 (load-bearing: tests do monkeypatch.setattr(qs_module.importer, ...))
 from modules.dependency_reasons import (  # noqa: F401 (re-exports for tests/legacy in-module callers)
     QS_ANIDB_DEP_SOURCE_PREFIXES,
     QS_ANIDB_OVERLAY_IMAGE_VALUES,
@@ -183,6 +178,7 @@ from blueprints.asset_routes import bp as asset_routes_bp
 from blueprints.kometa_updates import bp as kometa_updates_bp
 from blueprints.imagemaid_updates import bp as imagemaid_updates_bp
 from blueprints.config_routes import bp as config_routes_bp
+from blueprints.download_routes import bp as download_routes_bp
 from blueprints.test_libraries_routes import bp as test_libraries_routes_bp
 from blueprints.library_routes import (
     bp as library_routes_bp,
@@ -215,6 +211,7 @@ from blueprints.imagemaid_routes import (  # noqa: F401 (re-exports for tests/le
     validate_imagemaid,
 )
 from modules.assets import build_preview_image_data as _build_preview_image_data, list_overlay_fonts
+from modules.bundle_artifacts import dump_yaml_text as _dump_yaml_text
 from modules.tmdb_lookup import (
     get_active_tmdb_api_key as _get_active_tmdb_api_key,
     lookup_tmdb_by_imdb_id as _lookup_tmdb_by_imdb_id,
@@ -671,244 +668,6 @@ def _safe_int(value, default=0):
         return default
 
 
-def _yaml_path_suffix(path_value):
-    return str(path_value or "").strip().lower().endswith((".yml", ".yaml"))
-
-
-def _normalize_bundle_member_name(path_value):
-    normalized = str(path_value or "").replace("\\", "/").lstrip("/")
-    return "/".join(part for part in normalized.split("/") if part)
-
-
-def _is_allowed_bundle_member(path_value):
-    normalized = _normalize_bundle_member_name(path_value)
-    if not normalized:
-        return True
-    lowered = normalized.lower()
-    if _is_bundled_library_archive_member(normalized):
-        return _yaml_path_suffix(normalized)
-    if _is_bundled_overlay_image_archive_member(normalized):
-        return lowered.endswith(tuple(f".{ext}" for ext in helpers.ALLOWED_EXTENSIONS))
-    if _yaml_path_suffix(normalized):
-        return True
-    if lowered.endswith((".ttf", ".otf")):
-        return True
-    if lowered == "readme.txt":
-        return True
-    return False
-
-
-def _dump_yaml_text(data):
-    buffer = io.StringIO()
-    YAML().dump(data, buffer)
-    return buffer.getvalue()
-
-
-def _managed_bundle_location_for_path(path):
-    config_root = Path(helpers.CONFIG_DIR).resolve()
-    try:
-        relative = Path(path).resolve().relative_to(config_root)
-    except Exception:
-        return None
-    normalized_relative = _normalized_managed_library_relative_path(Path(*relative.parts).as_posix())
-    if not normalized_relative:
-        return None
-    info = _parse_managed_library_relative_path(normalized_relative)
-    if not info or info["layout"] != "config_first":
-        return None
-    return normalized_relative
-
-
-def _is_overlay_source_override_file_key(key):
-    normalized = str(key or "").strip()
-    return normalized == "file" or normalized.startswith("file_")
-
-
-def _parse_managed_overlay_image_relative_path(path_value):
-    normalized = str(path_value or "").replace("\\", "/").lstrip("/")
-    if not normalized:
-        return None
-    parts = [part for part in normalized.split("/") if part]
-    if len(parts) >= 3 and parts[1] == helpers.MANAGED_OVERLAY_IMAGE_DIR:
-        return {"config_name": parts[0], "remainder": parts[2:], "layout": "config_root"}
-    if len(parts) >= 4 and parts[0] == "config" and parts[2] == helpers.MANAGED_OVERLAY_IMAGE_DIR:
-        return {"config_name": parts[1], "remainder": parts[3:], "layout": "display"}
-    return None
-
-
-def _normalized_managed_overlay_image_relative_path(path_value):
-    info = _parse_managed_overlay_image_relative_path(path_value)
-    if not info:
-        return None
-    return Path(info["config_name"], helpers.MANAGED_OVERLAY_IMAGE_DIR, *info["remainder"]).as_posix()
-
-
-def _is_bundled_overlay_image_archive_member(path_value):
-    return _normalized_managed_overlay_image_relative_path(str(path_value or "").replace("\\", "/").lstrip("/")) is not None
-
-
-def _resolve_local_overlay_image_source(location):
-    raw = str(location or "").strip()
-    if not raw:
-        return None
-    expanded = Path(os.path.expandvars(os.path.expanduser(raw)))
-    if expanded.is_absolute():
-        try:
-            return expanded.resolve()
-        except OSError:
-            return expanded
-    managed_relative = _normalized_managed_overlay_image_relative_path(expanded)
-    if managed_relative:
-        try:
-            return (Path(helpers.CONFIG_DIR) / managed_relative).resolve()
-        except OSError:
-            return Path(helpers.CONFIG_DIR) / managed_relative
-    normalized_parts = [part for part in str(expanded).replace("\\", "/").split("/") if part]
-    if normalized_parts and normalized_parts[0] == helpers.MANAGED_OVERLAY_IMAGE_DIR:
-        try:
-            return (Path(helpers.CONFIG_DIR) / expanded).resolve()
-        except OSError:
-            return Path(helpers.CONFIG_DIR) / expanded
-    try:
-        return (Path.cwd() / expanded).resolve()
-    except OSError:
-        return Path.cwd() / expanded
-
-
-def _managed_overlay_image_bundle_location_for_path(path):
-    config_root = Path(helpers.CONFIG_DIR).resolve()
-    try:
-        relative = Path(path).resolve().relative_to(config_root)
-    except Exception:
-        return None
-    normalized_relative = _normalized_managed_overlay_image_relative_path(Path(*relative.parts).as_posix())
-    if not normalized_relative:
-        return None
-    return normalized_relative
-
-
-def _safe_overlay_bundle_slug(value, fallback):
-    slug = re.sub(r"[^A-Za-z0-9._-]+", "_", str(value or "").strip())
-    slug = slug.strip("._-")
-    return slug or fallback
-
-
-def _display_managed_overlay_image_location(location):
-    raw = str(location or "").strip().replace("\\", "/")
-    if not raw:
-        return raw
-    normalized_relative = _normalized_managed_overlay_image_relative_path(raw)
-    if normalized_relative:
-        return Path("config", *normalized_relative.split("/")).as_posix()
-    return raw
-
-
-def _normalize_overlay_source_override_entries_payload(libraries_data, config_name):
-    if not isinstance(libraries_data, dict):
-        return {}, [], False
-
-    normalized = dict(libraries_data)
-    errors = []
-    changed = False
-    pattern = re.compile(r"^(?P<library_id>(?:mov|sho)-library_.+?)-(?P<builder>movie|show|season|episode)-template_(?P<overlay_id>[^\[]+)\[(?P<template_key>[^\]]+)\]$")
-
-    for key, raw_value in list(normalized.items()):
-        if not isinstance(key, str) or "-template_overlay_" not in key or not key.endswith("]"):
-            continue
-        match = pattern.match(key)
-        if not match:
-            continue
-        template_key = str(match.group("template_key") or "").strip()
-        if not _is_overlay_source_override_file_key(template_key):
-            continue
-        location = str(raw_value or "").strip()
-        if not location:
-            continue
-        try:
-            normalized_location, entry_changed = validations.normalize_overlay_source_override_file_location(
-                location,
-                config_name=config_name,
-                library_id=match.group("library_id"),
-                overlay_id=match.group("overlay_id"),
-                template_key=template_key,
-            )
-        except ValueError as exc:
-            errors.append(f"{match.group('library_id')}: {match.group('overlay_id')}[{template_key}] {exc}")
-            continue
-        normalized[key] = normalized_location
-        changed = changed or bool(entry_changed) or normalized_location != location
-
-    return normalized, errors, changed
-
-
-def _rewrite_bundle_library_paths(config_data, bundle_root):
-    if not isinstance(config_data, dict):
-        return config_data
-    libraries = config_data.get("libraries")
-    if not isinstance(libraries, dict):
-        return config_data
-    root = Path(bundle_root).resolve()
-    for lib_cfg in libraries.values():
-        if not isinstance(lib_cfg, dict):
-            continue
-        for kind in LIBRARY_FILE_KINDS:
-            entries = lib_cfg.get(kind)
-            if not isinstance(entries, list):
-                continue
-            for entry in entries:
-                if not isinstance(entry, dict):
-                    continue
-                for entry_type in LOCAL_LIBRARY_FILE_TYPES:
-                    location = entry.get(entry_type)
-                    if not location:
-                        continue
-                    raw_location = str(location).strip()
-                    candidate = root / Path(raw_location)
-                    if not candidate.exists():
-                        normalized_relative = _normalized_managed_library_relative_path(raw_location)
-                        if normalized_relative:
-                            candidate = root / Path(normalized_relative)
-                    if not candidate.exists():
-                        continue
-                    entry[entry_type] = str(candidate.resolve())
-                    break
-    return config_data
-
-
-def _rewrite_bundle_overlay_image_paths(config_data, bundle_root):
-    if not isinstance(config_data, dict):
-        return config_data
-    libraries = config_data.get("libraries")
-    if not isinstance(libraries, dict):
-        return config_data
-    root = Path(bundle_root).resolve()
-    for lib_cfg in libraries.values():
-        if not isinstance(lib_cfg, dict):
-            continue
-        overlay_entries = lib_cfg.get("overlay_files")
-        if not isinstance(overlay_entries, list):
-            continue
-        for entry in overlay_entries:
-            if not isinstance(entry, dict):
-                continue
-            template_vars = entry.get("template_variables")
-            if not isinstance(template_vars, dict):
-                continue
-            for key, value in list(template_vars.items()):
-                if not _is_overlay_source_override_file_key(key) or not value:
-                    continue
-                raw_location = str(value).strip()
-                candidate = root / Path(raw_location)
-                if not candidate.exists():
-                    normalized_relative = _normalized_managed_overlay_image_relative_path(raw_location)
-                    if normalized_relative:
-                        candidate = root / Path(normalized_relative)
-                if not candidate.exists():
-                    continue
-                template_vars[key] = str(candidate.resolve())
-    return config_data
-
-
 def _normalize_generated_config_library_files(config_data, config_name):
     if not isinstance(config_data, dict):
         return config_data, False, []
@@ -963,144 +722,6 @@ def _normalize_generated_config_library_files(config_data, config_name):
                     new_entries.append(entry)
             lib_cfg[kind] = new_entries
     return config_data, changed, errors
-
-
-def _iter_bundle_artifacts(config_data):
-    seen = set()
-    if not isinstance(config_data, dict):
-        return []
-    libraries = config_data.get("libraries")
-    if not isinstance(libraries, dict):
-        return []
-    artifacts = []
-    for lib_cfg in libraries.values():
-        if not isinstance(lib_cfg, dict):
-            continue
-        for kind in LIBRARY_FILE_KINDS:
-            entries = lib_cfg.get(kind)
-            if not isinstance(entries, list):
-                continue
-            for entry in entries:
-                if not isinstance(entry, dict):
-                    continue
-                for entry_type in LOCAL_LIBRARY_FILE_TYPES:
-                    location = entry.get(entry_type)
-                    if not location:
-                        continue
-                    raw_location = str(location).strip()
-                    if not raw_location:
-                        continue
-                    source_path = _resolve_local_library_source(raw_location)
-                    if source_path is None:
-                        continue
-                    if not source_path.exists():
-                        continue
-                    archive_path = _managed_bundle_location_for_path(source_path)
-                    if not archive_path:
-                        archive_path = _normalized_managed_library_relative_path(raw_location) or Path(raw_location).as_posix()
-                    dedupe_key = (str(source_path), archive_path)
-                    if dedupe_key in seen:
-                        break
-                    seen.add(dedupe_key)
-                    artifacts.append(
-                        {
-                            "source": source_path,
-                            "archive": archive_path,
-                            "type": entry_type,
-                        }
-                    )
-                    break
-    return artifacts
-
-
-def _iter_overlay_source_bundle_artifacts(config_data, config_name):
-    seen = set()
-    changed = False
-    if not isinstance(config_data, dict):
-        return [], changed
-    libraries = config_data.get("libraries")
-    if not isinstance(libraries, dict):
-        return [], changed
-
-    config_slug = _normalize_config_name(config_name)
-    artifacts = []
-    for library_name, lib_cfg in libraries.items():
-        if not isinstance(lib_cfg, dict):
-            continue
-        overlay_entries = lib_cfg.get("overlay_files")
-        if not isinstance(overlay_entries, list):
-            continue
-        for entry in overlay_entries:
-            if not isinstance(entry, dict):
-                continue
-            template_vars = entry.get("template_variables")
-            if not isinstance(template_vars, dict):
-                continue
-            overlay_name = str(entry.get("default") or "overlay").strip()
-            for template_key, raw_value in list(template_vars.items()):
-                if not _is_overlay_source_override_file_key(template_key):
-                    continue
-                raw_location = str(raw_value or "").strip()
-                if not raw_location:
-                    continue
-                source_path = _resolve_local_overlay_image_source(raw_location)
-                if source_path is None or not source_path.exists() or not source_path.is_file():
-                    continue
-
-                archive_path = _managed_overlay_image_bundle_location_for_path(source_path)
-                if not archive_path:
-                    library_slug = _safe_overlay_bundle_slug(library_name, "library")
-                    overlay_slug = _safe_overlay_bundle_slug(overlay_name, "overlay")
-                    template_slug = _safe_overlay_bundle_slug(template_key, "image")
-                    stem_slug = _safe_overlay_bundle_slug(source_path.stem, "image")
-                    digest_source = f"{str(source_path).replace('\\', '/').lower()}|{library_slug}|{overlay_slug}|{template_slug}"
-                    digest = hashlib.sha1(digest_source.encode("utf-8", errors="ignore")).hexdigest()[:10]
-                    suffix = source_path.suffix or ".png"
-                    archive_path = Path(
-                        config_slug,
-                        helpers.MANAGED_OVERLAY_IMAGE_DIR,
-                        library_slug,
-                        overlay_slug,
-                        f"{template_slug}_{stem_slug}_{digest}{suffix}",
-                    ).as_posix()
-
-                display_location = _display_managed_overlay_image_location(archive_path)
-                if raw_location != display_location:
-                    template_vars[template_key] = display_location
-                    changed = True
-
-                dedupe_key = (str(source_path), archive_path)
-                if dedupe_key in seen:
-                    continue
-                seen.add(dedupe_key)
-                artifacts.append({"source": source_path, "archive": archive_path, "type": "overlay_image"})
-
-    return artifacts, changed
-
-
-def _bundle_write_path(zf, archive_name, source_path, redacted=False):
-    source_path = Path(source_path)
-    archive_name = Path(archive_name).as_posix()
-    if redacted and source_path.is_file() and _yaml_path_suffix(source_path.name):
-        text = source_path.read_text(encoding="utf-8", errors="replace")
-        zf.writestr(archive_name, helpers.redact_sensitive_data(text))
-        return
-    zf.write(source_path, archive_name)
-
-
-def _bundle_write_artifact(zf, artifact, redacted=False):
-    source_path = Path((artifact or {}).get("source", ""))
-    archive_path = Path(str((artifact or {}).get("archive", "")).replace("\\", "/"))
-    if not source_path.exists() or not str(archive_path):
-        return
-    if source_path.is_dir():
-        for child in sorted(source_path.rglob("*"), key=lambda item: item.as_posix().lower()):
-            if not child.is_file():
-                continue
-            relative_child = child.relative_to(source_path)
-            _bundle_write_path(zf, (archive_path / relative_child).as_posix(), child, redacted=redacted)
-        return
-    _bundle_write_path(zf, archive_path.as_posix(), source_path, redacted=redacted)
 
 
 def _is_blank_override_value(value):
@@ -1323,6 +944,7 @@ app.register_blueprint(asset_routes_bp)
 app.register_blueprint(kometa_updates_bp)
 app.register_blueprint(imagemaid_updates_bp)
 app.register_blueprint(config_routes_bp)
+app.register_blueprint(download_routes_bp)
 app.register_blueprint(test_libraries_routes_bp)
 app.register_blueprint(library_routes_bp)
 app.register_blueprint(import_config_routes_bp)
@@ -2833,180 +2455,6 @@ def workspace_app_readiness():
     config_name = request.args.get("config_name") or session.get("config_name")
     payload = _build_workspace_app_readiness(config_name)
     return jsonify(success=True, config_name=config_name, apps=payload)
-
-
-def _normalize_config_name(raw_name: str | None) -> str:
-    name = (raw_name or "").strip().lower().replace(" ", "_")
-    return name or "default"
-
-
-def _safe_bundle_name(raw_name: str | None) -> str:
-    safe = secure_filename(_normalize_config_name(raw_name))
-    return safe or "default"
-
-
-def _get_custom_font_files(config_name: str | None = None) -> list[Path]:
-    font_files: list[Path] = []
-    seen: set[str] = set()
-    candidate_dirs: list[Path] = []
-    if config_name:
-        helpers.migrate_legacy_custom_fonts_to_config(config_name)
-        candidate_dirs.append(helpers.get_custom_fonts_dir(config_name))
-    candidate_dirs.append(helpers.get_legacy_custom_fonts_dir())
-    for custom_dir in candidate_dirs:
-        if not custom_dir.is_dir():
-            continue
-        for entry in sorted(custom_dir.iterdir(), key=lambda p: p.name.lower()):
-            if not entry.is_file() or entry.suffix.lower() not in helpers.FONT_EXTENSIONS:
-                continue
-            if entry.name in seen:
-                continue
-            font_files.append(entry)
-            seen.add(entry.name)
-    return font_files
-
-
-def _bundle_artifacts_from_yaml(yaml_text, config_name=None):
-    parsed = importer.load_yaml_config(yaml_text)
-    if not parsed:
-        return [], yaml_text
-    artifact_files = list(_iter_bundle_artifacts(parsed))
-    overlay_artifacts, overlay_changed = _iter_overlay_source_bundle_artifacts(parsed, config_name)
-    artifact_files.extend(overlay_artifacts)
-    if overlay_changed:
-        return artifact_files, _dump_yaml_text(parsed)
-    return artifact_files, yaml_text
-
-
-def _build_config_bundle(
-    config_text: str,
-    config_filename: str,
-    font_files: list[Path],
-    artifact_files: list[dict] | None = None,
-    config_name: str | None = None,
-    redacted: bool = False,
-) -> BytesIO | None:
-    artifact_files = artifact_files or []
-    if not config_text or (not font_files and not artifact_files):
-        return None
-    name = _normalize_config_name(config_name)
-    font_names = [font.name for font in font_files]
-    has_artifacts = bool(artifact_files)
-    readme_lines = [
-        "Quickstart config bundle",
-        f"Config name: {name}",
-        "",
-        "This bundle includes:",
-        f"- {config_filename}",
-    ]
-    if font_names:
-        readme_lines.append(f"- {name}/fonts/ (custom fonts uploaded in Quickstart)")
-        readme_lines.append(f"- Fonts included: {', '.join(font_names)}")
-    if has_artifacts:
-        readme_lines.append(f"- {name}/metadata_files/, {name}/collection_files/, {name}/overlay_files/, {name}/overlay_images/ (config-owned library files and overlay images)")
-    readme_lines += [
-        "",
-        "Install steps:",
-        "1) Copy the config file into your Kometa config folder (config/).",
-    ]
-    if font_names:
-        readme_lines.append(f"2) Copy the font files from {name}/fonts/ into your Kometa config/fonts/ folder.")
-    if has_artifacts:
-        readme_lines.append(f"3) Copy {name}/ into your Kometa config/ folder.")
-    readme_lines += [
-        "",
-        "Note: Validate Kometa and Run Now both sync config-owned library files automatically.",
-        "Note: The Quickstart Run Now button also syncs referenced fonts automatically.",
-        "This bundle is for manual installs.",
-    ]
-    if redacted:
-        readme_lines += [
-            "",
-            "This bundle uses a redacted config and is safe to share.",
-            "Review before sharing in case you manually added sensitive data.",
-        ]
-    readme_lines.append("")
-    bundle = BytesIO()
-    with zipfile.ZipFile(bundle, "w", compression=zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr(config_filename, config_text)
-        for font_path in font_files:
-            zf.write(font_path, f"{name}/fonts/{font_path.name}")
-        for artifact in artifact_files:
-            _bundle_write_artifact(zf, artifact, redacted=redacted)
-        zf.writestr("README.txt", "\n".join(readme_lines))
-    bundle.seek(0)
-    return bundle
-
-
-@app.route("/download")
-def download():
-    yaml_content = session.get("yaml_content", "")
-    if yaml_content:
-        config_name = session.get("config_name")
-        custom_fonts = _get_custom_font_files(config_name)
-        artifact_files, bundle_yaml = _bundle_artifacts_from_yaml(yaml_content, config_name=config_name)
-        if custom_fonts or artifact_files:
-            bundle = _build_config_bundle(
-                bundle_yaml,
-                "config.yml",
-                custom_fonts,
-                artifact_files=artifact_files,
-                config_name=config_name,
-            )
-            if bundle:
-                bundle_name = f"{_safe_bundle_name(config_name)}_config_bundle.zip"
-                return send_file(
-                    bundle,
-                    mimetype="application/zip",
-                    as_attachment=True,
-                    download_name=bundle_name,
-                )
-        return send_file(
-            io.BytesIO(yaml_content.encode("utf-8")),
-            mimetype="text/yaml",
-            as_attachment=True,
-            download_name="config.yml",
-        )
-    flash("No configuration to download", "danger")
-    return redirect(url_for("step", name="900-kometa"))
-
-
-@app.route("/download_redacted")
-def download_redacted():
-    yaml_content = session.get("yaml_content", "")
-    if yaml_content:
-        # Redact sensitive information
-        redacted_content = helpers.redact_sensitive_data(yaml_content)
-
-        # Serve the redacted YAML as a file download
-        config_name = session.get("config_name")
-        custom_fonts = _get_custom_font_files(config_name)
-        artifact_files, bundle_yaml = _bundle_artifacts_from_yaml(redacted_content, config_name=config_name)
-        if custom_fonts or artifact_files:
-            bundle = _build_config_bundle(
-                bundle_yaml,
-                "config_redacted.yml",
-                custom_fonts,
-                artifact_files=artifact_files,
-                config_name=config_name,
-                redacted=True,
-            )
-            if bundle:
-                bundle_name = f"{_safe_bundle_name(config_name)}_config_bundle_redacted.zip"
-                return send_file(
-                    bundle,
-                    mimetype="application/zip",
-                    as_attachment=True,
-                    download_name=bundle_name,
-                )
-        return send_file(
-            io.BytesIO(redacted_content.encode("utf-8")),
-            mimetype="text/yaml",
-            as_attachment=True,
-            download_name="config_redacted.yml",
-        )
-    flash("No configuration to download", "danger")
-    return redirect(url_for("step", name="900-kometa"))
 
 
 @app.route("/path-validation-rules", methods=["GET"])

--- a/templates/900-kometa.html
+++ b/templates/900-kometa.html
@@ -337,8 +337,8 @@
         <!-- Download Buttons -->
         {% if yaml_content %}
         <br>
-        <a href="{{ url_for('download') }}" id="download-btn" class="btn btn-success d-none">Download Config</a>
-        <a href="{{ url_for('download_redacted') }}" id="download-redacted-btn" class="btn btn-warning d-none">Download
+        <a href="{{ url_for('download_routes.download') }}" id="download-btn" class="btn btn-success d-none">Download Config</a>
+        <a href="{{ url_for('download_routes.download_redacted') }}" id="download-redacted-btn" class="btn btn-warning d-none">Download
           Redacted
           Config</a>
         {% endif %}

--- a/tests/test_bug_fixes.py
+++ b/tests/test_bug_fixes.py
@@ -1,0 +1,181 @@
+"""Regression tests for two bugs found during the test-matrix expansion.
+
+Bug 1: ``database.reset_data()`` crashed with ``OperationalError: no such
+table: section_data`` on a fresh SQLite file because it issued a DELETE
+without first running ``CREATE TABLE IF NOT EXISTS``.  Every other helper
+in modules/database.py creates the table before use; reset_data was the
+sole exception.
+
+Bug 2: ``blueprints/validation_routes.validate_github()`` crashed with
+``AttributeError: 'tuple' object has no attribute 'get_json'`` whenever
+``modules.validations.validate_github_server()`` returned a
+``(jsonify(payload), 400)`` tuple (which it does on an invalid GitHub
+token).  The route called ``result.get_json()`` directly without first
+unpacking the tuple.  The radarr and sonarr routes already handled this
+pattern with ``isinstance(result, tuple)``; the other five routes (omdb,
+github, tmdb, mdblist, notifiarr) did not.  All seven now go through the
+new ``_unpack_validation_result`` helper.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ===========================================================================
+# Bug 1: database.reset_data() on a fresh SQLite file
+# ===========================================================================
+
+def test_reset_data_does_not_crash_on_empty_db(isolated_config_dir):
+    """reset_data() must not raise on a db file that has never had tables created."""
+    from modules import database
+
+    # Do NOT call any other database helper first -- this must be the very
+    # first operation on the fresh SQLite file in isolated_config_dir.
+    database.reset_data("nonexistent_config")  # should not raise
+
+
+def test_reset_data_section_does_not_crash_on_empty_db(isolated_config_dir):
+    from modules import database
+
+    database.reset_data("nonexistent_config", section="010-plex")  # should not raise
+
+
+def test_reset_data_removes_existing_rows(isolated_config_dir):
+    """reset_data() should delete the named config's rows after they've been saved."""
+    from modules import database
+
+    config_name = "bug1_test"
+    database.save_section_data(
+        name=config_name,
+        section="plex",
+        validated=True,
+        user_entered=True,
+        data={"plex": {"url": "http://localhost:32400"}},
+    )
+    _, _, pre = database.retrieve_section_data(config_name, "plex")
+    assert pre is not None, "pre-condition: data should be saved"
+
+    database.reset_data(config_name)
+
+    _, _, post = database.retrieve_section_data(config_name, "plex")
+    assert post is None, "data should be gone after reset_data()"
+
+
+def test_reset_data_section_removes_only_named_section(isolated_config_dir):
+    """reset_data(name, section=X) must not disturb other sections for the same config."""
+    from modules import database
+
+    config_name = "bug1_section_test"
+    for section in ("plex", "tmdb"):
+        database.save_section_data(
+            name=config_name,
+            section=section,
+            validated=True,
+            user_entered=True,
+            data={section: {"key": "val"}},
+        )
+
+    database.reset_data(config_name, section="plex")
+
+    _, _, plex_post = database.retrieve_section_data(config_name, "plex")
+    _, _, tmdb_post = database.retrieve_section_data(config_name, "tmdb")
+    assert plex_post is None, "plex section should be deleted"
+    assert tmdb_post is not None, "tmdb section should be untouched"
+
+
+# ===========================================================================
+# Bug 2: validate_github route crashed when validator returns a tuple
+# ===========================================================================
+
+def _err_tuple(message="Error"):
+    """Return the form validate_github_server uses on invalid-token: (jsonify({...}), 400)."""
+    mock = MagicMock()
+    mock.get_json.return_value = {"valid": False, "message": message}
+    return mock, 400  # tuple -- the form that previously crashed the route
+
+
+def _ok_response():
+    mock = MagicMock()
+    mock.get_json.return_value = {"valid": True, "message": "OK"}
+    return mock
+
+
+def test_validate_github_returns_400_when_validator_returns_tuple(client):
+    """validate_github must not crash when validate_github_server returns a tuple."""
+    with patch("modules.validations.validate_github_server", return_value=_err_tuple("Invalid GitHub token")):
+        resp = client.post("/validate_github", json={"github_token": "bad-token"})
+    # Before the fix this would 500; after the fix it must be 400.
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert data["valid"] is False
+
+
+def test_validate_github_returns_200_on_plain_success(client):
+    """Ensure the success path still works after the refactor."""
+    with patch("modules.validations.validate_github_server", return_value=_ok_response()):
+        resp = client.post("/validate_github", json={"github_token": "valid-token"})
+    assert resp.status_code == 200
+    assert resp.get_json()["valid"] is True
+
+
+def test_validate_github_plain_error_still_returns_400(client):
+    """If the validator returns a plain error response (no tuple), route still returns 400."""
+    err_mock = MagicMock()
+    err_mock.get_json.return_value = {"valid": False, "message": "network error"}
+    with patch("modules.validations.validate_github_server", return_value=err_mock):
+        resp = client.post("/validate_github", json={"github_token": "anything"})
+    assert resp.status_code == 400
+
+
+# ===========================================================================
+# _unpack_validation_result helper -- unit tests
+# ===========================================================================
+
+def test_unpack_validation_result_handles_plain_response():
+    from blueprints.validation_routes import _unpack_validation_result
+    mock = MagicMock()
+    result, code = _unpack_validation_result(mock)
+    assert result is mock
+    assert code is None  # sentinel: caller uses ``code or 400`` to get the fallback
+
+
+def test_unpack_validation_result_handles_tuple():
+    from blueprints.validation_routes import _unpack_validation_result
+    mock = MagicMock()
+    result, code = _unpack_validation_result((mock, 400))
+    assert result is mock
+    assert code == 400
+
+
+def test_unpack_validation_result_coerces_status_to_int():
+    from blueprints.validation_routes import _unpack_validation_result
+    mock = MagicMock()
+    _, code = _unpack_validation_result((mock, "400"))
+    assert isinstance(code, int)
+    assert code == 400
+
+
+# ===========================================================================
+# The other five routes that were hardened (omdb, tmdb, mdblist, notifiarr,
+# radarr, sonarr) -- verify they all also survive a tuple return from their
+# respective validator, confirming _unpack_validation_result is wired in.
+# ===========================================================================
+
+
+
+@pytest.mark.parametrize("route,mock_fn,payload", [
+    ("/validate_omdb",      "validate_omdb_server",      {"apikey": "k"}),
+    ("/validate_tmdb",      "validate_tmdb_server",      {"apikey": "k"}),
+    ("/validate_mdblist",   "validate_mdblist_server",   {"apikey": "k"}),
+    ("/validate_notifiarr", "validate_notifiarr_server", {"apikey": "k"}),
+    ("/validate_radarr",    "validate_radarr_server",    {"radarr_url": "http://r", "api_key": "k"}),
+    ("/validate_sonarr",    "validate_sonarr_server",    {"sonarr_url": "http://s", "api_key": "k"}),
+])
+def test_validate_route_survives_tuple_return_from_validator(client, route, mock_fn, payload):
+    """All seven routes must return 400 cleanly when the validator returns a tuple."""
+    err = MagicMock()
+    err.get_json.return_value = {"valid": False, "message": "fail"}
+    with patch(f"modules.validations.{mock_fn}", return_value=(err, 400)):
+        resp = client.post(route, json=payload)
+    assert resp.status_code == 400
+    assert resp.get_json()["valid"] is False

--- a/tests/test_bug_fixes.py
+++ b/tests/test_bug_fixes.py
@@ -20,10 +20,10 @@ new ``_unpack_validation_result`` helper.
 import pytest
 from unittest.mock import MagicMock, patch
 
-
 # ===========================================================================
 # Bug 1: database.reset_data() on a fresh SQLite file
 # ===========================================================================
+
 
 def test_reset_data_does_not_crash_on_empty_db(isolated_config_dir):
     """reset_data() must not raise on a db file that has never had tables created."""
@@ -87,6 +87,7 @@ def test_reset_data_section_removes_only_named_section(isolated_config_dir):
 # Bug 2: validate_github route crashed when validator returns a tuple
 # ===========================================================================
 
+
 def _err_tuple(message="Error"):
     """Return the form validate_github_server uses on invalid-token: (jsonify({...}), 400)."""
     mock = MagicMock()
@@ -131,8 +132,10 @@ def test_validate_github_plain_error_still_returns_400(client):
 # _unpack_validation_result helper -- unit tests
 # ===========================================================================
 
+
 def test_unpack_validation_result_handles_plain_response():
     from blueprints.validation_routes import _unpack_validation_result
+
     mock = MagicMock()
     result, code = _unpack_validation_result(mock)
     assert result is mock
@@ -141,6 +144,7 @@ def test_unpack_validation_result_handles_plain_response():
 
 def test_unpack_validation_result_handles_tuple():
     from blueprints.validation_routes import _unpack_validation_result
+
     mock = MagicMock()
     result, code = _unpack_validation_result((mock, 400))
     assert result is mock
@@ -149,6 +153,7 @@ def test_unpack_validation_result_handles_tuple():
 
 def test_unpack_validation_result_coerces_status_to_int():
     from blueprints.validation_routes import _unpack_validation_result
+
     mock = MagicMock()
     _, code = _unpack_validation_result((mock, "400"))
     assert isinstance(code, int)
@@ -162,15 +167,17 @@ def test_unpack_validation_result_coerces_status_to_int():
 # ===========================================================================
 
 
-
-@pytest.mark.parametrize("route,mock_fn,payload", [
-    ("/validate_omdb",      "validate_omdb_server",      {"apikey": "k"}),
-    ("/validate_tmdb",      "validate_tmdb_server",      {"apikey": "k"}),
-    ("/validate_mdblist",   "validate_mdblist_server",   {"apikey": "k"}),
-    ("/validate_notifiarr", "validate_notifiarr_server", {"apikey": "k"}),
-    ("/validate_radarr",    "validate_radarr_server",    {"radarr_url": "http://r", "api_key": "k"}),
-    ("/validate_sonarr",    "validate_sonarr_server",    {"sonarr_url": "http://s", "api_key": "k"}),
-])
+@pytest.mark.parametrize(
+    "route,mock_fn,payload",
+    [
+        ("/validate_omdb", "validate_omdb_server", {"apikey": "k"}),
+        ("/validate_tmdb", "validate_tmdb_server", {"apikey": "k"}),
+        ("/validate_mdblist", "validate_mdblist_server", {"apikey": "k"}),
+        ("/validate_notifiarr", "validate_notifiarr_server", {"apikey": "k"}),
+        ("/validate_radarr", "validate_radarr_server", {"radarr_url": "http://r", "api_key": "k"}),
+        ("/validate_sonarr", "validate_sonarr_server", {"sonarr_url": "http://s", "api_key": "k"}),
+    ],
+)
 def test_validate_route_survives_tuple_return_from_validator(client, route, mock_fn, payload):
     """All seven routes must return 400 cleanly when the validator returns a tuple."""
     err = MagicMock()


### PR DESCRIPTION
## Summary

Two bugs surfaced while writing the test-matrix expansion PR (#1330). Both are fixed here with regression tests.

---

## Bug 1 — `database.reset_data()` crashes on a fresh SQLite file

### What happened

`reset_data()` was the **only function in `modules/database.py`** that issued a `DELETE` without first running `CREATE TABLE IF NOT EXISTS`.  On a fresh config directory (clean install, CI, isolated test fixture) this raises:

```
sqlite3.OperationalError: no such table: section_data
```

Every other helper in the module (`save_section_data`, `retrieve_section_data`, `retrieve_all_section_data`, etc.) follows the pattern:

```python
cursor.execute(persisted_section_table_create())  # CREATE TABLE IF NOT EXISTS …
cursor.execute(sql, ...)
```

`reset_data` skipped the first line.

### Fix

```python
# modules/database.py  reset_data()
cursor.execute(persisted_section_table_create())  # ← added
sql = "DELETE from section_data where name == ?"
...
```

One line; matches the established pattern.

---

## Bug 2 — `validate_github` route crashes when the GitHub token is invalid

### What happened

`validate_github_server()` in `modules/validations.py` returns **either** a plain Flask response **or** a `(jsonify(payload), 400)` tuple depending on the HTTP outcome:

```python
# modules/validations.py
if response.status_code == 200:
    return jsonify({"valid": True, ...})
else:
    return jsonify({"valid": False, ...}), 400   # ← tuple
```

The `validate_github` route called `result.get_json()` directly without unpacking the tuple first:

```python
# blueprints/validation_routes.py  (before fix)
result = validations.validate_github_server(data)
if result.get_json().get("valid"):   # ← AttributeError when result is a tuple
    ...
```

This crashes with `AttributeError: 'tuple' object has no attribute 'get_json'` every time a GitHub token is rejected.

### Root cause: inconsistent route pattern

The `validate_radarr` and `validate_sonarr` routes already handled both forms:

```python
result = validations.validate_radarr_server(data)
status_code = 200
if isinstance(result, tuple):
    result, status_code = result
if result.get_json().get("valid"):
    ...
```

The other five routes (`omdb`, `github`, `tmdb`, `mdblist`, `notifiarr`) did not.

### Fix

A new module-level helper normalises both forms:

```python
def _unpack_validation_result(result):
    """Normalise a validator return value into (flask_response, status_code|None)."""
    if isinstance(result, tuple):
        return result[0], int(result[1])
    return result, None  # caller uses status_code or 400
```

All seven routes now use it:

```python
result, status_code = _unpack_validation_result(validations.validate_xxx_server(data))
if result.get_json().get("valid"):
    return jsonify(result.get_json())
return jsonify(result.get_json()), status_code or 400
```

The `None` sentinel ensures `None or 400 = 400` — the correct fallback for plain-response errors — while an explicit 400 from a tuple passes straight through.

---

## Tests — `tests/test_bug_fixes.py` (+16 tests)

**Bug 1 (4 tests)**
- `reset_data()` does not crash on a totally fresh SQLite file (no section arg)
- `reset_data(name, section=...)` does not crash on a fresh SQLite file
- `reset_data()` removes existing rows
- Section-scoped `reset_data(name, section=X)` leaves other sections untouched

**Bug 2 (6 tests)**
- `validate_github` returns 400 (not 500) when validator returns a tuple ← the crash
- `validate_github` returns 200 on success
- `validate_github` returns 400 on plain-response error
- `_unpack_validation_result` handles plain response (returns `None` sentinel)
- `_unpack_validation_result` handles tuple
- `_unpack_validation_result` coerces status code to `int`

**Hardening (6 tests — parametrized)**
- All 7 routes (radarr, sonarr, omdb, github, tmdb, mdblist, notifiarr) survive a tuple return from their validator and produce 400

---

## CI

- **817 tests pass** (801 existing + 16 new), zero regressions
- `ruff check` clean on all 3 changed files