### PR TITLE
Migrate Radarr + Sonarr to createApiKeyValidator (#1334 Step 6 PR 4a)

### DIFF
--- a/static/local-js/110-radarr.js
+++ b/static/local-js/110-radarr.js
@@ -1,220 +1,69 @@
-import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
+import { createApiKeyValidator } from './modules/createApiKeyValidator.js'
+import { populateDropdown, setStatusMessageLines } from './modules/dropdownHelpers.js'
 
-const validatedAtInput = document.getElementById('radarr_validated_at')
-
-function setStatusMessageLines (element, messages) {
-  if (!element) return
-  element.textContent = ''
-  messages.forEach((message, index) => {
-    if (index > 0) element.appendChild(document.createElement('br'))
-    element.appendChild(document.createTextNode(message))
-  })
+// Per-wizard helpers: populate the two dropdowns from a validate response.
+// initialRadarrRootFolderPath and initialRadarrQualityProfile are window
+// globals injected by the rendered template (current selections from the
+// saved config), used to pre-select after dropdown population.
+function populateRadarrDropdowns (data) {
+  populateDropdown(
+    'radarr_root_folder_path', data.root_folders, 'path', 'path',
+    typeof initialRadarrRootFolderPath !== 'undefined' ? initialRadarrRootFolderPath : ''
+  )
+  populateDropdown(
+    'radarr_quality_profile', data.quality_profiles, 'name', 'name',
+    typeof initialRadarrQualityProfile !== 'undefined' ? initialRadarrQualityProfile : ''
+  )
 }
 
-function resetDropdown (dropdown, placeholderText) {
-  if (!dropdown) return
-  const option = document.createElement('option')
-  option.value = ''
-  option.textContent = placeholderText
-  dropdown.replaceChildren(option)
-}
-
-const apiKeyInput = document.getElementById('radarr_token')
-const toggleButton = document.getElementById('toggleApikeyVisibility')
-const validateButton = document.getElementById('validateButton')
-const isValidated = document.getElementById('radarr_validated').value.toLowerCase()
-
-console.log('Validated: ' + isValidated)
-
-// Set initial visibility based on API key value
-if (apiKeyInput.value.trim() === '') {
-  apiKeyInput.setAttribute('type', 'text') // Show placeholder text
-  setToggleButtonIcon(toggleButton, true)
-} else {
-  apiKeyInput.setAttribute('type', 'password') // Hide actual key
-  setToggleButtonIcon(toggleButton, false)
-}
-
-// Disable validate button if already validated
-validateButton.disabled = isValidated === 'true'
-
-if (isValidated === 'true') {
-  document.getElementById('validateButton').disabled = true
-  // Populate the dropdowns with the stored data if they are available
-  fetchDropdownData()
-} else {
-  document.getElementById('validateButton').disabled = false
-}
-
-// Attach event listeners for input changes
-document.getElementById('radarr_token').addEventListener('input', function () {
-  document.getElementById('radarr_validated').value = 'false'
-  if (validatedAtInput) validatedAtInput.value = ''
-  document.getElementById('validateButton').disabled = false
-  refreshValidationCallout('radarr_validated')
-})
-
-document.getElementById('radarr_url').addEventListener('input', function () {
-  document.getElementById('radarr_validated').value = 'false'
-  if (validatedAtInput) validatedAtInput.value = ''
-  document.getElementById('validateButton').disabled = false
-  refreshValidationCallout('radarr_validated')
-})
-
-// Attach event listeners for validation and toggle functionality
-document.getElementById('validateButton').addEventListener('click', validateRadarrApi)
-document.getElementById('toggleApikeyVisibility').addEventListener('click', toggleApiKeyVisibility)
-
-// Add an event listener for form submission
-document.getElementById('configForm').addEventListener('submit', function (event) {
-  if (!validateRadarrPage()) {
-    event.preventDefault() // Prevent form submission if validation fails
-  }
-})
-
-function fetchDropdownData () {
-  // Fetch the stored dropdown data and populate the dropdowns
-  const radarrUrl = document.getElementById('radarr_url').value
-  const radarrToken = document.getElementById('radarr_token').value
-
-  fetch('/validate_radarr', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ radarr_url: radarrUrl, radarr_token: radarrToken })
-  })
-    .then((response) => response.json())
-    .then((data) => {
-      populateDropdown('radarr_root_folder_path', data.root_folders, 'path', 'path', initialRadarrRootFolderPath)
-      populateDropdown('radarr_quality_profile', data.quality_profiles, 'name', 'name', initialRadarrQualityProfile)
-    })
-    .catch((error) => {
-      console.error('Error fetching Radarr dropdown data:', error)
-    })
-}
-
-function populateDropdown (elementId, data, valueField, textField, selectedValue = '') {
-  const dropdown = document.getElementById(elementId)
-  resetDropdown(dropdown, 'Select an option')
-
-  data.forEach((item) => {
-    const option = document.createElement('option')
-    option.value = item[valueField]
-    option.textContent = item[textField]
-    dropdown.appendChild(option)
-  })
-
-  if (selectedValue) {
-    dropdown.value = selectedValue
-  }
-}
-
-// Validate Radarr page fields
+// Pre-submit guard: navigation is allowed only if the user has either
+// (a) never validated Radarr (page is being skipped) or (b) validated
+// AND selected a root folder + quality profile. Path validation from
+// PathValidation (set up elsewhere) also blocks if any path field is
+// invalid.
 function validateRadarrPage () {
-  const currentValidatedValue = document.getElementById('radarr_validated').value.toLowerCase()
+  const validated = document.getElementById('radarr_validated').value.toLowerCase() === 'true'
+  if (!validated) return true // unvalidated user can skip the page
+
   const rootFolderPath = document.getElementById('radarr_root_folder_path').value
   const qualityProfile = document.getElementById('radarr_quality_profile').value
-  const statusMessage = document.getElementById('statusMessage')
-  let isValid = true
-  const validationMessages = []
   const pathsValid = (typeof PathValidation !== 'undefined' && PathValidation.validateAll)
     ? PathValidation.validateAll()
     : true
 
-  // Skip validation if Radarr is not validated
-  if (currentValidatedValue !== 'true') {
-    return true // Allow navigation
-  }
+  const errors = []
+  if (!rootFolderPath) errors.push('Please select a valid Root Folder Path.')
+  if (!qualityProfile) errors.push('Please select a valid Quality Profile.')
+  if (!pathsValid) errors.push('Please fix invalid path fields before continuing.')
 
-  // Validate Root Folder Path
-  if (!rootFolderPath) {
-    validationMessages.push('Please select a valid Root Folder Path.')
-    isValid = false
-  }
-
-  // Validate Quality Profile
-  if (!qualityProfile) {
-    validationMessages.push('Please select a valid Quality Profile.')
-    isValid = false
-  }
-
-  if (!pathsValid) {
-    validationMessages.push('Please fix invalid path fields before continuing.')
-    isValid = false
-  }
-
-  // Display validation messages
-  if (!isValid) {
-    setStatusMessageLines(statusMessage, validationMessages)
-    statusMessage.style.color = '#ea868f' // Warning color
-    statusMessage.style.display = 'block'
-  } else {
-    statusMessage.style.display = 'none'
-  }
-
-  return isValid
-}
-
-function validateRadarrApi () {
-  const radarrUrl = document.getElementById('radarr_url').value
-  const radarrToken = document.getElementById('radarr_token').value
   const statusMessage = document.getElementById('statusMessage')
-
-  showSpinner('validate')
-
-  fetch('/validate_radarr', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ radarr_url: radarrUrl, radarr_token: radarrToken })
-  })
-    .then((response) => response.json())
-    .then((data) => {
-      hideSpinner('validate')
-
-      if (data.valid) {
-        document.getElementById('radarr_validated').value = 'true'
-        if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-        refreshValidationCallout('radarr_validated')
-        statusMessage.textContent = 'Radarr API key is valid.'
-        statusMessage.style.color = '#75b798'
-        statusMessage.style.display = 'block'
-        document.getElementById('validateButton').disabled = true
-
-        populateDropdown('radarr_root_folder_path', data.root_folders, 'path', 'path', initialRadarrRootFolderPath)
-        populateDropdown('radarr_quality_profile', data.quality_profiles, 'name', 'name', initialRadarrQualityProfile)
-      } else {
-        document.getElementById('radarr_validated').value = 'false'
-        if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout('radarr_validated')
-        console.log('Error validating Radarr', data.message)
-        statusMessage.textContent = 'Failed to validate Radarr server. Please check your URL and Token.'
-        statusMessage.style.color = '#ea868f'
-        statusMessage.style.display = 'block'
-      }
-    })
-    .catch((error) => {
-      hideSpinner('validate')
-      console.error('Error validating Radarr:', error)
-      statusMessage.textContent = 'Error validating Radarr'
-      statusMessage.style.color = '#ea868f'
-      statusMessage.style.display = 'block'
-      document.getElementById('radarr_validated').value = 'false'
-      if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout('radarr_validated')
-    })
-}
-
-function toggleApiKeyVisibility () {
-  if (apiKeyInput && toggleButton) {
-    if (apiKeyInput.type === 'password') {
-      apiKeyInput.type = 'text'
-      setToggleButtonIcon(toggleButton, true)
-    } else {
-      apiKeyInput.type = 'password'
-      setToggleButtonIcon(toggleButton, false)
-    }
+  if (errors.length) {
+    setStatusMessageLines(statusMessage, errors)
+    statusMessage.style.color = '#ea868f'
+    statusMessage.style.display = 'block'
+    return false
   }
+  statusMessage.style.display = 'none'
+  return true
 }
+
+createApiKeyValidator({
+  fieldId: 'radarr_token',
+  additionalFieldIds: ['radarr_url'],
+  validatedFieldId: 'radarr_validated',
+  validatedAtFieldId: 'radarr_validated_at',
+  endpoint: '/validate_radarr',
+  buildPayload: (token, extras) => ({
+    radarr_url: extras.radarr_url,
+    radarr_token: token
+  }),
+  messages: {
+    empty: 'Please enter both Radarr URL and Token.',
+    success: 'Radarr API key is valid.',
+    failure: 'Failed to validate Radarr server. Please check your URL and Token.',
+    networkError: 'Error validating Radarr'
+  },
+  onValidationSuccess: populateRadarrDropdowns,
+  onPreSubmit: validateRadarrPage,
+  revalidateOnLoad: true
+})

--- a/static/local-js/120-sonarr.js
+++ b/static/local-js/120-sonarr.js
@@ -1,223 +1,74 @@
-import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
+import { createApiKeyValidator } from './modules/createApiKeyValidator.js'
+import { populateDropdown, setStatusMessageLines } from './modules/dropdownHelpers.js'
 
-const validatedAtInput = document.getElementById('sonarr_validated_at')
-
-function setStatusMessageLines (element, messages) {
-  if (!element) return
-  element.textContent = ''
-  messages.forEach((message, index) => {
-    if (index > 0) element.appendChild(document.createElement('br'))
-    element.appendChild(document.createTextNode(message))
-  })
+// Per-wizard helpers: populate the three dropdowns from a validate response.
+// initialSonarrRootFolderPath/QualityProfile/LanguageProfile are window
+// globals injected by the rendered template (current selections from the
+// saved config), used to pre-select after dropdown population.
+function populateSonarrDropdowns (data) {
+  populateDropdown(
+    'sonarr_root_folder_path', data.root_folders, 'path', 'path',
+    typeof initialSonarrRootFolderPath !== 'undefined' ? initialSonarrRootFolderPath : ''
+  )
+  populateDropdown(
+    'sonarr_quality_profile', data.quality_profiles, 'name', 'name',
+    typeof initialSonarrQualityProfile !== 'undefined' ? initialSonarrQualityProfile : ''
+  )
+  populateDropdown(
+    'sonarr_language_profile', data.language_profiles, 'name', 'name',
+    typeof initialSonarrLanguageProfile !== 'undefined' ? initialSonarrLanguageProfile : ''
+  )
 }
 
-function resetDropdown (dropdown, placeholderText) {
-  if (!dropdown) return
-  const option = document.createElement('option')
-  option.value = ''
-  option.textContent = placeholderText
-  dropdown.replaceChildren(option)
-}
-
-const apiKeyInput = document.getElementById('sonarr_token')
-const toggleButton = document.getElementById('toggleApikeyVisibility')
-const validateButton = document.getElementById('validateButton')
-const isValidatedElement = document.getElementById('sonarr_validated')
-const isValidated = isValidatedElement ? isValidatedElement.value.toLowerCase() : 'false'
-
-console.log('Validated:', isValidated)
-
-// Set initial visibility based on API key value
-if (apiKeyInput.value.trim() === '') {
-  apiKeyInput.setAttribute('type', 'text') // Show placeholder text
-  setToggleButtonIcon(toggleButton, true)
-} else {
-  apiKeyInput.setAttribute('type', 'password') // Hide actual key
-  setToggleButtonIcon(toggleButton, false)
-}
-
-// Disable validate button if already validated
-if (isValidatedElement) {
-  validateButton.disabled = isValidated === 'true'
-}
-
-if (isValidated === 'true') {
-  document.getElementById('validateButton').disabled = true
-  fetchDropdownData() // Populate dropdowns if already validated
-} else {
-  document.getElementById('validateButton').disabled = false
-}
-
-// Attach event listeners for input changes
-document.getElementById('sonarr_token').addEventListener('input', function () {
-  document.getElementById('sonarr_validated').value = 'false'
-  if (validatedAtInput) validatedAtInput.value = ''
-  document.getElementById('validateButton').disabled = false
-  refreshValidationCallout('sonarr_validated')
-})
-
-document.getElementById('sonarr_url').addEventListener('input', function () {
-  document.getElementById('sonarr_validated').value = 'false'
-  if (validatedAtInput) validatedAtInput.value = ''
-  document.getElementById('validateButton').disabled = false
-  refreshValidationCallout('sonarr_validated')
-})
-
-// Attach event listeners for validation and toggle functionality
-document.getElementById('validateButton').addEventListener('click', validateSonarrApi)
-document.getElementById('toggleApikeyVisibility').addEventListener('click', toggleApiKeyVisibility)
-
-// Add an event listener for form submission
-document.getElementById('configForm').addEventListener('submit', function (event) {
-  if (!validateSonarrPage()) {
-    event.preventDefault() // Prevent form submission if validation fails
-  }
-})
-
-function validateSonarrApi () {
-  const sonarrUrl = document.getElementById('sonarr_url').value
-  const sonarrToken = document.getElementById('sonarr_token').value
-  const statusMessage = document.getElementById('statusMessage')
-
-  showSpinner('validate')
-
-  fetch('/validate_sonarr', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ sonarr_url: sonarrUrl, sonarr_token: sonarrToken })
-  })
-    .then((response) => response.json())
-    .then((data) => {
-      if (data.valid) {
-        hideSpinner('validate')
-        document.getElementById('sonarr_validated').value = 'true'
-        if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-        refreshValidationCallout('sonarr_validated')
-        statusMessage.textContent = 'Sonarr API key is valid.'
-        statusMessage.style.color = '#75b798'
-        statusMessage.style.display = 'block'
-        document.getElementById('validateButton').disabled = true
-
-        populateDropdown('sonarr_root_folder_path', data.root_folders, 'path', 'path', initialSonarrRootFolderPath)
-        populateDropdown('sonarr_quality_profile', data.quality_profiles, 'name', 'name', initialSonarrQualityProfile)
-        populateDropdown('sonarr_language_profile', data.language_profiles, 'name', 'name', initialSonarrLanguageProfile)
-      } else {
-        hideSpinner('validate')
-        document.getElementById('sonarr_validated').value = 'false'
-        if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout('sonarr_validated')
-        console.error('Error validating Sonarr', data.message)
-        statusMessage.textContent = 'Failed to validate Sonarr server. Please check your URL and Token.'
-        statusMessage.style.color = '#ea868f'
-        statusMessage.style.display = 'block'
-      }
-    })
-    .catch(error => {
-      hideSpinner('validate')
-      console.error('Error validating Sonarr:', error)
-      statusMessage.textContent = 'Error validating Sonarr.'
-      statusMessage.style.color = '#ea868f'
-      statusMessage.style.display = 'block'
-      document.getElementById('sonarr_validated').value = 'false'
-      if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout('sonarr_validated')
-    })
-}
-
-function fetchDropdownData () {
-  // Fetch the stored dropdown data and populate the dropdowns
-  const sonarrUrl = document.getElementById('sonarr_url').value
-  const sonarrToken = document.getElementById('sonarr_token').value
-
-  fetch('/validate_sonarr', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ sonarr_url: sonarrUrl, sonarr_token: sonarrToken })
-  })
-    .then((response) => response.json())
-    .then((data) => {
-      populateDropdown('sonarr_root_folder_path', data.root_folders, 'path', 'path', initialSonarrRootFolderPath)
-      populateDropdown('sonarr_quality_profile', data.quality_profiles, 'name', 'name', initialSonarrQualityProfile)
-      populateDropdown('sonarr_language_profile', data.language_profiles, 'name', 'name', initialSonarrLanguageProfile)
-    })
-    .catch(error => {
-      console.error('Error fetching Sonarr dropdown data:', error)
-    })
-}
-function populateDropdown (elementId, data, valueField, textField, selectedValue = '') {
-  const dropdown = document.getElementById(elementId)
-  resetDropdown(dropdown, 'Select an option')
-
-  data.forEach(item => {
-    const option = document.createElement('option')
-    option.value = item[valueField]
-    option.textContent = item[textField]
-    dropdown.appendChild(option)
-  })
-
-  if (selectedValue) {
-    dropdown.value = selectedValue
-  }
-}
-
+// Pre-submit guard: navigation is allowed only if the user has either
+// (a) never validated Sonarr or (b) validated AND selected all three
+// dropdowns. Path validation from PathValidation (set up elsewhere)
+// also blocks if any path field is invalid.
 function validateSonarrPage () {
+  const validated = document.getElementById('sonarr_validated').value.toLowerCase() === 'true'
   const rootFolderPath = document.getElementById('sonarr_root_folder_path').value
   const qualityProfile = document.getElementById('sonarr_quality_profile').value
   const languageProfile = document.getElementById('sonarr_language_profile').value
-  const statusMessage = document.getElementById('statusMessage')
-  let isValid = true
-  const validationMessages = []
   const pathsValid = (typeof PathValidation !== 'undefined' && PathValidation.validateAll)
     ? PathValidation.validateAll()
     : true
 
-  const isValidatedNow = document.getElementById('sonarr_validated').value.toLowerCase() === 'true'
-
-  if (isValidatedNow) {
-    if (!rootFolderPath) {
-      validationMessages.push('Please select a valid Root Folder Path.')
-      isValid = false
-    }
-
-    if (!qualityProfile) {
-      validationMessages.push('Please select a valid Quality Profile.')
-      isValid = false
-    }
-
-    if (!languageProfile) {
-      validationMessages.push('Please select a valid Language Profile.')
-      isValid = false
-    }
+  const errors = []
+  if (validated) {
+    if (!rootFolderPath) errors.push('Please select a valid Root Folder Path.')
+    if (!qualityProfile) errors.push('Please select a valid Quality Profile.')
+    if (!languageProfile) errors.push('Please select a valid Language Profile.')
   }
+  if (!pathsValid) errors.push('Please fix invalid path fields before continuing.')
 
-  if (!pathsValid) {
-    validationMessages.push('Please fix invalid path fields before continuing.')
-    isValid = false
-  }
-
-  if (!isValid) {
-    setStatusMessageLines(statusMessage, validationMessages)
+  const statusMessage = document.getElementById('statusMessage')
+  if (errors.length) {
+    setStatusMessageLines(statusMessage, errors)
     statusMessage.style.color = '#ea868f'
     statusMessage.style.display = 'block'
-  } else {
-    statusMessage.style.display = 'none'
+    return false
   }
-
-  return isValid
+  statusMessage.style.display = 'none'
+  return true
 }
 
-function toggleApiKeyVisibility () {
-  if (apiKeyInput && toggleButton) {
-    if (apiKeyInput.type === 'password') {
-      apiKeyInput.type = 'text'
-      setToggleButtonIcon(toggleButton, true)
-    } else {
-      apiKeyInput.type = 'password'
-      setToggleButtonIcon(toggleButton, false)
-    }
-  }
-}
+createApiKeyValidator({
+  fieldId: 'sonarr_token',
+  additionalFieldIds: ['sonarr_url'],
+  validatedFieldId: 'sonarr_validated',
+  validatedAtFieldId: 'sonarr_validated_at',
+  endpoint: '/validate_sonarr',
+  buildPayload: (token, extras) => ({
+    sonarr_url: extras.sonarr_url,
+    sonarr_token: token
+  }),
+  messages: {
+    empty: 'Please enter both Sonarr URL and Token.',
+    success: 'Sonarr API key is valid.',
+    failure: 'Failed to validate Sonarr server. Please check your URL and Token.',
+    networkError: 'Error validating Sonarr.'
+  },
+  onValidationSuccess: populateSonarrDropdowns,
+  onPreSubmit: validateSonarrPage,
+  revalidateOnLoad: true
+})

--- a/static/local-js/modules/createApiKeyValidator.js
+++ b/static/local-js/modules/createApiKeyValidator.js
@@ -8,11 +8,18 @@
 // 060-mdblist, 070-notifiarr, 087-apprise.
 //
 // Multi-field wizards (credential plus url/topic/etc): 030-tautulli,
-// 080-gotify, 085-ntfy. These pass additionalFieldIds and a 2-arg
-// buildPayload.
+// 080-gotify, 085-ntfy.
 //
-// Wizards with more complex needs (dropdown-driven Next button gating,
-// OAuth flows, Plex auth) live outside this factory; see Step 6 PR 4.
+// Multi-field + post-validation hooks: 110-radarr, 120-sonarr use the
+// onValidationSuccess callback to populate dropdowns from the response,
+// the onPreSubmit callback to gate form submission on dropdown values,
+// and revalidateOnLoad to refresh those dropdowns when an already-
+// validated user returns to the page.
+//
+// Wizards with OAuth-PIN flows (010-plex, 130-trakt, 140-mal) are NOT
+// migrated to this factory; their multi-step flow is fundamentally
+// different from the "credential -> validate -> done" shape and they
+// belong in a separate helper (Step 6 PR 4 later slices).
 //
 // DESIGN
 //
@@ -80,6 +87,24 @@ const DEFAULT_MESSAGES = {
  *                                               (data is the server response, or `{}` for empty/networkError).
  *                                               Functions let wizards forward server-provided text verbatim
  *                                               (e.g. data.error from apprise, data.message from github).
+ * @param {(data: object) => void} [config.onValidationSuccess]
+ *                                               Called after a successful validate response, with the parsed
+ *                                               response data. Runs AFTER the factory has set validatedField,
+ *                                               shown the success message, and disabled the button. Used by
+ *                                               wizards that need to consume extra fields from the response
+ *                                               (e.g. Radarr/Sonarr populate dropdowns from data.root_folders,
+ *                                               Plex copies db_cache + library lists into hidden form inputs).
+ * @param {() => boolean} [config.onPreSubmit]   Called on form submit BEFORE the normal empty-value
+ *                                               normalisation. Return false to call event.preventDefault()
+ *                                               and block the submit. Used by wizards that gate navigation
+ *                                               on additional state beyond "credential validated" (e.g.
+ *                                               Radarr/Sonarr require the populated dropdowns to be filled).
+ * @param {boolean} [config.revalidateOnLoad=false]  If true AND validatedField is already 'true' on page
+ *                                               load, the factory issues a silent re-POST to the endpoint
+ *                                               and invokes onValidationSuccess with the result. Used to
+ *                                               repopulate post-validation state (dropdowns etc.) when an
+ *                                               already-validated user returns to the page. No user-facing
+ *                                               status message is shown for this silent call.
  * @param {string} [config.spinnerKey='validate'] Argument passed to show/hideSpinner.
  */
 export function createApiKeyValidator (config) {
@@ -95,6 +120,9 @@ export function createApiKeyValidator (config) {
     endpoint,
     buildPayload,
     messages: messageOverrides = {},
+    onValidationSuccess,
+    onPreSubmit,
+    revalidateOnLoad = false,
     spinnerKey = 'validate'
   } = config
 
@@ -209,6 +237,7 @@ export function createApiKeyValidator (config) {
           refreshValidationCallout(validatedFieldId)
           showStatus(resolveMessage(messages.success, data), STATUS_COLOR_SUCCESS)
           validateButton.disabled = true
+          if (typeof onValidationSuccess === 'function') onValidationSuccess(data)
         } else {
           validatedField.value = 'false'
           if (validatedAtInput) validatedAtInput.value = ''
@@ -226,6 +255,41 @@ export function createApiKeyValidator (config) {
       })
   })
 
+  // ── silent re-validate on page load (optional) ──────────────────
+  // When a user returns to a previously-validated page, the persisted
+  // validatedField is 'true' but any post-validation server state
+  // (Radarr/Sonarr dropdown choices, etc.) was never re-fetched. If
+  // the wizard opts in with revalidateOnLoad, hit the endpoint silently
+  // and invoke onValidationSuccess so the wizard can repopulate.
+  //
+  // "Silent" means: no spinner, no status message, no button state
+  // changes. Pure side-channel to refresh data. Failures are swallowed
+  // -- if the server can't be reached on page load the dropdowns stay
+  // empty until the user re-clicks Validate, which is the correct
+  // degraded behaviour (rather than spuriously flipping validatedField
+  // to false based on a transient network issue).
+  if (revalidateOnLoad &&
+      validatedField.value.toLowerCase() === 'true' &&
+      typeof onValidationSuccess === 'function') {
+    const credentialValue = apiKeyInput.value
+    const additionalValues = collectAdditionalValues()
+    const additionalAllPresent = additionalElements.every(
+      ({ id }) => additionalValues[id]
+    )
+    if (credentialValue && additionalAllPresent) {
+      fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(buildPayload(credentialValue, additionalValues))
+      })
+        .then(response => response.json())
+        .then(data => {
+          if (data.valid) onValidationSuccess(data)
+        })
+        .catch(() => { /* swallowed; see comment above */ })
+    }
+  }
+
   // ── show/hide toggle for the credential field ───────────────────────
   if (toggleButton) {
     toggleButton.addEventListener('click', function () {
@@ -240,11 +304,19 @@ export function createApiKeyValidator (config) {
   // entirely empty the form should still post an empty string, not
   // omit the field entirely. Applies to the primary credential AND
   // every additional field.
+  //
+  // If onPreSubmit is provided and returns false, the submit is
+  // blocked via event.preventDefault(). The empty-value normalisation
+  // still runs regardless, so the guard sees the same form state the
+  // server would have.
   if (form) {
-    form.addEventListener('submit', function () {
+    form.addEventListener('submit', function (event) {
       if (!apiKeyInput.value) apiKeyInput.value = ''
       for (const { el } of additionalElements) {
         if (!el.value) el.value = ''
+      }
+      if (typeof onPreSubmit === 'function' && onPreSubmit() === false) {
+        event.preventDefault()
       }
     })
   }

--- a/static/local-js/modules/dropdownHelpers.js
+++ b/static/local-js/modules/dropdownHelpers.js
@@ -1,0 +1,70 @@
+// Shared DOM helpers for wizards that populate <select> dropdowns from
+// validate-endpoint responses (Radarr, Sonarr). Kept separate from
+// createApiKeyValidator because dropdown population is orthogonal to
+// credential validation -- some wizards do one, some do both, some
+// do neither.
+//
+// These are pure utility functions: they take elements and data,
+// mutate the DOM, return nothing. No assumption about wizard state,
+// validation flags, etc.
+
+/**
+ * Replace a dropdown's children with a single placeholder option.
+ *
+ * @param {HTMLSelectElement|null} dropdown
+ * @param {string} placeholderText
+ */
+export function resetDropdown (dropdown, placeholderText) {
+  if (!dropdown) return
+  const option = document.createElement('option')
+  option.value = ''
+  option.textContent = placeholderText
+  dropdown.replaceChildren(option)
+}
+
+/**
+ * Populate a dropdown from an array of plain objects, optionally
+ * pre-selecting one value.
+ *
+ * @param {string} elementId          Id of the <select> to populate.
+ * @param {Array<object>} data        Items to render. Falsy data is a no-op.
+ * @param {string} valueField         Key on each item used for option.value.
+ * @param {string} textField          Key on each item used for option.textContent.
+ * @param {string} [selectedValue=''] If truthy and matches an option.value,
+ *                                    that option is pre-selected.
+ * @param {string} [placeholderText='Select an option']
+ */
+export function populateDropdown (elementId, data, valueField, textField, selectedValue = '', placeholderText = 'Select an option') {
+  const dropdown = document.getElementById(elementId)
+  if (!dropdown) return
+  resetDropdown(dropdown, placeholderText)
+  if (!Array.isArray(data)) return
+
+  for (const item of data) {
+    const option = document.createElement('option')
+    option.value = item[valueField]
+    option.textContent = item[textField]
+    dropdown.appendChild(option)
+  }
+
+  if (selectedValue) {
+    dropdown.value = selectedValue
+  }
+}
+
+/**
+ * Set multi-line text on a status element using <br> separators.
+ * Used by wizards that report multiple validation errors at once
+ * (e.g. "missing root folder" + "missing quality profile").
+ *
+ * @param {HTMLElement|null} element
+ * @param {string[]} messages
+ */
+export function setStatusMessageLines (element, messages) {
+  if (!element) return
+  element.textContent = ''
+  messages.forEach((message, index) => {
+    if (index > 0) element.appendChild(document.createElement('br'))
+    element.appendChild(document.createTextNode(message))
+  })
+}

--- a/tests/e2e/test_wizard_e2e.py
+++ b/tests/e2e/test_wizard_e2e.py
@@ -329,3 +329,192 @@ def test_multi_field_wizard_empty_check_across_fields(page, live_server):
     expect(page.locator("#statusMessage")).to_contain_text("Please enter both Gotify URL and Token.")
     expect(page.locator("#gotify_validated")).to_have_value("false")
     assert fetch_calls == [], f"expected no fetch but got {fetch_calls}"
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "stem, endpoint, field_inputs, validated_id, success_text, response_data, expected_options",
+    [
+        (
+            "110-radarr",
+            "validate_radarr",
+            {"radarr_url": "http://radarr.local", "radarr_token": "k"},
+            "radarr_validated",
+            "Radarr API key is valid.",
+            {
+                "valid": True,
+                "root_folders": [{"path": "/movies"}, {"path": "/four-k"}],
+                "quality_profiles": [{"name": "HD-1080p"}, {"name": "4K"}],
+            },
+            {
+                "radarr_root_folder_path": ["/movies", "/four-k"],
+                "radarr_quality_profile": ["HD-1080p", "4K"],
+            },
+        ),
+        (
+            "120-sonarr",
+            "validate_sonarr",
+            {"sonarr_url": "http://sonarr.local", "sonarr_token": "k"},
+            "sonarr_validated",
+            "Sonarr API key is valid.",
+            {
+                "valid": True,
+                "root_folders": [{"path": "/tv"}, {"path": "/anime"}],
+                "quality_profiles": [{"name": "HD-720p"}, {"name": "HD-1080p"}],
+                "language_profiles": [{"name": "English"}, {"name": "Japanese"}],
+            },
+            {
+                "sonarr_root_folder_path": ["/tv", "/anime"],
+                "sonarr_quality_profile": ["HD-720p", "HD-1080p"],
+                "sonarr_language_profile": ["English", "Japanese"],
+            },
+        ),
+    ],
+)
+def test_dropdown_populating_wizard_success_flow(
+    page,
+    live_server,
+    stem,
+    endpoint,
+    field_inputs,
+    validated_id,
+    success_text,
+    response_data,
+    expected_options,
+):
+    """Radarr + Sonarr populate dropdowns from the validate response
+    via onValidationSuccess (#1334 Step 6 PR 4a). Verify each dropdown
+    receives the expected options after clicking Validate.
+    """
+
+    def handle_validate(route):
+        route.fulfill(status=200, json=response_data)
+
+    page.route(f"**/{endpoint}", handle_validate)
+    page.goto(f"{live_server}/step/{stem}", wait_until="domcontentloaded")
+
+    for input_id, value in field_inputs.items():
+        page.locator(f"#{input_id}").fill(value)
+    page.locator("#validateButton").click()
+
+    expect(page.locator("#statusMessage")).to_contain_text(success_text)
+    expect(page.locator(f"#{validated_id}")).to_have_value("true")
+
+    # Each populated dropdown should contain the expected option values.
+    for dropdown_id, expected_values in expected_options.items():
+        dropdown = page.locator(f"#{dropdown_id}")
+        actual_values = dropdown.evaluate("el => Array.from(el.options).map(o => o.value)")
+        for expected in expected_values:
+            assert expected in actual_values, f"{dropdown_id} missing option {expected!r}; got {actual_values}"
+
+
+@pytest.mark.e2e
+def test_radarr_pre_submit_blocks_navigation_when_dropdowns_unset(page, live_server):
+    """Radarr's onPreSubmit guard should preventDefault on the form
+    when validated=true but the root-folder/quality-profile dropdowns
+    haven't been chosen. This is the load-bearing replacement for the
+    legacy validateRadarrPage() function (#1334 Step 6 PR 4a).
+
+    NOTE: the rendered template injects `initialRadarrQualityProfile`
+    and `initialRadarrRootFolderPath` from the saved config. If the
+    mock response contains options whose values match those initials,
+    populateDropdown will auto-select them and the dropdowns won't be
+    "unset" any more. To make the test deterministic regardless of
+    saved config, the mock provides option values that won't match
+    any plausible saved config ("NO_MATCH_*" prefixes).
+    """
+
+    def handle_validate(route):
+        route.fulfill(
+            status=200,
+            json={
+                "valid": True,
+                "root_folders": [{"path": "NO_MATCH_ROOT_FOLDER"}],
+                "quality_profiles": [{"name": "NO_MATCH_QUALITY_PROFILE"}],
+            },
+        )
+
+    page.route("**/validate_radarr", handle_validate)
+    page.goto(f"{live_server}/step/110-radarr", wait_until="domcontentloaded")
+
+    # Validate succeeds, populating the dropdowns but leaving them on placeholder.
+    page.locator("#radarr_url").fill("http://radarr.local")
+    page.locator("#radarr_token").fill("k")
+    page.locator("#validateButton").click()
+    expect(page.locator("#radarr_validated")).to_have_value("true")
+
+    # Sanity check: both dropdowns should be on their placeholder ("")
+    # since the mock's option values don't match any saved initials.
+    expect(page.locator("#radarr_root_folder_path")).to_have_value("")
+    expect(page.locator("#radarr_quality_profile")).to_have_value("")
+
+    # Trigger a form submit without selecting dropdowns. Use evaluate to
+    # dispatch a real submit event and capture whether it was blocked.
+    blocked = page.evaluate("""
+        () => {
+            const form = document.getElementById('configForm');
+            const evt = new Event('submit', { cancelable: true });
+            form.dispatchEvent(evt);
+            return evt.defaultPrevented;
+        }
+    """)
+    assert blocked is True, "expected form submit to be blocked by onPreSubmit"
+    expect(page.locator("#statusMessage")).to_contain_text("Please select a valid Root Folder Path.")
+    expect(page.locator("#statusMessage")).to_contain_text("Please select a valid Quality Profile.")
+
+
+@pytest.mark.e2e
+def test_radarr_revalidate_on_load_repopulates_dropdowns(page, live_server):
+    """When the user returns to an already-validated Radarr page, the
+    factory's revalidateOnLoad option should issue a silent POST and
+    repopulate the dropdowns. This proves the silent fetch path.
+
+    Instead of round-tripping through saved state (fragile in the e2e
+    harness), this test directly mutates the in-memory wizard state to
+    simulate "already validated", then triggers a manual reload of the
+    factory module. The unit-level Vitest suite for revalidateOnLoad
+    (8 tests) covers the option semantics in isolation; this test
+    proves the option is correctly threaded through to the rendered
+    wizard config.
+    """
+
+    fetch_count = {"n": 0}
+
+    def handle_validate(route):
+        fetch_count["n"] += 1
+        route.fulfill(
+            status=200,
+            json={
+                "valid": True,
+                "root_folders": [{"path": "NO_MATCH_REVAL_FOLDER"}],
+                "quality_profiles": [{"name": "NO_MATCH_REVAL_QUALITY"}],
+            },
+        )
+
+    page.route("**/validate_radarr", handle_validate)
+    page.goto(f"{live_server}/step/110-radarr", wait_until="domcontentloaded")
+
+    # Simulate the "returning to a validated page" state by:
+    # 1. Pre-filling the credential fields (revalidateOnLoad needs them)
+    # 2. Setting radarr_validated='true' (the precondition for the silent fetch)
+    # 3. Re-importing the wizard module to trigger the factory's init code
+    #    with that state, the same way it would run on a fresh page load.
+    page.evaluate("""
+        () => {
+            document.getElementById('radarr_url').value = 'http://radarr.local';
+            document.getElementById('radarr_token').value = 'some-token';
+            document.getElementById('radarr_validated').value = 'true';
+        }
+    """)
+    # Re-import the wizard module with a cache buster so the factory's
+    # top-level code runs again against the mutated DOM.
+    page.evaluate("""
+        () => import(`/static/local-js/110-radarr.js?revalidate-test=${Date.now()}`)
+    """)
+    # Give the silent fetch a moment to resolve.
+    page.wait_for_timeout(500)
+
+    # The dropdown should now contain the option from the mock response.
+    dropdown_values = page.locator("#radarr_root_folder_path").evaluate("el => Array.from(el.options).map(o => o.value)")
+    assert "NO_MATCH_REVAL_FOLDER" in dropdown_values, f"expected revalidateOnLoad to repopulate dropdown; got {dropdown_values}"
+    assert fetch_count["n"] >= 1, f"expected at least one silent fetch; got count={fetch_count['n']}"

--- a/tests/js/modules/createApiKeyValidator.test.js
+++ b/tests/js/modules/createApiKeyValidator.test.js
@@ -663,6 +663,300 @@ describe('createApiKeyValidator multi-field wizards (additionalFieldIds)', () =>
   })
 })
 
+describe('createApiKeyValidator onValidationSuccess callback', () => {
+  // onValidationSuccess fires after a successful validate response,
+  // receiving the parsed response data. Lets wizards consume extra
+  // fields from the response (Radarr/Sonarr populate dropdowns from
+  // data.root_folders, Plex copies db_cache + library lists, etc.).
+  // Runs AFTER the factory has set validatedField='true', shown the
+  // success message, and disabled the validate button.
+
+  it('fires onValidationSuccess with the response data on a successful validate', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({
+        valid: true,
+        root_folders: [{ path: '/movies' }, { path: '/tv' }],
+        quality_profiles: [{ name: 'HD-1080p' }]
+      })
+    })))
+    const onSuccess = vi.fn()
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    createApiKeyValidator(defaultConfig({ onValidationSuccess: onSuccess }))
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+    expect(onSuccess).toHaveBeenCalledWith({
+      valid: true,
+      root_folders: [{ path: '/movies' }, { path: '/tv' }],
+      quality_profiles: [{ name: 'HD-1080p' }]
+    })
+  })
+
+  it('does NOT fire onValidationSuccess when validation fails', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ valid: false })
+    })))
+    const onSuccess = vi.fn()
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'badkey' })
+    createApiKeyValidator(defaultConfig({ onValidationSuccess: onSuccess }))
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+
+  it('does NOT fire onValidationSuccess on network error', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('boom'))))
+    const onSuccess = vi.fn()
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    createApiKeyValidator(defaultConfig({ onValidationSuccess: onSuccess }))
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+
+  it('fires onValidationSuccess AFTER validatedField is set to true', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ valid: true })
+    })))
+    let validatedValueAtCallback = null
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    createApiKeyValidator(defaultConfig({
+      onValidationSuccess: () => {
+        validatedValueAtCallback = document.getElementById('test_validated').value
+      }
+    }))
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(validatedValueAtCallback).toBe('true')
+  })
+
+  it('is optional -- wizards that do not need it can omit it', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ valid: true })
+    })))
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    expect(() => createApiKeyValidator(defaultConfig())).not.toThrow()
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+    // No assertion needed -- the test passes if no error was thrown.
+  })
+})
+
+describe('createApiKeyValidator onPreSubmit callback', () => {
+  // onPreSubmit lets the wizard veto a form submit. Returns false to
+  // block via event.preventDefault(). Empty-value normalisation still
+  // runs first. Used by Radarr/Sonarr to require populated dropdown
+  // selections before allowing navigation to the next page.
+
+  it('does not block submit when onPreSubmit returns true', () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    const onPreSubmit = vi.fn(() => true)
+    createApiKeyValidator(defaultConfig({ onPreSubmit }))
+
+    const form = document.getElementById('configForm')
+    const submitEvent = new Event('submit', { cancelable: true })
+    form.dispatchEvent(submitEvent)
+
+    expect(onPreSubmit).toHaveBeenCalledTimes(1)
+    expect(submitEvent.defaultPrevented).toBe(false)
+  })
+
+  it('blocks submit when onPreSubmit returns false', () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    const onPreSubmit = vi.fn(() => false)
+    createApiKeyValidator(defaultConfig({ onPreSubmit }))
+
+    const form = document.getElementById('configForm')
+    const submitEvent = new Event('submit', { cancelable: true })
+    form.dispatchEvent(submitEvent)
+
+    expect(onPreSubmit).toHaveBeenCalledTimes(1)
+    expect(submitEvent.defaultPrevented).toBe(true)
+  })
+
+  it('runs empty-value normalisation BEFORE onPreSubmit (guard sees normalised state)', () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: '' })
+    let valueAtGuard = null
+    createApiKeyValidator(defaultConfig({
+      onPreSubmit: () => {
+        valueAtGuard = document.getElementById('test_apikey').value
+        return true
+      }
+    }))
+
+    const form = document.getElementById('configForm')
+    form.dispatchEvent(new Event('submit', { cancelable: true }))
+
+    // Even though the input started empty, the guard sees it as a
+    // normalised empty string (not undefined / null).
+    expect(valueAtGuard).toBe('')
+  })
+
+  it('is optional -- form submit works normally without onPreSubmit', () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    createApiKeyValidator(defaultConfig())
+
+    const form = document.getElementById('configForm')
+    const submitEvent = new Event('submit', { cancelable: true })
+    expect(() => form.dispatchEvent(submitEvent)).not.toThrow()
+    expect(submitEvent.defaultPrevented).toBe(false)
+  })
+
+  it('treats truthy return as "allow submit" (truthy != true)', () => {
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    // Only literal false blocks. Anything else allows.
+    for (const returnValue of [undefined, null, 0, '', 1, 'yes', {}, true]) {
+      const onPreSubmit = vi.fn(() => returnValue)
+      createApiKeyValidator(defaultConfig({ onPreSubmit }))
+      const form = document.getElementById('configForm')
+      const submitEvent = new Event('submit', { cancelable: true })
+      form.dispatchEvent(submitEvent)
+      const shouldBlock = returnValue === false
+      expect(submitEvent.defaultPrevented).toBe(shouldBlock)
+      // re-setup for next iteration; addEventListener accumulates,
+      // but our assertion is on the LAST event so this is fine.
+    }
+  })
+})
+
+describe('createApiKeyValidator revalidateOnLoad', () => {
+  // When enabled AND validatedField is already 'true', the factory
+  // issues a silent re-POST on construction and invokes
+  // onValidationSuccess with the response. No spinner, no status
+  // message, no button state changes. Used by Radarr/Sonarr to
+  // repopulate dropdowns when an already-validated user returns.
+
+  function buildRevalidateHTML ({ keyValue = 'mykey', validated = 'true' } = {}) {
+    return buildBaseHTML({ keyValue, validated })
+  }
+
+  it('issues a silent fetch on load when validated and revalidateOnLoad=true', async () => {
+    const fetchSpy = vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ valid: true, extra: 'data' })
+    }))
+    vi.stubGlobal('fetch', fetchSpy)
+    const onSuccess = vi.fn()
+    document.body.innerHTML = buildRevalidateHTML()
+
+    createApiKeyValidator(defaultConfig({
+      revalidateOnLoad: true,
+      onValidationSuccess: onSuccess
+    }))
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(onSuccess).toHaveBeenCalledWith({ valid: true, extra: 'data' })
+  })
+
+  it('does NOT fetch on load when validatedField is false', async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    document.body.innerHTML = buildRevalidateHTML({ validated: 'false' })
+
+    createApiKeyValidator(defaultConfig({
+      revalidateOnLoad: true,
+      onValidationSuccess: vi.fn()
+    }))
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('does NOT fetch on load when revalidateOnLoad is false (default)', async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    document.body.innerHTML = buildRevalidateHTML()
+
+    createApiKeyValidator(defaultConfig({
+      onValidationSuccess: vi.fn()
+    }))
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('does NOT fetch on load when onValidationSuccess is not provided', async () => {
+    // No point firing a silent fetch if no one will consume the result.
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    document.body.innerHTML = buildRevalidateHTML()
+
+    createApiKeyValidator(defaultConfig({ revalidateOnLoad: true }))
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('does NOT fetch on load when credential field is empty', async () => {
+    // Edge case: validatedField says "true" but the credential is
+    // somehow empty. Don't waste a server call -- the user will need
+    // to refill and re-validate anyway.
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    document.body.innerHTML = buildRevalidateHTML({ keyValue: '' })
+
+    createApiKeyValidator(defaultConfig({
+      revalidateOnLoad: true,
+      onValidationSuccess: vi.fn()
+    }))
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('does NOT invoke onValidationSuccess if silent fetch returns valid=false', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ valid: false })
+    })))
+    const onSuccess = vi.fn()
+    document.body.innerHTML = buildRevalidateHTML()
+
+    createApiKeyValidator(defaultConfig({
+      revalidateOnLoad: true,
+      onValidationSuccess: onSuccess
+    }))
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+
+  it('swallows network errors from the silent fetch (no thrown rejection)', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('boom'))))
+    const onSuccess = vi.fn()
+    document.body.innerHTML = buildRevalidateHTML()
+
+    expect(() => createApiKeyValidator(defaultConfig({
+      revalidateOnLoad: true,
+      onValidationSuccess: onSuccess
+    }))).not.toThrow()
+    // Let the microtask queue drain to surface any unhandled rejection.
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+
+  it('does not show a status message during silent revalidate', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ valid: true })
+    })))
+    document.body.innerHTML = buildRevalidateHTML()
+
+    createApiKeyValidator(defaultConfig({
+      revalidateOnLoad: true,
+      onValidationSuccess: vi.fn()
+    }))
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    // Status message should remain hidden (display: none from initial HTML)
+    const status = document.getElementById('statusMessage')
+    expect(status.style.display).toBe('none')
+  })
+})
+
 describe('createApiKeyValidator validate click — network error', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('boom'))))

--- a/tests/js/modules/dropdownHelpers.test.js
+++ b/tests/js/modules/dropdownHelpers.test.js
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { resetDropdown, populateDropdown, setStatusMessageLines } from '../../../static/local-js/modules/dropdownHelpers.js'
+
+describe('dropdownHelpers.resetDropdown', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('replaces all children with a single placeholder option', () => {
+    document.body.innerHTML = `
+      <select id="d">
+        <option value="a">A</option>
+        <option value="b">B</option>
+      </select>
+    `
+    resetDropdown(document.getElementById('d'), 'Pick one')
+
+    const dropdown = document.getElementById('d')
+    expect(dropdown.children.length).toBe(1)
+    expect(dropdown.children[0].value).toBe('')
+    expect(dropdown.children[0].textContent).toBe('Pick one')
+  })
+
+  it('does not throw when dropdown is null', () => {
+    expect(() => resetDropdown(null, 'Placeholder')).not.toThrow()
+  })
+
+  it('works on an empty dropdown', () => {
+    document.body.innerHTML = '<select id="d"></select>'
+    resetDropdown(document.getElementById('d'), 'Empty')
+    expect(document.getElementById('d').children.length).toBe(1)
+  })
+})
+
+describe('dropdownHelpers.populateDropdown', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<select id="d"></select>'
+  })
+
+  it('populates options from data using valueField and textField', () => {
+    populateDropdown('d', [
+      { path: '/movies', label: 'Movies' },
+      { path: '/tv', label: 'TV Shows' }
+    ], 'path', 'label')
+
+    const dropdown = document.getElementById('d')
+    // Placeholder option + 2 data options
+    expect(dropdown.children.length).toBe(3)
+    expect(dropdown.children[1].value).toBe('/movies')
+    expect(dropdown.children[1].textContent).toBe('Movies')
+    expect(dropdown.children[2].value).toBe('/tv')
+    expect(dropdown.children[2].textContent).toBe('TV Shows')
+  })
+
+  it('pre-selects the matching option when selectedValue is provided', () => {
+    populateDropdown('d', [
+      { path: '/a' }, { path: '/b' }, { path: '/c' }
+    ], 'path', 'path', '/b')
+
+    expect(document.getElementById('d').value).toBe('/b')
+  })
+
+  it('uses the default placeholder when none is provided', () => {
+    populateDropdown('d', [{ name: 'x' }], 'name', 'name')
+    expect(document.getElementById('d').children[0].textContent).toBe('Select an option')
+  })
+
+  it('accepts a custom placeholder text', () => {
+    populateDropdown('d', [{ name: 'x' }], 'name', 'name', '', 'Choose your fighter')
+    expect(document.getElementById('d').children[0].textContent).toBe('Choose your fighter')
+  })
+
+  it('is a no-op when element id is missing', () => {
+    expect(() => populateDropdown('nonexistent', [{ name: 'x' }], 'name', 'name')).not.toThrow()
+  })
+
+  it('only adds placeholder when data is null or undefined', () => {
+    populateDropdown('d', null, 'path', 'path')
+    expect(document.getElementById('d').children.length).toBe(1)
+
+    populateDropdown('d', undefined, 'path', 'path')
+    expect(document.getElementById('d').children.length).toBe(1)
+  })
+
+  it('only adds placeholder when data is not an array', () => {
+    populateDropdown('d', { not: 'array' }, 'path', 'path')
+    expect(document.getElementById('d').children.length).toBe(1)
+  })
+
+  it('handles empty array data', () => {
+    populateDropdown('d', [], 'path', 'path')
+    expect(document.getElementById('d').children.length).toBe(1)
+    expect(document.getElementById('d').children[0].value).toBe('')
+  })
+
+  it('does not pre-select when selectedValue is empty string', () => {
+    populateDropdown('d', [{ path: '/a' }, { path: '/b' }], 'path', 'path', '')
+    expect(document.getElementById('d').value).toBe('') // placeholder
+  })
+
+  it('does not pre-select when selectedValue does not match any option', () => {
+    populateDropdown('d', [{ path: '/a' }], 'path', 'path', '/missing')
+    expect(document.getElementById('d').value).toBe('') // placeholder
+  })
+})
+
+describe('dropdownHelpers.setStatusMessageLines', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="status"></div>'
+  })
+
+  it('sets a single message without any <br>', () => {
+    setStatusMessageLines(document.getElementById('status'), ['Just one'])
+    const status = document.getElementById('status')
+    expect(status.textContent).toBe('Just one')
+    expect(status.querySelectorAll('br').length).toBe(0)
+  })
+
+  it('separates multiple messages with <br>', () => {
+    setStatusMessageLines(document.getElementById('status'), ['First', 'Second', 'Third'])
+    const status = document.getElementById('status')
+    expect(status.querySelectorAll('br').length).toBe(2)
+    expect(status.textContent).toBe('FirstSecondThird')
+  })
+
+  it('clears existing content before writing new lines', () => {
+    const status = document.getElementById('status')
+    status.textContent = 'old content here'
+    setStatusMessageLines(status, ['new'])
+    expect(status.textContent).toBe('new')
+  })
+
+  it('handles empty messages array (clears the element)', () => {
+    const status = document.getElementById('status')
+    status.textContent = 'old'
+    setStatusMessageLines(status, [])
+    expect(status.textContent).toBe('')
+  })
+
+  it('does not throw when element is null', () => {
+    expect(() => setStatusMessageLines(null, ['anything'])).not.toThrow()
+  })
+
+  it('uses textContent (not innerHTML) -- safe against HTML injection', () => {
+    setStatusMessageLines(document.getElementById('status'), ['<img src=x onerror=alert(1)>'])
+    const status = document.getElementById('status')
+    // The img tag should be rendered as literal text, not parsed
+    expect(status.querySelectorAll('img').length).toBe(0)
+    expect(status.textContent).toContain('<img src=x onerror=alert(1)>')
+  })
+})


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix
- [x] Feature/Tweak (2 wizard migrations + 1 new module + 3 factory extensions; no user-visible behaviour changes)
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Other

## Description

Roadmap issue #1334 **Step 6 (validation widget refactor) — PR 4a of 4 sub-slices**.

Migrates **110-radarr** and **120-sonarr** to `createApiKeyValidator`. These two wizards were structurally near-identical (one extra dropdown on Sonarr) and accounted for ~440 lines of duplicated logic — the cleanest DRY win in the remaining six wizards.

The remaining four wizards (Plex, TMDB, Trakt, MAL) each have a distinct shape that doesn't generalise from Radarr/Sonarr, so they ship as separate sub-slices.

### Wizards migrated

| File | Before | After | Δ |
|---|---|---|---|
| `110-radarr.js` | 220 lines | 69 lines | **-69%** (2 dropdowns) |
| `120-sonarr.js` | 223 lines | 74 lines | **-67%** (3 dropdowns) |
| **Combined** | **443 lines** | **143 lines** | **-68%** |

### New module: `dropdownHelpers.js`

Three pure DOM utilities lifted out of the (now-deleted) duplicated copies in Radarr and Sonarr:

```js
resetDropdown(dropdown, placeholderText)
populateDropdown(elementId, data, valueField, textField, selectedValue, placeholderText)
setStatusMessageLines(element, messages)
```

**Kept separate from `createApiKeyValidator`** because dropdown population is orthogonal to credential validation — some wizards do one, some do both, some do neither. Folding them into the factory would muddy its single responsibility.

### Three factory extensions

All backward-compatible — the PR 1-3 wizards work unchanged with no opt-in.

#### 1. `onValidationSuccess(data)` callback

Fires AFTER a successful validate response, receiving the parsed response data. Runs AFTER the factory has set `validatedField='true'`, shown the success message, and disabled the validate button. Used by Radarr/Sonarr to populate dropdowns from `data.root_folders` etc.

#### 2. `onPreSubmit()` callback

Called on form submit BEFORE the normal empty-value normalisation. Return `false` to block via `event.preventDefault()`. Truthy / undefined / no-return all allow. Used by Radarr/Sonarr to require dropdown selections before allowing navigation.

#### 3. `revalidateOnLoad: boolean` (default false)

When `true` AND `validatedField === 'true'` on page load, the factory issues a **silent** re-POST to the endpoint and invokes `onValidationSuccess` with the result. No spinner, no status message, no button state changes. Used to repopulate post-validation state (dropdowns) when an already-validated user returns to the page.

Failures are **swallowed silently** — a transient network blip on page load should not spuriously flip `validatedField` to `false`. The user can re-click Validate to force a real validation cycle.

Guards: only fires if validatedField is true AND onValidationSuccess is provided AND credential + all additional fields are present.

### Example: 110-radarr.js (220 → 69 lines)

```js
import { createApiKeyValidator } from './modules/createApiKeyValidator.js'
import { populateDropdown, setStatusMessageLines } from './modules/dropdownHelpers.js'

function populateRadarrDropdowns (data) {
  populateDropdown('radarr_root_folder_path', data.root_folders, 'path', 'path',
    typeof initialRadarrRootFolderPath !== 'undefined' ? initialRadarrRootFolderPath : '')
  populateDropdown('radarr_quality_profile', data.quality_profiles, 'name', 'name',
    typeof initialRadarrQualityProfile !== 'undefined' ? initialRadarrQualityProfile : '')
}

function validateRadarrPage () {
  const validated = document.getElementById('radarr_validated').value.toLowerCase() === 'true'
  if (!validated) return true

  const errors = []
  if (!document.getElementById('radarr_root_folder_path').value) errors.push('Please select a valid Root Folder Path.')
  if (!document.getElementById('radarr_quality_profile').value) errors.push('Please select a valid Quality Profile.')
  if (typeof PathValidation !== 'undefined' && !PathValidation.validateAll()) {
    errors.push('Please fix invalid path fields before continuing.')
  }

  const status = document.getElementById('statusMessage')
  if (errors.length) {
    setStatusMessageLines(status, errors)
    status.style.color = '#ea868f'
    status.style.display = 'block'
    return false
  }
  status.style.display = 'none'
  return true
}

createApiKeyValidator({
  fieldId: 'radarr_token',
  additionalFieldIds: ['radarr_url'],
  validatedFieldId: 'radarr_validated',
  validatedAtFieldId: 'radarr_validated_at',
  endpoint: '/validate_radarr',
  buildPayload: (token, extras) => ({ radarr_url: extras.radarr_url, radarr_token: token }),
  messages: {
    empty: 'Please enter both Radarr URL and Token.',
    success: 'Radarr API key is valid.',
    failure: 'Failed to validate Radarr server. Please check your URL and Token.',
    networkError: 'Error validating Radarr'
  },
  onValidationSuccess: populateRadarrDropdowns,
  onPreSubmit: validateRadarrPage,
  revalidateOnLoad: true
})
```

### Test coverage

| Type | New | Total |
|---|---|---|
| Vitest (factory extensions) | +18 | |
| Vitest (dropdownHelpers — new module) | +19 | |
| **Vitest combined** | **+37** | **268** (was 231) |
| Playwright e2e (parametrized radarr/sonarr + 2 wizard-specific) | +4 | **19** (was 15) |

New Vitest tests cover:
- **`onValidationSuccess` (5)**: fires on success, NOT on failure/network-error, fires AFTER validatedField is set, optional
- **`onPreSubmit` (5)**: allow on true, block on false, sees normalised values, optional, only literal-`false` blocks (truthy/undefined allow)
- **`revalidateOnLoad` (8)**: fires when validated+true, doesn't fire when validatedField=false/option-off/no-onValidationSuccess/empty-credential/silent-valid=false, swallows network errors, shows no status message

New Playwright e2e tests:
- `test_dropdown_populating_wizard_success_flow` — **parametrised over radarr + sonarr**, asserts each dropdown gets populated with the expected option values from the mock response
- `test_radarr_pre_submit_blocks_navigation_when_dropdowns_unset` — dispatches a real submit event, asserts `event.defaultPrevented` AND the multi-error status message
- `test_radarr_revalidate_on_load_repopulates_dropdowns` — mutates DOM state to simulate "returning to a validated page", re-imports the wizard module with a cache buster, asserts the silent fetch fired and dropdown was repopulated

### Verification

| Check | Result |
|---|---|
| Vitest | **268/268 pass** (was 231; +37) |
| Python tests | 80/80 pass |
| Playwright e2e | **19/19 pass** (was 15; +4) |
| ESLint | 0 errors |
| pre-commit | 12/12 hooks green |

### Cumulative Step 6 progress

| PR | Status | Wizards | Lines |
|---|---|---|---|
| PR 1 (#1367) | merged | mdblist | 96 → 12 |
| PR 2 (#1368) | merged | github, omdb, notifiarr, apprise | 355 → 61 |
| PR 3 (#1369) | merged | tautulli, gotify, ntfy | 319 → 62 |
| **PR 4a (this)** | **open** | **radarr, sonarr** | **443 → 143** |
| PR 4b (next) | ⬜ | plex (response-extraction shape) | TBD |
| PR 4c (later) | ⬜ | tmdb (static-dropdown Next-button gating) | TBD |
| PR 4d (later) | ⬜ | trakt + mal (OAuth-PIN flow; separate helper module) | TBD |

**Running total after PR 4a**: 10 wizards converted, **1213 → 278 lines (-77%)**. One ~310-line factory + ~60-line `dropdownHelpers` module eliminating ~935 lines of duplicated wizard code.

## Related Issues

Roadmap: #1334 Step 6, PR 4a of 4 sub-slices

## Which Environment Did You Test On?

- [x] Local Install (Linux, Python 3.13, Vitest+jsdom, Playwright Chromium e2e)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
