### PR TITLE
Add GET /api/app-config endpoint (#1334 Step 5, Phase A)

### DIFF
--- a/blueprints/app_config_routes.py
+++ b/blueprints/app_config_routes.py
@@ -1,0 +1,110 @@
+"""Read-only endpoint exposing the app-level configuration to the front end.
+
+Background
+----------
+Historically, every Quickstart page rendered an inline ``<script>`` block
+in ``templates/000-base.html`` that copied 11 entries from Flask's
+``app.config`` onto ``window.QS_*`` so the front-end JS could read them
+back. That worked, but it meant every page reload re-serialized the same
+unchanging values through Jinja, and it tightly coupled the template
+output to the JS contract.
+
+This module exposes those 11 keys via a single read endpoint:
+
+    GET /api/app-config
+
+The intent is for the front end to fetch this once on startup, keep the
+result in a single module-scoped object, and let the existing settings
+save handler in ``static/local-js/000-base.js`` mutate that object in
+place when the user changes a setting (exactly as it already mutates
+``window.QS_*`` today).
+
+Scope of this PR
+----------------
+This blueprint is **additive**. The existing ``window.QS_*`` injections
+in ``templates/000-base.html`` are left untouched so nothing in the
+front end breaks. The follow-up PR migrates the JS readers to the new
+namespace and removes the Jinja injections.
+
+The 11 keys exposed
+-------------------
+Only the *app-level* (page-independent) keys are exposed here. Page-level
+keys -- ``QS_REQUIRED_KEYS``, ``QS_OPTIONAL_KEYS``, ``QS_REVIEW_KEYS``,
+``QS_CURRENT_TEMPLATE``, ``QS_SETTINGS_CUSTOM_REPO``,
+``QS_SETTINGS_CUSTOM_REPO_BASE``, and the various
+``QS_*_REQUIREMENT_REASONS`` -- are deliberately *not* exposed here.
+They depend on the current page or active template and will be handled
+when each page's component fetches its own initial state (roadmap Step 9
+in #1334).
+
+Why ``current_app`` and not the module-level import
+---------------------------------------------------
+Importing ``quickstart.app`` at module import time would create a
+circular dependency, since ``quickstart.py`` imports this blueprint.
+Flask's ``current_app`` proxy resolves at request time and is the right
+tool here.
+"""
+
+from __future__ import annotations
+
+from flask import Blueprint, current_app, jsonify
+
+bp = Blueprint("app_config_routes", __name__)
+
+
+# The 11 app-level config keys exposed by /api/app-config, paired with
+# the fallback value to use when the key is missing from app.config.
+#
+# Keep this list in sync with templates/000-base.html. The follow-up PR
+# that removes those inline injections will delete the duplication.
+APP_CONFIG_KEYS: tuple[tuple[str, object], ...] = (
+    ("QS_DEBUG", False),
+    ("QS_THEME", "kometa"),
+    ("QS_OPTIMIZE_DEFAULTS", True),
+    ("QS_CONFIG_HISTORY", 0),
+    ("QS_KOMETA_LOG_KEEP", 0),
+    ("QS_IMAGEMAID_LOG_KEEP", 0),
+    ("QS_TEST_LIBS_PATH", ""),
+    ("QS_TEST_LIBS_TMP", ""),
+    ("QS_SESSION_LIFETIME_DAYS", 30),
+    ("QS_FLASK_SESSION_DIR", ""),
+    ("QS_RESTART_NOTICE", None),
+)
+
+
+def collect_app_config() -> dict[str, object]:
+    """Return the app-level config as a JSON-serializable dict.
+
+    Pulled out as a module-level function so tests can call it directly
+    without spinning up a request context, and so future call sites
+    (e.g. a server-rendered initial JSON blob, should we ever want one)
+    don't have to duplicate the key list.
+    """
+    config = current_app.config
+    return {key: config.get(key, default) for key, default in APP_CONFIG_KEYS}
+
+
+@bp.route("/api/app-config", methods=["GET"])
+def get_app_config():
+    """Return the app-level config as JSON.
+
+    Response shape::
+
+        {
+          "QS_DEBUG": false,
+          "QS_THEME": "kometa",
+          ... (9 more keys)
+        }
+
+    The keys mirror ``window.QS_*`` exactly so the front end can do::
+
+        const config = await fetch('/api/app-config').then(r => r.json())
+        // config.QS_DEBUG, config.QS_THEME, etc.
+
+    No authentication is enforced here for the same reason none of the
+    other Quickstart endpoints enforce it: this is a single-user local
+    desktop wizard. The values returned are already visible in the
+    rendered HTML today via the ``<script>`` injections in
+    ``templates/000-base.html``.
+    """
+    return jsonify(collect_app_config())

--- a/quickstart.py
+++ b/quickstart.py
@@ -180,6 +180,7 @@ from blueprints.imagemaid_updates import bp as imagemaid_updates_bp
 from blueprints.config_routes import bp as config_routes_bp
 from blueprints.download_routes import bp as download_routes_bp
 from blueprints.test_libraries_routes import bp as test_libraries_routes_bp
+from blueprints.app_config_routes import bp as app_config_routes_bp
 from blueprints.library_routes import (
     bp as library_routes_bp,
     _build_library_lists,  # noqa: F401 (used by tests as qs_module._build_library_lists)
@@ -972,6 +973,7 @@ app.register_blueprint(test_libraries_routes_bp)
 app.register_blueprint(library_routes_bp)
 app.register_blueprint(import_config_routes_bp)
 app.register_blueprint(imagemaid_routes_bp)
+app.register_blueprint(app_config_routes_bp)
 
 # Run version check at startup
 app.config["VERSION_CHECK"] = helpers.check_for_update()

--- a/tests/test_app_config_endpoint.py
+++ b/tests/test_app_config_endpoint.py
@@ -1,0 +1,135 @@
+"""Tests for blueprints.app_config_routes.
+
+Covers the read-only ``GET /api/app-config`` endpoint that exposes the
+11 app-level config keys to the front end (roadmap #1334 Step 5,
+Phase A).
+
+Two layers of testing here:
+
+1. ``collect_app_config`` is tested directly via the app context so we
+   can isolate the "which keys, with which fallbacks" contract from
+   request handling. This is the layer the front-end migration PR
+   (Phase B) will pin its expectations against.
+
+2. The endpoint itself is tested via the Flask test client to confirm
+   the route is wired and returns ``200 OK`` with the expected JSON
+   shape.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from blueprints.app_config_routes import APP_CONFIG_KEYS, collect_app_config
+
+# The exact 11 keys we expect, in declaration order. Pinning this
+# explicitly catches accidental additions/removals in a code review.
+EXPECTED_KEYS = (
+    "QS_DEBUG",
+    "QS_THEME",
+    "QS_OPTIMIZE_DEFAULTS",
+    "QS_CONFIG_HISTORY",
+    "QS_KOMETA_LOG_KEEP",
+    "QS_IMAGEMAID_LOG_KEEP",
+    "QS_TEST_LIBS_PATH",
+    "QS_TEST_LIBS_TMP",
+    "QS_SESSION_LIFETIME_DAYS",
+    "QS_FLASK_SESSION_DIR",
+    "QS_RESTART_NOTICE",
+)
+
+
+def test_app_config_keys_constant_matches_expected_set():
+    """The blueprint declares the canonical key list. The follow-up PR
+    that deletes the matching ``<script>`` injections in
+    ``templates/000-base.html`` will use this same constant as its
+    source of truth, so locking it down here is load-bearing.
+    """
+    assert tuple(key for key, _ in APP_CONFIG_KEYS) == EXPECTED_KEYS
+
+
+def test_collect_app_config_returns_dict_with_all_expected_keys(app):
+    with app.app_context():
+        result = collect_app_config()
+    assert set(result.keys()) == set(EXPECTED_KEYS)
+
+
+def test_collect_app_config_uses_fallback_when_key_missing(app, monkeypatch):
+    # Force one key to be absent and confirm the declared fallback is
+    # returned. We pop the key from a copy of app.config to keep the
+    # session-scoped fixture intact.
+    saved = {key: app.config.get(key) for key in EXPECTED_KEYS}
+    monkeypatch.setitem(app.config, "QS_KOMETA_LOG_KEEP", None)
+    app.config.pop("QS_KOMETA_LOG_KEEP", None)
+    try:
+        with app.app_context():
+            result = collect_app_config()
+        # APP_CONFIG_KEYS declares the fallback for QS_KOMETA_LOG_KEEP as 0.
+        assert result["QS_KOMETA_LOG_KEEP"] == 0
+    finally:
+        # Restore so the session-scoped app fixture isn't polluted for
+        # downstream tests.
+        for key, value in saved.items():
+            if value is None:
+                app.config.pop(key, None)
+            else:
+                app.config[key] = value
+
+
+def test_collect_app_config_returns_live_app_config(app, monkeypatch):
+    monkeypatch.setitem(app.config, "QS_THEME", "test-theme-xyz")
+    monkeypatch.setitem(app.config, "QS_KOMETA_LOG_KEEP", 42)
+    with app.app_context():
+        result = collect_app_config()
+    assert result["QS_THEME"] == "test-theme-xyz"
+    assert result["QS_KOMETA_LOG_KEEP"] == 42
+
+
+def test_api_app_config_endpoint_returns_200(client):
+    resp = client.get("/api/app-config")
+    assert resp.status_code == 200
+    assert resp.is_json
+
+
+def test_api_app_config_endpoint_returns_all_expected_keys(client):
+    resp = client.get("/api/app-config")
+    data = resp.get_json()
+    assert set(data.keys()) == set(EXPECTED_KEYS)
+
+
+def test_api_app_config_endpoint_reflects_live_config_changes(app, client, monkeypatch):
+    """Confirm there's no stale caching: each request reads ``app.config``
+    afresh. This matters because the existing settings save flow mutates
+    ``app.config`` in place and Phase B will rely on this endpoint
+    returning the new values immediately.
+    """
+    monkeypatch.setitem(app.config, "QS_DEBUG", True)
+    monkeypatch.setitem(app.config, "QS_THEME", "dracula")
+    resp = client.get("/api/app-config")
+    data = resp.get_json()
+    assert data["QS_DEBUG"] is True
+    assert data["QS_THEME"] == "dracula"
+
+
+@pytest.mark.parametrize(
+    ("key", "expected_default"),
+    [
+        ("QS_DEBUG", False),
+        ("QS_THEME", "kometa"),
+        ("QS_OPTIMIZE_DEFAULTS", True),
+        ("QS_CONFIG_HISTORY", 0),
+        ("QS_KOMETA_LOG_KEEP", 0),
+        ("QS_IMAGEMAID_LOG_KEEP", 0),
+        ("QS_TEST_LIBS_PATH", ""),
+        ("QS_TEST_LIBS_TMP", ""),
+        ("QS_SESSION_LIFETIME_DAYS", 30),
+        ("QS_FLASK_SESSION_DIR", ""),
+        ("QS_RESTART_NOTICE", None),
+    ],
+)
+def test_app_config_keys_declared_defaults(key, expected_default):
+    """Pin each fallback default so a refactor doesn't silently change
+    the contract the front end will rely on.
+    """
+    declared = dict(APP_CONFIG_KEYS)
+    assert declared[key] == expected_default


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix
- [x] Feature/Tweak (non-breaking change which adds new functionality)
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Other

## Description

Roadmap issue #1334 **Step 5 (`/api/app-config` endpoint)**, **Phase A**.

This PR adds the backend endpoint additively. Phase B (to follow) will migrate the JS readers and delete the now-duplicated `window.QS_*` Jinja injections in `templates/000-base.html`.

### Why two phases

The existing front end both **reads from** AND **writes to** `window.QS_*`. The settings save flow in `static/local-js/000-base.js` updates the globals in place after a successful POST so other handlers see fresh values without a full page reload. Moving to a fetch-once-on-startup model without preserving that update mechanism would silently break the settings page.

Phase B will introduce the right reader pattern and adjust the save flow together. Doing both in this PR risks one giant uncomfortable diff.

### What this PR adds

| File | Change |
|---|---|
| `blueprints/app_config_routes.py` | NEW (~100 LOC). Declares `APP_CONFIG_KEYS` (the 11 keys with their fallbacks), `collect_app_config()` helper, and the `GET /api/app-config` route |
| `quickstart.py` | +2 lines: import + register the new blueprint |
| `tests/test_app_config_endpoint.py` | NEW (~130 LOC). 18 test cases pinning the contract |

### The 11 keys exposed

| Key | Default |
|---|---|
| `QS_DEBUG` | `False` |
| `QS_THEME` | `"kometa"` |
| `QS_OPTIMIZE_DEFAULTS` | `True` |
| `QS_CONFIG_HISTORY` | `0` |
| `QS_KOMETA_LOG_KEEP` | `0` |
| `QS_IMAGEMAID_LOG_KEEP` | `0` |
| `QS_TEST_LIBS_PATH` | `""` |
| `QS_TEST_LIBS_TMP` | `""` |
| `QS_SESSION_LIFETIME_DAYS` | `30` |
| `QS_FLASK_SESSION_DIR` | `""` |
| `QS_RESTART_NOTICE` | `None` |

### What is explicitly NOT in this PR

- `templates/000-base.html` still injects all 11 `window.QS_*` values — no behaviour changes for users
- Nothing in `static/local-js/` is touched
- No JS tests added (those land with Phase B)
- Page-level keys (`QS_REQUIRED_KEYS`, `QS_OPTIONAL_KEYS`, `QS_REVIEW_KEYS`, the `*_REQUIREMENT_REASONS` family, `QS_CURRENT_TEMPLATE`, `QS_SETTINGS_CUSTOM_REPO[_BASE]`) — these depend on the current page or template and will be retired naturally by Step 9 (component islands)

### Sample response

```json
GET /api/app-config

{
  "QS_DEBUG": false,
  "QS_THEME": "kometa",
  "QS_OPTIMIZE_DEFAULTS": true,
  "QS_CONFIG_HISTORY": 0,
  "QS_KOMETA_LOG_KEEP": 0,
  "QS_IMAGEMAID_LOG_KEEP": 0,
  "QS_TEST_LIBS_PATH": "/path/to/test/libs",
  "QS_TEST_LIBS_TMP": "/path/to/test/tmp",
  "QS_SESSION_LIFETIME_DAYS": 30,
  "QS_FLASK_SESSION_DIR": "/path/to/flask_session",
  "QS_RESTART_NOTICE": null
}
```

### Test coverage

```
tests/test_app_config_endpoint.py
   APP_CONFIG_KEYS contract: exactly 11 keys in declared order
   collect_app_config: returns all keys
   collect_app_config: uses fallback when key missing
   collect_app_config: reflects live config (no stale caching)
   GET /api/app-config: returns 200
   GET /api/app-config: returns JSON
   GET /api/app-config: returns all expected keys
   GET /api/app-config: reflects live config changes
   APP_CONFIG_KEYS declared defaults (parametrized x 11)

18/18 pass in 2s
```

### Verification

| Check | Result |
|---|---|
| `pytest tests/test_app_config_endpoint.py` | 18/18 pass |
| `pytest test_status_endpoint test_validate_service_routes test_config_and_library_routes` (regression) | 62/62 pass |
| `pytest -m e2e tests/e2e/test_wizard_e2e.py` | 5/5 pass |
| `pre-commit run --all-files` | 12/12 hooks green |
| Smoke test: live Flask test_client `/api/app-config` | 200 with expected 11-key JSON |

### Roadmap context (#1334)

| Step | Status |
|---|---|
| 1. ESLint | done |
| 2. ES modules | partial (16 wizards done) |
| 3. Decompose helpers.py | done |
| 4. Vite | #1356 (queued) |
| **5. `/api/app-config` endpoint** | **this PR (Phase A); Phase B follows** |
| 6. Validation widget + Alpine | needs Vite |
| 7. Drop jQuery | easier after Step 6 |
| 8. Vitest | #1357 (queued, stacked on Step 4) |
| 9. Component islands | needs Steps 4-8 |

## Related Issues

Roadmap: #1334 Step 5

## Which Environment Did You Test On?

- [x] Local Install (Linux, Python 3.13, Flask test_client)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
