### PR TITLE
Pin black==26.5.1 and add a pre-commit hook to enforce it locally

### DIFF
--- a/.github/workflows/validate-pull.yml
+++ b/.github/workflows/validate-pull.yml
@@ -122,7 +122,7 @@ jobs:
         id: format-code
         run: |
             pip install -r requirements.txt
-            pip install black
+            pip install -r requirements-dev.txt
             black . -l 180
 
       - name: Update PART File and Commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,8 @@ repos:
     hooks:
       - id: ruff
         args: [ --fix ]
+-   repo: https://github.com/psf/black
+    rev: 26.5.1
+    hooks:
+      - id: black
+        args: [ -l, '180' ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+black==26.5.1
 playwright>=1.60.0
 pytest>=9.1.1
 pytest-playwright>=0.8.0

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -5,16 +5,89 @@ from urllib.parse import urlparse
 import pytest
 from werkzeug.serving import make_server
 
-
 # Chromium/Playwright will refuse to navigate to these ports.
 # Keep the E2E live server off the browser's unsafe-port list.
 BROWSER_UNSAFE_PORTS = {
-    1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 69,
-    77, 79, 87, 95, 101, 102, 103, 104, 109, 110, 111, 113, 115, 117, 119,
-    123, 135, 137, 139, 143, 161, 179, 389, 427, 465, 512, 513, 514, 515,
-    526, 530, 531, 532, 540, 548, 554, 556, 563, 587, 601, 636, 989, 990,
-    993, 995, 1719, 1720, 1723, 2049, 3659, 4045, 5060, 5061, 6000, 6566,
-    6665, 6666, 6667, 6668, 6669, 6697, 10080
+    1,
+    7,
+    9,
+    11,
+    13,
+    15,
+    17,
+    19,
+    20,
+    21,
+    22,
+    23,
+    25,
+    37,
+    42,
+    43,
+    53,
+    69,
+    77,
+    79,
+    87,
+    95,
+    101,
+    102,
+    103,
+    104,
+    109,
+    110,
+    111,
+    113,
+    115,
+    117,
+    119,
+    123,
+    135,
+    137,
+    139,
+    143,
+    161,
+    179,
+    389,
+    427,
+    465,
+    512,
+    513,
+    514,
+    515,
+    526,
+    530,
+    531,
+    532,
+    540,
+    548,
+    554,
+    556,
+    563,
+    587,
+    601,
+    636,
+    989,
+    990,
+    993,
+    995,
+    1719,
+    1720,
+    1723,
+    2049,
+    3659,
+    4045,
+    5060,
+    5061,
+    6000,
+    6566,
+    6665,
+    6666,
+    6667,
+    6668,
+    6669,
+    6697,
+    10080,
 }
 
 
@@ -27,10 +100,7 @@ def _make_safe_live_server(app, host="127.0.0.1", attempts=25):
             return server, port
         last_port = port
         server.server_close()
-    raise RuntimeError(
-        f"Could not allocate a browser-safe test server port after {attempts} attempts; "
-        f"last rejected port was {last_port}."
-    )
+    raise RuntimeError(f"Could not allocate a browser-safe test server port after {attempts} attempts; last rejected port was {last_port}.")
 
 
 def _can_create_overlapped_pipe():


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [x] Other — tooling / DX

## Description

Follow-up to #1353. That PR fixed the one file the CI auto-format workflow was rewriting on every triggering PR push. **This PR closes the loop so the drift doesn't reopen.**

### The plumbing today (before this PR)

| Where | What |
|---|---|
| `.pre-commit-config.yaml` | No black hook. Local devs never run it. |
| `requirements-dev.txt` | No black. Local devs can't easily install the right version. |
| `.github/workflows/validate-pull.yml` | `pip install black` — **unpinned**. Picks up whatever's on PyPI that minute. |

So black runs only in CI, only against whatever version PyPI is currently serving. A future black release that changes formatting decisions will silently start force-pushing "Code Format" commits onto every triggering PR — exactly the surprise that motivated #1353.

### What this PR changes (three coordinated edits, one source of truth)

**1. `requirements-dev.txt`** — add the pin

```diff
+ black==26.5.1
  playwright>=1.60.0
  pytest>=9.1.1
  pytest-playwright>=0.8.0
  ruff==0.15.20
```

`26.5.1` is the current latest, and the version that produced the canonical formatting in #1353.

**2. `.pre-commit-config.yaml`** — add the hook

```diff
  -   repo: https://github.com/astral-sh/ruff-pre-commit
      rev: v0.15.18
      hooks:
        - id: ruff
          args: [ --fix ]
+ -   repo: https://github.com/psf/black
+     rev: 26.5.1
+     hooks:
+       - id: black
+         args: [ -l, '180' ]
```

`pre-commit run --all-files` now reports **12 hooks (was 11)**, all pass.

**3. `.github/workflows/validate-pull.yml`** — sync CI to the pin

```diff
        - name: Format Code
          id: format-code
          run: |
              pip install -r requirements.txt
-             pip install black
+             pip install -r requirements-dev.txt
              black . -l 180
```

By installing from `requirements-dev.txt` instead of unpinned `black`, CI and local dev share **exactly one version pin** (DRY: bump the pin in one file, both consumers follow).

### Why pin at all?

Black's stable releases occasionally change formatting decisions (rare but it happens). Without a pin:
- A new release silently changes the canonical format
- The next CI run finds "drift" everywhere
- Every triggering PR collects an auto-"Code Format" commit
- Local pre-commit doesn't catch it because there's no hook

Pinning + a pre-commit hook means **format changes are deliberate**: someone bumps the pin, reformats once, commits.

### Why stack on #1353 instead of merging that into this?

Independent reviewability. #1353 is "data fix" (one file's formatting). This PR is "policy fix" (lock in the formatter version). They're easier to discuss separately and easier to revert independently.

**Merge order: land #1353 first.** Until conftest.py is canonical, the new black hook will fail on develop.

### Verification

- `pre-commit run --all-files` (12 hooks now, all pass)
- Sanity check: introduced deliberate formatting drift (`def f(a,b,c)`), the new black hook caught and auto-fixed it
- 961 unit tests pass
- 5/5 wizard e2e tests pass
- `black --check . -l 180` from clean tree: 108 files unchanged

### Diff size

```
 .github/workflows/validate-pull.yml | 2 +-
 .pre-commit-config.yaml             | 5 +++++
 requirements-dev.txt                | 1 +
 3 files changed, 7 insertions(+), 1 deletion(-)
```

8-line PR. Tiny but durable.

## Related Issues

- Stacks on #1353 (the one-time reformat of `tests/e2e/conftest.py`)
- Prevents reopening of the "auto Code Format commit appears on every PR" papercut

## Which Environment Did You Test On?

- [x] Local Install (Linux via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
