### PR TITLE
Migrate 4 simple wizards to createApiKeyValidator (#1334 Step 6 PR 2)

### DIFF
--- a/static/local-js/040-github.js
+++ b/static/local-js/040-github.js
@@ -1,93 +1,16 @@
-import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
+import { createApiKeyValidator } from './modules/createApiKeyValidator.js'
 
-const validatedAtInput = document.getElementById('github_validated_at')
-
-const apiKeyInput = document.getElementById('github_token')
-const validateButton = document.getElementById('validateButton')
-const toggleButton = document.getElementById('toggleApikeyVisibility')
-const isValidated = document.getElementById('github_validated').value.toLowerCase() === 'true'
-console.log('Validated: ' + isValidated)
-
-// Set initial visibility based on API key value
-if (apiKeyInput.value.trim() === '') {
-  apiKeyInput.setAttribute('type', 'text') // Show placeholder text
-  setToggleButtonIcon(toggleButton, true)
-} else {
-  apiKeyInput.setAttribute('type', 'password') // Hide actual key
-  setToggleButtonIcon(toggleButton, false)
-}
-
-// Disable validate button if already validated
-validateButton.disabled = isValidated
-
-// Reset validation status when user types
-apiKeyInput.addEventListener('input', function () {
-  document.getElementById('github_validated').value = 'false'
-  if (validatedAtInput) validatedAtInput.value = ''
-  validateButton.disabled = false
-  refreshValidationCallout('github_validated')
-})
-
-document.getElementById('toggleApikeyVisibility').addEventListener('click', function () {
-  const apikeyInput = document.getElementById('github_token')
-  const currentType = apikeyInput.getAttribute('type')
-  apikeyInput.setAttribute('type', currentType === 'password' ? 'text' : 'password')
-  setToggleButtonIcon(this, currentType === 'password')
-})
-
-document.getElementById('validateButton').addEventListener('click', function () {
-  const apiKey = document.getElementById('github_token').value
-  const statusMessage = document.getElementById('statusMessage')
-
-  if (!apiKey) {
-    statusMessage.textContent = 'Please enter a GitHub Personal Access Token.'
-    statusMessage.style.color = '#ea868f'
-    statusMessage.style.display = 'block'
-    return
-  }
-
-  showSpinner('validate')
-
-  fetch('/validate_github', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ github_token: apiKey })
-  })
-    .then(response => response.json())
-    .then(data => {
-      if (data.valid) {
-        hideSpinner('validate')
-        statusMessage.textContent = data.message
-        statusMessage.style.color = '#75b798'
-        document.getElementById('validateButton').disabled = true
-        document.getElementById('github_validated').value = 'true'
-        if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-        refreshValidationCallout('github_validated')
-      } else {
-        statusMessage.textContent = data.message
-        statusMessage.style.color = '#ea868f'
-        document.getElementById('github_validated').value = 'false'
-        if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout('github_validated')
-      }
-      statusMessage.style.display = 'block'
-    })
-    .catch(error => {
-      hideSpinner('validate')
-      console.log(error)
-      statusMessage.textContent = 'Error validating GitHub token.'
-      statusMessage.style.color = '#ea868f'
-      statusMessage.style.display = 'block'
-      document.getElementById('github_validated').value = 'false'
-      if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout('github_validated')
-    })
-})
-
-document.getElementById('configForm').addEventListener('submit', function () {
-  if (!apiKeyInput.value) {
-    apiKeyInput.value = ''
+createApiKeyValidator({
+  fieldId: 'github_token',
+  validatedFieldId: 'github_validated',
+  validatedAtFieldId: 'github_validated_at',
+  endpoint: '/validate_github',
+  buildPayload: (token) => ({ github_token: token }),
+  messages: {
+    empty: 'Please enter a GitHub Personal Access Token.',
+    // GitHub server returns custom data.message on both success and failure
+    success: (data) => data.message,
+    failure: (data) => data.message,
+    networkError: 'Error validating GitHub token.'
   }
 })

--- a/static/local-js/050-omdb.js
+++ b/static/local-js/050-omdb.js
@@ -1,94 +1,15 @@
-import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
+import { createApiKeyValidator } from './modules/createApiKeyValidator.js'
 
-const validatedAtInput = document.getElementById('omdb_validated_at')
-
-const apiKeyInput = document.getElementById('omdb_apikey')
-const validateButton = document.getElementById('validateButton')
-const toggleButton = document.getElementById('toggleApikeyVisibility')
-const isValidated = document.getElementById('omdb_validated').value.toLowerCase()
-console.log('Validated: ' + isValidated)
-
-// Set initial visibility based on API key value
-if (apiKeyInput.value.trim() === '') {
-  apiKeyInput.setAttribute('type', 'text') // Show placeholder text
-  setToggleButtonIcon(toggleButton, true)
-} else {
-  apiKeyInput.setAttribute('type', 'password') // Hide actual key
-  setToggleButtonIcon(toggleButton, false)
-}
-
-// Disable validate button if already validated
-validateButton.disabled = isValidated === 'true'
-
-// Reset validation status when user types
-apiKeyInput.addEventListener('input', function () {
-  document.getElementById('omdb_validated').value = 'false'
-  if (validatedAtInput) validatedAtInput.value = ''
-  validateButton.disabled = false
-  refreshValidationCallout('omdb_validated')
-})
-
-document.getElementById('toggleApikeyVisibility').addEventListener('click', function () {
-  const apikeyInput = document.getElementById('omdb_apikey')
-  const currentType = apikeyInput.getAttribute('type')
-  apikeyInput.setAttribute('type', currentType === 'password' ? 'text' : 'password')
-  setToggleButtonIcon(this, currentType === 'password')
-})
-
-document.getElementById('validateButton').addEventListener('click', function () {
-  const apiKey = document.getElementById('omdb_apikey').value
-  const statusMessage = document.getElementById('statusMessage')
-
-  if (!apiKey) {
-    statusMessage.textContent = 'Please enter an OMDb API key.'
-    statusMessage.style.color = '#ea868f'
-    statusMessage.style.display = 'block'
-    return
-  }
-
-  showSpinner('validate')
-
-  fetch('/validate_omdb', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ omdb_apikey: apiKey })
-  })
-    .then((response) => response.json())
-    .then((data) => {
-      if (data.valid) {
-        hideSpinner('validate')
-        document.getElementById('omdb_validated').value = 'true'
-        if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-        refreshValidationCallout('omdb_validated')
-        statusMessage.textContent = 'OMDb API key is valid.'
-        statusMessage.style.color = '#75b798'
-        document.getElementById('validateButton').disabled = true
-      } else {
-        hideSpinner('validate')
-        document.getElementById('omdb_validated').value = 'false'
-        if (validatedAtInput) validatedAtInput.value = ''
-        statusMessage.textContent = 'OMDb API key is invalid.'
-        statusMessage.style.color = '#ea868f'
-        refreshValidationCallout('omdb_validated')
-      }
-      statusMessage.style.display = 'block'
-    })
-    .catch(error => {
-      hideSpinner('validate')
-      console.error('Error validating OMDb server:', error)
-      statusMessage.textContent = 'Error validating OMDb API key.'
-      statusMessage.style.color = '#ea868f'
-      statusMessage.style.display = 'block'
-      document.getElementById('omdb_validated').value = 'false'
-      if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout('omdb_validated')
-    })
-})
-
-document.getElementById('configForm').addEventListener('submit', function (event) {
-  if (!apiKeyInput.value) {
-    apiKeyInput.value = ''
+createApiKeyValidator({
+  fieldId: 'omdb_apikey',
+  validatedFieldId: 'omdb_validated',
+  validatedAtFieldId: 'omdb_validated_at',
+  endpoint: '/validate_omdb',
+  buildPayload: (apiKey) => ({ omdb_apikey: apiKey }),
+  messages: {
+    empty: 'Please enter an OMDb API key.',
+    success: 'OMDb API key is valid.',
+    failure: 'OMDb API key is invalid.',
+    networkError: 'Error validating OMDb API key.'
   }
 })

--- a/static/local-js/070-notifiarr.js
+++ b/static/local-js/070-notifiarr.js
@@ -1,99 +1,14 @@
-import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
+import { createApiKeyValidator } from './modules/createApiKeyValidator.js'
 
-const validatedAtInput = document.getElementById('notifiarr_validated_at')
-
-const apiKeyInput = document.getElementById('notifiarr_apikey')
-const validateButton = document.getElementById('validateButton')
-const toggleButton = document.getElementById('toggleApikeyVisibility')
-const isValidated = document.getElementById('notifiarr_validated').value.toLowerCase()
-
-console.log('Validated: ' + isValidated)
-
-// Set initial visibility based on API key value
-if (apiKeyInput.value.trim() === '') {
-  apiKeyInput.setAttribute('type', 'text') // Show placeholder text
-  setToggleButtonIcon(toggleButton, true)
-} else {
-  apiKeyInput.setAttribute('type', 'password') // Hide actual key
-  setToggleButtonIcon(toggleButton, false)
-}
-
-// Disable validate button if already validated
-validateButton.disabled = isValidated === 'true'
-
-// Reset validation status when user types
-apiKeyInput.addEventListener('input', function () {
-  document.getElementById('notifiarr_validated').value = 'false'
-  if (validatedAtInput) validatedAtInput.value = ''
-  validateButton.disabled = false
-  refreshValidationCallout('notifiarr_validated')
-})
-
-async function validateNotifiarrApikey (apikey) {
-  showSpinner('validate')
-  const apiUrl = '/validate_notifiarr'
-  const response = await fetch(apiUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ notifiarr_apikey: apikey })
-  })
-
-  if (response.ok) {
-    hideSpinner('validate')
-    const data = await response.json()
-    return data.valid
-  } else {
-    hideSpinner('validate')
-    const errorData = await response.json()
-    console.error('Error validating Notifiarr apikey:', errorData.message)
-    return false
-  }
-}
-
-document.getElementById('validateButton').addEventListener('click', function () {
-  const apiKey = document.getElementById('notifiarr_apikey').value
-  const statusMessage = document.getElementById('statusMessage')
-
-  if (!apiKey) {
-    statusMessage.textContent = 'Please enter a Notifiarr API key.'
-    statusMessage.style.color = '#ea868f'
-    statusMessage.style.display = 'block'
-    return
-  }
-
-  validateButton.disabled = true
-
-  validateNotifiarrApikey(apiKey).then(isValid => {
-    if (isValid) {
-      document.getElementById('notifiarr_validated').value = 'true'
-      if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-      refreshValidationCallout('notifiarr_validated')
-      statusMessage.textContent = 'Notifiarr API key is valid.'
-      statusMessage.style.color = '#75b798'
-      validateButton.disabled = true
-    } else {
-      document.getElementById('notifiarr_validated').value = 'false'
-      if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout('notifiarr_validated')
-      statusMessage.textContent = 'Notifiarr API key is invalid.'
-      statusMessage.style.color = '#ea868f'
-      validateButton.disabled = false
-    }
-    statusMessage.style.display = 'block'
-  })
-})
-
-document.getElementById('toggleApikeyVisibility').addEventListener('click', function () {
-  const apikeyInput = document.getElementById('notifiarr_apikey')
-  const currentType = apikeyInput.getAttribute('type')
-  apikeyInput.setAttribute('type', currentType === 'password' ? 'text' : 'password')
-  setToggleButtonIcon(this, currentType === 'password')
-})
-
-document.getElementById('configForm').addEventListener('submit', function (event) {
-  if (!apiKeyInput.value) {
-    apiKeyInput.value = ''
+createApiKeyValidator({
+  fieldId: 'notifiarr_apikey',
+  validatedFieldId: 'notifiarr_validated',
+  validatedAtFieldId: 'notifiarr_validated_at',
+  endpoint: '/validate_notifiarr',
+  buildPayload: (apiKey) => ({ notifiarr_apikey: apiKey }),
+  messages: {
+    empty: 'Please enter a Notifiarr API key.',
+    success: 'Notifiarr API key is valid.',
+    failure: 'Notifiarr API key is invalid.'
   }
 })

--- a/static/local-js/087-apprise.js
+++ b/static/local-js/087-apprise.js
@@ -1,69 +1,16 @@
-import { refreshValidationCallout } from './modules/validationPageBase.js'
+import { createApiKeyValidator } from './modules/createApiKeyValidator.js'
 
-const validatedAtInput = document.getElementById('apprise_validated_at')
-
-const locationInput = document.getElementById('apprise_location')
-const validateButton = document.getElementById('validateButton')
-const isValidated = document.getElementById('apprise_validated').value.toLowerCase()
-
-validateButton.disabled = isValidated === 'true'
-
-locationInput.addEventListener('input', function () {
-  document.getElementById('apprise_validated').value = 'false'
-  if (validatedAtInput) validatedAtInput.value = ''
-  validateButton.disabled = false
-  refreshValidationCallout('apprise_validated')
-})
-
-document.getElementById('validateButton').addEventListener('click', function () {
-  const appriseLocation = document.getElementById('apprise_location').value.trim()
-  const statusMessage = document.getElementById('statusMessage')
-
-  if (!appriseLocation) {
-    statusMessage.textContent = 'Please enter an Apprise YAML path or URL.'
-    statusMessage.style.color = '#ea868f'
-    statusMessage.style.display = 'block'
-    return
+createApiKeyValidator({
+  fieldId: 'apprise_location',
+  validatedFieldId: 'apprise_validated',
+  validatedAtFieldId: 'apprise_validated_at',
+  endpoint: '/validate_apprise',
+  buildPayload: (location) => ({ apprise_location: location }),
+  messages: {
+    empty: 'Please enter an Apprise YAML path or URL.',
+    success: 'Apprise location validated successfully!',
+    // Apprise server returns the actual failure reason in data.error
+    failure: (data) => data.error,
+    networkError: 'An error occurred while validating the Apprise location.'
   }
-
-  showSpinner('validate')
-
-  fetch('/validate_apprise', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      apprise_location: appriseLocation
-    })
-  })
-    .then((response) => response.json())
-    .then((data) => {
-      hideSpinner('validate')
-      if (data.valid) {
-        document.getElementById('apprise_validated').value = 'true'
-        if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-        refreshValidationCallout('apprise_validated')
-        statusMessage.textContent = 'Apprise location validated successfully!'
-        statusMessage.style.color = '#75b798'
-      } else {
-        document.getElementById('apprise_validated').value = 'false'
-        if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout('apprise_validated')
-        statusMessage.textContent = data.error
-        statusMessage.style.color = '#ea868f'
-      }
-      document.getElementById('validateButton').disabled = data.valid
-      statusMessage.style.display = 'block'
-    })
-    .catch((error) => {
-      hideSpinner('validate')
-      console.error('Error validating Apprise location:', error)
-      document.getElementById('apprise_validated').value = 'false'
-      if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout('apprise_validated')
-      statusMessage.textContent = 'An error occurred while validating the Apprise location.'
-      statusMessage.style.color = '#ea868f'
-      statusMessage.style.display = 'block'
-    })
 })

--- a/static/local-js/modules/createApiKeyValidator.js
+++ b/static/local-js/modules/createApiKeyValidator.js
@@ -57,6 +57,10 @@ const DEFAULT_MESSAGES = {
  *                                                                    on Gotify). The main fieldId is always
  *                                                                    reset; this is for additional ones.
  * @param {object} [config.messages]             Override individual status strings (empty/success/failure/networkError).
+ *                                               Each value may be a literal string OR a (data) => string function
+ *                                               (data is the server response, or `{}` for empty/networkError).
+ *                                               Functions let wizards forward server-provided text verbatim
+ *                                               (e.g. data.error from apprise, data.message from github).
  * @param {string} [config.spinnerKey='validate'] Argument passed to show/hideSpinner.
  */
 export function createApiKeyValidator (config) {
@@ -131,11 +135,21 @@ export function createApiKeyValidator (config) {
     statusMessage.style.display = 'block'
   }
 
+  // Message values can be either a literal string or a (data) => string
+  // function. Functions let the wizard show server-provided text
+  // verbatim (e.g. apprise returns data.error, github returns
+  // data.message) without forcing the factory to know which fields
+  // matter for each service.
+  function resolveMessage (messageValue, data) {
+    if (typeof messageValue === 'function') return messageValue(data || {})
+    return messageValue
+  }
+
   // ── validate click handler ──────────────────────────────────────────
   validateButton.addEventListener('click', function () {
     const apiKey = apiKeyInput.value
     if (!apiKey) {
-      showStatus(messages.empty, STATUS_COLOR_ERROR)
+      showStatus(resolveMessage(messages.empty, {}), STATUS_COLOR_ERROR)
       return
     }
 
@@ -154,19 +168,19 @@ export function createApiKeyValidator (config) {
           validatedField.value = 'true'
           if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
           refreshValidationCallout(validatedFieldId)
-          showStatus(messages.success, STATUS_COLOR_SUCCESS)
+          showStatus(resolveMessage(messages.success, data), STATUS_COLOR_SUCCESS)
           validateButton.disabled = true
         } else {
           validatedField.value = 'false'
           if (validatedAtInput) validatedAtInput.value = ''
           refreshValidationCallout(validatedFieldId)
-          showStatus(messages.failure, STATUS_COLOR_ERROR)
+          showStatus(resolveMessage(messages.failure, data), STATUS_COLOR_ERROR)
         }
       })
       .catch(() => {
         if (validatedAtInput) validatedAtInput.value = ''
         refreshValidationCallout(validatedFieldId)
-        showStatus(messages.networkError, STATUS_COLOR_ERROR)
+        showStatus(resolveMessage(messages.networkError, {}), STATUS_COLOR_ERROR)
       })
       .finally(() => {
         if (typeof hideSpinner === 'function') hideSpinner(spinnerKey)

--- a/tests/e2e/test_wizard_e2e.py
+++ b/tests/e2e/test_wizard_e2e.py
@@ -153,24 +153,106 @@ def test_running_pill_visible(page, live_server):
 
 
 @pytest.mark.e2e
-def test_mdblist_validate_button_uses_factory(page, live_server):
-    """Smoke test for the createApiKeyValidator factory on a real page.
+@pytest.mark.parametrize(
+    "stem, endpoint, field_id, validated_id, success_text",
+    [
+        (
+            "060-mdblist",
+            "validate_mdblist",
+            "mdblist_apikey",
+            "mdblist_validated",
+            "API key is valid!",
+        ),
+        (
+            "050-omdb",
+            "validate_omdb",
+            "omdb_apikey",
+            "omdb_validated",
+            "OMDb API key is valid.",
+        ),
+        (
+            "070-notifiarr",
+            "validate_notifiarr",
+            "notifiarr_apikey",
+            "notifiarr_validated",
+            "Notifiarr API key is valid.",
+        ),
+        (
+            "087-apprise",
+            "validate_apprise",
+            "apprise_location",
+            "apprise_validated",
+            "Apprise location validated successfully!",
+        ),
+    ],
+)
+def test_simple_validator_wizard_success_flow(page, live_server, stem, endpoint, field_id, validated_id, success_text):
+    """End-to-end smoke for every wizard migrated to createApiKeyValidator.
 
-    060-mdblist.js was migrated to the shared factory under #1334 Step 6
-    PR 1. The Vitest suite for the factory locks in the contract in
-    isolation, but only an actual rendered page proves that the
-    factory's IDs (validateButton, statusMessage, toggleApikeyVisibility)
-    line up with the wizard template.
+    Vitest covers the factory contract in isolation. This test proves
+    each wizard's config IDs actually line up with its rendered template
+    -- a typo in fieldId / endpoint / messages would only surface here.
+
+    Server response includes a `message` field so the github-style
+    function-valued success message also gets exercised (040-github has
+    its own subtest below because the server response shape is different).
     """
 
     def handle_validate(route):
         route.fulfill(status=200, json={"valid": True})
 
-    page.route("**/validate_mdblist", handle_validate)
-    page.goto(f"{live_server}/step/060-mdblist", wait_until="domcontentloaded")
+    page.route(f"**/{endpoint}", handle_validate)
+    page.goto(f"{live_server}/step/{stem}", wait_until="domcontentloaded")
 
-    page.locator("#mdblist_apikey").fill("some-key")
+    page.locator(f"#{field_id}").fill("some-credential")
     page.locator("#validateButton").click()
-    expect(page.locator("#statusMessage")).to_contain_text("API key is valid!")
-    expect(page.locator("#mdblist_validated")).to_have_value("true")
+    expect(page.locator("#statusMessage")).to_contain_text(success_text)
+    expect(page.locator(f"#{validated_id}")).to_have_value("true")
     expect(page.locator("#validateButton")).to_be_disabled()
+
+
+@pytest.mark.e2e
+def test_github_validator_uses_server_message(page, live_server):
+    """040-github uses function-valued messages that pull data.message
+    from the server response. Verify that a custom server message
+    appears in the UI verbatim.
+    """
+
+    def handle_validate(route):
+        route.fulfill(
+            status=200,
+            json={"valid": True, "message": "Token belongs to: testuser"},
+        )
+
+    page.route("**/validate_github", handle_validate)
+    page.goto(f"{live_server}/step/040-github", wait_until="domcontentloaded")
+
+    page.locator("#github_token").fill("ghp_FakeButLooksReal")
+    page.locator("#validateButton").click()
+    expect(page.locator("#statusMessage")).to_contain_text("Token belongs to: testuser")
+    expect(page.locator("#github_validated")).to_have_value("true")
+
+
+@pytest.mark.e2e
+def test_apprise_validator_uses_server_error_on_failure(page, live_server):
+    """087-apprise uses a function-valued failure message that pulls
+    data.error from the server response. Verify that a custom server
+    error appears in the UI verbatim.
+    """
+
+    def handle_validate(route):
+        route.fulfill(
+            status=200,
+            json={
+                "valid": False,
+                "error": "Apprise YAML at /missing.yml could not be read.",
+            },
+        )
+
+    page.route("**/validate_apprise", handle_validate)
+    page.goto(f"{live_server}/step/087-apprise", wait_until="domcontentloaded")
+
+    page.locator("#apprise_location").fill("/missing.yml")
+    page.locator("#validateButton").click()
+    expect(page.locator("#statusMessage")).to_contain_text("Apprise YAML at /missing.yml could not be read.")
+    expect(page.locator("#apprise_validated")).to_have_value("false")

--- a/tests/js/modules/createApiKeyValidator.test.js
+++ b/tests/js/modules/createApiKeyValidator.test.js
@@ -419,6 +419,86 @@ describe('createApiKeyValidator validate click — server says invalid', () => {
   })
 })
 
+describe('createApiKeyValidator function-valued messages', () => {
+  // Messages can be either a literal string OR a function that takes
+  // the parsed server response and returns a string. Lets wizards
+  // forward server-provided text verbatim (apprise uses data.error,
+  // github uses data.message on both success and failure).
+
+  it('uses a function-valued success message with response data', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ valid: true, message: 'Server says: hello!' })
+    })))
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    createApiKeyValidator(defaultConfig({
+      messages: { success: (data) => data.message }
+    }))
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(document.getElementById('statusMessage').textContent).toBe('Server says: hello!')
+  })
+
+  it('uses a function-valued failure message with response data', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ valid: false, error: 'Apprise YAML at /missing.yml not found.' })
+    })))
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    createApiKeyValidator(defaultConfig({
+      messages: { failure: (data) => data.error }
+    }))
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(document.getElementById('statusMessage').textContent).toBe('Apprise YAML at /missing.yml not found.')
+  })
+
+  it('function-valued messages receive {} for empty-credential case', () => {
+    let received = null
+    document.body.innerHTML = buildBaseHTML({ keyValue: '' })
+    createApiKeyValidator(defaultConfig({
+      messages: { empty: (data) => { received = data; return 'go away' } }
+    }))
+    document.getElementById('validateButton').click()
+
+    expect(received).toEqual({})
+    expect(document.getElementById('statusMessage').textContent).toBe('go away')
+  })
+
+  it('function-valued messages receive {} for network error case', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('boom'))))
+    let received = null
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    createApiKeyValidator(defaultConfig({
+      messages: { networkError: (data) => { received = data; return 'network sad' } }
+    }))
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(received).toEqual({})
+    expect(document.getElementById('statusMessage').textContent).toBe('network sad')
+  })
+
+  it('string and function-valued messages can be mixed in the same wizard', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ valid: true, message: 'all good' })
+    })))
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    createApiKeyValidator(defaultConfig({
+      messages: {
+        empty: 'literal empty',
+        success: (data) => data.message,
+        failure: 'literal failure',
+        networkError: 'literal network'
+      }
+    }))
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(document.getElementById('statusMessage').textContent).toBe('all good')
+  })
+})
+
 describe('createApiKeyValidator validate click — network error', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('boom'))))


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix
- [x] Feature/Tweak (4 wizard migrations + 1 small factory extension; no user-visible behaviour changes)
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Other

## Description

Roadmap issue #1334 **Step 6 (validation widget refactor) — PR 2 of 4**.

Migrates 4 simple-credential wizards to the `createApiKeyValidator` factory from PR 1 (#1367). Also extends the factory with one small capability (function-valued messages) that was needed to migrate the github and apprise wizards verbatim.

### Wizards migrated

| File | Before | After | Δ |
|---|---|---|---|
| `040-github.js` | 93 lines | 16 lines | **-83%** |
| `050-omdb.js` | 94 lines | 15 lines | **-85%** |
| `070-notifiarr.js` | 99 lines | 14 lines | **-86%** |
| `087-apprise.js` | 69 lines | 16 lines | **-77%** |
| **Combined** | **355 lines** | **61 lines** | **-83%** |

### Factory extension: function-valued messages

PR 1 accepted messages as **literal strings only**:

```js
messages: { success: 'API key is valid!' }
```

Two of the migrated wizards needed to **forward server-provided text verbatim**:

- **040-github** — server returns `data.message` on both success and failure (e.g. "Token belongs to: testuser"). Hard-coding would drop information.
- **087-apprise** — server returns `data.error` on failure with the actual reason (e.g. "Apprise YAML at /missing.yml could not be read."). Hard-coding would hide the diagnostic.

Rather than per-wizard JSON-pluck shims, the factory now accepts each message as **either a string OR a function** taking the parsed server response:

```js
messages: {
  success: (data) => data.message,        // function
  failure: 'API key is invalid.'          // string still works
}
```

Both forms mix freely in the same wizard. The empty and networkError cases pass `{}` since there's no response data in those code paths. Implementation is a 3-line `resolveMessage(value, data)` helper invoked at the 4 `showStatus` call sites. Strings short-circuit; functions are called with the data.

### Example: 087-apprise.js before → after

**Before (69 lines)**: imperative wiring of toggle button, validate handler, response branching, fetch error handling, status message updates with color hex codes, refresh validation callout, input listener, validated-at timestamp management — all duplicated from 12 other wizards.

**After (16 lines)**:
```js
import { createApiKeyValidator } from './modules/createApiKeyValidator.js'

createApiKeyValidator({
  fieldId: 'apprise_location',
  validatedFieldId: 'apprise_validated',
  validatedAtFieldId: 'apprise_validated_at',
  endpoint: '/validate_apprise',
  buildPayload: (location) => ({ apprise_location: location }),
  messages: {
    empty: 'Please enter an Apprise YAML path or URL.',
    success: 'Apprise location validated successfully!',
    // Apprise server returns the actual failure reason in data.error
    failure: (data) => data.error,
    networkError: 'An error occurred while validating the Apprise location.'
  }
})
```

(No toggle button because apprise location isn't a secret — the factory gracefully no-ops on missing optional buttons.)

### Test coverage

**Vitest: +5 tests for function-valued messages** (suite now 49 total, up from 44)
- function-valued success message receives response data
- function-valued failure message receives response data
- function-valued empty message receives `{}`
- function-valued networkError message receives `{}`
- string and function-valued messages can mix in one wizard config

**Playwright e2e: +5 load-bearing browser tests** (suite now 11, up from 6)
- `test_simple_validator_wizard_success_flow` — **parametrised** over all 4 migrated wizards. Each mocks the endpoint, fills the credential field on the real rendered page, clicks the real validate button, asserts success message + validated flip + button disable.
- `test_github_validator_uses_server_message` — proves the `(data) => data.message` config works end-to-end
- `test_apprise_validator_uses_server_error_on_failure` — proves the `(data) => data.error` config works end-to-end

(The mdblist test from PR 1 is now part of the parametrised suite — no duplication.)

This matters because **Vitest can't catch a typo'd config field id** — only an actual rendered template can. Each migrated wizard now has a guaranteed end-to-end smoke test.

### Verification

| Check | Result |
|---|---|
| Vitest | **224/224 pass** (was 219; +5 function-message tests) |
| Python tests | 80/80 pass |
| Playwright e2e | **11/11 pass** (was 6; +5 wizard-specific tests) |
| ESLint | 0 errors |
| pre-commit | 12/12 hooks green |

### Roadmap impact

| PR | Status | Wizards | Lines |
|---|---|---|---|
| PR 1 (#1367) | merged | 1 (mdblist) | 96 → 12 |
| **PR 2 (this)** | **open** | **4 (github, omdb, notifiarr, apprise)** | **355 → 61** |
| PR 3 (next) | ⬜ | 5 (tautulli, gotify, ntfy, tmdb, anidb — multi-field) | ~600 → ~80 (est) |
| PR 4 (later) | ⬜ | 5 (plex oauth, radarr, sonarr, trakt, mal — complex) | TBD |

**Running total after PR 2**: 5 wizards converted, 451 → 73 lines (-84%). Roughly 378 lines of duplicated wizard logic collapsed into one ~190-line factory + tiny per-wizard configs.

PR 3 will require small additional factory shape (multi-field `buildPayload` + multi-field empty validation) — same axis as PR 2's function-valued messages.

## Related Issues

Roadmap: #1334 Step 6, PR 2 of 4

## Which Environment Did You Test On?

- [x] Local Install (Linux, Python 3.13, Vitest+jsdom, Playwright Chromium e2e)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
