### PR TITLE
Drop jQuery from 16 wizard ES modules (#1334 Step 7 — Phase 1)

### DIFF
--- a/static/local-js/010-plex.js
+++ b/static/local-js/010-plex.js
@@ -1,47 +1,45 @@
 import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
 
-$(document).ready(function () {
-  const validateButton = document.getElementById('validateButton')
-  const isValidated = document.getElementById('plex_validated').value.toLowerCase()
-  const validatedAtInput = document.getElementById('plex_validated_at')
-  const hiddenSection = document.getElementById('hidden')
-  const plexDbCache = document.getElementById('plexDbCache')
-  const plexTokenInput = document.getElementById('plex_token')
-  const plexUrlInput = document.getElementById('plex_url')
-  const toggleButton = document.getElementById('toggleApikeyVisibility')
+const validateButton = document.getElementById('validateButton')
+const isValidated = document.getElementById('plex_validated').value.toLowerCase()
+const validatedAtInput = document.getElementById('plex_validated_at')
+const hiddenSection = document.getElementById('hidden')
+const plexDbCache = document.getElementById('plexDbCache')
+const plexTokenInput = document.getElementById('plex_token')
+const plexUrlInput = document.getElementById('plex_url')
+const toggleButton = document.getElementById('toggleApikeyVisibility')
 
-  validateButton.disabled = (isValidated === 'true')
+validateButton.disabled = (isValidated === 'true')
 
-  console.log('Validated: ' + isValidated)
+console.log('Validated: ' + isValidated)
 
-  if (isValidated === 'true') {
-    hiddenSection.style.display = 'block'
-    plexDbCache.style.display = 'block'
-  }
+if (isValidated === 'true') {
+  hiddenSection.style.display = 'block'
+  plexDbCache.style.display = 'block'
+}
 
-  // Set initial visibility based on token value
-  if (plexTokenInput.value.trim() === '') {
-    plexTokenInput.setAttribute('type', 'text') // Show placeholder text
-    setToggleButtonIcon(toggleButton, true)
-  } else {
-    plexTokenInput.setAttribute('type', 'password') // Hide actual token
-    setToggleButtonIcon(toggleButton, false)
-  }
+// Set initial visibility based on token value
+if (plexTokenInput.value.trim() === '') {
+  plexTokenInput.setAttribute('type', 'text') // Show placeholder text
+  setToggleButtonIcon(toggleButton, true)
+} else {
+  plexTokenInput.setAttribute('type', 'password') // Hide actual token
+  setToggleButtonIcon(toggleButton, false)
+}
 
-  // Enable validate button and reset validation when token or URL changes
-  plexTokenInput.addEventListener('input', function () {
-    validateButton.disabled = false
-    document.getElementById('plex_validated').value = 'false'
-    if (validatedAtInput) validatedAtInput.value = ''
-    refreshValidationCallout('plex_validated')
-  })
+// Enable validate button and reset validation when token or URL changes
+plexTokenInput.addEventListener('input', function () {
+  validateButton.disabled = false
+  document.getElementById('plex_validated').value = 'false'
+  if (validatedAtInput) validatedAtInput.value = ''
+  refreshValidationCallout('plex_validated')
+})
 
-  plexUrlInput.addEventListener('input', function () {
-    validateButton.disabled = false
-    document.getElementById('plex_validated').value = 'false'
-    if (validatedAtInput) validatedAtInput.value = ''
-    refreshValidationCallout('plex_validated')
-  })
+plexUrlInput.addEventListener('input', function () {
+  validateButton.disabled = false
+  document.getElementById('plex_validated').value = 'false'
+  if (validatedAtInput) validatedAtInput.value = ''
+  refreshValidationCallout('plex_validated')
 })
 
 // Toggle password visibility
@@ -57,7 +55,6 @@ document.getElementById('validateButton').addEventListener('click', function () 
   const plexUrl = document.getElementById('plex_url').value
   const plexToken = document.getElementById('plex_token').value
   const statusMessage = document.getElementById('statusMessage')
-  const plexDbCache = document.getElementById('plexDbCache')
   const currentDbCache = document.getElementById('plex_db_cache').value
 
   if (!plexUrl || !plexToken) {
@@ -115,7 +112,6 @@ document.getElementById('validateButton').addEventListener('click', function () 
 
         statusMessage.textContent = 'Plex server validated successfully!'
         statusMessage.style.color = '#75b798'
-        const hiddenSection = document.getElementById('hidden')
         hiddenSection.style.display = 'block'
 
         if (Number(currentDbCache) !== serverDbCache) {
@@ -147,7 +143,6 @@ document.getElementById('validateButton').addEventListener('click', function () 
       statusMessage.textContent = 'Error occurred during validation.'
       statusMessage.style.color = '#ea868f'
       statusMessage.style.display = 'block'
-      const validatedAtInput = document.getElementById('plex_validated_at')
       if (validatedAtInput) validatedAtInput.value = ''
       refreshValidationCallout('plex_validated')
     })

--- a/static/local-js/027-playlist_files.js
+++ b/static/local-js/027-playlist_files.js
@@ -1,58 +1,71 @@
 import { refreshValidationCallout } from './modules/validationPageBase.js'
 
 const validatedAtInput = document.getElementById('playlist_files_validated_at')
+const plexValidEl = document.getElementById('plex_valid')
+const plexValid = !!plexValidEl && plexValidEl.dataset.plexValid === 'True'
+console.log('Plex Valid:', plexValid)
 
-$(document).ready(function () {
-  const plexValid = $('#plex_valid').length > 0 && $('#plex_valid').data('plex-valid') === 'True'
-  console.log('Plex Valid:', plexValid)
+const librariesContainer = document.getElementById('libraries-container')
+const validationMessages = document.getElementById('validation-messages')
 
-  if (!plexValid) {
-    $('#libraries-container').hide()
-    $('#validation-messages').html(
+if (!plexValid) {
+  if (librariesContainer) librariesContainer.style.display = 'none'
+  if (validationMessages) {
+    validationMessages.innerHTML =
       'Plex settings have not been validated successfully. Please <a href="javascript:void(0);" onclick="jumpTo(\'010-plex\');">return to the Plex page</a> and hit the validate button and ensure success before returning here.<br>'
-    ).show()
-  } else {
-    $('#libraries-container').show()
-    $('#validation-messages').hide()
+    validationMessages.style.display = ''
   }
+} else {
+  if (librariesContainer) librariesContainer.style.display = ''
+  if (validationMessages) validationMessages.style.display = 'none'
+}
 
-  // Initialize checkboxes based on preselected libraries
-  const selectedLibraries = $('#libraries').val().split(',').map(item => item.trim())
-  console.log('Preselected Libraries:', selectedLibraries)
-  $('.library-checkbox').each(function () {
-    if (selectedLibraries.includes($(this).val())) {
-      $(this).prop('checked', true)
-    }
-  })
+const librariesInput = document.getElementById('libraries')
+const validatedField = document.getElementById('playlist_files_validated')
 
-  // Update hidden input field when checkboxes are changed
-  $('.library-checkbox').change(function () {
-    const updatedLibraries = []
-    $('.library-checkbox:checked').each(function () {
-      updatedLibraries.push($(this).val())
-    })
-    $('#libraries').val(updatedLibraries.join(', '))
+// Initialize checkboxes based on preselected libraries
+const initialLibrariesRaw = librariesInput && librariesInput.value ? librariesInput.value : ''
+const selectedLibraries = initialLibrariesRaw.split(',').map(item => item.trim())
+console.log('Preselected Libraries:', selectedLibraries)
+
+const libraryCheckboxes = document.querySelectorAll('.library-checkbox')
+libraryCheckboxes.forEach(checkbox => {
+  if (selectedLibraries.includes(checkbox.value)) {
+    checkbox.checked = true
+  }
+})
+
+// Update validation state
+function updateValidationState (isValid) {
+  if (validatedField) validatedField.value = isValid ? 'true' : 'false'
+  if (validatedAtInput) {
+    validatedAtInput.value = isValid ? new Date().toISOString() : ''
+  }
+  refreshValidationCallout('playlist_files_validated')
+  console.log('Validation State Updated:', isValid)
+}
+
+// Update hidden input field when checkboxes are changed
+libraryCheckboxes.forEach(checkbox => {
+  checkbox.addEventListener('change', function () {
+    const updatedLibraries = Array.from(document.querySelectorAll('.library-checkbox:checked'))
+      .map(box => box.value)
+    if (librariesInput) librariesInput.value = updatedLibraries.join(', ')
     updateValidationState(updatedLibraries.length > 0)
     console.log('Updated Libraries:', updatedLibraries)
   })
-
-  // Update validation state
-  function updateValidationState (isValid) {
-    $('#playlist_files_validated').val(isValid ? 'true' : 'false')
-    if (validatedAtInput) {
-      validatedAtInput.value = isValid ? new Date().toISOString() : ''
-    }
-    refreshValidationCallout('playlist_files_validated')
-    console.log('Validation State Updated:', isValid)
-  }
-
-  // Preserve data on form submission for backend processing
-  $('#configForm').on('submit', function () {
-    // Log the data being submitted for debugging
-    console.log('Form Submitted:')
-    console.log('Default:', $('#default').val())
-    console.log('Libraries:', $('#libraries').val())
-    console.log('Validated:', $('#playlist_files_validated').val())
-    console.log('Template Variables:', $('#template_variables').val())
-  })
 })
+
+// Preserve data on form submission for backend processing
+const configForm = document.getElementById('configForm')
+if (configForm) {
+  configForm.addEventListener('submit', function () {
+    const defaultEl = document.getElementById('default')
+    const templateVariables = document.getElementById('template_variables')
+    console.log('Form Submitted:')
+    console.log('Default:', defaultEl ? defaultEl.value : '')
+    console.log('Libraries:', librariesInput ? librariesInput.value : '')
+    console.log('Validated:', validatedField ? validatedField.value : '')
+    console.log('Template Variables:', templateVariables ? templateVariables.value : '')
+  })
+}

--- a/static/local-js/030-tautulli.js
+++ b/static/local-js/030-tautulli.js
@@ -2,40 +2,38 @@ import { setToggleButtonIcon, refreshValidationCallout } from './modules/validat
 
 const validatedAtInput = document.getElementById('tautulli_validated_at')
 
-$(document).ready(function () {
-  const apiKeyInput = document.getElementById('tautulli_apikey')
-  const urlInput = document.getElementById('tautulli_url')
-  const validateButton = document.getElementById('validateButton')
-  const toggleButton = document.getElementById('toggleApikeyVisibility')
-  const isValidated = document.getElementById('tautulli_validated').value.toLowerCase()
-  console.log('Validated: ' + isValidated)
+const apiKeyInput = document.getElementById('tautulli_apikey')
+const urlInput = document.getElementById('tautulli_url')
+const validateButton = document.getElementById('validateButton')
+const toggleButton = document.getElementById('toggleApikeyVisibility')
+const isValidated = document.getElementById('tautulli_validated').value.toLowerCase()
+console.log('Validated: ' + isValidated)
 
-  // Set initial visibility based on API key value
-  if (apiKeyInput.value.trim() === '') {
-    apiKeyInput.setAttribute('type', 'text') // Show placeholder text
-    setToggleButtonIcon(toggleButton, true)
-  } else {
-    apiKeyInput.setAttribute('type', 'password') // Hide actual key
-    setToggleButtonIcon(toggleButton, false)
-  }
+// Set initial visibility based on API key value
+if (apiKeyInput.value.trim() === '') {
+  apiKeyInput.setAttribute('type', 'text') // Show placeholder text
+  setToggleButtonIcon(toggleButton, true)
+} else {
+  apiKeyInput.setAttribute('type', 'password') // Hide actual key
+  setToggleButtonIcon(toggleButton, false)
+}
 
-  // Disable validate button if already validated
-  validateButton.disabled = isValidated === 'true'
+// Disable validate button if already validated
+validateButton.disabled = isValidated === 'true'
 
-  // Reset validation status when user types
-  apiKeyInput.addEventListener('input', function () {
-    document.getElementById('tautulli_validated').value = 'false'
-    if (validatedAtInput) validatedAtInput.value = ''
-    validateButton.disabled = false
-    refreshValidationCallout('tautulli_validated')
-  })
+// Reset validation status when user types
+apiKeyInput.addEventListener('input', function () {
+  document.getElementById('tautulli_validated').value = 'false'
+  if (validatedAtInput) validatedAtInput.value = ''
+  validateButton.disabled = false
+  refreshValidationCallout('tautulli_validated')
+})
 
-  urlInput.addEventListener('input', function () {
-    document.getElementById('tautulli_validated').value = 'false'
-    if (validatedAtInput) validatedAtInput.value = ''
-    validateButton.disabled = false
-    refreshValidationCallout('tautulli_validated')
-  })
+urlInput.addEventListener('input', function () {
+  document.getElementById('tautulli_validated').value = 'false'
+  if (validatedAtInput) validatedAtInput.value = ''
+  validateButton.disabled = false
+  refreshValidationCallout('tautulli_validated')
 })
 
 document.getElementById('toggleApikeyVisibility').addEventListener('click', function () {
@@ -100,8 +98,6 @@ document.getElementById('validateButton').addEventListener('click', function () 
 })
 
 document.getElementById('configForm').addEventListener('submit', function () {
-  const apiKeyInput = document.getElementById('tautulli_apikey')
-  const urlInput = document.getElementById('tautulli_url')
   if (!apiKeyInput.value) {
     apiKeyInput.value = ''
   }

--- a/static/local-js/040-github.js
+++ b/static/local-js/040-github.js
@@ -2,32 +2,30 @@ import { setToggleButtonIcon, refreshValidationCallout } from './modules/validat
 
 const validatedAtInput = document.getElementById('github_validated_at')
 
-$(document).ready(function () {
-  const apiKeyInput = document.getElementById('github_token')
-  const validateButton = document.getElementById('validateButton')
-  const toggleButton = document.getElementById('toggleApikeyVisibility')
-  const isValidated = document.getElementById('github_validated').value.toLowerCase() === 'true'
-  console.log('Validated: ' + isValidated)
+const apiKeyInput = document.getElementById('github_token')
+const validateButton = document.getElementById('validateButton')
+const toggleButton = document.getElementById('toggleApikeyVisibility')
+const isValidated = document.getElementById('github_validated').value.toLowerCase() === 'true'
+console.log('Validated: ' + isValidated)
 
-  // Set initial visibility based on API key value
-  if (apiKeyInput.value.trim() === '') {
-    apiKeyInput.setAttribute('type', 'text') // Show placeholder text
-    setToggleButtonIcon(toggleButton, true)
-  } else {
-    apiKeyInput.setAttribute('type', 'password') // Hide actual key
-    setToggleButtonIcon(toggleButton, false)
-  }
+// Set initial visibility based on API key value
+if (apiKeyInput.value.trim() === '') {
+  apiKeyInput.setAttribute('type', 'text') // Show placeholder text
+  setToggleButtonIcon(toggleButton, true)
+} else {
+  apiKeyInput.setAttribute('type', 'password') // Hide actual key
+  setToggleButtonIcon(toggleButton, false)
+}
 
-  // Disable validate button if already validated
-  validateButton.disabled = isValidated
+// Disable validate button if already validated
+validateButton.disabled = isValidated
 
-  // Reset validation status when user types
-  apiKeyInput.addEventListener('input', function () {
-    document.getElementById('github_validated').value = 'false'
-    if (validatedAtInput) validatedAtInput.value = ''
-    validateButton.disabled = false
-    refreshValidationCallout('github_validated')
-  })
+// Reset validation status when user types
+apiKeyInput.addEventListener('input', function () {
+  document.getElementById('github_validated').value = 'false'
+  if (validatedAtInput) validatedAtInput.value = ''
+  validateButton.disabled = false
+  refreshValidationCallout('github_validated')
 })
 
 document.getElementById('toggleApikeyVisibility').addEventListener('click', function () {
@@ -89,7 +87,6 @@ document.getElementById('validateButton').addEventListener('click', function () 
 })
 
 document.getElementById('configForm').addEventListener('submit', function () {
-  const apiKeyInput = document.getElementById('github_token')
   if (!apiKeyInput.value) {
     apiKeyInput.value = ''
   }

--- a/static/local-js/050-omdb.js
+++ b/static/local-js/050-omdb.js
@@ -2,32 +2,30 @@ import { setToggleButtonIcon, refreshValidationCallout } from './modules/validat
 
 const validatedAtInput = document.getElementById('omdb_validated_at')
 
-$(document).ready(function () {
-  const apiKeyInput = document.getElementById('omdb_apikey')
-  const validateButton = document.getElementById('validateButton')
-  const toggleButton = document.getElementById('toggleApikeyVisibility')
-  const isValidated = document.getElementById('omdb_validated').value.toLowerCase()
-  console.log('Validated: ' + isValidated)
+const apiKeyInput = document.getElementById('omdb_apikey')
+const validateButton = document.getElementById('validateButton')
+const toggleButton = document.getElementById('toggleApikeyVisibility')
+const isValidated = document.getElementById('omdb_validated').value.toLowerCase()
+console.log('Validated: ' + isValidated)
 
-  // Set initial visibility based on API key value
-  if (apiKeyInput.value.trim() === '') {
-    apiKeyInput.setAttribute('type', 'text') // Show placeholder text
-    setToggleButtonIcon(toggleButton, true)
-  } else {
-    apiKeyInput.setAttribute('type', 'password') // Hide actual key
-    setToggleButtonIcon(toggleButton, false)
-  }
+// Set initial visibility based on API key value
+if (apiKeyInput.value.trim() === '') {
+  apiKeyInput.setAttribute('type', 'text') // Show placeholder text
+  setToggleButtonIcon(toggleButton, true)
+} else {
+  apiKeyInput.setAttribute('type', 'password') // Hide actual key
+  setToggleButtonIcon(toggleButton, false)
+}
 
-  // Disable validate button if already validated
-  validateButton.disabled = isValidated === 'true'
+// Disable validate button if already validated
+validateButton.disabled = isValidated === 'true'
 
-  // Reset validation status when user types
-  apiKeyInput.addEventListener('input', function () {
-    document.getElementById('omdb_validated').value = 'false'
-    if (validatedAtInput) validatedAtInput.value = ''
-    validateButton.disabled = false
-    refreshValidationCallout('omdb_validated')
-  })
+// Reset validation status when user types
+apiKeyInput.addEventListener('input', function () {
+  document.getElementById('omdb_validated').value = 'false'
+  if (validatedAtInput) validatedAtInput.value = ''
+  validateButton.disabled = false
+  refreshValidationCallout('omdb_validated')
 })
 
 document.getElementById('toggleApikeyVisibility').addEventListener('click', function () {
@@ -90,7 +88,6 @@ document.getElementById('validateButton').addEventListener('click', function () 
 })
 
 document.getElementById('configForm').addEventListener('submit', function (event) {
-  const apiKeyInput = document.getElementById('omdb_apikey')
   if (!apiKeyInput.value) {
     apiKeyInput.value = ''
   }

--- a/static/local-js/060-mdblist.js
+++ b/static/local-js/060-mdblist.js
@@ -1,98 +1,95 @@
 import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
 
-$(document).ready(function () {
-  const apiKeyInput = document.getElementById('mdblist_apikey')
-  const validateButton = document.getElementById('validateButton')
-  const toggleButton = document.getElementById('toggleApikeyVisibility')
-  const isValidated = document.getElementById('mdblist_validated').value.toLowerCase()
-  const validatedAtInput = document.getElementById('mdblist_validated_at')
+const apiKeyInput = document.getElementById('mdblist_apikey')
+const validateButton = document.getElementById('validateButton')
+const toggleButton = document.getElementById('toggleApikeyVisibility')
+const isValidated = document.getElementById('mdblist_validated').value.toLowerCase()
+const validatedAtInput = document.getElementById('mdblist_validated_at')
 
-  console.log('Validated: ' + isValidated)
+console.log('Validated: ' + isValidated)
 
-  // Set initial visibility based on API key value
-  if (apiKeyInput.value.trim() === '') {
-    apiKeyInput.setAttribute('type', 'text') // Show placeholder text
-    setToggleButtonIcon(toggleButton, true)
-  } else {
-    apiKeyInput.setAttribute('type', 'password') // Hide actual key
-    setToggleButtonIcon(toggleButton, false)
+// Set initial visibility based on API key value
+if (apiKeyInput.value.trim() === '') {
+  apiKeyInput.setAttribute('type', 'text') // Show placeholder text
+  setToggleButtonIcon(toggleButton, true)
+} else {
+  apiKeyInput.setAttribute('type', 'password') // Hide actual key
+  setToggleButtonIcon(toggleButton, false)
+}
+
+// Disable validate button if already validated
+validateButton.disabled = isValidated === 'true'
+
+// Reset validation status when user types
+apiKeyInput.addEventListener('input', function () {
+  document.getElementById('mdblist_validated').value = 'false'
+  if (validatedAtInput) validatedAtInput.value = ''
+  validateButton.disabled = false
+  refreshValidationCallout('mdblist_validated')
+})
+
+document.getElementById('validateButton').addEventListener('click', function () {
+  const apiKey = apiKeyInput.value
+  const statusMessage = document.getElementById('statusMessage')
+
+  if (!apiKey) {
+    statusMessage.textContent = 'Please enter an API key.'
+    statusMessage.style.color = '#ea868f'
+    statusMessage.style.display = 'block'
+    return
   }
 
-  // Disable validate button if already validated
-  validateButton.disabled = isValidated === 'true'
+  showSpinner('validate')
 
-  // Reset validation status when user types
-  apiKeyInput.addEventListener('input', function () {
-    document.getElementById('mdblist_validated').value = 'false'
-    if (validatedAtInput) validatedAtInput.value = ''
-    validateButton.disabled = false
-    refreshValidationCallout('mdblist_validated')
+  fetch('/validate_mdblist', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ mdblist_apikey: apiKey })
   })
-
-  document.getElementById('validateButton').addEventListener('click', function () {
-    const apiKey = apiKeyInput.value
-    const statusMessage = document.getElementById('statusMessage')
-
-    if (!apiKey) {
-      statusMessage.textContent = 'Please enter an API key.'
-      statusMessage.style.color = '#ea868f'
-      statusMessage.style.display = 'block'
-      return
-    }
-
-    showSpinner('validate')
-
-    fetch('/validate_mdblist', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({ mdblist_apikey: apiKey })
-    })
-      .then(response => response.json())
-      .then(data => {
-        if (data.valid) {
-          console.log('valid')
-          hideSpinner('validate')
-          document.getElementById('mdblist_validated').value = 'true'
-          if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-          refreshValidationCallout('mdblist_validated')
-          statusMessage.textContent = 'API key is valid!'
-          statusMessage.style.color = '#75b798'
-          validateButton.disabled = true
-        } else {
-          console.log('NOT valid')
-          document.getElementById('mdblist_validated').value = 'false'
-          if (validatedAtInput) validatedAtInput.value = ''
-          refreshValidationCallout('mdblist_validated')
-          statusMessage.textContent = 'Failed to validate MDBList server. Please check your API Key.'
-          statusMessage.style.color = '#ea868f'
-        }
-        statusMessage.style.display = 'block'
-      })
-      .catch(error => {
-        console.error('Error validating MDBList server:', error)
-        statusMessage.textContent = 'An error occurred. Please try again.'
-        statusMessage.style.color = '#ea868f'
-        statusMessage.style.display = 'block'
+    .then(response => response.json())
+    .then(data => {
+      if (data.valid) {
+        console.log('valid')
+        hideSpinner('validate')
+        document.getElementById('mdblist_validated').value = 'true'
+        if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
+        refreshValidationCallout('mdblist_validated')
+        statusMessage.textContent = 'API key is valid!'
+        statusMessage.style.color = '#75b798'
+        validateButton.disabled = true
+      } else {
+        console.log('NOT valid')
+        document.getElementById('mdblist_validated').value = 'false'
         if (validatedAtInput) validatedAtInput.value = ''
         refreshValidationCallout('mdblist_validated')
-      })
-      .finally(() => {
-        hideSpinner('validate')
-        statusMessage.style.display = 'block'
-      })
-  })
+        statusMessage.textContent = 'Failed to validate MDBList server. Please check your API Key.'
+        statusMessage.style.color = '#ea868f'
+      }
+      statusMessage.style.display = 'block'
+    })
+    .catch(error => {
+      console.error('Error validating MDBList server:', error)
+      statusMessage.textContent = 'An error occurred. Please try again.'
+      statusMessage.style.color = '#ea868f'
+      statusMessage.style.display = 'block'
+      if (validatedAtInput) validatedAtInput.value = ''
+      refreshValidationCallout('mdblist_validated')
+    })
+    .finally(() => {
+      hideSpinner('validate')
+      statusMessage.style.display = 'block'
+    })
+})
 
-  document.getElementById('toggleApikeyVisibility').addEventListener('click', function () {
-    const currentType = apiKeyInput.getAttribute('type')
-    apiKeyInput.setAttribute('type', currentType === 'password' ? 'text' : 'password')
-    setToggleButtonIcon(this, currentType === 'password')
-  })
+document.getElementById('toggleApikeyVisibility').addEventListener('click', function () {
+  const currentType = apiKeyInput.getAttribute('type')
+  apiKeyInput.setAttribute('type', currentType === 'password' ? 'text' : 'password')
+  setToggleButtonIcon(this, currentType === 'password')
 })
 
 document.getElementById('configForm').addEventListener('submit', function () {
-  const apiKeyInput = document.getElementById('mdblist_apikey')
   if (!apiKeyInput.value) {
     apiKeyInput.value = ''
   }

--- a/static/local-js/070-notifiarr.js
+++ b/static/local-js/070-notifiarr.js
@@ -2,33 +2,31 @@ import { setToggleButtonIcon, refreshValidationCallout } from './modules/validat
 
 const validatedAtInput = document.getElementById('notifiarr_validated_at')
 
-$(document).ready(function () {
-  const apiKeyInput = document.getElementById('notifiarr_apikey')
-  const validateButton = document.getElementById('validateButton')
-  const toggleButton = document.getElementById('toggleApikeyVisibility')
-  const isValidated = document.getElementById('notifiarr_validated').value.toLowerCase()
+const apiKeyInput = document.getElementById('notifiarr_apikey')
+const validateButton = document.getElementById('validateButton')
+const toggleButton = document.getElementById('toggleApikeyVisibility')
+const isValidated = document.getElementById('notifiarr_validated').value.toLowerCase()
 
-  console.log('Validated: ' + isValidated)
+console.log('Validated: ' + isValidated)
 
-  // Set initial visibility based on API key value
-  if (apiKeyInput.value.trim() === '') {
-    apiKeyInput.setAttribute('type', 'text') // Show placeholder text
-    setToggleButtonIcon(toggleButton, true)
-  } else {
-    apiKeyInput.setAttribute('type', 'password') // Hide actual key
-    setToggleButtonIcon(toggleButton, false)
-  }
+// Set initial visibility based on API key value
+if (apiKeyInput.value.trim() === '') {
+  apiKeyInput.setAttribute('type', 'text') // Show placeholder text
+  setToggleButtonIcon(toggleButton, true)
+} else {
+  apiKeyInput.setAttribute('type', 'password') // Hide actual key
+  setToggleButtonIcon(toggleButton, false)
+}
 
-  // Disable validate button if already validated
-  validateButton.disabled = isValidated === 'true'
+// Disable validate button if already validated
+validateButton.disabled = isValidated === 'true'
 
-  // Reset validation status when user types
-  apiKeyInput.addEventListener('input', function () {
-    document.getElementById('notifiarr_validated').value = 'false'
-    if (validatedAtInput) validatedAtInput.value = ''
-    validateButton.disabled = false
-    refreshValidationCallout('notifiarr_validated')
-  })
+// Reset validation status when user types
+apiKeyInput.addEventListener('input', function () {
+  document.getElementById('notifiarr_validated').value = 'false'
+  if (validatedAtInput) validatedAtInput.value = ''
+  validateButton.disabled = false
+  refreshValidationCallout('notifiarr_validated')
 })
 
 async function validateNotifiarrApikey (apikey) {
@@ -95,7 +93,6 @@ document.getElementById('toggleApikeyVisibility').addEventListener('click', func
 })
 
 document.getElementById('configForm').addEventListener('submit', function (event) {
-  const apiKeyInput = document.getElementById('notifiarr_apikey')
   if (!apiKeyInput.value) {
     apiKeyInput.value = ''
   }

--- a/static/local-js/080-gotify.js
+++ b/static/local-js/080-gotify.js
@@ -2,40 +2,38 @@ import { setToggleButtonIcon, refreshValidationCallout } from './modules/validat
 
 const validatedAtInput = document.getElementById('gotify_validated_at')
 
-$(document).ready(function () {
-  const gotifyTokenInput = document.getElementById('gotify_token')
-  const validateButton = document.getElementById('validateButton')
-  const toggleButton = document.getElementById('toggleTokenVisibility')
-  const isValidated = document.getElementById('gotify_validated').value.toLowerCase()
+const gotifyTokenInput = document.getElementById('gotify_token')
+const validateButton = document.getElementById('validateButton')
+const toggleButton = document.getElementById('toggleTokenVisibility')
+const isValidated = document.getElementById('gotify_validated').value.toLowerCase()
 
-  console.log('Validated: ' + isValidated)
+console.log('Validated: ' + isValidated)
 
-  // Set initial visibility based on API key value
-  if (gotifyTokenInput.value.trim() === '') {
-    gotifyTokenInput.setAttribute('type', 'text') // Show placeholder text
-    setToggleButtonIcon(toggleButton, true)
-  } else {
-    gotifyTokenInput.setAttribute('type', 'password') // Hide actual key
-    setToggleButtonIcon(toggleButton, false)
-  }
+// Set initial visibility based on API key value
+if (gotifyTokenInput.value.trim() === '') {
+  gotifyTokenInput.setAttribute('type', 'text') // Show placeholder text
+  setToggleButtonIcon(toggleButton, true)
+} else {
+  gotifyTokenInput.setAttribute('type', 'password') // Hide actual key
+  setToggleButtonIcon(toggleButton, false)
+}
 
-  // Disable validate button if already validated
-  validateButton.disabled = isValidated === 'true'
+// Disable validate button if already validated
+validateButton.disabled = isValidated === 'true'
 
-  // Reset validation status when user types
-  gotifyTokenInput.addEventListener('input', function () {
-    document.getElementById('gotify_validated').value = 'false'
-    if (validatedAtInput) validatedAtInput.value = ''
-    validateButton.disabled = false
-    refreshValidationCallout('gotify_validated')
-  })
+// Reset validation status when user types
+gotifyTokenInput.addEventListener('input', function () {
+  document.getElementById('gotify_validated').value = 'false'
+  if (validatedAtInput) validatedAtInput.value = ''
+  validateButton.disabled = false
+  refreshValidationCallout('gotify_validated')
+})
 
-  document.getElementById('gotify_url').addEventListener('input', function () {
-    document.getElementById('gotify_validated').value = 'false'
-    if (validatedAtInput) validatedAtInput.value = ''
-    validateButton.disabled = false
-    refreshValidationCallout('gotify_validated')
-  })
+document.getElementById('gotify_url').addEventListener('input', function () {
+  document.getElementById('gotify_validated').value = 'false'
+  if (validatedAtInput) validatedAtInput.value = ''
+  validateButton.disabled = false
+  refreshValidationCallout('gotify_validated')
 })
 
 // Function to toggle API key visibility

--- a/static/local-js/085-ntfy.js
+++ b/static/local-js/085-ntfy.js
@@ -2,54 +2,51 @@ import { setToggleButtonIcon, refreshValidationCallout } from './modules/validat
 
 const validatedAtInput = document.getElementById('ntfy_validated_at')
 
-$(document).ready(function () {
-  const tokenInput = document.getElementById('ntfy_token')
-  const toggleButton = document.getElementById('toggleTokenVisibility')
-  const isValidated = document.getElementById('ntfy_validated').value.toLowerCase()
-  const validateButton = document.getElementById('validateButton')
+const tokenInput = document.getElementById('ntfy_token')
+const toggleButton = document.getElementById('toggleTokenVisibility')
+const isValidated = document.getElementById('ntfy_validated').value.toLowerCase()
+const validateButton = document.getElementById('validateButton')
 
-  console.log('Validated: ' + isValidated)
+console.log('Validated: ' + isValidated)
 
-  // Set initial visibility based on API key value
-  if (tokenInput.value.trim() === '') {
-    tokenInput.setAttribute('type', 'text') // Show placeholder text
-    setToggleButtonIcon(toggleButton, true)
-  } else {
-    tokenInput.setAttribute('type', 'password') // Hide actual key
-    setToggleButtonIcon(toggleButton, false)
-  }
+// Set initial visibility based on API key value
+if (tokenInput.value.trim() === '') {
+  tokenInput.setAttribute('type', 'text') // Show placeholder text
+  setToggleButtonIcon(toggleButton, true)
+} else {
+  tokenInput.setAttribute('type', 'password') // Hide actual key
+  setToggleButtonIcon(toggleButton, false)
+}
 
-  if (isValidated === 'true') {
-    validateButton.disabled = true
-  } else {
-    validateButton.disabled = false
-  }
+if (isValidated === 'true') {
+  validateButton.disabled = true
+} else {
+  validateButton.disabled = false
+}
 
-  tokenInput.addEventListener('input', function () {
-    document.getElementById('ntfy_validated').value = 'false'
-    if (validatedAtInput) validatedAtInput.value = ''
-    validateButton.disabled = false
-    refreshValidationCallout('ntfy_validated')
-  })
+tokenInput.addEventListener('input', function () {
+  document.getElementById('ntfy_validated').value = 'false'
+  if (validatedAtInput) validatedAtInput.value = ''
+  validateButton.disabled = false
+  refreshValidationCallout('ntfy_validated')
+})
 
-  document.getElementById('ntfy_url').addEventListener('input', function () {
-    document.getElementById('ntfy_validated').value = 'false'
-    if (validatedAtInput) validatedAtInput.value = ''
-    validateButton.disabled = false
-    refreshValidationCallout('ntfy_validated')
-  })
+document.getElementById('ntfy_url').addEventListener('input', function () {
+  document.getElementById('ntfy_validated').value = 'false'
+  if (validatedAtInput) validatedAtInput.value = ''
+  validateButton.disabled = false
+  refreshValidationCallout('ntfy_validated')
+})
 
-  document.getElementById('ntfy_topic').addEventListener('input', function () {
-    document.getElementById('ntfy_validated').value = 'false'
-    if (validatedAtInput) validatedAtInput.value = ''
-    validateButton.disabled = false
-    refreshValidationCallout('ntfy_validated')
-  })
+document.getElementById('ntfy_topic').addEventListener('input', function () {
+  document.getElementById('ntfy_validated').value = 'false'
+  if (validatedAtInput) validatedAtInput.value = ''
+  validateButton.disabled = false
+  refreshValidationCallout('ntfy_validated')
 })
 
 // Function to toggle API key visibility
 document.getElementById('toggleTokenVisibility').addEventListener('click', function () {
-  const tokenInput = document.getElementById('ntfy_token')
   const currentType = tokenInput.getAttribute('type')
   tokenInput.setAttribute('type', currentType === 'password' ? 'text' : 'password')
   setToggleButtonIcon(this, currentType === 'password')

--- a/static/local-js/087-apprise.js
+++ b/static/local-js/087-apprise.js
@@ -2,19 +2,17 @@ import { refreshValidationCallout } from './modules/validationPageBase.js'
 
 const validatedAtInput = document.getElementById('apprise_validated_at')
 
-$(document).ready(function () {
-  const locationInput = document.getElementById('apprise_location')
-  const validateButton = document.getElementById('validateButton')
-  const isValidated = document.getElementById('apprise_validated').value.toLowerCase()
+const locationInput = document.getElementById('apprise_location')
+const validateButton = document.getElementById('validateButton')
+const isValidated = document.getElementById('apprise_validated').value.toLowerCase()
 
-  validateButton.disabled = isValidated === 'true'
+validateButton.disabled = isValidated === 'true'
 
-  locationInput.addEventListener('input', function () {
-    document.getElementById('apprise_validated').value = 'false'
-    if (validatedAtInput) validatedAtInput.value = ''
-    validateButton.disabled = false
-    refreshValidationCallout('apprise_validated')
-  })
+locationInput.addEventListener('input', function () {
+  document.getElementById('apprise_validated').value = 'false'
+  if (validatedAtInput) validatedAtInput.value = ''
+  validateButton.disabled = false
+  refreshValidationCallout('apprise_validated')
 })
 
 document.getElementById('validateButton').addEventListener('click', function () {

--- a/static/local-js/090-webhooks.js
+++ b/static/local-js/090-webhooks.js
@@ -77,79 +77,87 @@ function updateValidationState () {
   }
 }
 
-$(document).ready(function () {
-  const isValidated = document.getElementById('webhooks_validated').value.toLowerCase() === 'true'
-  initialValidated = isValidated
-  console.log('Page Load - Is Validated:', isValidated)
+const isValidated = document.getElementById('webhooks_validated').value.toLowerCase() === 'true'
+initialValidated = isValidated
+console.log('Page Load - Is Validated:', isValidated)
 
-  $('select.form-select').each(function () {
-    const selectElement = this
-    const customInputId = selectElement.id + '_custom'
-    const customUrl = $('#' + customInputId).find('input.custom-webhook-url').val()
+document.querySelectorAll('select.form-select').forEach(selectElement => {
+  const customInputId = selectElement.id + '_custom'
+  const customUrlEl = document.getElementById(customInputId)?.querySelector('input.custom-webhook-url')
+  const customUrl = customUrlEl ? customUrlEl.value : ''
 
-    showCustomInput(selectElement, isValidated)
+  showCustomInput(selectElement, isValidated)
 
-    if (selectElement.value === 'custom' && customUrl) {
-      validatedWebhooks[selectElement.id] = isValidated
-      console.log(`Custom webhook found: ${selectElement.id}, URL: ${customUrl}`)
-    } else {
-      validatedWebhooks[selectElement.id] = isValidated
-    }
-  })
-  initialConfigured = hasConfiguredWebhooks()
-
-  if (isValidated === true) {
-    $('.validate-button').prop('disabled', true)
+  if (selectElement.value === 'custom' && customUrl) {
+    validatedWebhooks[selectElement.id] = isValidated
+    console.log(`Custom webhook found: ${selectElement.id}, URL: ${customUrl}`)
   } else {
-    $('.validate-button').prop('disabled', false)
+    validatedWebhooks[selectElement.id] = isValidated
   }
+})
+initialConfigured = hasConfiguredWebhooks()
 
-  document.querySelectorAll('select.form-select, input.custom-webhook-url').forEach((element) => {
-    const markTouched = (event) => {
-      if (event && event.isTrusted === false) return
-      webhooksTouched = true
-      updateValidationState()
-    }
-    element.addEventListener('change', markTouched)
-    element.addEventListener('input', markTouched)
-  })
+document.querySelectorAll('.validate-button').forEach(button => {
+  button.disabled = isValidated === true
+})
 
-  updateValidationState()
+document.querySelectorAll('select.form-select, input.custom-webhook-url').forEach((element) => {
+  const markTouched = (event) => {
+    if (event && event.isTrusted === false) return
+    webhooksTouched = true
+    updateValidationState()
+  }
+  element.addEventListener('change', markTouched)
+  element.addEventListener('input', markTouched)
+})
 
-  // Debugging for navigation actions
-  document.getElementById('configForm').addEventListener('submit', function (event) {
-    const actionType = event.submitter?.getAttribute('onclick')?.includes('loading') ? event.submitter.innerText.trim() : 'unknown'
-    console.log(`Form Submitted - Action: ${actionType}`)
+updateValidationState()
 
-    $('select.form-select').each(function () {
-      if ($(this).val() === 'custom') {
-        const customInputId = $(this).attr('id') + '_custom'
-        const customUrl = $('#' + customInputId).find('input.custom-webhook-url').val()
-        if (customUrl) {
-          console.log(`Serializing custom webhook for dropdown: ${$(this).attr('id')}, URL: ${customUrl}`)
-          $(this).append('<option value="' + customUrl + '" selected="selected">' + customUrl + '</option>')
-          $(this).val(customUrl)
-        } else {
-          console.log(`Custom webhook dropdown ${$(this).attr('id')} has no URL to serialize.`)
-        }
+// Debugging for navigation actions
+document.getElementById('configForm').addEventListener('submit', function (event) {
+  const actionType = event.submitter?.getAttribute('onclick')?.includes('loading') ? event.submitter.innerText.trim() : 'unknown'
+  console.log(`Form Submitted - Action: ${actionType}`)
+
+  document.querySelectorAll('select.form-select').forEach(selectElement => {
+    if (selectElement.value === 'custom') {
+      const customInputId = selectElement.id + '_custom'
+      const customUrlEl = document.getElementById(customInputId)?.querySelector('input.custom-webhook-url')
+      const customUrl = customUrlEl ? customUrlEl.value : ''
+      if (customUrl) {
+        console.log(`Serializing custom webhook for dropdown: ${selectElement.id}, URL: ${customUrl}`)
+        const option = document.createElement('option')
+        option.value = customUrl
+        option.textContent = customUrl
+        option.selected = true
+        selectElement.appendChild(option)
+        selectElement.value = customUrl
+      } else {
+        console.log(`Custom webhook dropdown ${selectElement.id} has no URL to serialize.`)
       }
-    })
+    }
   })
 })
 
 function validateWebhook (webhookType) {
-  const inputGroup = $('#webhooks_' + webhookType + '_custom').find('.input-group')
-  const webhookUrl = inputGroup.find('input.custom-webhook-url').val()
-  const validationMessage = inputGroup.siblings('.validation-message')
-  const validateButton = inputGroup.find('.validate-button')
+  const customContainer = document.getElementById('webhooks_' + webhookType + '_custom')
+  if (!customContainer) return
+  const inputGroup = customContainer.querySelector('.input-group')
+  if (!inputGroup) return
+  const webhookUrlEl = inputGroup.querySelector('input.custom-webhook-url')
+  const webhookUrl = webhookUrlEl ? webhookUrlEl.value : ''
+  // .validation-message is a sibling of .input-group, both children of customContainer
+  const validationMessage = customContainer.querySelector('.validation-message')
+  const validateButton = inputGroup.querySelector('.validate-button')
   const webhookTypeFormatted = webhookType.replace(/_/g, ' ').replace(/\b\w/g, function (l) { return l.toUpperCase() })
 
   webhooksTouched = true
   console.log(`Validating webhook: ${webhookType}, URL: ${webhookUrl}`)
 
   showSpinner(webhookType)
-  validationMessage.html('<div class="alert alert-info" role="alert">Validating...</div>')
-  validationMessage.show()
+  if (validationMessage) {
+    validationMessage.innerHTML = '<div class="alert alert-info" role="alert">Validating...</div>'
+    validationMessage.style.display = ''
+  }
 
   fetch('/validate_webhook', {
     method: 'POST',
@@ -166,13 +174,13 @@ function validateWebhook (webhookType) {
       if (data.success) {
         console.log(`Webhook validation successful for: ${webhookType}`)
         hideSpinner(webhookType)
-        validationMessage.html('<div class="alert alert-success" role="alert">' + data.success + '</div>')
-        validateButton.prop('disabled', true)
+        if (validationMessage) validationMessage.innerHTML = '<div class="alert alert-success" role="alert">' + data.success + '</div>'
+        if (validateButton) validateButton.disabled = true
         validatedWebhooks['webhooks_' + webhookType] = true
       } else {
         console.error(`Webhook validation failed for: ${webhookType}, Error: ${data.error}`)
         hideSpinner(webhookType)
-        validationMessage.html('<div class="alert alert-danger" role="alert">' + data.error + '</div>')
+        if (validationMessage) validationMessage.innerHTML = '<div class="alert alert-danger" role="alert">' + data.error + '</div>'
         validatedWebhooks['webhooks_' + webhookType] = false
       }
       updateValidationState()
@@ -180,10 +188,11 @@ function validateWebhook (webhookType) {
     .catch((error) => {
       console.error(`Error during webhook validation for: ${webhookType}`, error)
       hideSpinner(webhookType)
-      validationMessage.html('<div class="alert alert-danger" role="alert">An error occurred. Please try again.</div>')
+      if (validationMessage) validationMessage.innerHTML = '<div class="alert alert-danger" role="alert">An error occurred. Please try again.</div>'
       validatedWebhooks['webhooks_' + webhookType] = false
       updateValidationState()
     })
 }
 
 window.validateWebhook = validateWebhook
+window.setWebhookValidated = setWebhookValidated

--- a/static/local-js/100-anidb.js
+++ b/static/local-js/100-anidb.js
@@ -1,9 +1,7 @@
-$(document).ready(function () {
-  const enableToggle = document.getElementById('anidb_enable')
-  const fields = document.getElementById('anidb-fields')
+const enableToggle = document.getElementById('anidb_enable')
+const fields = document.getElementById('anidb-fields')
 
-  if (!enableToggle || !fields) return
-
+if (enableToggle && fields) {
   const updateVisibility = () => {
     const enabled = enableToggle.checked
     fields.classList.toggle('d-none', !enabled)
@@ -19,4 +17,4 @@ $(document).ready(function () {
 
   updateVisibility()
   enableToggle.addEventListener('change', updateVisibility)
-})
+}

--- a/static/local-js/110-radarr.js
+++ b/static/local-js/110-radarr.js
@@ -19,59 +19,57 @@ function resetDropdown (dropdown, placeholderText) {
   dropdown.replaceChildren(option)
 }
 
-$(document).ready(function () {
-  const apiKeyInput = document.getElementById('radarr_token')
-  const toggleButton = document.getElementById('toggleApikeyVisibility')
-  const validateButton = document.getElementById('validateButton')
-  const isValidated = document.getElementById('radarr_validated').value.toLowerCase()
+const apiKeyInput = document.getElementById('radarr_token')
+const toggleButton = document.getElementById('toggleApikeyVisibility')
+const validateButton = document.getElementById('validateButton')
+const isValidated = document.getElementById('radarr_validated').value.toLowerCase()
 
-  console.log('Validated: ' + isValidated)
+console.log('Validated: ' + isValidated)
 
-  // Set initial visibility based on API key value
-  if (apiKeyInput.value.trim() === '') {
-    apiKeyInput.setAttribute('type', 'text') // Show placeholder text
-    setToggleButtonIcon(toggleButton, true)
-  } else {
-    apiKeyInput.setAttribute('type', 'password') // Hide actual key
-    setToggleButtonIcon(toggleButton, false)
+// Set initial visibility based on API key value
+if (apiKeyInput.value.trim() === '') {
+  apiKeyInput.setAttribute('type', 'text') // Show placeholder text
+  setToggleButtonIcon(toggleButton, true)
+} else {
+  apiKeyInput.setAttribute('type', 'password') // Hide actual key
+  setToggleButtonIcon(toggleButton, false)
+}
+
+// Disable validate button if already validated
+validateButton.disabled = isValidated === 'true'
+
+if (isValidated === 'true') {
+  document.getElementById('validateButton').disabled = true
+  // Populate the dropdowns with the stored data if they are available
+  fetchDropdownData()
+} else {
+  document.getElementById('validateButton').disabled = false
+}
+
+// Attach event listeners for input changes
+document.getElementById('radarr_token').addEventListener('input', function () {
+  document.getElementById('radarr_validated').value = 'false'
+  if (validatedAtInput) validatedAtInput.value = ''
+  document.getElementById('validateButton').disabled = false
+  refreshValidationCallout('radarr_validated')
+})
+
+document.getElementById('radarr_url').addEventListener('input', function () {
+  document.getElementById('radarr_validated').value = 'false'
+  if (validatedAtInput) validatedAtInput.value = ''
+  document.getElementById('validateButton').disabled = false
+  refreshValidationCallout('radarr_validated')
+})
+
+// Attach event listeners for validation and toggle functionality
+document.getElementById('validateButton').addEventListener('click', validateRadarrApi)
+document.getElementById('toggleApikeyVisibility').addEventListener('click', toggleApiKeyVisibility)
+
+// Add an event listener for form submission
+document.getElementById('configForm').addEventListener('submit', function (event) {
+  if (!validateRadarrPage()) {
+    event.preventDefault() // Prevent form submission if validation fails
   }
-
-  // Disable validate button if already validated
-  validateButton.disabled = isValidated === 'true'
-
-  if (isValidated === 'true') {
-    document.getElementById('validateButton').disabled = true
-    // Populate the dropdowns with the stored data if they are available
-    fetchDropdownData()
-  } else {
-    document.getElementById('validateButton').disabled = false
-  }
-
-  // Attach event listeners for input changes
-  document.getElementById('radarr_token').addEventListener('input', function () {
-    document.getElementById('radarr_validated').value = 'false'
-    if (validatedAtInput) validatedAtInput.value = ''
-    document.getElementById('validateButton').disabled = false
-    refreshValidationCallout('radarr_validated')
-  })
-
-  document.getElementById('radarr_url').addEventListener('input', function () {
-    document.getElementById('radarr_validated').value = 'false'
-    if (validatedAtInput) validatedAtInput.value = ''
-    document.getElementById('validateButton').disabled = false
-    refreshValidationCallout('radarr_validated')
-  })
-
-  // Attach event listeners for validation and toggle functionality
-  document.getElementById('validateButton').addEventListener('click', validateRadarrApi)
-  document.getElementById('toggleApikeyVisibility').addEventListener('click', toggleApiKeyVisibility)
-
-  // Add an event listener for form submission
-  document.getElementById('configForm').addEventListener('submit', function (event) {
-    if (!validateRadarrPage()) {
-      event.preventDefault() // Prevent form submission if validation fails
-    }
-  })
 })
 
 function fetchDropdownData () {
@@ -114,7 +112,7 @@ function populateDropdown (elementId, data, valueField, textField, selectedValue
 
 // Validate Radarr page fields
 function validateRadarrPage () {
-  const isValidated = document.getElementById('radarr_validated').value.toLowerCase()
+  const currentValidatedValue = document.getElementById('radarr_validated').value.toLowerCase()
   const rootFolderPath = document.getElementById('radarr_root_folder_path').value
   const qualityProfile = document.getElementById('radarr_quality_profile').value
   const statusMessage = document.getElementById('statusMessage')
@@ -125,7 +123,7 @@ function validateRadarrPage () {
     : true
 
   // Skip validation if Radarr is not validated
-  if (isValidated !== 'true') {
+  if (currentValidatedValue !== 'true') {
     return true // Allow navigation
   }
 
@@ -210,8 +208,6 @@ function validateRadarrApi () {
 }
 
 function toggleApiKeyVisibility () {
-  const apiKeyInput = document.getElementById('radarr_token')
-  const toggleButton = document.getElementById('toggleApikeyVisibility')
   if (apiKeyInput && toggleButton) {
     if (apiKeyInput.type === 'password') {
       apiKeyInput.type = 'text'

--- a/static/local-js/120-sonarr.js
+++ b/static/local-js/120-sonarr.js
@@ -19,61 +19,59 @@ function resetDropdown (dropdown, placeholderText) {
   dropdown.replaceChildren(option)
 }
 
-$(document).ready(function () {
-  const apiKeyInput = document.getElementById('sonarr_token')
-  const toggleButton = document.getElementById('toggleApikeyVisibility')
-  const validateButton = document.getElementById('validateButton')
-  const isValidatedElement = document.getElementById('sonarr_validated')
-  const isValidated = isValidatedElement ? isValidatedElement.value.toLowerCase() : 'false'
+const apiKeyInput = document.getElementById('sonarr_token')
+const toggleButton = document.getElementById('toggleApikeyVisibility')
+const validateButton = document.getElementById('validateButton')
+const isValidatedElement = document.getElementById('sonarr_validated')
+const isValidated = isValidatedElement ? isValidatedElement.value.toLowerCase() : 'false'
 
-  console.log('Validated:', isValidated)
+console.log('Validated:', isValidated)
 
-  // Set initial visibility based on API key value
-  if (apiKeyInput.value.trim() === '') {
-    apiKeyInput.setAttribute('type', 'text') // Show placeholder text
-    setToggleButtonIcon(toggleButton, true)
-  } else {
-    apiKeyInput.setAttribute('type', 'password') // Hide actual key
-    setToggleButtonIcon(toggleButton, false)
+// Set initial visibility based on API key value
+if (apiKeyInput.value.trim() === '') {
+  apiKeyInput.setAttribute('type', 'text') // Show placeholder text
+  setToggleButtonIcon(toggleButton, true)
+} else {
+  apiKeyInput.setAttribute('type', 'password') // Hide actual key
+  setToggleButtonIcon(toggleButton, false)
+}
+
+// Disable validate button if already validated
+if (isValidatedElement) {
+  validateButton.disabled = isValidated === 'true'
+}
+
+if (isValidated === 'true') {
+  document.getElementById('validateButton').disabled = true
+  fetchDropdownData() // Populate dropdowns if already validated
+} else {
+  document.getElementById('validateButton').disabled = false
+}
+
+// Attach event listeners for input changes
+document.getElementById('sonarr_token').addEventListener('input', function () {
+  document.getElementById('sonarr_validated').value = 'false'
+  if (validatedAtInput) validatedAtInput.value = ''
+  document.getElementById('validateButton').disabled = false
+  refreshValidationCallout('sonarr_validated')
+})
+
+document.getElementById('sonarr_url').addEventListener('input', function () {
+  document.getElementById('sonarr_validated').value = 'false'
+  if (validatedAtInput) validatedAtInput.value = ''
+  document.getElementById('validateButton').disabled = false
+  refreshValidationCallout('sonarr_validated')
+})
+
+// Attach event listeners for validation and toggle functionality
+document.getElementById('validateButton').addEventListener('click', validateSonarrApi)
+document.getElementById('toggleApikeyVisibility').addEventListener('click', toggleApiKeyVisibility)
+
+// Add an event listener for form submission
+document.getElementById('configForm').addEventListener('submit', function (event) {
+  if (!validateSonarrPage()) {
+    event.preventDefault() // Prevent form submission if validation fails
   }
-
-  // Disable validate button if already validated
-  if (isValidatedElement) {
-    validateButton.disabled = isValidated === 'true'
-  }
-
-  if (isValidated === 'true') {
-    document.getElementById('validateButton').disabled = true
-    fetchDropdownData() // Populate dropdowns if already validated
-  } else {
-    document.getElementById('validateButton').disabled = false
-  }
-
-  // Attach event listeners for input changes
-  document.getElementById('sonarr_token').addEventListener('input', function () {
-    document.getElementById('sonarr_validated').value = 'false'
-    if (validatedAtInput) validatedAtInput.value = ''
-    document.getElementById('validateButton').disabled = false
-    refreshValidationCallout('sonarr_validated')
-  })
-
-  document.getElementById('sonarr_url').addEventListener('input', function () {
-    document.getElementById('sonarr_validated').value = 'false'
-    if (validatedAtInput) validatedAtInput.value = ''
-    document.getElementById('validateButton').disabled = false
-    refreshValidationCallout('sonarr_validated')
-  })
-
-  // Attach event listeners for validation and toggle functionality
-  document.getElementById('validateButton').addEventListener('click', validateSonarrApi)
-  document.getElementById('toggleApikeyVisibility').addEventListener('click', toggleApiKeyVisibility)
-
-  // Add an event listener for form submission
-  document.getElementById('configForm').addEventListener('submit', function (event) {
-    if (!validateSonarrPage()) {
-      event.preventDefault() // Prevent form submission if validation fails
-    }
-  })
 })
 
 function validateSonarrApi () {
@@ -177,9 +175,9 @@ function validateSonarrPage () {
     ? PathValidation.validateAll()
     : true
 
-  const isValidated = document.getElementById('sonarr_validated').value.toLowerCase() === 'true'
+  const isValidatedNow = document.getElementById('sonarr_validated').value.toLowerCase() === 'true'
 
-  if (isValidated) {
+  if (isValidatedNow) {
     if (!rootFolderPath) {
       validationMessages.push('Please select a valid Root Folder Path.')
       isValid = false
@@ -213,8 +211,6 @@ function validateSonarrPage () {
 }
 
 function toggleApiKeyVisibility () {
-  const apiKeyInput = document.getElementById('sonarr_token')
-  const toggleButton = document.getElementById('toggleApikeyVisibility')
   if (apiKeyInput && toggleButton) {
     if (apiKeyInput.type === 'password') {
       apiKeyInput.type = 'text'

--- a/static/local-js/130-trakt.js
+++ b/static/local-js/130-trakt.js
@@ -2,57 +2,54 @@ import { setToggleButtonIcon, refreshValidationCallout } from './modules/validat
 
 const validatedAtInput = document.getElementById('trakt_validated_at')
 
-$(document).ready(function () {
-  const traktClientSecretInput = document.getElementById('trakt_client_secret')
-  const toggleButton = document.getElementById('toggleClientSecretVisibility')
-  const validateButton = document.getElementById('validate_trakt_pin')
-  const checkTokenButton = document.getElementById('trakt_check_token')
-  const isValidatedElement = document.getElementById('trakt_validated')
-  const isValidated = isValidatedElement.value.toLowerCase()
-  console.log('Validated:', isValidated)
-  const isBlankTokenValue = (value) => {
-    if (!value) return true
-    const trimmed = value.trim()
-    if (!trimmed) return true
-    return trimmed.toLowerCase() === 'none' || trimmed.toLowerCase() === 'null'
-  }
+const traktClientSecretInput = document.getElementById('trakt_client_secret')
+const toggleButton = document.getElementById('toggleClientSecretVisibility')
+const validateButton = document.getElementById('validate_trakt_pin')
+const checkTokenButton = document.getElementById('trakt_check_token')
+const isValidatedElement = document.getElementById('trakt_validated')
+const isValidated = isValidatedElement.value.toLowerCase()
+console.log('Validated:', isValidated)
+const isBlankTokenValue = (value) => {
+  if (!value) return true
+  const trimmed = value.trim()
+  if (!trimmed) return true
+  return trimmed.toLowerCase() === 'none' || trimmed.toLowerCase() === 'null'
+}
 
-  // Set initial visibility based on Client Secret value
-  if (traktClientSecretInput.value.trim() === '') {
-    traktClientSecretInput.setAttribute('type', 'text') // Show placeholder text
-    setToggleButtonIcon(toggleButton, true)
+// Set initial visibility based on Client Secret value
+if (traktClientSecretInput.value.trim() === '') {
+  traktClientSecretInput.setAttribute('type', 'text') // Show placeholder text
+  setToggleButtonIcon(toggleButton, true)
+} else {
+  traktClientSecretInput.setAttribute('type', 'password') // Hide actual secret
+  setToggleButtonIcon(toggleButton, false)
+}
+
+// Disable validate button if already validated
+validateButton.disabled = isValidated === 'true'
+if (checkTokenButton) {
+  const accessToken = document.getElementById('access_token')?.value || ''
+  checkTokenButton.disabled = isBlankTokenValue(accessToken)
+}
+
+// Reset validation status when user types
+const inputFields = ['trakt_client_id', 'trakt_client_secret', 'trakt_pin']
+inputFields.forEach(field => {
+  const inputElement = document.getElementById(field)
+  if (inputElement) {
+    inputElement.addEventListener('input', function () {
+      isValidatedElement.value = 'false'
+      if (validatedAtInput) validatedAtInput.value = ''
+      validateButton.disabled = false
+      if (checkTokenButton) checkTokenButton.disabled = true
+      refreshValidationCallout('trakt_validated')
+    })
   } else {
-    traktClientSecretInput.setAttribute('type', 'password') // Hide actual secret
-    setToggleButtonIcon(toggleButton, false)
+    console.warn(`Warning: Element with ID '${field}' not found.`)
   }
-
-  // Disable validate button if already validated
-  validateButton.disabled = isValidated === 'true'
-  if (checkTokenButton) {
-    const accessToken = document.getElementById('access_token')?.value || ''
-    checkTokenButton.disabled = isBlankTokenValue(accessToken)
-  }
-
-  // Reset validation status when user types
-  const inputFields = ['trakt_client_id', 'trakt_client_secret', 'trakt_pin']
-  inputFields.forEach(field => {
-    const inputElement = document.getElementById(field)
-    if (inputElement) {
-      inputElement.addEventListener('input', function () {
-        isValidatedElement.value = 'false'
-        if (validatedAtInput) validatedAtInput.value = ''
-        validateButton.disabled = false
-        if (checkTokenButton) checkTokenButton.disabled = true
-        refreshValidationCallout('trakt_validated')
-      })
-    } else {
-      console.warn(`Warning: Element with ID '${field}' not found.`)
-    }
-  })
 })
 
 document.getElementById('toggleClientSecretVisibility').addEventListener('click', function () {
-  const traktClientSecretInput = document.getElementById('trakt_client_secret')
   const currentType = traktClientSecretInput.getAttribute('type')
   traktClientSecretInput.setAttribute('type', currentType === 'password' ? 'text' : 'password')
   setToggleButtonIcon(this, currentType === 'password')

--- a/static/local-js/140-mal.js
+++ b/static/local-js/140-mal.js
@@ -2,53 +2,50 @@ import { setToggleButtonIcon, refreshValidationCallout } from './modules/validat
 
 const validatedAtInput = document.getElementById('mal_validated_at')
 
-$(document).ready(function () {
-  const clientSecretInput = document.getElementById('mal_client_secret')
-  const toggleButton = document.getElementById('toggleClientSecretVisibility')
-  const validateButton = document.getElementById('validate_mal_url')
-  const checkTokenButton = document.getElementById('mal_check_token')
-  const isValidatedElement = document.getElementById('mal_validated')
-  const isValidated = isValidatedElement ? isValidatedElement.value.toLowerCase() : 'false'
-  console.log('Validated:', isValidated)
+const clientSecretInput = document.getElementById('mal_client_secret')
+const toggleButton = document.getElementById('toggleClientSecretVisibility')
+const validateButton = document.getElementById('validate_mal_url')
+const checkTokenButton = document.getElementById('mal_check_token')
+const isValidatedElement = document.getElementById('mal_validated')
+const isValidated = isValidatedElement ? isValidatedElement.value.toLowerCase() : 'false'
+console.log('Validated:', isValidated)
 
-  // Ensure initial visibility based on input value
-  if (clientSecretInput.value.trim() === '') {
-    clientSecretInput.setAttribute('type', 'text') // Show placeholder text
-    setToggleButtonIcon(toggleButton, true)
+// Ensure initial visibility based on input value
+if (clientSecretInput.value.trim() === '') {
+  clientSecretInput.setAttribute('type', 'text') // Show placeholder text
+  setToggleButtonIcon(toggleButton, true)
+} else {
+  clientSecretInput.setAttribute('type', 'password') // Hide actual key
+  setToggleButtonIcon(toggleButton, false)
+}
+
+// Disable validate button if already validated
+if (isValidated === 'true') {
+  validateButton.disabled = true
+}
+if (checkTokenButton) {
+  const accessToken = document.getElementById('access_token')?.value || ''
+  checkTokenButton.disabled = !accessToken.trim()
+}
+
+// Reset validation status when user types
+const inputFields = ['mal_client_id', 'mal_client_secret', 'mal_code_verifier', 'mal_localhost_url']
+inputFields.forEach(field => {
+  const inputElement = document.getElementById(field)
+  if (inputElement) {
+    inputElement.addEventListener('input', function () {
+      isValidatedElement.value = 'false'
+      if (validatedAtInput) validatedAtInput.value = ''
+      validateButton.disabled = false
+      if (checkTokenButton) checkTokenButton.disabled = true
+      refreshValidationCallout('mal_validated')
+    })
   } else {
-    clientSecretInput.setAttribute('type', 'password') // Hide actual key
-    setToggleButtonIcon(toggleButton, false)
+    console.warn(`Warning: Element with ID '${field}' not found.`)
   }
-
-  // Disable validate button if already validated
-  if (isValidated === 'true') {
-    validateButton.disabled = true
-  }
-  if (checkTokenButton) {
-    const accessToken = document.getElementById('access_token')?.value || ''
-    checkTokenButton.disabled = !accessToken.trim()
-  }
-
-  // Reset validation status when user types
-  const inputFields = ['mal_client_id', 'mal_client_secret', 'mal_code_verifier', 'mal_localhost_url']
-  inputFields.forEach(field => {
-    const inputElement = document.getElementById(field)
-    if (inputElement) {
-      inputElement.addEventListener('input', function () {
-        isValidatedElement.value = 'false'
-        if (validatedAtInput) validatedAtInput.value = ''
-        validateButton.disabled = false
-        if (checkTokenButton) checkTokenButton.disabled = true
-        refreshValidationCallout('mal_validated')
-      })
-    } else {
-      console.warn(`Warning: Element with ID '${field}' not found.`)
-    }
-  })
 })
 
 document.getElementById('toggleClientSecretVisibility').addEventListener('click', function () {
-  const clientSecretInput = document.getElementById('mal_client_secret')
   const currentType = clientSecretInput.getAttribute('type')
   clientSecretInput.setAttribute('type', currentType === 'password' ? 'text' : 'password')
   setToggleButtonIcon(this, currentType === 'password')


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix (well, sort of — fixes one latent inline-handler bug as a drive-by)
- [x] Feature/Tweak (non-breaking change which adds new functionality)
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Other

## Description

Roadmap issue #1334 **Step 7 (drop jQuery)**. First slice: removes jQuery from the 16 wizard ES modules that have been migrated under Step 2.

### What this does

Eliminates **33 jQuery references → 0** across 16 wizard files.

| Category | Files | Treatment |
|---|---|---|
| **A: Trivial** | 14 wizards (010, 030, 040, 050, 060, 070, 080, 085, 087, 100, 110, 120, 130, 140) | Each had exactly one jQuery ref: the `$(document).ready(function () { ... })` wrapper. ES modules already defer-load, so the wrapper is dead weight. Removed; body dedented by 2 spaces. |
| **B: Real jQuery use** | 027-playlist_files, 090-webhooks | Mechanical translation: `$('#x').val()` → `document.getElementById('x').value`, `.each()` → `.forEach()`, `.hide()/.show()` → `style.display`, `.find()` → `.querySelector()`, `.prop('disabled', true)` → `.disabled = true`, etc. |

### Side-effect cleanups (from un-wrapping)

Moving constants from function-local (inside `$(document).ready`) to module-scope surfaced 19 ESLint `no-shadow` errors. All fixed:

- **10 redundant DOM re-reads removed**: a `const apiKeyInput = document.getElementById('foo')` inside a `configForm` submit handler that re-fetched the SAME element already in module scope. (Affects 030, 040, 050, 060, 070, 085, 110, 120, 130, 140.)
- **2 deliberate stale-check renames**: 110-radarr and 120-sonarr had `const isValidated = ...` inside `validateRadarrPage`/`validateSonarrPage` that re-read the field because it may have changed since module init. Renamed inner to `currentValidatedValue` / `isValidatedNow` to preserve semantics without shadowing.
- **3 redundant re-reads in 010-plex**: `plexDbCache`, `hiddenSection`, `validatedAtInput`.

Plus a small refactor in **100-anidb.js**: top-level `if (!enableToggle || !fields) return` (legal inside the ready wrapper, illegal at module top-level) → wrapped body in `if (enableToggle && fields) { ... }`.

### Drive-by bug fix in 090-webhooks.js

`templates/090-webhooks.html` line 60:
```html
oninput="setWebhookValidated(false, '{{ webhook }}')"
```
calls `setWebhookValidated`, but 090-webhooks.js (already an ES module on develop) had no `window` export for it. Inline `oninput=` handlers can only see globals, not module-scope identifiers — so this was throwing `ReferenceError` on every keystroke in custom-webhook-url fields. **Pre-existing latent bug on develop.** Added `window.setWebhookValidated = setWebhookValidated` alongside the existing `window.validateWebhook` export. One-line fix.

### What this PR does NOT touch

| File | jQuery refs | Why deferred |
|---|---|---|
| `905-analytics.js` | 108 | Big surface; deserves its own PR(s) |
| `900-kometa.js` | 257 | Same |
| `915-imagemaid.js` | 91 | Same |
| `000-base.js` | 6 | Shared infrastructure used by the still-classic 905/900/915 files. Can't migrate until they do. |
| `validationHandler.js` | 5 | Same — used by 025-libraries which is also still classic |
| `025-libraries.js` | many | Deferred from Step 2 (6,257 lines, dynamic-loads 4 helper scripts). Its own future PR. |

### Verification

| Check | Result |
|---|---|
| ESLint | 0 errors |
| Python tests | 80/80 pass |
| Vitest (validationPageBase + appConfig) | 24/24 pass |
| **Playwright wizard e2e** | **5/5 pass** (the load-bearing check — exercises actual browser JS) |
| pre-commit | 12/12 hooks green |
| jQuery refs across the 16 files | **33 → 0** |

### Diff size

```
16 files changed, 582 insertions(+), 604 deletions(-)
```

Net **-22 lines** even with the verbose `document.getElementById` calls replacing terse `$('#id')` — because of the wrapper removal and dedup of redundant re-reads.

### Roadmap impact

Step 7 was originally pencilled in after Step 6 (validation widget). Moving this slice earlier because:

1. All 16 wizards have already been converted to ES modules (#1348, #1349, #1360).
2. ES modules already provide DOM-ready ordering for free — `$(document).ready` is just noise.
3. Doing this BEFORE Step 6 simplifies Step 6's footprint: the new validation widget can be designed around vanilla-DOM primitives with no jQuery interop to worry about.

After this PR, jQuery is still loaded globally (for the 905/900/915 classic scripts) but **no individual wizard module depends on it**. When the big files eventually migrate, jQuery can be dropped from the page entirely.

## Related Issues

Roadmap: #1334 Step 7 (Phase 1 / 3)

## Which Environment Did You Test On?

- [x] Local Install (Linux, Python 3.13, Flask test_client + Playwright Chromium e2e + Vitest+jsdom)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
