### PR TITLE
Add createApiKeyValidator factory + migrate 060-mdblist (#1334 Step 6 PR 1)

### DIFF
--- a/static/local-js/060-mdblist.js
+++ b/static/local-js/060-mdblist.js
@@ -1,96 +1,12 @@
-import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
+import { createApiKeyValidator } from './modules/createApiKeyValidator.js'
 
-const apiKeyInput = document.getElementById('mdblist_apikey')
-const validateButton = document.getElementById('validateButton')
-const toggleButton = document.getElementById('toggleApikeyVisibility')
-const isValidated = document.getElementById('mdblist_validated').value.toLowerCase()
-const validatedAtInput = document.getElementById('mdblist_validated_at')
-
-console.log('Validated: ' + isValidated)
-
-// Set initial visibility based on API key value
-if (apiKeyInput.value.trim() === '') {
-  apiKeyInput.setAttribute('type', 'text') // Show placeholder text
-  setToggleButtonIcon(toggleButton, true)
-} else {
-  apiKeyInput.setAttribute('type', 'password') // Hide actual key
-  setToggleButtonIcon(toggleButton, false)
-}
-
-// Disable validate button if already validated
-validateButton.disabled = isValidated === 'true'
-
-// Reset validation status when user types
-apiKeyInput.addEventListener('input', function () {
-  document.getElementById('mdblist_validated').value = 'false'
-  if (validatedAtInput) validatedAtInput.value = ''
-  validateButton.disabled = false
-  refreshValidationCallout('mdblist_validated')
-})
-
-document.getElementById('validateButton').addEventListener('click', function () {
-  const apiKey = apiKeyInput.value
-  const statusMessage = document.getElementById('statusMessage')
-
-  if (!apiKey) {
-    statusMessage.textContent = 'Please enter an API key.'
-    statusMessage.style.color = '#ea868f'
-    statusMessage.style.display = 'block'
-    return
-  }
-
-  showSpinner('validate')
-
-  fetch('/validate_mdblist', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ mdblist_apikey: apiKey })
-  })
-    .then(response => response.json())
-    .then(data => {
-      if (data.valid) {
-        console.log('valid')
-        hideSpinner('validate')
-        document.getElementById('mdblist_validated').value = 'true'
-        if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-        refreshValidationCallout('mdblist_validated')
-        statusMessage.textContent = 'API key is valid!'
-        statusMessage.style.color = '#75b798'
-        validateButton.disabled = true
-      } else {
-        console.log('NOT valid')
-        document.getElementById('mdblist_validated').value = 'false'
-        if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout('mdblist_validated')
-        statusMessage.textContent = 'Failed to validate MDBList server. Please check your API Key.'
-        statusMessage.style.color = '#ea868f'
-      }
-      statusMessage.style.display = 'block'
-    })
-    .catch(error => {
-      console.error('Error validating MDBList server:', error)
-      statusMessage.textContent = 'An error occurred. Please try again.'
-      statusMessage.style.color = '#ea868f'
-      statusMessage.style.display = 'block'
-      if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout('mdblist_validated')
-    })
-    .finally(() => {
-      hideSpinner('validate')
-      statusMessage.style.display = 'block'
-    })
-})
-
-document.getElementById('toggleApikeyVisibility').addEventListener('click', function () {
-  const currentType = apiKeyInput.getAttribute('type')
-  apiKeyInput.setAttribute('type', currentType === 'password' ? 'text' : 'password')
-  setToggleButtonIcon(this, currentType === 'password')
-})
-
-document.getElementById('configForm').addEventListener('submit', function () {
-  if (!apiKeyInput.value) {
-    apiKeyInput.value = ''
+createApiKeyValidator({
+  fieldId: 'mdblist_apikey',
+  validatedFieldId: 'mdblist_validated',
+  validatedAtFieldId: 'mdblist_validated_at',
+  endpoint: '/validate_mdblist',
+  buildPayload: (apiKey) => ({ mdblist_apikey: apiKey }),
+  messages: {
+    failure: 'Failed to validate MDBList server. Please check your API Key.'
   }
 })

--- a/static/local-js/modules/createApiKeyValidator.js
+++ b/static/local-js/modules/createApiKeyValidator.js
@@ -1,0 +1,196 @@
+// Shared factory for the simplest validation wizard shape: ONE credential
+// input (api key or token), one validate button, server endpoint that
+// returns { valid: boolean }. Used by all the "just a key" pages —
+// 050-omdb, 060-mdblist, 070-notifiarr, etc.
+//
+// Wizards with extra fields (Tautulli url + key, Gotify url + token, etc.)
+// are NOT covered here. PR 2 of #1334 Step 6 will introduce a multi-field
+// variant that builds on the same idea.
+//
+// DESIGN
+//
+//   The factory takes a config object describing every per-wizard
+//   variable (field ids, endpoint, payload shape, status messages),
+//   does all the DOM wiring once, and returns nothing. It is purely
+//   side-effectful: the wizard module that imports it calls the factory
+//   at module top level and that's it.
+//
+//   We accept fields by ID rather than passing pre-resolved elements
+//   because: (a) all existing wizards lookup by ID, (b) the test suite
+//   can populate document.body once per test, (c) the factory can
+//   gracefully no-op if an expected element is absent (defence in depth
+//   for partial template rendering).
+//
+//   Default messages match what 060-mdblist used to say verbatim, so
+//   the canary wizard's user-visible text is unchanged.
+//
+//   STATUS COLORS: the legacy code used hex literals (#ea868f, #75b798).
+//   We preserve those exactly to avoid any visual regression.
+
+import { setToggleButtonIcon, refreshValidationCallout } from './validationPageBase.js'
+
+const STATUS_COLOR_ERROR = '#ea868f'
+const STATUS_COLOR_SUCCESS = '#75b798'
+
+const DEFAULT_MESSAGES = {
+  empty: 'Please enter an API key.',
+  success: 'API key is valid!',
+  failure: 'API key is invalid.',
+  networkError: 'An error occurred. Please try again.'
+}
+
+/**
+ * Wire up a single-credential validation wizard.
+ *
+ * @param {object} config
+ * @param {string} config.fieldId                Element id of the credential input.
+ * @param {string} config.validatedFieldId       Element id of the hidden "<service>_validated" input.
+ * @param {string} [config.validatedAtFieldId]   Element id of the hidden "<service>_validated_at" timestamp input.
+ * @param {string} [config.toggleButtonId='toggleApikeyVisibility']  Id of the show/hide toggle button.
+ * @param {string} [config.validateButtonId='validateButton']        Id of the validate button.
+ * @param {string} [config.statusMessageId='statusMessage']          Id of the status callout element.
+ * @param {string} [config.formId='configForm']                      Id of the wrapping form (for submit reset).
+ * @param {string} config.endpoint               URL the validate button POSTs to.
+ * @param {(apiKey: string) => object} config.buildPayload           Builds the JSON body for the POST.
+ * @param {string[]} [config.resetOnInputFieldIds=[]]                Extra field ids that should also reset
+ *                                                                    validation state on input (e.g. url field
+ *                                                                    on Gotify). The main fieldId is always
+ *                                                                    reset; this is for additional ones.
+ * @param {object} [config.messages]             Override individual status strings (empty/success/failure/networkError).
+ * @param {string} [config.spinnerKey='validate'] Argument passed to show/hideSpinner.
+ */
+export function createApiKeyValidator (config) {
+  const {
+    fieldId,
+    validatedFieldId,
+    validatedAtFieldId,
+    toggleButtonId = 'toggleApikeyVisibility',
+    validateButtonId = 'validateButton',
+    statusMessageId = 'statusMessage',
+    formId = 'configForm',
+    endpoint,
+    buildPayload,
+    resetOnInputFieldIds = [],
+    messages: messageOverrides = {},
+    spinnerKey = 'validate'
+  } = config
+
+  if (!fieldId) throw new Error('createApiKeyValidator: fieldId is required')
+  if (!validatedFieldId) throw new Error('createApiKeyValidator: validatedFieldId is required')
+  if (!endpoint) throw new Error('createApiKeyValidator: endpoint is required')
+  if (typeof buildPayload !== 'function') {
+    throw new Error('createApiKeyValidator: buildPayload must be a function')
+  }
+
+  const messages = { ...DEFAULT_MESSAGES, ...messageOverrides }
+
+  const apiKeyInput = document.getElementById(fieldId)
+  const validatedField = document.getElementById(validatedFieldId)
+  const validatedAtInput = validatedAtFieldId ? document.getElementById(validatedAtFieldId) : null
+  const validateButton = document.getElementById(validateButtonId)
+  const toggleButton = document.getElementById(toggleButtonId)
+  const form = document.getElementById(formId)
+
+  // If the credential or validate button isn't on the page, this wizard
+  // isn't fully rendered — bail. Other helpers tolerate missing optional
+  // elements, but these two are load-bearing.
+  if (!apiKeyInput || !validatedField || !validateButton) return
+
+  // ── initial visibility of the credential field ──────────────────────
+  if (apiKeyInput.value.trim() === '') {
+    apiKeyInput.setAttribute('type', 'text') // show placeholder text
+    if (toggleButton) setToggleButtonIcon(toggleButton, true)
+  } else {
+    apiKeyInput.setAttribute('type', 'password')
+    if (toggleButton) setToggleButtonIcon(toggleButton, false)
+  }
+
+  // ── initial button state ────────────────────────────────────────────
+  validateButton.disabled = validatedField.value.toLowerCase() === 'true'
+
+  // ── reset validation state when the user types ──────────────────────
+  function resetValidation () {
+    validatedField.value = 'false'
+    if (validatedAtInput) validatedAtInput.value = ''
+    validateButton.disabled = false
+    refreshValidationCallout(validatedFieldId)
+  }
+
+  apiKeyInput.addEventListener('input', resetValidation)
+  for (const extraId of resetOnInputFieldIds) {
+    const extra = document.getElementById(extraId)
+    if (extra) extra.addEventListener('input', resetValidation)
+  }
+
+  // ── status message helpers ──────────────────────────────────────────
+  function showStatus (text, color) {
+    const statusMessage = document.getElementById(statusMessageId)
+    if (!statusMessage) return
+    statusMessage.textContent = text
+    statusMessage.style.color = color
+    statusMessage.style.display = 'block'
+  }
+
+  // ── validate click handler ──────────────────────────────────────────
+  validateButton.addEventListener('click', function () {
+    const apiKey = apiKeyInput.value
+    if (!apiKey) {
+      showStatus(messages.empty, STATUS_COLOR_ERROR)
+      return
+    }
+
+    // showSpinner/hideSpinner are still globals from 000-base.js.
+    // When/if they migrate to a shared module, swap these calls.
+    if (typeof showSpinner === 'function') showSpinner(spinnerKey)
+
+    fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(buildPayload(apiKey))
+    })
+      .then(response => response.json())
+      .then(data => {
+        if (data.valid) {
+          validatedField.value = 'true'
+          if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
+          refreshValidationCallout(validatedFieldId)
+          showStatus(messages.success, STATUS_COLOR_SUCCESS)
+          validateButton.disabled = true
+        } else {
+          validatedField.value = 'false'
+          if (validatedAtInput) validatedAtInput.value = ''
+          refreshValidationCallout(validatedFieldId)
+          showStatus(messages.failure, STATUS_COLOR_ERROR)
+        }
+      })
+      .catch(() => {
+        if (validatedAtInput) validatedAtInput.value = ''
+        refreshValidationCallout(validatedFieldId)
+        showStatus(messages.networkError, STATUS_COLOR_ERROR)
+      })
+      .finally(() => {
+        if (typeof hideSpinner === 'function') hideSpinner(spinnerKey)
+      })
+  })
+
+  // ── show/hide toggle for the credential field ───────────────────────
+  if (toggleButton) {
+    toggleButton.addEventListener('click', function () {
+      const currentType = apiKeyInput.getAttribute('type')
+      apiKeyInput.setAttribute('type', currentType === 'password' ? 'text' : 'password')
+      setToggleButtonIcon(this, currentType === 'password')
+    })
+  }
+
+  // ── on form submit, normalise an absent value to empty string ───────
+  // Preserved verbatim from the legacy wizards — when the field is
+  // entirely empty the form should still post an empty string, not
+  // omit the field entirely.
+  if (form) {
+    form.addEventListener('submit', function () {
+      if (!apiKeyInput.value) {
+        apiKeyInput.value = ''
+      }
+    })
+  }
+}

--- a/tests/e2e/test_wizard_e2e.py
+++ b/tests/e2e/test_wizard_e2e.py
@@ -150,3 +150,27 @@ def test_running_pill_visible(page, live_server):
     badge = page.locator("#qs-running-badge")
     expect(badge).not_to_have_class(re.compile(r"\bd-none\b"))
     expect(badge).to_contain_text("Kometa running")
+
+
+@pytest.mark.e2e
+def test_mdblist_validate_button_uses_factory(page, live_server):
+    """Smoke test for the createApiKeyValidator factory on a real page.
+
+    060-mdblist.js was migrated to the shared factory under #1334 Step 6
+    PR 1. The Vitest suite for the factory locks in the contract in
+    isolation, but only an actual rendered page proves that the
+    factory's IDs (validateButton, statusMessage, toggleApikeyVisibility)
+    line up with the wizard template.
+    """
+
+    def handle_validate(route):
+        route.fulfill(status=200, json={"valid": True})
+
+    page.route("**/validate_mdblist", handle_validate)
+    page.goto(f"{live_server}/step/060-mdblist", wait_until="domcontentloaded")
+
+    page.locator("#mdblist_apikey").fill("some-key")
+    page.locator("#validateButton").click()
+    expect(page.locator("#statusMessage")).to_contain_text("API key is valid!")
+    expect(page.locator("#mdblist_validated")).to_have_value("true")
+    expect(page.locator("#validateButton")).to_be_disabled()

--- a/tests/js/modules/createApiKeyValidator.test.js
+++ b/tests/js/modules/createApiKeyValidator.test.js
@@ -1,0 +1,572 @@
+// Tests for static/local-js/modules/createApiKeyValidator.js
+// (#1334 Step 6 PR 1).
+//
+// This factory is the shared replacement for ~9 near-duplicate wizard
+// modules. The tests below lock down the full behavioural contract so
+// every wizard migration in PR 2 has a safety net.
+//
+// Pattern follows the existing modules/*.test.js style:
+//   - import the factory by name (it's a proper ES module from day 1)
+//   - one describe block per behaviour cluster
+//   - beforeEach resets document.body and the window-global shims
+//
+// SHIMS:
+//
+//   The factory calls showSpinner/hideSpinner as plain globals (legacy
+//   pattern inherited from 000-base.js). We stub them as window globals
+//   per test and verify call counts where it matters.
+//
+//   The factory delegates to refreshValidationCallout from
+//   validationPageBase.js — that delegate is itself a no-op when
+//   window.QSValidationCallouts is undefined, so we don't have to stub
+//   anything for it. Where we want to verify refresh DID fire, we stub
+//   window.QSValidationCallouts.refresh and assert on it.
+//
+//   fetch is stubbed per test with vi.stubGlobal('fetch', ...) and
+//   restored in afterEach. Don't import fetch — just trust the stub.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApiKeyValidator } from '../../../static/local-js/modules/createApiKeyValidator.js'
+
+function buildBaseHTML ({ keyValue = '', validated = 'false', extraInputs = '' } = {}) {
+  return `
+    <form id="configForm">
+      <input id="test_apikey" type="password" value="${keyValue}">
+      <input id="test_validated" type="hidden" value="${validated}">
+      <input id="test_validated_at" type="hidden" value="">
+      <button id="toggleApikeyVisibility" type="button">
+        <i class="bi"></i>
+      </button>
+      <button id="validateButton" type="button">Validate</button>
+      <div id="statusMessage" style="display:none"></div>
+      ${extraInputs}
+    </form>
+  `
+}
+
+function defaultConfig (overrides = {}) {
+  return {
+    fieldId: 'test_apikey',
+    validatedFieldId: 'test_validated',
+    validatedAtFieldId: 'test_validated_at',
+    endpoint: '/validate_test',
+    buildPayload: (apiKey) => ({ test_apikey: apiKey }),
+    ...overrides
+  }
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+  window.showSpinner = vi.fn()
+  window.hideSpinner = vi.fn()
+  delete window.QSValidationCallouts
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  delete window.showSpinner
+  delete window.hideSpinner
+  delete window.QSValidationCallouts
+})
+
+describe('createApiKeyValidator config validation', () => {
+  it('throws when fieldId is missing', () => {
+    document.body.innerHTML = buildBaseHTML()
+    expect(() => createApiKeyValidator({
+      validatedFieldId: 'test_validated',
+      endpoint: '/x',
+      buildPayload: () => ({})
+    })).toThrow(/fieldId is required/)
+  })
+
+  it('throws when validatedFieldId is missing', () => {
+    document.body.innerHTML = buildBaseHTML()
+    expect(() => createApiKeyValidator({
+      fieldId: 'test_apikey',
+      endpoint: '/x',
+      buildPayload: () => ({})
+    })).toThrow(/validatedFieldId is required/)
+  })
+
+  it('throws when endpoint is missing', () => {
+    document.body.innerHTML = buildBaseHTML()
+    expect(() => createApiKeyValidator({
+      fieldId: 'test_apikey',
+      validatedFieldId: 'test_validated',
+      buildPayload: () => ({})
+    })).toThrow(/endpoint is required/)
+  })
+
+  it('throws when buildPayload is not a function', () => {
+    document.body.innerHTML = buildBaseHTML()
+    expect(() => createApiKeyValidator({
+      fieldId: 'test_apikey',
+      validatedFieldId: 'test_validated',
+      endpoint: '/x',
+      buildPayload: 'not a function'
+    })).toThrow(/buildPayload must be a function/)
+  })
+})
+
+describe('createApiKeyValidator graceful no-op on missing DOM', () => {
+  it('returns without throwing when the credential input is absent', () => {
+    document.body.innerHTML = '<form id="configForm"></form>'
+    expect(() => createApiKeyValidator(defaultConfig())).not.toThrow()
+  })
+
+  it('returns without throwing when validatedField is absent', () => {
+    document.body.innerHTML = `
+      <form id="configForm">
+        <input id="test_apikey" type="password">
+        <button id="validateButton">Validate</button>
+      </form>
+    `
+    expect(() => createApiKeyValidator(defaultConfig())).not.toThrow()
+  })
+
+  it('returns without throwing when validateButton is absent', () => {
+    document.body.innerHTML = `
+      <form id="configForm">
+        <input id="test_apikey" type="password">
+        <input id="test_validated" type="hidden" value="false">
+      </form>
+    `
+    expect(() => createApiKeyValidator(defaultConfig())).not.toThrow()
+  })
+})
+
+describe('createApiKeyValidator initial field state', () => {
+  it('switches an empty credential field to type="text" so placeholder shows', () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: '' })
+    createApiKeyValidator(defaultConfig())
+    expect(document.getElementById('test_apikey').getAttribute('type')).toBe('text')
+  })
+
+  it('keeps a populated credential field as type="password"', () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'secret123' })
+    createApiKeyValidator(defaultConfig())
+    expect(document.getElementById('test_apikey').getAttribute('type')).toBe('password')
+  })
+
+  it('treats whitespace-only credential as empty (still password initially, then text)', () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: '   ' })
+    createApiKeyValidator(defaultConfig())
+    expect(document.getElementById('test_apikey').getAttribute('type')).toBe('text')
+  })
+
+  it('disables the validate button when the page loads with validated=true', () => {
+    document.body.innerHTML = buildBaseHTML({ validated: 'true' })
+    createApiKeyValidator(defaultConfig())
+    expect(document.getElementById('validateButton').disabled).toBe(true)
+  })
+
+  it('enables the validate button when the page loads with validated=false', () => {
+    document.body.innerHTML = buildBaseHTML({ validated: 'false' })
+    createApiKeyValidator(defaultConfig())
+    expect(document.getElementById('validateButton').disabled).toBe(false)
+  })
+
+  it('treats "TRUE" (uppercase) as validated', () => {
+    document.body.innerHTML = buildBaseHTML({ validated: 'TRUE' })
+    createApiKeyValidator(defaultConfig())
+    expect(document.getElementById('validateButton').disabled).toBe(true)
+  })
+})
+
+describe('createApiKeyValidator reset-on-input', () => {
+  it('resets validated field and re-enables button when user types in credential field', () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'old', validated: 'true' })
+    createApiKeyValidator(defaultConfig())
+    const input = document.getElementById('test_apikey')
+    const validated = document.getElementById('test_validated')
+    const button = document.getElementById('validateButton')
+
+    expect(validated.value).toBe('true')
+    expect(button.disabled).toBe(true)
+
+    input.dispatchEvent(new Event('input'))
+
+    expect(validated.value).toBe('false')
+    expect(button.disabled).toBe(false)
+  })
+
+  it('clears validated_at timestamp on input', () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'old', validated: 'true' })
+    document.getElementById('test_validated_at').value = '2026-01-01T00:00:00Z'
+    createApiKeyValidator(defaultConfig())
+
+    document.getElementById('test_apikey').dispatchEvent(new Event('input'))
+    expect(document.getElementById('test_validated_at').value).toBe('')
+  })
+
+  it('also resets on input for extra fields in resetOnInputFieldIds', () => {
+    document.body.innerHTML = buildBaseHTML({
+      keyValue: 'old',
+      validated: 'true',
+      extraInputs: '<input id="test_url" type="text">'
+    })
+    createApiKeyValidator(defaultConfig({
+      resetOnInputFieldIds: ['test_url']
+    }))
+
+    document.getElementById('test_url').dispatchEvent(new Event('input'))
+    expect(document.getElementById('test_validated').value).toBe('false')
+    expect(document.getElementById('validateButton').disabled).toBe(false)
+  })
+
+  it('ignores missing extra field ids without throwing', () => {
+    document.body.innerHTML = buildBaseHTML({ validated: 'true' })
+    expect(() => createApiKeyValidator(defaultConfig({
+      resetOnInputFieldIds: ['nonexistent_field']
+    }))).not.toThrow()
+  })
+
+  it('calls refreshValidationCallout when the field is reset', () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'old', validated: 'true' })
+    const refreshSpy = vi.fn()
+    window.QSValidationCallouts = { refresh: refreshSpy }
+
+    createApiKeyValidator(defaultConfig())
+    document.getElementById('test_apikey').dispatchEvent(new Event('input'))
+
+    expect(refreshSpy).toHaveBeenCalledWith('test_validated')
+  })
+})
+
+describe('createApiKeyValidator validate click — empty credential', () => {
+  it('shows the empty-message and does not call fetch', () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: '' })
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+
+    createApiKeyValidator(defaultConfig())
+    document.getElementById('validateButton').click()
+
+    const status = document.getElementById('statusMessage')
+    expect(status.textContent).toBe('Please enter an API key.')
+    expect(status.style.color).toBe('rgb(234, 134, 143)') // #ea868f as rgb
+    expect(status.style.display).toBe('block')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('uses the custom empty message when provided', () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: '' })
+    vi.stubGlobal('fetch', vi.fn())
+
+    createApiKeyValidator(defaultConfig({
+      messages: { empty: 'Please enter an OMDb API key.' }
+    }))
+    document.getElementById('validateButton').click()
+
+    expect(document.getElementById('statusMessage').textContent).toBe('Please enter an OMDb API key.')
+  })
+})
+
+describe('createApiKeyValidator validate click — server says valid', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ valid: true })
+    })))
+  })
+
+  it('POSTs to the configured endpoint with the configured payload', async () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    createApiKeyValidator(defaultConfig({
+      endpoint: '/validate_omdb',
+      buildPayload: (key) => ({ omdb_apikey: key })
+    }))
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(fetch).toHaveBeenCalledWith('/validate_omdb', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ omdb_apikey: 'mykey' })
+    })
+  })
+
+  it('sets validated field to "true" on success', async () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    createApiKeyValidator(defaultConfig())
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(document.getElementById('test_validated').value).toBe('true')
+  })
+
+  it('stamps validated_at with an ISO timestamp on success', async () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    createApiKeyValidator(defaultConfig())
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    const stamp = document.getElementById('test_validated_at').value
+    expect(stamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+  })
+
+  it('shows success message in success color', async () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    createApiKeyValidator(defaultConfig())
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    const status = document.getElementById('statusMessage')
+    expect(status.textContent).toBe('API key is valid!')
+    expect(status.style.color).toBe('rgb(117, 183, 152)') // #75b798
+  })
+
+  it('uses the custom success message when provided', async () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    createApiKeyValidator(defaultConfig({
+      messages: { success: 'OMDb API key is valid.' }
+    }))
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(document.getElementById('statusMessage').textContent).toBe('OMDb API key is valid.')
+  })
+
+  it('disables the validate button after a successful validation', async () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    createApiKeyValidator(defaultConfig())
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(document.getElementById('validateButton').disabled).toBe(true)
+  })
+
+  it('calls showSpinner and hideSpinner with the configured key', async () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    createApiKeyValidator(defaultConfig({ spinnerKey: 'omdb-validate' }))
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(window.showSpinner).toHaveBeenCalledWith('omdb-validate')
+    expect(window.hideSpinner).toHaveBeenCalledWith('omdb-validate')
+  })
+
+  it('defaults spinnerKey to "validate" when not configured', async () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    createApiKeyValidator(defaultConfig())
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(window.showSpinner).toHaveBeenCalledWith('validate')
+    expect(window.hideSpinner).toHaveBeenCalledWith('validate')
+  })
+})
+
+describe('createApiKeyValidator validate click — server says invalid', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ valid: false })
+    })))
+  })
+
+  it('sets validated field to "false"', async () => {
+    // Start with validated=false so the button is enabled and clickable.
+    // (A disabled validate button silently swallows clicks, which is
+    //  intended production behaviour after a successful validation.)
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'badkey', validated: 'false' })
+    createApiKeyValidator(defaultConfig())
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(document.getElementById('test_validated').value).toBe('false')
+  })
+
+  it('clears validated_at on failure', async () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'badkey' })
+    document.getElementById('test_validated_at').value = '2026-01-01T00:00:00Z'
+    createApiKeyValidator(defaultConfig())
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(document.getElementById('test_validated_at').value).toBe('')
+  })
+
+  it('shows failure message in error color', async () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'badkey' })
+    createApiKeyValidator(defaultConfig())
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    const status = document.getElementById('statusMessage')
+    expect(status.textContent).toBe('API key is invalid.')
+    expect(status.style.color).toBe('rgb(234, 134, 143)') // #ea868f
+  })
+
+  it('uses the custom failure message when provided', async () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'badkey' })
+    createApiKeyValidator(defaultConfig({
+      messages: { failure: 'Failed to validate MDBList server. Please check your API Key.' }
+    }))
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(document.getElementById('statusMessage').textContent).toBe(
+      'Failed to validate MDBList server. Please check your API Key.'
+    )
+  })
+
+  it('does NOT disable the validate button on failure (user can retry)', async () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'badkey' })
+    createApiKeyValidator(defaultConfig())
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(document.getElementById('validateButton').disabled).toBe(false)
+  })
+})
+
+describe('createApiKeyValidator validate click — network error', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('boom'))))
+  })
+
+  it('shows the network-error message in error color', async () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    createApiKeyValidator(defaultConfig())
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    const status = document.getElementById('statusMessage')
+    expect(status.textContent).toBe('An error occurred. Please try again.')
+    expect(status.style.color).toBe('rgb(234, 134, 143)') // #ea868f
+  })
+
+  it('clears validated_at on network failure', async () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    document.getElementById('test_validated_at').value = '2026-01-01T00:00:00Z'
+    createApiKeyValidator(defaultConfig())
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(document.getElementById('test_validated_at').value).toBe('')
+  })
+
+  it('still calls hideSpinner in finally (even though fetch rejected)', async () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    createApiKeyValidator(defaultConfig())
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(window.hideSpinner).toHaveBeenCalledWith('validate')
+  })
+})
+
+describe('createApiKeyValidator toggle visibility button', () => {
+  it('toggles credential field from password to text on click', () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'secret' })
+    createApiKeyValidator(defaultConfig())
+    expect(document.getElementById('test_apikey').getAttribute('type')).toBe('password')
+
+    document.getElementById('toggleApikeyVisibility').click()
+    expect(document.getElementById('test_apikey').getAttribute('type')).toBe('text')
+  })
+
+  it('toggles credential field from text back to password on second click', () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'secret' })
+    createApiKeyValidator(defaultConfig())
+    const toggle = document.getElementById('toggleApikeyVisibility')
+
+    toggle.click()
+    toggle.click()
+    expect(document.getElementById('test_apikey').getAttribute('type')).toBe('password')
+  })
+
+  it('accepts a custom toggleButtonId (for wizards using toggleTokenVisibility)', () => {
+    document.body.innerHTML = `
+      <form id="configForm">
+        <input id="test_apikey" type="password" value="secret">
+        <input id="test_validated" type="hidden" value="false">
+        <input id="test_validated_at" type="hidden" value="">
+        <button id="toggleTokenVisibility" type="button"><i class="bi"></i></button>
+        <button id="validateButton" type="button">Validate</button>
+        <div id="statusMessage" style="display:none"></div>
+      </form>
+    `
+    createApiKeyValidator(defaultConfig({ toggleButtonId: 'toggleTokenVisibility' }))
+
+    document.getElementById('toggleTokenVisibility').click()
+    expect(document.getElementById('test_apikey').getAttribute('type')).toBe('text')
+  })
+
+  it('does not throw when toggle button is absent', () => {
+    document.body.innerHTML = `
+      <form id="configForm">
+        <input id="test_apikey" type="password" value="secret">
+        <input id="test_validated" type="hidden" value="false">
+        <input id="test_validated_at" type="hidden" value="">
+        <button id="validateButton" type="button">Validate</button>
+        <div id="statusMessage" style="display:none"></div>
+      </form>
+    `
+    expect(() => createApiKeyValidator(defaultConfig())).not.toThrow()
+  })
+})
+
+describe('createApiKeyValidator form submit normalization', () => {
+  it('preserves an existing credential value on form submit', () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    createApiKeyValidator(defaultConfig())
+
+    const form = document.getElementById('configForm')
+    const submitEvent = new Event('submit', { cancelable: true })
+    submitEvent.preventDefault() // prevent jsdom from navigating
+    form.dispatchEvent(submitEvent)
+
+    expect(document.getElementById('test_apikey').value).toBe('mykey')
+  })
+
+  it('normalises an empty-string credential to empty-string on submit (no-op safety)', () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: '' })
+    createApiKeyValidator(defaultConfig())
+
+    const form = document.getElementById('configForm')
+    form.dispatchEvent(new Event('submit'))
+
+    expect(document.getElementById('test_apikey').value).toBe('')
+  })
+
+  it('does not throw when the form element is absent', () => {
+    document.body.innerHTML = `
+      <input id="test_apikey" type="password" value="secret">
+      <input id="test_validated" type="hidden" value="false">
+      <button id="validateButton" type="button">Validate</button>
+      <div id="statusMessage" style="display:none"></div>
+    `
+    expect(() => createApiKeyValidator(defaultConfig())).not.toThrow()
+  })
+})
+
+describe('createApiKeyValidator without validatedAtFieldId', () => {
+  // Some legacy templates may not have the _validated_at hidden input.
+  // The factory should tolerate that — we never assigned to a null el.
+
+  it('still works when validatedAtFieldId is omitted', async () => {
+    document.body.innerHTML = `
+      <form id="configForm">
+        <input id="test_apikey" type="password" value="mykey">
+        <input id="test_validated" type="hidden" value="false">
+        <button id="validateButton" type="button">Validate</button>
+        <div id="statusMessage" style="display:none"></div>
+      </form>
+    `
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ valid: true })
+    })))
+
+    expect(() => createApiKeyValidator({
+      fieldId: 'test_apikey',
+      validatedFieldId: 'test_validated',
+      endpoint: '/x',
+      buildPayload: () => ({})
+    })).not.toThrow()
+
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(document.getElementById('test_validated').value).toBe('true')
+  })
+})


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix
- [x] Feature/Tweak (new shared module + canary migration; no behaviour changes for the user)
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Other

## Description

Roadmap issue #1334 **Step 6 (validation widget refactor) — PR 1 of 4**.

Introduces a shared ES module factory that wires up the standard "one credential + one validate button" wizard shape, and migrates the cleanest existing example (060-mdblist) as the canary. **PR 2 will migrate the remaining 8 simple api-key wizards on top of this factory.**

### Why not Alpine

The original #1334 roadmap sketched this as an Alpine-based declarative widget (`x-data` + `x-bind` + `x-on`). After deeper analysis this PR uses a **vanilla ES module factory** instead:

1. Each wizard renders one fixed form server-side and validates on click. There is no list / no dynamic add-remove / no reactive cascade. Alpine's value proposition is reactive HTML bindings — that pays off in component-islands territory (libraries cards, overlay editor), not here.

2. Alpine adds ~15KB runtime + a new mental model (`x-data`, `x-bind`, `x-show`, `x-on`) that nothing else in the codebase uses. The Zen of Python's "one obvious way to do it" applies to JS too — don't introduce a second declarative paradigm when an imperative one fits.

3. A vanilla factory is trivially Vitest-testable (44 tests in this PR), zero new runtime cost, and fits the existing `modules/*` pattern (appConfig.js, validationPageBase.js).

**Alpine remains the right tool for Step 9** (component islands). This PR just declines to use it where vanilla is strictly simpler.

### What's in this PR

| File | Lines | Purpose |
|---|---|---|
| `static/local-js/modules/createApiKeyValidator.js` | **NEW, 168** | Single exported `createApiKeyValidator(config)` function |
| `static/local-js/060-mdblist.js` | **96 → 12 (-88%)** | Replaced imperative impl with one factory call |
| `tests/js/modules/createApiKeyValidator.test.js` | **NEW, 44 tests** | Locks down full factory contract |
| `tests/e2e/test_wizard_e2e.py` | **+1 test** | Real-page validate flow on 060-mdblist |

### Factory config spec

| Required | |
|---|---|
| `fieldId` | element id of the credential input |
| `validatedFieldId` | element id of the hidden `<service>_validated` input |
| `endpoint` | URL the validate button POSTs to |
| `buildPayload` | `(apiKey) => {}` returning the JSON body |

| Optional with sensible defaults | Default |
|---|---|
| `validatedAtFieldId` | (no timestamp) |
| `toggleButtonId` | `'toggleApikeyVisibility'` |
| `validateButtonId` | `'validateButton'` |
| `statusMessageId` | `'statusMessage'` |
| `formId` | `'configForm'` |
| `resetOnInputFieldIds` | `[]` — extra fields that also clear validation (e.g. url field on Gotify/Ntfy in PR 2) |
| `messages` | override individual status strings (`{empty, success, failure, networkError}`) |
| `spinnerKey` | `'validate'` |

Throws clear errors on missing/malformed required config. Gracefully no-ops if the credential input or validate button isn't in the DOM (partial template render). Preserves status colors **exactly** (`#ea868f` error, `#75b798` success) — zero visual regression.

### What 060-mdblist looks like now

```js
import { createApiKeyValidator } from './modules/createApiKeyValidator.js'

createApiKeyValidator({
  fieldId: 'mdblist_apikey',
  validatedFieldId: 'mdblist_validated',
  validatedAtFieldId: 'mdblist_validated_at',
  endpoint: '/validate_mdblist',
  buildPayload: (apiKey) => ({ mdblist_apikey: apiKey }),
  messages: {
    failure: 'Failed to validate MDBList server. Please check your API Key.'
  }
})
```

That's the whole file. (Down from 96 lines.)

### Test coverage breakdown

44 Vitest tests cover:

| Cluster | # tests |
|---|---|
| Config validation (required-field errors) | 4 |
| Graceful no-op on missing DOM | 3 |
| Initial state (empty/populated, validated true/false/TRUE) | 6 |
| Reset-on-input (main field, validated_at, extras, refresh fires) | 5 |
| Empty-credential click | 2 |
| Success path (POST shape, validated=true, timestamp, message+color, custom message, button disable, spinner key) | 8 |
| Failure path (validated=false, timestamp clear, message+color, custom, button NOT disabled) | 5 |
| Network error (message, timestamp, hideSpinner in finally) | 3 |
| Toggle button (toggle, untoggle, custom id, missing) | 4 |
| Form submit normalization | 3 |
| No-validatedAtField legacy template tolerance | 1 |

Plus a **load-bearing Playwright e2e test** that mocks `/validate_mdblist`, fills the credential field on the real rendered page, clicks the real validate button, and asserts the full success flow. **This is the proof that the factory's IDs line up with the wizard template** — Vitest alone can't catch a typo'd config field.

### Verification

| Check | Result |
|---|---|
| Vitest | **219/219 pass** (was 175; +44 factory tests) |
| Python tests | 80/80 pass |
| Playwright e2e | **6/6 pass** (was 5; +1 mdblist validate flow) |
| ESLint | 0 errors |
| pre-commit | 12/12 hooks green |

### Roadmap path forward

| PR | Scope |
|---|---|
| **PR 1 (THIS PR)** | Factory + 1 canary wizard (060-mdblist) |
| PR 2 (next) | Migrate 040-github, 050-omdb, 070-notifiarr, 087-apprise (4 other clean single-credential wizards) |
| PR 3 (later) | Extend factory or fork for multi-field wizards: 030-tautulli (url + key), 080-gotify (url + token), 085-ntfy (url + token + topic), 020-tmdb, 100-anidb |
| PR 4 (later) | Complex wizards with wizard-specific glue: 010-plex (oauth), 110-radarr, 120-sonarr (dropdown population), 130-trakt, 140-mal (oauth flow) |

Expected total cleanup once Step 6 lands: **~700-1000 lines of duplicated wizard code collapsed into a single ~170-line factory**.

The Vitest coverage from PR #1366 (Step 8) was the prerequisite that made this safe. If the factory breaks how URL or path validation is wired up, those 175 existing tests catch it immediately — and now the 44 factory-specific tests catch contract violations the next migration might introduce.

## Related Issues

Roadmap: #1334 Step 6, PR 1 of 4

## Which Environment Did You Test On?

- [x] Local Install (Linux, Python 3.13, Vitest+jsdom, Playwright Chromium e2e)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
