### PR TITLE
Extract shared validation helpers + convert base scripts and 080-gotify to ES modules (PR 2a of #1346)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -56,6 +56,19 @@ const quickstartGlobals = {
   initialSonarrLanguageProfile: 'readonly'
 }
 
+// Files that have been migrated to ES modules as part of roadmap step 2
+// (issue #1346). Keep this list in sync with MODULE_PAGE_SCRIPTS in
+// quickstart.py for page scripts. The modules/ subdirectory is always
+// module-scoped by virtue of the glob.
+const moduleFiles = [
+  'static/local-js/modules/**/*.js',
+  'static/local-js/000-base.js',
+  'static/local-js/pathValidation.js',
+  'static/local-js/urlValidation.js',
+  'static/local-js/templateStringList.js',
+  'static/local-js/080-gotify.js'
+]
+
 module.exports = [
   {
     files: ['static/local-js/**/*.js'],
@@ -74,6 +87,12 @@ module.exports = [
       'no-shadow': 'error',
       'no-global-assign': 'error',
       'no-implied-eval': 'error'
+    }
+  },
+  {
+    files: moduleFiles,
+    languageOptions: {
+      sourceType: 'module'
     }
   }
 ]

--- a/quickstart.py
+++ b/quickstart.py
@@ -403,6 +403,15 @@ LOGSCAN_PROGRESS_CACHE = {"mtime": None, "size": None, "data": None}
 
 VALIDATION_DOC_BASE = "/step/"
 VALIDATION_DOC_FALLBACK = "/step/900-kometa"
+# Page scripts that have been migrated to ES modules (roadmap step 2,
+# issue #1346). The template renders <script type="module"> for these and
+# stays on classic <script defer> for everything else. Add a template name
+# here when its JS file becomes a module.
+MODULE_PAGE_SCRIPTS = frozenset(
+    {
+        "080-gotify",
+    }
+)
 VALIDATION_DOCS = {
     "settings": f"{VALIDATION_DOC_BASE}150-settings",
     "libraries": f"{VALIDATION_DOC_BASE}025-libraries",
@@ -1887,6 +1896,7 @@ def step(name):
     page_info["header_style"] = header_style
     page_info["save_error"] = save_error
     page_info["template_name"] = name
+    page_info["template_uses_module"] = name in MODULE_PAGE_SCRIPTS
     page_info.update(_build_kometa_install_context(selected_config))
     settings_payload = persistence.retrieve_settings("150-settings") or {}
     settings_section = settings_payload.get("settings", {}) if isinstance(settings_payload, dict) else {}

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -4241,3 +4241,18 @@ style.textContent = `
   }
 `
 document.head.appendChild(style)
+
+// Module compatibility shims.
+// Now that this file loads as type="module", its top-level declarations are
+// no longer visible to unconverted classic <script> pages. Re-publish the
+// names that other files reference until those files are themselves modules.
+// Remove each entry as its consumers are converted.
+window.escapeHtml = escapeHtml
+window.hideNavigationLoadingOverlay = hideNavigationLoadingOverlay
+window.hideSpinner = hideSpinner
+window.jumpTo = jumpTo
+window.loading = loading
+window.setButtonIconAndText = setButtonIconAndText
+window.showNavigationLoadingOverlay = showNavigationLoadingOverlay
+window.showSpinner = showSpinner
+window.showToast = showToast

--- a/static/local-js/080-gotify.js
+++ b/static/local-js/080-gotify.js
@@ -1,15 +1,4 @@
-function refreshValidationCallout () {
-  if (window.QSValidationCallouts && typeof window.QSValidationCallouts.refresh === 'function') {
-    window.QSValidationCallouts.refresh('gotify_validated')
-  }
-}
-
-function setToggleButtonIcon (button, showPlainText) {
-  if (!button) return
-  const icon = document.createElement('i')
-  icon.className = showPlainText ? 'fas fa-eye-slash' : 'fas fa-eye'
-  button.replaceChildren(icon)
-}
+import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
 
 const validatedAtInput = document.getElementById('gotify_validated_at')
 
@@ -38,14 +27,14 @@ $(document).ready(function () {
     document.getElementById('gotify_validated').value = 'false'
     if (validatedAtInput) validatedAtInput.value = ''
     validateButton.disabled = false
-    refreshValidationCallout()
+    refreshValidationCallout('gotify_validated')
   })
 
   document.getElementById('gotify_url').addEventListener('input', function () {
     document.getElementById('gotify_validated').value = 'false'
     if (validatedAtInput) validatedAtInput.value = ''
     validateButton.disabled = false
-    refreshValidationCallout()
+    refreshValidationCallout('gotify_validated')
   })
 })
 
@@ -88,14 +77,14 @@ document.getElementById('validateButton').addEventListener('click', function () 
         hideSpinner('validate')
         document.getElementById('gotify_validated').value = 'true'
         if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-        refreshValidationCallout()
+        refreshValidationCallout('gotify_validated')
         statusMessage.textContent = 'Gotify credentials validated successfully!'
         statusMessage.style.color = '#75b798'
       } else {
         hideSpinner('validate')
         document.getElementById('gotify_validated').value = 'false'
         if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout()
+        refreshValidationCallout('gotify_validated')
         statusMessage.textContent = data.error
         statusMessage.style.color = '#ea868f'
       }
@@ -109,6 +98,6 @@ document.getElementById('validateButton').addEventListener('click', function () 
       statusMessage.style.color = '#ea868f'
       statusMessage.style.display = 'block'
       if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout()
+      refreshValidationCallout('gotify_validated')
     })
 })

--- a/static/local-js/modules/validationPageBase.js
+++ b/static/local-js/modules/validationPageBase.js
@@ -1,0 +1,18 @@
+// Shared helpers used by every credential-style wizard page.
+//
+// Eliminates the 13x duplication of setToggleButtonIcon and the 15x
+// duplication of refreshValidationCallout that grew because the codebase
+// had no module system. Page scripts import these as needed.
+
+export function setToggleButtonIcon (button, showPlainText) {
+  if (!button) return
+  const icon = document.createElement('i')
+  icon.className = showPlainText ? 'fas fa-eye-slash' : 'fas fa-eye'
+  button.replaceChildren(icon)
+}
+
+export function refreshValidationCallout (fieldName) {
+  if (window.QSValidationCallouts && typeof window.QSValidationCallouts.refresh === 'function') {
+    window.QSValidationCallouts.refresh(fieldName)
+  }
+}

--- a/templates/000-base.html
+++ b/templates/000-base.html
@@ -74,10 +74,10 @@
     window.QS_TRAKT_REQUIREMENT_REASONS = {{ (trakt_requirement_reasons if trakt_requirement_reasons is defined else []) | tojson }};
     window.QS_MAL_REQUIREMENT_REASONS = {{ (mal_requirement_reasons if mal_requirement_reasons is defined else []) | tojson }};
   </script>
-  <script type="text/javascript" src="{{ url_for('static', filename='local-js/000-base.js') }}" defer></script>
-  <script type="text/javascript" src="{{ url_for('static', filename='local-js/pathValidation.js') }}" defer></script>
-  <script type="text/javascript" src="{{ url_for('static', filename='local-js/urlValidation.js') }}" defer></script>
-  <script type="text/javascript" src="{{ url_for('static', filename='local-js/templateStringList.js') }}" defer></script>
+  <script type="module" src="{{ url_for('static', filename='local-js/000-base.js') }}"></script>
+  <script type="module" src="{{ url_for('static', filename='local-js/pathValidation.js') }}"></script>
+  <script type="module" src="{{ url_for('static', filename='local-js/urlValidation.js') }}"></script>
+  <script type="module" src="{{ url_for('static', filename='local-js/templateStringList.js') }}"></script>
   <div class="header-container text-center">
     <img src="{{ url_for('static', filename='images/logo.webp') }}" alt="QUICKSTART" class="header-image" />
   </div>
@@ -144,8 +144,13 @@
   <script type="text/javascript"
     src="{{ url_for('static', filename='local-js/001-start.js') }}" defer></script>
   {% if page_info['template_name'] != '001-start' %}
+  {% if page_info.get('template_uses_module') %}
+  <script type="module"
+    src="{{ url_for('static', filename='local-js/' + page_info['template_name'] + '.js') }}"></script>
+  {% else %}
   <script type="text/javascript"
     src="{{ url_for('static', filename='local-js/' + page_info['template_name'] + '.js') }}" defer></script>
+  {% endif %}
   {% endif %}
 
   <!-- Footer -->


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

First slice of roadmap step 2 (ES modules) per the plan in #1346. Establishes the migration pattern with the smallest reviewable change.

### What this PR does

**1. Extracts the shared validation helpers into a new module**

`static/local-js/modules/validationPageBase.js` exports two functions that are currently copy-pasted across the wizard pages:

- `setToggleButtonIcon(button, showPlainText)` — 13 byte-identical copies today
- `refreshValidationCallout(fieldName)` — 15 copies today, now parameterised on the field name (the only variation that existed across copies)

**2. Flips the 4 always-loaded base scripts to `type="module"`**

- `000-base.js`, `pathValidation.js`, `urlValidation.js`, `templateStringList.js` now load as `<script type="module">` from `templates/000-base.html` (`defer` is implicit for modules).

Because module scope is isolated, the 28 unconverted classic-script pages can no longer see top-level declarations from these files. A 9-name `window.*` shim block at the bottom of `000-base.js` republishes the names that other files reach for:

```js
window.escapeHtml = escapeHtml
window.hideNavigationLoadingOverlay = hideNavigationLoadingOverlay
window.hideSpinner = hideSpinner
window.jumpTo = jumpTo
window.loading = loading
window.setButtonIconAndText = setButtonIconAndText
window.showNavigationLoadingOverlay = showNavigationLoadingOverlay
window.showSpinner = showSpinner
window.showToast = showToast
```

The other three base files already self-publish via `window.PathValidation`, `window.URLValidation`, and `window.QSTemplateStringLists` — no new shims needed.

Each shim entry comes off as its consumers are themselves converted to modules.

**3. Converts `080-gotify.js` as the reference page**

- Drops the two duplicated function copies
- Imports them: `import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'`
- `refreshValidationCallout()` calls become `refreshValidationCallout('gotify_validated')`
- Remaining cross-file references (`$`, `showSpinner`, `hideSpinner`) still resolve via `window.*` until their producers are converted in later PRs

**4. Template + Python plumbing for per-page module flag**

- `quickstart.py` gains `MODULE_PAGE_SCRIPTS = frozenset({"080-gotify"})` — the registry of converted pages. Add an entry when a page is converted.
- `page_info["template_uses_module"] = name in MODULE_PAGE_SCRIPTS`
- `templates/000-base.html` renders `<script type="module">` when that flag is true, otherwise the classic `<script type="text/javascript" defer>` as today.

**5. ESLint config split for module vs. classic files**

`eslint.config.js` gains a second config block that flips `sourceType` to `'module'` for the converted files and everything under `modules/**`. The `moduleFiles` list is the explicit registry of what's been migrated; keep it in sync with `MODULE_PAGE_SCRIPTS` for page scripts.

The per-file `/* global */` headers stay on the converted files for the benefit of the legacy `standard` pre-commit hook, which doesn't read `eslint.config.js`. They become redundant once #1345 lands.

### What this PR does NOT do

- Convert any other page script (PR 2b will batch-convert the remaining 14 simple wizards using this same recipe)
- Touch the complex handlers (`overlayHandler.js`, `eventHandler.js`, `025-libraries.js`) — those are scoped for PRs 2e–2h
- Remove jQuery (Step 7 of the roadmap)
- Strip the redundant `/* global */` headers (#1345)
- Address the `standard` vs. ESLint overlap (separate discussion)

### Verification

- `pre-commit run --all-files` passes (all 11 hooks including `standard` and `eslint`)
- `pytest` — **961 passed**, 26 e2e deselected by default
- `pytest -m e2e tests/e2e/test_wizard_e2e.py` — **5 passed** (includes `test_wizard_happy_path_all_steps` which walks every wizard page including 080-gotify)
- `pytest -m e2e tests/e2e/test_collection_layout_e2e.py` — 1 passed
- `pytest -m e2e tests/e2e/test_ratings_overlay_e2e.py` — 9 passed
- `pytest -m e2e tests/e2e/test_final_yaml_ratings_e2e.py` — 4 passed
- `pytest -m e2e tests/e2e/test_final_page_e2e.py` — 5 passed, 1 fails identically on `develop` (pip-not-found in test venv fixture — unrelated to this PR)
- Manual render check: `/step/080-gotify` renders `<script type="module">` for the page script; `/step/040-github` (not in `MODULE_PAGE_SCRIPTS`) still renders `<script type="text/javascript" defer>` as today

### Diff size

```
 eslint.config.js                      | 19 +++++++++++++++++++
 quickstart.py                         |  9 +++++++++
 static/local-js/000-base.js           | 19 +++++++++++++++++++
 static/local-js/080-gotify.js         | 28 ++++++++++------------------
 static/local-js/modules/validationPageBase.js | 19 +++++++++++++++++++
 static/local-js/pathValidation.js     |  4 ++++
 static/local-js/templateStringList.js |  4 ++++
 static/local-js/urlValidation.js      |  4 ++++
 templates/000-base.html               | 13 +++++++++----
 9 files changed, 113 insertions(+), 22 deletions(-)
```

## Related Issues

- Part of #1346 (Step 2 plan and PR sequence)
- Roadmap #1335
- Prereq #1344 (ESLint setup, already merged)

## Which Environment Did You Test On?

- [x] Local Install (Linux via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
