### PR TITLE
Eliminate runtime-injected inline handlers + opt-in HTML helper

### DIFF
--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -4253,13 +4253,19 @@ document.head.appendChild(style)
 //     rating-mapping pills)
 //   - templates/partials/_workspace_macros.html (step dropdown items,
 //     step rail buttons, prev/next form-submit buttons, sidebar donate)
+// AND the runtime-injected HTML strings in:
+//   - static/local-js/validationHandler.js (Plex-not-validated message)
+//   - static/local-js/027-playlist_files.js (same; copy-paste)
+//   - static/local-js/overlayHandler.js (rating-mapping service pills)
 //
 // Two patterns:
 //   - [data-jumpto-page]  -> jumpTo(page, label?)
 //     Read `data-jumpto-page` and optional `data-jumpto-label`. Calls
 //     jumpTo() inside the click handler. The element is typically an
 //     <a href="javascript:void(0);"> or a <button type="button">, so no
-//     default action needs preventing.
+//     default action needs preventing for buttons; for anchors we call
+//     preventDefault to keep the browser from chasing the `javascript:`
+//     href.
 //   - [data-nav-action]   -> loading(action, target)
 //     Read `data-nav-action` ('prev' | 'next') and `data-nav-target`
 //     (the human-readable page label). Used on <button type="submit">
@@ -4267,44 +4273,43 @@ document.head.appendChild(style)
 //     the spinner starts before navigation. We MUST NOT preventDefault
 //     here or the form won't submit.
 //
+// EVENT DELEGATION (vs per-element binding): the listeners attach ONCE
+// to document.body and use event.target.closest() to find the matching
+// element. This means elements added AFTER DOMContentLoaded (e.g. the
+// overlay handler's runtime-generated rating-mapping pills) are picked
+// up automatically -- no re-binding needed.
+//
 // NOTE: jumpTo and loading remain exposed on window because they have
 // cross-module callers (e.g. 001-start.js does
-// `window.loading('jump', ...)`). When all consumers are converted to
-// ES module imports the window shims can be removed.
+// `window.loading('jump', ...)`) AND because the test suite stubs them
+// to observe behaviour. When all consumers are converted to ES module
+// imports the window shims can be removed.
 document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('[data-jumpto-page]').forEach((el) => {
-    if (el.dataset.qsJumpBound === '1') return
-    el.dataset.qsJumpBound = '1'
-    el.addEventListener('click', (event) => {
-      // For <a href="javascript:void(0);"> the default action is harmless,
-      // but call preventDefault to match the inline-handler semantics
-      // (the inline handler never returned anything, so the void(0) href
-      // was what stopped navigation; explicit preventDefault is clearer).
-      const tag = (el.tagName || '').toLowerCase()
+  document.body.addEventListener('click', (event) => {
+    const jumpEl = event.target.closest('[data-jumpto-page]')
+    if (jumpEl) {
+      const tag = (jumpEl.tagName || '').toLowerCase()
       if (tag === 'a') event.preventDefault()
-      const page = el.dataset.jumptoPage
-      const label = el.dataset.jumptoLabel
-      if (!page) return
-      // Route through window so cross-module callers and tests can
-      // observe / intercept the call. This mirrors how 001-start.js
-      // calls window.loading('jump', ...) from outside this module.
-      const fn = (typeof window !== 'undefined' && window.jumpTo) || jumpTo
-      fn(page, label)
-    })
-  })
+      const page = jumpEl.dataset.jumptoPage
+      const label = jumpEl.dataset.jumptoLabel
+      if (page) {
+        const fn = (typeof window !== 'undefined' && window.jumpTo) || jumpTo
+        fn(page, label)
+      }
+      return
+    }
 
-  document.querySelectorAll('[data-nav-action]').forEach((el) => {
-    if (el.dataset.qsNavBound === '1') return
-    el.dataset.qsNavBound = '1'
-    el.addEventListener('click', () => {
+    const navEl = event.target.closest('[data-nav-action]')
+    if (navEl) {
       // Do NOT preventDefault -- this button is type="submit" and the form
       // submission carries the navigation. We just kick off the spinner.
-      const action = el.dataset.navAction
-      const target = el.dataset.navTarget
-      if (!action) return
-      const fn = (typeof window !== 'undefined' && window.loading) || loading
-      fn(action, target)
-    })
+      const action = navEl.dataset.navAction
+      const target = navEl.dataset.navTarget
+      if (action) {
+        const fn = (typeof window !== 'undefined' && window.loading) || loading
+        fn(action, target)
+      }
+    }
   })
 })
 

--- a/static/local-js/027-playlist_files.js
+++ b/static/local-js/027-playlist_files.js
@@ -11,8 +11,13 @@ const validationMessages = document.getElementById('validation-messages')
 if (!plexValid) {
   if (librariesContainer) librariesContainer.style.display = 'none'
   if (validationMessages) {
+    // The <a data-jumpto-page="010-plex"> link is picked up by the
+    // delegated click listener in 000-base.js. Same message text is
+    // duplicated in static/local-js/validationHandler.js (line ~60);
+    // they can't share a module-level constant yet because
+    // validationHandler.js is loaded as a classic script (no imports).
     validationMessages.innerHTML =
-      'Plex settings have not been validated successfully. Please <a href="javascript:void(0);" onclick="jumpTo(\'010-plex\');">return to the Plex page</a> and hit the validate button and ensure success before returning here.<br>'
+      'Plex settings have not been validated successfully. Please <a href="javascript:void(0);" data-jumpto-page="010-plex">return to the Plex page</a> and hit the validate button and ensure success before returning here.<br>'
     validationMessages.style.display = ''
   }
 } else {

--- a/static/local-js/overlayHandler.js
+++ b/static/local-js/overlayHandler.js
@@ -4870,7 +4870,7 @@ const OverlayHandler = {
               }
               const viaHtml = serviceTag
                 ? (jumpTarget && serviceTag !== 'N/A'
-                    ? ` <a class="rating-mapping-option-via rating-mapping-option-link rating-mapping-option-via--${validationStatus}" href="javascript:void(0);" onclick="jumpTo('${jumpTarget}')">${escapeHtml(serviceTag)}</a>`
+                    ? ` <a class="rating-mapping-option-via rating-mapping-option-link rating-mapping-option-via--${validationStatus}" href="javascript:void(0);" data-jumpto-page="${escapeHtml(jumpTarget)}">${escapeHtml(serviceTag)}</a>`
                     : ` <span class="rating-mapping-option-via rating-mapping-option-via--${validationStatus}">${escapeHtml(serviceTag)}</span>`)
                 : ''
               return `<div class="rating-mapping-option${isPicked ? ' is-picked' : ''}"><span class="rating-mapping-option-label">${escapeHtml(labelText)}</span>${pickedHtml}${arrowHtml}${viaHtml}</div>`

--- a/static/local-js/validationHandler.js
+++ b/static/local-js/validationHandler.js
@@ -44,7 +44,8 @@ const ValidationHandler = {
       console.log('[DEBUG] Validation Failed! Disabling navigation.')
       ValidationHandler.showValidationMessage(
         'Please review your selections: ensure you have picked at least one library, selected an item inside each chosen library, and if using Separators, selected a valid <strong>Placeholder IMDb ID</strong>. Items needing attention are highlighted in red below.',
-        'danger'
+        'danger',
+        { html: true }
       )
       ValidationHandler.disableNavigation(false)
     }
@@ -57,8 +58,9 @@ const ValidationHandler = {
     if (!plexValid) {
       console.log('[DEBUG] Plex validation failed! Disabling navigation.')
       ValidationHandler.showValidationMessage(
-        'Plex settings have not been validated successfully. Please <a href="javascript:void(0);" onclick="jumpTo(\'010-plex\');">return to the Plex page</a> and hit the validate button and ensure success before returning here.<br>',
-        'danger'
+        'Plex settings have not been validated successfully. Please <a href="javascript:void(0);" data-jumpto-page="010-plex">return to the Plex page</a> and hit the validate button and ensure success before returning here.<br>',
+        'danger',
+        { html: true }
       )
       ValidationHandler.disableNavigation()
       return false
@@ -297,13 +299,21 @@ const ValidationHandler = {
     })
   },
 
-  showValidationMessage: function (message, type) {
+  showValidationMessage: function (message, type, options) {
     const validationBox = document.getElementById('validation-messages')
     if (!validationBox) return
 
     console.log(`[DEBUG] Showing validation message: "${message}" (${type})`)
 
-    validationBox.textContent = message
+    // Default to textContent (safe against XSS). Callers that need to
+    // render HTML (e.g. embedded links or <strong>) must pass
+    // { html: true } explicitly so the choice is auditable.
+    const useHtml = !!(options && options.html)
+    if (useHtml) {
+      validationBox.innerHTML = message
+    } else {
+      validationBox.textContent = message
+    }
     validationBox.classList.remove('alert-danger', 'alert-success')
     validationBox.classList.add(`alert-${type}`)
     validationBox.style.display = 'block'

--- a/tests/e2e/test_wizard_e2e.py
+++ b/tests/e2e/test_wizard_e2e.py
@@ -1150,10 +1150,11 @@ def test_nav_jumpto_data_attr_dispatches_to_jumpto_function(page, live_server):
 @pytest.mark.e2e
 def test_nav_jumpto_data_attr_includes_label_when_present(page, live_server):
     """If the element carries both data-jumpto-page and data-jumpto-label,
-    both values should be forwarded to jumpTo().
+    both values should be forwarded to jumpTo(). Verified by injecting
+    a synthetic element AFTER DOMContentLoaded -- this exercises the
+    event-delegation behaviour (delegated listener picks up elements
+    added at runtime, not just those present at page load).
     """
-    # Inject a synthetic test element so we don't depend on whether the
-    # current page renders any specific [data-jumpto-label] producer.
     page.goto(f"{live_server}/step/001-start", wait_until="domcontentloaded")
     page.evaluate("""
         window.__jumpToCalls = []
@@ -1164,17 +1165,14 @@ def test_nav_jumpto_data_attr_includes_label_when_present(page, live_server):
         el.dataset.jumptoPage = '020-tmdb'
         el.dataset.jumptoLabel = 'TMDb Custom Label'
         document.body.appendChild(el)
-        // Bind the click listener the same way the production code does.
-        // We can't re-trigger DOMContentLoaded for the new element, so
-        // dispatch the binding explicitly via a synthetic event.
-        el.addEventListener('click', (event) => {
-            event.preventDefault()
-            window.jumpTo(el.dataset.jumptoPage, el.dataset.jumptoLabel)
-        })
     """)
     page.evaluate("document.getElementById('__synthetic_jumpto').click()")
     calls = page.evaluate("window.__jumpToCalls")
-    assert calls == [["020-tmdb", "TMDb Custom Label"]], f"expected jumpTo('020-tmdb', 'TMDb Custom Label'), got {calls}"
+    # The runtime-added element must be picked up by the delegated
+    # listener installed at DOMContentLoaded -- proves we're NOT using
+    # per-element binding (which would miss this).
+    assert calls, "expected jumpTo() to be called for a runtime-added [data-jumpto-page] element"
+    assert calls[-1] == ["020-tmdb", "TMDb Custom Label"], f"expected jumpTo('020-tmdb', 'TMDb Custom Label'), got {calls[-1]}"
 
 
 @pytest.mark.e2e
@@ -1296,3 +1294,95 @@ def test_nav_no_inline_handlers_remain_in_base_layout(page, live_server):
     # workspace step nav, etc.
     nav_offenders = [o for o in inline_count if (o.get("tag") in ("A", "BUTTON")) and (o.get("value", "").startswith("jumpTo(") or o.get("value", "").startswith("loading("))]
     assert not nav_offenders, f"Found leftover inline jumpTo/loading handlers in the navigation: " f"{nav_offenders}"
+
+
+# Runtime-injected inline-handler cleanup (chore/runtime-html-inline-handlers).
+# Three files previously composed HTML strings containing onclick="jumpTo(...)"
+# and inserted them via innerHTML:
+#   - static/local-js/validationHandler.js (Plex-not-validated message)
+#   - static/local-js/027-playlist_files.js (same; copy-paste)
+#   - static/local-js/overlayHandler.js (rating-mapping service pills)
+# These now use data-jumpto-page instead. The delegated click listener in
+# 000-base.js (now using event delegation on document.body) picks them up
+# even when the element is added to the DOM AFTER DOMContentLoaded.
+
+
+@pytest.mark.e2e
+def test_runtime_added_jumpto_element_triggers_jumpto_via_delegation(page, live_server):
+    """Belt-and-braces version of the synthetic-element test specific to
+    the runtime-HTML-injection use case: simulate the overlayHandler /
+    027-playlist_files / validationHandler pattern by setting innerHTML
+    on a container, then assert the resulting [data-jumpto-page] anchor
+    triggers jumpTo via the delegated listener.
+    """
+    page.goto(f"{live_server}/step/001-start", wait_until="domcontentloaded")
+    page.evaluate("""
+        window.__jumpToCalls = []
+        window.jumpTo = (page, label) => { window.__jumpToCalls.push([page, label]) }
+        const host = document.createElement('div')
+        host.id = '__runtime_host'
+        document.body.appendChild(host)
+        // Mirror the production pattern: assign innerHTML with a string
+        // containing <a data-jumpto-page="..."> -- the link is parsed
+        // from the string at innerHTML-assignment time, the delegated
+        // listener doesn't need re-binding.
+        host.innerHTML =
+          'Please <a href="javascript:void(0);" data-jumpto-page="010-plex" id="__runtime_link">return to the Plex page</a>.'
+    """)
+    page.evaluate("document.getElementById('__runtime_link').click()")
+    calls = page.evaluate("window.__jumpToCalls")
+    assert calls, "expected jumpTo() to be called for the runtime-innerHTML-added link"
+    assert calls[-1][0] == "010-plex", f"expected page='010-plex', got {calls[-1]}"
+
+
+@pytest.mark.e2e
+def test_validation_handler_show_message_textcontent_by_default(page, live_server):
+    """validationHandler.showValidationMessage defaults to textContent --
+    HTML in the message string should render as plain text. This is the
+    safe-against-XSS default.
+    """
+    # Pick a page that includes #validation-messages in its template.
+    # 900-kometa has it (templates/900-kometa.html:272).
+    page.goto(f"{live_server}/step/900-kometa", wait_until="domcontentloaded")
+    page.add_script_tag(path="static/local-js/validationHandler.js")
+    # Need jQuery for the existing $('#plex_valid') call -- 900-kometa
+    # already loads it as part of the base layout.
+    page.evaluate("""
+        ValidationHandler.showValidationMessage(
+            'Plain <strong>text</strong> message', 'danger'
+        )
+    """)
+    box = page.locator("#validation-messages")
+    expect(box).to_have_text("Plain <strong>text</strong> message")
+    # innerHTML should contain the literal &lt; (escaped); no <strong> tag.
+    inner = box.evaluate("el => el.innerHTML")
+    assert "<strong>" not in inner, f"expected escaped HTML, got: {inner[:200]}"
+    assert "&lt;strong&gt;" in inner or "&lt;/strong&gt;" in inner, f"expected HTML-escaped <strong>, got: {inner[:200]}"
+
+
+@pytest.mark.e2e
+def test_validation_handler_show_message_html_opt_in_renders_html(page, live_server):
+    """When called with {html: true}, showValidationMessage uses innerHTML.
+    A link inside the message becomes a real anchor.
+    """
+    page.goto(f"{live_server}/step/900-kometa", wait_until="domcontentloaded")
+    page.add_script_tag(path="static/local-js/validationHandler.js")
+    page.evaluate("""
+        ValidationHandler.showValidationMessage(
+            'Please <a href=\"javascript:void(0);\" data-jumpto-page=\"010-plex\">click here</a>.',
+            'danger',
+            { html: true }
+        )
+    """)
+    box = page.locator("#validation-messages")
+    # The <a> element should exist as a real DOM node, not plain text.
+    expect(box.locator('a[data-jumpto-page="010-plex"]')).to_be_attached()
+    # And clicking it should trigger the delegated jumpTo handler.
+    page.evaluate("""
+        window.__jumpToCalls = []
+        window.jumpTo = (page, label) => { window.__jumpToCalls.push([page, label]) }
+        document.querySelector('#validation-messages a[data-jumpto-page=\"010-plex\"]').click()
+    """)
+    calls = page.evaluate("window.__jumpToCalls")
+    assert calls, "expected click on the rendered <a> to trigger jumpTo"
+    assert calls[-1][0] == "010-plex", f"expected page='010-plex', got {calls[-1]}"


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix — `ValidationHandler.showValidationMessage` was using `textContent` even when callers passed HTML strings; now opt-in via `{html: true}`
- [x] Feature/Tweak — inline-handler cleanup (the 3 runtime-injected HTML strings from #1377's audit)
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Other

## Description

Fourth slice of the inline-handler cleanup that started with #1375. Targets the **3 runtime-injected HTML strings** called out in #1377's audit:

- `static/local-js/validationHandler.js` — Plex-not-validated message
- `static/local-js/027-playlist_files.js` — same message; copy-paste
- `static/local-js/overlayHandler.js` — rating-mapping service pills

Each previously composed an HTML string containing `onclick="jumpTo('...')"` and inserted it via `innerHTML`. They now use `data-jumpto-page="..."` instead.

### Refactor: per-element binding → event delegation

The PR #1377 listener used `querySelectorAll(...).forEach(addEventListener)` — which only catches elements present at `DOMContentLoaded`. But the overlayHandler generates rating-mapping pills **at runtime** inside template-literal strings, so per-element binding can't reach them.

New approach: a single delegated listener at `document.body` using `event.target.closest()`:

```js
document.body.addEventListener('click', (event) => {
  const jumpEl = event.target.closest('[data-jumpto-page]')
  if (jumpEl) { /* jumpTo(...) */; return }
  const navEl = event.target.closest('[data-nav-action]')
  if (navEl) { /* loading(...) */ }
})
```

Simpler (one listener instead of N), no `qsJumpBound` flags, works for runtime-added elements automatically.

### Bonus bug fix — `{html: true}` opt-in for `showValidationMessage`

`ValidationHandler.showValidationMessage(message, type)` was hard-coded to use `textContent`. But two callers passed HTML strings:

```js
ValidationHandler.showValidationMessage(
  'Please <a href="...">return to the Plex page</a>...',
  'danger'
)
```

These rendered as **plain text including the tags**. In practice, the `#validation-messages` box doesn't exist on the libraries page so users never saw it — but the broken contract was a future foot-gun.

New signature: `showValidationMessage(message, type, { html = false })`. Default uses `textContent` (safe against XSS). Callers that need HTML pass `{ html: true }` explicitly.

### Why the 027-playlist_files duplication stays

The Plex-not-validated message string is duplicated VERBATIM between `validationHandler.js` and `027-playlist_files.js`. Consolidating would require either:
- A shared ES module — **impossible today** because `validationHandler.js` loads as a classic script, while `027-playlist_files.js` is a module. Different loader contexts.
- A `window.*` global — more pollution, opposite of where this work is heading.

Left with a code comment pointing at the duplication. When `validationHandler.js` itself converts to an ES module (separate refactor), both can import a shared `errorMessages.js`.

### Tally

| File | Change |
|---|---|
| `000-base.js` | Per-element binding → event delegation (-23 / +37) |
| `027-playlist_files.js` | `onclick="jumpTo('010-plex')"` → `data-jumpto-page="010-plex"` |
| `overlayHandler.js` | `onclick="jumpTo('${jumpTarget}')"` → `data-jumpto-page="${escapeHtml(jumpTarget)}"` (note the `escapeHtml` — defense in depth) |
| `validationHandler.js` | New `{html: true}` opt-in; 2 HTML-bearing callers updated; inline-onclick → data-attribute |

**3 more inline handlers eliminated. Zero remaining in `static/local-js/`** outside the color-picker macro (Group B, template-side).

### Test coverage — 3 new e2e tests

- **`test_runtime_added_jumpto_element_triggers_jumpto_via_delegation`** — assigns `innerHTML` to a container with a `<a data-jumpto-page="...">` link, clicks it, asserts `window.jumpTo` fires. **Proves event delegation** — the listener was bound BEFORE the new element existed.
- **`test_validation_handler_show_message_textcontent_by_default`** — calls `showValidationMessage('Plain <strong>text</strong>', 'danger')` without `{html: true}`. Asserts the rendered text is the literal string (HTML escaped). Pins the safe default.
- **`test_validation_handler_show_message_html_opt_in_renders_html`** — calls with `{html: true}`. Asserts the rendered DOM contains a real `<a>` element. Then clicks it and asserts the delegated `jumpTo` fires. **End-to-end demonstration of the new path**: opt-in HTML → real DOM → delegated handler → jumpTo.

Plus one existing test (`test_nav_jumpto_data_attr_includes_label_when_present`) updated to reflect the event-delegation change (was using both per-element binding AND the new delegation, causing double-fires).

### Verification

| Check | Result |
|---|---|
| Vitest | 306/306 pass |
| Python tests | 80/80 pass |
| Playwright e2e | **46/46 pass** (was 43; +3 new) |
| ESLint | 0 errors |
| pre-commit | 12/12 hooks green |
| Diff stat | 5 files, +160 / -50 |

### Cumulative inline-handler cleanup

| PR | Status | Handlers | Notable |
|---|---|---|---|
| #1375 | merged | 9 (Trakt + MAL) | First cleanup pass |
| #1376 | merged | 4 (webhooks + config-modal) | **Fixed a latent bug** on the webhooks page |
| #1377 | merged | 10 (navigation Group A) | Introduced `data-jumpto-page` + `data-nav-action` |
| **this** | **open** | **3 (runtime HTML injections)** | **Event delegation; opt-in HTML helper** |

**26 inline handlers eliminated total.**

### Remaining

- **Group B (4 handlers)** — color-picker macro IIFEs in `_macros.html`. Hostile pattern (Jinja loop vars interpolated INTO function bodies). Last-mile work.
- **`window.jumpTo` / `window.loading` shims** — only `001-start.js`'s `window.loading('jump', ...)` call still relies on them. Converting that file to import from `000-base.js` would let us remove both shims. Future work.

## Related Issues

Follows #1375, #1376, #1377. Continues #1334 roadmap work.

The `{html: true}` opt-in is a small bug fix for a previously-undiagnosed UX issue with `ValidationHandler.showValidationMessage` callers (no GitHub issue exists because, AFAICT, the affected code path isn't user-reachable in the current page layout — but the contract was wrong).

## Which Environment Did You Test On?

- [x] Local Install (Linux, Python 3.13, Vitest+jsdom, Playwright Chromium e2e)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
