### PR TITLE
Migrate front end to window.QS_AppConfig (#1334 Step 5, Phase B)

### DIFF
--- a/quickstart.py
+++ b/quickstart.py
@@ -180,6 +180,7 @@ from blueprints.imagemaid_updates import bp as imagemaid_updates_bp
 from blueprints.config_routes import bp as config_routes_bp
 from blueprints.download_routes import bp as download_routes_bp
 from blueprints.test_libraries_routes import bp as test_libraries_routes_bp
+from blueprints import app_config_routes
 from blueprints.app_config_routes import bp as app_config_routes_bp
 from blueprints.library_routes import (
     bp as library_routes_bp,
@@ -1006,6 +1007,13 @@ def inject_version_info():
     return {
         "version_info": app.config.get("VERSION_CHECK") or {},
         "overlay_fonts": list_overlay_fonts(),
+        # Roadmap #1334 Step 5 (Phase B): expose the app-level config
+        # dict to every template so 000-base.html can emit a single
+        # ``window.QS_AppConfig = {...}`` line instead of 11 individual
+        # ``window.QS_FOO = ...`` lines. The dict shape is identical to
+        # what GET /api/app-config returns, so the front-end has one
+        # contract to consume.
+        "qs_app_config": app_config_routes.collect_app_config(),
     }
 
 

--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -1,5 +1,7 @@
+import { getAppConfig, setAppConfig } from './modules/appConfig.js'
+
 (function () {
-  const isDebug = typeof window.QS_DEBUG !== 'undefined' && String(window.QS_DEBUG).toLowerCase() === 'true'
+  const isDebug = String(getAppConfig('QS_DEBUG', false)).toLowerCase() === 'true'
 
   function getLocalTimestamp () {
     const now = new Date()
@@ -2612,7 +2614,7 @@ document.addEventListener('qs:bulk-validation-complete', () => {
 })
 
 document.addEventListener('DOMContentLoaded', () => {
-  const notice = window.QS_RESTART_NOTICE
+  const notice = getAppConfig('QS_RESTART_NOTICE')
   if (!notice || notice.reason !== 'update') return
 
   const noticeKey = `qs_restart_notice_${notice.reason}_${notice.created_at || ''}`
@@ -3079,26 +3081,26 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function getCurrentDebug () {
-    const raw = (triggerBtn && triggerBtn.dataset.currentDebug) ? triggerBtn.dataset.currentDebug : window.QS_DEBUG
+    const raw = (triggerBtn && triggerBtn.dataset.currentDebug) ? triggerBtn.dataset.currentDebug : getAppConfig('QS_DEBUG', false)
     return String(raw).toLowerCase() === 'true'
   }
 
   function getCurrentTheme () {
     if (triggerBtn && triggerBtn.dataset.currentTheme) return triggerBtn.dataset.currentTheme
-    return window.QS_THEME || 'kometa'
+    return getAppConfig('QS_THEME', 'kometa') || 'kometa'
   }
 
   function getCurrentOptimizeDefaults () {
     const raw = (triggerBtn && triggerBtn.dataset.currentOptimizeDefaults)
       ? triggerBtn.dataset.currentOptimizeDefaults
-      : window.QS_OPTIMIZE_DEFAULTS
+      : getAppConfig('QS_OPTIMIZE_DEFAULTS', true)
     return String(raw).toLowerCase() === 'true'
   }
 
   function getCurrentConfigHistory () {
     const raw = (triggerBtn && triggerBtn.dataset.currentConfigHistory)
       ? triggerBtn.dataset.currentConfigHistory
-      : window.QS_CONFIG_HISTORY
+      : getAppConfig('QS_CONFIG_HISTORY', 0)
     const parsed = Number.parseInt(raw, 10)
     return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0
   }
@@ -3106,7 +3108,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function getCurrentLogKeep () {
     const raw = (triggerBtn && triggerBtn.dataset.currentLogKeep)
       ? triggerBtn.dataset.currentLogKeep
-      : window.QS_KOMETA_LOG_KEEP
+      : getAppConfig('QS_KOMETA_LOG_KEEP', 0)
     const parsed = Number.parseInt(raw, 10)
     return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0
   }
@@ -3114,32 +3116,32 @@ document.addEventListener('DOMContentLoaded', () => {
   function getCurrentImageMaidLogKeep () {
     const raw = (triggerBtn && triggerBtn.dataset.currentImagemaidLogKeep)
       ? triggerBtn.dataset.currentImagemaidLogKeep
-      : window.QS_IMAGEMAID_LOG_KEEP
+      : getAppConfig('QS_IMAGEMAID_LOG_KEEP', 0)
     const parsed = Number.parseInt(raw, 10)
     return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0
   }
 
   function getCurrentTestLibsTmp () {
     if (triggerBtn && triggerBtn.dataset.currentTestLibsTmp) return triggerBtn.dataset.currentTestLibsTmp
-    return window.QS_TEST_LIBS_TMP || ''
+    return getAppConfig('QS_TEST_LIBS_TMP', '') || ''
   }
 
   function getCurrentTestLibsPath () {
     if (triggerBtn && triggerBtn.dataset.currentTestLibsPath) return triggerBtn.dataset.currentTestLibsPath
-    return window.QS_TEST_LIBS_PATH || ''
+    return getAppConfig('QS_TEST_LIBS_PATH', '') || ''
   }
 
   function getCurrentSessionLifetimeDays () {
     const raw = (triggerBtn && triggerBtn.dataset.currentSessionLifetime)
       ? triggerBtn.dataset.currentSessionLifetime
-      : window.QS_SESSION_LIFETIME_DAYS
+      : getAppConfig('QS_SESSION_LIFETIME_DAYS', 30)
     const parsed = Number.parseInt(raw, 10)
     return Number.isFinite(parsed) && parsed >= 1 ? parsed : 30
   }
 
   function getCurrentSessionDir () {
     if (triggerBtn && triggerBtn.dataset.currentSessionDir) return triggerBtn.dataset.currentSessionDir
-    return window.QS_FLASK_SESSION_DIR || ''
+    return getAppConfig('QS_FLASK_SESSION_DIR', '') || ''
   }
 
   function getQuickstartRoot () {
@@ -3237,8 +3239,8 @@ document.addEventListener('DOMContentLoaded', () => {
       if (data.final_path) triggerBtn.dataset.currentTestLibsPath = data.final_path
       if (data.temp_path) triggerBtn.dataset.currentTestLibsTmp = data.temp_path
     }
-    if (typeof data.final_path === 'string') window.QS_TEST_LIBS_PATH = data.final_path
-    if (typeof data.temp_path === 'string') window.QS_TEST_LIBS_TMP = data.temp_path
+    if (typeof data.final_path === 'string') setAppConfig({ QS_TEST_LIBS_PATH: data.final_path })
+    if (typeof data.temp_path === 'string') setAppConfig({ QS_TEST_LIBS_TMP: data.temp_path })
     if (testLibsTmpInput && data.temp_path) testLibsTmpInput.value = data.temp_path
     if (testLibsPathInput && data.final_path) testLibsPathInput.value = data.final_path
     return data
@@ -3404,47 +3406,47 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!data.restart) {
           if (data.theme) {
             document.documentElement.setAttribute('data-theme', data.theme)
-            window.QS_THEME = data.theme
+            setAppConfig({ QS_THEME: data.theme })
             if (triggerBtn) triggerBtn.dataset.currentTheme = data.theme
             updateThemeUi(data.theme)
           }
           if (typeof payload.debug !== 'undefined') {
             const debugFlag = Boolean(payload.debug)
-            window.QS_DEBUG = debugFlag
+            setAppConfig({ QS_DEBUG: debugFlag })
             if (triggerBtn) triggerBtn.dataset.currentDebug = debugFlag ? 'true' : 'false'
           }
           if (typeof payload.optimize_defaults !== 'undefined') {
             const optimizeFlag = Boolean(payload.optimize_defaults)
-            window.QS_OPTIMIZE_DEFAULTS = optimizeFlag
+            setAppConfig({ QS_OPTIMIZE_DEFAULTS: optimizeFlag })
             if (triggerBtn) triggerBtn.dataset.currentOptimizeDefaults = optimizeFlag ? 'true' : 'false'
           }
           if (typeof payload.config_history !== 'undefined') {
             const historyFlag = Number(payload.config_history)
-            window.QS_CONFIG_HISTORY = historyFlag
+            setAppConfig({ QS_CONFIG_HISTORY: historyFlag })
             if (triggerBtn) triggerBtn.dataset.currentConfigHistory = String(historyFlag)
           }
           if (typeof payload.kometa_log_keep !== 'undefined') {
             const logKeepFlag = Number(payload.kometa_log_keep)
-            window.QS_KOMETA_LOG_KEEP = logKeepFlag
+            setAppConfig({ QS_KOMETA_LOG_KEEP: logKeepFlag })
             if (triggerBtn) triggerBtn.dataset.currentLogKeep = String(logKeepFlag)
           }
           if (typeof payload.imagemaid_log_keep !== 'undefined') {
             const imagemaidLogKeepFlag = Number(payload.imagemaid_log_keep)
-            window.QS_IMAGEMAID_LOG_KEEP = imagemaidLogKeepFlag
+            setAppConfig({ QS_IMAGEMAID_LOG_KEEP: imagemaidLogKeepFlag })
             if (triggerBtn) triggerBtn.dataset.currentImagemaidLogKeep = String(imagemaidLogKeepFlag)
           }
           if (typeof data.session_lifetime_days !== 'undefined' || typeof payload.session_lifetime_days !== 'undefined') {
             const lifetimeFlag = Number(
               (typeof data.session_lifetime_days !== 'undefined') ? data.session_lifetime_days : payload.session_lifetime_days
             )
-            window.QS_SESSION_LIFETIME_DAYS = lifetimeFlag
+            setAppConfig({ QS_SESSION_LIFETIME_DAYS: lifetimeFlag })
             if (triggerBtn) triggerBtn.dataset.currentSessionLifetime = String(lifetimeFlag)
           }
           if (typeof data.session_dir !== 'undefined' || typeof payload.session_dir !== 'undefined') {
             const sessionDirFlag = String(
               (typeof data.session_dir !== 'undefined') ? data.session_dir : (payload.session_dir || '')
             )
-            window.QS_FLASK_SESSION_DIR = sessionDirFlag
+            setAppConfig({ QS_FLASK_SESSION_DIR: sessionDirFlag })
             if (triggerBtn) triggerBtn.dataset.currentSessionDir = sessionDirFlag
           }
           if (hasPortChange && triggerBtn) {
@@ -3479,37 +3481,37 @@ document.addEventListener('DOMContentLoaded', () => {
 
         if (data.theme) {
           document.documentElement.setAttribute('data-theme', data.theme)
-          window.QS_THEME = data.theme
+          setAppConfig({ QS_THEME: data.theme })
           if (triggerBtn) triggerBtn.dataset.currentTheme = data.theme
           updateThemeUi(data.theme)
         }
         if (typeof payload.config_history !== 'undefined') {
           const historyFlag = Number(payload.config_history)
-          window.QS_CONFIG_HISTORY = historyFlag
+          setAppConfig({ QS_CONFIG_HISTORY: historyFlag })
           if (triggerBtn) triggerBtn.dataset.currentConfigHistory = String(historyFlag)
         }
         if (typeof payload.kometa_log_keep !== 'undefined') {
           const logKeepFlag = Number(payload.kometa_log_keep)
-          window.QS_KOMETA_LOG_KEEP = logKeepFlag
+          setAppConfig({ QS_KOMETA_LOG_KEEP: logKeepFlag })
           if (triggerBtn) triggerBtn.dataset.currentLogKeep = String(logKeepFlag)
         }
         if (typeof payload.imagemaid_log_keep !== 'undefined') {
           const imagemaidLogKeepFlag = Number(payload.imagemaid_log_keep)
-          window.QS_IMAGEMAID_LOG_KEEP = imagemaidLogKeepFlag
+          setAppConfig({ QS_IMAGEMAID_LOG_KEEP: imagemaidLogKeepFlag })
           if (triggerBtn) triggerBtn.dataset.currentImagemaidLogKeep = String(imagemaidLogKeepFlag)
         }
         if (typeof data.session_lifetime_days !== 'undefined' || typeof payload.session_lifetime_days !== 'undefined') {
           const lifetimeFlag = Number(
             (typeof data.session_lifetime_days !== 'undefined') ? data.session_lifetime_days : payload.session_lifetime_days
           )
-          window.QS_SESSION_LIFETIME_DAYS = lifetimeFlag
+          setAppConfig({ QS_SESSION_LIFETIME_DAYS: lifetimeFlag })
           if (triggerBtn) triggerBtn.dataset.currentSessionLifetime = String(lifetimeFlag)
         }
         if (typeof data.session_dir !== 'undefined' || typeof payload.session_dir !== 'undefined') {
           const sessionDirFlag = String(
             (typeof data.session_dir !== 'undefined') ? data.session_dir : (payload.session_dir || '')
           )
-          window.QS_FLASK_SESSION_DIR = sessionDirFlag
+          setAppConfig({ QS_FLASK_SESSION_DIR: sessionDirFlag })
           if (triggerBtn) triggerBtn.dataset.currentSessionDir = sessionDirFlag
         }
         const rawPort = data.new_port ?? portNum ?? getCurrentPort()

--- a/static/local-js/905-analytics.js
+++ b/static/local-js/905-analytics.js
@@ -1641,10 +1641,10 @@ $(document).ready(function () {
     if (!$tablePolicy.length) return
     const kometaKeepLimit = storage && Number.isFinite(storage.kometa_keep_limit)
       ? storage.kometa_keep_limit
-      : (parseInt(window.QS_KOMETA_LOG_KEEP || '0', 10) || 0)
+      : (parseInt((window.QS_AppConfig && window.QS_AppConfig.QS_KOMETA_LOG_KEEP) || '0', 10) || 0)
     const imagemaidKeepLimit = storage && Number.isFinite(storage.imagemaid_keep_limit)
       ? storage.imagemaid_keep_limit
-      : (parseInt(window.QS_IMAGEMAID_LOG_KEEP || '0', 10) || 0)
+      : (parseInt((window.QS_AppConfig && window.QS_AppConfig.QS_IMAGEMAID_LOG_KEEP) || '0', 10) || 0)
     const kometaRetentionLabel = storage && storage.kometa_retention_label
       ? storage.kometa_retention_label
       : (kometaKeepLimit > 0 ? `Keep last ${kometaKeepLimit} archived logs` : 'Keep all archived logs')

--- a/static/local-js/modules/appConfig.js
+++ b/static/local-js/modules/appConfig.js
@@ -1,0 +1,85 @@
+// App-level config accessors (#1334 Step 5, Phase B).
+//
+// Replaces the 11 `window.QS_*` globals that used to be sprayed across
+// the template via individual `<script>` tags in
+// `templates/000-base.html`. The data is still inline (server-rendered
+// for synchronous startup access), but it lives behind a single object
+// at `window.QS_AppConfig` and is read through these helpers.
+//
+// Why a thin wrapper instead of just reading `window.QS_AppConfig.QS_FOO`
+// directly: centralising the access pattern means future refactors
+// (e.g. moving to a fetched bootstrap, or wrapping in a reactive
+// Proxy for component frameworks) only need to change this file. The
+// indirection is cheap and the call sites get clearer.
+//
+// In-place updates: the settings save flow still mutates the object so
+// other handlers see fresh values without a page reload. The shape of
+// the mutation contract is identical to the old `window.QS_FOO = value`
+// pattern, just routed through `setAppConfig({ QS_FOO: value })`.
+
+// The object the template populates. Bridging back to window keeps
+// classic (non-module) scripts working without an import.
+const NAMESPACE = 'QS_AppConfig'
+
+function getNamespace () {
+  if (typeof window === 'undefined') return {}
+  if (!window[NAMESPACE] || typeof window[NAMESPACE] !== 'object') {
+    window[NAMESPACE] = {}
+  }
+  return window[NAMESPACE]
+}
+
+/**
+ * Read a single app-level config value. Returns `fallback` (default
+ * `undefined`) when the key is missing or the namespace hasn't been
+ * populated yet.
+ */
+export function getAppConfig (key, fallback) {
+  const ns = getNamespace()
+  return Object.prototype.hasOwnProperty.call(ns, key) ? ns[key] : fallback
+}
+
+/**
+ * Merge `patch` into the app-level config namespace. Mutates in place
+ * so any code that captured a reference to `window.QS_AppConfig` still
+ * sees the new values. Returns the (mutated) namespace for chaining.
+ */
+export function setAppConfig (patch) {
+  if (!patch || typeof patch !== 'object') return getNamespace()
+  const ns = getNamespace()
+  for (const [key, value] of Object.entries(patch)) {
+    ns[key] = value
+  }
+  return ns
+}
+
+/**
+ * Re-hydrate the namespace from `GET /api/app-config`. The settings
+ * save flow can call this after a write to be extra-safe that the
+ * client view matches the server, but it isn't required for the
+ * normal flow because `setAppConfig` already keeps the namespace in
+ * sync with the server response.
+ *
+ * Returns the fresh namespace on success, or the existing one on
+ * failure (we never want a transient fetch error to wipe the values
+ * the page started with).
+ */
+export async function refreshAppConfig () {
+  try {
+    const res = await fetch('/api/app-config', { headers: { Accept: 'application/json' } })
+    if (!res.ok) return getNamespace()
+    const data = await res.json()
+    if (data && typeof data === 'object') {
+      const ns = getNamespace()
+      // Replace every known key but don't blow away any unknown keys
+      // someone might have added; merge wins over wholesale replace
+      // for forward compatibility.
+      for (const [key, value] of Object.entries(data)) {
+        ns[key] = value
+      }
+    }
+  } catch {
+    // Network failure or invalid JSON. Keep what we had.
+  }
+  return getNamespace()
+}

--- a/templates/000-base.html
+++ b/templates/000-base.html
@@ -48,17 +48,13 @@
 
 <body>
   <script>
-    window.QS_DEBUG = "{{ 'true' if config['QS_DEBUG'] else 'false' }}";
-    window.QS_THEME = "{{ config.get('QS_THEME', 'kometa') }}";
-    window.QS_OPTIMIZE_DEFAULTS = "{{ 'true' if config.get('QS_OPTIMIZE_DEFAULTS', True) else 'false' }}";
-    window.QS_CONFIG_HISTORY = "{{ config.get('QS_CONFIG_HISTORY', 0) }}";
-    window.QS_KOMETA_LOG_KEEP = "{{ config.get('QS_KOMETA_LOG_KEEP', 0) }}";
-    window.QS_IMAGEMAID_LOG_KEEP = "{{ config.get('QS_IMAGEMAID_LOG_KEEP', 0) }}";
-    window.QS_TEST_LIBS_PATH = {{ config.get('QS_TEST_LIBS_PATH', '') | tojson }};
-    window.QS_TEST_LIBS_TMP = {{ config.get('QS_TEST_LIBS_TMP', '') | tojson }};
-    window.QS_SESSION_LIFETIME_DAYS = "{{ config.get('QS_SESSION_LIFETIME_DAYS', 30) }}";
-    window.QS_FLASK_SESSION_DIR = {{ config.get('QS_FLASK_SESSION_DIR', '') | tojson }};
-    window.QS_RESTART_NOTICE = {{ config.get('QS_RESTART_NOTICE') | tojson }};
+    // Roadmap #1334 Step 5 (Phase B): the 11 app-level config values
+    // formerly emitted as individual ``window.QS_FOO`` globals are now
+    // exposed as a single ``window.QS_AppConfig`` object that mirrors
+    // ``GET /api/app-config`` exactly. JS readers access it via the
+    // ``getAppConfig`` / ``setAppConfig`` helpers in
+    // ``static/local-js/modules/appConfig.js``.
+    window.QS_AppConfig = {{ qs_app_config | tojson }};
     window.QS_CURRENT_TEMPLATE = {{ (page_info.get('template_name', '') if page_info else '') | tojson }};
     window.QS_SETTINGS_CUSTOM_REPO = {{ (page_info.get('settings_custom_repo', '') if page_info else '') | tojson }};
     window.QS_SETTINGS_CUSTOM_REPO_BASE = {{ (page_info.get('settings_custom_repo_base', '') if page_info else '') | tojson }};

--- a/tests/js/modules/appConfig.test.js
+++ b/tests/js/modules/appConfig.test.js
@@ -1,0 +1,174 @@
+// Tests for static/local-js/modules/appConfig.js (#1334 Step 5, Phase B).
+//
+// These tests don't currently run in CI because Vitest is on a separate
+// branch (PR #1357) that hasn't merged yet. Once it lands, this file
+// is automatically picked up by the include glob in vite.config.js
+// (`tests/js/**/*.test.js`) and runs with everything else.
+//
+// Coverage of the contract that 000-base.js depends on:
+//
+//   - getAppConfig returns the value when the key exists, the fallback
+//     when it doesn't, and `undefined` when no fallback is given.
+//   - setAppConfig merges into the namespace and mutates in place
+//     (so other code that captured a reference to window.QS_AppConfig
+//     sees the new values).
+//   - refreshAppConfig hits /api/app-config, merges the response, and
+//     swallows network errors gracefully.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  getAppConfig,
+  refreshAppConfig,
+  setAppConfig
+} from '../../../static/local-js/modules/appConfig.js'
+
+describe('getAppConfig', () => {
+  beforeEach(() => {
+    delete window.QS_AppConfig
+  })
+
+  it('returns undefined when the namespace is missing and no fallback given', () => {
+    expect(getAppConfig('QS_DEBUG')).toBeUndefined()
+  })
+
+  it('returns the fallback when the namespace is missing', () => {
+    expect(getAppConfig('QS_DEBUG', 'fallback-value')).toBe('fallback-value')
+  })
+
+  it('returns the live value when the key is present', () => {
+    window.QS_AppConfig = { QS_DEBUG: true, QS_THEME: 'dracula' }
+    expect(getAppConfig('QS_DEBUG')).toBe(true)
+    expect(getAppConfig('QS_THEME')).toBe('dracula')
+  })
+
+  it('returns the fallback when the key is missing from a populated namespace', () => {
+    window.QS_AppConfig = { QS_THEME: 'kometa' }
+    expect(getAppConfig('QS_DEBUG', false)).toBe(false)
+  })
+
+  it('distinguishes between falsy values and missing keys', () => {
+    // A common bug: `||` collapses both. The helper uses hasOwnProperty
+    // so falsy values come through unchanged.
+    window.QS_AppConfig = { QS_DEBUG: false, QS_KOMETA_LOG_KEEP: 0, QS_THEME: '' }
+    expect(getAppConfig('QS_DEBUG', true)).toBe(false)
+    expect(getAppConfig('QS_KOMETA_LOG_KEEP', 99)).toBe(0)
+    expect(getAppConfig('QS_THEME', 'kometa')).toBe('')
+  })
+})
+
+describe('setAppConfig', () => {
+  beforeEach(() => {
+    delete window.QS_AppConfig
+  })
+
+  it('creates the namespace when it does not exist', () => {
+    expect(window.QS_AppConfig).toBeUndefined()
+    setAppConfig({ QS_DEBUG: true })
+    expect(window.QS_AppConfig).toEqual({ QS_DEBUG: true })
+  })
+
+  it('merges into an existing namespace without dropping other keys', () => {
+    window.QS_AppConfig = { QS_DEBUG: false, QS_THEME: 'kometa' }
+    setAppConfig({ QS_THEME: 'dracula' })
+    expect(window.QS_AppConfig).toEqual({ QS_DEBUG: false, QS_THEME: 'dracula' })
+  })
+
+  it('mutates in place so captured references see the new values', () => {
+    window.QS_AppConfig = { QS_DEBUG: false }
+    const captured = window.QS_AppConfig
+    setAppConfig({ QS_DEBUG: true, QS_THEME: 'dracula' })
+    // captured is the same object reference; the settings save flow
+    // relies on this so other handlers that have already read
+    // window.QS_AppConfig still see live values.
+    expect(captured).toBe(window.QS_AppConfig)
+    expect(captured.QS_DEBUG).toBe(true)
+    expect(captured.QS_THEME).toBe('dracula')
+  })
+
+  it('is a no-op when patch is null or not an object', () => {
+    window.QS_AppConfig = { QS_DEBUG: true }
+    setAppConfig(null)
+    setAppConfig(undefined)
+    setAppConfig('not an object')
+    expect(window.QS_AppConfig).toEqual({ QS_DEBUG: true })
+  })
+
+  it('returns the namespace for convenience', () => {
+    const result = setAppConfig({ QS_DEBUG: true })
+    expect(result).toBe(window.QS_AppConfig)
+  })
+})
+
+describe('refreshAppConfig', () => {
+  beforeEach(() => {
+    delete window.QS_AppConfig
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('fetches /api/app-config and merges the response', async () => {
+    window.QS_AppConfig = { QS_DEBUG: false }
+    const fetchMock = vi.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ QS_DEBUG: true, QS_THEME: 'dracula' })
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await refreshAppConfig()
+
+    expect(fetchMock).toHaveBeenCalledExactlyOnceWith(
+      '/api/app-config',
+      { headers: { Accept: 'application/json' } }
+    )
+    expect(window.QS_AppConfig.QS_DEBUG).toBe(true)
+    expect(window.QS_AppConfig.QS_THEME).toBe('dracula')
+  })
+
+  it('preserves keys not present in the response (forward compat)', async () => {
+    window.QS_AppConfig = { QS_DEBUG: false, EXOTIC_FUTURE_KEY: 'sentinel' }
+    vi.stubGlobal('fetch', () => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ QS_DEBUG: true })
+    }))
+
+    await refreshAppConfig()
+
+    expect(window.QS_AppConfig.QS_DEBUG).toBe(true)
+    expect(window.QS_AppConfig.EXOTIC_FUTURE_KEY).toBe('sentinel')
+  })
+
+  it('keeps the existing namespace intact on HTTP failure', async () => {
+    window.QS_AppConfig = { QS_DEBUG: true }
+    vi.stubGlobal('fetch', () => Promise.resolve({
+      ok: false,
+      json: () => Promise.resolve({ QS_DEBUG: 'oh no' })
+    }))
+
+    await refreshAppConfig()
+
+    expect(window.QS_AppConfig.QS_DEBUG).toBe(true)
+  })
+
+  it('keeps the existing namespace intact on network error', async () => {
+    window.QS_AppConfig = { QS_DEBUG: true }
+    vi.stubGlobal('fetch', () => Promise.reject(new Error('network down')))
+
+    await refreshAppConfig()
+
+    expect(window.QS_AppConfig.QS_DEBUG).toBe(true)
+  })
+
+  it('keeps the existing namespace intact on invalid JSON', async () => {
+    window.QS_AppConfig = { QS_DEBUG: true }
+    vi.stubGlobal('fetch', () => Promise.resolve({
+      ok: true,
+      json: () => Promise.reject(new Error('not JSON'))
+    }))
+
+    await refreshAppConfig()
+
+    expect(window.QS_AppConfig.QS_DEBUG).toBe(true)
+  })
+})


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix
- [x] Feature/Tweak (non-breaking change which adds new functionality)
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Other

## Description

Roadmap issue #1334 **Step 5, Phase B**. Stacked on top of #1358 (Phase A, which added the `GET /api/app-config` endpoint).

This PR is the actual cleanup: the 11 `window.QS_*` globals are gone, replaced with a single `window.QS_AppConfig` object accessed via helper functions.

### Why two phases (recap)

The existing JS doesn't just **read** `window.QS_*` — it **writes** to them too, mutating in place after a settings save so other handlers see fresh values without a page reload. Phase A added the endpoint additively without touching the JS so the migration could be reviewed in isolation. Phase B (this PR) is where the actual reader/writer migration lands.

### What changes

| File | Diff | Purpose |
|---|---|---|
| `templates/000-base.html` | -11 / +7 lines | Replaces the 11 individual `window.QS_FOO = ...` injections with a single `window.QS_AppConfig = {{ qs_app_config\|tojson }};` line |
| `quickstart.py` | +8 lines | Extends the existing `app.context_processor` to inject `qs_app_config` via Phase A's `collect_app_config()` helper (single source of truth, no key list duplication) |
| `static/local-js/modules/appConfig.js` | NEW (~85 LOC) | `getAppConfig()`, `setAppConfig()`, `refreshAppConfig()` helpers |
| `static/local-js/000-base.js` | -29 / +29 lines | Every read site uses `getAppConfig('QS_FOO', fallback)`; every write site uses `setAppConfig({ QS_FOO: value })` |
| `static/local-js/905-analytics.js` | -2 / +2 lines | Two read sites in a classic (non-module) script read via `window.QS_AppConfig.QS_FOO` directly. No import overhead for two call sites |
| `tests/js/modules/appConfig.test.js` | NEW (~174 LOC) | 15 Vitest cases. Won't run in CI on this branch (Vitest is in #1357), but auto-picked up once that lands |

### The contract preserved by `setAppConfig`

```js
// BEFORE: settings save flow mutates 11 globals in place
window.QS_DEBUG = newValue
window.QS_THEME = newTheme

// AFTER: settings save flow mutates the namespace in place
setAppConfig({ QS_DEBUG: newValue })
setAppConfig({ QS_THEME: newTheme })

// Code that captured the namespace earlier still sees fresh values:
const captured = window.QS_AppConfig
setAppConfig({ QS_DEBUG: true })
captured.QS_DEBUG // => true (test #4 pins this)
```

### What is explicitly NOT in this PR

- **Page-level vars in the template** (`QS_REQUIRED_KEYS`, `QS_OPTIONAL_KEYS`, `QS_REVIEW_KEYS`, `QS_CURRENT_TEMPLATE`, `QS_SETTINGS_CUSTOM_REPO[_BASE]`, the `QS_*_REQUIREMENT_REASONS` family) — deliberately untouched. They depend on the current page or active template and are handled by roadmap Step 9 (component islands).
- **No new dependencies.** Vitest stays on its own PR (#1357).
- **No changes to `/api/app-config` itself.** Phase A's endpoint is unchanged.

### Verification

| Check | Result |
|---|---|
| `pytest test_app_config_endpoint + test_status_endpoint + test_validate_service_routes + test_config_and_library_routes` | **80/80 pass** |
| `pytest -m e2e tests/e2e/test_wizard_e2e.py` (Playwright; exercises real JS) | **5/5 pass** |
| `pre-commit run --all-files` | 12/12 hooks green |
| Manual smoke (Flask test_client, GET `/` → follow redirect → `/step/001-start`) | Rendered HTML contains `window.QS_AppConfig = {...}` with all 11 keys; **zero** occurrences of old `window.QS_DEBUG`/`QS_THEME`/etc |
| JS tests via borrowed Vitest config | **15/15 pass** in ~1.3s (won't run on this branch's CI; auto-picked up once #1357 merges) |

### Sample rendered template output

Before:
```html
<script>
  window.QS_DEBUG = "false";
  window.QS_THEME = "kometa";
  window.QS_OPTIMIZE_DEFAULTS = "true";
  window.QS_CONFIG_HISTORY = "0";
  window.QS_KOMETA_LOG_KEEP = "0";
  window.QS_IMAGEMAID_LOG_KEEP = "0";
  window.QS_TEST_LIBS_PATH = "/path/...";
  window.QS_TEST_LIBS_TMP = "/path/...";
  window.QS_SESSION_LIFETIME_DAYS = "30";
  window.QS_FLASK_SESSION_DIR = "/path/...";
  window.QS_RESTART_NOTICE = null;
  ...
```

After:
```html
<script>
  // ...comment block explaining the migration...
  window.QS_AppConfig = {"QS_CONFIG_HISTORY": 0, "QS_DEBUG": false, "QS_FLASK_SESSION_DIR": "/path/...", "QS_IMAGEMAID_LOG_KEEP": 0, "QS_KOMETA_LOG_KEEP": 0, "QS_OPTIMIZE_DEFAULTS": true, "QS_RESTART_NOTICE": null, "QS_SESSION_LIFETIME_DAYS": 30, "QS_TEST_LIBS_PATH": "/path/...", "QS_TEST_LIBS_TMP": "/path/...", "QS_THEME": "kometa"};
  ...
```

### Diff size

```
quickstart.py                        |   8 ++
static/local-js/000-base.js          |  58 +++++++------
static/local-js/905-analytics.js     |   4 +-
static/local-js/modules/appConfig.js |  85 +++++++++++++++++ (new)
templates/000-base.html              |  18 ++--
tests/js/modules/appConfig.test.js   | 174 +++++++++++++++++++++++++++++++++++ (new, dormant)
6 files changed, 306 insertions(+), 41 deletions(-)
```

### Roadmap context (#1334)

| Step | Status |
|---|---|
| 1. ESLint | done |
| 2. ES modules | partial (16 wizards done) |
| 3. Decompose helpers.py | done |
| 4. Vite | #1356 (queued) |
| **5. `/api/app-config` endpoint** | Phase A: #1358 (queued); **Phase B: this PR** |
| 6. Validation widget + Alpine | needs Vite |
| 7. Drop jQuery | easier after Step 6 |
| 8. Vitest | #1357 (queued, stacked on Step 4) |
| 9. Component islands; page-level globals retired naturally | needs Steps 4-8 |

## Related Issues

Roadmap: #1334 Step 5 (Phase B)

Stacked on: #1358 (Phase A — must merge first)

## Which Environment Did You Test On?

- [x] Local Install (Linux, Python 3.13, Flask test_client + Playwright e2e + local Vitest run for JS tests)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other


---

**Repost note:** This PR replaces #1359, which was auto-closed by GitHub when its base branch (`feat/app-config-endpoint`) was deleted on merge of #1358. Branch contents are identical (same cherry-pick on top of current develop) and now re-target `develop` directly. All tests still pass: 62/62 Python route, 24/24 Vitest (the 15 in `appConfig.test.js` are this PR's new tests), 12/12 pre-commit.
