### PR TITLE
Update gap analyser script

### DIFF
--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -147,6 +147,11 @@ LIBRARY_OVERLAY_ONLY_KEYS = {
     "back_color",
     "back_line_color",
 }
+INTERNAL_OVERLAY_TEMPLATE_KEYS = {
+    "final_horizontal_offset",
+    "final_vertical_offset",
+    "final_name",
+}
 
 
 def json_default(value: Any) -> Any:
@@ -961,6 +966,55 @@ def key_is_valid_for_default(key: str, default_files: list[Path]) -> tuple[bool,
                 matched.append(path)
                 break
     return bool(matched), matched
+
+
+@lru_cache(maxsize=None)
+def default_file_uses_dynamic_collections(path: Path) -> bool:
+    try:
+        parsed, _encoding = load_yaml(path)
+    except Exception:
+        return False
+    return isinstance(parsed, dict) and isinstance(parsed.get("dynamic_collections"), dict)
+
+
+def resolve_matched_default_file_paths(row: dict[str, Any]) -> list[Path]:
+    matched_paths = row.get("matched_default_files")
+    if not isinstance(matched_paths, (list, set, tuple)):
+        return []
+    defaults_root = ROOT / "config" / "kometa" / "defaults"
+    resolved: list[Path] = []
+    for raw_path in matched_paths:
+        if not raw_path:
+            continue
+        path = defaults_root / str(raw_path)
+        if path.is_file():
+            resolved.append(path)
+    return resolved
+
+
+def is_dynamic_collection_child_instance_key(row: dict[str, Any]) -> bool:
+    key = str(row.get("key") or "")
+    if not key:
+        return False
+    for path in resolve_matched_default_file_paths(row):
+        if not default_file_uses_dynamic_collections(path):
+            continue
+        for pattern in patterns_from_default_file(path):
+            if key == pattern or not PLACEHOLDER_RE.search(pattern):
+                continue
+            if key_matches_pattern(key, pattern):
+                return True
+    return False
+
+
+def get_structural_finding_exclusion(row: dict[str, Any]) -> str | None:
+    kind = str(row.get("kind") or "")
+    key = str(row.get("key") or "")
+    if kind == "overlay" and key in INTERNAL_OVERLAY_TEMPLATE_KEYS:
+        return "internal_overlay_finalizer_key_not_user_facing"
+    if is_dynamic_collection_child_instance_key(row):
+        return "dynamic_collection_child_instance_key_not_ranked"
+    return None
 
 
 def classify_validation_level(
@@ -2239,6 +2293,9 @@ QUICKSTART_RECOMMENDATION_EXCLUSIONS: dict[tuple[str, str], str] = {
 
 
 def get_quickstart_recommendation_exclusion(row: dict[str, Any]) -> str | None:
+    structural_reason = get_structural_finding_exclusion(row)
+    if structural_reason:
+        return structural_reason
     kind = str(row.get("kind") or "")
     key = str(row.get("key") or "")
     if kind == "library" and key in LIBRARY_OVERLAY_ONLY_KEYS:
@@ -2254,6 +2311,9 @@ MERGED_FIX_QUEUE_EXCLUSIONS: dict[tuple[str, str], str] = {
 
 
 def get_merged_fix_queue_exclusion(row: dict[str, Any]) -> str | None:
+    structural_reason = get_structural_finding_exclusion(row)
+    if structural_reason:
+        return structural_reason
     kind = str(row.get("kind") or "")
     key = str(row.get("key") or "")
     return MERGED_FIX_QUEUE_EXCLUSIONS.get((kind, key))
@@ -2397,7 +2457,7 @@ def build_merged_fix_queue(
                 "needs_schema_support": False,
                 "needs_quickstart_support": False,
                 "needs_importer_support": False,
-                "quickstart_exclusion_reason": get_quickstart_recommendation_exclusion({"kind": kind, "key": key}),
+                "quickstart_exclusion_reason": None,
             },
         )
 
@@ -2410,6 +2470,8 @@ def build_merged_fix_queue(
         bucket["verified_files"].update(str(path) for path in item.get("files", []) if path)
         bucket["libraries"].update(str(lib) for lib in item.get("libraries", []) if lib)
         bucket["matched_default_files"].update(str(path) for path in item.get("matched_default_files", []) if path)
+        if not bucket["quickstart_exclusion_reason"]:
+            bucket["quickstart_exclusion_reason"] = get_quickstart_recommendation_exclusion(item)
         if item.get("validation_level"):
             bucket["validation_levels"].add(str(item.get("validation_level")))
         if item.get("kometa_declared") and not item.get("schema_declared"):

--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -540,13 +540,13 @@ def collect_overlay_runtime_aliases(overlay: dict[str, Any]) -> set[str]:
 
     oid = overlay.get("id")
     if oid:
-        aliases.add(str(oid).replace("overlay_", "", 1))
+        aliases.add(str(oid).replace("overlay_", "", 1).strip().lower())
 
     source_overrides = overlay.get("source_overrides")
     if isinstance(source_overrides, dict):
         fixed_key = source_overrides.get("fixed_key")
         if isinstance(fixed_key, str) and fixed_key.strip():
-            aliases.add(fixed_key.strip())
+            aliases.add(fixed_key.strip().lower())
 
     return aliases
 
@@ -663,7 +663,7 @@ def build_qs_overlay_map(qs_overlays_path: Path, *, enrich_runtime_support: bool
 
 
 def overlay_key_supported_in_quickstart(alias: str | None, key: str, qs_overlays: dict[str, set[str]]) -> bool:
-    alias_text = str(alias or "")
+    alias_text = str(alias or "").strip().lower()
     if key in qs_overlays.get(alias_text, set()):
         return True
 
@@ -748,6 +748,14 @@ def resolve_default_paths(alias: str, kind: str, kometa_defaults: Path) -> list[
         path = kometa_defaults / "overlays" / f"{alias}.yml"
         if path.exists():
             support_files.append(path)
+        else:
+            alias_lower = str(alias or "").strip().lower()
+            overlays_dir = kometa_defaults / "overlays"
+            if alias_lower and overlays_dir.is_dir():
+                for candidate in overlays_dir.glob("*.yml"):
+                    if candidate.stem.strip().lower() == alias_lower:
+                        support_files.append(candidate)
+                        break
         return support_files
     if kind == "playlist":
         path = kometa_defaults / "playlist.yml"
@@ -2494,7 +2502,8 @@ def build_merged_fix_queue(
         for reason in item.get("reasons", []):
             if reason:
                 bucket["importer_reasons"].add(str(reason))
-        if item.get("import_status") != "mapped" and not bucket["quickstart_exclusion_reason"]:
+        has_verified_support_signal = bucket["verified_occurrences"] > 0 or bool(bucket["matched_default_files"])
+        if item.get("import_status") != "mapped" and has_verified_support_signal and not bucket["quickstart_exclusion_reason"]:
             bucket["needs_importer_support"] = True
 
     ranked: list[dict[str, Any]] = []

--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -30,7 +30,7 @@ try:
 except ImportError:
     py7zr = None
 
-CACHE_VERSION = 4
+CACHE_VERSION = 5
 CACHE_SAVE_EVERY_ITEMS = 1000
 CACHE_SAVE_EVERY_SECS = 60.0
 VERIFY_CHECKPOINT_VERSION = 2
@@ -41,6 +41,8 @@ ARCHIVE_CACHE_VERSION = 1
 ARCHIVE_CACHE_DIRNAME = "template_gap_archive_cache"
 QS_SPECIAL_LIBRARY_TEMPLATE_KEYS = {
     "placeholder_imdb_id",
+    "placeholder_tmdb_movie",
+    "placeholder_tvdb_show",
     "sep_style",
 }
 QS_SPECIAL_GLOBAL_SUPPORTED_KEYS = {
@@ -122,6 +124,29 @@ PROBABLE_ARTIFACT_PATH_PARTS = {
     "fromdownloads",
 }
 YAML_SUFFIXES = {".yml", ".yaml"}
+QUICKSTART_SAMPLE_CONFIG_FILENAMES = {
+    "prototype_config.yml",
+    "prototype_comprehensive.yml",
+    "kitchen_sink_config.yml",
+}
+QUICKSTART_SAMPLE_CONFIG_PATH_PARTS = {
+    "json-schema",
+    "quickstart-development",
+}
+LIBRARY_OVERLAY_ONLY_KEYS = {
+    "horizontal_align",
+    "vertical_align",
+    "horizontal_offset",
+    "vertical_offset",
+    "back_width",
+    "back_height",
+    "back_padding",
+    "back_radius",
+    "back_line_width",
+    "back_align",
+    "back_color",
+    "back_line_color",
+}
 
 
 def json_default(value: Any) -> Any:
@@ -221,6 +246,17 @@ def is_probable_non_config_artifact(path: Path) -> bool:
     if lower_parts.intersection(PROBABLE_ARTIFACT_PATH_PARTS) and filename.lower().startswith("parsed_"):
         return True
     return False
+
+
+def is_quickstart_sample_config(path: Path) -> bool:
+    normalized = str(path).replace("\\", "/")
+    parts = [part.lower() for part in normalized.split("/") if part]
+    if not parts:
+        return False
+    filename = parts[-1]
+    if filename not in QUICKSTART_SAMPLE_CONFIG_FILENAMES:
+        return False
+    return any(part in QUICKSTART_SAMPLE_CONFIG_PATH_PARTS for part in parts[:-1])
 
 
 def load_json(path: Path) -> Any:
@@ -494,6 +530,35 @@ def collect_qs_keys(raw: Any) -> set[str]:
     return keys
 
 
+def collect_overlay_runtime_aliases(overlay: dict[str, Any]) -> set[str]:
+    aliases: set[str] = set()
+
+    oid = overlay.get("id")
+    if oid:
+        aliases.add(str(oid).replace("overlay_", "", 1))
+
+    source_overrides = overlay.get("source_overrides")
+    if isinstance(source_overrides, dict):
+        fixed_key = source_overrides.get("fixed_key")
+        if isinstance(fixed_key, str) and fixed_key.strip():
+            aliases.add(fixed_key.strip())
+
+    return aliases
+
+
+def collect_overlay_source_override_keys(source_overrides: Any) -> set[str]:
+    keys: set[str] = set()
+    if not isinstance(source_overrides, dict):
+        return keys
+
+    source_types = source_overrides.get("source_types")
+    if isinstance(source_types, list):
+        for source_type in source_types:
+            if isinstance(source_type, str) and source_type.strip():
+                keys.add(source_type.strip())
+    return keys
+
+
 def collect_declared_yaml_patterns(raw: Any, *, parent_key: str | None = None) -> set[str]:
     patterns: set[str] = set()
     if isinstance(raw, dict):
@@ -550,8 +615,8 @@ def build_qs_overlay_map(qs_overlays_path: Path, *, enrich_runtime_support: bool
             oid = overlay.get("id")
             if not oid:
                 continue
-            alias = str(oid).replace("overlay_", "", 1)
             keys = collect_qs_keys(overlay.get("template_variables"))
+            keys.update(collect_overlay_source_override_keys(overlay.get("source_overrides")))
 
             if enrich_runtime_support:
                 # Quickstart injects horizontal/vertical offset controls at render time
@@ -587,7 +652,8 @@ def build_qs_overlay_map(qs_overlays_path: Path, *, enrich_runtime_support: bool
             # Some Quickstart defaults intentionally reuse the same alias for
             # different media types. Merge their declared keys so later entries
             # do not erase earlier support and create false-positive gaps.
-            mapping.setdefault(alias, set()).update(keys)
+            for alias in collect_overlay_runtime_aliases(overlay):
+                mapping.setdefault(alias, set()).update(keys)
     return mapping
 
 
@@ -595,6 +661,11 @@ def overlay_key_supported_in_quickstart(alias: str | None, key: str, qs_overlays
     alias_text = str(alias or "")
     if key in qs_overlays.get(alias_text, set()):
         return True
+
+    source_override_prefixes = ("file", "url", "git", "repo")
+    for prefix in source_override_prefixes:
+        if key.startswith(f"{prefix}_") and prefix in qs_overlays.get(alias_text, set()):
+            return True
 
     # Quickstart models subtitle language flags as a dedicated overlay alias,
     # while user configs legitimately express that selection as
@@ -1778,6 +1849,25 @@ def prefilter_yaml_files(
                 checkpoint_callback(idx, total_files)
             continue
         stats["cache_misses"] += 1
+        if yaml_type_focus == "config" and is_quickstart_sample_config(path):
+            skip_record = {
+                "file": str(path),
+                "error_type": "IgnoredSampleConfig",
+                "reason": "known Quickstart schema sample config",
+                "detail": f"IgnoredSampleConfig: {path.name}",
+                "stage": "prefilter",
+                "noise": True,
+                "noise_reason": "quickstart_sample_config",
+            }
+            skipped_files.append(skip_record)
+            stats["artifact_skips"] += 1
+            if isinstance(files_cache, dict):
+                files_cache[cache_key] = {"signature": signature, "prefilter_skip": skip_record, "contains_relevant_yaml": False}
+            if progress_callback:
+                progress_callback(idx, total_files, len(candidate_files), len(skipped_files), path)
+            if checkpoint_callback:
+                checkpoint_callback(idx, total_files)
+            continue
         try:
             raw_text, encoding_used = read_text_with_fallbacks(path)
         except Exception as exc:
@@ -2151,6 +2241,8 @@ QUICKSTART_RECOMMENDATION_EXCLUSIONS: dict[tuple[str, str], str] = {
 def get_quickstart_recommendation_exclusion(row: dict[str, Any]) -> str | None:
     kind = str(row.get("kind") or "")
     key = str(row.get("key") or "")
+    if kind == "library" and key in LIBRARY_OVERLAY_ONLY_KEYS:
+        return "overlay_rendering_key_misclassified_at_library_scope"
     return QUICKSTART_RECOMMENDATION_EXCLUSIONS.get((kind, key))
 
 
@@ -2305,7 +2397,7 @@ def build_merged_fix_queue(
                 "needs_schema_support": False,
                 "needs_quickstart_support": False,
                 "needs_importer_support": False,
-                "quickstart_exclusion_reason": QUICKSTART_RECOMMENDATION_EXCLUSIONS.get((kind, key)),
+                "quickstart_exclusion_reason": get_quickstart_recommendation_exclusion({"kind": kind, "key": key}),
             },
         )
 

--- a/tests/test_template_gap_analyzer.py
+++ b/tests/test_template_gap_analyzer.py
@@ -205,6 +205,17 @@ def test_overlay_key_supported_in_quickstart_uses_direct_alias_match_when_availa
     assert module.overlay_key_supported_in_quickstart("ratings", "rating3_image", qs_overlays) is True
 
 
+def test_overlay_key_supported_in_quickstart_is_case_insensitive_for_overlay_aliases():
+    module = _load_gap_analyzer_module()
+
+    qs_overlays = {
+        "status": {"horizontal_align", "vertical_align", "horizontal_offset", "vertical_offset"},
+    }
+
+    assert module.overlay_key_supported_in_quickstart("Status", "horizontal_align", qs_overlays) is True
+    assert module.overlay_key_supported_in_quickstart("STATUS", "vertical_offset", qs_overlays) is True
+
+
 def test_overlay_key_supported_in_quickstart_accepts_prefixed_source_override_keys():
     module = _load_gap_analyzer_module()
 
@@ -550,6 +561,15 @@ def test_resolve_default_paths_for_collection_does_not_cross_into_overlay_defaul
     assert any(path.parts[-2:] == ("show", "network.yml") for path in network_defaults)
     assert module.key_is_valid_for_default("horizontal_align", network_defaults)[0] is False
     assert module.key_is_valid_for_default("vertical_align", network_defaults)[0] is False
+
+
+def test_resolve_default_paths_for_overlays_is_case_insensitive():
+    module = _load_gap_analyzer_module()
+    kometa_defaults = _kometa_defaults_root()
+
+    status_defaults = module.resolve_default_paths("Status", "overlay", kometa_defaults)
+
+    assert any(path.name.lower() == "status.yml" for path in status_defaults)
 
 
 def test_classify_yaml_document_type_distinguishes_config_and_external_yaml():
@@ -1026,6 +1046,29 @@ def test_build_merged_fix_queue_suppresses_excluded_quickstart_only_keys():
     assert len(ranked) == 1
     assert ranked[0]["key"] == "horizontal_align"
     assert ranked[0]["action_targets"] == ["importer"]
+
+
+def test_build_merged_fix_queue_suppresses_importer_only_rows_without_verified_default_support():
+    module = _load_gap_analyzer_module()
+
+    verified_rows = []
+    importer_rows = [
+        {
+            "kind": "overlay",
+            "default": "ratings",
+            "key": "horizontal_align",
+            "import_status": "unmapped",
+            "reason_class": "missing_template_variable_support",
+            "occurrences": 3,
+            "files": ["config.yml"],
+            "libraries": ["Movies"],
+            "reasons": ["Template variable not available in Quickstart."],
+        }
+    ]
+
+    ranked = module.build_merged_fix_queue(verified_rows, importer_rows)
+
+    assert ranked == []
 
 
 def test_quickstart_recommendation_summary_excludes_overlay_style_keys_misclassified_as_library_scope():

--- a/tests/test_template_gap_analyzer.py
+++ b/tests/test_template_gap_analyzer.py
@@ -1113,6 +1113,187 @@ def test_build_merged_fix_queue_excludes_overlay_style_keys_misclassified_as_lib
     assert ranked == []
 
 
+def test_quickstart_recommendation_summary_excludes_internal_overlay_finalizer_keys():
+    module = _load_gap_analyzer_module()
+
+    rows = [
+        {
+            "kind": "overlay",
+            "default": "resolution",
+            "key": "final_horizontal_offset",
+            "file": "config.yml",
+            "library": "Movies",
+            "matched_default_files": ["overlays/resolution.yml"],
+            "supported_in_quickstart": False,
+            "quickstart_declared": False,
+            "schema_declared": False,
+            "kometa_declared": True,
+            "validation_level": "works_in_kometa_missing_from_quickstart_and_schema",
+            "name_verified": True,
+            "value_shape_verified": True,
+            "value_shape_rule": "number",
+        }
+    ]
+
+    summary = module.build_quickstart_recommendation_summary(rows)
+    excluded = module.build_quickstart_recommendation_exclusion_summary(rows)
+
+    assert summary == {}
+    assert excluded[("overlay", "resolution", "final_horizontal_offset")]["reason"] == "internal_overlay_finalizer_key_not_user_facing"
+
+
+def test_quickstart_recommendation_summary_excludes_dynamic_collection_child_instance_keys_but_keeps_real_family_keys():
+    module = _load_gap_analyzer_module()
+
+    rows = [
+        {
+            "kind": "collection",
+            "default": "seasonal",
+            "key": "trakt_list_christmas",
+            "file": "config.yml",
+            "library": "Movies",
+            "matched_default_files": ["movie/seasonal.yml"],
+            "supported_in_quickstart": False,
+            "quickstart_declared": False,
+            "schema_declared": False,
+            "kometa_declared": True,
+            "validation_level": "works_in_kometa_missing_from_quickstart_and_schema",
+            "name_verified": True,
+            "value_shape_verified": True,
+            "value_shape_rule": "string",
+        },
+        {
+            "kind": "collection",
+            "default": "franchise",
+            "key": "movie_645",
+            "file": "config.yml",
+            "library": "Movies",
+            "matched_default_files": ["movie/franchise.yml"],
+            "supported_in_quickstart": False,
+            "quickstart_declared": False,
+            "schema_declared": False,
+            "kometa_declared": True,
+            "validation_level": "works_in_kometa_missing_from_quickstart_and_schema",
+            "name_verified": True,
+            "value_shape_verified": True,
+            "value_shape_rule": "dynamic",
+        },
+        {
+            "kind": "collection",
+            "default": "franchise",
+            "key": "title_override",
+            "file": "config.yml",
+            "library": "Movies",
+            "matched_default_files": ["movie/franchise.yml"],
+            "supported_in_quickstart": False,
+            "quickstart_declared": False,
+            "schema_declared": False,
+            "kometa_declared": True,
+            "validation_level": "works_in_kometa_missing_from_quickstart_and_schema",
+            "name_verified": True,
+            "value_shape_verified": True,
+            "value_shape_rule": "dynamic",
+        },
+    ]
+
+    summary = module.build_quickstart_recommendation_summary(rows)
+    ranked = module.serialize_ranked_summary(summary)
+    excluded = module.build_quickstart_recommendation_exclusion_summary(rows)
+
+    assert [item["key"] for item in ranked] == ["title_override"]
+    assert excluded[("collection", "seasonal", "trakt_list_christmas")]["reason"] == "dynamic_collection_child_instance_key_not_ranked"
+    assert excluded[("collection", "franchise", "movie_645")]["reason"] == "dynamic_collection_child_instance_key_not_ranked"
+
+
+def test_build_merged_fix_queue_excludes_internal_and_dynamic_instance_false_positives():
+    module = _load_gap_analyzer_module()
+
+    verified_rows = [
+        {
+            "kind": "overlay",
+            "default": "resolution",
+            "key": "final_vertical_offset",
+            "occurrences": 8,
+            "files": ["config.yml"],
+            "libraries": ["Movies"],
+            "matched_default_files": ["overlays/resolution.yml"],
+            "supported_in_quickstart": False,
+            "quickstart_declared": False,
+            "schema_declared": False,
+            "kometa_declared": True,
+            "validation_level": "works_in_kometa_missing_from_quickstart_and_schema",
+        },
+        {
+            "kind": "collection",
+            "default": "seasonal",
+            "key": "trakt_list_halloween",
+            "occurrences": 5,
+            "files": ["config.yml"],
+            "libraries": ["Movies"],
+            "matched_default_files": ["movie/seasonal.yml"],
+            "supported_in_quickstart": False,
+            "quickstart_declared": False,
+            "schema_declared": False,
+            "kometa_declared": True,
+            "validation_level": "works_in_kometa_missing_from_quickstart_and_schema",
+        },
+        {
+            "kind": "collection",
+            "default": "franchise",
+            "key": "build_collection",
+            "occurrences": 4,
+            "files": ["config.yml"],
+            "libraries": ["Movies"],
+            "matched_default_files": ["movie/franchise.yml"],
+            "supported_in_quickstart": False,
+            "quickstart_declared": False,
+            "schema_declared": False,
+            "kometa_declared": True,
+            "validation_level": "works_in_kometa_missing_from_quickstart_and_schema",
+        },
+    ]
+    importer_rows = [
+        {
+            "kind": "overlay",
+            "default": "resolution",
+            "key": "final_vertical_offset",
+            "import_status": "unmapped",
+            "reason_class": "missing_template_variable_support",
+            "occurrences": 8,
+            "files": ["config.yml"],
+            "libraries": ["Movies"],
+            "reasons": ["Template variable not available in Quickstart."],
+        },
+        {
+            "kind": "collection",
+            "default": "seasonal",
+            "key": "trakt_list_halloween",
+            "import_status": "unmapped",
+            "reason_class": "missing_template_variable_support",
+            "occurrences": 5,
+            "files": ["config.yml"],
+            "libraries": ["Movies"],
+            "reasons": ["Template variable not available in Quickstart."],
+        },
+        {
+            "kind": "collection",
+            "default": "franchise",
+            "key": "build_collection",
+            "import_status": "unmapped",
+            "reason_class": "missing_template_variable_support",
+            "occurrences": 4,
+            "files": ["config.yml"],
+            "libraries": ["Movies"],
+            "reasons": ["Template variable not available in Quickstart."],
+        },
+    ]
+
+    ranked = module.build_merged_fix_queue(verified_rows, importer_rows)
+
+    assert [item["key"] for item in ranked] == ["build_collection"]
+    assert ranked[0]["action_targets"] == ["schema", "quickstart", "importer"]
+
+
 def test_build_merged_fix_queue_excludes_internal_library_type_metadata():
     module = _load_gap_analyzer_module()
 

--- a/tests/test_template_gap_analyzer.py
+++ b/tests/test_template_gap_analyzer.py
@@ -129,6 +129,27 @@ def test_build_qs_overlay_map_includes_runtime_offset_and_alignment_keys_for_rep
     assert "vertical_offset" in overlay_map["status"]
 
 
+def test_build_qs_overlay_map_includes_source_override_types_for_repo_file():
+    module = _load_gap_analyzer_module()
+    qs_overlays = Path(__file__).resolve().parents[1] / "static" / "json" / "quickstart_overlays.json"
+
+    overlay_map = module.build_qs_overlay_map(qs_overlays)
+
+    assert {"file", "url", "git", "repo"} <= overlay_map["resolution"]
+    assert {"file", "url", "git", "repo"} <= overlay_map["audio_codec"]
+    assert {"file", "url", "git", "repo"} <= overlay_map["network"]
+
+
+def test_build_qs_overlay_map_exposes_fixed_key_overlay_aliases_for_repo_file():
+    module = _load_gap_analyzer_module()
+    qs_overlays = Path(__file__).resolve().parents[1] / "static" / "json" / "quickstart_overlays.json"
+
+    overlay_map = module.build_qs_overlay_map(qs_overlays)
+
+    assert "commonsense" in overlay_map
+    assert {"horizontal_align", "vertical_align", "horizontal_offset", "vertical_offset", "back_width", "back_color"} <= overlay_map["commonsense"]
+
+
 def test_build_qs_overlay_map_can_skip_runtime_support_enrichment(tmp_path):
     module = _load_gap_analyzer_module()
     qs_overlays = tmp_path / "quickstart_overlays.json"
@@ -182,6 +203,19 @@ def test_overlay_key_supported_in_quickstart_uses_direct_alias_match_when_availa
 
     assert module.overlay_key_supported_in_quickstart("ratings", "rating3", qs_overlays) is True
     assert module.overlay_key_supported_in_quickstart("ratings", "rating3_image", qs_overlays) is True
+
+
+def test_overlay_key_supported_in_quickstart_accepts_prefixed_source_override_keys():
+    module = _load_gap_analyzer_module()
+
+    qs_overlays = {
+        "resolution": {"file", "url", "git", "repo"},
+    }
+
+    assert module.overlay_key_supported_in_quickstart("resolution", "file_4k", qs_overlays) is True
+    assert module.overlay_key_supported_in_quickstart("resolution", "url_4k", qs_overlays) is True
+    assert module.overlay_key_supported_in_quickstart("resolution", "git_4k", qs_overlays) is True
+    assert module.overlay_key_supported_in_quickstart("resolution", "repo_4k", qs_overlays) is True
 
 
 def test_quickstart_recommendation_summary_skips_runtime_supported_overlay_keys():
@@ -448,6 +482,17 @@ def test_build_qs_collection_map_preserves_dynamic_family_edge_cases_for_repo_fi
     assert "data_limit" not in collection_map["network"]
 
 
+def test_build_qs_library_template_keys_includes_separator_placeholder_keys_for_repo_file():
+    module = _load_gap_analyzer_module()
+    qs_attributes = Path(__file__).resolve().parents[1] / "static" / "json" / "quickstart_attributes.json"
+
+    keys = module.build_qs_library_template_keys(qs_attributes)
+
+    assert "placeholder_imdb_id" in keys
+    assert "placeholder_tmdb_movie" in keys
+    assert "placeholder_tvdb_show" in keys
+
+
 def test_key_is_valid_for_default_understands_dynamic_data_limit_from_repo_defaults():
     module = _load_gap_analyzer_module()
     kometa_defaults = _kometa_defaults_root()
@@ -561,6 +606,31 @@ settings:
     assert candidates == [config_file]
     assert skipped == []
     assert stats["artifact_skips"] == 0
+
+
+def test_prefilter_yaml_files_skips_quickstart_schema_sample_configs_when_focus_is_config(tmp_path):
+    module = _load_gap_analyzer_module()
+    sample_file = tmp_path / "json-schema" / "prototype_comprehensive.yml"
+    sample_file.parent.mkdir(parents=True, exist_ok=True)
+    sample_file.write_text(
+        """
+libraries:
+  Movies:
+    collection_files:
+      - pmm: basic
+settings:
+  cache: true
+""".strip(),
+        encoding="utf-8",
+    )
+
+    candidates, skipped, stats = module.prefilter_yaml_files([sample_file], yaml_type_focus="config")
+
+    assert candidates == []
+    assert len(skipped) == 1
+    assert skipped[0]["error_type"] == "IgnoredSampleConfig"
+    assert skipped[0]["noise_reason"] == "quickstart_sample_config"
+    assert stats["artifact_skips"] == 1
 
 
 def test_scan_uploaded_configs_excludes_external_yaml_when_focus_is_config(tmp_path):
@@ -956,6 +1026,91 @@ def test_build_merged_fix_queue_suppresses_excluded_quickstart_only_keys():
     assert len(ranked) == 1
     assert ranked[0]["key"] == "horizontal_align"
     assert ranked[0]["action_targets"] == ["importer"]
+
+
+def test_quickstart_recommendation_summary_excludes_overlay_style_keys_misclassified_as_library_scope():
+    module = _load_gap_analyzer_module()
+
+    rows = [
+        {
+            "kind": "library",
+            "default": None,
+            "key": "horizontal_align",
+            "file": "config.yml",
+            "library": "Shows",
+            "matched_default_files": [],
+            "supported_in_quickstart": False,
+            "quickstart_declared": False,
+            "schema_declared": True,
+            "kometa_declared": True,
+            "validation_level": "works_in_kometa_missing_from_quickstart",
+            "name_verified": True,
+            "value_shape_verified": True,
+            "value_shape_rule": "string",
+        },
+        {
+            "kind": "library",
+            "default": None,
+            "key": "back_width",
+            "file": "config.yml",
+            "library": "Shows",
+            "matched_default_files": [],
+            "supported_in_quickstart": False,
+            "quickstart_declared": False,
+            "schema_declared": True,
+            "kometa_declared": True,
+            "validation_level": "works_in_kometa_missing_from_quickstart",
+            "name_verified": True,
+            "value_shape_verified": True,
+            "value_shape_rule": "number",
+        },
+    ]
+
+    summary = module.build_quickstart_recommendation_summary(rows)
+    ranked = module.serialize_ranked_summary(summary)
+    excluded = module.build_quickstart_recommendation_exclusion_summary(rows)
+
+    assert ranked == []
+    assert excluded[("library", "", "horizontal_align")]["reason"] == "overlay_rendering_key_misclassified_at_library_scope"
+    assert excluded[("library", "", "back_width")]["reason"] == "overlay_rendering_key_misclassified_at_library_scope"
+
+
+def test_build_merged_fix_queue_excludes_overlay_style_keys_misclassified_as_library_scope():
+    module = _load_gap_analyzer_module()
+
+    verified_rows = [
+        {
+            "kind": "library",
+            "default": None,
+            "key": "horizontal_align",
+            "occurrences": 10,
+            "files": ["config.yml"],
+            "libraries": ["Shows"],
+            "matched_default_files": [],
+            "supported_in_quickstart": False,
+            "quickstart_declared": False,
+            "schema_declared": True,
+            "kometa_declared": True,
+            "validation_level": "works_in_kometa_missing_from_quickstart",
+        }
+    ]
+    importer_rows = [
+        {
+            "kind": "library",
+            "default": None,
+            "key": "horizontal_align",
+            "import_status": "unmapped",
+            "reason_class": "missing_template_variable_support",
+            "occurrences": 10,
+            "files": ["config.yml"],
+            "libraries": ["Shows"],
+            "reasons": ["Template variable not available in Quickstart."],
+        }
+    ]
+
+    ranked = module.build_merged_fix_queue(verified_rows, importer_rows)
+
+    assert ranked == []
 
 
 def test_build_merged_fix_queue_excludes_internal_library_type_metadata():


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Fix template-gap analyzer false positives caused by overlay alias drift and importer-only noise.
This updates the analyzer to treat overlay defaults case-insensitively, so mixed-case names like Status correctly map back to Quickstart support and Kometa overlay defaults. It also tightens the merged fix queue so importer-only misses are not promoted into the backlog unless there is verified Kometa-default support behind them. That prevents unsupported or misclassified rows from poisoning the “next things to add” recommendations.
Tests were added for:
case-insensitive overlay alias support
case-insensitive overlay default path resolution
suppression of importer-only unverified merged-queue entries

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
