### PR TITLE
Eliminate inline event handlers from Trakt + MAL templates

### DIFF
--- a/static/local-js/130-trakt.js
+++ b/static/local-js/130-trakt.js
@@ -10,30 +10,27 @@ import {
 } from './modules/oauthValidationHelpers.js'
 
 // Trakt OAuth-PIN flow. Layered on top of oauthValidationHelpers.
-// Wizard-specific glue (kept here, not in the helper module):
-//
-//   - Authorization URL construction (Trakt-specific URL shape, gated
-//     on client_id length === 64).
-//   - Six access-token field bookkeeping on validation success.
-//   - Pin field + URL button live-gating (inline oninput attributes
-//     in the template require these as window-exposed functions).
-//   - The Check Token re-validation path, which talks to a different
-//     endpoint and consumes a different response shape.
+// All DOM event wiring uses addEventListener -- no inline oninput /
+// onclick attributes in the template, no window-exposed functions.
+// Module-local everything, the way it should be.
 
 const VALIDATED_FIELD_ID = 'trakt_validated'
 
 const validatedAtInput = document.getElementById('trakt_validated_at')
-const traktClientSecretInput = document.getElementById('trakt_client_secret')
+const clientIdInput = document.getElementById('trakt_client_id')
+const clientSecretInput = document.getElementById('trakt_client_secret')
+const pinInput = document.getElementById('trakt_pin')
+const urlField = document.getElementById('trakt_url')
 const toggleButton = document.getElementById('toggleClientSecretVisibility')
+const openUrlButton = document.getElementById('trakt_open_url')
 const validateButton = document.getElementById('validate_trakt_pin')
 const checkTokenButton = document.getElementById('trakt_check_token')
 const isValidatedElement = document.getElementById('trakt_validated')
 
-wireSecretToggle(traktClientSecretInput, toggleButton)
+wireSecretToggle(clientSecretInput, toggleButton)
 
 // Initial button enable/disable from persisted state.
-const isValidated = isValidatedElement.value.toLowerCase()
-validateButton.disabled = isValidated === 'true'
+validateButton.disabled = isValidatedElement.value.toLowerCase() === 'true'
 if (checkTokenButton) {
   const accessToken = document.getElementById('access_token')?.value || ''
   checkTokenButton.disabled = isBlankTokenValue(accessToken)
@@ -48,8 +45,13 @@ wireCredentialResetListeners({
   validatedFieldId: VALIDATED_FIELD_ID
 })
 
+// Build the authorization URL when the client_id reaches the expected
+// 64-char length. Editing the credential also invalidates the saved
+// validated state (wireCredentialResetListeners already handles the
+// reset; this also clears the validatedAt and refreshes the callout
+// for symmetry with the legacy behavior).
 function updateTraktURL () {
-  const traktClientId = document.getElementById('trakt_client_id').value
+  const traktClientId = clientIdInput.value
   let myURL = ''
   if (traktClientId.length === 64) {
     isValidatedElement.value = 'false'
@@ -57,41 +59,34 @@ function updateTraktURL () {
     refreshValidationCallout(VALIDATED_FIELD_ID)
     myURL = 'https://trakt.tv/oauth/authorize?response_type=code&client_id=' + traktClientId + '&redirect_uri=urn:ietf:wg:oauth:2.0:oob'
   }
-  document.getElementById('trakt_url').value = myURL
-  checkURLStart()
+  urlField.value = myURL
+  // The URL is built from credentials, so re-check the open-URL gate
+  // here directly. Listening on the hidden urlField for 'input' events
+  // wouldn't work -- programmatic .value assignment doesn't fire them.
+  openUrlButton.disabled = urlField.value === ''
 }
 
-function openTraktUrl () {
-  const url = document.getElementById('trakt_url').value
+// Wire updateTraktURL to the Client ID only. The legacy template wired
+// it to Client Secret too, but updateTraktURL doesn't read the secret,
+// so the second wiring was a no-op.
+clientIdInput.addEventListener('input', updateTraktURL)
+
+openUrlButton.addEventListener('click', function () {
+  const url = urlField.value
   if (url) {
     showSpinner('retrieve')
     window.open(url, '_blank').focus()
   }
-}
+})
 
-function checkPinField () {
-  const pin = document.getElementById('trakt_pin').value
-  document.getElementById('validate_trakt_pin').disabled = pin === ''
-}
+pinInput.addEventListener('input', function () {
+  validateButton.disabled = pinInput.value === ''
+})
 
-function checkURLStart () {
-  const url = document.getElementById('trakt_url').value
-  document.getElementById('trakt_open_url').disabled = url === ''
-}
-
-// Templates wire these as inline oninput / onclick handlers, so they
-// must be on window. (Eliminating inline handlers is HTML cleanup
-// work, out of scope for Step 6.)
-window.updateTraktURL = updateTraktURL
-window.openTraktUrl = openTraktUrl
-window.checkPinField = checkPinField
-window.checkURLStart = checkURLStart
-
-window.onload = function () {
-  document.getElementById('trakt_open_url').disabled = true
-  document.getElementById('validate_trakt_pin').disabled = true
-  checkURLStart()
-}
+// Initial gating after the page has rendered. Replaces the previous
+// `window.onload = ...` block.
+openUrlButton.disabled = true
+validateButton.disabled = true
 
 // Trakt-specific success bookkeeping: copy 6 authorization fields into
 // hidden form inputs, clear the PIN + URL, disable PIN-flow buttons,
@@ -106,19 +101,19 @@ function applyTraktPinSuccess (data) {
   document.getElementById('refresh_token').value = data.trakt_authorization_refresh_token
   document.getElementById('scope').value = data.trakt_authorization_scope
   document.getElementById('created_at').value = data.trakt_authorization_created_at
-  document.getElementById('trakt_pin').value = ''
-  document.getElementById('trakt_url').value = ''
-  document.getElementById('trakt_open_url').disabled = true
-  document.getElementById('validate_trakt_pin').disabled = true
+  pinInput.value = ''
+  urlField.value = ''
+  openUrlButton.disabled = true
+  validateButton.disabled = true
   if (checkTokenButton) checkTokenButton.disabled = false
 }
 
 // PIN flow: POST /validate_trakt with id/secret/pin -> access tokens.
 validateButton.addEventListener('click', function () {
   const statusMessage = document.getElementById('statusMessage')
-  const traktClient = document.getElementById('trakt_client_id').value
-  const traktSecret = document.getElementById('trakt_client_secret').value
-  const traktPin = document.getElementById('trakt_pin').value
+  const traktClient = clientIdInput.value
+  const traktSecret = clientSecretInput.value
+  const traktPin = pinInput.value
 
   if (!traktClient || !traktSecret || !traktPin) {
     showStatusMessage(statusMessage, 'ID, secret, and PIN are all required.', STATUS_COLOR_ERROR)
@@ -155,14 +150,14 @@ if (checkTokenButton) {
   checkTokenButton.addEventListener('click', function () {
     const statusMessage = document.getElementById('statusMessage')
     const accessToken = document.getElementById('access_token')?.value || ''
-    const clientId = document.getElementById('trakt_client_id')?.value || ''
+    const clientId = clientIdInput?.value || ''
 
     if (isBlankTokenValue(accessToken) || isBlankTokenValue(clientId)) {
       showStatusMessage(statusMessage, 'Missing access token or client ID.', STATUS_COLOR_ERROR)
       return
     }
 
-    const clientSecret = document.getElementById('trakt_client_secret')?.value || ''
+    const clientSecret = clientSecretInput?.value || ''
     const refreshToken = document.getElementById('refresh_token')?.value || ''
 
     performValidationRequest({

--- a/static/local-js/140-mal.js
+++ b/static/local-js/140-mal.js
@@ -9,6 +9,9 @@ import {
 } from './modules/oauthValidationHelpers.js'
 
 // MyAnimeList OAuth flow. Layered on top of oauthValidationHelpers.
+// All DOM event wiring uses addEventListener -- no inline oninput /
+// onclick attributes in the template, no window-exposed functions.
+//
 // Shape mirrors Trakt (#130) but with three notable differences:
 //   - URL build is gated on client_id.length === 32 (Trakt is 64) and
 //     incorporates a code_verifier PKCE challenge.
@@ -19,8 +22,13 @@ import {
 const VALIDATED_FIELD_ID = 'mal_validated'
 
 const validatedAtInput = document.getElementById('mal_validated_at')
+const clientIdInput = document.getElementById('mal_client_id')
 const clientSecretInput = document.getElementById('mal_client_secret')
+const codeVerifierInput = document.getElementById('mal_code_verifier')
+const urlField = document.getElementById('mal_url')
+const localhostUrlInput = document.getElementById('mal_localhost_url')
 const toggleButton = document.getElementById('toggleClientSecretVisibility')
+const authorizeButton = document.getElementById('mal_get_localhost_url')
 const validateButton = document.getElementById('validate_mal_url')
 const checkTokenButton = document.getElementById('mal_check_token')
 const isValidatedElement = document.getElementById('mal_validated')
@@ -44,20 +52,12 @@ wireCredentialResetListeners({
   validatedFieldId: VALIDATED_FIELD_ID
 })
 
-// The "Authorize" button opens the constructed authorization URL in
-// a new tab. The legacy code wired this directly rather than via
-// window-exposed function, so keep the same shape.
-document.getElementById('mal_get_localhost_url').addEventListener('click', function () {
-  const url = document.getElementById('mal_url').value
-  if (url) {
-    showSpinner('retrieve')
-    window.open(url, '_blank').focus()
-  }
-})
-
+// Build the authorization URL when the client_id reaches the expected
+// 32-char length. MAL needs the PKCE code_verifier to be present in
+// the URL as the code_challenge query param.
 function updateMALTargetURL () {
-  const malClientId = document.getElementById('mal_client_id').value
-  const codeVerifier = document.getElementById('mal_code_verifier').value
+  const malClientId = clientIdInput.value
+  const codeVerifier = codeVerifierInput.value
   let myURL = ''
   if (malClientId.length === 32) {
     isValidatedElement.value = 'false'
@@ -65,36 +65,36 @@ function updateMALTargetURL () {
     refreshValidationCallout(VALIDATED_FIELD_ID)
     myURL = 'https://myanimelist.net/v1/oauth2/authorize?response_type=code&client_id=' + malClientId + '&code_challenge=' + codeVerifier
   }
-  document.getElementById('mal_url').value = myURL
-  enableLocalURLButton()
+  urlField.value = myURL
+  // Listening on the hidden urlField for 'input' events wouldn't work --
+  // programmatic .value assignment doesn't fire them. Re-check the
+  // Authorize button gate here directly.
+  authorizeButton.disabled = urlField.value === ''
 }
 
-function openMALUrl () {
-  const url = document.getElementById('mal_url').value
-  if (url) window.open(url, '_blank').focus()
-}
+// Wire updateMALTargetURL to the Client ID only. The legacy template
+// wired it to Client Secret too, but updateMALTargetURL doesn't read
+// the secret, so the second wiring was a no-op.
+clientIdInput.addEventListener('input', updateMALTargetURL)
 
-function checkURLField () {
-  const localURL = document.getElementById('mal_localhost_url').value
-  document.getElementById('validate_mal_url').disabled = localURL === ''
-}
+// The "Authorize" button opens the constructed authorization URL in
+// a new tab.
+authorizeButton.addEventListener('click', function () {
+  const url = urlField.value
+  if (url) {
+    showSpinner('retrieve')
+    window.open(url, '_blank').focus()
+  }
+})
 
-function enableLocalURLButton () {
-  const url = document.getElementById('mal_url').value
-  document.getElementById('mal_get_localhost_url').disabled = url === ''
-}
+localhostUrlInput.addEventListener('input', function () {
+  validateButton.disabled = localhostUrlInput.value === ''
+})
 
-// Templates wire these as inline oninput handlers, so they must be on
-// window. (Eliminating inline handlers is HTML cleanup, out of scope.)
-window.updateMALTargetURL = updateMALTargetURL
-window.openMALUrl = openMALUrl
-window.checkURLField = checkURLField
-window.enableLocalURLButton = enableLocalURLButton
-
-window.onload = function () {
-  document.getElementById('validate_mal_url').disabled = true
-  enableLocalURLButton()
-}
+// Initial gating after the page has rendered. Replaces the previous
+// `window.onload = ...` block.
+validateButton.disabled = true
+authorizeButton.disabled = urlField.value === ''
 
 // MAL-specific success bookkeeping: copy 4 authorization fields into
 // hidden form inputs and disable both auth-flow buttons.
@@ -106,8 +106,8 @@ function applyMALAuthSuccess (data) {
   document.getElementById('token_type').value = data.mal_authorization_token_type
   document.getElementById('expires_in').value = data.mal_authorization_expires_in
   document.getElementById('refresh_token').value = data.mal_authorization_refresh_token
-  document.getElementById('mal_get_localhost_url').disabled = true
-  document.getElementById('validate_mal_url').disabled = true
+  authorizeButton.disabled = true
+  validateButton.disabled = true
   if (checkTokenButton) checkTokenButton.disabled = false
 }
 
@@ -115,10 +115,10 @@ function applyMALAuthSuccess (data) {
 // access tokens.
 validateButton.addEventListener('click', function () {
   const statusMessage = document.getElementById('statusMessage')
-  const malClient = document.getElementById('mal_client_id').value
-  const malSecret = document.getElementById('mal_client_secret').value
-  const malVerifier = document.getElementById('mal_code_verifier').value
-  const malLocalhostURL = document.getElementById('mal_localhost_url').value
+  const malClient = clientIdInput.value
+  const malSecret = clientSecretInput.value
+  const malVerifier = codeVerifierInput.value
+  const malLocalhostURL = localhostUrlInput.value
 
   if (!malClient || !malSecret || !malVerifier || !malLocalhostURL) {
     showStatusMessage(statusMessage, 'ID, secret, and localhost URL are all required.', STATUS_COLOR_ERROR)

--- a/templates/130-trakt.html
+++ b/templates/130-trakt.html
@@ -11,7 +11,7 @@
   </span>
   <input type="text" class="form-control" id="trakt_client_id" name="trakt_client_id"
     value="{{ data['trakt']['client_id'] | string if data['trakt']['client_id'] and 'Enter Trakt Client ID' not in data['trakt']['client_id'] | string else '' }}"
-    aria-describedby="trakt_client_id_text" oninput="updateTraktURL(this)">
+    aria-describedby="trakt_client_id_text">
 </div>
 <div class="input-group mb-2">
   <span class="input-group-text" id="trakt_client_secret_text" style="width: 150px; justify-content: space-between;">
@@ -23,19 +23,19 @@
   </span>
   <input type="password" class="form-control" id="trakt_client_secret" name="trakt_client_secret"
     value="{{ data['trakt']['client_secret'] | string if data['trakt']['client_secret'] and 'Enter Trakt Client Secret' not in data['trakt']['client_secret'] | string else '' }}"
-    title="Client Secret" aria-label="Client Secret" oninput="updateTraktURL(this)"
+    title="Client Secret" aria-label="Client Secret"
     aria-describedby="trakt_client_secret_text">
   <button class="btn btn-outline-secondary" id="toggleClientSecretVisibility" type="button">
     <i class="fas fa-eye"></i>
   </button>
-  <button class="btn btn-success" id="trakt_open_url" type="button" onclick="openTraktUrl()">
+  <button class="btn btn-success" id="trakt_open_url" type="button">
     Retrieve PIN <i id="spinner_retrieve" class="spinner-border spinner-border-sm" style="display:none;"></i>
   </button>
 </div>
 
 
 
-<input type="hidden" class="form-control" id="trakt_url" name="trakt_url" readonly oninput="checkURLStart(this)">
+<input type="hidden" class="form-control" id="trakt_url" name="trakt_url" readonly>
 <div class="form-text mb-2" id="pin-info">
   When you click "Retrieve PIN" above, you will be taken to a Trakt web page. Log in and allow your application access
   to your Trakt account. Trakt will display a PIN. Copy that PIN and paste it into the "Trakt PIN" field below.<br>
@@ -52,7 +52,7 @@
     </span>
   </span>
   <input type="text" class="form-control" placeholder="Trakt PIN" aria-label="Trakt PIN" id="trakt_pin" name="trakt_pin"
-    oninput="checkPinField(this)" aria-describedby="trakt_pin_text">
+    aria-describedby="trakt_pin_text">
   <button class="btn btn-success" type="button" id="validate_trakt_pin">
     Validate PIN <i id="spinner_validate" class="spinner-border spinner-border-sm" style="display:none;"></i>
   </button>

--- a/templates/140-mal.html
+++ b/templates/140-mal.html
@@ -11,7 +11,7 @@
   </span>
   <input type="text" class="form-control" id="mal_client_id" name="mal_client_id"
     value="{{ data['mal']['client_id'] | string if data['mal']['client_id'] and 'Enter MyAnimeList Client ID' not in data['mal']['client_id'] | string else '' }}"
-    oninput="updateMALTargetURL(this)" aria-describedby="mal_client_id_text">
+    aria-describedby="mal_client_id_text">
 </div>
 <div class="input-group mb-2">
   <input type="hidden" class="form-control" id="mal_code_verifier" name="mal_code_verifier"
@@ -27,7 +27,7 @@
   </span>
   <input type="password" class="form-control" id="mal_client_secret" name="mal_client_secret"
     value="{{ data['mal']['client_secret'] | string if data['mal']['client_secret'] and 'Enter MyAnimeList Client Secret' not in data['mal']['client_secret'] | string else '' }}"
-    title="Client Secret" aria-label="Client Secret" oninput="updateMALTargetURL(this)"
+    title="Client Secret" aria-label="Client Secret"
     aria-describedby="mal_client_secret_text">
   <button class="btn btn-outline-secondary" id="toggleClientSecretVisibility" type="button">
     <i class="fas fa-eye"></i>
@@ -50,7 +50,7 @@
     aria-describedby="mal_cache_expiration_text">
 </div>
 
-<input type="hidden" class="form-control" id="mal_url" name="mal_url" readonly oninput="enableLocalURLButton(this)">
+<input type="hidden" class="form-control" id="mal_url" name="mal_url" readonly>
 
 <div class="input-group mb-2" id="localhost_url_field">
   <span class="input-group-text" id="mal_localhost_url_text" style="width: 175px; justify-content: space-between;">
@@ -61,7 +61,7 @@
     </span>
   </span>
   <input type="text" class="form-control" id="mal_localhost_url" name="mal_localhost_url"
-    placeholder="Enter your localhost URL here" aria-label="Localhost URL" oninput="checkURLField(this)"
+    placeholder="Enter your localhost URL here" aria-label="Localhost URL"
     aria-describedby="mal_localhost_url_text">
   <button type="button" class="btn btn-success" id="validate_mal_url">
     Complete Authentication <i id="spinner_validate" class="spinner-border spinner-border-sm" style="display:none;"></i>

--- a/tests/e2e/test_wizard_e2e.py
+++ b/tests/e2e/test_wizard_e2e.py
@@ -940,3 +940,45 @@ def test_mal_authorize_button_enabled_when_client_id_is_exactly_32_chars(page, l
     assert "myanimelist.net/v1/oauth2/authorize" in mal_url_value
     assert MAL_CLIENT_ID_32 in mal_url_value
     expect(page.locator("#mal_get_localhost_url")).to_be_enabled()
+
+
+# These tests cover behaviors that USED to be wired via inline
+# oninput="checkPinField" / oninput="checkURLField" attributes in
+# the templates and are now driven by addEventListener('input', ...)
+# in the JS modules. (Inline-handler-cleanup follow-up to Step 6 PR 4d.)
+
+
+@pytest.mark.e2e
+def test_trakt_validate_button_enables_when_user_types_in_pin_field(page, live_server):
+    """Typing into the PIN field should enable the Validate PIN button;
+    clearing it should disable it again. Previously wired via inline
+    oninput="checkPinField(this)", now via addEventListener.
+    """
+    page.goto(f"{live_server}/step/130-trakt", wait_until="domcontentloaded")
+
+    # Initially disabled (the page just loaded with no PIN entered).
+    expect(page.locator("#validate_trakt_pin")).to_be_disabled()
+
+    page.locator("#trakt_pin").fill("12345678")
+    expect(page.locator("#validate_trakt_pin")).to_be_enabled()
+
+    page.locator("#trakt_pin").fill("")
+    expect(page.locator("#validate_trakt_pin")).to_be_disabled()
+
+
+@pytest.mark.e2e
+def test_mal_validate_button_enables_when_user_types_in_localhost_url(page, live_server):
+    """Typing into the Localhost URL field should enable the Complete
+    Authentication button. Previously wired via inline
+    oninput="checkURLField(this)", now via addEventListener.
+    """
+    page.goto(f"{live_server}/step/140-mal", wait_until="domcontentloaded")
+
+    # Initially disabled (no URL filled in).
+    expect(page.locator("#validate_mal_url")).to_be_disabled()
+
+    page.locator("#mal_localhost_url").fill("http://localhost/callback?code=xyz")
+    expect(page.locator("#validate_mal_url")).to_be_enabled()
+
+    page.locator("#mal_localhost_url").fill("")
+    expect(page.locator("#validate_mal_url")).to_be_disabled()


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix
- [x] Feature/Tweak (template + JS cleanup; removes inline event-handler attributes; no user-facing behavior changes; +2 e2e tests for safety)
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Other

## Description

Follow-up to #1374 (Step 6 PR 4d). Removes **all 9 inline event-handler attributes** from the Trakt and MAL templates so the wizard JS modules can use `addEventListener` throughout instead of leaking functions onto `window` for inline `oninput=""` / `onclick=""` to find.

### Inline handlers eliminated

| Template | Inline handlers before | Inline handlers after |
|---|---|---|
| `130-trakt.html` | 5 | **0** |
| `140-mal.html` | 4 | **0** |

| JS module | Window exports before | Window exports after |
|---|---|---|
| `130-trakt.js` | 4 | **0** |
| `140-mal.js` | 4 | **0** |

### Dead-code findings (fixed in passing)

While converting, I found four pieces of legacy cruft worth removing:

1. **`oninput="checkURLStart(this)"` on `<input type="hidden" id="trakt_url" readonly>`** — this **never fired**. Hidden inputs don't emit `input` events, and `el.value = "..."` doesn't trigger them either. The button actually got re-enabled because `updateTraktURL()` calls the gating logic at the end of its own body. Removed the attribute; removed the now-unused standalone `checkURLStart` function; folded its logic into `updateTraktURL` where it already lived in spirit.

2. **Same dead-`oninput`-on-hidden-input** for MAL's `enableLocalURLButton`. Same fix.

3. **`openMALUrl` was completely dead code** — exported to `window` but the template's Authorize button used `addEventListener` directly. Deleted the function and its export.

4. **`oninput="updateTraktURL(this)"` on `#trakt_client_secret` was a no-op** — `updateTraktURL` only reads `trakt_client_id`, not the secret. `wireCredentialResetListeners` already handles the "credential changed → invalidate" case for both fields, so dropping the no-op wiring is safe. New JS wires `updateTraktURL` only to the Client ID input. Same fix for MAL.

### Test coverage

The existing PR #1374 e2e tests already exercised the credential-URL-gate path (test_trakt_url_button_enabled_when_client_id_is_exactly_64_chars and the MAL equivalent), so those provided immediate proof the new `addEventListener('input', ...)` wiring fires correctly. I added two more for the PIN-field and Localhost-URL gating paths since the PR #1374 tests deliberately bypassed those with `page.evaluate("...disabled = false")`:

- **`test_trakt_validate_button_enables_when_user_types_in_pin_field`** — types into the PIN field, asserts the Validate PIN button becomes enabled; clears, asserts it disables again
- **`test_mal_validate_button_enables_when_user_types_in_localhost_url`** — same shape for MAL

### What's NOT in scope

18 inline handlers remain in 6 OTHER templates. Three groups, each deserving its own focused PR:

| Group | Where | Count | Difficulty |
|---|---|---|---|
| **A**: Navigation `onclick="jumpTo(...)"` / `onclick='loading(...)'` | `templates/000-base.html`, `templates/partials/_workspace_macros.html`, `templates/900-kometa.html` | 9 | Medium — pass Jinja-interpolated args; needs data-attributes + delegated listeners |
| **B**: Color-picker inline IIFEs | `templates/partials/_macros.html` ~line 2088 | 4 | Hostile — macro-generated, read Jinja loop variables at template-render time |
| **C**: Single-line handlers in `090-webhooks.html` (3) + `_config_workspace_modal.html` (1) | as listed | 4 | Trivial — same shape as this PR |

Recommended sequence: **C → A → B**.

This PR is intentionally scoped to Trakt + MAL because that's the explicit follow-up I proposed at the end of PR #1374.

### Verification

| Check | Result |
|---|---|
| Vitest | 306/306 pass (helper-module tests unaffected) |
| Python tests | 80/80 pass |
| Playwright e2e | **34/34 pass** (was 32; +2 input-driven gating tests) |
| ESLint | 0 errors |
| pre-commit | 12/12 hooks green |

### Diff stats

| File | Lines |
|---|---|
| `static/local-js/130-trakt.js` | -5 lines (206 → 201) |
| `static/local-js/140-mal.js` | 0 lines (190 → 190) |
| `templates/130-trakt.html` | trivial (handler attributes only) |
| `templates/140-mal.html` | trivial |
| `tests/e2e/test_wizard_e2e.py` | +42 lines (2 new tests) |

Line counts barely move because what got removed (window exports, dead functions) was roughly balanced by what got added (explicit `addEventListener` calls). **The win is structural cleanliness, not line count.**

## Related Issues

Follows up #1374 (Step 6 PR 4d). Continues #1334 roadmap work outside the numbered steps.

## Which Environment Did You Test On?

- [x] Local Install (Linux, Python 3.13, Vitest+jsdom, Playwright Chromium e2e)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
