### PR TITLE
Migrate 3 multi-field wizards to createApiKeyValidator (#1334 Step 6 PR 3)

### DIFF
--- a/static/local-js/030-tautulli.js
+++ b/static/local-js/030-tautulli.js
@@ -1,107 +1,19 @@
-import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
+import { createApiKeyValidator } from './modules/createApiKeyValidator.js'
 
-const validatedAtInput = document.getElementById('tautulli_validated_at')
-
-const apiKeyInput = document.getElementById('tautulli_apikey')
-const urlInput = document.getElementById('tautulli_url')
-const validateButton = document.getElementById('validateButton')
-const toggleButton = document.getElementById('toggleApikeyVisibility')
-const isValidated = document.getElementById('tautulli_validated').value.toLowerCase()
-console.log('Validated: ' + isValidated)
-
-// Set initial visibility based on API key value
-if (apiKeyInput.value.trim() === '') {
-  apiKeyInput.setAttribute('type', 'text') // Show placeholder text
-  setToggleButtonIcon(toggleButton, true)
-} else {
-  apiKeyInput.setAttribute('type', 'password') // Hide actual key
-  setToggleButtonIcon(toggleButton, false)
-}
-
-// Disable validate button if already validated
-validateButton.disabled = isValidated === 'true'
-
-// Reset validation status when user types
-apiKeyInput.addEventListener('input', function () {
-  document.getElementById('tautulli_validated').value = 'false'
-  if (validatedAtInput) validatedAtInput.value = ''
-  validateButton.disabled = false
-  refreshValidationCallout('tautulli_validated')
-})
-
-urlInput.addEventListener('input', function () {
-  document.getElementById('tautulli_validated').value = 'false'
-  if (validatedAtInput) validatedAtInput.value = ''
-  validateButton.disabled = false
-  refreshValidationCallout('tautulli_validated')
-})
-
-document.getElementById('toggleApikeyVisibility').addEventListener('click', function () {
-  const apikeyInput = document.getElementById('tautulli_apikey')
-  const currentType = apikeyInput.getAttribute('type')
-  apikeyInput.setAttribute('type', currentType === 'password' ? 'text' : 'password')
-  setToggleButtonIcon(this, currentType === 'password')
-})
-
-// Tautulli validation script
-document.getElementById('validateButton').addEventListener('click', function () {
-  const tautulliUrl = document.getElementById('tautulli_url').value
-  const tautulliApikey = document.getElementById('tautulli_apikey').value
-  const statusMessage = document.getElementById('statusMessage')
-
-  if (!tautulliUrl || !tautulliApikey) {
-    statusMessage.textContent = 'Please enter both Tautulli URL and API Key.'
-    statusMessage.style.display = 'block'
-    return
-  }
-  showSpinner('validate')
-  fetch('/validate_tautulli', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      tautulli_url: tautulliUrl,
-      tautulli_apikey: tautulliApikey
-    })
-  })
-    .then((response) => response.json())
-    .then((data) => {
-      if (data.valid) {
-        hideSpinner('validate')
-        document.getElementById('tautulli_validated').value = 'true'
-        if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-        refreshValidationCallout('tautulli_validated')
-        statusMessage.textContent = 'Tautulli server validated successfully!'
-        statusMessage.style.color = '#75b798'
-        document.getElementById('validateButton').disabled = true
-      } else {
-        document.getElementById('tautulli_validated').value = 'false'
-        if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout('tautulli_validated')
-        statusMessage.textContent = 'Failed to validate Tautulli server. Please check your URL and API Key.'
-        statusMessage.style.color = '#ea868f'
-      }
-      statusMessage.style.display = 'block'
-    })
-    .catch((error) => {
-      console.error('Error validating Tautulli server:', error)
-      statusMessage.textContent = 'An error occurred while validating Tautulli server.'
-      statusMessage.style.color = '#ea868f'
-      statusMessage.style.display = 'block'
-      if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout('tautulli_validated')
-    })
-    .finally(() => {
-      hideSpinner('validate')
-    })
-})
-
-document.getElementById('configForm').addEventListener('submit', function () {
-  if (!apiKeyInput.value) {
-    apiKeyInput.value = ''
-  }
-  if (!urlInput.value) {
-    urlInput.value = ''
+createApiKeyValidator({
+  fieldId: 'tautulli_apikey',
+  additionalFieldIds: ['tautulli_url'],
+  validatedFieldId: 'tautulli_validated',
+  validatedAtFieldId: 'tautulli_validated_at',
+  endpoint: '/validate_tautulli',
+  buildPayload: (apiKey, extras) => ({
+    tautulli_url: extras.tautulli_url,
+    tautulli_apikey: apiKey
+  }),
+  messages: {
+    empty: 'Please enter both Tautulli URL and API Key.',
+    success: 'Tautulli server validated successfully!',
+    failure: 'Failed to validate Tautulli server. Please check your URL and API Key.',
+    networkError: 'An error occurred while validating Tautulli server.'
   }
 })

--- a/static/local-js/080-gotify.js
+++ b/static/local-js/080-gotify.js
@@ -1,101 +1,21 @@
-import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
+import { createApiKeyValidator } from './modules/createApiKeyValidator.js'
 
-const validatedAtInput = document.getElementById('gotify_validated_at')
-
-const gotifyTokenInput = document.getElementById('gotify_token')
-const validateButton = document.getElementById('validateButton')
-const toggleButton = document.getElementById('toggleTokenVisibility')
-const isValidated = document.getElementById('gotify_validated').value.toLowerCase()
-
-console.log('Validated: ' + isValidated)
-
-// Set initial visibility based on API key value
-if (gotifyTokenInput.value.trim() === '') {
-  gotifyTokenInput.setAttribute('type', 'text') // Show placeholder text
-  setToggleButtonIcon(toggleButton, true)
-} else {
-  gotifyTokenInput.setAttribute('type', 'password') // Hide actual key
-  setToggleButtonIcon(toggleButton, false)
-}
-
-// Disable validate button if already validated
-validateButton.disabled = isValidated === 'true'
-
-// Reset validation status when user types
-gotifyTokenInput.addEventListener('input', function () {
-  document.getElementById('gotify_validated').value = 'false'
-  if (validatedAtInput) validatedAtInput.value = ''
-  validateButton.disabled = false
-  refreshValidationCallout('gotify_validated')
-})
-
-document.getElementById('gotify_url').addEventListener('input', function () {
-  document.getElementById('gotify_validated').value = 'false'
-  if (validatedAtInput) validatedAtInput.value = ''
-  validateButton.disabled = false
-  refreshValidationCallout('gotify_validated')
-})
-
-// Function to toggle API key visibility
-document.getElementById('toggleTokenVisibility').addEventListener('click', function () {
-  const tokenInput = document.getElementById('gotify_token')
-  const currentType = tokenInput.getAttribute('type')
-  tokenInput.setAttribute('type', currentType === 'password' ? 'text' : 'password')
-  setToggleButtonIcon(this, currentType === 'password')
-})
-
-// Event listener for the validate button
-document.getElementById('validateButton').addEventListener('click', function () {
-  const gotifyUrl = document.getElementById('gotify_url').value
-  const gotifyToken = document.getElementById('gotify_token').value
-  const statusMessage = document.getElementById('statusMessage')
-
-  if (!gotifyUrl || !gotifyToken) {
-    statusMessage.textContent = 'Please enter both Gotify URL and Token.'
-    statusMessage.style.color = '#ea868f'
-    statusMessage.style.display = 'block'
-    return
+createApiKeyValidator({
+  fieldId: 'gotify_token',
+  additionalFieldIds: ['gotify_url'],
+  validatedFieldId: 'gotify_validated',
+  validatedAtFieldId: 'gotify_validated_at',
+  toggleButtonId: 'toggleTokenVisibility',
+  endpoint: '/validate_gotify',
+  buildPayload: (token, extras) => ({
+    gotify_url: extras.gotify_url,
+    gotify_token: token
+  }),
+  messages: {
+    empty: 'Please enter both Gotify URL and Token.',
+    success: 'Gotify credentials validated successfully!',
+    // Gotify server returns the actual failure reason in data.error
+    failure: (data) => data.error,
+    networkError: 'An error occurred while validating Gotify credentials.'
   }
-
-  showSpinner('validate')
-
-  fetch('/validate_gotify', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      gotify_url: gotifyUrl,
-      gotify_token: gotifyToken
-    })
-  })
-    .then((response) => response.json())
-    .then((data) => {
-      if (data.valid) {
-        hideSpinner('validate')
-        document.getElementById('gotify_validated').value = 'true'
-        if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-        refreshValidationCallout('gotify_validated')
-        statusMessage.textContent = 'Gotify credentials validated successfully!'
-        statusMessage.style.color = '#75b798'
-      } else {
-        hideSpinner('validate')
-        document.getElementById('gotify_validated').value = 'false'
-        if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout('gotify_validated')
-        statusMessage.textContent = data.error
-        statusMessage.style.color = '#ea868f'
-      }
-      document.getElementById('validateButton').disabled = data.valid
-      statusMessage.style.display = 'block'
-    })
-    .catch((error) => {
-      hideSpinner('validate')
-      console.error('Error validating Gotify credentials:', error)
-      statusMessage.textContent = 'An error occurred while validating Gotify credentials.'
-      statusMessage.style.color = '#ea868f'
-      statusMessage.style.display = 'block'
-      if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout('gotify_validated')
-    })
 })

--- a/static/local-js/085-ntfy.js
+++ b/static/local-js/085-ntfy.js
@@ -1,111 +1,22 @@
-import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
+import { createApiKeyValidator } from './modules/createApiKeyValidator.js'
 
-const validatedAtInput = document.getElementById('ntfy_validated_at')
-
-const tokenInput = document.getElementById('ntfy_token')
-const toggleButton = document.getElementById('toggleTokenVisibility')
-const isValidated = document.getElementById('ntfy_validated').value.toLowerCase()
-const validateButton = document.getElementById('validateButton')
-
-console.log('Validated: ' + isValidated)
-
-// Set initial visibility based on API key value
-if (tokenInput.value.trim() === '') {
-  tokenInput.setAttribute('type', 'text') // Show placeholder text
-  setToggleButtonIcon(toggleButton, true)
-} else {
-  tokenInput.setAttribute('type', 'password') // Hide actual key
-  setToggleButtonIcon(toggleButton, false)
-}
-
-if (isValidated === 'true') {
-  validateButton.disabled = true
-} else {
-  validateButton.disabled = false
-}
-
-tokenInput.addEventListener('input', function () {
-  document.getElementById('ntfy_validated').value = 'false'
-  if (validatedAtInput) validatedAtInput.value = ''
-  validateButton.disabled = false
-  refreshValidationCallout('ntfy_validated')
-})
-
-document.getElementById('ntfy_url').addEventListener('input', function () {
-  document.getElementById('ntfy_validated').value = 'false'
-  if (validatedAtInput) validatedAtInput.value = ''
-  validateButton.disabled = false
-  refreshValidationCallout('ntfy_validated')
-})
-
-document.getElementById('ntfy_topic').addEventListener('input', function () {
-  document.getElementById('ntfy_validated').value = 'false'
-  if (validatedAtInput) validatedAtInput.value = ''
-  validateButton.disabled = false
-  refreshValidationCallout('ntfy_validated')
-})
-
-// Function to toggle API key visibility
-document.getElementById('toggleTokenVisibility').addEventListener('click', function () {
-  const currentType = tokenInput.getAttribute('type')
-  tokenInput.setAttribute('type', currentType === 'password' ? 'text' : 'password')
-  setToggleButtonIcon(this, currentType === 'password')
-})
-
-// Event listener for the validate button
-document.getElementById('validateButton').addEventListener('click', function () {
-  const ntfyUrl = document.getElementById('ntfy_url').value
-  const ntfyToken = document.getElementById('ntfy_token').value
-  const ntfyTopic = document.getElementById('ntfy_topic').value
-  const statusMessage = document.getElementById('statusMessage')
-
-  if (!ntfyUrl || !ntfyToken || !ntfyTopic) {
-    statusMessage.textContent = 'Please enter ntfy URL, Token and Topic.'
-    statusMessage.style.color = '#ea868f'
-    statusMessage.style.display = 'block'
-    return
+createApiKeyValidator({
+  fieldId: 'ntfy_token',
+  additionalFieldIds: ['ntfy_url', 'ntfy_topic'],
+  validatedFieldId: 'ntfy_validated',
+  validatedAtFieldId: 'ntfy_validated_at',
+  toggleButtonId: 'toggleTokenVisibility',
+  endpoint: '/validate_ntfy',
+  buildPayload: (token, extras) => ({
+    ntfy_url: extras.ntfy_url,
+    ntfy_token: token,
+    ntfy_topic: extras.ntfy_topic
+  }),
+  messages: {
+    empty: 'Please enter ntfy URL, Token and Topic.',
+    success: 'ntfy credentials validated successfully! Ensure you are subscribed to topic to see test message.',
+    // ntfy server returns the actual failure reason in data.error
+    failure: (data) => data.error,
+    networkError: 'An error occurred while validating ntfy credentials.'
   }
-
-  showSpinner('validate')
-
-  fetch('/validate_ntfy', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      ntfy_url: ntfyUrl,
-      ntfy_token: ntfyToken,
-      ntfy_topic: ntfyTopic
-    })
-  })
-    .then((response) => response.json())
-    .then((data) => {
-      if (data.valid) {
-        hideSpinner('validate')
-        document.getElementById('ntfy_validated').value = 'true'
-        if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-        refreshValidationCallout('ntfy_validated')
-        statusMessage.textContent = 'ntfy credentials validated successfully! Ensure you are subscribed to topic to see test message.'
-        statusMessage.style.color = '#75b798'
-      } else {
-        hideSpinner('validate')
-        document.getElementById('ntfy_validated').value = 'false'
-        if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout('ntfy_validated')
-        statusMessage.textContent = data.error
-        statusMessage.style.color = '#ea868f'
-      }
-      document.getElementById('validateButton').disabled = data.valid
-      statusMessage.style.display = 'block'
-    })
-    .catch((error) => {
-      hideSpinner('validate')
-      console.error('Error validating ntfy credentials:', error)
-      statusMessage.textContent = 'An error occurred while validating ntfy credentials.'
-      statusMessage.style.color = '#ea868f'
-      statusMessage.style.display = 'block'
-      if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout('ntfy_validated')
-    })
 })

--- a/static/local-js/modules/createApiKeyValidator.js
+++ b/static/local-js/modules/createApiKeyValidator.js
@@ -1,11 +1,18 @@
-// Shared factory for the simplest validation wizard shape: ONE credential
-// input (api key or token), one validate button, server endpoint that
-// returns { valid: boolean }. Used by all the "just a key" pages —
-// 050-omdb, 060-mdblist, 070-notifiarr, etc.
+// Shared factory for credential-validation wizards: ONE primary credential
+// input (api key or token), zero or more additional non-secret fields
+// (url, topic, etc.), one validate button, server endpoint that returns
+// { valid: boolean }. Used by every "fill in a credential then click
+// Validate" page in the wizard.
 //
-// Wizards with extra fields (Tautulli url + key, Gotify url + token, etc.)
-// are NOT covered here. PR 2 of #1334 Step 6 will introduce a multi-field
-// variant that builds on the same idea.
+// Single-field wizards (just an api key): 040-github, 050-omdb,
+// 060-mdblist, 070-notifiarr, 087-apprise.
+//
+// Multi-field wizards (credential plus url/topic/etc): 030-tautulli,
+// 080-gotify, 085-ntfy. These pass additionalFieldIds and a 2-arg
+// buildPayload.
+//
+// Wizards with more complex needs (dropdown-driven Next button gating,
+// OAuth flows, Plex auth) live outside this factory; see Step 6 PR 4.
 //
 // DESIGN
 //
@@ -21,8 +28,12 @@
 //   gracefully no-op if an expected element is absent (defence in depth
 //   for partial template rendering).
 //
-//   Default messages match what 060-mdblist used to say verbatim, so
-//   the canary wizard's user-visible text is unchanged.
+//   The PRIMARY field (config.fieldId) is the credential -- it gets
+//   the show/hide toggle treatment. ADDITIONAL fields
+//   (config.additionalFieldIds) are non-secret accompanying inputs
+//   that participate in the empty-validation check, the reset-on-input
+//   listener wiring, and the payload builder. The toggle never applies
+//   to them.
 //
 //   STATUS COLORS: the legacy code used hex literals (#ea868f, #75b798).
 //   We preserve those exactly to avoid any visual regression.
@@ -40,10 +51,17 @@ const DEFAULT_MESSAGES = {
 }
 
 /**
- * Wire up a single-credential validation wizard.
+ * Wire up a credential-validation wizard.
  *
  * @param {object} config
- * @param {string} config.fieldId                Element id of the credential input.
+ * @param {string} config.fieldId                Element id of the primary credential input.
+ *                                               Gets the show/hide toggle treatment.
+ * @param {string[]} [config.additionalFieldIds=[]]  Element ids of additional non-secret fields
+ *                                                   (e.g. url, topic). All are required for
+ *                                                   the empty-validation check, get input
+ *                                                   listeners that reset validation, and have
+ *                                                   their values passed to buildPayload as the
+ *                                                   second argument.
  * @param {string} config.validatedFieldId       Element id of the hidden "<service>_validated" input.
  * @param {string} [config.validatedAtFieldId]   Element id of the hidden "<service>_validated_at" timestamp input.
  * @param {string} [config.toggleButtonId='toggleApikeyVisibility']  Id of the show/hide toggle button.
@@ -51,11 +69,12 @@ const DEFAULT_MESSAGES = {
  * @param {string} [config.statusMessageId='statusMessage']          Id of the status callout element.
  * @param {string} [config.formId='configForm']                      Id of the wrapping form (for submit reset).
  * @param {string} config.endpoint               URL the validate button POSTs to.
- * @param {(apiKey: string) => object} config.buildPayload           Builds the JSON body for the POST.
- * @param {string[]} [config.resetOnInputFieldIds=[]]                Extra field ids that should also reset
- *                                                                    validation state on input (e.g. url field
- *                                                                    on Gotify). The main fieldId is always
- *                                                                    reset; this is for additional ones.
+ * @param {(credentialValue: string, additionalValues: object) => object} config.buildPayload
+ *                                               Builds the JSON body for the POST. The first
+ *                                               argument is the credential field's value. The
+ *                                               second is `{ [id]: value, ... }` for every id
+ *                                               in additionalFieldIds (or `{}` if none).
+ *                                               Single-field wizards can ignore the second arg.
  * @param {object} [config.messages]             Override individual status strings (empty/success/failure/networkError).
  *                                               Each value may be a literal string OR a (data) => string function
  *                                               (data is the server response, or `{}` for empty/networkError).
@@ -66,6 +85,7 @@ const DEFAULT_MESSAGES = {
 export function createApiKeyValidator (config) {
   const {
     fieldId,
+    additionalFieldIds = [],
     validatedFieldId,
     validatedAtFieldId,
     toggleButtonId = 'toggleApikeyVisibility',
@@ -74,7 +94,6 @@ export function createApiKeyValidator (config) {
     formId = 'configForm',
     endpoint,
     buildPayload,
-    resetOnInputFieldIds = [],
     messages: messageOverrides = {},
     spinnerKey = 'validate'
   } = config
@@ -100,6 +119,13 @@ export function createApiKeyValidator (config) {
   // elements, but these two are load-bearing.
   if (!apiKeyInput || !validatedField || !validateButton) return
 
+  // Resolve additional field elements once. Missing ones are silently
+  // dropped from listener-wiring, empty-check, and payload-building --
+  // same defence-in-depth posture as the optional toggle button.
+  const additionalElements = additionalFieldIds
+    .map(id => ({ id, el: document.getElementById(id) }))
+    .filter(entry => entry.el)
+
   // ── initial visibility of the credential field ──────────────────────
   if (apiKeyInput.value.trim() === '') {
     apiKeyInput.setAttribute('type', 'text') // show placeholder text
@@ -121,9 +147,8 @@ export function createApiKeyValidator (config) {
   }
 
   apiKeyInput.addEventListener('input', resetValidation)
-  for (const extraId of resetOnInputFieldIds) {
-    const extra = document.getElementById(extraId)
-    if (extra) extra.addEventListener('input', resetValidation)
+  for (const { el } of additionalElements) {
+    el.addEventListener('input', resetValidation)
   }
 
   // ── status message helpers ──────────────────────────────────────────
@@ -145,10 +170,24 @@ export function createApiKeyValidator (config) {
     return messageValue
   }
 
+  function collectAdditionalValues () {
+    const out = {}
+    for (const { id, el } of additionalElements) {
+      out[id] = el.value
+    }
+    return out
+  }
+
   // ── validate click handler ──────────────────────────────────────────
   validateButton.addEventListener('click', function () {
-    const apiKey = apiKeyInput.value
-    if (!apiKey) {
+    const credentialValue = apiKeyInput.value
+    const additionalValues = collectAdditionalValues()
+
+    // Every additional field is required alongside the credential.
+    const additionalAllPresent = additionalElements.every(
+      ({ id }) => additionalValues[id]
+    )
+    if (!credentialValue || !additionalAllPresent) {
       showStatus(resolveMessage(messages.empty, {}), STATUS_COLOR_ERROR)
       return
     }
@@ -160,7 +199,7 @@ export function createApiKeyValidator (config) {
     fetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(buildPayload(apiKey))
+      body: JSON.stringify(buildPayload(credentialValue, additionalValues))
     })
       .then(response => response.json())
       .then(data => {
@@ -199,11 +238,13 @@ export function createApiKeyValidator (config) {
   // ── on form submit, normalise an absent value to empty string ───────
   // Preserved verbatim from the legacy wizards — when the field is
   // entirely empty the form should still post an empty string, not
-  // omit the field entirely.
+  // omit the field entirely. Applies to the primary credential AND
+  // every additional field.
   if (form) {
     form.addEventListener('submit', function () {
-      if (!apiKeyInput.value) {
-        apiKeyInput.value = ''
+      if (!apiKeyInput.value) apiKeyInput.value = ''
+      for (const { el } of additionalElements) {
+        if (!el.value) el.value = ''
       }
     })
   }

--- a/tests/e2e/test_wizard_e2e.py
+++ b/tests/e2e/test_wizard_e2e.py
@@ -256,3 +256,76 @@ def test_apprise_validator_uses_server_error_on_failure(page, live_server):
     page.locator("#validateButton").click()
     expect(page.locator("#statusMessage")).to_contain_text("Apprise YAML at /missing.yml could not be read.")
     expect(page.locator("#apprise_validated")).to_have_value("false")
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "stem, endpoint, field_inputs, validated_id, success_text",
+    [
+        (
+            "030-tautulli",
+            "validate_tautulli",
+            {"tautulli_url": "http://tautulli.local:8181", "tautulli_apikey": "k"},
+            "tautulli_validated",
+            "Tautulli server validated successfully!",
+        ),
+        (
+            "080-gotify",
+            "validate_gotify",
+            {"gotify_url": "http://gotify.local", "gotify_token": "tok"},
+            "gotify_validated",
+            "Gotify credentials validated successfully!",
+        ),
+        (
+            "085-ntfy",
+            "validate_ntfy",
+            {"ntfy_url": "http://ntfy.local", "ntfy_token": "tok", "ntfy_topic": "alerts"},
+            "ntfy_validated",
+            "ntfy credentials validated successfully!",
+        ),
+    ],
+)
+def test_multi_field_validator_wizard_success_flow(page, live_server, stem, endpoint, field_inputs, validated_id, success_text):
+    """Multi-field wizards use the createApiKeyValidator factory's
+    additionalFieldIds + 2-arg buildPayload (#1334 Step 6 PR 3). Each
+    needs every field filled before validation can succeed.
+    """
+
+    def handle_validate(route):
+        route.fulfill(status=200, json={"valid": True})
+
+    page.route(f"**/{endpoint}", handle_validate)
+    page.goto(f"{live_server}/step/{stem}", wait_until="domcontentloaded")
+
+    for input_id, value in field_inputs.items():
+        page.locator(f"#{input_id}").fill(value)
+    page.locator("#validateButton").click()
+
+    expect(page.locator("#statusMessage")).to_contain_text(success_text)
+    expect(page.locator(f"#{validated_id}")).to_have_value("true")
+    expect(page.locator("#validateButton")).to_be_disabled()
+
+
+@pytest.mark.e2e
+def test_multi_field_wizard_empty_check_across_fields(page, live_server):
+    """Verify the multi-field empty-check on the rendered page: filling
+    only the credential without the url should NOT trigger the fetch
+    and should show the configured empty message.
+    """
+
+    fetch_calls = []
+
+    def handle_validate(route):
+        fetch_calls.append(route.request.url)
+        route.fulfill(status=200, json={"valid": True})
+
+    page.route("**/validate_gotify", handle_validate)
+    page.goto(f"{live_server}/step/080-gotify", wait_until="domcontentloaded")
+
+    page.locator("#gotify_token").fill("some-token")
+    # gotify_url deliberately left empty
+    page.locator("#validateButton").click()
+
+    expect(page.locator("#statusMessage")).to_contain_text("Please enter both Gotify URL and Token.")
+    expect(page.locator("#gotify_validated")).to_have_value("false")
+    assert fetch_calls == [], f"expected no fetch but got {fetch_calls}"

--- a/tests/js/modules/createApiKeyValidator.test.js
+++ b/tests/js/modules/createApiKeyValidator.test.js
@@ -199,14 +199,14 @@ describe('createApiKeyValidator reset-on-input', () => {
     expect(document.getElementById('test_validated_at').value).toBe('')
   })
 
-  it('also resets on input for extra fields in resetOnInputFieldIds', () => {
+  it('also resets on input for extra fields in additionalFieldIds', () => {
     document.body.innerHTML = buildBaseHTML({
       keyValue: 'old',
       validated: 'true',
-      extraInputs: '<input id="test_url" type="text">'
+      extraInputs: '<input id="test_url" type="text" value="http://x">'
     })
     createApiKeyValidator(defaultConfig({
-      resetOnInputFieldIds: ['test_url']
+      additionalFieldIds: ['test_url']
     }))
 
     document.getElementById('test_url').dispatchEvent(new Event('input'))
@@ -217,7 +217,7 @@ describe('createApiKeyValidator reset-on-input', () => {
   it('ignores missing extra field ids without throwing', () => {
     document.body.innerHTML = buildBaseHTML({ validated: 'true' })
     expect(() => createApiKeyValidator(defaultConfig({
-      resetOnInputFieldIds: ['nonexistent_field']
+      additionalFieldIds: ['nonexistent_field']
     }))).not.toThrow()
   })
 
@@ -496,6 +496,170 @@ describe('createApiKeyValidator function-valued messages', () => {
     await new Promise(resolve => setTimeout(resolve, 0))
 
     expect(document.getElementById('statusMessage').textContent).toBe('all good')
+  })
+})
+
+describe('createApiKeyValidator multi-field wizards (additionalFieldIds)', () => {
+  // These tests cover the multi-field shape used by tautulli (url +
+  // apikey), gotify (url + token), ntfy (url + token + topic). Only
+  // the primary `fieldId` gets the show/hide toggle; the others are
+  // plain inputs that contribute to required-field validation, the
+  // reset-on-input listener wiring, and the payload builder.
+
+  function buildMultiFieldHTML ({
+    primaryValue = '',
+    urlValue = '',
+    topicValue = '',
+    validated = 'false'
+  } = {}) {
+    return `
+      <form id="configForm">
+        <input id="test_url" type="text" value="${urlValue}">
+        <input id="test_apikey" type="password" value="${primaryValue}">
+        <input id="test_topic" type="text" value="${topicValue}">
+        <input id="test_validated" type="hidden" value="${validated}">
+        <input id="test_validated_at" type="hidden" value="">
+        <button id="toggleApikeyVisibility" type="button"><i class="bi"></i></button>
+        <button id="validateButton" type="button">Validate</button>
+        <div id="statusMessage" style="display:none"></div>
+      </form>
+    `
+  }
+
+  it('passes additional field values as the second arg to buildPayload', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ valid: true })
+    })))
+    document.body.innerHTML = buildMultiFieldHTML({
+      primaryValue: 'mykey',
+      urlValue: 'http://server',
+      topicValue: 'alerts'
+    })
+    const buildPayload = vi.fn((credential, extras) => ({
+      key: credential,
+      url: extras.test_url,
+      topic: extras.test_topic
+    }))
+    createApiKeyValidator(defaultConfig({
+      additionalFieldIds: ['test_url', 'test_topic'],
+      buildPayload
+    }))
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(buildPayload).toHaveBeenCalledWith('mykey', {
+      test_url: 'http://server',
+      test_topic: 'alerts'
+    })
+    expect(fetch).toHaveBeenCalledWith('/validate_test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key: 'mykey', url: 'http://server', topic: 'alerts' })
+    })
+  })
+
+  it('passes an empty object as the second arg when no additionalFieldIds', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ valid: true })
+    })))
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    const buildPayload = vi.fn((credential, extras) => ({ key: credential }))
+    createApiKeyValidator(defaultConfig({ buildPayload }))
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(buildPayload).toHaveBeenCalledWith('mykey', {})
+  })
+
+  it('shows the empty message when the credential is filled but an additional field is empty', () => {
+    document.body.innerHTML = buildMultiFieldHTML({
+      primaryValue: 'mykey',
+      urlValue: '', // url missing
+      topicValue: 'alerts'
+    })
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+
+    createApiKeyValidator(defaultConfig({
+      additionalFieldIds: ['test_url', 'test_topic'],
+      messages: { empty: 'Please enter all fields.' }
+    }))
+    document.getElementById('validateButton').click()
+
+    expect(document.getElementById('statusMessage').textContent).toBe('Please enter all fields.')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('shows the empty message when an additional field is filled but the credential is empty', () => {
+    document.body.innerHTML = buildMultiFieldHTML({
+      primaryValue: '', // credential missing
+      urlValue: 'http://server',
+      topicValue: 'alerts'
+    })
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+
+    createApiKeyValidator(defaultConfig({
+      additionalFieldIds: ['test_url', 'test_topic']
+    }))
+    document.getElementById('validateButton').click()
+
+    expect(document.getElementById('statusMessage').textContent).toBe('Please enter an API key.')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('resets validation when ANY additional field receives an input event', () => {
+    document.body.innerHTML = buildMultiFieldHTML({
+      primaryValue: 'mykey',
+      urlValue: 'http://server',
+      topicValue: 'alerts',
+      validated: 'true'
+    })
+    createApiKeyValidator(defaultConfig({
+      additionalFieldIds: ['test_url', 'test_topic']
+    }))
+    expect(document.getElementById('validateButton').disabled).toBe(true)
+
+    // Typing in the topic field should reset validation
+    document.getElementById('test_topic').dispatchEvent(new Event('input'))
+    expect(document.getElementById('test_validated').value).toBe('false')
+    expect(document.getElementById('validateButton').disabled).toBe(false)
+  })
+
+  it('normalises absent additional field values on form submit', () => {
+    document.body.innerHTML = buildMultiFieldHTML({
+      primaryValue: 'mykey',
+      urlValue: '',
+      topicValue: ''
+    })
+    createApiKeyValidator(defaultConfig({
+      additionalFieldIds: ['test_url', 'test_topic']
+    }))
+
+    const form = document.getElementById('configForm')
+    form.dispatchEvent(new Event('submit'))
+
+    expect(document.getElementById('test_url').value).toBe('')
+    expect(document.getElementById('test_topic').value).toBe('')
+  })
+
+  it('treats a missing additional field as absent (does not block validation)', async () => {
+    // additionalFieldIds includes one id that does not exist on the page.
+    // The factory should silently drop it from the empty check and the
+    // payload rather than crash. (Protects against template/JS drift.)
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ valid: true })
+    })))
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    const buildPayload = vi.fn((credential, extras) => ({ key: credential, ...extras }))
+    createApiKeyValidator(defaultConfig({
+      additionalFieldIds: ['nonexistent_topic'],
+      buildPayload
+    }))
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(buildPayload).toHaveBeenCalledWith('mykey', {})
   })
 })
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix
- [x] Feature/Tweak (3 wizard migrations + 1 factory extension; no user-visible behaviour changes)
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Other

## Description

Roadmap issue #1334 **Step 6 (validation widget refactor) — PR 3 of 4**.

Migrates the 3 **multi-field** credential wizards to the `createApiKeyValidator` factory. These wizards validate a credential PLUS one or two additional non-secret fields (url, topic). Extends the factory with one focused option (`additionalFieldIds`) that makes multi-field wizards as concise as single-field ones.

### Wizards migrated

| File | Before | After | Δ | Fields |
|---|---|---|---|---|
| `030-tautulli.js` | 107 lines | 19 lines | **-83%** | url + apikey |
| `080-gotify.js` | 101 lines | 21 lines | **-80%** | url + token |
| `085-ntfy.js` | 111 lines | 22 lines | **-81%** | url + token + topic |
| **Combined** | **319 lines** | **62 lines** | **-81%** |

### Factory extension: `additionalFieldIds`

PR 1's factory had a forward-looking config option called `resetOnInputFieldIds` that wired up input listeners on extra fields but did nothing else. That half-feature has been **renamed and extended** into a proper multi-field abstraction:

```js
createApiKeyValidator({
  fieldId: 'ntfy_token',
  additionalFieldIds: ['ntfy_url', 'ntfy_topic'],
  buildPayload: (token, extras) => ({
    ntfy_url: extras.ntfy_url,
    ntfy_token: token,
    ntfy_topic: extras.ntfy_topic
  }),
  // ...
})
```

When supplied, each id:

1. Gets the **reset-on-input listener** (as before)
2. Participates in the **empty-field check** — validate button click is rejected with the configured empty-message if the credential OR any additional field is blank
3. Has its value passed to **`buildPayload` as the second arg** — `{ [id]: value, ... }`
4. Gets **form-submit empty-value normalization** (preserved from each legacy wizard)

**Rename was safe**: `resetOnInputFieldIds` was only used internally and in factory tests (no wizard had adopted it yet). Zero migration cost for the existing PR 1/2 wizards.

**Missing-element tolerance**: if an id in `additionalFieldIds` doesn't exist on the page, it's silently dropped from listener wiring, empty check, and payload. Same defence-in-depth posture as the optional toggle button.

### Example: 085-ntfy.js (111 → 22 lines)

```js
import { createApiKeyValidator } from './modules/createApiKeyValidator.js'

createApiKeyValidator({
  fieldId: 'ntfy_token',
  additionalFieldIds: ['ntfy_url', 'ntfy_topic'],
  validatedFieldId: 'ntfy_validated',
  validatedAtFieldId: 'ntfy_validated_at',
  toggleButtonId: 'toggleTokenVisibility',
  endpoint: '/validate_ntfy',
  buildPayload: (token, extras) => ({
    ntfy_url: extras.ntfy_url,
    ntfy_token: token,
    ntfy_topic: extras.ntfy_topic
  }),
  messages: {
    empty: 'Please enter ntfy URL, Token and Topic.',
    success: 'ntfy credentials validated successfully! Ensure you are subscribed to topic to see test message.',
    failure: (data) => data.error,
    networkError: 'An error occurred while validating ntfy credentials.'
  }
})
```

### Test coverage

| Type | New | Total |
|---|---|---|
| Vitest (multi-field tests) | +7 | **231** (was 224) |
| Playwright e2e (load-bearing browser tests) | +4 | **15** (was 11) |

New Vitest tests cover:
- `buildPayload` receives `{ [id]: value }` as 2nd arg with all additional values
- `buildPayload` receives `{}` as 2nd arg when no additionalFieldIds
- Empty message fires when credential filled but additional empty
- Empty message fires when additional filled but credential empty
- Validation resets on input to ANY additional field
- Form submit normalises empty values on additional fields
- Missing additional element ids are silently tolerated

New Playwright e2e tests:
- `test_multi_field_validator_wizard_success_flow` — **parametrised over tautulli, gotify, ntfy**
- `test_multi_field_wizard_empty_check_across_fields` — fills only the token on gotify (leaves url empty), clicks Validate, asserts the empty message appears AND no fetch was issued. **Load-bearing** proof that the multi-field empty-check fires before the network request.

### Verification

| Check | Result |
|---|---|
| Vitest | **231/231 pass** (was 224; +7 multi-field tests) |
| Python tests | 80/80 pass |
| Playwright e2e | **15/15 pass** (was 11; +4 multi-field tests) |
| ESLint | 0 errors |
| pre-commit | 12/12 hooks green |

### What's NOT in this PR (deliberately)

| File | Reason |
|---|---|
| `100-anidb.js` (20 lines) | No validate button at all — just a "section enable" visibility toggle. Wrong shape for the credential-validation factory. Could justify a separate `createSectionVisibilityToggle` helper later, but not in scope. |
| `020-tmdb.js` (149 lines) | Deferred to PR 4 — has API-key validation PLUS language/region dropdown gating that controls Next button enablement. The dropdown-gating concern lives outside the factory's "credential → validate → done" scope. |

### Cumulative Step 6 progress

| PR | Status | Wizards | Lines saved |
|---|---|---|---|
| PR 1 (#1367) | merged | mdblist | 96 → 12 |
| PR 2 (#1368) | merged | github, omdb, notifiarr, apprise | 355 → 61 |
| **PR 3 (this)** | **open** | **tautulli, gotify, ntfy** | **319 → 62** |
| PR 4 (next) | ⬜ | 020-tmdb + 5 complex (plex, radarr, sonarr, trakt, mal) | TBD |

**Running total after PR 3**: 8 wizards converted, **770 → 135 lines (-82%)**. Roughly 635 lines of duplicated wizard logic collapsed into one ~225-line factory + tiny per-wizard configs.

## Related Issues

Roadmap: #1334 Step 6, PR 3 of 4

## Which Environment Did You Test On?

- [x] Local Install (Linux, Python 3.13, Vitest+jsdom, Playwright Chromium e2e)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
