### PR TITLE
Bring tests/e2e/conftest.py in line with black format

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -5,16 +5,89 @@ from urllib.parse import urlparse
 import pytest
 from werkzeug.serving import make_server
 
-
 # Chromium/Playwright will refuse to navigate to these ports.
 # Keep the E2E live server off the browser's unsafe-port list.
 BROWSER_UNSAFE_PORTS = {
-    1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 69,
-    77, 79, 87, 95, 101, 102, 103, 104, 109, 110, 111, 113, 115, 117, 119,
-    123, 135, 137, 139, 143, 161, 179, 389, 427, 465, 512, 513, 514, 515,
-    526, 530, 531, 532, 540, 548, 554, 556, 563, 587, 601, 636, 989, 990,
-    993, 995, 1719, 1720, 1723, 2049, 3659, 4045, 5060, 5061, 6000, 6566,
-    6665, 6666, 6667, 6668, 6669, 6697, 10080
+    1,
+    7,
+    9,
+    11,
+    13,
+    15,
+    17,
+    19,
+    20,
+    21,
+    22,
+    23,
+    25,
+    37,
+    42,
+    43,
+    53,
+    69,
+    77,
+    79,
+    87,
+    95,
+    101,
+    102,
+    103,
+    104,
+    109,
+    110,
+    111,
+    113,
+    115,
+    117,
+    119,
+    123,
+    135,
+    137,
+    139,
+    143,
+    161,
+    179,
+    389,
+    427,
+    465,
+    512,
+    513,
+    514,
+    515,
+    526,
+    530,
+    531,
+    532,
+    540,
+    548,
+    554,
+    556,
+    563,
+    587,
+    601,
+    636,
+    989,
+    990,
+    993,
+    995,
+    1719,
+    1720,
+    1723,
+    2049,
+    3659,
+    4045,
+    5060,
+    5061,
+    6000,
+    6566,
+    6665,
+    6666,
+    6667,
+    6668,
+    6669,
+    6697,
+    10080,
 }
 
 
@@ -27,10 +100,7 @@ def _make_safe_live_server(app, host="127.0.0.1", attempts=25):
             return server, port
         last_port = port
         server.server_close()
-    raise RuntimeError(
-        f"Could not allocate a browser-safe test server port after {attempts} attempts; "
-        f"last rejected port was {last_port}."
-    )
+    raise RuntimeError(f"Could not allocate a browser-safe test server port after {attempts} attempts; last rejected port was {last_port}.")
 
 
 def _can_create_overlapped_pipe():


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Tiny fix for an annoying CI papercut.

### The problem

The repo's auto-format workflow (`.github/workflows/validate-pull.yml`) runs `black . -l 180` on every PR push and force-pushes the result as a "Code Format" commit if anything changed.

`tests/e2e/conftest.py` was added on develop in #1351 in a hand-formatted style that black wants to rewrite. Because the workflow doesn't run before merges land on develop (only on PR branches), the drift persisted on the main branch.

Consequence: **every PR branch pushed since #1351 inherits an automatic 92-line "Code Format" commit reformatting this unrelated file**. Both #1348 and #1349 collected one. Any future PR will too.

### The fix

Run black on the file once on develop. That's it.

```diff
- 1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 69,
- 77, 79, 87, 95, 101, 102, 103, 104, 109, 110, 111, 113, 115, 117, 119,
- ... (compact)
+ 1,
+ 7,
+ 9,
+ ...
+ 10080,
  (one per line, black's default for a set this size)
```

```diff
- raise RuntimeError(
-     f"Could not allocate a browser-safe test server port after {attempts} attempts; "
-     f"last rejected port was {last_port}."
- )
+ raise RuntimeError(f"Could not allocate a browser-safe test server port after {attempts} attempts; last rejected port was {last_port}.")
```

Plus one removed blank line after the imports block.

**Total diff:** 1 file, +81 / −11.

### Why is the `RuntimeError` now one line?

Black wanted to collapse the multi-line call because everything fits in the configured 180-char budget. I went one step further and merged the two implicit-concatenated f-strings into one — they were already a single conceptual message, the split was purely for visual width. Final line is 157 characters, comfortably under 180.

If reviewers prefer to keep the two-fragment string as-is, no problem — black is fine with that too, the diff is just a touch larger.

### Verification

- `black --check . -l 180` → "108 files would be left unchanged" (zero drift, whole repo)
- `pre-commit run --all-files` → all 11 hooks pass
- `pytest -m e2e tests/e2e/test_wizard_e2e.py` → 5/5 pass
- `pytest -m e2e tests/e2e/test_{collection_layout,ratings_overlay,final_yaml_ratings}_e2e.py` → 14/14 pass
- `test_final_page_e2e` → 5/6 pass (the 6th fails identically on develop with "pip not found in venv" — pre-existing fixture bug)
- `test_ratings_matrix_artifacts_e2e` → hangs on develop too (pre-existing, unrelated)

### Why not run black on the whole repo?

`ruff format` disagrees with `black` about 20 other files (mostly around long-line wrapping). The repo's _authoritative_ formatter is black per the workflow, but local devs running `ruff format` would see drift. That's a separate conversation worth having, but it's out of scope for this fix.

This PR only touches the one file that black actively rewrites on every push.

## Related Issues

None directly — but unblocks cleaner force-pushes on every open and future PR.

## Which Environment Did You Test On?

- [x] Local Install (Linux via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
