### PR TITLE
Convert 001-start, 027-playlist_files, 100-anidb, 150-settings to ES modules (#1334 Step 2)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -66,8 +66,10 @@ const moduleFiles = [
   'static/local-js/pathValidation.js',
   'static/local-js/urlValidation.js',
   'static/local-js/templateStringList.js',
+  'static/local-js/001-start.js',
   'static/local-js/010-plex.js',
   'static/local-js/020-tmdb.js',
+  'static/local-js/027-playlist_files.js',
   'static/local-js/030-tautulli.js',
   'static/local-js/040-github.js',
   'static/local-js/050-omdb.js',
@@ -77,10 +79,12 @@ const moduleFiles = [
   'static/local-js/085-ntfy.js',
   'static/local-js/087-apprise.js',
   'static/local-js/090-webhooks.js',
+  'static/local-js/100-anidb.js',
   'static/local-js/110-radarr.js',
   'static/local-js/120-sonarr.js',
   'static/local-js/130-trakt.js',
-  'static/local-js/140-mal.js'
+  'static/local-js/140-mal.js',
+  'static/local-js/150-settings.js'
 ]
 
 module.exports = [

--- a/quickstart.py
+++ b/quickstart.py
@@ -409,8 +409,10 @@ VALIDATION_DOC_FALLBACK = "/step/900-kometa"
 # here when its JS file becomes a module.
 MODULE_PAGE_SCRIPTS = frozenset(
     {
+        "001-start",
         "010-plex",
         "020-tmdb",
+        "027-playlist_files",
         "030-tautulli",
         "040-github",
         "050-omdb",
@@ -420,10 +422,12 @@ MODULE_PAGE_SCRIPTS = frozenset(
         "085-ntfy",
         "087-apprise",
         "090-webhooks",
+        "100-anidb",
         "110-radarr",
         "120-sonarr",
         "130-trakt",
         "140-mal",
+        "150-settings",
     }
 )
 VALIDATION_DOCS = {

--- a/static/local-js/027-playlist_files.js
+++ b/static/local-js/027-playlist_files.js
@@ -1,3 +1,5 @@
+import { refreshValidationCallout } from './modules/validationPageBase.js'
+
 const validatedAtInput = document.getElementById('playlist_files_validated_at')
 
 $(document).ready(function () {
@@ -40,9 +42,7 @@ $(document).ready(function () {
     if (validatedAtInput) {
       validatedAtInput.value = isValid ? new Date().toISOString() : ''
     }
-    if (window.QSValidationCallouts && typeof window.QSValidationCallouts.refresh === 'function') {
-      window.QSValidationCallouts.refresh('playlist_files_validated')
-    }
+    refreshValidationCallout('playlist_files_validated')
     console.log('Validation State Updated:', isValid)
   }
 

--- a/static/local-js/150-settings.js
+++ b/static/local-js/150-settings.js
@@ -1,3 +1,5 @@
+import { refreshValidationCallout } from './modules/validationPageBase.js'
+
 document.addEventListener('DOMContentLoaded', function () {
   const validatedAtInput = document.getElementById('settings_validated_at')
   let settingsTouched = false
@@ -167,9 +169,7 @@ document.addEventListener('DOMContentLoaded', function () {
         validatedAtInput.value = ''
       }
     }
-    if (window.QSValidationCallouts && typeof window.QSValidationCallouts.refresh === 'function') {
-      window.QSValidationCallouts.refresh('settings_validated')
-    }
+    refreshValidationCallout('settings_validated')
   }
 
   function showAccordionForField (field) {

--- a/templates/000-base.html
+++ b/templates/000-base.html
@@ -141,8 +141,8 @@
     </div>
   </div>
 
-  <script type="text/javascript"
-    src="{{ url_for('static', filename='local-js/001-start.js') }}" defer></script>
+  <script type="module"
+    src="{{ url_for('static', filename='local-js/001-start.js') }}"></script>
   {% if page_info['template_name'] != '001-start' %}
   {% if page_info.get('template_uses_module') %}
   <script type="module"


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix
- [x] Feature/Tweak (non-breaking change which adds new functionality)
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Other

## Description

Roadmap issue #1334 **Step 2 (ES modules)**. Finishes the migration that PR #1348 / #1349 started — picks up four more wizard scripts that don't have heavy jQuery internals.

### What this converts

| File | Lines | Source changes |
|---|---|---|
| `static/local-js/100-anidb.js` | 22 | **None.** Module-scoped DOM code inside `$(document).ready` already; the conversion is purely declarative |
| `static/local-js/027-playlist_files.js` | 58 | +1/-3: import `refreshValidationCallout` and collapse the 4-line inline `if (QSValidationCallouts && ...)` pattern to a single call |
| `static/local-js/150-settings.js` | 423 | +1/-3: same dedup as above |
| `static/local-js/001-start.js` | 2806 | **None.** Already exports `window.toggleConfigInput` for the inline `onchange=` handler in `_config_workspace_modal.html`; the other 6 top-level functions have zero external callers (audited via grep) |

### What changes outside the JS files

| File | Diff | Why |
|---|---|---|
| `quickstart.py` | +4 lines | 4 names added to `MODULE_PAGE_SCRIPTS` alphabetically |
| `eslint.config.js` | +4 lines | Same 4 paths added to `moduleFiles` so ESLint parses with `sourceType: 'module'` |
| `templates/000-base.html` | -1/+1 | The unconditional 001-start.js `<script>` tag (always-loaded because 001-start owns the config workspace modal) flipped from `type="text/javascript" defer` to `type="module"`. The other three files are picked up automatically by the existing `{% if template_uses_module %}` branch |

### What this PR explicitly does NOT do

- **`905-analytics.js`, `900-kometa.js`, `915-imagemaid.js`** stay as classic scripts. They contain 91-259 jQuery references each. Converting them to modules without first migrating off jQuery (roadmap Step 7) is more risk than payoff
- **`025-libraries.js`** (6,257 lines) is left for a follow-up. It dynamically loads four classic helper scripts (`overlayHandler.js`, `imageHandler.js`, `validationHandler.js`, `eventHandler.js`) and shares top-level functions with them via `window`. Converting cleanly needs those four to migrate together — worth a focused PR
- **`910-sponsor.js`** is 0 bytes. Adding it to `MODULE_PAGE_SCRIPTS` would emit `<script type="module" src=".../910-sponsor.js"></script>` that loads nothing. Status quo is identical in effect

### Verification

| Check | Result |
|---|---|
| `pytest test_status_endpoint + test_validate_service_routes + test_config_and_library_routes` | 62/62 pass |
| `pytest -m e2e tests/e2e/test_wizard_e2e.py` (Playwright) | **5/5 pass** |
| Page render: `GET /step/001-start`, `/step/100-anidb`, `/step/150-settings` | Each renders with `<script type="module">` for its page script and zero classic `<script defer>` for the same file |
| `pre-commit run --all-files` | 12/12 hooks green |
| Cross-script call audit (grep over `templates/` + `static/`) | Every top-level function in 001-start and the inline-validation lines in 027/150 confirmed to have no external callers that module-scoping would silently break |

### Roadmap progress on Step 2

| Stage | Modules / 30 |
|---|---|
| Before #1348 | 0 |
| After #1348 (PR 2a) | 2 + 4 shared modules |
| After #1349 (PR 2b) | 16 |
| **After this PR** | **20** |

Remaining 10: 3 jQuery-heavy (Step 7), 1 large library page (its own follow-up), 1 empty file (910-sponsor — no point), 5 shared handler/validator scripts (these are dependencies of other modules, not page entry points).

### Diff size

```
eslint.config.js                      | 6 +++++-
quickstart.py                         | 4 ++++
static/local-js/027-playlist_files.js | 6 +++---
static/local-js/150-settings.js       | 6 +++---
templates/000-base.html               | 4 ++--
5 files changed, 17 insertions(+), 9 deletions(-)
```

## Related Issues

Roadmap: #1334 Step 2
Continues: #1348, #1349

## Which Environment Did You Test On?

- [x] Local Install (Linux, Python 3.13, Flask test_client + Playwright e2e)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
