### PR TITLE
Migrate Plex to createApiKeyValidator (#1334 Step 6 PR 4b)

### DIFF
--- a/static/local-js/010-plex.js
+++ b/static/local-js/010-plex.js
@@ -1,149 +1,102 @@
-import { setToggleButtonIcon, refreshValidationCallout } from './modules/validationPageBase.js'
+import { createApiKeyValidator } from './modules/createApiKeyValidator.js'
 
-const validateButton = document.getElementById('validateButton')
-const isValidated = document.getElementById('plex_validated').value.toLowerCase()
-const validatedAtInput = document.getElementById('plex_validated_at')
+// ── pre-config wizard init ──────────────────────────────────────────
+// The "hidden" section + plexDbCache element are revealed for users
+// who have already validated. Runs once at module load, before the
+// factory does its own initial-state wiring.
 const hiddenSection = document.getElementById('hidden')
 const plexDbCache = document.getElementById('plexDbCache')
-const plexTokenInput = document.getElementById('plex_token')
-const plexUrlInput = document.getElementById('plex_url')
-const toggleButton = document.getElementById('toggleApikeyVisibility')
 
-validateButton.disabled = (isValidated === 'true')
+;(function showSavedSectionsIfValidated () {
+  const validated = document.getElementById('plex_validated')?.value.toLowerCase() === 'true'
+  if (validated) {
+    if (hiddenSection) hiddenSection.style.display = 'block'
+    if (plexDbCache) plexDbCache.style.display = 'block'
+  }
+})()
 
-console.log('Validated: ' + isValidated)
-
-if (isValidated === 'true') {
-  hiddenSection.style.display = 'block'
-  plexDbCache.style.display = 'block'
-}
-
-// Set initial visibility based on token value
-if (plexTokenInput.value.trim() === '') {
-  plexTokenInput.setAttribute('type', 'text') // Show placeholder text
-  setToggleButtonIcon(toggleButton, true)
-} else {
-  plexTokenInput.setAttribute('type', 'password') // Hide actual token
-  setToggleButtonIcon(toggleButton, false)
-}
-
-// Enable validate button and reset validation when token or URL changes
-plexTokenInput.addEventListener('input', function () {
-  validateButton.disabled = false
-  document.getElementById('plex_validated').value = 'false'
-  if (validatedAtInput) validatedAtInput.value = ''
-  refreshValidationCallout('plex_validated')
-})
-
-plexUrlInput.addEventListener('input', function () {
-  validateButton.disabled = false
-  document.getElementById('plex_validated').value = 'false'
-  if (validatedAtInput) validatedAtInput.value = ''
-  refreshValidationCallout('plex_validated')
-})
-
-// Toggle password visibility
-document.getElementById('toggleApikeyVisibility').addEventListener('click', function () {
-  const apikeyInput = document.getElementById('plex_token')
-  const currentType = apikeyInput.getAttribute('type')
-  apikeyInput.setAttribute('type', currentType === 'password' ? 'text' : 'password')
-  setToggleButtonIcon(this, currentType === 'password')
-})
-
-// Plex validation script
-document.getElementById('validateButton').addEventListener('click', function () {
-  const plexUrl = document.getElementById('plex_url').value
-  const plexToken = document.getElementById('plex_token').value
-  const statusMessage = document.getElementById('statusMessage')
-  const currentDbCache = document.getElementById('plex_db_cache').value
-
-  if (!plexUrl || !plexToken) {
-    statusMessage.textContent = 'Please enter both Plex URL and Token.'
-    statusMessage.style.display = 'block'
-    return
+// ── post-validation success handler ──────────────────────────────────
+// Plex's response carries a LOT of extra state that needs to land in
+// hidden form fields + visible UI:
+//   - db_cache value (with mismatch warning if the user's input differs)
+//   - plex-pass status banners
+//   - user list + 3 library lists (movie / show / music) into hidden inputs
+function applyPlexResponse (data) {
+  // Plex-pass status banners. Only updated on a successful validate --
+  // the legacy code updated them unconditionally (so a failed validate
+  // would briefly show "no plex pass" even though no token was checked).
+  // That was a latent bug; preserving it would be slavish. The banners
+  // now ONLY reflect actual server responses.
+  const passSuccess = document.getElementById('plex-pass-status-success')
+  const passWarning = document.getElementById('plex-pass-status-warning')
+  if (passSuccess && passWarning) {
+    if (data.has_plex_pass) {
+      passSuccess.classList.remove('d-none')
+      passSuccess.style.display = 'block'
+      passWarning.classList.add('d-none')
+      passWarning.style.display = 'none'
+    } else {
+      passSuccess.classList.add('d-none')
+      passSuccess.style.display = 'none'
+      passWarning.classList.remove('d-none')
+      passWarning.style.display = 'block'
+    }
   }
 
-  document.getElementById('plex_validated').value = ''
-  const validatedAtField = document.getElementById('plex_validated_at')
-  if (validatedAtField) validatedAtField.value = ''
-  showSpinner('validate')
-  validateButton.disabled = true
+  // DB cache value + mismatch warning. Note: we capture currentDbCache
+  // at response time (not click time). The legacy code captured at
+  // click time, but the user almost never edits db_cache during the
+  // validate round-trip, and reading the latest value is arguably more
+  // correct (it reflects what the user actually wants right now).
+  const dbCacheInput = document.getElementById('plex_db_cache')
+  const currentDbCache = dbCacheInput ? dbCacheInput.value : ''
+  const serverDbCache = data.db_cache
 
-  fetch('/validate_plex', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ plex_url: plexUrl, plex_token: plexToken })
-  })
-    .then(response => response.json())
-    .then(data => {
-      const passSuccess = document.getElementById('plex-pass-status-success')
-      const passWarning = document.getElementById('plex-pass-status-warning')
+  if (plexDbCache) {
+    plexDbCache.textContent = 'Database cache value retrieved from server is: ' + serverDbCache + ' MB'
+    plexDbCache.style.color = '#75b798'
+    plexDbCache.style.display = 'block'
 
-      console.log('has_plex_pass:', data.has_plex_pass)
-      console.log('success div:', passSuccess)
-      console.log('warning div:', passWarning)
+    if (Number(currentDbCache) !== serverDbCache) {
+      plexDbCache.textContent += '.\nWarning: The value in the input box (' + currentDbCache + ' MB) does not match the value retrieved from the server (' + serverDbCache + ' MB).'
+      plexDbCache.style.color = '#ea868f'
+    }
+  }
+  if (dbCacheInput) dbCacheInput.value = serverDbCache
 
-      if (data.has_plex_pass) {
-        passSuccess.classList.remove('d-none')
-        passSuccess.style.display = 'block'
+  // Hidden tmp_ inputs that hold the lists for the next wizard pages.
+  const tmpUserList = document.getElementById('tmp_user_list')
+  const tmpMusicLibraries = document.getElementById('tmp_music_libraries')
+  const tmpMovieLibraries = document.getElementById('tmp_movie_libraries')
+  const tmpShowLibraries = document.getElementById('tmp_show_libraries')
+  if (tmpUserList) tmpUserList.value = data.user_list
+  if (tmpMusicLibraries) tmpMusicLibraries.value = data.music_libraries
+  if (tmpMovieLibraries) tmpMovieLibraries.value = data.movie_libraries
+  if (tmpShowLibraries) tmpShowLibraries.value = data.show_libraries
 
-        passWarning.classList.add('d-none')
-        passWarning.style.display = 'none'
-      } else {
-        passSuccess.classList.add('d-none')
-        passSuccess.style.display = 'none'
+  // Reveal the "hidden" section that holds the db_cache configuration.
+  if (hiddenSection) hiddenSection.style.display = 'block'
+}
 
-        passWarning.classList.remove('d-none')
-        passWarning.style.display = 'block'
-      }
-
-      if (data.validated) {
-        hideSpinner('validate')
-        validateButton.disabled = true
-        const serverDbCache = data.db_cache
-        plexDbCache.textContent = 'Database cache value retrieved from server is: ' + serverDbCache + ' MB'
-        plexDbCache.style.color = '#75b798'
-
-        document.getElementById('plex_validated').value = 'true'
-        if (validatedAtField) validatedAtField.value = new Date().toISOString()
-        refreshValidationCallout('plex_validated')
-
-        statusMessage.textContent = 'Plex server validated successfully!'
-        statusMessage.style.color = '#75b798'
-        hiddenSection.style.display = 'block'
-
-        if (Number(currentDbCache) !== serverDbCache) {
-          plexDbCache.textContent += '.\nWarning: The value in the input box (' + currentDbCache + ' MB) does not match the value retrieved from the server (' + serverDbCache + ' MB).'
-          plexDbCache.style.color = '#ea868f'
-        }
-
-        // Update the input field to match the server's db_cache value
-        document.getElementById('plex_db_cache').value = serverDbCache
-        document.getElementById('tmp_user_list').value = data.user_list
-        document.getElementById('tmp_music_libraries').value = data.music_libraries
-        document.getElementById('tmp_movie_libraries').value = data.movie_libraries
-        document.getElementById('tmp_show_libraries').value = data.show_libraries
-      } else {
-        hideSpinner('validate')
-        validateButton.disabled = false
-        document.getElementById('plex_validated').value = false
-        if (validatedAtField) validatedAtField.value = ''
-        refreshValidationCallout('plex_validated')
-        statusMessage.textContent = 'Failed to validate Plex server. Please check your URL and Token.'
-        statusMessage.style.color = '#ea868f'
-      }
-      statusMessage.style.display = 'block'
-    })
-    .catch(error => {
-      hideSpinner('validate')
-      console.error('Error:', error)
-      validateButton.disabled = false
-      statusMessage.textContent = 'Error occurred during validation.'
-      statusMessage.style.color = '#ea868f'
-      statusMessage.style.display = 'block'
-      if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout('plex_validated')
-    })
+createApiKeyValidator({
+  fieldId: 'plex_token',
+  additionalFieldIds: ['plex_url'],
+  validatedFieldId: 'plex_validated',
+  validatedAtFieldId: 'plex_validated_at',
+  endpoint: '/validate_plex',
+  buildPayload: (token, extras) => ({
+    plex_url: extras.plex_url,
+    plex_token: token
+  }),
+  messages: {
+    empty: 'Please enter both Plex URL and Token.',
+    success: 'Plex server validated successfully!',
+    failure: 'Failed to validate Plex server. Please check your URL and Token.',
+    networkError: 'Error occurred during validation.'
+  },
+  // Plex's server returns `{validated: true, ...}` on success but
+  // `{valid: false, error: '...'}` on failure (asymmetric naming
+  // preserved from the legacy API endpoint).
+  isValid: (data) => data.validated === true,
+  onValidationSuccess: applyPlexResponse
 })

--- a/static/local-js/modules/createApiKeyValidator.js
+++ b/static/local-js/modules/createApiKeyValidator.js
@@ -105,6 +105,12 @@ const DEFAULT_MESSAGES = {
  *                                               repopulate post-validation state (dropdowns etc.) when an
  *                                               already-validated user returns to the page. No user-facing
  *                                               status message is shown for this silent call.
+ * @param {(data: object) => boolean} [config.isValid]  Predicate that decides whether the server response
+ *                                               counts as a successful validation. Defaults to
+ *                                               `(data) => !!data.valid`. Override when the wizard's server
+ *                                               returns a different success marker (e.g. Plex returns
+ *                                               `data.validated` for success but `data.valid: false` on
+ *                                               failure -- asymmetric naming preserved from the legacy API).
  * @param {string} [config.spinnerKey='validate'] Argument passed to show/hideSpinner.
  */
 export function createApiKeyValidator (config) {
@@ -123,6 +129,7 @@ export function createApiKeyValidator (config) {
     onValidationSuccess,
     onPreSubmit,
     revalidateOnLoad = false,
+    isValid = (data) => !!data.valid,
     spinnerKey = 'validate'
   } = config
 
@@ -231,7 +238,7 @@ export function createApiKeyValidator (config) {
     })
       .then(response => response.json())
       .then(data => {
-        if (data.valid) {
+        if (isValid(data)) {
           validatedField.value = 'true'
           if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
           refreshValidationCallout(validatedFieldId)
@@ -284,7 +291,7 @@ export function createApiKeyValidator (config) {
       })
         .then(response => response.json())
         .then(data => {
-          if (data.valid) onValidationSuccess(data)
+          if (isValid(data)) onValidationSuccess(data)
         })
         .catch(() => { /* swallowed; see comment above */ })
     }

--- a/tests/e2e/test_wizard_e2e.py
+++ b/tests/e2e/test_wizard_e2e.py
@@ -518,3 +518,128 @@ def test_radarr_revalidate_on_load_repopulates_dropdowns(page, live_server):
     dropdown_values = page.locator("#radarr_root_folder_path").evaluate("el => Array.from(el.options).map(o => o.value)")
     assert "NO_MATCH_REVAL_FOLDER" in dropdown_values, f"expected revalidateOnLoad to repopulate dropdown; got {dropdown_values}"
     assert fetch_count["n"] >= 1, f"expected at least one silent fetch; got count={fetch_count['n']}"
+
+
+@pytest.mark.e2e
+def test_plex_validator_success_populates_extra_state(page, live_server):
+    """Plex's onValidationSuccess hook copies db_cache + 4 library lists
+    into hidden form inputs and reveals the "hidden" section. Verify
+    each piece of state lands where it should (#1334 Step 6 PR 4b).
+
+    Plex's response shape is asymmetric: success returns
+    `{validated: true, ...}` while failure returns `{valid: false, ...}`.
+    The factory's `isValid` option lets the wizard configure
+    `(data) => data.validated === true` for the success check.
+    """
+
+    def handle_validate(route):
+        route.fulfill(
+            status=200,
+            json={
+                "validated": True,
+                "db_cache": 1024,
+                "user_list": ["alice", "bob"],
+                "music_libraries": ["Music"],
+                "movie_libraries": ["Movies", "4K Movies"],
+                "show_libraries": ["TV", "Anime"],
+                "has_plex_pass": True,
+            },
+        )
+
+    page.route("**/validate_plex", handle_validate)
+    page.goto(f"{live_server}/step/010-plex", wait_until="domcontentloaded")
+
+    page.locator("#plex_url").fill("http://plex.local:32400")
+    page.locator("#plex_token").fill("some-token")
+    page.locator("#validateButton").click()
+
+    # Success status + validatedField flip + button disable.
+    expect(page.locator("#statusMessage")).to_contain_text("Plex server validated successfully!")
+    expect(page.locator("#plex_validated")).to_have_value("true")
+    expect(page.locator("#validateButton")).to_be_disabled()
+
+    # Hidden inputs populated by onValidationSuccess.
+    # The legacy code copies arrays-as-strings (.value = arrayLiteral)
+    # so the JS forms "alice,bob" etc. We just check that each value
+    # contains the expected entries (substring match is the contract).
+    user_list = page.locator("#tmp_user_list").evaluate("el => el.value")
+    assert "alice" in user_list and "bob" in user_list, f"unexpected user_list: {user_list!r}"
+    movie_libs = page.locator("#tmp_movie_libraries").evaluate("el => el.value")
+    assert "Movies" in movie_libs and "4K Movies" in movie_libs, f"unexpected movies: {movie_libs!r}"
+    show_libs = page.locator("#tmp_show_libraries").evaluate("el => el.value")
+    assert "TV" in show_libs and "Anime" in show_libs, f"unexpected shows: {show_libs!r}"
+    music_libs = page.locator("#tmp_music_libraries").evaluate("el => el.value")
+    assert "Music" in music_libs, f"unexpected music: {music_libs!r}"
+
+    # DB cache value pushed into the input.
+    expect(page.locator("#plex_db_cache")).to_have_value("1024")
+
+    # Plex Pass success banner visible, warning banner hidden.
+    expect(page.locator("#plex-pass-status-success")).to_be_visible()
+    expect(page.locator("#plex-pass-status-warning")).to_be_hidden()
+
+    # Hidden section revealed for further config.
+    expect(page.locator("#hidden")).to_be_visible()
+
+
+@pytest.mark.e2e
+def test_plex_validator_failure_uses_legacy_failure_message(page, live_server):
+    """Plex's failure path: server returns `{valid: false, error: '...'}`.
+    The factory's `isValid: (data) => data.validated === true` predicate
+    correctly treats this as a failure. The configured static failure
+    message is shown (not data.error -- the legacy plex wizard didn't
+    forward that field either).
+    """
+
+    def handle_validate(route):
+        route.fulfill(status=200, json={"valid": False, "error": "bad token"})
+
+    page.route("**/validate_plex", handle_validate)
+    page.goto(f"{live_server}/step/010-plex", wait_until="domcontentloaded")
+
+    page.locator("#plex_url").fill("http://plex.local")
+    page.locator("#plex_token").fill("badtoken")
+    page.locator("#validateButton").click()
+
+    expect(page.locator("#statusMessage")).to_contain_text("Failed to validate Plex server. Please check your URL and Token.")
+    expect(page.locator("#plex_validated")).to_have_value("false")
+
+
+@pytest.mark.e2e
+def test_plex_db_cache_mismatch_warning(page, live_server):
+    """When the user's db_cache input doesn't match what Plex reports,
+    the plexDbCache element shows a warning in error color appended to
+    the standard "value retrieved" message. Verifies the bespoke
+    mismatch-detection logic survives the migration.
+    """
+
+    def handle_validate(route):
+        # Server returns db_cache=2048 while the page's default input
+        # is something different (1024 from the dummy data).
+        route.fulfill(
+            status=200,
+            json={
+                "validated": True,
+                "db_cache": 2048,
+                "user_list": [],
+                "music_libraries": [],
+                "movie_libraries": [],
+                "show_libraries": [],
+                "has_plex_pass": False,
+            },
+        )
+
+    page.route("**/validate_plex", handle_validate)
+    page.goto(f"{live_server}/step/010-plex", wait_until="domcontentloaded")
+
+    # Force a mismatch: set the input to something other than 2048.
+    page.evaluate("document.getElementById('plex_db_cache').value = '999'")
+    page.locator("#plex_url").fill("http://plex.local")
+    page.locator("#plex_token").fill("sometoken")
+    page.locator("#validateButton").click()
+
+    # The plexDbCache element should now contain the mismatch warning.
+    expect(page.locator("#plexDbCache")).to_contain_text("Database cache value retrieved from server is: 2048 MB")
+    expect(page.locator("#plexDbCache")).to_contain_text("Warning: The value in the input box (999 MB) does not match the value retrieved from the server (2048 MB).")
+    # And the input value should now be overwritten with the server's value.
+    expect(page.locator("#plex_db_cache")).to_have_value("2048")

--- a/tests/js/modules/createApiKeyValidator.test.js
+++ b/tests/js/modules/createApiKeyValidator.test.js
@@ -957,6 +957,108 @@ describe('createApiKeyValidator revalidateOnLoad', () => {
   })
 })
 
+describe('createApiKeyValidator isValid predicate', () => {
+  // The factory's success check is configurable via the `isValid`
+  // option. Default predicate is `(data) => !!data.valid`. Override
+  // when the wizard's server returns a different success marker --
+  // most notably Plex, whose successful response uses `data.validated`
+  // (boolean) but whose failure response uses `data.valid: false`
+  // (asymmetric naming preserved from the legacy API).
+
+  it('uses the default predicate when isValid is not provided', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ valid: true })
+    })))
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    createApiKeyValidator(defaultConfig())
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(document.getElementById('test_validated').value).toBe('true')
+  })
+
+  it('treats a custom predicate returning true as success', async () => {
+    // Mimics Plex: server returns { validated: true, ... } on success.
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ validated: true, db_cache: 1024 })
+    })))
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    createApiKeyValidator(defaultConfig({
+      isValid: (data) => data.validated === true
+    }))
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(document.getElementById('test_validated').value).toBe('true')
+  })
+
+  it('treats a custom predicate returning false as failure', async () => {
+    // Mimics Plex: server returns { valid: false, error: '...' } on failure.
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ valid: false, error: 'bad token' })
+    })))
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    createApiKeyValidator(defaultConfig({
+      isValid: (data) => data.validated === true
+    }))
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(document.getElementById('test_validated').value).toBe('false')
+  })
+
+  it('isValid is consulted by the silent revalidateOnLoad fetch too', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ validated: true, db_cache: 1024 })
+    })))
+    const onSuccess = vi.fn()
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey', validated: 'true' })
+    createApiKeyValidator(defaultConfig({
+      isValid: (data) => data.validated === true,
+      revalidateOnLoad: true,
+      onValidationSuccess: onSuccess
+    }))
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(onSuccess).toHaveBeenCalledWith({ validated: true, db_cache: 1024 })
+  })
+
+  it('silent revalidateOnLoad does NOT invoke callback when isValid rejects', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ valid: false, error: 'token expired' })
+    })))
+    const onSuccess = vi.fn()
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey', validated: 'true' })
+    createApiKeyValidator(defaultConfig({
+      isValid: (data) => data.validated === true,
+      revalidateOnLoad: true,
+      onValidationSuccess: onSuccess
+    }))
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+
+  it('predicate receives the full server response object', async () => {
+    let receivedData = null
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      json: () => Promise.resolve({ status: 'ok', some_field: 'whatever', nested: { x: 1 } })
+    })))
+    document.body.innerHTML = buildBaseHTML({ keyValue: 'mykey' })
+    createApiKeyValidator(defaultConfig({
+      isValid: (data) => {
+        receivedData = data
+        return data.status === 'ok'
+      }
+    }))
+    document.getElementById('validateButton').click()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(receivedData).toEqual({ status: 'ok', some_field: 'whatever', nested: { x: 1 } })
+    expect(document.getElementById('test_validated').value).toBe('true')
+  })
+})
+
 describe('createApiKeyValidator validate click — network error', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('boom'))))


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix
- [x] Feature/Tweak (1 wizard migration + 1 small factory extension; one minor behaviour difference)
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Other

## Description

Roadmap issue #1334 **Step 6 (validation widget refactor) — PR 4b of 4 sub-slices**.

Migrates **010-plex** to `createApiKeyValidator`. Adds one focused factory option (`isValid` predicate) to handle Plex's asymmetric server response shape.

### Wizard migrated

| File | Before | After | Δ |
|---|---|---|---|
| `010-plex.js` | 149 lines | 102 lines | **-32%** |

Smaller percentage than prior PRs because Plex has the most wizard-specific response-extraction in the suite (db_cache value + mismatch warning, plex-pass status banners, 4 library lists into hidden inputs). What's **gone** is the duplicated credential infrastructure (show/hide toggle, input listeners, fetch, validated bookkeeping); what **stays** is the legitimately-Plex-specific glue.

### Factory extension: `isValid` predicate

Plex's `/validate_plex` endpoint has an **asymmetric response shape**:

```
Success: { "validated": true, "db_cache": ..., ... }
Failure: { "valid":     false, "error": "..." }
```

Every other wizard's endpoint uses `"valid": true|false` for both. The legacy plex JS read `data.validated`. To preserve that after migration:

```js
isValid: (data) => data.validated === true
```

Default is `(data) => !!data.valid`, so all 10 previously-migrated wizards work unchanged with no opt-in.

The predicate is consulted by **both the validate-click path and the silent `revalidateOnLoad` path** — a Plex wizard with revalidateOnLoad would correctly not invoke `onValidationSuccess` if the server returned a failure shape on silent re-check.

+6 Vitest tests covering: default predicate behaviour, true/false return values, full data object passed in, integration with revalidateOnLoad in both success and failure cases.

### Plex-specific glue (kept in the wizard, not the factory)

- **Pre-config IIFE** — reveals the "hidden" + "plexDbCache" elements on page load if already validated.

- **`applyPlexResponse(data)`** (called via `onValidationSuccess`):
  - **Plex Pass banner toggle** — shows the success/warning banner based on `data.has_plex_pass`. **Behavioural difference vs legacy**: the banner toggle used to fire on EVERY response (including failures), which would briefly flash "no plex pass" when validation failed even though no token had been checked. That was a latent bug. The new code only updates the banner inside the success branch. **Not a regression** — it eliminates a misleading flash, doesn't introduce one.
  - **db_cache value + mismatch warning** — unconditional "value retrieved" message on success; if the user's input differs, a warning is appended and color switches to error red. Input then gets overwritten with server value.
  - **4 hidden `tmp_*` inputs** populated for subsequent wizard pages (user_list, music/movie/show libraries).
  - **"hidden" section** revealed.

**Behavioural note**: legacy captured the user's `db_cache` input value at click time; new code reads it at response time. The window where these would differ is 1-2 seconds of HTTP round-trip, and editing a numeric `db_cache` value mid-validate is realistically nonexistent.

### Test coverage

| Type | New | Total |
|---|---|---|
| Vitest (isValid predicate) | +6 | **274** (was 268) |
| Playwright e2e (Plex success / failure / mismatch warning) | +3 | **22** (was 19) |

New Playwright tests:
- **`test_plex_validator_success_populates_extra_state`** — mocks a full success response, asserts every piece of extracted state (status, validated flip, button disable, 4 hidden tmp_* inputs, db_cache value, both Plex Pass banners, hidden section reveal)
- **`test_plex_validator_failure_uses_legacy_failure_message`** — mocks the asymmetric failure shape (`data.valid: false`), verifies the `isValid` predicate treats it as a failure with the static message
- **`test_plex_db_cache_mismatch_warning`** — sets db_cache input to a non-matching value, verifies the mismatch warning appears AND the input gets overwritten with the server value

### Verification

| Check | Result |
|---|---|
| Vitest | **274/274 pass** (was 268; +6 isValid tests) |
| Python tests | 80/80 pass |
| Playwright e2e | **22/22 pass** (was 19; +3 Plex tests) |
| ESLint | 0 errors |
| pre-commit | 12/12 hooks green |

### Cumulative Step 6 progress

| PR | Status | Wizards | Lines |
|---|---|---|---|
| PR 1 (#1367) | merged | mdblist | 96 → 12 |
| PR 2 (#1368) | merged | github, omdb, notifiarr, apprise | 355 → 61 |
| PR 3 (#1369) | merged | tautulli, gotify, ntfy | 319 → 62 |
| PR 4a (#1370) | merged | radarr, sonarr | 443 → 143 |
| **PR 4b (this)** | **open** | **plex** | **149 → 102** |
| PR 4c (next) | ⬜ | tmdb (static-dropdown gating) | TBD |
| PR 4d (later) | ⬜ | trakt + mal (OAuth-PIN; separate module) | TBD |

**Running total after PR 4b**: 11 wizards converted, **1362 → 380 lines (-72%)**. One ~320-line factory + ~60-line `dropdownHelpers` module eliminating ~980 lines of duplicated wizard code.

## Related Issues

Roadmap: #1334 Step 6, PR 4b of 4 sub-slices

## Which Environment Did You Test On?

- [x] Local Install (Linux, Python 3.13, Vitest+jsdom, Playwright Chromium e2e)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
