### PR TITLE
ratings overides v1

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -53,6 +53,7 @@ Trakt
 truthy
 txt
 ui
+unreferenced
 venv
 walkthrough
 walkthroughs

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ This reduces the chance of Plex background maintenance colliding with long Komet
 ### Live Previews & Assets
 - **Overlay Preview Generator:** Combines overlays and template variables into real-time preview images
 - **Custom Artwork Uploads:** Drag-and-drop or fetch library images from a URL so you can see what the overlays look like on your favorite poster.
+- **Overlay Image Source Overrides:** Supported overlay families can override built-in badge images per key using `file`, `url`, `git`, or `repo` sources, validate those images before save, preview the result live on the canvas, and optionally convert remote sources into managed local files with `Make Local`.
+- **Managed Overlay Cleanup:** When a managed override image is replaced or removed, Quickstart cleans up the old managed file and can sweep unreferenced managed override images to avoid config bloat.
 
 ![Overlay Preview Canvas](static/images/readme/overlay-preview.png)
 

--- a/modules/importer.py
+++ b/modules/importer.py
@@ -400,7 +400,34 @@ def _collect_overlay_source_override_keys(overlay_meta: Any) -> set[str]:
         source_types = ["file", "url", "git", "repo"]
 
     allowed = set(source_types)
-    if str(config.get("key_mode") or "").strip().lower() != "from_use_toggles":
+    key_mode = str(config.get("key_mode") or "").strip().lower()
+    if key_mode == "from_select_options":
+        key_fields = {
+            str(item).strip()
+            for item in (config.get("key_fields") or [])
+            if str(item).strip()
+        }
+        template_variables = overlay_meta.get("template_variables")
+        if isinstance(template_variables, dict):
+            for field_key in key_fields:
+                field_meta = template_variables.get(field_key)
+                if not isinstance(field_meta, dict):
+                    continue
+                options = field_meta.get("options")
+                if not isinstance(options, list):
+                    continue
+                for option in options:
+                    if isinstance(option, dict):
+                        option_value = str(option.get("value") or "").strip()
+                    else:
+                        option_value = str(option).strip()
+                    if not option_value:
+                        continue
+                    for source_type in source_types:
+                        allowed.add(f"{source_type}_{option_value}")
+        return allowed
+
+    if key_mode != "from_use_toggles":
         return allowed
 
     excluded_toggle_keys = {str(item).strip() for item in (config.get("exclude_toggle_keys") or []) if str(item).strip()}

--- a/static/json/quickstart_overlays.json
+++ b/static/json/quickstart_overlays.json
@@ -603,6 +603,23 @@
         "label": "Ratings",
         "url": "https://kometa.wiki/en/nightly/defaults/overlays/ratings/",
         "image_url": "https://kometa.wiki/en/nightly/assets/images/defaults/overlays/ratings.png",
+        "source_overrides": {
+          "title": "Image Source Overrides",
+          "description": "Advanced: override the built-in rating image for a specific rating image key using a local file, URL, Community-Configs git path, or custom_repo repo path.",
+          "source_types": [
+            "file",
+            "url",
+            "git",
+            "repo"
+          ],
+          "key_mode": "from_select_options",
+          "key_fields": [
+            "rating1_image",
+            "rating2_image",
+            "rating3_image"
+          ],
+          "key_placeholder": "Rating image key"
+        },
         "default_offsets": {
           "horizontal": 15,
           "vertical": 0,
@@ -1059,6 +1076,22 @@
         "label": "Ratings",
         "url": "https://kometa.wiki/en/nightly/defaults/overlays/ratings/",
         "image_url": "https://kometa.wiki/en/nightly/assets/images/defaults/overlays/ratings.png",
+        "source_overrides": {
+          "title": "Image Source Overrides",
+          "description": "Advanced: override the built-in rating image for a specific rating image key using a local file, URL, Community-Configs git path, or custom_repo repo path.",
+          "source_types": [
+            "file",
+            "url",
+            "git",
+            "repo"
+          ],
+          "key_mode": "from_select_options",
+          "key_fields": [
+            "rating1_image",
+            "rating2_image"
+          ],
+          "key_placeholder": "Rating image key"
+        },
         "default_offsets": {
           "horizontal": 15,
           "vertical": 0,

--- a/static/local-js/overlayHandler.js
+++ b/static/local-js/overlayHandler.js
@@ -1,4 +1,4 @@
-/* global EventHandler, ValidationHandler, toggleOverlayTemplateSection, FontFace, FileReader, Image, requestAnimationFrame, boardState, ResizeObserver, DOMParser */
+/* global EventHandler, ValidationHandler, toggleOverlayTemplateSection, FontFace, FileReader, Image, requestAnimationFrame, boardState, ResizeObserver, DOMParser, applyPosition */
 
 const OverlayHandler = {
   baseDimensions: {
@@ -2299,6 +2299,9 @@ const OverlayHandler = {
           keyMode: String(parsed.key_mode || '').trim().toLowerCase(),
           fixedKey: String(parsed.fixed_key || '').trim(),
           keyPlaceholder: String(parsed.key_placeholder || '').trim(),
+          keyFields: Array.isArray(parsed.key_fields)
+            ? parsed.key_fields.map(item => String(item || '').trim()).filter(Boolean)
+            : [],
           sourceTypes,
           excludeToggleKeys: Array.isArray(parsed.exclude_toggle_keys)
             ? parsed.exclude_toggle_keys.map(item => String(item || '').trim()).filter(Boolean)
@@ -2339,6 +2342,23 @@ const OverlayHandler = {
       }
       if (config.keyMode === 'bundled_preview_keys') {
         return getBundledOverlayKeyOptions(cfg)
+      }
+      if (config.keyMode === 'from_select_options') {
+        const seen = new Set()
+        ;(config.keyFields || []).forEach((fieldKey) => {
+          const input = getTemplateInput(cfg, fieldKey)
+          if (!input || input.tagName !== 'SELECT') return
+          Array.from(input.options || []).forEach((option) => {
+            const value = String(option.value || '').trim()
+            if (!value || seen.has(value)) return
+            seen.add(value)
+            options.push({
+              value,
+              label: String(option.textContent || value).trim() || value
+            })
+          })
+        })
+        return options
       }
       if (config.keyMode !== 'from_use_toggles') return options
 
@@ -3180,6 +3200,15 @@ const OverlayHandler = {
       })
     }
 
+    const refreshRatingsOverlayPreview = (cfg) => {
+      if (cfg?.id !== 'overlay_ratings' || !cfg.layer) return
+      buildBackdropDataUrl(cfg).then(dataUrl => {
+        if (!dataUrl) return
+        cfg.layer.src = dataUrl
+        applyPosition(cfg)
+      })
+    }
+
     const refreshSingleBadgeOverlayPreview = (cfg) => {
       if (!cfg?.layer || !['overlay_network', 'overlay_studio'].includes(cfg.id)) return
       buildBackdropDataUrl(cfg).then(dataUrl => {
@@ -3445,6 +3474,8 @@ const OverlayHandler = {
           setLanguageCountPreviewSelectedKey(cfg, badgeKey)
           syncLanguageCountPreviewControls(cfg)
           refreshLanguageCountOverlayPreview(cfg)
+        } else if (cfg.id === 'overlay_ratings') {
+          refreshRatingsOverlayPreview(cfg)
         } else if (isRegionalContentRatingOverlay(cfg) && badgeKey) {
           setContentRatingPreviewSelectedKey(cfg, badgeKey)
           syncContentRatingPreviewControls(cfg)
@@ -3554,6 +3585,8 @@ const OverlayHandler = {
           setLanguageCountPreviewSelectedKey(cfg, badgeKey)
           syncLanguageCountPreviewControls(cfg)
           refreshLanguageCountOverlayPreview(cfg)
+        } else if (cfg.id === 'overlay_ratings') {
+          refreshRatingsOverlayPreview(cfg)
         } else if (isRegionalContentRatingOverlay(cfg) && badgeKey) {
           setContentRatingPreviewSelectedKey(cfg, badgeKey)
           syncContentRatingPreviewControls(cfg)
@@ -3598,7 +3631,8 @@ const OverlayHandler = {
       const requestedKey = String(entry.badgeKey || '').trim()
       const useBundledPreviewKeys = config.keyMode === 'bundled_preview_keys'
       const useFixedKey = config.keyMode === 'fixed_key'
-      const useFreeTextKey = config.keyMode !== 'from_use_toggles' && !useFixedKey
+      const useSelectKeys = config.keyMode === 'from_use_toggles' || config.keyMode === 'from_select_options'
+      const useFreeTextKey = !useSelectKeys && !useFixedKey && !useBundledPreviewKeys
       let keySelect
       if (useFixedKey) {
         keySelect = document.createElement('input')
@@ -3885,6 +3919,9 @@ const OverlayHandler = {
         if (didStateChange) {
           refreshLanguageCountOverlayPreview(cfg)
         }
+      }
+      if (cfg.id === 'overlay_ratings' && didStateChange) {
+        refreshRatingsOverlayPreview(cfg)
       }
       if (isRegionalContentRatingOverlay(cfg)) {
         syncContentRatingPreviewControls(cfg)
@@ -4977,6 +5014,22 @@ const OverlayHandler = {
       hydrateRatingMappingSamples(cfg, token)
     }
 
+    const getRatingsPreviewOverrideEntries = (cfg) => {
+      const config = getOverlaySourceOverrideConfig(cfg)
+      const section = cfg?.container?.querySelector('[data-overlay-source-editor="true"]')
+      const hiddenHost = section?.querySelector('[data-overlay-source-hidden]')
+      if (!config || !hiddenHost) return []
+      return readOverlaySourceOverrideState(cfg, config, hiddenHost)
+    }
+
+    const getRatingsPreviewOverrideEntry = (cfg, imageValue, imageLabel = '') => {
+      const imageKey = normalizeRatingImageKey(imageValue, imageLabel)
+      if (!imageKey) return null
+      return getRatingsPreviewOverrideEntries(cfg).find(entry => {
+        return entry.badgeKey === imageKey && entry.sourceType && entry.value
+      }) || null
+    }
+
     const getTemplateValue = (cfg, key, fallback) => {
       const input = getTemplateInput(cfg, key)
       if (!input) return fallback
@@ -5041,18 +5094,33 @@ const OverlayHandler = {
       if (!imageVal) return null
       const imageKey = normalizeRatingImageKey(imageVal, labelVal)
       const sample = getRatingSampleValue(ratingType, imageVal, labelVal, sampleVariant)
-      const urls = getRatingSampleImageUrls(imageVal, labelVal, sample)
-      if (!urls.length) return null
       let img
       let useStarFallback = false
-      try {
-        img = await loadImageWithFallback(urls)
-      } catch (err) {
-        if (imageKey === 'star' || imageKey === 'plex_star') {
-          useStarFallback = true
-        } else {
-          console.warn('[OverlayBoards] Failed to load rating image', { value: imageVal, label: labelVal, err })
-          return null
+      const overrideEntry = getRatingsPreviewOverrideEntry(cfg, imageVal, labelVal)
+      if (overrideEntry) {
+        try {
+          img = await loadImage(buildOverlaySourcePreviewUrl(overrideEntry.sourceType, overrideEntry.value))
+        } catch (err) {
+          console.warn('[OverlayBoards] Failed to load rating override image', {
+            value: imageVal,
+            label: labelVal,
+            override: overrideEntry,
+            err
+          })
+        }
+      }
+      if (!img) {
+        const urls = getRatingSampleImageUrls(imageVal, labelVal, sample)
+        if (!urls.length) return null
+        try {
+          img = await loadImageWithFallback(urls)
+        } catch (err) {
+          if (imageKey === 'star' || imageKey === 'plex_star') {
+            useStarFallback = true
+          } else {
+            console.warn('[OverlayBoards] Failed to load rating image', { value: imageVal, label: labelVal, err })
+            return null
+          }
         }
       }
       const overrideFont = (fontOverride || '').toString().trim()
@@ -5480,10 +5548,26 @@ const OverlayHandler = {
         if (isEmpty(ratingVal) || isEmpty(imageVal)) continue
         const label = imageSelect?.selectedOptions?.[0]?.textContent?.trim()
         const sample = getRatingSampleValue(ratingVal, imageVal, label)
-        const urls = getRatingSampleImageUrls(imageVal, label, sample)
-        if (!urls.length) continue
         try {
-          const img = await loadImageWithFallback(urls)
+          const overrideEntry = getRatingsPreviewOverrideEntry(cfg, imageVal, label)
+          let img = null
+          if (overrideEntry) {
+            try {
+              img = await loadImage(buildOverlaySourcePreviewUrl(overrideEntry.sourceType, overrideEntry.value))
+            } catch (overrideError) {
+              console.warn('[OverlayBoards] Failed to load rating override image', {
+                value: imageVal,
+                label,
+                override: overrideEntry,
+                err: overrideError
+              })
+            }
+          }
+          if (!img) {
+            const urls = getRatingSampleImageUrls(imageVal, label, sample)
+            if (!urls.length) continue
+            img = await loadImageWithFallback(urls)
+          }
           const text = sample.text || 'NR'
           const hOffset = Number(getSlotValue(`${slot.ratingKey}_horizontal_offset`, 0))
           const vOffset = Number(getSlotValue(`${slot.ratingKey}_vertical_offset`, 0))
@@ -8090,10 +8174,7 @@ const OverlayHandler = {
             applyRatingFontDefaults(cfg)
             updateRatingSyncStatus(cfg)
             renderRatingMappingModal(cfg)
-            buildBackdropDataUrl(cfg).then(dataUrl => {
-              layer.src = dataUrl
-              applyPosition(cfg)
-            })
+            refreshRatingsOverlayPreview(cfg)
           }
           const scheduleRatingsUpdate = (event, forceSync = false, preserveExistingSources = false) => {
             if (!cfg.container) return

--- a/tests/test_importer_overlay_files.py
+++ b/tests/test_importer_overlay_files.py
@@ -127,6 +127,42 @@ def test_prepare_import_payload_accepts_resolution_source_override_template_vari
     assert any("libraries.Movies.overlay_files[0].template_variables.repo_openmatte" in line for line in report.lines)
 
 
+def test_prepare_import_payload_accepts_ratings_source_override_template_variables():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Movies": {
+                    "overlay_files": [
+                        {
+                            "default": "ratings",
+                            "template_variables": {
+                                "file_rt_tomato": "config/overlays/ratings/rt_tomato.png",
+                                "url_imdb": "https://example.com/imdb.png",
+                                "git_tmdb": "defaults/overlays/images/ratings/tmdb.png",
+                                "repo_star": "overlays/ratings/star.png",
+                            },
+                        }
+                    ]
+                }
+            }
+        },
+        {"Movies"},
+        set(),
+        set(),
+    )
+
+    libraries_payload = payload["libraries"]["libraries"]
+    assert libraries_payload["mov-library_movies-movie-overlay_ratings"] is True
+    assert libraries_payload["mov-library_movies-movie-template_overlay_ratings[file_rt_tomato]"] == "config/overlays/ratings/rt_tomato.png"
+    assert libraries_payload["mov-library_movies-movie-template_overlay_ratings[url_imdb]"] == "https://example.com/imdb.png"
+    assert libraries_payload["mov-library_movies-movie-template_overlay_ratings[git_tmdb]"] == "defaults/overlays/images/ratings/tmdb.png"
+    assert libraries_payload["mov-library_movies-movie-template_overlay_ratings[repo_star]"] == "overlays/ratings/star.png"
+    assert any("libraries.Movies.overlay_files[0].template_variables.file_rt_tomato" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[0].template_variables.url_imdb" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[0].template_variables.git_tmdb" in line for line in report.lines)
+    assert any("libraries.Movies.overlay_files[0].template_variables.repo_star" in line for line in report.lines)
+
+
 def test_prepare_import_payload_accepts_audio_codec_template_variables():
     payload, report = importer.prepare_import_payload(
         {


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

PR Title
Add ratings overlay source overrides with controlled badge-key import support
PR Description
Summary
This PR adds the new overlay source-override pattern to overlay_ratings, so ratings can now override built-in rating badge images the same way newer overlay families already do.
What Changed
Added source_overrides metadata to both overlay_ratings definitions in static/json/quickstart_overlays.json.
Introduced a new override key mode, from_select_options, for overlays whose valid keys come from existing select fields instead of use_<key> toggles.
Wired ratings preview/composite rendering to honor overrides for the selected rating1_image, rating2_image, and rating3_image keys in static/local-js/overlayHandler.js.
Extended importer support in modules/importer.py so ratings override variables like:file_rt_tomato
url_imdb
git_tmdb
repo_star
are accepted during import.

Added importer regression coverage in tests/test_importer_overlay_files.py.
Behavior
Ratings override keys are now controlled by the actual rating image dropdown options, not free text.
Ratings preview uses the selected rating-image key and will render the override image when one exists.
No static asset copy was needed for ratings, since ratings already had an existing preview/render path and this change only extends it to honor overrides.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
