### PR TITLE
Add Vitest coverage for 3 shared validation modules (#1334 Step 8)

### DIFF
--- a/tests/js/pathValidation.test.js
+++ b/tests/js/pathValidation.test.js
@@ -1,0 +1,361 @@
+// Tests for static/local-js/pathValidation.js (#1334 Step 8 — coverage push).
+//
+// Same pattern as urlValidation.test.js: side-effect import that runs
+// the IIFE in jsdom, then access via window.PathValidation. Switch to
+// named imports if/when this module gets a proper `export`.
+//
+// What makes pathValidation interesting to test:
+//   - It fetches rules from /path-validation-rules at attach time, so
+//     fetch must be mocked. We use vi.stubGlobal('fetch', ...) for that.
+//   - Validation behaviour depends on a per-rule object AND a runtime
+//     platform (linux vs windows). The platform comes from the same
+//     /path-validation-rules response.
+//   - The module has internal cached state (rules, meta, loadPromise)
+//     that we can't reset between tests because there is no resetForTests
+//     export. Instead each test relies on attach() being callable
+//     repeatedly with no surprises, and we are careful to scope DOM
+//     and assertions to the test under examination.
+//
+// CAVEAT: The module caches `loadPromise` after the first attach() call
+// so subsequent fetch mocks won't be hit. The tests work around this
+// by setting up the desired mock BEFORE the first attach in each block
+// and accepting that the rules+meta from that first attach persist
+// across the rest of the file. This matches production reality (the
+// module is initialised once per page load) but means test ordering
+// matters within a file. We deliberately put the linux/posix tests
+// first and the windows-specific tests after the platform has been
+// set to windows.
+//
+// Why this module is high value to lock down:
+//   - Called from 000-base.js, 001-start.js, 150-settings.js, 915-
+//     imagemaid.js, validationHandler.js. Anything that takes a
+//     filesystem path uses this.
+//   - A regression in validateValue could silently accept "C:\bad"
+//     on a Linux user's setup or reject "/var/log" on Linux as
+//     Windows-style.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Set up a fetch mock BEFORE importing pathValidation, so the module's
+// init paths see a usable global. The first attach() call will pin the
+// rules/meta to whatever this mock returns, so we shape it as a
+// permissive linux config that most tests can use.
+const defaultRulesResponse = {
+  rules: [
+    { id: 'config-dir', allow_relative: false, ui: { platform_status: true, hint_docker: 'Map this to your config volume.' } },
+    { id: 'assets-dir', allow_relative: false, ui: { platform_status: true } },
+    { id: 'logs-dir', allow_relative: true, ui: { platform_status: false } }
+  ],
+  platform: 'linux',
+  is_docker: false
+}
+
+vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+  ok: true,
+  json: () => Promise.resolve(defaultRulesResponse)
+})))
+
+await import('../../static/local-js/pathValidation.js')
+const PathValidation = window.PathValidation
+
+// Prime the module's internal cache with the default response.
+// All subsequent attach() calls reuse this state.
+await PathValidation.init()
+
+describe('PathValidation.attach', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('binds an input whose name matches a rule id', async () => {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="config-dir" value="/etc/kometa">
+      </div>
+    `
+    await PathValidation.attach(document)
+    const input = document.querySelector('input[name="config-dir"]')
+    expect(input.dataset.pathValidationBound).toBe('true')
+    expect(input.dataset.pathValid).toBe('true')
+  })
+
+  it('binds an input whose name ends with -<rule-id>', async () => {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="custom-config-dir" value="/etc/kometa">
+      </div>
+    `
+    await PathValidation.attach(document)
+    const input = document.querySelector('input[name="custom-config-dir"]')
+    expect(input.dataset.pathValidationBound).toBe('true')
+  })
+
+  it('honors data-path-rule as an explicit rule selector', async () => {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="something-else" data-path-rule="assets-dir" value="/var/assets">
+      </div>
+    `
+    await PathValidation.attach(document)
+    const input = document.querySelector('input[name="something-else"]')
+    expect(input.dataset.pathValidationBound).toBe('true')
+  })
+
+  it('does not bind inputs whose name matches no rule', async () => {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="random-field" value="anything">
+      </div>
+    `
+    await PathValidation.attach(document)
+    const input = document.querySelector('input[name="random-field"]')
+    expect(input.dataset.pathValidationBound).toBeUndefined()
+  })
+
+  it('marks an invalid path with is-invalid and sets feedback message', async () => {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="config-dir" value="relative/path">
+      </div>
+    `
+    await PathValidation.attach(document)
+    const input = document.querySelector('input[name="config-dir"]')
+    expect(input.classList.contains('is-invalid')).toBe(true)
+    expect(input.dataset.pathValid).toBe('false')
+    const feedback = document.querySelector('.invalid-feedback')
+    expect(feedback.textContent).toBe('Path must be absolute.')
+  })
+
+  it('accepts a relative path when the rule sets allow_relative: true', async () => {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="logs-dir" value="relative/path">
+      </div>
+    `
+    await PathValidation.attach(document)
+    const input = document.querySelector('input[name="logs-dir"]')
+    expect(input.dataset.pathValid).toBe('true')
+  })
+
+  it('clears is-invalid when value becomes valid after input event', async () => {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="config-dir" value="bad/relative">
+      </div>
+    `
+    await PathValidation.attach(document)
+    const input = document.querySelector('input[name="config-dir"]')
+    expect(input.classList.contains('is-invalid')).toBe(true)
+
+    input.value = '/good/absolute'
+    input.dispatchEvent(new Event('input'))
+
+    expect(input.classList.contains('is-invalid')).toBe(false)
+    expect(input.dataset.pathValid).toBe('true')
+  })
+
+  it('does not double-bind on repeated attach()', async () => {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="config-dir" value="/etc/kometa">
+      </div>
+    `
+    await PathValidation.attach(document)
+    await PathValidation.attach(document)
+    await PathValidation.attach(document)
+    // Inputs default to listening once per bind, so triple-bind would
+    // wire up three listeners. We can't easily count listeners in jsdom,
+    // but we can verify the bound flag is still 'true' (idempotent) and
+    // no exception fires.
+    const input = document.querySelector('input[name="config-dir"]')
+    expect(input.dataset.pathValidationBound).toBe('true')
+  })
+})
+
+describe('PathValidation.validateValue (via validateAll round-trip on linux)', () => {
+  // validateValue is not exported. We exercise it through attach + value
+  // assignment, then read the .pathValid dataset attribute. This is a
+  // less direct but more user-realistic interface.
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  async function checkPath (value, ruleName = 'config-dir') {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="${ruleName}" value="${value}">
+      </div>
+    `
+    await PathValidation.attach(document)
+    const input = document.querySelector(`input[name="${ruleName}"]`)
+    return input.dataset.pathValid === 'true'
+  }
+
+  async function pathError (value, ruleName = 'config-dir') {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="${ruleName}" value="${value}">
+      </div>
+    `
+    await PathValidation.attach(document)
+    const feedback = document.querySelector('.invalid-feedback')
+    return feedback ? feedback.textContent : null
+  }
+
+  it('accepts empty string as valid (caller decides required-ness)', async () => {
+    expect(await checkPath('')).toBe(true)
+  })
+
+  it('accepts whitespace-only as valid', async () => {
+    expect(await checkPath('   ')).toBe(true)
+  })
+
+  it('accepts "none" as a valid sentinel', async () => {
+    expect(await checkPath('none')).toBe(true)
+  })
+
+  it('accepts "null" as a valid sentinel', async () => {
+    expect(await checkPath('null')).toBe(true)
+  })
+
+  it('accepts "NONE" case-insensitively', async () => {
+    expect(await checkPath('NONE')).toBe(true)
+  })
+
+  it('accepts a standard linux absolute path', async () => {
+    expect(await checkPath('/var/lib/kometa')).toBe(true)
+  })
+
+  it('rejects a Windows-style absolute path on linux', async () => {
+    expect(await checkPath('C:\\\\Users\\\\bob')).toBe(false)
+    expect(await pathError('C:\\\\Users\\\\bob')).toBe('Windows-style paths are not valid on Linux/macOS/Docker.')
+  })
+
+  it('rejects a UNC-style path on linux', async () => {
+    expect(await checkPath('\\\\\\\\server\\\\share')).toBe(false)
+  })
+
+  it('rejects a relative path when rule requires absolute', async () => {
+    expect(await checkPath('relative/sub/dir')).toBe(false)
+    expect(await pathError('relative/sub/dir')).toBe('Path must be absolute.')
+  })
+
+  it('rejects a literal \\0 null sequence', async () => {
+    expect(await checkPath('/var/lib/\\0nasty')).toBe(false)
+    expect(await pathError('/var/lib/\\0nasty')).toBe('Contains an invalid null sequence.')
+  })
+
+  it('rejects a literal \\x00 sequence', async () => {
+    expect(await checkPath('/var/lib/\\x00nasty')).toBe(false)
+    expect(await pathError('/var/lib/\\x00nasty')).toBe('Contains an invalid null sequence.')
+  })
+
+  it('rejects a literal \\u0000 sequence', async () => {
+    expect(await checkPath('/var/lib/\\u0000nasty')).toBe(false)
+    expect(await pathError('/var/lib/\\u0000nasty')).toBe('Contains an invalid null sequence.')
+  })
+})
+
+describe('PathValidation.validateAll', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('returns true when all bound inputs are valid', async () => {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="config-dir" value="/etc/kometa">
+      </div>
+      <div class="input-group">
+        <input type="text" name="assets-dir" value="/var/assets">
+      </div>
+    `
+    await PathValidation.attach(document)
+    expect(PathValidation.validateAll(document)).toBe(true)
+  })
+
+  it('returns false when any bound input is invalid', async () => {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="config-dir" value="/etc/kometa">
+      </div>
+      <div class="input-group">
+        <input type="text" name="assets-dir" value="not absolute">
+      </div>
+    `
+    await PathValidation.attach(document)
+    expect(PathValidation.validateAll(document)).toBe(false)
+  })
+
+  it('returns true when container has no path inputs at all', async () => {
+    document.body.innerHTML = '<div></div>'
+    expect(PathValidation.validateAll(document)).toBe(true)
+  })
+
+  it('scopes validation to the passed container', async () => {
+    document.body.innerHTML = `
+      <div id="card-a" class="input-group">
+        <input type="text" name="config-dir" value="bad relative">
+      </div>
+      <div id="card-b" class="input-group">
+        <input type="text" name="assets-dir" value="/var/assets">
+      </div>
+    `
+    await PathValidation.attach(document)
+    const cardB = document.getElementById('card-b')
+    expect(PathValidation.validateAll(cardB)).toBe(true)
+  })
+})
+
+describe('PathValidation platform-status hint rendering', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('renders both Windows and Linux/macOS/Docker lines for rules that opt in', async () => {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="config-dir" value="/etc/kometa">
+      </div>
+    `
+    await PathValidation.attach(document)
+    const hintEl = document.querySelector('[data-path-hint="platform-status"]')
+    expect(hintEl).not.toBeNull()
+    expect(hintEl.textContent).toMatch(/Windows.*OK/)
+    expect(hintEl.textContent).toMatch(/Linux\/macOS\/Docker.*OK/)
+  })
+
+  it('omits the platform-status hint when rule.ui.platform_status is false', async () => {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="logs-dir" value="relative/ok">
+      </div>
+    `
+    await PathValidation.attach(document)
+    const hintEl = document.querySelector('[data-path-hint="platform-status"]')
+    expect(hintEl).toBeNull()
+  })
+
+  it('shows the Windows line as failed when the value contains a reserved Windows segment', async () => {
+    // Path must be Windows-absolute AND contain a reserved name, or the
+    // "must be absolute" check runs first and we never reach the
+    // reserved-segment branch. (The value is also invalid on linux
+    // because Windows-style paths are rejected there — but we're only
+    // asserting the Windows line here.)
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="config-dir" value="C:\\\\path\\\\with\\\\CON">
+      </div>
+    `
+    await PathValidation.attach(document)
+    const hintEl = document.querySelector('[data-path-hint="platform-status"]')
+    const windowsLine = hintEl.querySelector('.text-danger')
+    expect(windowsLine).not.toBeNull()
+    expect(windowsLine.textContent).toMatch(/Windows.*reserved/)
+  })
+})

--- a/tests/js/templateStringList.test.js
+++ b/tests/js/templateStringList.test.js
@@ -1,0 +1,452 @@
+// Tests for static/local-js/templateStringList.js (#1334 Step 8 — coverage push).
+//
+// Same side-effect-import pattern as urlValidation.test.js and
+// pathValidation.test.js. Public API is on window.QSTemplateStringLists.
+//
+// SCOPE NOTE: This module exposes three things via QSTemplateStringLists:
+//
+//   1. presetConfigs — an object of 16 validation presets. Each has
+//      a `validate` function (and sometimes `normalize`,
+//      `duplicateInsensitive`, `allowedValues`, `lookupService`). These
+//      validators are PURE — perfect unit-test targets.
+//
+//   2. setup(scope) — wires up the [data-template-string-list] widget
+//      with text input, add button, item chips, hidden JSON store,
+//      lookup caching, fetch-backed async validation, mutual exclusion
+//      with sibling lists, etc. This is END-TO-END WIDGET LOGIC and is
+//      not covered here — Playwright is the right tool for that.
+//
+//   3. validateAll(scope) — walks bound widgets and re-runs validation.
+//      Smoke-tested with a minimal happy path here; the per-preset
+//      coverage is what protects refactors.
+//
+// 90% of the safety-net value for the price of 10% of the test surface
+// comes from the preset validators alone. That's why this file leans
+// hard on them.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+await import('../../static/local-js/templateStringList.js')
+const QSTemplateStringLists = window.QSTemplateStringLists
+const presets = QSTemplateStringLists.presetConfigs
+
+describe('QSTemplateStringLists exports its public API', () => {
+  it('exposes presetConfigs, setup, and validateAll', () => {
+    expect(typeof QSTemplateStringLists.setup).toBe('function')
+    expect(typeof QSTemplateStringLists.validateAll).toBe('function')
+    expect(typeof QSTemplateStringLists.presetConfigs).toBe('object')
+  })
+
+  it('defines all 16 known presets', () => {
+    const expected = [
+      'generic_text', 'name_like',
+      'tmdb_collection_id', 'numeric_id', 'imdb_id_tmdb', 'imdb_id_plex',
+      'year', 'decade', 'language_code',
+      'aspect_key', 'resolution_key', 'streaming_key',
+      'universe_key', 'based_key', 'seasonal_key',
+      'content_rating'
+    ]
+    for (const name of expected) {
+      expect(presets[name], `missing preset: ${name}`).toBeDefined()
+      expect(typeof presets[name].validate, `${name}.validate not a function`).toBe('function')
+    }
+  })
+})
+
+describe('presets.generic_text', () => {
+  it('rejects empty string', () => {
+    expect(presets.generic_text.validate('')).toEqual({
+      valid: false,
+      message: 'Enter a value before adding it.'
+    })
+  })
+
+  it('accepts any non-empty string', () => {
+    expect(presets.generic_text.validate('anything goes here')).toEqual({ valid: true })
+  })
+
+  it('is duplicate-sensitive (case matters)', () => {
+    expect(presets.generic_text.duplicateInsensitive).toBe(false)
+  })
+})
+
+describe('presets.name_like', () => {
+  it('rejects empty string', () => {
+    expect(presets.name_like.validate('').valid).toBe(false)
+  })
+
+  it('rejects pure punctuation with no letters or numbers', () => {
+    const result = presets.name_like.validate('...!!!')
+    expect(result.valid).toBe(false)
+    expect(result.message).toBe('Enter a text value with letters or numbers.')
+  })
+
+  it('accepts a simple alphanumeric name', () => {
+    expect(presets.name_like.validate('Star Wars').valid).toBe(true)
+  })
+
+  it('accepts names with common punctuation', () => {
+    expect(presets.name_like.validate('Mr. & Mrs. Smith').valid).toBe(true)
+    expect(presets.name_like.validate('Spider-Man (2002)').valid).toBe(true)
+    expect(presets.name_like.validate('Hello, World!').valid).toBe(true)
+  })
+
+  it('accepts non-ASCII letters (Unicode-aware)', () => {
+    expect(presets.name_like.validate('Amélie').valid).toBe(true)
+    expect(presets.name_like.validate('東京物語').valid).toBe(true)
+  })
+
+  it('rejects names with unsupported symbols', () => {
+    const result = presets.name_like.validate('Star $$$ Wars')
+    expect(result.valid).toBe(false)
+    expect(result.message).toBe('Use letters, numbers, spaces, or common punctuation only.')
+  })
+
+  it('normalizes multiple internal whitespace to single space', () => {
+    expect(presets.name_like.normalize('Star    Wars')).toBe('Star Wars')
+  })
+
+  it('is duplicate-insensitive', () => {
+    expect(presets.name_like.duplicateInsensitive).toBe(true)
+  })
+})
+
+describe('presets.tmdb_collection_id', () => {
+  it('accepts a numeric string', () => {
+    expect(presets.tmdb_collection_id.validate('131292').valid).toBe(true)
+  })
+
+  it('accepts a single-digit numeric', () => {
+    expect(presets.tmdb_collection_id.validate('7').valid).toBe(true)
+  })
+
+  it('rejects a non-numeric string', () => {
+    const result = presets.tmdb_collection_id.validate('tt1234567')
+    expect(result.valid).toBe(false)
+    expect(result.message).toBe('Enter a numeric TMDb collection ID like 131292.')
+  })
+
+  it('rejects a string with mixed letters and numbers', () => {
+    expect(presets.tmdb_collection_id.validate('131292x').valid).toBe(false)
+  })
+
+  it('rejects empty string', () => {
+    expect(presets.tmdb_collection_id.validate('').valid).toBe(false)
+  })
+
+  it('uses the tmdb lookup service', () => {
+    expect(presets.tmdb_collection_id.lookupService).toBe('tmdb')
+  })
+})
+
+describe('presets.numeric_id', () => {
+  it('accepts a numeric ID like 603', () => {
+    expect(presets.numeric_id.validate('603').valid).toBe(true)
+  })
+
+  it('rejects a non-numeric string', () => {
+    expect(presets.numeric_id.validate('foo').valid).toBe(false)
+  })
+
+  it('rejects negative numbers (no leading sign)', () => {
+    expect(presets.numeric_id.validate('-1').valid).toBe(false)
+  })
+})
+
+describe('presets.imdb_id_tmdb', () => {
+  it('accepts a 7-digit IMDb ID', () => {
+    expect(presets.imdb_id_tmdb.validate('tt1234567').valid).toBe(true)
+  })
+
+  it('accepts an 8-digit IMDb ID', () => {
+    expect(presets.imdb_id_tmdb.validate('tt12345678').valid).toBe(true)
+  })
+
+  it('accepts uppercase TT prefix (case-insensitive regex)', () => {
+    expect(presets.imdb_id_tmdb.validate('TT1234567').valid).toBe(true)
+  })
+
+  it('rejects a 6-digit ID (too short)', () => {
+    expect(presets.imdb_id_tmdb.validate('tt123456').valid).toBe(false)
+  })
+
+  it('rejects a 9-digit ID (too long)', () => {
+    expect(presets.imdb_id_tmdb.validate('tt123456789').valid).toBe(false)
+  })
+
+  it('rejects an ID without the tt prefix', () => {
+    expect(presets.imdb_id_tmdb.validate('1234567').valid).toBe(false)
+  })
+
+  it('normalizes to lowercase', () => {
+    expect(presets.imdb_id_tmdb.normalize('TT1234567')).toBe('tt1234567')
+  })
+
+  it('uses the tmdb lookup service', () => {
+    expect(presets.imdb_id_tmdb.lookupService).toBe('tmdb')
+  })
+})
+
+describe('presets.imdb_id_plex', () => {
+  it('shares the validation rules with imdb_id_tmdb', () => {
+    expect(presets.imdb_id_plex.validate('tt1234567').valid).toBe(true)
+    expect(presets.imdb_id_plex.validate('not-imdb').valid).toBe(false)
+  })
+
+  it('uses the plex lookup service (not tmdb)', () => {
+    expect(presets.imdb_id_plex.lookupService).toBe('plex')
+  })
+})
+
+describe('presets.year', () => {
+  it('accepts a 4-digit year', () => {
+    expect(presets.year.validate('2022').valid).toBe(true)
+    expect(presets.year.validate('1900').valid).toBe(true)
+  })
+
+  it('rejects a 3-digit year', () => {
+    expect(presets.year.validate('999').valid).toBe(false)
+  })
+
+  it('rejects a 5-digit year', () => {
+    expect(presets.year.validate('20223').valid).toBe(false)
+  })
+
+  it('rejects non-numeric input', () => {
+    expect(presets.year.validate('twenty').valid).toBe(false)
+  })
+})
+
+describe('presets.decade', () => {
+  it('accepts a 4-digit decade ending in 0', () => {
+    expect(presets.decade.validate('2020').valid).toBe(true)
+    expect(presets.decade.validate('1990').valid).toBe(true)
+  })
+
+  it('accepts a 5-digit decade ending in 0 (e.g. far-future)', () => {
+    // The regex is /^\d{3,4}0$/ which means "3 or 4 digits, then a 0"
+    // — total length 4 or 5. So the minimum is 4 chars like "1000"
+    // and the max is 5 chars like "10000".
+    expect(presets.decade.validate('10000').valid).toBe(true)
+  })
+
+  it('rejects a 3-character value (regex requires at least 4 total chars)', () => {
+    expect(presets.decade.validate('190').valid).toBe(false)
+  })
+
+  it('rejects a year not ending in 0', () => {
+    expect(presets.decade.validate('2021').valid).toBe(false)
+  })
+
+  it('rejects pure single digit 0', () => {
+    expect(presets.decade.validate('0').valid).toBe(false)
+  })
+})
+
+describe('presets.language_code', () => {
+  it('accepts a 2-letter code', () => {
+    expect(presets.language_code.validate('en').valid).toBe(true)
+    expect(presets.language_code.validate('fr').valid).toBe(true)
+  })
+
+  it('accepts a 3-letter code', () => {
+    expect(presets.language_code.validate('fil').valid).toBe(true)
+    expect(presets.language_code.validate('myn').valid).toBe(true)
+  })
+
+  it('rejects an uppercase code (must be lowercase)', () => {
+    expect(presets.language_code.validate('EN').valid).toBe(false)
+  })
+
+  it('rejects a 1-letter code', () => {
+    expect(presets.language_code.validate('a').valid).toBe(false)
+  })
+
+  it('rejects a 4-letter code', () => {
+    expect(presets.language_code.validate('abcd').valid).toBe(false)
+  })
+
+  it('rejects codes with digits', () => {
+    expect(presets.language_code.validate('en1').valid).toBe(false)
+  })
+
+  it('normalizes uppercase to lowercase', () => {
+    expect(presets.language_code.normalize('EN')).toBe('en')
+    expect(presets.language_code.normalize('FiL')).toBe('fil')
+  })
+})
+
+describe('presets.aspect_key', () => {
+  it('accepts known aspect ratios', () => {
+    expect(presets.aspect_key.validate('1.78').valid).toBe(true)
+    expect(presets.aspect_key.validate('2.35').valid).toBe(true)
+    expect(presets.aspect_key.validate('1.33').valid).toBe(true)
+  })
+
+  it('rejects unknown aspect ratios', () => {
+    expect(presets.aspect_key.validate('1.79').valid).toBe(false)
+    expect(presets.aspect_key.validate('9:16').valid).toBe(false)
+  })
+
+  it('exposes the full allowedValues set', () => {
+    expect(presets.aspect_key.allowedValues).toBeInstanceOf(Set)
+    expect(presets.aspect_key.allowedValues.has('1.78')).toBe(true)
+    expect(presets.aspect_key.allowedValues.has('2.77')).toBe(true)
+  })
+})
+
+describe('presets.resolution_key', () => {
+  it('accepts known resolution keys', () => {
+    expect(presets.resolution_key.validate('4k').valid).toBe(true)
+    expect(presets.resolution_key.validate('1080').valid).toBe(true)
+    expect(presets.resolution_key.validate('sd').valid).toBe(true)
+  })
+
+  it('rejects unknown resolutions', () => {
+    expect(presets.resolution_key.validate('1440').valid).toBe(false)
+    expect(presets.resolution_key.validate('hd').valid).toBe(false)
+  })
+
+  it('normalizes to lowercase before validating', () => {
+    expect(presets.resolution_key.normalize('4K')).toBe('4k')
+    expect(presets.resolution_key.normalize('SD')).toBe('sd')
+  })
+})
+
+describe('presets.streaming_key', () => {
+  it('accepts known streaming services', () => {
+    expect(presets.streaming_key.validate('netflix').valid).toBe(true)
+    expect(presets.streaming_key.validate('disney').valid).toBe(true)
+    expect(presets.streaming_key.validate('hbomax').valid).toBe(true)
+  })
+
+  it('rejects unknown services', () => {
+    expect(presets.streaming_key.validate('vidangel').valid).toBe(false)
+  })
+
+  it('normalizes case before validating', () => {
+    expect(presets.streaming_key.normalize('NETFLIX')).toBe('netflix')
+  })
+})
+
+describe('presets.universe_key', () => {
+  it('accepts known universe keys', () => {
+    expect(presets.universe_key.validate('mcu').valid).toBe(true)
+    expect(presets.universe_key.validate('star').valid).toBe(true)
+    expect(presets.universe_key.validate('wizard').valid).toBe(true)
+  })
+
+  it('rejects unknown universe keys', () => {
+    expect(presets.universe_key.validate('starwars').valid).toBe(false)
+  })
+})
+
+describe('presets.based_key', () => {
+  it('accepts the four valid based keys', () => {
+    expect(presets.based_key.validate('books').valid).toBe(true)
+    expect(presets.based_key.validate('comics').valid).toBe(true)
+    expect(presets.based_key.validate('true_story').valid).toBe(true)
+    expect(presets.based_key.validate('video_games').valid).toBe(true)
+  })
+
+  it('rejects unknown based keys', () => {
+    expect(presets.based_key.validate('manga').valid).toBe(false)
+  })
+})
+
+describe('presets.seasonal_key', () => {
+  it('accepts known seasonal keys', () => {
+    expect(presets.seasonal_key.validate('halloween').valid).toBe(true)
+    expect(presets.seasonal_key.validate('christmas').valid).toBe(true)
+    expect(presets.seasonal_key.validate('lgbtq').valid).toBe(true)
+  })
+
+  it('rejects unknown seasonal keys', () => {
+    expect(presets.seasonal_key.validate('birthday').valid).toBe(false)
+  })
+})
+
+describe('presets.content_rating', () => {
+  it('accepts standard MPAA ratings', () => {
+    expect(presets.content_rating.validate('PG-13').valid).toBe(true)
+    expect(presets.content_rating.validate('R').valid).toBe(true)
+  })
+
+  it('accepts TV ratings', () => {
+    expect(presets.content_rating.validate('TV-14').valid).toBe(true)
+    expect(presets.content_rating.validate('TV-MA').valid).toBe(true)
+  })
+
+  it('accepts age-as-number ratings', () => {
+    expect(presets.content_rating.validate('15').valid).toBe(true)
+    expect(presets.content_rating.validate('18').valid).toBe(true)
+  })
+
+  it('accepts single-letter ratings', () => {
+    expect(presets.content_rating.validate('M').valid).toBe(true)
+  })
+
+  it('rejects ratings starting with a non-alphanumeric character', () => {
+    expect(presets.content_rating.validate('-13').valid).toBe(false)
+    expect(presets.content_rating.validate('(unrated)').valid).toBe(false)
+  })
+
+  it('rejects ratings with unsupported symbols', () => {
+    expect(presets.content_rating.validate('R**').valid).toBe(false)
+    expect(presets.content_rating.validate('PG@13').valid).toBe(false)
+  })
+
+  it('normalizes whitespace runs to single space', () => {
+    expect(presets.content_rating.normalize('PG  13')).toBe('PG 13')
+  })
+})
+
+describe('QSTemplateStringLists.validateAll smoke test', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('returns true when called with a scope containing no widgets', () => {
+    expect(QSTemplateStringLists.validateAll(document)).toBe(true)
+  })
+
+  it('handles a missing scope gracefully (defaults to document)', () => {
+    // We are mostly checking that this doesn't throw — validateAll
+    // is called from form submit handlers where a missing scope
+    // would otherwise crash submission.
+    expect(() => QSTemplateStringLists.validateAll()).not.toThrow()
+  })
+})
+
+describe('QSTemplateStringLists.setup smoke test', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('does not throw when scope contains no widget wrappers', () => {
+    expect(() => QSTemplateStringLists.setup(document)).not.toThrow()
+  })
+
+  it('does not bind incomplete wrappers (missing required children)', () => {
+    document.body.innerHTML = `
+      <div data-template-string-list>
+        <!-- intentionally missing input, addBtn, list, hidden -->
+      </div>
+    `
+    expect(() => QSTemplateStringLists.setup(document)).not.toThrow()
+    const wrapper = document.querySelector('[data-template-string-list]')
+    expect(wrapper.dataset.listenerAdded).toBeUndefined()
+  })
+
+  // Full widget interaction (typing, clicking add, removing chips, etc.)
+  // is covered by Playwright. The unit-test guarantee here is just
+  // "setup does not crash on common edge cases."
+})

--- a/tests/js/urlValidation.test.js
+++ b/tests/js/urlValidation.test.js
@@ -1,0 +1,425 @@
+// Tests for static/local-js/urlValidation.js (#1334 Step 8 — coverage push).
+//
+// urlValidation.js predates the ES-module migration and is still an IIFE
+// that pins itself to window.URLValidation. We can't `import` the public
+// API the way we do for the modules/ files, so the pattern here is a
+// side-effect import that runs the IIFE in jsdom, then reads off
+// window.URLValidation.
+//
+// Once urlValidation.js gets a proper `export` alongside the window
+// assignment (a separate refactor), these tests should switch to a
+// named import. Until then, the side-effect pattern keeps this PR
+// purely additive — zero production code changes.
+//
+// Why this module is high value to lock down:
+//   - Called from 000-base.js, validationHandler.js, 025-libraries.js
+//     (4 sites), totalling ~10 usages across the codebase.
+//   - Every credential-style page with a URL field uses this on input
+//     and on form submit. A regression in `validateValue` would silently
+//     accept malformed URLs across every wizard at once.
+//   - The hostname / IPv4 / IPv6 helpers are pure functions with many
+//     edge cases. Lock them down before any refactor touches them.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import '../../static/local-js/urlValidation.js'
+
+const URLValidation = window.URLValidation
+
+describe('URLValidation.validateValue', () => {
+  describe('empty / null inputs', () => {
+    it('treats null as valid (caller decides what required-ness means)', () => {
+      expect(URLValidation.validateValue(null)).toEqual({ valid: true })
+    })
+
+    it('treats undefined as valid', () => {
+      expect(URLValidation.validateValue(undefined)).toEqual({ valid: true })
+    })
+
+    it('treats empty string as valid', () => {
+      expect(URLValidation.validateValue('')).toEqual({ valid: true })
+    })
+
+    it('treats whitespace-only as valid', () => {
+      expect(URLValidation.validateValue('   \t\n  ')).toEqual({ valid: true })
+    })
+  })
+
+  describe('placeholder rejection', () => {
+    it('rejects bare "http://"', () => {
+      const result = URLValidation.validateValue('http://')
+      expect(result.valid).toBe(false)
+      expect(result.message).toBe('URL is incomplete.')
+    })
+
+    it('rejects bare "https://"', () => {
+      const result = URLValidation.validateValue('https://')
+      expect(result.valid).toBe(false)
+      expect(result.message).toBe('URL is incomplete.')
+    })
+
+    it('rejects placeholders case-insensitively', () => {
+      const result = URLValidation.validateValue('HTTPS://')
+      expect(result.valid).toBe(false)
+      expect(result.message).toBe('URL is incomplete.')
+    })
+
+    it('rejects placeholders with surrounding whitespace', () => {
+      const result = URLValidation.validateValue('  http://  ')
+      expect(result.valid).toBe(false)
+      expect(result.message).toBe('URL is incomplete.')
+    })
+  })
+
+  describe('empty port detection', () => {
+    it('rejects "http://example.com:"', () => {
+      const result = URLValidation.validateValue('http://example.com:')
+      expect(result.valid).toBe(false)
+      expect(result.message).toBe('URL port is missing after ":"')
+    })
+
+    it('rejects "https://localhost:" before URL parsing would catch it', () => {
+      const result = URLValidation.validateValue('https://localhost:')
+      expect(result.valid).toBe(false)
+      expect(result.message).toBe('URL port is missing after ":"')
+    })
+
+    it('accepts a present port', () => {
+      expect(URLValidation.validateValue('http://example.com:8080').valid).toBe(true)
+    })
+  })
+
+  describe('URL parse failures', () => {
+    it('rejects a string that is not a URL at all', () => {
+      const result = URLValidation.validateValue('not a url')
+      expect(result.valid).toBe(false)
+      expect(result.message).toBe('Please enter a valid URL.')
+    })
+
+    it('rejects a bare hostname with no scheme', () => {
+      const result = URLValidation.validateValue('example.com')
+      expect(result.valid).toBe(false)
+      // Without a scheme, URL parse fails first
+      expect(result.message).toBe('Please enter a valid URL.')
+    })
+  })
+
+  describe('protocol enforcement', () => {
+    it('rejects ftp://', () => {
+      const result = URLValidation.validateValue('ftp://example.com')
+      expect(result.valid).toBe(false)
+      expect(result.message).toBe('URL must start with http:// or https://.')
+    })
+
+    it('rejects file://', () => {
+      const result = URLValidation.validateValue('file:///etc/passwd')
+      expect(result.valid).toBe(false)
+      expect(result.message).toBe('URL must start with http:// or https://.')
+    })
+
+    it('rejects ws:// even though it parses', () => {
+      const result = URLValidation.validateValue('ws://example.com')
+      expect(result.valid).toBe(false)
+      expect(result.message).toBe('URL must start with http:// or https://.')
+    })
+
+    it('accepts http://', () => {
+      expect(URLValidation.validateValue('http://example.com').valid).toBe(true)
+    })
+
+    it('accepts https://', () => {
+      expect(URLValidation.validateValue('https://example.com').valid).toBe(true)
+    })
+  })
+
+  describe('port range', () => {
+    it('accepts port 1', () => {
+      expect(URLValidation.validateValue('http://example.com:1').valid).toBe(true)
+    })
+
+    it('accepts port 65535', () => {
+      expect(URLValidation.validateValue('http://example.com:65535').valid).toBe(true)
+    })
+
+    // Note: URL parser may normalise port 0 by dropping it from .port,
+    // and 65536+ becomes a URL parse failure. The explicit branch in
+    // validateValue covers integer ports that survive URL parse but are
+    // out of range — testing it directly is tricky because the parser
+    // rejects most invalid ports up-front. The presence of the branch
+    // is still worth keeping as a defence-in-depth check.
+  })
+
+  describe('hostname validation', () => {
+    it('accepts localhost', () => {
+      expect(URLValidation.validateValue('http://localhost').valid).toBe(true)
+    })
+
+    it('accepts localhost with port', () => {
+      expect(URLValidation.validateValue('http://localhost:8080').valid).toBe(true)
+    })
+
+    it('accepts a single-label hostname', () => {
+      expect(URLValidation.validateValue('http://myserver').valid).toBe(true)
+    })
+
+    it('accepts a normal domain', () => {
+      expect(URLValidation.validateValue('https://example.com').valid).toBe(true)
+    })
+
+    it('accepts a subdomain', () => {
+      expect(URLValidation.validateValue('https://api.example.com').valid).toBe(true)
+    })
+
+    it('accepts an IPv4 address', () => {
+      expect(URLValidation.validateValue('http://192.168.1.1').valid).toBe(true)
+    })
+
+    it('accepts an IPv4 address with port', () => {
+      expect(URLValidation.validateValue('http://192.168.1.1:32400').valid).toBe(true)
+    })
+
+    it('rejects bracketed IPv6 (current behaviour — see SUBTLE-BUG below)', () => {
+      // SUBTLE BUG in production: URL.hostname returns the bracketed form
+      // "[::1]" for IPv6, but isIPv6() regex is /^[0-9a-f:]+$/i which
+      // does not allow brackets. So validateValue rejects valid IPv6
+      // URLs as "URL hostname is invalid." This test locks in the
+      // current behaviour so a future fix in urlValidation.js will
+      // need to update this expectation.
+      const result = URLValidation.validateValue('http://[::1]')
+      expect(result.valid).toBe(false)
+      expect(result.message).toBe('URL hostname is invalid.')
+    })
+
+    it('rejects a hostname starting with a hyphen', () => {
+      const result = URLValidation.validateValue('http://-example.com')
+      expect(result.valid).toBe(false)
+      expect(result.message).toBe('URL hostname is invalid.')
+    })
+
+    it('rejects a hostname ending with a hyphen', () => {
+      const result = URLValidation.validateValue('http://example-.com')
+      expect(result.valid).toBe(false)
+      expect(result.message).toBe('URL hostname is invalid.')
+    })
+
+    it('rejects a TLD that is too short', () => {
+      const result = URLValidation.validateValue('http://example.x')
+      expect(result.valid).toBe(false)
+      expect(result.message).toBe('URL hostname is invalid.')
+    })
+
+    it('rejects a numeric-only TLD', () => {
+      const result = URLValidation.validateValue('http://example.123')
+      expect(result.valid).toBe(false)
+      // The URL parser rejects this before isValidHostname runs, so we
+      // get the generic parse-failure message rather than the hostname-
+      // specific one. Either way it's rejected — that's what matters.
+      expect(result.message).toBe('Please enter a valid URL.')
+    })
+  })
+
+  describe('paths and query strings', () => {
+    it('accepts a URL with a path', () => {
+      expect(URLValidation.validateValue('https://example.com/api/v1/things').valid).toBe(true)
+    })
+
+    it('accepts a URL with a query string', () => {
+      expect(URLValidation.validateValue('https://example.com/search?q=foo').valid).toBe(true)
+    })
+
+    it('accepts a URL with a fragment', () => {
+      expect(URLValidation.validateValue('https://example.com/page#section').valid).toBe(true)
+    })
+  })
+
+  describe('non-string inputs', () => {
+    it('coerces a number to string and rejects it', () => {
+      const result = URLValidation.validateValue(42)
+      expect(result.valid).toBe(false)
+      expect(result.message).toBe('Please enter a valid URL.')
+    })
+
+    it('coerces an object to string and rejects it', () => {
+      const result = URLValidation.validateValue({ toString: () => 'http://x.io' })
+      expect(result.valid).toBe(true)
+    })
+  })
+})
+
+describe('URLValidation.attach + validateAll', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('binds inputs whose name matches the URL pattern', () => {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="my_url" value="http://example.com">
+      </div>
+    `
+    URLValidation.attach(document)
+    const input = document.querySelector('input[name="my_url"]')
+    expect(input.dataset.urlValidationBound).toBe('true')
+    expect(input.dataset.urlValid).toBe('true')
+  })
+
+  it('binds inputs whose id matches the URL pattern', () => {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" id="webhook-url" value="http://example.com">
+      </div>
+    `
+    URLValidation.attach(document)
+    const input = document.getElementById('webhook-url')
+    expect(input.dataset.urlValidationBound).toBe('true')
+  })
+
+  it('binds inputs with type="url" even without url in the name', () => {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="url" name="endpoint" value="http://example.com">
+      </div>
+    `
+    URLValidation.attach(document)
+    const input = document.querySelector('input[name="endpoint"]')
+    expect(input.dataset.urlValidationBound).toBe('true')
+  })
+
+  it('does not bind unrelated inputs', () => {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="username" value="bob">
+      </div>
+    `
+    URLValidation.attach(document)
+    const input = document.querySelector('input[name="username"]')
+    expect(input.dataset.urlValidationBound).toBeUndefined()
+  })
+
+  it('honors data-url-skip="true" as an opt-out', () => {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="my_url" data-url-skip="true" value="http://example.com">
+      </div>
+    `
+    URLValidation.attach(document)
+    const input = document.querySelector('input[name="my_url"]')
+    expect(input.dataset.urlValidationBound).toBeUndefined()
+  })
+
+  it('marks the input is-invalid and adds feedback for a bad URL', () => {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="my_url" value="not a url">
+      </div>
+    `
+    URLValidation.attach(document)
+    const input = document.querySelector('input[name="my_url"]')
+    expect(input.classList.contains('is-invalid')).toBe(true)
+    expect(input.dataset.urlValid).toBe('false')
+    const feedback = document.querySelector('.invalid-feedback')
+    expect(feedback).not.toBeNull()
+    expect(feedback.textContent).toBe('Please enter a valid URL.')
+  })
+
+  it('clears is-invalid when the value becomes valid after input event', () => {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="my_url" value="not a url">
+      </div>
+    `
+    URLValidation.attach(document)
+    const input = document.querySelector('input[name="my_url"]')
+    expect(input.classList.contains('is-invalid')).toBe(true)
+
+    input.value = 'https://example.com'
+    input.dispatchEvent(new Event('input'))
+
+    expect(input.classList.contains('is-invalid')).toBe(false)
+    expect(input.dataset.urlValid).toBe('true')
+  })
+
+  it('reuses an existing .invalid-feedback element if one is already in the input-group', () => {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="my_url" value="not a url">
+        <div class="invalid-feedback">existing message</div>
+      </div>
+    `
+    URLValidation.attach(document)
+    const feedbacks = document.querySelectorAll('.invalid-feedback')
+    expect(feedbacks.length).toBe(1)
+    expect(feedbacks[0].textContent).toBe('Please enter a valid URL.')
+  })
+
+  it('does not double-bind on repeated attach() calls', () => {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="my_url" value="http://example.com">
+      </div>
+    `
+    URLValidation.attach(document)
+    URLValidation.attach(document)
+    URLValidation.attach(document)
+    // If it double-bound, dispatching input would still produce only
+    // one validation pass — but the cheaper assertion is that the
+    // bound-flag prevents re-entry. We verify by ensuring validateAll
+    // still returns the same result (no thrown error from re-binding).
+    expect(URLValidation.validateAll(document)).toBe(true)
+  })
+
+  it('validateAll returns true when all bound inputs are valid', () => {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="my_url" value="https://a.io">
+      </div>
+      <div class="input-group">
+        <input type="text" name="other_url" value="https://b.io">
+      </div>
+    `
+    URLValidation.attach(document)
+    expect(URLValidation.validateAll(document)).toBe(true)
+  })
+
+  it('validateAll returns false when any bound input is invalid', () => {
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="my_url" value="https://a.io">
+      </div>
+      <div class="input-group">
+        <input type="text" name="other_url" value="not a url">
+      </div>
+    `
+    URLValidation.attach(document)
+    expect(URLValidation.validateAll(document)).toBe(false)
+  })
+
+  it('validateAll binds previously-unbound url inputs in the container', () => {
+    // Simulates a freshly-injected card / partial that attach() never saw.
+    document.body.innerHTML = `
+      <div class="input-group">
+        <input type="text" name="my_url" value="not a url">
+      </div>
+    `
+    expect(URLValidation.validateAll(document)).toBe(false)
+    const input = document.querySelector('input[name="my_url"]')
+    expect(input.dataset.urlValidationBound).toBe('true')
+  })
+
+  it('scopes validation to the passed container', () => {
+    document.body.innerHTML = `
+      <div id="card-a" class="input-group">
+        <input type="text" name="my_url" value="not a url">
+      </div>
+      <div id="card-b" class="input-group">
+        <input type="text" name="other_url" value="https://valid.io">
+      </div>
+    `
+    const cardB = document.getElementById('card-b')
+    // Only card B is being validated — card A has a bad URL but isn't in scope.
+    expect(URLValidation.validateAll(cardB)).toBe(true)
+  })
+})


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix
- [x] Feature/Tweak (additive — new tests, no production code changes)
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Other

## Description

Roadmap issue #1334 **Step 8 (Vitest)** — coverage expansion. Adds unit tests for the three largest untested ES-module-adjacent helpers in `static/local-js`. **Pure additive PR — zero production code changes.**

### Why these three modules

| Module | Lines | Call sites | Why it matters |
|---|---|---|---|
| `urlValidation.js` | 162 | 000-base, validationHandler, 025-libraries (4 sites) | Every credential-style page with a URL field uses it. A regression in `validateValue` would silently accept malformed URLs everywhere at once. |
| `pathValidation.js` | 258 | 000-base, 001-start, 150-settings, 915-imagemaid, validationHandler | Anything accepting a filesystem path uses it. A regression could silently accept `C:\bad` on Linux or reject `/var/log` as Windows-style. |
| `templateStringList.js` | 609 | 025-libraries, 150-settings | Backs the chip-list editor for template variables. 16 pure-function validators (year, decade, language code, aspect ratio, IMDb ID, streaming service key, etc.) that get pasted into every library card. |

**Together: ~1,029 lines of code that 16+ call sites depend on, previously with ZERO test coverage.**

### Test counts

| File | New tests |
|---|---|
| `tests/js/urlValidation.test.js` | 50 |
| `tests/js/pathValidation.test.js` | 27 |
| `tests/js/templateStringList.test.js` | 74 |
| **TOTAL NEW** | **151** |
| Existing (appConfig + validationPageBase) | 24 |
| **GRAND TOTAL** | **175 tests in 5 files** |

### Verification

| Check | Result |
|---|---|
| Vitest (all suites) | **175/175 pass** |
| Python tests | 80/80 pass |
| Playwright wizard e2e | 5/5 pass |
| ESLint | 0 errors |
| pre-commit | 12/12 hooks green |

### Import pattern note

These three modules predate the ES-module migration. They are still IIFEs that pin themselves to `window.X` rather than using `export` statements. So unlike `modules/appConfig.js` and `modules/validationPageBase.js` (which the existing tests import by name), these tests use a side-effect import + window-access pattern:

```js
await import('../../static/local-js/urlValidation.js')
const URLValidation = window.URLValidation
```

When these modules eventually get proper `export` statements (a separate refactor, not in scope here), the tests can switch to named imports with a one-line diff per file. Until then, the side-effect pattern keeps this PR strictly additive.

### Drive-by discovery (NOT fixed here)

While writing urlValidation tests, the IPv6 branch was found to have a subtle bug:

- `URL.hostname` returns the bracketed form (e.g. `'[::1]'`) for IPv6 URLs
- But `isIPv6()` uses `/^[0-9a-f:]+$/i` which does not allow brackets
- So `validateValue` rejects valid IPv6 URLs as `'URL hostname is invalid.'`

The test locks in the current (buggy) behaviour with an explicit comment documenting the issue, so any future fix in `urlValidation.js` will need to update this expectation. **Fixing the source belongs in its own PR.**

### Roadmap impact

Step 8 was already started with 2 test suites (24 tests). This PR brings the suite to 175 tests across 5 files. The remaining work on Step 8 will be coverage for **new** shared modules as they get extracted — starting with the upcoming Step 6 (validation widget refactor).

**Step 6 is the next big-bang item.** Doing this Step 8 coverage first gives the refactor a safety net: any regression in URL/path/template-string handling triggered by the wizard restructuring will be caught immediately by these tests rather than discovered in production.

## Related Issues

Roadmap: #1334 Step 8

## Which Environment Did You Test On?

- [x] Local Install (Linux, Python 3.13, Vitest+jsdom, Playwright Chromium)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
