### PR TITLE
5 overlays with text overlays

### DIFF
--- a/static/json/quickstart_overlays.json
+++ b/static/json/quickstart_overlays.json
@@ -288,7 +288,7 @@
         ],
         "template_variables": [
           {
-            "input_type": "text",
+            "input_type": "hidden",
             "key": "text",
             "label": "Text",
             "default": "S03E15"
@@ -2683,7 +2683,7 @@
         "extra_url": "https://trash-guides.info/",
         "template_variables": [
           {
-            "input_type": "text",
+            "input_type": "hidden",
             "key": "text",
             "label": "Text",
             "default": "1.78"
@@ -5723,7 +5723,7 @@
         "extra_url": "https://trash-guides.info/",
         "template_variables": [
           {
-            "input_type": "text",
+            "input_type": "hidden",
             "key": "text",
             "label": "Text",
             "default": "HDTV"

--- a/static/local-js/overlayHandler.js
+++ b/static/local-js/overlayHandler.js
@@ -520,8 +520,13 @@ const OverlayHandler = {
         }
         return el.value || fallback
       }
+      const mode = getOverlayTextPreviewMode(cfg)
+      const selectedPreview = ['toggle_text', 'episode_info'].includes(mode)
+        ? getOverlayTextPreviewSelectedValue(cfg)
+        : ''
+      if (selectedPreview) syncOverlayTextPreviewTextInput(cfg)
       return {
-        text: getVal('text', ''),
+        text: selectedPreview || getVal('text', ''),
         font: getVal('font', 'Inter-Medium.ttf'),
         font_size: getVal('font_size', 55),
         font_color: getVal('font_color', '#FFFFFFFF'),
@@ -564,7 +569,8 @@ const OverlayHandler = {
         return el.value || fallback
       }
 
-      const text = getVal('text_airing', 'AIRING')
+      const previewKey = getOverlayTextPreviewSelectedValue(cfg) || 'airing'
+      const text = getVal(`text_${previewKey}`, 'AIRING')
       return {
         text,
         font: getVal('font', 'Inter-Medium.ttf'),
@@ -646,6 +652,143 @@ const OverlayHandler = {
       const templateName = container?.dataset.overlayTemplate
       if (!container || !templateName) return null
       return container.querySelector(`[name="${templateName}[${key}]"]`)
+    }
+
+    const getOverlayTextPreviewMode = (cfg) => {
+      const overlayId = String(cfg?.id || '').trim()
+      if (overlayId === 'overlay_aspect' || overlayId === 'overlay_video_format') return 'toggle_text'
+      if (overlayId === 'overlay_episode_info') return 'episode_info'
+      if (overlayId === 'overlay_status') return 'status'
+      if (overlayId === 'overlay_runtimes') return 'runtime'
+      return ''
+    }
+
+    const getOverlayTextPreviewStateKey = (cfg) => {
+      const overlayId = String(cfg?.id || '').trim()
+      if (overlayId === 'overlay_aspect') return 'aspect_text'
+      if (overlayId === 'overlay_video_format') return 'video_format_text'
+      if (overlayId === 'overlay_episode_info') return 'episode_info_text'
+      if (overlayId === 'overlay_status') return 'status_text'
+      if (overlayId === 'overlay_runtimes') return 'runtime_minutes'
+      return ''
+    }
+
+    const getOverlayTextPreviewOptions = (cfg) => {
+      const mode = getOverlayTextPreviewMode(cfg)
+      if (!mode || !cfg?.container) return []
+
+      if (mode === 'episode_info') {
+        return [
+          { value: 'S01E01', label: 'S01E01' },
+          { value: 'S03E15', label: 'S03E15' },
+          { value: 'S10E22', label: 'S10E22' },
+          { value: 'S00E01', label: 'Special (S00E01)' }
+        ]
+      }
+
+      if (mode === 'runtime') {
+        return [
+          { value: '24', label: '24 min' },
+          { value: '45', label: '45 min' },
+          { value: '93', label: '93 min (1h 33m)' },
+          { value: '130', label: '130 min (2h 10m)' }
+        ]
+      }
+
+      const templateName = cfg.container.dataset.overlayTemplate
+      if (!templateName) return []
+
+      if (mode === 'toggle_text') {
+        const options = []
+        const seen = new Set()
+        const toggleInputs = Array.from(cfg.container.querySelectorAll(`[name^="${templateName}[use_"]`))
+          .filter(input => String(input?.type || '').toLowerCase() === 'checkbox')
+        toggleInputs.forEach((input) => {
+          const keyMatch = /\[([^\]]+)\]$/.exec(String(input.name || ''))
+          const toggleKey = String(keyMatch?.[1] || '').trim()
+          if (!toggleKey.startsWith('use_')) return
+          const labelEl = input.closest('.form-check')?.querySelector('.form-check-label')
+          let label = String(labelEl?.textContent || toggleKey.slice(4)).replace(/\s+/g, ' ').trim()
+          if (label.toLowerCase().startsWith('use ')) {
+            label = label.slice(4).trim()
+          }
+          if (!label || seen.has(label)) return
+          seen.add(label)
+          options.push({
+            value: label,
+            label,
+            enabled: input.checked
+          })
+        })
+        return options
+      }
+
+      if (mode === 'status') {
+        const statusDefs = [
+          { key: 'airing', label: 'Airing' },
+          { key: 'returning', label: 'Returning' },
+          { key: 'canceled', label: 'Canceled' },
+          { key: 'ended', label: 'Ended' }
+        ]
+        return statusDefs.map((statusDef) => {
+          const toggle = cfg.container.querySelector(`[name="${templateName}[use_${statusDef.key}]"]`)
+          return {
+            value: statusDef.key,
+            label: statusDef.label,
+            enabled: Boolean(toggle?.checked)
+          }
+        })
+      }
+
+      return []
+    }
+
+    const pickDefaultOverlayTextPreviewValue = (cfg) => {
+      const mode = getOverlayTextPreviewMode(cfg)
+      const options = getOverlayTextPreviewOptions(cfg)
+      if (mode === 'runtime') return options.find(option => option.value === '93')?.value || options[0]?.value || '93'
+      if (mode === 'episode_info') return options.find(option => option.value === 'S03E15')?.value || options[0]?.value || 'S03E15'
+      return options.find(option => option.enabled)?.value || options[0]?.value || ''
+    }
+
+    const getOverlayTextPreviewSelectedValue = (cfg) => {
+      const mode = getOverlayTextPreviewMode(cfg)
+      if (!mode) return ''
+      const stateKey = getOverlayTextPreviewStateKey(cfg)
+      const state = ensureResolutionPreviewState(cfg)
+      const options = getOverlayTextPreviewOptions(cfg)
+      const values = new Set(options.map(option => String(option.value || '').trim()))
+      const current = String(state[stateKey] || '').trim()
+      if (current && values.has(current)) return current
+
+      let fallback = ''
+      if (mode === 'toggle_text' || mode === 'episode_info') {
+        const textInput = getTemplateInput(cfg, 'text')
+        const currentText = String(textInput?.value || textInput?.dataset?.default || '').trim()
+        if (currentText && values.has(currentText)) {
+          fallback = currentText
+        }
+      }
+      if (!fallback) fallback = pickDefaultOverlayTextPreviewValue(cfg)
+      state[stateKey] = fallback
+      return fallback
+    }
+
+    const setOverlayTextPreviewSelectedValue = (cfg, value) => {
+      const stateKey = getOverlayTextPreviewStateKey(cfg)
+      if (!stateKey) return
+      const state = ensureResolutionPreviewState(cfg)
+      state[stateKey] = String(value || '').trim()
+    }
+
+    const syncOverlayTextPreviewTextInput = (cfg) => {
+      const mode = getOverlayTextPreviewMode(cfg)
+      if (!['toggle_text', 'episode_info'].includes(mode)) return
+      const textInput = getTemplateInput(cfg, 'text')
+      if (!textInput) return
+      const selected = getOverlayTextPreviewSelectedValue(cfg)
+      textInput.value = selected
+      textInput.dataset.default = selected
     }
 
     const setTemplateNumber = (cfg, key, value, emit = true) => {
@@ -2203,6 +2346,171 @@ const OverlayHandler = {
         previewSelect.addEventListener('change', () => {
           setContentRatingPreviewSelectedKey(cfg, previewSelect.value)
           refreshContentRatingOverlayPreview(cfg)
+        })
+      }
+    }
+
+    const ensureOverlayTextPreviewControl = (cfg) => {
+      const mode = getOverlayTextPreviewMode(cfg)
+      if (!mode || !cfg?.container) return
+
+      const anchorInput = getTemplateInput(cfg, 'font') || (mode === 'status' ? getTemplateInput(cfg, 'text_airing') : null)
+      const anchorRow = anchorInput?.closest('.font-row') ||
+        anchorInput?.closest('.rgba-group') ||
+        anchorInput?.closest('.input-group') ||
+        anchorInput?.closest('.mb-3') ||
+        anchorInput?.parentElement
+      if (!anchorRow) return
+
+      let previewWrap = cfg.container.querySelector('[data-overlay-text-preview-wrap]')
+      let previewSelect = cfg.container.querySelector('[data-overlay-text-preview-select]')
+      if (!previewWrap) {
+        let label = 'Preview badge'
+        if (mode === 'runtime') label = 'Preview runtime'
+        else if (mode === 'status') label = 'Preview status'
+        else if (mode === 'episode_info') label = 'Preview text'
+        previewWrap = document.createElement('div')
+        previewWrap.className = 'mb-3 w-100'
+        previewWrap.dataset.overlayTextPreviewWrap = 'true'
+        previewWrap.style.flexBasis = '100%'
+        previewWrap.style.width = '100%'
+        previewWrap.innerHTML = `
+          <label class="form-label small fw-semibold mb-1">${label}</label>
+          <select class="form-select form-select-sm" data-overlay-text-preview-select="true"></select>
+        `
+        previewSelect = previewWrap.querySelector('[data-overlay-text-preview-select]')
+      }
+
+      anchorRow.insertAdjacentElement('beforebegin', previewWrap)
+
+      if (previewSelect && previewSelect.dataset.listenerAdded !== 'true') {
+        previewSelect.dataset.listenerAdded = 'true'
+        previewSelect.addEventListener('change', () => {
+          setOverlayTextPreviewSelectedValue(cfg, previewSelect.value)
+          syncOverlayTextPreviewTextInput(cfg)
+          refreshOverlayTextPreview(cfg)
+        })
+      }
+    }
+
+    const syncOverlayTextPreviewControls = (cfg) => {
+      const mode = getOverlayTextPreviewMode(cfg)
+      if (!mode || !cfg?.container) return
+      const select = cfg.container.querySelector('[data-overlay-text-preview-select="true"]')
+      if (!select) return
+
+      const options = getOverlayTextPreviewOptions(cfg)
+      const selected = getOverlayTextPreviewSelectedValue(cfg)
+      select.replaceChildren()
+      options.forEach((option) => {
+        const el = document.createElement('option')
+        el.value = option.value
+        el.textContent = option.label
+        select.appendChild(el)
+      })
+
+      if (selected && options.some(option => option.value === selected)) {
+        select.value = selected
+      } else if (options[0]?.value) {
+        setOverlayTextPreviewSelectedValue(cfg, options[0].value)
+        select.value = options[0].value
+      }
+      select.disabled = options.length === 0
+      syncOverlayTextPreviewTextInput(cfg)
+    }
+
+    const refreshOverlayTextPreview = (cfg) => {
+      if (!cfg?.layer) return
+      if (cfg.id === 'overlay_runtimes') {
+        const { font } = getRuntimeVars(cfg)
+        ensureRuntimeFontLoaded(font).then(family => {
+          const { family: norm } = normalizeFontFile(font)
+          const dataUrl = buildRuntimeDataUrl(cfg, family || norm)
+          if (BACKDROP_TEXT_OVERLAYS.has(cfg.id)) {
+            buildBackdropDataUrl(cfg, dataUrl).then(backdropUrl => {
+              cfg.layer.src = backdropUrl
+            })
+            return
+          }
+          cfg.layer.src = dataUrl
+        })
+        return
+      }
+
+      if (cfg.id === 'overlay_status') {
+        const vars = getStatusTextVars(cfg)
+        ensureRuntimeFontLoaded(vars.font).then(family => {
+          const { family: norm } = normalizeFontFile(vars.font)
+          const dataUrl = buildSimpleTextDataUrl(cfg, vars, family || norm)
+          if (BACKDROP_TEXT_OVERLAYS.has(cfg.id)) {
+            buildBackdropDataUrl(cfg, dataUrl).then(backdropUrl => {
+              cfg.layer.src = backdropUrl
+            })
+            return
+          }
+          cfg.layer.src = dataUrl
+        })
+        return
+      }
+
+      if (cfg.id === 'overlay_aspect' || cfg.id === 'overlay_video_format' || cfg.id === 'overlay_episode_info') {
+        const vars = getSimpleTextVars(cfg)
+        ensureRuntimeFontLoaded(vars.font).then(family => {
+          const { family: norm } = normalizeFontFile(vars.font)
+          const dataUrl = buildSimpleTextDataUrl(cfg, vars, family || norm)
+          if (BACKDROP_TEXT_OVERLAYS.has(cfg.id)) {
+            buildBackdropDataUrl(cfg, dataUrl).then(backdropUrl => {
+              cfg.layer.src = backdropUrl
+            })
+            return
+          }
+          cfg.layer.src = dataUrl
+        })
+      }
+    }
+
+    const bindOverlayTextPreviewInputs = (cfg) => {
+      const mode = getOverlayTextPreviewMode(cfg)
+      if (!mode || !cfg?.container) return
+      const templateName = cfg.container.dataset.overlayTemplate
+      if (!templateName) return
+
+      if (mode === 'toggle_text') {
+        const toggleInputs = Array.from(cfg.container.querySelectorAll(`[name^="${templateName}[use_"]`))
+          .filter(input => String(input?.type || '').toLowerCase() === 'checkbox')
+        toggleInputs.forEach((input) => {
+          if (input.dataset.overlayTextPreviewBound === 'true') return
+          input.dataset.overlayTextPreviewBound = 'true'
+          input.addEventListener('change', () => {
+            syncOverlayTextPreviewControls(cfg)
+            refreshOverlayTextPreview(cfg)
+          })
+        })
+      }
+
+      if (mode === 'status') {
+        const selectors = [
+          `[name="${templateName}[use_airing]"]`,
+          `[name="${templateName}[use_returning]"]`,
+          `[name="${templateName}[use_canceled]"]`,
+          `[name="${templateName}[use_ended]"]`,
+          `[name="${templateName}[text_airing]"]`,
+          `[name="${templateName}[text_returning]"]`,
+          `[name="${templateName}[text_canceled]"]`,
+          `[name="${templateName}[text_ended]"]`
+        ]
+        const inputs = cfg.container.querySelectorAll(selectors.join(', '))
+        inputs.forEach((input) => {
+          if (input.dataset.overlayTextPreviewBound === 'true') return
+          input.dataset.overlayTextPreviewBound = 'true'
+          input.addEventListener('input', () => {
+            syncOverlayTextPreviewControls(cfg)
+            refreshOverlayTextPreview(cfg)
+          })
+          input.addEventListener('change', () => {
+            syncOverlayTextPreviewControls(cfg)
+            refreshOverlayTextPreview(cfg)
+          })
         })
       }
     }
@@ -5766,7 +6074,7 @@ const OverlayHandler = {
     const buildRuntimeDataUrl = (cfg, loadedFamily = null) => {
       const { text, format, font, font_size: fontSize, font_color: fontColor, stroke_width: strokeWidth, stroke_color: strokeColor } = getRuntimeVars(cfg)
       const { family: normalizedFamily } = normalizeFontFile(font)
-      const runtimeMinutes = 93
+      const runtimeMinutes = Number(getOverlayTextPreviewSelectedValue(cfg) || 93) || 93
       const runtimeH = Math.floor(runtimeMinutes / 60)
       const runtimeM = runtimeMinutes % 60
       const rendered = format
@@ -7312,6 +7620,7 @@ const OverlayHandler = {
         }
         ensureResolutionToggleFamilyGroups(cfg)
         ensureContentRatingPreviewControl(cfg)
+        ensureOverlayTextPreviewControl(cfg)
         ensureSingleBadgeOverlayPreviewControl(cfg)
         ensureStreamingPreviewControl(cfg)
         ensureAudioCodecPreviewControl(cfg)
@@ -7320,12 +7629,14 @@ const OverlayHandler = {
         ensureOverlaySourceOverrideEditor(cfg)
         bindResolutionPreviewInputs(cfg)
         bindContentRatingPreviewInputs(cfg)
+        bindOverlayTextPreviewInputs(cfg)
         bindSingleBadgeOverlayPreviewInputs(cfg)
         bindStreamingPreviewInputs(cfg)
         bindAudioCodecPreviewInputs(cfg)
         bindRibbonPreviewInputs(cfg)
         bindLanguageCountPreviewInputs(cfg)
         syncContentRatingPreviewControls(cfg)
+        syncOverlayTextPreviewControls(cfg)
         syncSingleBadgeOverlayPreviewControls(cfg)
         syncStreamingPreviewControls(cfg)
         syncRibbonPreviewControls(cfg)

--- a/tests/test_bundle_artifacts.py
+++ b/tests/test_bundle_artifacts.py
@@ -12,15 +12,16 @@ from unittest.mock import patch
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # helpers
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture(autouse=True)
 def _patch_config_dir(tmp_path, monkeypatch):
     """Point helpers.CONFIG_DIR at a temp dir so path-resolution helpers work."""
     import modules.helpers as helpers
+
     monkeypatch.setattr(helpers, "CONFIG_DIR", str(tmp_path))
     return tmp_path
 
@@ -29,24 +30,29 @@ def _patch_config_dir(tmp_path, monkeypatch):
 # yaml_path_suffix
 # ---------------------------------------------------------------------------
 
+
 def test_yaml_path_suffix_accepts_yml():
     from modules.bundle_artifacts import yaml_path_suffix
+
     assert yaml_path_suffix("config.yml") is True
 
 
 def test_yaml_path_suffix_accepts_yaml():
     from modules.bundle_artifacts import yaml_path_suffix
+
     assert yaml_path_suffix("config.yaml") is True
 
 
 def test_yaml_path_suffix_case_insensitive():
     from modules.bundle_artifacts import yaml_path_suffix
+
     assert yaml_path_suffix("CONFIG.YML") is True
     assert yaml_path_suffix("UPPER.YAML") is True
 
 
 def test_yaml_path_suffix_rejects_other_extensions():
     from modules.bundle_artifacts import yaml_path_suffix
+
     assert yaml_path_suffix("image.png") is False
     assert yaml_path_suffix("font.ttf") is False
     assert yaml_path_suffix("README.txt") is False
@@ -54,6 +60,7 @@ def test_yaml_path_suffix_rejects_other_extensions():
 
 def test_yaml_path_suffix_rejects_empty_and_none():
     from modules.bundle_artifacts import yaml_path_suffix
+
     assert yaml_path_suffix("") is False
     assert yaml_path_suffix(None) is False
 
@@ -62,24 +69,29 @@ def test_yaml_path_suffix_rejects_empty_and_none():
 # normalize_bundle_member_name
 # ---------------------------------------------------------------------------
 
+
 def test_normalize_bundle_member_name_strips_leading_slashes():
     from modules.bundle_artifacts import normalize_bundle_member_name
+
     assert normalize_bundle_member_name("/foo/bar.yml") == "foo/bar.yml"
     assert normalize_bundle_member_name("///foo/bar") == "foo/bar"
 
 
 def test_normalize_bundle_member_name_converts_backslashes():
     from modules.bundle_artifacts import normalize_bundle_member_name
+
     assert normalize_bundle_member_name("\\foo\\bar.yml") == "foo/bar.yml"
 
 
 def test_normalize_bundle_member_name_collapses_double_slashes():
     from modules.bundle_artifacts import normalize_bundle_member_name
+
     assert normalize_bundle_member_name("foo//bar.yml") == "foo/bar.yml"
 
 
 def test_normalize_bundle_member_name_empty_and_none():
     from modules.bundle_artifacts import normalize_bundle_member_name
+
     assert normalize_bundle_member_name("") == ""
     assert normalize_bundle_member_name(None) == ""
 
@@ -88,31 +100,37 @@ def test_normalize_bundle_member_name_empty_and_none():
 # is_allowed_bundle_member
 # ---------------------------------------------------------------------------
 
+
 def test_is_allowed_bundle_member_allows_yml():
     from modules.bundle_artifacts import is_allowed_bundle_member
+
     assert is_allowed_bundle_member("myconfig.yml") is True
 
 
 def test_is_allowed_bundle_member_allows_font_extensions():
     from modules.bundle_artifacts import is_allowed_bundle_member
+
     assert is_allowed_bundle_member("fonts/custom.ttf") is True
     assert is_allowed_bundle_member("fonts/custom.otf") is True
 
 
 def test_is_allowed_bundle_member_allows_readme():
     from modules.bundle_artifacts import is_allowed_bundle_member
+
     assert is_allowed_bundle_member("README.txt") is True
     assert is_allowed_bundle_member("readme.txt") is True
 
 
 def test_is_allowed_bundle_member_rejects_executables():
     from modules.bundle_artifacts import is_allowed_bundle_member
+
     assert is_allowed_bundle_member("evil.exe") is False
     assert is_allowed_bundle_member("shell.sh") is False
 
 
 def test_is_allowed_bundle_member_rejects_path_traversal():
     from modules.bundle_artifacts import is_allowed_bundle_member
+
     # Path traversal attempts should be rejected or safely normalized
     # ../../etc/passwd after normalize becomes etc/passwd which has no allowed ext
     assert is_allowed_bundle_member("../../etc/passwd") is False
@@ -120,6 +138,7 @@ def test_is_allowed_bundle_member_rejects_path_traversal():
 
 def test_is_allowed_bundle_member_allows_empty_path():
     from modules.bundle_artifacts import is_allowed_bundle_member
+
     # Empty member name: normalize_bundle_member_name returns "" which triggers early True
     assert is_allowed_bundle_member("") is True
 
@@ -128,18 +147,22 @@ def test_is_allowed_bundle_member_allows_empty_path():
 # normalize_config_name
 # ---------------------------------------------------------------------------
 
+
 def test_normalize_config_name_lowercases_and_replaces_spaces():
     from modules.bundle_artifacts import normalize_config_name
+
     assert normalize_config_name("My Config") == "my_config"
 
 
 def test_normalize_config_name_strips_whitespace():
     from modules.bundle_artifacts import normalize_config_name
+
     assert normalize_config_name("  test  ") == "test"
 
 
 def test_normalize_config_name_falls_back_to_default_on_empty():
     from modules.bundle_artifacts import normalize_config_name
+
     assert normalize_config_name("") == "default"
     assert normalize_config_name("   ") == "default"
     assert normalize_config_name(None) == "default"
@@ -149,8 +172,10 @@ def test_normalize_config_name_falls_back_to_default_on_empty():
 # safe_bundle_name
 # ---------------------------------------------------------------------------
 
+
 def test_safe_bundle_name_sanitises_special_chars():
     from modules.bundle_artifacts import safe_bundle_name
+
     result = safe_bundle_name("My Config!")
     # werkzeug secure_filename drops punctuation, keeps alphanumerics and underscores
     assert result  # non-empty
@@ -159,6 +184,7 @@ def test_safe_bundle_name_sanitises_special_chars():
 
 def test_safe_bundle_name_falls_back_to_default():
     from modules.bundle_artifacts import safe_bundle_name
+
     assert safe_bundle_name(None) == "default"
     assert safe_bundle_name("") == "default"
 
@@ -167,19 +193,23 @@ def test_safe_bundle_name_falls_back_to_default():
 # safe_overlay_bundle_slug
 # ---------------------------------------------------------------------------
 
+
 def test_safe_overlay_bundle_slug_replaces_special_chars_with_underscore():
     from modules.bundle_artifacts import safe_overlay_bundle_slug
+
     assert safe_overlay_bundle_slug("My Library!", "library") == "My_Library"
 
 
 def test_safe_overlay_bundle_slug_uses_fallback_when_result_empty():
     from modules.bundle_artifacts import safe_overlay_bundle_slug
+
     assert safe_overlay_bundle_slug("", "fallback") == "fallback"
     assert safe_overlay_bundle_slug("!!!", "fallback") == "fallback"
 
 
 def test_safe_overlay_bundle_slug_preserves_dots_and_dashes():
     from modules.bundle_artifacts import safe_overlay_bundle_slug
+
     assert safe_overlay_bundle_slug("my-lib.v2", "lib") == "my-lib.v2"
 
 
@@ -187,19 +217,23 @@ def test_safe_overlay_bundle_slug_preserves_dots_and_dashes():
 # is_overlay_source_override_file_key
 # ---------------------------------------------------------------------------
 
+
 def test_is_overlay_source_override_file_key_accepts_file():
     from modules.bundle_artifacts import is_overlay_source_override_file_key
+
     assert is_overlay_source_override_file_key("file") is True
 
 
 def test_is_overlay_source_override_file_key_accepts_file_underscore_suffix():
     from modules.bundle_artifacts import is_overlay_source_override_file_key
+
     assert is_overlay_source_override_file_key("file_1") is True
     assert is_overlay_source_override_file_key("file_extra") is True
 
 
 def test_is_overlay_source_override_file_key_rejects_unrelated_keys():
     from modules.bundle_artifacts import is_overlay_source_override_file_key
+
     assert is_overlay_source_override_file_key("url") is False
     assert is_overlay_source_override_file_key("") is False
     assert is_overlay_source_override_file_key(None) is False
@@ -209,9 +243,11 @@ def test_is_overlay_source_override_file_key_rejects_unrelated_keys():
 # parse_managed_overlay_image_relative_path
 # ---------------------------------------------------------------------------
 
+
 def test_parse_managed_overlay_image_relative_path_config_root_layout():
     from modules.bundle_artifacts import parse_managed_overlay_image_relative_path
     import modules.helpers as helpers
+
     moid = helpers.MANAGED_OVERLAY_IMAGE_DIR
     result = parse_managed_overlay_image_relative_path(f"myconfig/{moid}/subdir/img.png")
     assert result is not None
@@ -223,6 +259,7 @@ def test_parse_managed_overlay_image_relative_path_config_root_layout():
 def test_parse_managed_overlay_image_relative_path_display_layout():
     from modules.bundle_artifacts import parse_managed_overlay_image_relative_path
     import modules.helpers as helpers
+
     moid = helpers.MANAGED_OVERLAY_IMAGE_DIR
     result = parse_managed_overlay_image_relative_path(f"config/myconfig/{moid}/img.png")
     assert result is not None
@@ -232,6 +269,7 @@ def test_parse_managed_overlay_image_relative_path_display_layout():
 
 def test_parse_managed_overlay_image_relative_path_returns_none_for_unrelated():
     from modules.bundle_artifacts import parse_managed_overlay_image_relative_path
+
     assert parse_managed_overlay_image_relative_path("some/random/path.yml") is None
     assert parse_managed_overlay_image_relative_path("") is None
     assert parse_managed_overlay_image_relative_path(None) is None
@@ -241,9 +279,11 @@ def test_parse_managed_overlay_image_relative_path_returns_none_for_unrelated():
 # normalized_managed_overlay_image_relative_path
 # ---------------------------------------------------------------------------
 
+
 def test_normalized_managed_overlay_image_relative_path_round_trips():
     from modules.bundle_artifacts import normalized_managed_overlay_image_relative_path
     import modules.helpers as helpers
+
     moid = helpers.MANAGED_OVERLAY_IMAGE_DIR
     canonical = f"myconfig/{moid}/lib/overlay/img.png"
     # Both layouts should normalize to the same canonical form
@@ -254,6 +294,7 @@ def test_normalized_managed_overlay_image_relative_path_round_trips():
 
 def test_normalized_managed_overlay_image_relative_path_returns_none_for_unrelated():
     from modules.bundle_artifacts import normalized_managed_overlay_image_relative_path
+
     assert normalized_managed_overlay_image_relative_path("random/path.png") is None
 
 
@@ -261,9 +302,11 @@ def test_normalized_managed_overlay_image_relative_path_returns_none_for_unrelat
 # display_managed_overlay_image_location
 # ---------------------------------------------------------------------------
 
+
 def test_display_managed_overlay_image_location_converts_to_display_form():
     from modules.bundle_artifacts import display_managed_overlay_image_location
     import modules.helpers as helpers
+
     moid = helpers.MANAGED_OVERLAY_IMAGE_DIR
     # config_root form should be converted to display form (config/...)
     canonical = f"myconfig/{moid}/lib/overlay/img.png"
@@ -273,12 +316,14 @@ def test_display_managed_overlay_image_location_converts_to_display_form():
 
 def test_display_managed_overlay_image_location_passthrough_for_unknown():
     from modules.bundle_artifacts import display_managed_overlay_image_location
+
     raw = "/absolute/some/path.png"
     assert display_managed_overlay_image_location(raw) == raw
 
 
 def test_display_managed_overlay_image_location_empty_returns_empty():
     from modules.bundle_artifacts import display_managed_overlay_image_location
+
     assert display_managed_overlay_image_location("") == ""
     assert display_managed_overlay_image_location(None) == ""
 
@@ -287,8 +332,10 @@ def test_display_managed_overlay_image_location_empty_returns_empty():
 # dump_yaml_text
 # ---------------------------------------------------------------------------
 
+
 def test_dump_yaml_text_produces_valid_yaml():
     from modules.bundle_artifacts import dump_yaml_text
+
     data = {"key": "value", "nested": {"a": 1}}
     result = dump_yaml_text(data)
     assert isinstance(result, str)
@@ -298,6 +345,7 @@ def test_dump_yaml_text_produces_valid_yaml():
 def test_dump_yaml_text_round_trips_through_ruamel():
     from modules.bundle_artifacts import dump_yaml_text
     from ruamel.yaml import YAML
+
     data = {"plex": {"url": "http://localhost:32400", "token": "abc"}}
     text = dump_yaml_text(data)
     parsed = YAML().load(text)
@@ -308,14 +356,17 @@ def test_dump_yaml_text_round_trips_through_ruamel():
 # build_config_bundle
 # ---------------------------------------------------------------------------
 
+
 def test_build_config_bundle_returns_none_when_no_fonts_or_artifacts():
     from modules.bundle_artifacts import build_config_bundle
+
     result = build_config_bundle("yaml: true\n", "config.yml", font_files=[], artifact_files=[])
     assert result is None
 
 
 def test_build_config_bundle_returns_zip_when_fonts_present(tmp_path):
     from modules.bundle_artifacts import build_config_bundle
+
     font = tmp_path / "custom.ttf"
     font.write_bytes(b"fake font data")
 
@@ -335,6 +386,7 @@ def test_build_config_bundle_returns_zip_when_fonts_present(tmp_path):
 
 def test_build_config_bundle_includes_artifact_files(tmp_path):
     from modules.bundle_artifacts import build_config_bundle
+
     artifact_file = tmp_path / "collections.yml"
     artifact_file.write_text("collections: []\n")
 
@@ -354,12 +406,11 @@ def test_build_config_bundle_includes_artifact_files(tmp_path):
 
 def test_build_config_bundle_redacted_flag_mentioned_in_readme(tmp_path):
     from modules.bundle_artifacts import build_config_bundle
+
     font = tmp_path / "f.ttf"
     font.write_bytes(b"data")
 
-    result = build_config_bundle(
-        "yaml: true\n", "config.yml", font_files=[font], redacted=True
-    )
+    result = build_config_bundle("yaml: true\n", "config.yml", font_files=[font], redacted=True)
     assert result is not None
     with zipfile.ZipFile(result) as zf:
         readme = zf.read("README.txt").decode()
@@ -368,6 +419,7 @@ def test_build_config_bundle_redacted_flag_mentioned_in_readme(tmp_path):
 
 def test_build_config_bundle_returns_none_when_config_text_empty(tmp_path):
     from modules.bundle_artifacts import build_config_bundle
+
     font = tmp_path / "f.ttf"
     font.write_bytes(b"data")
     result = build_config_bundle("", "config.yml", font_files=[font])
@@ -378,8 +430,10 @@ def test_build_config_bundle_returns_none_when_config_text_empty(tmp_path):
 # get_custom_font_files
 # ---------------------------------------------------------------------------
 
+
 def test_get_custom_font_files_returns_empty_when_no_font_dir(tmp_path):
     from modules.bundle_artifacts import get_custom_font_files
+
     # CONFIG_DIR is tmp_path but no fonts/ subdirectory created
     result = get_custom_font_files(config_name="noconfig")
     assert result == []
@@ -431,8 +485,10 @@ def test_get_custom_font_files_deduplicates_across_dirs(tmp_path, monkeypatch):
 # iter_bundle_artifacts -- smoke tests via empty / no-library cases
 # ---------------------------------------------------------------------------
 
+
 def test_iter_bundle_artifacts_returns_empty_for_non_dict():
     from modules.bundle_artifacts import iter_bundle_artifacts
+
     assert iter_bundle_artifacts([]) == []
     assert iter_bundle_artifacts(None) == []
     assert iter_bundle_artifacts("string") == []
@@ -440,6 +496,7 @@ def test_iter_bundle_artifacts_returns_empty_for_non_dict():
 
 def test_iter_bundle_artifacts_returns_empty_for_no_libraries():
     from modules.bundle_artifacts import iter_bundle_artifacts
+
     assert iter_bundle_artifacts({}) == []
     assert iter_bundle_artifacts({"plex": {"url": "http://x"}}) == []
 
@@ -448,8 +505,10 @@ def test_iter_bundle_artifacts_returns_empty_for_no_libraries():
 # iter_overlay_source_bundle_artifacts -- smoke tests
 # ---------------------------------------------------------------------------
 
+
 def test_iter_overlay_source_bundle_artifacts_returns_empty_for_non_dict():
     from modules.bundle_artifacts import iter_overlay_source_bundle_artifacts
+
     result, changed = iter_overlay_source_bundle_artifacts(None, "myconfig")
     assert result == []
     assert changed is False
@@ -457,6 +516,7 @@ def test_iter_overlay_source_bundle_artifacts_returns_empty_for_non_dict():
 
 def test_iter_overlay_source_bundle_artifacts_returns_empty_when_no_overlay_files():
     from modules.bundle_artifacts import iter_overlay_source_bundle_artifacts
+
     data = {"libraries": {"Movies": {"collection_files": []}}}
     result, changed = iter_overlay_source_bundle_artifacts(data, "myconfig")
     assert result == []
@@ -467,8 +527,10 @@ def test_iter_overlay_source_bundle_artifacts_returns_empty_when_no_overlay_file
 # bundle_write_artifact -- directory artifact flattened into zip
 # ---------------------------------------------------------------------------
 
+
 def test_bundle_write_artifact_writes_single_file(tmp_path):
     from modules.bundle_artifacts import bundle_write_artifact
+
     src = tmp_path / "collections.yml"
     src.write_text("collections: []\n")
     artifact = {"source": src, "archive": "myconfig/collection_files/collections.yml"}
@@ -483,6 +545,7 @@ def test_bundle_write_artifact_writes_single_file(tmp_path):
 
 def test_bundle_write_artifact_writes_directory_recursively(tmp_path):
     from modules.bundle_artifacts import bundle_write_artifact
+
     src_dir = tmp_path / "mydir"
     src_dir.mkdir()
     (src_dir / "a.yml").write_text("a: 1\n")
@@ -501,6 +564,7 @@ def test_bundle_write_artifact_writes_directory_recursively(tmp_path):
 
 def test_bundle_write_artifact_skips_missing_source(tmp_path):
     from modules.bundle_artifacts import bundle_write_artifact
+
     artifact = {"source": tmp_path / "does_not_exist.yml", "archive": "archive/path.yml"}
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w") as zf:
@@ -513,6 +577,7 @@ def test_bundle_write_artifact_skips_missing_source(tmp_path):
 def test_bundle_write_artifact_redacts_yaml_content(tmp_path):
     from modules.bundle_artifacts import bundle_write_artifact
     import modules.helpers as helpers
+
     src = tmp_path / "config.yml"
     src.write_text("tmdb:\n  apikey: REAL_SECRET\n")
 

--- a/tests/test_config_and_library_routes.py
+++ b/tests/test_config_and_library_routes.py
@@ -8,11 +8,10 @@ Covers:
   - quickstart.py                → /lookup_template_string_value
 """
 
-
-
 # ===========================================================================
 # /activate-config
 # ===========================================================================
+
 
 def test_activate_config_creates_new_config_and_sets_session(client, isolated_config_dir):
     resp = client.post("/activate-config", json={"name": "myprofile"})
@@ -58,8 +57,10 @@ def test_activate_config_sanitises_name(client, isolated_config_dir):
 # /clear_session
 # ===========================================================================
 
+
 def test_clear_session_returns_success(client, isolated_config_dir):
     from modules import database
+
     # Ensure the DB table exists before the route tries to flush it
     database.get_unique_config_names()
     with client.session_transaction() as sess:
@@ -73,6 +74,7 @@ def test_clear_session_returns_success(client, isolated_config_dir):
 
 def test_clear_session_without_name_uses_session_config(client, isolated_config_dir):
     from modules import database
+
     database.get_unique_config_names()
     with client.session_transaction() as sess:
         sess["config_name"] = "fallback_config"
@@ -86,8 +88,10 @@ def test_clear_session_without_name_uses_session_config(client, isolated_config_
 # /clear_data/<name>  and  /clear_data/<name>/<section>
 # ===========================================================================
 
+
 def test_clear_data_redirects_to_root(client, isolated_config_dir):
     from modules import database
+
     # Ensure section_data table exists (reset_data does not CREATE TABLE IF NOT EXISTS)
     database.get_unique_config_names()
     resp = client.get("/clear_data/some_config")
@@ -97,6 +101,7 @@ def test_clear_data_redirects_to_root(client, isolated_config_dir):
 
 def test_clear_data_section_redirects_to_root(client, isolated_config_dir):
     from modules import database
+
     database.get_unique_config_names()
     resp = client.get("/clear_data/some_config/010-plex")
     assert resp.status_code == 302
@@ -104,6 +109,7 @@ def test_clear_data_section_redirects_to_root(client, isolated_config_dir):
 
 def test_clear_data_removes_db_entries(client, isolated_config_dir):
     from modules import database
+
     config_name = "clear_data_test"
     # Seed some data (also initialises the table)
     database.save_section_data(
@@ -123,6 +129,7 @@ def test_clear_data_removes_db_entries(client, isolated_config_dir):
 # ===========================================================================
 # /autosave_library/<library_id>
 # ===========================================================================
+
 
 def test_autosave_library_returns_success_for_empty_payload(client, isolated_config_dir, qs_module, monkeypatch):
     """Empty libraries payload (no fields) should autosave without error."""
@@ -224,6 +231,7 @@ def test_autosave_library_reports_normalized_flag(client, isolated_config_dir, q
 # /autosave-imagemaid
 # ===========================================================================
 
+
 def test_autosave_imagemaid_returns_success(client, isolated_config_dir, qs_module, monkeypatch):
     monkeypatch.setattr(qs_module, "_resolve_request_config_name", lambda payload: "pytest_im")
     monkeypatch.setattr(qs_module, "_imagemaid_settings_to_form_payload", lambda payload: {})
@@ -269,6 +277,7 @@ def test_autosave_imagemaid_returns_validated_false_on_change(client, isolated_c
 # /validate-imagemaid
 # ===========================================================================
 
+
 def test_validate_imagemaid_returns_success_when_valid(client, isolated_config_dir, qs_module, monkeypatch):
     monkeypatch.setattr(qs_module, "_resolve_request_config_name", lambda payload: "pytest_im")
     monkeypatch.setattr(qs_module, "_imagemaid_settings_to_form_payload", lambda payload: {})
@@ -306,6 +315,7 @@ def test_validate_imagemaid_returns_400_when_invalid(client, isolated_config_dir
 # /lookup_template_string_value
 # ===========================================================================
 
+
 def test_lookup_template_string_value_requires_preset_and_value(client, isolated_config_dir):
     resp = client.post("/lookup_template_string_value", json={})
     assert resp.status_code == 400
@@ -328,11 +338,14 @@ def test_lookup_template_string_value_numeric_id_hit(client, isolated_config_dir
     )
     monkeypatch.setattr(qs_module, "_build_tmdb_library_type_warning", lambda *a, **kw: "")
 
-    resp = client.post("/lookup_template_string_value", json={
-        "preset": "numeric_id",
-        "value": "603",
-        "media_type": "movie",
-    })
+    resp = client.post(
+        "/lookup_template_string_value",
+        json={
+            "preset": "numeric_id",
+            "value": "603",
+            "media_type": "movie",
+        },
+    )
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["valid"] is True
@@ -351,11 +364,14 @@ def test_lookup_template_string_value_numeric_id_type_mismatch_adds_warning(clie
         lambda msg, result_type, expected, value_label="ID": "Type mismatch: show vs movie library",
     )
 
-    resp = client.post("/lookup_template_string_value", json={
-        "preset": "numeric_id",
-        "value": "1396",
-        "media_type": "movie",
-    })
+    resp = client.post(
+        "/lookup_template_string_value",
+        json={
+            "preset": "numeric_id",
+            "value": "1396",
+            "media_type": "movie",
+        },
+    )
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["valid"] is True
@@ -371,11 +387,14 @@ def test_lookup_template_string_value_imdb_id_tmdb_hit(client, isolated_config_d
     )
     monkeypatch.setattr(qs_module, "_build_tmdb_library_type_warning", lambda *a, **kw: "")
 
-    resp = client.post("/lookup_template_string_value", json={
-        "preset": "imdb_id_tmdb",
-        "value": "tt0133093",
-        "media_type": "movie",
-    })
+    resp = client.post(
+        "/lookup_template_string_value",
+        json={
+            "preset": "imdb_id_tmdb",
+            "value": "tt0133093",
+            "media_type": "movie",
+        },
+    )
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["valid"] is True
@@ -391,11 +410,14 @@ def test_lookup_template_string_value_imdb_id_plex_requires_library_name(client,
     monkeypatch.setattr(qs_module, "_build_tmdb_library_type_warning", lambda *a, **kw: "")
 
     # No library_name provided for imdb_id_plex
-    resp = client.post("/lookup_template_string_value", json={
-        "preset": "imdb_id_plex",
-        "value": "tt0133093",
-        "media_type": "movie",
-    })
+    resp = client.post(
+        "/lookup_template_string_value",
+        json={
+            "preset": "imdb_id_plex",
+            "value": "tt0133093",
+            "media_type": "movie",
+        },
+    )
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["valid"] is False
@@ -415,10 +437,13 @@ def test_lookup_template_string_value_tmdb_collection_id_hit(client, isolated_co
     monkeypatch.setattr(qs_module, "_get_active_tmdb_api_key", lambda: "fake-key")
 
     with patch.object(qs.requests, "get", return_value=ok_resp):
-        resp = client.post("/lookup_template_string_value", json={
-            "preset": "tmdb_collection_id",
-            "value": "131296",
-        })
+        resp = client.post(
+            "/lookup_template_string_value",
+            json={
+                "preset": "tmdb_collection_id",
+                "value": "131296",
+            },
+        )
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["valid"] is True
@@ -428,10 +453,13 @@ def test_lookup_template_string_value_tmdb_collection_id_hit(client, isolated_co
 def test_lookup_template_string_value_tmdb_collection_id_no_key(client, isolated_config_dir, qs_module, monkeypatch):
     monkeypatch.setattr(qs_module, "_get_active_tmdb_api_key", lambda: "")
 
-    resp = client.post("/lookup_template_string_value", json={
-        "preset": "tmdb_collection_id",
-        "value": "131296",
-    })
+    resp = client.post(
+        "/lookup_template_string_value",
+        json={
+            "preset": "tmdb_collection_id",
+            "value": "131296",
+        },
+    )
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["valid"] is False

--- a/tests/test_tmdb_lookup.py
+++ b/tests/test_tmdb_lookup.py
@@ -10,26 +10,28 @@ we patch it directly for the lookup-function tests.
 
 from unittest.mock import MagicMock, patch
 
-
-
 # ---------------------------------------------------------------------------
 # normalize_tmdb_library_media_type  (pure, no mocking)
 # ---------------------------------------------------------------------------
 
+
 def test_normalize_tmdb_library_media_type_movie_variants():
     from modules.tmdb_lookup import normalize_tmdb_library_media_type
+
     for v in ("movie", "movies", "mov", "MOVIE", "Movies"):
         assert normalize_tmdb_library_media_type(v) == "movie", f"failed for {v!r}"
 
 
 def test_normalize_tmdb_library_media_type_show_variants():
     from modules.tmdb_lookup import normalize_tmdb_library_media_type
+
     for v in ("show", "shows", "sho", "tv", "season", "seasons", "episode", "episodes"):
         assert normalize_tmdb_library_media_type(v) == "show", f"failed for {v!r}"
 
 
 def test_normalize_tmdb_library_media_type_passthrough_unknown():
     from modules.tmdb_lookup import normalize_tmdb_library_media_type
+
     assert normalize_tmdb_library_media_type("anime") == "anime"
     assert normalize_tmdb_library_media_type("") == ""
     assert normalize_tmdb_library_media_type(None) == ""
@@ -39,14 +41,17 @@ def test_normalize_tmdb_library_media_type_passthrough_unknown():
 # build_tmdb_library_type_warning  (pure, no mocking)
 # ---------------------------------------------------------------------------
 
+
 def test_build_tmdb_library_type_warning_returns_empty_when_types_agree():
     from modules.tmdb_lookup import build_tmdb_library_type_warning
+
     assert build_tmdb_library_type_warning("Found: The Matrix", "movie", "movie") == ""
     assert build_tmdb_library_type_warning("Found: Breaking Bad", "show", "show") == ""
 
 
 def test_build_tmdb_library_type_warning_returns_message_on_mismatch():
     from modules.tmdb_lookup import build_tmdb_library_type_warning
+
     msg = build_tmdb_library_type_warning("Found: Breaking Bad", "show", "movie")
     assert msg  # non-empty
     assert "show" in msg
@@ -55,6 +60,7 @@ def test_build_tmdb_library_type_warning_returns_message_on_mismatch():
 
 def test_build_tmdb_library_type_warning_movie_result_in_show_library():
     from modules.tmdb_lookup import build_tmdb_library_type_warning
+
     msg = build_tmdb_library_type_warning("Found: The Matrix", "movie", "show")
     assert "movie" in msg
     assert "show/season/episode library" in msg
@@ -62,6 +68,7 @@ def test_build_tmdb_library_type_warning_movie_result_in_show_library():
 
 def test_build_tmdb_library_type_warning_returns_empty_for_unknown_result_type():
     from modules.tmdb_lookup import build_tmdb_library_type_warning
+
     # If result_type is not movie/show (e.g. collection, person), no warning needed
     # unless the expected library type is a known type
     # collection result in a movie library: warning IS generated (collection != movie)
@@ -71,12 +78,14 @@ def test_build_tmdb_library_type_warning_returns_empty_for_unknown_result_type()
 
 def test_build_tmdb_library_type_warning_returns_empty_when_expected_unknown():
     from modules.tmdb_lookup import build_tmdb_library_type_warning
+
     # expected_media_type is something unrecognized — no warning
     assert build_tmdb_library_type_warning("msg", "movie", "anime") == ""
 
 
 def test_build_tmdb_library_type_warning_uses_custom_value_label():
     from modules.tmdb_lookup import build_tmdb_library_type_warning
+
     msg = build_tmdb_library_type_warning("Found it", "show", "movie", value_label="IMDb ID")
     assert "IMDb ID" in msg
 
@@ -85,8 +94,10 @@ def test_build_tmdb_library_type_warning_uses_custom_value_label():
 # get_active_tmdb_api_key  (needs Flask app context + DB)
 # ---------------------------------------------------------------------------
 
+
 def test_get_active_tmdb_api_key_returns_empty_when_no_session(app):
     from modules.tmdb_lookup import get_active_tmdb_api_key
+
     with app.test_request_context("/"):
         # No config_name in session
         result = get_active_tmdb_api_key()
@@ -110,6 +121,7 @@ def test_get_active_tmdb_api_key_reads_apikey_from_db(app, isolated_config_dir):
 
     with app.test_request_context("/"):
         from flask import session
+
         session["config_name"] = config_name
         result = get_active_tmdb_api_key()
 
@@ -133,6 +145,7 @@ def test_get_active_tmdb_api_key_accepts_alt_key_names(app, isolated_config_dir)
 
     with app.test_request_context("/"):
         from flask import session
+
         session["config_name"] = config_name
         result = get_active_tmdb_api_key()
 
@@ -142,6 +155,7 @@ def test_get_active_tmdb_api_key_accepts_alt_key_names(app, isolated_config_dir)
 # ---------------------------------------------------------------------------
 # lookup_tmdb_by_imdb_id
 # ---------------------------------------------------------------------------
+
 
 def _mock_response(status_code, json_data=None):
     mock = MagicMock()
@@ -153,12 +167,12 @@ def _mock_response(status_code, json_data=None):
 
 def test_lookup_tmdb_by_imdb_id_returns_movie_result():
     from modules import tmdb_lookup
+
     payload = {
         "movie_results": [{"id": 603, "title": "The Matrix"}],
         "tv_results": [],
     }
-    with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value="fake-key"), \
-         patch.object(tmdb_lookup.requests, "get", return_value=_mock_response(200, payload)):
+    with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value="fake-key"), patch.object(tmdb_lookup.requests, "get", return_value=_mock_response(200, payload)):
         result = tmdb_lookup.lookup_tmdb_by_imdb_id("tt0133093")
 
     assert result["valid"] is True
@@ -170,12 +184,12 @@ def test_lookup_tmdb_by_imdb_id_returns_movie_result():
 
 def test_lookup_tmdb_by_imdb_id_returns_show_result():
     from modules import tmdb_lookup
+
     payload = {
         "movie_results": [],
         "tv_results": [{"id": 1396, "name": "Breaking Bad"}],
     }
-    with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value="fake-key"), \
-         patch.object(tmdb_lookup.requests, "get", return_value=_mock_response(200, payload)):
+    with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value="fake-key"), patch.object(tmdb_lookup.requests, "get", return_value=_mock_response(200, payload)):
         result = tmdb_lookup.lookup_tmdb_by_imdb_id("tt0903747")
 
     assert result["valid"] is True
@@ -186,12 +200,12 @@ def test_lookup_tmdb_by_imdb_id_returns_show_result():
 def test_lookup_tmdb_by_imdb_id_prefers_media_type_hint_movie():
     """When both movie and TV results exist, media_type='movie' should win."""
     from modules import tmdb_lookup
+
     payload = {
         "movie_results": [{"id": 1, "title": "Movie Version"}],
         "tv_results": [{"id": 2, "name": "Show Version"}],
     }
-    with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value="fake-key"), \
-         patch.object(tmdb_lookup.requests, "get", return_value=_mock_response(200, payload)):
+    with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value="fake-key"), patch.object(tmdb_lookup.requests, "get", return_value=_mock_response(200, payload)):
         result = tmdb_lookup.lookup_tmdb_by_imdb_id("tt9999999", media_type="movie")
 
     assert result["result_type"] == "movie"
@@ -200,12 +214,12 @@ def test_lookup_tmdb_by_imdb_id_prefers_media_type_hint_movie():
 
 def test_lookup_tmdb_by_imdb_id_prefers_media_type_hint_show():
     from modules import tmdb_lookup
+
     payload = {
         "movie_results": [{"id": 1, "title": "Movie Version"}],
         "tv_results": [{"id": 2, "name": "Show Version"}],
     }
-    with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value="fake-key"), \
-         patch.object(tmdb_lookup.requests, "get", return_value=_mock_response(200, payload)):
+    with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value="fake-key"), patch.object(tmdb_lookup.requests, "get", return_value=_mock_response(200, payload)):
         result = tmdb_lookup.lookup_tmdb_by_imdb_id("tt9999999", media_type="show")
 
     assert result["result_type"] == "show"
@@ -214,8 +228,8 @@ def test_lookup_tmdb_by_imdb_id_prefers_media_type_hint_show():
 
 def test_lookup_tmdb_by_imdb_id_404_means_not_found():
     from modules import tmdb_lookup
-    with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value="fake-key"), \
-         patch.object(tmdb_lookup.requests, "get", return_value=_mock_response(404)):
+
+    with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value="fake-key"), patch.object(tmdb_lookup.requests, "get", return_value=_mock_response(404)):
         result = tmdb_lookup.lookup_tmdb_by_imdb_id("tt0000000")
 
     assert result["valid"] is False
@@ -224,8 +238,8 @@ def test_lookup_tmdb_by_imdb_id_404_means_not_found():
 
 def test_lookup_tmdb_by_imdb_id_401_means_bad_api_key():
     from modules import tmdb_lookup
-    with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value="bad-key"), \
-         patch.object(tmdb_lookup.requests, "get", return_value=_mock_response(401)):
+
+    with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value="bad-key"), patch.object(tmdb_lookup.requests, "get", return_value=_mock_response(401)):
         result = tmdb_lookup.lookup_tmdb_by_imdb_id("tt0133093")
 
     assert result["valid"] is False
@@ -235,6 +249,7 @@ def test_lookup_tmdb_by_imdb_id_401_means_bad_api_key():
 
 def test_lookup_tmdb_by_imdb_id_no_api_key_configured():
     from modules import tmdb_lookup
+
     with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value=""):
         result = tmdb_lookup.lookup_tmdb_by_imdb_id("tt0133093")
 
@@ -245,8 +260,8 @@ def test_lookup_tmdb_by_imdb_id_no_api_key_configured():
 def test_lookup_tmdb_by_imdb_id_network_error():
     import requests as req_lib
     from modules import tmdb_lookup
-    with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value="key"), \
-         patch.object(tmdb_lookup.requests, "get", side_effect=req_lib.RequestException("timeout")):
+
+    with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value="key"), patch.object(tmdb_lookup.requests, "get", side_effect=req_lib.RequestException("timeout")):
         result = tmdb_lookup.lookup_tmdb_by_imdb_id("tt0133093")
 
     assert result["valid"] is False
@@ -255,9 +270,9 @@ def test_lookup_tmdb_by_imdb_id_network_error():
 
 def test_lookup_tmdb_by_imdb_id_empty_results_means_not_found():
     from modules import tmdb_lookup
+
     payload = {"movie_results": [], "tv_results": []}
-    with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value="key"), \
-         patch.object(tmdb_lookup.requests, "get", return_value=_mock_response(200, payload)):
+    with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value="key"), patch.object(tmdb_lookup.requests, "get", return_value=_mock_response(200, payload)):
         result = tmdb_lookup.lookup_tmdb_by_imdb_id("tt9999999")
 
     assert result["valid"] is False
@@ -268,12 +283,14 @@ def test_lookup_tmdb_by_imdb_id_empty_results_means_not_found():
 # lookup_tmdb_numeric_id
 # ---------------------------------------------------------------------------
 
+
 def test_lookup_tmdb_numeric_id_finds_movie():
     from modules import tmdb_lookup
+
     movie_payload = {"id": 603, "title": "The Matrix"}
-    with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value="key"), \
-         patch.object(tmdb_lookup, "lookup_tmdb_external_ids", return_value={}), \
-         patch.object(tmdb_lookup.requests, "get", return_value=_mock_response(200, movie_payload)):
+    with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value="key"), patch.object(tmdb_lookup, "lookup_tmdb_external_ids", return_value={}), patch.object(
+        tmdb_lookup.requests, "get", return_value=_mock_response(200, movie_payload)
+    ):
         result = tmdb_lookup.lookup_tmdb_numeric_id("603", media_type="movie")
 
     assert result["valid"] is True
@@ -283,11 +300,12 @@ def test_lookup_tmdb_numeric_id_finds_movie():
 
 def test_lookup_tmdb_numeric_id_includes_tvdb_id_when_present():
     from modules import tmdb_lookup
+
     tv_payload = {"id": 1396, "name": "Breaking Bad"}
     external_ids = {"tvdb_id": 81189}
-    with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value="key"), \
-         patch.object(tmdb_lookup, "lookup_tmdb_external_ids", return_value=external_ids), \
-         patch.object(tmdb_lookup.requests, "get", return_value=_mock_response(200, tv_payload)):
+    with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value="key"), patch.object(tmdb_lookup, "lookup_tmdb_external_ids", return_value=external_ids), patch.object(
+        tmdb_lookup.requests, "get", return_value=_mock_response(200, tv_payload)
+    ):
         result = tmdb_lookup.lookup_tmdb_numeric_id("1396", media_type="show")
 
     assert result["valid"] is True
@@ -297,9 +315,9 @@ def test_lookup_tmdb_numeric_id_includes_tvdb_id_when_present():
 
 def test_lookup_tmdb_numeric_id_no_match_exhausts_all_endpoints():
     from modules import tmdb_lookup
+
     # All four endpoints return 404 → "not found"
-    with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value="key"), \
-         patch.object(tmdb_lookup.requests, "get", return_value=_mock_response(404)):
+    with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value="key"), patch.object(tmdb_lookup.requests, "get", return_value=_mock_response(404)):
         result = tmdb_lookup.lookup_tmdb_numeric_id("9999999")
 
     assert result["valid"] is False
@@ -308,8 +326,8 @@ def test_lookup_tmdb_numeric_id_no_match_exhausts_all_endpoints():
 
 def test_lookup_tmdb_numeric_id_401_short_circuits():
     from modules import tmdb_lookup
-    with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value="bad-key"), \
-         patch.object(tmdb_lookup.requests, "get", return_value=_mock_response(401)):
+
+    with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value="bad-key"), patch.object(tmdb_lookup.requests, "get", return_value=_mock_response(401)):
         result = tmdb_lookup.lookup_tmdb_numeric_id("603")
 
     assert result["valid"] is False
@@ -318,6 +336,7 @@ def test_lookup_tmdb_numeric_id_401_short_circuits():
 
 def test_lookup_tmdb_numeric_id_no_api_key():
     from modules import tmdb_lookup
+
     with patch.object(tmdb_lookup, "get_active_tmdb_api_key", return_value=""):
         result = tmdb_lookup.lookup_tmdb_numeric_id("603")
 
@@ -329,8 +348,10 @@ def test_lookup_tmdb_numeric_id_no_api_key():
 # lookup_tmdb_external_ids
 # ---------------------------------------------------------------------------
 
+
 def test_lookup_tmdb_external_ids_returns_payload():
     from modules import tmdb_lookup
+
     ext_payload = {"id": 1396, "imdb_id": "tt0903747", "tvdb_id": 81189}
     with patch.object(tmdb_lookup.requests, "get", return_value=_mock_response(200, ext_payload)):
         result = tmdb_lookup.lookup_tmdb_external_ids("tv", "1396", "key")
@@ -341,12 +362,14 @@ def test_lookup_tmdb_external_ids_returns_payload():
 
 def test_lookup_tmdb_external_ids_returns_empty_on_bad_endpoint():
     from modules import tmdb_lookup
+
     result = tmdb_lookup.lookup_tmdb_external_ids("invalid", "123", "key")
     assert result == {}
 
 
 def test_lookup_tmdb_external_ids_returns_empty_on_http_error():
     from modules import tmdb_lookup
+
     with patch.object(tmdb_lookup.requests, "get", return_value=_mock_response(500)):
         result = tmdb_lookup.lookup_tmdb_external_ids("movie", "603", "key")
     assert result == {}
@@ -354,6 +377,7 @@ def test_lookup_tmdb_external_ids_returns_empty_on_http_error():
 
 def test_lookup_tmdb_external_ids_returns_empty_on_missing_args():
     from modules import tmdb_lookup
+
     assert tmdb_lookup.lookup_tmdb_external_ids("movie", "", "key") == {}
     assert tmdb_lookup.lookup_tmdb_external_ids("movie", "603", "") == {}
     assert tmdb_lookup.lookup_tmdb_external_ids("", "603", "key") == {}

--- a/tests/test_validate_service_routes.py
+++ b/tests/test_validate_service_routes.py
@@ -17,10 +17,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # helpers
 # ---------------------------------------------------------------------------
+
 
 def _ok_response(extra=None):
     """Build a Flask-style response mock that returns a success payload."""
@@ -41,12 +41,16 @@ def _err_response(message="Error"):
 # Simple pass-through routes (mock modules.validations.*_server)
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("route,mock_fn,payload", [
-    ("/validate_tautulli",   "validate_tautulli_server",   {"tautulli_url": "http://t", "apikey": "k"}),
-    ("/validate_trakt",      "validate_trakt_server",      {"client_id": "id", "client_secret": "sec"}),
-    ("/validate_mal",        "validate_mal_server",        {"client_id": "id", "client_secret": "sec"}),
-    ("/validate_webhook",    "validate_webhook_server",    {"webhook_url": "http://hook"}),
-])
+
+@pytest.mark.parametrize(
+    "route,mock_fn,payload",
+    [
+        ("/validate_tautulli", "validate_tautulli_server", {"tautulli_url": "http://t", "apikey": "k"}),
+        ("/validate_trakt", "validate_trakt_server", {"client_id": "id", "client_secret": "sec"}),
+        ("/validate_mal", "validate_mal_server", {"client_id": "id", "client_secret": "sec"}),
+        ("/validate_webhook", "validate_webhook_server", {"webhook_url": "http://hook"}),
+    ],
+)
 def test_validate_passthrough_route_proxies_success(client, route, mock_fn, payload):
     with patch(f"modules.validations.{mock_fn}", return_value=_ok_response()):
         resp = client.post(route, json=payload)
@@ -54,10 +58,13 @@ def test_validate_passthrough_route_proxies_success(client, route, mock_fn, payl
     assert resp.status_code in (200, 201, 302)
 
 
-@pytest.mark.parametrize("route,mock_fn,payload", [
-    ("/validate_tautulli",   "validate_tautulli_server",   {"tautulli_url": "http://t", "apikey": "k"}),
-    ("/validate_trakt",      "validate_trakt_server",      {"client_id": "id", "client_secret": "sec"}),
-])
+@pytest.mark.parametrize(
+    "route,mock_fn,payload",
+    [
+        ("/validate_tautulli", "validate_tautulli_server", {"tautulli_url": "http://t", "apikey": "k"}),
+        ("/validate_trakt", "validate_trakt_server", {"client_id": "id", "client_secret": "sec"}),
+    ],
+)
 def test_validate_passthrough_route_proxies_failure_payload(client, route, mock_fn, payload):
     with patch(f"modules.validations.{mock_fn}", return_value=_err_response("Service unreachable")):
         resp = client.post(route, json=payload)
@@ -69,15 +76,19 @@ def test_validate_passthrough_route_proxies_failure_payload(client, route, mock_
 # Routes that use result.get_json().get("valid") to choose status code
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("route,mock_fn,payload", [
-    ("/validate_radarr",   "validate_radarr_server",   {"radarr_url": "http://r", "api_key": "k"}),
-    ("/validate_sonarr",   "validate_sonarr_server",   {"sonarr_url": "http://s", "api_key": "k"}),
-    ("/validate_omdb",     "validate_omdb_server",     {"apikey": "k"}),
-    ("/validate_github",   "validate_github_server",   {"token": "t"}),
-    ("/validate_tmdb",     "validate_tmdb_server",     {"apikey": "k"}),
-    ("/validate_mdblist",  "validate_mdblist_server",  {"apikey": "k"}),
-    ("/validate_notifiarr","validate_notifiarr_server",{"apikey": "k"}),
-])
+
+@pytest.mark.parametrize(
+    "route,mock_fn,payload",
+    [
+        ("/validate_radarr", "validate_radarr_server", {"radarr_url": "http://r", "api_key": "k"}),
+        ("/validate_sonarr", "validate_sonarr_server", {"sonarr_url": "http://s", "api_key": "k"}),
+        ("/validate_omdb", "validate_omdb_server", {"apikey": "k"}),
+        ("/validate_github", "validate_github_server", {"token": "t"}),
+        ("/validate_tmdb", "validate_tmdb_server", {"apikey": "k"}),
+        ("/validate_mdblist", "validate_mdblist_server", {"apikey": "k"}),
+        ("/validate_notifiarr", "validate_notifiarr_server", {"apikey": "k"}),
+    ],
+)
 def test_validate_route_returns_200_on_success(client, route, mock_fn, payload):
     with patch(f"modules.validations.{mock_fn}", return_value=_ok_response()):
         resp = client.post(route, json=payload)
@@ -89,10 +100,14 @@ def test_validate_route_returns_200_on_success(client, route, mock_fn, payload):
 # radarr / sonarr unpack ``(response, status_code)`` tuples from the validator;
 # the others call result.get_json() directly and hardcode 400 on failure.
 
-@pytest.mark.parametrize("route,mock_fn,payload", [
-    ("/validate_radarr",   "validate_radarr_server",   {"radarr_url": "http://r", "api_key": "k"}),
-    ("/validate_sonarr",   "validate_sonarr_server",   {"sonarr_url": "http://s", "api_key": "k"}),
-])
+
+@pytest.mark.parametrize(
+    "route,mock_fn,payload",
+    [
+        ("/validate_radarr", "validate_radarr_server", {"radarr_url": "http://r", "api_key": "k"}),
+        ("/validate_sonarr", "validate_sonarr_server", {"sonarr_url": "http://s", "api_key": "k"}),
+    ],
+)
 def test_validate_arr_route_returns_400_on_failure_via_tuple(client, route, mock_fn, payload):
     # These routes do: if isinstance(result, tuple): result, status_code = result
     # so we must return a tuple to get the 400 propagated.
@@ -102,13 +117,16 @@ def test_validate_arr_route_returns_400_on_failure_via_tuple(client, route, mock
     assert resp.get_json()["valid"] is False
 
 
-@pytest.mark.parametrize("route,mock_fn,payload", [
-    ("/validate_omdb",     "validate_omdb_server",     {"apikey": "k"}),
-    ("/validate_github",   "validate_github_server",   {"token": "t"}),
-    ("/validate_tmdb",     "validate_tmdb_server",     {"apikey": "k"}),
-    ("/validate_mdblist",  "validate_mdblist_server",  {"apikey": "k"}),
-    ("/validate_notifiarr","validate_notifiarr_server",{"apikey": "k"}),
-])
+@pytest.mark.parametrize(
+    "route,mock_fn,payload",
+    [
+        ("/validate_omdb", "validate_omdb_server", {"apikey": "k"}),
+        ("/validate_github", "validate_github_server", {"token": "t"}),
+        ("/validate_tmdb", "validate_tmdb_server", {"apikey": "k"}),
+        ("/validate_mdblist", "validate_mdblist_server", {"apikey": "k"}),
+        ("/validate_notifiarr", "validate_notifiarr_server", {"apikey": "k"}),
+    ],
+)
 def test_validate_simple_route_returns_400_on_failure(client, route, mock_fn, payload):
     # These routes call result.get_json() directly and hardcode status 400.
     with patch(f"modules.validations.{mock_fn}", return_value=_err_response("Bad credentials")):
@@ -120,6 +138,7 @@ def test_validate_simple_route_returns_400_on_failure(client, route, mock_fn, pa
 # ---------------------------------------------------------------------------
 # URL-validation gates (gotify, ntfy)
 # ---------------------------------------------------------------------------
+
 
 def test_validate_gotify_rejects_bad_url(client):
     resp = client.post("/validate_gotify", json={"gotify_url": "not-a-url"})
@@ -161,6 +180,7 @@ def test_validate_ntfy_missing_url_returns_400(client):
 # validate_trakt_token -- token exchange flow
 # ---------------------------------------------------------------------------
 
+
 def test_validate_trakt_token_missing_access_and_client_id_returns_400(client):
     resp = client.post("/validate_trakt_token", json={})
     assert resp.status_code == 400
@@ -171,31 +191,39 @@ def test_validate_trakt_token_missing_access_and_client_id_returns_400(client):
 
 def test_validate_trakt_token_valid_access_token_returns_200(client):
     import blueprints.validation_routes as vr
+
     ok_resp = MagicMock()
     ok_resp.status_code = 200
 
     with patch.object(vr.requests, "get", return_value=ok_resp):
-        resp = client.post("/validate_trakt_token", json={
-            "access_token": "valid-token",
-            "client_id": "my-client-id",
-            "client_secret": "my-secret",
-            "refresh_token": "refresh",
-        })
+        resp = client.post(
+            "/validate_trakt_token",
+            json={
+                "access_token": "valid-token",
+                "client_id": "my-client-id",
+                "client_secret": "my-secret",
+                "refresh_token": "refresh",
+            },
+        )
     assert resp.status_code == 200
     assert resp.get_json()["valid"] is True
 
 
 def test_validate_trakt_token_401_without_refresh_returns_400(client):
     import blueprints.validation_routes as vr
+
     err_resp = MagicMock()
     err_resp.status_code = 401
 
     with patch.object(vr.requests, "get", return_value=err_resp):
-        resp = client.post("/validate_trakt_token", json={
-            "access_token": "expired-token",
-            "client_id": "my-client-id",
-            # no refresh_token or client_secret -- refresh can't be attempted
-        })
+        resp = client.post(
+            "/validate_trakt_token",
+            json={
+                "access_token": "expired-token",
+                "client_id": "my-client-id",
+                # no refresh_token or client_secret -- refresh can't be attempted
+            },
+        )
     assert resp.status_code == 400
     assert resp.get_json()["valid"] is False
 
@@ -205,12 +233,15 @@ def test_validate_trakt_token_network_error_returns_400(client):
     import requests as req_lib
 
     with patch.object(vr.requests, "get", side_effect=req_lib.exceptions.RequestException("timeout")):
-        resp = client.post("/validate_trakt_token", json={
-            "access_token": "token",
-            "client_id": "id",
-            "client_secret": "secret",
-            "refresh_token": "refresh",
-        })
+        resp = client.post(
+            "/validate_trakt_token",
+            json={
+                "access_token": "token",
+                "client_id": "id",
+                "client_secret": "secret",
+                "refresh_token": "refresh",
+            },
+        )
     assert resp.status_code == 400
     assert resp.get_json()["valid"] is False
 
@@ -218,6 +249,7 @@ def test_validate_trakt_token_network_error_returns_400(client):
 # ---------------------------------------------------------------------------
 # validate_mal_token -- token check flow
 # ---------------------------------------------------------------------------
+
 
 def test_validate_mal_token_missing_access_token_returns_400(client):
     resp = client.post("/validate_mal_token", json={})
@@ -229,6 +261,7 @@ def test_validate_mal_token_missing_access_token_returns_400(client):
 
 def test_validate_mal_token_valid_token_returns_200(client):
     import blueprints.validation_routes as vr
+
     ok_resp = MagicMock()
     ok_resp.status_code = 200
 
@@ -240,6 +273,7 @@ def test_validate_mal_token_valid_token_returns_200(client):
 
 def test_validate_mal_token_401_returns_400(client):
     import blueprints.validation_routes as vr
+
     err_resp = MagicMock()
     err_resp.status_code = 401
 
@@ -252,6 +286,7 @@ def test_validate_mal_token_401_returns_400(client):
 # ---------------------------------------------------------------------------
 # validate_library_service_overrides
 # ---------------------------------------------------------------------------
+
 
 def test_validate_library_service_overrides_returns_json(client, isolated_config_dir):
     resp = client.post(


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Title
Add preview-driven text overlay UX for 5 overlay families
Description
Summary
This PR upgrades Quickstart’s text-based overlay handling for five overlay families so they behave more like the newer overlay preview flows instead of relying on freeform text entry.
The new behavior covers:
overlay_aspect
overlay_episode_info
overlay_runtimes
overlay_status
overlay_video_format
What changed
Added preview selection logic in overlayHandler.js for the five text overlays.
Replaced preview-only raw text entry with structured preview controls where appropriate.
Synced preview selections back into the hidden/generated text values used by the existing renderer.
Updated runtime and status preview generation so the canvas reflects the selected preview sample instead of a hardcoded/default-only value.
Fixed preview control placement so the preview dropdown renders on its own row instead of collapsing into the font row/pill layout.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
