### PR TITLE
Convert 14 simple wizard scripts to ES modules (PR 2b of #1346)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: '^.*bootstrap.bundle.js$|^tests/fixtures/'
+exclude: '^.*bootstrap.bundle.js$|^tests/fixtures/|^PART$'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -66,7 +66,21 @@ const moduleFiles = [
   'static/local-js/pathValidation.js',
   'static/local-js/urlValidation.js',
   'static/local-js/templateStringList.js',
-  'static/local-js/080-gotify.js'
+  'static/local-js/010-plex.js',
+  'static/local-js/020-tmdb.js',
+  'static/local-js/030-tautulli.js',
+  'static/local-js/040-github.js',
+  'static/local-js/050-omdb.js',
+  'static/local-js/060-mdblist.js',
+  'static/local-js/070-notifiarr.js',
+  'static/local-js/080-gotify.js',
+  'static/local-js/085-ntfy.js',
+  'static/local-js/087-apprise.js',
+  'static/local-js/090-webhooks.js',
+  'static/local-js/110-radarr.js',
+  'static/local-js/120-sonarr.js',
+  'static/local-js/130-trakt.js',
+  'static/local-js/140-mal.js'
 ]
 
 module.exports = [

--- a/quickstart.py
+++ b/quickstart.py
@@ -409,7 +409,21 @@ VALIDATION_DOC_FALLBACK = "/step/900-kometa"
 # here when its JS file becomes a module.
 MODULE_PAGE_SCRIPTS = frozenset(
     {
+        "010-plex",
+        "020-tmdb",
+        "030-tautulli",
+        "040-github",
+        "050-omdb",
+        "060-mdblist",
+        "070-notifiarr",
         "080-gotify",
+        "085-ntfy",
+        "087-apprise",
+        "090-webhooks",
+        "110-radarr",
+        "120-sonarr",
+        "130-trakt",
+        "140-mal",
     }
 )
 VALIDATION_DOCS = {

--- a/static/local-js/010-plex.js
+++ b/static/local-js/010-plex.js
@@ -1,15 +1,4 @@
-function refreshValidationCallout () {
-  if (window.QSValidationCallouts && typeof window.QSValidationCallouts.refresh === 'function') {
-    window.QSValidationCallouts.refresh('plex_validated')
-  }
-}
-
-function setToggleButtonIcon (button, showPlainText) {
-  if (!button) return
-  const icon = document.createElement('i')
-  icon.className = showPlainText ? 'fas fa-eye-slash' : 'fas fa-eye'
-  button.replaceChildren(icon)
-}
+import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
 
 $(document).ready(function () {
   const validateButton = document.getElementById('validateButton')
@@ -44,14 +33,14 @@ $(document).ready(function () {
     validateButton.disabled = false
     document.getElementById('plex_validated').value = 'false'
     if (validatedAtInput) validatedAtInput.value = ''
-    refreshValidationCallout()
+    refreshValidationCallout('plex_validated')
   })
 
   plexUrlInput.addEventListener('input', function () {
     validateButton.disabled = false
     document.getElementById('plex_validated').value = 'false'
     if (validatedAtInput) validatedAtInput.value = ''
-    refreshValidationCallout()
+    refreshValidationCallout('plex_validated')
   })
 })
 
@@ -122,7 +111,7 @@ document.getElementById('validateButton').addEventListener('click', function () 
 
         document.getElementById('plex_validated').value = 'true'
         if (validatedAtField) validatedAtField.value = new Date().toISOString()
-        refreshValidationCallout()
+        refreshValidationCallout('plex_validated')
 
         statusMessage.textContent = 'Plex server validated successfully!'
         statusMessage.style.color = '#75b798'
@@ -145,7 +134,7 @@ document.getElementById('validateButton').addEventListener('click', function () 
         validateButton.disabled = false
         document.getElementById('plex_validated').value = false
         if (validatedAtField) validatedAtField.value = ''
-        refreshValidationCallout()
+        refreshValidationCallout('plex_validated')
         statusMessage.textContent = 'Failed to validate Plex server. Please check your URL and Token.'
         statusMessage.style.color = '#ea868f'
       }
@@ -160,6 +149,6 @@ document.getElementById('validateButton').addEventListener('click', function () 
       statusMessage.style.display = 'block'
       const validatedAtInput = document.getElementById('plex_validated_at')
       if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout()
+      refreshValidationCallout('plex_validated')
     })
 })

--- a/static/local-js/020-tmdb.js
+++ b/static/local-js/020-tmdb.js
@@ -1,15 +1,4 @@
-function refreshValidationCallout () {
-  if (window.QSValidationCallouts && typeof window.QSValidationCallouts.refresh === 'function') {
-    window.QSValidationCallouts.refresh('tmdb_validated')
-  }
-}
-
-function setToggleButtonIcon (button, showPlainText) {
-  if (!button) return
-  const icon = document.createElement('i')
-  icon.className = showPlainText ? 'fas fa-eye-slash' : 'fas fa-eye'
-  button.replaceChildren(icon)
-}
+import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
 
 document.addEventListener('DOMContentLoaded', function () {
   const validateButton = document.getElementById('validateButton')
@@ -102,13 +91,13 @@ document.addEventListener('DOMContentLoaded', function () {
         if (data.valid) {
           tmdbValidatedInput.value = 'true'
           if (tmdbValidatedAtInput) tmdbValidatedAtInput.value = new Date().toISOString()
-          refreshValidationCallout()
+          refreshValidationCallout('tmdb_validated')
           statusMessage.textContent = 'API key is valid!'
           statusMessage.style.color = '#75b798' // Green
         } else {
           tmdbValidatedInput.value = 'false'
           if (tmdbValidatedAtInput) tmdbValidatedAtInput.value = ''
-          refreshValidationCallout()
+          refreshValidationCallout('tmdb_validated')
           statusMessage.textContent = 'Failed to validate TMDb. Please check your API Key.'
           statusMessage.style.color = '#ea868f' // Red
         }
@@ -119,7 +108,7 @@ document.addEventListener('DOMContentLoaded', function () {
         statusMessage.textContent = 'An error occurred. Please try again.'
         statusMessage.style.color = '#ea868f' // Red
         if (tmdbValidatedAtInput) tmdbValidatedAtInput.value = ''
-        refreshValidationCallout()
+        refreshValidationCallout('tmdb_validated')
       })
       .finally(() => {
         hideSpinner('validate')
@@ -138,7 +127,7 @@ document.addEventListener('DOMContentLoaded', function () {
   apiKeyInput.addEventListener('input', function () {
     tmdbValidatedInput.value = 'false' // Mark API key as invalid
     if (tmdbValidatedAtInput) tmdbValidatedAtInput.value = ''
-    refreshValidationCallout()
+    refreshValidationCallout('tmdb_validated')
     validateButton.disabled = false // Re-enable the validate button
     statusMessage.style.display = 'none' // Hide validation message
     updateNavigationState() // Disable Next and JumpTo

--- a/static/local-js/030-tautulli.js
+++ b/static/local-js/030-tautulli.js
@@ -1,15 +1,4 @@
-function refreshValidationCallout () {
-  if (window.QSValidationCallouts && typeof window.QSValidationCallouts.refresh === 'function') {
-    window.QSValidationCallouts.refresh('tautulli_validated')
-  }
-}
-
-function setToggleButtonIcon (button, showPlainText) {
-  if (!button) return
-  const icon = document.createElement('i')
-  icon.className = showPlainText ? 'fas fa-eye-slash' : 'fas fa-eye'
-  button.replaceChildren(icon)
-}
+import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
 
 const validatedAtInput = document.getElementById('tautulli_validated_at')
 
@@ -38,14 +27,14 @@ $(document).ready(function () {
     document.getElementById('tautulli_validated').value = 'false'
     if (validatedAtInput) validatedAtInput.value = ''
     validateButton.disabled = false
-    refreshValidationCallout()
+    refreshValidationCallout('tautulli_validated')
   })
 
   urlInput.addEventListener('input', function () {
     document.getElementById('tautulli_validated').value = 'false'
     if (validatedAtInput) validatedAtInput.value = ''
     validateButton.disabled = false
-    refreshValidationCallout()
+    refreshValidationCallout('tautulli_validated')
   })
 })
 
@@ -84,14 +73,14 @@ document.getElementById('validateButton').addEventListener('click', function () 
         hideSpinner('validate')
         document.getElementById('tautulli_validated').value = 'true'
         if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-        refreshValidationCallout()
+        refreshValidationCallout('tautulli_validated')
         statusMessage.textContent = 'Tautulli server validated successfully!'
         statusMessage.style.color = '#75b798'
         document.getElementById('validateButton').disabled = true
       } else {
         document.getElementById('tautulli_validated').value = 'false'
         if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout()
+        refreshValidationCallout('tautulli_validated')
         statusMessage.textContent = 'Failed to validate Tautulli server. Please check your URL and API Key.'
         statusMessage.style.color = '#ea868f'
       }
@@ -103,7 +92,7 @@ document.getElementById('validateButton').addEventListener('click', function () 
       statusMessage.style.color = '#ea868f'
       statusMessage.style.display = 'block'
       if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout()
+      refreshValidationCallout('tautulli_validated')
     })
     .finally(() => {
       hideSpinner('validate')

--- a/static/local-js/040-github.js
+++ b/static/local-js/040-github.js
@@ -1,15 +1,4 @@
-function refreshValidationCallout () {
-  if (window.QSValidationCallouts && typeof window.QSValidationCallouts.refresh === 'function') {
-    window.QSValidationCallouts.refresh('github_validated')
-  }
-}
-
-function setToggleButtonIcon (button, showPlainText) {
-  if (!button) return
-  const icon = document.createElement('i')
-  icon.className = showPlainText ? 'fas fa-eye-slash' : 'fas fa-eye'
-  button.replaceChildren(icon)
-}
+import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
 
 const validatedAtInput = document.getElementById('github_validated_at')
 
@@ -37,7 +26,7 @@ $(document).ready(function () {
     document.getElementById('github_validated').value = 'false'
     if (validatedAtInput) validatedAtInput.value = ''
     validateButton.disabled = false
-    refreshValidationCallout()
+    refreshValidationCallout('github_validated')
   })
 })
 
@@ -77,13 +66,13 @@ document.getElementById('validateButton').addEventListener('click', function () 
         document.getElementById('validateButton').disabled = true
         document.getElementById('github_validated').value = 'true'
         if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-        refreshValidationCallout()
+        refreshValidationCallout('github_validated')
       } else {
         statusMessage.textContent = data.message
         statusMessage.style.color = '#ea868f'
         document.getElementById('github_validated').value = 'false'
         if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout()
+        refreshValidationCallout('github_validated')
       }
       statusMessage.style.display = 'block'
     })
@@ -95,7 +84,7 @@ document.getElementById('validateButton').addEventListener('click', function () 
       statusMessage.style.display = 'block'
       document.getElementById('github_validated').value = 'false'
       if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout()
+      refreshValidationCallout('github_validated')
     })
 })
 

--- a/static/local-js/050-omdb.js
+++ b/static/local-js/050-omdb.js
@@ -1,15 +1,4 @@
-function refreshValidationCallout () {
-  if (window.QSValidationCallouts && typeof window.QSValidationCallouts.refresh === 'function') {
-    window.QSValidationCallouts.refresh('omdb_validated')
-  }
-}
-
-function setToggleButtonIcon (button, showPlainText) {
-  if (!button) return
-  const icon = document.createElement('i')
-  icon.className = showPlainText ? 'fas fa-eye-slash' : 'fas fa-eye'
-  button.replaceChildren(icon)
-}
+import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
 
 const validatedAtInput = document.getElementById('omdb_validated_at')
 
@@ -37,7 +26,7 @@ $(document).ready(function () {
     document.getElementById('omdb_validated').value = 'false'
     if (validatedAtInput) validatedAtInput.value = ''
     validateButton.disabled = false
-    refreshValidationCallout()
+    refreshValidationCallout('omdb_validated')
   })
 })
 
@@ -74,7 +63,7 @@ document.getElementById('validateButton').addEventListener('click', function () 
         hideSpinner('validate')
         document.getElementById('omdb_validated').value = 'true'
         if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-        refreshValidationCallout()
+        refreshValidationCallout('omdb_validated')
         statusMessage.textContent = 'OMDb API key is valid.'
         statusMessage.style.color = '#75b798'
         document.getElementById('validateButton').disabled = true
@@ -84,7 +73,7 @@ document.getElementById('validateButton').addEventListener('click', function () 
         if (validatedAtInput) validatedAtInput.value = ''
         statusMessage.textContent = 'OMDb API key is invalid.'
         statusMessage.style.color = '#ea868f'
-        refreshValidationCallout()
+        refreshValidationCallout('omdb_validated')
       }
       statusMessage.style.display = 'block'
     })
@@ -96,7 +85,7 @@ document.getElementById('validateButton').addEventListener('click', function () 
       statusMessage.style.display = 'block'
       document.getElementById('omdb_validated').value = 'false'
       if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout()
+      refreshValidationCallout('omdb_validated')
     })
 })
 

--- a/static/local-js/060-mdblist.js
+++ b/static/local-js/060-mdblist.js
@@ -1,15 +1,4 @@
-function refreshValidationCallout () {
-  if (window.QSValidationCallouts && typeof window.QSValidationCallouts.refresh === 'function') {
-    window.QSValidationCallouts.refresh('mdblist_validated')
-  }
-}
-
-function setToggleButtonIcon (button, showPlainText) {
-  if (!button) return
-  const icon = document.createElement('i')
-  icon.className = showPlainText ? 'fas fa-eye-slash' : 'fas fa-eye'
-  button.replaceChildren(icon)
-}
+import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
 
 $(document).ready(function () {
   const apiKeyInput = document.getElementById('mdblist_apikey')
@@ -37,7 +26,7 @@ $(document).ready(function () {
     document.getElementById('mdblist_validated').value = 'false'
     if (validatedAtInput) validatedAtInput.value = ''
     validateButton.disabled = false
-    refreshValidationCallout()
+    refreshValidationCallout('mdblist_validated')
   })
 
   document.getElementById('validateButton').addEventListener('click', function () {
@@ -67,7 +56,7 @@ $(document).ready(function () {
           hideSpinner('validate')
           document.getElementById('mdblist_validated').value = 'true'
           if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-          refreshValidationCallout()
+          refreshValidationCallout('mdblist_validated')
           statusMessage.textContent = 'API key is valid!'
           statusMessage.style.color = '#75b798'
           validateButton.disabled = true
@@ -75,7 +64,7 @@ $(document).ready(function () {
           console.log('NOT valid')
           document.getElementById('mdblist_validated').value = 'false'
           if (validatedAtInput) validatedAtInput.value = ''
-          refreshValidationCallout()
+          refreshValidationCallout('mdblist_validated')
           statusMessage.textContent = 'Failed to validate MDBList server. Please check your API Key.'
           statusMessage.style.color = '#ea868f'
         }
@@ -87,7 +76,7 @@ $(document).ready(function () {
         statusMessage.style.color = '#ea868f'
         statusMessage.style.display = 'block'
         if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout()
+        refreshValidationCallout('mdblist_validated')
       })
       .finally(() => {
         hideSpinner('validate')

--- a/static/local-js/070-notifiarr.js
+++ b/static/local-js/070-notifiarr.js
@@ -1,15 +1,4 @@
-function refreshValidationCallout () {
-  if (window.QSValidationCallouts && typeof window.QSValidationCallouts.refresh === 'function') {
-    window.QSValidationCallouts.refresh('notifiarr_validated')
-  }
-}
-
-function setToggleButtonIcon (button, showPlainText) {
-  if (!button) return
-  const icon = document.createElement('i')
-  icon.className = showPlainText ? 'fas fa-eye-slash' : 'fas fa-eye'
-  button.replaceChildren(icon)
-}
+import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
 
 const validatedAtInput = document.getElementById('notifiarr_validated_at')
 
@@ -38,7 +27,7 @@ $(document).ready(function () {
     document.getElementById('notifiarr_validated').value = 'false'
     if (validatedAtInput) validatedAtInput.value = ''
     validateButton.disabled = false
-    refreshValidationCallout()
+    refreshValidationCallout('notifiarr_validated')
   })
 })
 
@@ -82,14 +71,14 @@ document.getElementById('validateButton').addEventListener('click', function () 
     if (isValid) {
       document.getElementById('notifiarr_validated').value = 'true'
       if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-      refreshValidationCallout()
+      refreshValidationCallout('notifiarr_validated')
       statusMessage.textContent = 'Notifiarr API key is valid.'
       statusMessage.style.color = '#75b798'
       validateButton.disabled = true
     } else {
       document.getElementById('notifiarr_validated').value = 'false'
       if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout()
+      refreshValidationCallout('notifiarr_validated')
       statusMessage.textContent = 'Notifiarr API key is invalid.'
       statusMessage.style.color = '#ea868f'
       validateButton.disabled = false

--- a/static/local-js/085-ntfy.js
+++ b/static/local-js/085-ntfy.js
@@ -1,15 +1,4 @@
-function refreshValidationCallout () {
-  if (window.QSValidationCallouts && typeof window.QSValidationCallouts.refresh === 'function') {
-    window.QSValidationCallouts.refresh('ntfy_validated')
-  }
-}
-
-function setToggleButtonIcon (button, showPlainText) {
-  if (!button) return
-  const icon = document.createElement('i')
-  icon.className = showPlainText ? 'fas fa-eye-slash' : 'fas fa-eye'
-  button.replaceChildren(icon)
-}
+import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
 
 const validatedAtInput = document.getElementById('ntfy_validated_at')
 
@@ -40,21 +29,21 @@ $(document).ready(function () {
     document.getElementById('ntfy_validated').value = 'false'
     if (validatedAtInput) validatedAtInput.value = ''
     validateButton.disabled = false
-    refreshValidationCallout()
+    refreshValidationCallout('ntfy_validated')
   })
 
   document.getElementById('ntfy_url').addEventListener('input', function () {
     document.getElementById('ntfy_validated').value = 'false'
     if (validatedAtInput) validatedAtInput.value = ''
     validateButton.disabled = false
-    refreshValidationCallout()
+    refreshValidationCallout('ntfy_validated')
   })
 
   document.getElementById('ntfy_topic').addEventListener('input', function () {
     document.getElementById('ntfy_validated').value = 'false'
     if (validatedAtInput) validatedAtInput.value = ''
     validateButton.disabled = false
-    refreshValidationCallout()
+    refreshValidationCallout('ntfy_validated')
   })
 })
 
@@ -99,14 +88,14 @@ document.getElementById('validateButton').addEventListener('click', function () 
         hideSpinner('validate')
         document.getElementById('ntfy_validated').value = 'true'
         if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-        refreshValidationCallout()
+        refreshValidationCallout('ntfy_validated')
         statusMessage.textContent = 'ntfy credentials validated successfully! Ensure you are subscribed to topic to see test message.'
         statusMessage.style.color = '#75b798'
       } else {
         hideSpinner('validate')
         document.getElementById('ntfy_validated').value = 'false'
         if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout()
+        refreshValidationCallout('ntfy_validated')
         statusMessage.textContent = data.error
         statusMessage.style.color = '#ea868f'
       }
@@ -120,6 +109,6 @@ document.getElementById('validateButton').addEventListener('click', function () 
       statusMessage.style.color = '#ea868f'
       statusMessage.style.display = 'block'
       if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout()
+      refreshValidationCallout('ntfy_validated')
     })
 })

--- a/static/local-js/087-apprise.js
+++ b/static/local-js/087-apprise.js
@@ -1,8 +1,4 @@
-function refreshValidationCallout () {
-  if (window.QSValidationCallouts && typeof window.QSValidationCallouts.refresh === 'function') {
-    window.QSValidationCallouts.refresh('apprise_validated')
-  }
-}
+import { refreshValidationCallout } from './modules/validationPageBase.js'
 
 const validatedAtInput = document.getElementById('apprise_validated_at')
 
@@ -17,7 +13,7 @@ $(document).ready(function () {
     document.getElementById('apprise_validated').value = 'false'
     if (validatedAtInput) validatedAtInput.value = ''
     validateButton.disabled = false
-    refreshValidationCallout()
+    refreshValidationCallout('apprise_validated')
   })
 })
 
@@ -49,13 +45,13 @@ document.getElementById('validateButton').addEventListener('click', function () 
       if (data.valid) {
         document.getElementById('apprise_validated').value = 'true'
         if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-        refreshValidationCallout()
+        refreshValidationCallout('apprise_validated')
         statusMessage.textContent = 'Apprise location validated successfully!'
         statusMessage.style.color = '#75b798'
       } else {
         document.getElementById('apprise_validated').value = 'false'
         if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout()
+        refreshValidationCallout('apprise_validated')
         statusMessage.textContent = data.error
         statusMessage.style.color = '#ea868f'
       }
@@ -67,7 +63,7 @@ document.getElementById('validateButton').addEventListener('click', function () 
       console.error('Error validating Apprise location:', error)
       document.getElementById('apprise_validated').value = 'false'
       if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout()
+      refreshValidationCallout('apprise_validated')
       statusMessage.textContent = 'An error occurred while validating the Apprise location.'
       statusMessage.style.color = '#ea868f'
       statusMessage.style.display = 'block'

--- a/static/local-js/090-webhooks.js
+++ b/static/local-js/090-webhooks.js
@@ -1,8 +1,4 @@
-function refreshValidationCallout () {
-  if (window.QSValidationCallouts && typeof window.QSValidationCallouts.refresh === 'function') {
-    window.QSValidationCallouts.refresh('webhooks_validated')
-  }
-}
+import { refreshValidationCallout } from './modules/validationPageBase.js'
 
 const validatedWebhooks = {}
 const validatedAtInput = document.getElementById('webhooks_validated_at')
@@ -29,7 +25,7 @@ function hasConfiguredWebhooks () {
 
 function setWebhookValidated (state, webhookType = null) {
   document.getElementById('webhooks_validated').value = state ? 'true' : 'false'
-  refreshValidationCallout()
+  refreshValidationCallout('webhooks_validated')
 
   if (webhookType) {
     // Enable the validate button if the URL changes and validation is false

--- a/static/local-js/110-radarr.js
+++ b/static/local-js/110-radarr.js
@@ -1,17 +1,6 @@
-function refreshValidationCallout () {
-  if (window.QSValidationCallouts && typeof window.QSValidationCallouts.refresh === 'function') {
-    window.QSValidationCallouts.refresh('radarr_validated')
-  }
-}
+import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
 
 const validatedAtInput = document.getElementById('radarr_validated_at')
-
-function setToggleButtonIcon (button, showPlainText) {
-  if (!button) return
-  const icon = document.createElement('i')
-  icon.className = showPlainText ? 'fas fa-eye-slash' : 'fas fa-eye'
-  button.replaceChildren(icon)
-}
 
 function setStatusMessageLines (element, messages) {
   if (!element) return
@@ -63,14 +52,14 @@ $(document).ready(function () {
     document.getElementById('radarr_validated').value = 'false'
     if (validatedAtInput) validatedAtInput.value = ''
     document.getElementById('validateButton').disabled = false
-    refreshValidationCallout()
+    refreshValidationCallout('radarr_validated')
   })
 
   document.getElementById('radarr_url').addEventListener('input', function () {
     document.getElementById('radarr_validated').value = 'false'
     if (validatedAtInput) validatedAtInput.value = ''
     document.getElementById('validateButton').disabled = false
-    refreshValidationCallout()
+    refreshValidationCallout('radarr_validated')
   })
 
   // Attach event listeners for validation and toggle functionality
@@ -190,7 +179,7 @@ function validateRadarrApi () {
       if (data.valid) {
         document.getElementById('radarr_validated').value = 'true'
         if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-        refreshValidationCallout()
+        refreshValidationCallout('radarr_validated')
         statusMessage.textContent = 'Radarr API key is valid.'
         statusMessage.style.color = '#75b798'
         statusMessage.style.display = 'block'
@@ -201,7 +190,7 @@ function validateRadarrApi () {
       } else {
         document.getElementById('radarr_validated').value = 'false'
         if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout()
+        refreshValidationCallout('radarr_validated')
         console.log('Error validating Radarr', data.message)
         statusMessage.textContent = 'Failed to validate Radarr server. Please check your URL and Token.'
         statusMessage.style.color = '#ea868f'
@@ -216,7 +205,7 @@ function validateRadarrApi () {
       statusMessage.style.display = 'block'
       document.getElementById('radarr_validated').value = 'false'
       if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout()
+      refreshValidationCallout('radarr_validated')
     })
 }
 

--- a/static/local-js/120-sonarr.js
+++ b/static/local-js/120-sonarr.js
@@ -1,17 +1,6 @@
-function refreshValidationCallout () {
-  if (window.QSValidationCallouts && typeof window.QSValidationCallouts.refresh === 'function') {
-    window.QSValidationCallouts.refresh('sonarr_validated')
-  }
-}
+import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
 
 const validatedAtInput = document.getElementById('sonarr_validated_at')
-
-function setToggleButtonIcon (button, showPlainText) {
-  if (!button) return
-  const icon = document.createElement('i')
-  icon.className = showPlainText ? 'fas fa-eye-slash' : 'fas fa-eye'
-  button.replaceChildren(icon)
-}
 
 function setStatusMessageLines (element, messages) {
   if (!element) return
@@ -65,14 +54,14 @@ $(document).ready(function () {
     document.getElementById('sonarr_validated').value = 'false'
     if (validatedAtInput) validatedAtInput.value = ''
     document.getElementById('validateButton').disabled = false
-    refreshValidationCallout()
+    refreshValidationCallout('sonarr_validated')
   })
 
   document.getElementById('sonarr_url').addEventListener('input', function () {
     document.getElementById('sonarr_validated').value = 'false'
     if (validatedAtInput) validatedAtInput.value = ''
     document.getElementById('validateButton').disabled = false
-    refreshValidationCallout()
+    refreshValidationCallout('sonarr_validated')
   })
 
   // Attach event listeners for validation and toggle functionality
@@ -107,7 +96,7 @@ function validateSonarrApi () {
         hideSpinner('validate')
         document.getElementById('sonarr_validated').value = 'true'
         if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-        refreshValidationCallout()
+        refreshValidationCallout('sonarr_validated')
         statusMessage.textContent = 'Sonarr API key is valid.'
         statusMessage.style.color = '#75b798'
         statusMessage.style.display = 'block'
@@ -120,7 +109,7 @@ function validateSonarrApi () {
         hideSpinner('validate')
         document.getElementById('sonarr_validated').value = 'false'
         if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout()
+        refreshValidationCallout('sonarr_validated')
         console.error('Error validating Sonarr', data.message)
         statusMessage.textContent = 'Failed to validate Sonarr server. Please check your URL and Token.'
         statusMessage.style.color = '#ea868f'
@@ -135,7 +124,7 @@ function validateSonarrApi () {
       statusMessage.style.display = 'block'
       document.getElementById('sonarr_validated').value = 'false'
       if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout()
+      refreshValidationCallout('sonarr_validated')
     })
 }
 

--- a/static/local-js/130-trakt.js
+++ b/static/local-js/130-trakt.js
@@ -1,15 +1,4 @@
-function refreshValidationCallout () {
-  if (window.QSValidationCallouts && typeof window.QSValidationCallouts.refresh === 'function') {
-    window.QSValidationCallouts.refresh('trakt_validated')
-  }
-}
-
-function setToggleButtonIcon (button, showPlainText) {
-  if (!button) return
-  const icon = document.createElement('i')
-  icon.className = showPlainText ? 'fas fa-eye-slash' : 'fas fa-eye'
-  button.replaceChildren(icon)
-}
+import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
 
 const validatedAtInput = document.getElementById('trakt_validated_at')
 
@@ -54,7 +43,7 @@ $(document).ready(function () {
         if (validatedAtInput) validatedAtInput.value = ''
         validateButton.disabled = false
         if (checkTokenButton) checkTokenButton.disabled = true
-        refreshValidationCallout()
+        refreshValidationCallout('trakt_validated')
       })
     } else {
       console.warn(`Warning: Element with ID '${field}' not found.`)
@@ -76,7 +65,7 @@ function updateTraktURL () {
     document.getElementById('trakt_validated').value = 'false'
     const validatedAtField = document.getElementById('trakt_validated_at')
     if (validatedAtField) validatedAtField.value = ''
-    refreshValidationCallout()
+    refreshValidationCallout('trakt_validated')
     myURL = 'https://trakt.tv/oauth/authorize?response_type=code&client_id=' + traktClientId + '&redirect_uri=urn:ietf:wg:oauth:2.0:oob'
   }
   console.log('updateTraktURL: ' + myURL)
@@ -148,7 +137,7 @@ document.getElementById('validate_trakt_pin').addEventListener('click', function
         hideSpinner('validate')
         document.getElementById('trakt_validated').value = 'true'
         if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-        refreshValidationCallout()
+        refreshValidationCallout('trakt_validated')
         statusMessage.textContent = 'Trakt credentials validated successfully!'
         statusMessage.style.color = '#75b798'
         document.getElementById('access_token').value = data.trakt_authorization_access_token
@@ -167,7 +156,7 @@ document.getElementById('validate_trakt_pin').addEventListener('click', function
         hideSpinner('validate')
         document.getElementById('trakt_validated').value = 'false'
         if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout()
+        refreshValidationCallout('trakt_validated')
         statusMessage.textContent = data.error
         statusMessage.style.color = '#ea868f'
       }
@@ -180,7 +169,7 @@ document.getElementById('validate_trakt_pin').addEventListener('click', function
       statusMessage.style.color = '#ea868f'
       statusMessage.style.display = 'block'
       if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout()
+      refreshValidationCallout('trakt_validated')
     })
 })
 
@@ -233,13 +222,13 @@ if (traktCheckButton) {
           }
           document.getElementById('trakt_validated').value = 'true'
           if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-          refreshValidationCallout()
+          refreshValidationCallout('trakt_validated')
           statusMessage.textContent = 'Trakt token is valid.'
           statusMessage.style.color = '#75b798'
         } else {
           document.getElementById('trakt_validated').value = 'false'
           if (validatedAtInput) validatedAtInput.value = ''
-          refreshValidationCallout()
+          refreshValidationCallout('trakt_validated')
           statusMessage.textContent = data.error || 'Trakt token is invalid.'
           statusMessage.style.color = '#ea868f'
         }
@@ -252,7 +241,7 @@ if (traktCheckButton) {
         statusMessage.style.color = '#ea868f'
         statusMessage.style.display = 'block'
         if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout()
+        refreshValidationCallout('trakt_validated')
       })
   })
 }

--- a/static/local-js/140-mal.js
+++ b/static/local-js/140-mal.js
@@ -1,15 +1,4 @@
-function refreshValidationCallout () {
-  if (window.QSValidationCallouts && typeof window.QSValidationCallouts.refresh === 'function') {
-    window.QSValidationCallouts.refresh('mal_validated')
-  }
-}
-
-function setToggleButtonIcon (button, showPlainText) {
-  if (!button) return
-  const icon = document.createElement('i')
-  icon.className = showPlainText ? 'fas fa-eye-slash' : 'fas fa-eye'
-  button.replaceChildren(icon)
-}
+import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
 
 const validatedAtInput = document.getElementById('mal_validated_at')
 
@@ -50,7 +39,7 @@ $(document).ready(function () {
         if (validatedAtInput) validatedAtInput.value = ''
         validateButton.disabled = false
         if (checkTokenButton) checkTokenButton.disabled = true
-        refreshValidationCallout()
+        refreshValidationCallout('mal_validated')
       })
     } else {
       console.warn(`Warning: Element with ID '${field}' not found.`)
@@ -81,7 +70,7 @@ function updateMALTargetURL () {
     document.getElementById('mal_validated').value = 'false'
     const validatedAtField = document.getElementById('mal_validated_at')
     if (validatedAtField) validatedAtField.value = ''
-    refreshValidationCallout()
+    refreshValidationCallout('mal_validated')
     myURL = 'https://myanimelist.net/v1/oauth2/authorize?response_type=code&client_id=' + malClientId + '&code_challenge=' + codeVerifier
   }
   console.log('updateMALTargetURL: ' + myURL)
@@ -153,7 +142,7 @@ document.getElementById('validate_mal_url').addEventListener('click', function (
         hideSpinner('validate')
         document.getElementById('mal_validated').value = 'true'
         if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-        refreshValidationCallout()
+        refreshValidationCallout('mal_validated')
         statusMessage.textContent = 'MyAnimeList credentials validated successfully!'
         statusMessage.style.color = '#75b798'
         document.getElementById('access_token').value = data.mal_authorization_access_token
@@ -168,7 +157,7 @@ document.getElementById('validate_mal_url').addEventListener('click', function (
         hideSpinner('validate')
         document.getElementById('mal_validated').value = 'false'
         if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout()
+        refreshValidationCallout('mal_validated')
         statusMessage.textContent = data.error
         statusMessage.style.color = '#ea868f'
       }
@@ -181,7 +170,7 @@ document.getElementById('validate_mal_url').addEventListener('click', function (
       statusMessage.style.color = '#ea868f'
       statusMessage.style.display = 'block'
       if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout()
+      refreshValidationCallout('mal_validated')
     })
 })
 
@@ -210,13 +199,13 @@ if (malCheckButton) {
         if (data.valid) {
           document.getElementById('mal_validated').value = 'true'
           if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-          refreshValidationCallout()
+          refreshValidationCallout('mal_validated')
           statusMessage.textContent = 'MyAnimeList token is valid.'
           statusMessage.style.color = '#75b798'
         } else {
           document.getElementById('mal_validated').value = 'false'
           if (validatedAtInput) validatedAtInput.value = ''
-          refreshValidationCallout()
+          refreshValidationCallout('mal_validated')
           statusMessage.textContent = data.error || 'MyAnimeList token is invalid.'
           statusMessage.style.color = '#ea868f'
         }
@@ -229,7 +218,7 @@ if (malCheckButton) {
         statusMessage.style.color = '#ea868f'
         statusMessage.style.display = 'block'
         if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout()
+        refreshValidationCallout('mal_validated')
       })
   })
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Second slice of roadmap step 2 (ES modules) per the plan in #1346. Stacks on top of #1348 (PR 2a).

### What this PR does

Mechanical batch-conversion of 14 wizard scripts to ES modules using the recipe established in #1348. The diff is overwhelmingly negative — every deletion is a copy-pasted helper definition.

**Files converted (14):**

| Category | Files |
|---|---|
| Standard wizards with both helpers (12) | `010-plex`, `020-tmdb`, `030-tautulli`, `040-github`, `050-omdb`, `060-mdblist`, `070-notifiarr`, `085-ntfy`, `110-radarr`, `120-sonarr`, `130-trakt`, `140-mal` |
| Refresh-only (no password toggle) (2) | `087-apprise`, `090-webhooks` |

**Per-file recipe (applied identically to every file):**

1. Strip the local `function refreshValidationCallout` definition (5 lines per file).
2. If present, strip the local `function setToggleButtonIcon` definition (6 lines per file).
3. Insert `import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'` immediately after the `/* global */` header. Apprise and webhooks import only `refreshValidationCallout`.
4. Parameterise every bare `refreshValidationCallout()` call site with the page's field name (e.g. `refreshValidationCallout('plex_validated')`).
5. Leave the per-file `/* global */` headers alone — scheduled for removal in #1345.

**66 `refreshValidationCallout` call sites parameterised across the 14 files.** The conversion was scripted to guarantee uniformity across the batch; the script is throwaway and not committed.

**Plumbing changes:**

- `quickstart.py`: `MODULE_PAGE_SCRIPTS` grows from 1 entry (`080-gotify`) to 15.
- `eslint.config.js`: the `moduleFiles` list grows in lockstep so ESLint parses each converted file with `sourceType: 'module'`.

### What this PR does NOT do

- Convert `100-anidb.js` — it doesn't use the validation helpers at all (it's a show/hide toggle for fields). It will land as a leaf module in PR 2d per the plan in #1346.
- Convert the complex pages (`001-start`, `025-libraries`, `150-settings`, `900-kometa`, `905-analytics`, `910-sponsor`, `915-imagemaid`) — scoped for PRs 2d–2h.
- Strip the redundant per-file `/* global */` headers (#1345).
- Remove jQuery, drop the `standard` hook, etc.

### Verification

- `pre-commit run --all-files` passes all 11 hooks
- `pytest` — **961 passed**, 26 e2e deselected by default
- `pytest -m e2e tests/e2e/test_wizard_e2e.py` — **5 passed**. The `test_wizard_happy_path_all_steps` test walks every wizard page including all 14 converted here in a real browser, which is the real "loads-as-a-module-and-resolves-the-import" proof
- `pytest -m e2e tests/e2e/test_collection_layout_e2e.py tests/e2e/test_ratings_overlay_e2e.py tests/e2e/test_final_yaml_ratings_e2e.py` — 14 passed (no regressions in adjacent areas)
- Manual render check via `app.test_client()` confirms all 14 converted pages render `<script type="module">` and the unconverted `100-anidb` still renders the classic `<script type="text/javascript" defer>` as expected

### Diff summary

```
 eslint.config.js                 | 16 +++++++++++++++-
 quickstart.py                    | 14 ++++++++++++++
 static/local-js/010-plex.js      | 24 ++++++------------------
 static/local-js/020-tmdb.js      | 22 +++++-----------------
 static/local-js/030-tautulli.js  | 24 ++++++------------------
 static/local-js/040-github.js    | 22 +++++-----------------
 static/local-js/050-omdb.js      | 22 +++++-----------------
 static/local-js/060-mdblist.js   | 22 +++++-----------------
 static/local-js/070-notifiarr.js | 20 ++++----------------
 static/local-js/085-ntfy.js      | 26 +++++++-------------------
 static/local-js/087-apprise.js   | 15 +++++----------
 static/local-js/090-webhooks.js  |  9 ++-------
 static/local-js/110-radarr.js    | 24 ++++++------------------
 static/local-js/120-sonarr.js    | 24 ++++++------------------
 static/local-js/130-trakt.js     | 30 +++++++++---------------------
 static/local-js/140-mal.js       | 30 +++++++++---------------------
 16 files changed, 109 insertions(+), 235 deletions(-)
```

**Net: -126 lines.** Every deleted line is a duplicated helper definition.

### Cumulative roadmap progress after PR 2a + 2b

- **15 of ~28** page scripts converted to ES modules
- 2 of the 3 known duplicate-helper symptoms eliminated:
  - `setToggleButtonIcon`: was 13 copies → now exactly 1 in `modules/validationPageBase.js`
  - `refreshValidationCallout`: was 15 copies → now exactly 1 in `modules/validationPageBase.js`
- `validatedAtInput` is still defined locally in each file (13 copies); it's a DOM lookup, not a function, so it stays per-file

## Related Issues

- Part of #1346 (Step 2 plan and PR sequence)
- Stacks on #1348 (PR 2a — base scripts + 080-gotify reference)
- Roadmap #1335

## Which Environment Did You Test On?

- [x] Local Install (Linux via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
