### PR TITLE
Exclude auto-managed PART file from pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: '^.*bootstrap.bundle.js$|^tests/fixtures/'
+exclude: '^.*bootstrap.bundle.js$|^tests/fixtures/|^PART$'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Other

## Description

`develop`'s Lint workflow currently fails on every push. See [run 28272347883](https://github.com/Kometa-Team/Quickstart/actions/runs/28272347883). The cause is the `PART` file.

### What's happening

`PART` is auto-managed by the **"Update PART File and Commit"** step in `.github/workflows/validate-pull.yml`. When a PR is labelled `build`/`build-full`, the step runs:

```bash
echo "$new_value" > PART   # writes '1\n', '2\n', etc.
```

So PART normally contains a digit + a trailing newline. But it's currently sitting on develop as **just `\n`** (a single newline, no digit). That state confuses `end-of-file-fixer` from `pre-commit-hooks`:

| Hook expectation | Current PART state | What the hook does |
|---|---|---|
| Empty file → zero bytes | `\n` (1 byte) | Strips the newline, file becomes zero bytes |
| Hook always fails when it modifies | (no diff to commit on develop) | Lint run reports "files were modified by this hook", exits 1 |
| Next merge to develop | re-creates `\n` somehow | Cycle never converges |

This failure also bleeds into **every PR rebased on develop**: pre-commit checks fail on PART even when the PR itself touches no PART-relevant files. Currently affecting #1349 right now, and would affect any future PR similarly.

### Fix

Two paths:

1. **Force PART to be empty** (zero bytes) so end-of-file-fixer is happy.  
    Fragile: the next build-labelled PR rewrites PART to `1\n`, and the next zero-PART reset puts us right back where we are.

2. **Exclude PART from pre-commit entirely.**  
    Correct semantically: PART is a build artifact, not a source file. The exclude pattern in `.pre-commit-config.yaml` is the documented mechanism for this (already used for `bootstrap.bundle.js` and `tests/fixtures/`).

This PR takes path 2.

```diff
- exclude: '^.*bootstrap.bundle.js$|^tests/fixtures/'
+ exclude: '^.*bootstrap.bundle.js$|^tests/fixtures/|^PART$'
```

### Verification

| Check | Before | After |
|---|---|---|
| `pre-commit run --all-files` | 11 pass, 1 fail (end-of-file-fixer on PART) | **12/12 pass** |
| Sanity: corrupt PART with `printf "garbage   \n\n\n"`, run hooks on it | Hooks would rewrite | All hooks report `no files to check` |
| `don't commit to branch` hook | Still runs (acts on branch, not files) |  unchanged |

### Diff size

```
 .pre-commit-config.yaml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

A 1-line change. Smallest possible fix to a real failing CI signal.

## Related Issues

- Unblocks Lint on develop (currently red since #1348 merged)
- Unblocks #1349's CI (Lint currently failing for the same reason)
- Future-proofs every other PR against the same false-positive failure

## Which Environment Did You Test On?

- [x] Local Install (Linux via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
