### PR TITLE
Retire window.jumpTo / window.loading shims; CustomEvent test seam

### DIFF
--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -4279,11 +4279,20 @@ document.head.appendChild(style)
 // overlay handler's runtime-generated rating-mapping pills) are picked
 // up automatically -- no re-binding needed.
 //
-// NOTE: jumpTo and loading remain exposed on window because they have
-// cross-module callers (e.g. 001-start.js does
-// `window.loading('jump', ...)`) AND because the test suite stubs them
-// to observe behaviour. When all consumers are converted to ES module
-// imports the window shims can be removed.
+// TEST SEAM via CANCELABLE CustomEvent (NOT window.* shim):
+// Before calling jumpTo() / loading(), the listener dispatches a
+// cancelable custom event ('qs:nav:jump' or 'qs:nav:loading') on
+// document with { page, label } or { action, target } in event.detail.
+// Tests subscribe to the event and call event.preventDefault() to
+// observe the call args WITHOUT triggering real navigation / spinner.
+// Production code that doesn't listen has zero overhead beyond the
+// CustomEvent allocation.
+//
+// This replaces the previous `(typeof window !== 'undefined' &&
+// window.jumpTo) || jumpTo` indirection that existed solely so the
+// e2e test suite could spy on calls by overwriting window.jumpTo.
+// CustomEvent is a documented test seam (not a leaked implementation
+// detail) and doesn't require polluting the global namespace.
 document.addEventListener('DOMContentLoaded', () => {
   document.body.addEventListener('click', (event) => {
     const jumpEl = event.target.closest('[data-jumpto-page]')
@@ -4293,8 +4302,12 @@ document.addEventListener('DOMContentLoaded', () => {
       const page = jumpEl.dataset.jumptoPage
       const label = jumpEl.dataset.jumptoLabel
       if (page) {
-        const fn = (typeof window !== 'undefined' && window.jumpTo) || jumpTo
-        fn(page, label)
+        const navEvent = new CustomEvent('qs:nav:jump', {
+          cancelable: true,
+          detail: { page, label }
+        })
+        const allowed = document.dispatchEvent(navEvent)
+        if (allowed) jumpTo(page, label)
       }
       return
     }
@@ -4306,8 +4319,12 @@ document.addEventListener('DOMContentLoaded', () => {
       const action = navEl.dataset.navAction
       const target = navEl.dataset.navTarget
       if (action) {
-        const fn = (typeof window !== 'undefined' && window.loading) || loading
-        fn(action, target)
+        const navEvent = new CustomEvent('qs:nav:loading', {
+          cancelable: true,
+          detail: { action, target }
+        })
+        const allowed = document.dispatchEvent(navEvent)
+        if (allowed) loading(action, target)
       }
     }
   })
@@ -4318,12 +4335,19 @@ document.addEventListener('DOMContentLoaded', () => {
 // no longer visible to unconverted classic <script> pages. Re-publish the
 // names that other files reference until those files are themselves modules.
 // Remove each entry as its consumers are converted.
+//
+// jumpTo + loading are NO LONGER shimmed -- the delegated nav listener
+// above no longer routes through window.* (uses CustomEvent as the test
+// seam instead) and 001-start.js imports `loading` directly. See PR
+// #1383 (chore/retire-jumpto-loading-shims) for the migration.
 window.escapeHtml = escapeHtml
 window.hideNavigationLoadingOverlay = hideNavigationLoadingOverlay
 window.hideSpinner = hideSpinner
-window.jumpTo = jumpTo
-window.loading = loading
 window.setButtonIconAndText = setButtonIconAndText
 window.showNavigationLoadingOverlay = showNavigationLoadingOverlay
 window.showSpinner = showSpinner
 window.showToast = showToast
+
+// ES module exports for other modules. Currently consumed by
+// static/local-js/001-start.js (which is also loaded as type="module").
+export { loading, jumpTo }

--- a/static/local-js/001-start.js
+++ b/static/local-js/001-start.js
@@ -2,6 +2,12 @@
 /* Helpers for the config UI      */
 /* ============================== */
 
+// `loading` is the navigation-spinner helper defined in 000-base.js.
+// 000-base.js is loaded as an ES module on every page (templates/000-base.html),
+// so we import it directly here instead of relying on `window.loading`,
+// which was retired in PR #1383 (chore/retire-jumpto-loading-shims).
+import { loading } from './000-base.js'
+
 function toggleConfigInput (selectElement) {
   const box = document.getElementById('newConfigInput')
   if (!box) return
@@ -123,11 +129,13 @@ document.addEventListener('DOMContentLoaded', function () {
       if (!href || !href.startsWith('/step/')) return
       event.preventDefault()
       const targetLabel = String(link.dataset.qsTargetLabel || link.textContent || '').trim()
-      if (typeof window.loading === 'function') {
-        window.loading('jump', targetLabel)
-      } else if (typeof window.showNavigationLoadingOverlay === 'function') {
-        window.showNavigationLoadingOverlay('jump', targetLabel)
-      }
+      // `loading` is imported from 000-base.js at the top of this file.
+      // The previous `window.showNavigationLoadingOverlay` fallback is
+      // still reachable via the window shim (kept in 000-base.js); we
+      // route through `loading()` first because it composes both the
+      // overlay AND the per-button spinner-state plumbing, while the
+      // overlay fallback is overlay-only.
+      loading('jump', targetLabel)
       window.setTimeout(() => {
         window.location.assign(href)
       }, 60)
@@ -792,10 +800,12 @@ document.addEventListener('DOMContentLoaded', function () {
     const title = document.getElementById('orphanedArtifactsRestoreModalLabel')
     if (title) title.innerHTML = `<i class="bi bi-arrow-counterclockwise me-2"></i>Restore ${orphanedRestoreTarget}`
 
-    const loading = document.createElement('div')
-    loading.className = 'small text-muted'
-    loading.textContent = 'Loading saved versions...'
-    orphanedArtifactsRestoreList.appendChild(loading)
+    // Local element name `loadingMsg` (not `loading`) to avoid shadowing
+    // the `loading` spinner function imported from 000-base.js.
+    const loadingMsg = document.createElement('div')
+    loadingMsg.className = 'small text-muted'
+    loadingMsg.textContent = 'Loading saved versions...'
+    orphanedArtifactsRestoreList.appendChild(loadingMsg)
 
     const modal = bootstrap.Modal.getOrCreateInstance(orphanedArtifactsRestoreModalEl)
     modal.show()
@@ -839,10 +849,12 @@ document.addEventListener('DOMContentLoaded', function () {
       orphanedArtifactsModalEl.querySelectorAll('.btn-close').forEach(el => { el.disabled = false })
     }
 
-    const loading = document.createElement('div')
-    loading.className = 'small text-muted'
-    loading.textContent = 'Scanning config storage...'
-    orphanedArtifactsList.appendChild(loading)
+    // Local element name `loadingMsg` (not `loading`) to avoid shadowing
+    // the `loading` spinner function imported from 000-base.js.
+    const loadingMsg = document.createElement('div')
+    loadingMsg.className = 'small text-muted'
+    loadingMsg.textContent = 'Scanning config storage...'
+    orphanedArtifactsList.appendChild(loadingMsg)
 
     try {
       const res = await fetch('/orphaned-config-artifacts')

--- a/tests/e2e/test_wizard_e2e.py
+++ b/tests/e2e/test_wizard_e2e.py
@@ -1117,16 +1117,23 @@ def test_config_workspace_modal_changing_selector_shows_new_config_input(page, l
 def test_nav_jumpto_data_attr_dispatches_to_jumpto_function(page, live_server):
     """Clicking an element with data-jumpto-page should call jumpTo()
     with the page and (if present) the label. We capture this by
-    stubbing window.jumpTo on the client side and observing the args.
+    listening to the 'qs:nav:jump' CustomEvent and preventing default
+    so the real navigation never fires (the test seam introduced in
+    PR #1383 chore/retire-jumpto-loading-shims, replacing the previous
+    window.jumpTo spy).
     """
     page.goto(f"{live_server}/step/001-start", wait_until="domcontentloaded")
 
-    # Replace window.jumpTo with a spy that records each call's args.
+    # Install the test seam: cancel every 'qs:nav:jump' event and
+    # record its detail. The listener in 000-base.js checks the return
+    # value of dispatchEvent() and skips the real jumpTo() call when
+    # the event is cancelled, so no navigation happens.
     page.evaluate("""
         window.__jumpToCalls = []
-        window.jumpTo = function (page, label) {
-            window.__jumpToCalls.push([page, label])
-        }
+        document.addEventListener('qs:nav:jump', (e) => {
+            e.preventDefault()
+            window.__jumpToCalls.push([e.detail.page, e.detail.label])
+        })
     """)
 
     # The 'Donate' sponsor button in the sidebar footer carries
@@ -1142,7 +1149,7 @@ def test_nav_jumpto_data_attr_dispatches_to_jumpto_function(page, live_server):
         el.click()
     """)
     calls = page.evaluate("window.__jumpToCalls")
-    assert calls, "expected jumpTo() to be called when [data-jumpto-page] was clicked"
+    assert calls, "expected qs:nav:jump to fire when [data-jumpto-page] was clicked"
     # No data-jumpto-label on the sponsor link, so the label arg should be undefined/None.
     assert calls[-1][0] == "910-sponsor", f"expected page='910-sponsor', got {calls[-1]}"
 
@@ -1150,15 +1157,18 @@ def test_nav_jumpto_data_attr_dispatches_to_jumpto_function(page, live_server):
 @pytest.mark.e2e
 def test_nav_jumpto_data_attr_includes_label_when_present(page, live_server):
     """If the element carries both data-jumpto-page and data-jumpto-label,
-    both values should be forwarded to jumpTo(). Verified by injecting
-    a synthetic element AFTER DOMContentLoaded -- this exercises the
-    event-delegation behaviour (delegated listener picks up elements
+    both values should be forwarded to the qs:nav:jump event. Verified by
+    injecting a synthetic element AFTER DOMContentLoaded -- this exercises
+    the event-delegation behaviour (delegated listener picks up elements
     added at runtime, not just those present at page load).
     """
     page.goto(f"{live_server}/step/001-start", wait_until="domcontentloaded")
     page.evaluate("""
         window.__jumpToCalls = []
-        window.jumpTo = (page, label) => { window.__jumpToCalls.push([page, label]) }
+        document.addEventListener('qs:nav:jump', (e) => {
+            e.preventDefault()
+            window.__jumpToCalls.push([e.detail.page, e.detail.label])
+        })
         const el = document.createElement('a')
         el.id = '__synthetic_jumpto'
         el.href = 'javascript:void(0);'
@@ -1171,22 +1181,28 @@ def test_nav_jumpto_data_attr_includes_label_when_present(page, live_server):
     # The runtime-added element must be picked up by the delegated
     # listener installed at DOMContentLoaded -- proves we're NOT using
     # per-element binding (which would miss this).
-    assert calls, "expected jumpTo() to be called for a runtime-added [data-jumpto-page] element"
-    assert calls[-1] == ["020-tmdb", "TMDb Custom Label"], f"expected jumpTo('020-tmdb', 'TMDb Custom Label'), got {calls[-1]}"
+    assert calls, "expected qs:nav:jump to fire for a runtime-added [data-jumpto-page] element"
+    assert calls[-1] == ["020-tmdb", "TMDb Custom Label"], f"expected page='020-tmdb', label='TMDb Custom Label', got {calls[-1]}"
 
 
 @pytest.mark.e2e
 def test_nav_next_button_data_attr_fires_loading_before_submit(page, live_server):
-    """The Next button is a form-submit. Clicking it should call
-    loading('next', target) BEFORE the form submits. The click listener
-    MUST NOT preventDefault or the form won't navigate.
+    """The Next button is a form-submit. Clicking it should fire
+    qs:nav:loading with action='next' BEFORE the form submits. The click
+    listener MUST NOT preventDefault or the form won't navigate.
     """
     page.goto(f"{live_server}/step/010-plex", wait_until="domcontentloaded")
 
-    # Stub window.loading to capture its args.
+    # Install the qs:nav:loading test seam. Cancel the event so the
+    # real loading() call (which would start spinners + DOM mutation)
+    # never fires; we just observe what action/target would have been
+    # passed.
     page.evaluate("""
         window.__loadingCalls = []
-        window.loading = (action, target) => { window.__loadingCalls.push([action, target]) }
+        document.addEventListener('qs:nav:loading', (e) => {
+            e.preventDefault()
+            window.__loadingCalls.push([e.detail.action, e.detail.target])
+        })
     """)
 
     next_btn = page.locator('button[data-nav-action="next"]').first
@@ -1230,7 +1246,10 @@ def test_nav_step_rail_button_clicks_call_jumpto(page, live_server):
 
     page.evaluate("""
         window.__jumpToCalls = []
-        window.jumpTo = (page, label) => { window.__jumpToCalls.push([page, label]) }
+        document.addEventListener('qs:nav:jump', (e) => {
+            e.preventDefault()
+            window.__jumpToCalls.push([e.detail.page, e.detail.label])
+        })
     """)
 
     # qs-step-link is the class on the per-step rail button. We look for
@@ -1316,7 +1335,10 @@ def test_runtime_added_jumpto_element_triggers_jumpto_via_delegation(page, live_
     page.goto(f"{live_server}/step/001-start", wait_until="domcontentloaded")
     page.evaluate("""
         window.__jumpToCalls = []
-        window.jumpTo = (page, label) => { window.__jumpToCalls.push([page, label]) }
+        document.addEventListener('qs:nav:jump', (e) => {
+            e.preventDefault()
+            window.__jumpToCalls.push([e.detail.page, e.detail.label])
+        })
         const host = document.createElement('div')
         host.id = '__runtime_host'
         document.body.appendChild(host)
@@ -1378,11 +1400,14 @@ def test_validation_handler_show_message_html_opt_in_renders_html(page, live_ser
     # And clicking it should trigger the delegated jumpTo handler.
     page.evaluate("""
         window.__jumpToCalls = []
-        window.jumpTo = (page, label) => { window.__jumpToCalls.push([page, label]) }
+        document.addEventListener('qs:nav:jump', (e) => {
+            e.preventDefault()
+            window.__jumpToCalls.push([e.detail.page, e.detail.label])
+        })
         document.querySelector('#validation-messages a[data-jumpto-page=\"010-plex\"]').click()
     """)
     calls = page.evaluate("window.__jumpToCalls")
-    assert calls, "expected click on the rendered <a> to trigger jumpTo"
+    assert calls, "expected click on the rendered <a> to trigger qs:nav:jump"
     assert calls[-1][0] == "010-plex", f"expected page='010-plex', got {calls[-1]}"
 
 
@@ -1458,3 +1483,109 @@ def test_macros_html_contains_no_inline_event_handlers(page, live_server):
     pattern = re.compile(r"\bon(click|input|change|submit|load|key\w*|focus|blur|mouse\w*)=", re.IGNORECASE)
     hits = pattern.findall(macros)
     assert not hits, f"found inline event handlers in _macros.html: {hits[:5]}"
+
+
+# window.jumpTo / window.loading shim retirement
+# (chore/retire-jumpto-loading-shims).
+# Previously 000-base.js published `window.jumpTo` and `window.loading`
+# as compatibility shims so that:
+#   - 001-start.js could call window.loading('jump', label)
+#   - the e2e test suite could spy on calls by overwriting them
+# Both consumers have been migrated:
+#   - 001-start.js now does `import { loading } from './000-base.js'`
+#   - the delegated nav listener dispatches cancelable CustomEvents
+#     ('qs:nav:jump' and 'qs:nav:loading') that tests subscribe to.
+# These tests pin the new contract so the shims can't sneak back in.
+
+
+@pytest.mark.e2e
+def test_window_jumpto_and_loading_shims_are_retired(page, live_server):
+    """window.jumpTo and window.loading must NOT be set by 000-base.js."""
+    page.goto(f"{live_server}/step/001-start", wait_until="domcontentloaded")
+    # Give the module a beat to finish executing.
+    page.wait_for_timeout(200)
+    state = page.evaluate("""() => ({
+            jumpTo: typeof window.jumpTo,
+            loading: typeof window.loading
+        })""")
+    assert state["jumpTo"] == "undefined", f"window.jumpTo should be undefined (retired shim), got {state['jumpTo']}"
+    assert state["loading"] == "undefined", f"window.loading should be undefined (retired shim), got {state['loading']}"
+
+
+@pytest.mark.e2e
+def test_qs_nav_jump_event_is_cancelable_and_carries_detail(page, live_server):
+    """The CustomEvent test seam contract: 'qs:nav:jump' must be a
+    cancelable event with { page, label } in detail. Cancelling it
+    must skip the underlying jumpTo() call.
+    """
+    page.goto(f"{live_server}/step/001-start", wait_until="domcontentloaded")
+    page.evaluate("""() => {
+            window.__capturedEvent = null
+            window.__jumpToFiredAfterCancel = false
+            // Wrap jumpTo to detect if it ran AFTER cancel. We can't
+            // import the module function from inside evaluate(), but we
+            // can observe the form-submission side-effect: jumpTo()
+            // mutates form.action and submits. Stub the form's submit
+            // to detect that.
+            const form = document.getElementById('configForm')
+            if (form) {
+                form.addEventListener('submit', () => {
+                    window.__jumpToFiredAfterCancel = true
+                }, { capture: true })
+            }
+            document.addEventListener('qs:nav:jump', (e) => {
+                window.__capturedEvent = {
+                    type: e.type,
+                    cancelable: e.cancelable,
+                    page: e.detail.page,
+                    label: e.detail.label
+                }
+                e.preventDefault()
+            })
+            // Synthesize a link to click.
+            const el = document.createElement('a')
+            el.id = '__seam_link'
+            el.href = 'javascript:void(0);'
+            el.dataset.jumptoPage = '030-tautulli'
+            el.dataset.jumptoLabel = 'Tautulli Test'
+            document.body.appendChild(el)
+            el.click()
+        }""")
+    captured = page.evaluate("window.__capturedEvent")
+    fired = page.evaluate("window.__jumpToFiredAfterCancel")
+    assert captured is not None, "qs:nav:jump event did not fire"
+    assert captured["type"] == "qs:nav:jump"
+    assert captured["cancelable"] is True, "qs:nav:jump must be cancelable"
+    assert captured["page"] == "030-tautulli"
+    assert captured["label"] == "Tautulli Test"
+    assert fired is False, "jumpTo() should NOT have run after preventDefault()"
+
+
+@pytest.mark.e2e
+def test_qs_nav_loading_event_is_cancelable_and_carries_detail(page, live_server):
+    """Same contract for the loading event."""
+    page.goto(f"{live_server}/step/010-plex", wait_until="domcontentloaded")
+    page.evaluate("""() => {
+            window.__capturedEvent = null
+            document.addEventListener('qs:nav:loading', (e) => {
+                window.__capturedEvent = {
+                    type: e.type,
+                    cancelable: e.cancelable,
+                    action: e.detail.action,
+                    target: e.detail.target
+                }
+                e.preventDefault()
+            })
+            // Intercept form submit so the page doesn't actually navigate.
+            document.getElementById('configForm').addEventListener('submit',
+                (e) => { e.preventDefault() })
+            const btn = document.querySelector('button[data-nav-action="next"]')
+            if (!btn) throw new Error('No button[data-nav-action=next] on the page')
+            btn.click()
+        }""")
+    captured = page.evaluate("window.__capturedEvent")
+    assert captured is not None, "qs:nav:loading event did not fire"
+    assert captured["type"] == "qs:nav:loading"
+    assert captured["cancelable"] is True, "qs:nav:loading must be cancelable"
+    assert captured["action"] == "next"
+    assert captured["target"], "qs:nav:loading must carry a non-empty target"


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix — fixes a long-standing leaky abstraction (test-only behaviour leaking into the public API surface)
- [x] Feature/Tweak — closes out the inline-handler sprint by retiring the last cross-module navigation shims
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Other

## Description

Closes out the inline-handler sprint that started with #1375. The last remaining piece of cross-module navigation glue — the `window.jumpTo` and `window.loading` shims published by `000-base.js` — are now retired.

### What motivated the shims

- **`001-start.js`** had `window.loading('jump', label)` for the start-page step-link click handler.
- **The delegated nav listener** (#1377) used `(typeof window !== 'undefined' && window.jumpTo) || jumpTo` so the e2e test suite could spy on calls by overwriting `window.jumpTo`.

Both reasons are gone:
- `001-start.js` imports `loading()` directly from `000-base.js` (both are already `type="module"`).
- The test suite observes navigation via a **documented CustomEvent contract** that doesn't pollute `window`.

### The new test seam — CustomEvent

```js
// In 000-base.js's delegated click listener:
const navEvent = new CustomEvent('qs:nav:jump', {
  cancelable: true,
  detail: { page, label }
})
const allowed = document.dispatchEvent(navEvent)
if (allowed) jumpTo(page, label)
```

Tests subscribe and cancel:
```js
document.addEventListener('qs:nav:jump', (e) => {
  e.preventDefault()
  __jumpToCalls.push([e.detail.page, e.detail.label])
})
```

### Why CustomEvent instead of just calling `jumpTo()` directly?

The point of the indirection in #1377 was a test seam — e2e tests need to know "what page would have been navigated to" WITHOUT actually navigating (which would tear down the page mid-test). The `window.jumpTo` overwrite was a pragmatic but ugly seam: it leaked test-only behaviour into the public API surface.

**CustomEvent is the right primitive for this:**
- It's a **documented protocol** (`dispatchEvent` + listener), not a monkey-patched global.
- It's **cancelable**, which gives tests fine-grained control over whether the real navigation runs.
- It **composes** — multiple listeners can observe without interfering.
- It **doesn't require window namespace pollution**.

Production code that doesn't care just doesn't listen. Same observable shape as before; cleaner architecture.

### Tally

| File | Change |
|---|---|
| `000-base.js` | Listener dispatches CustomEvent; `window.jumpTo` / `window.loading` shims removed; `export { loading, jumpTo }` added |
| `001-start.js` | `import { loading } from './000-base.js'`; two local `loading` vars renamed to `loadingMsg` to avoid shadow |
| `test_wizard_e2e.py` | 5 existing tests migrated to CustomEvent seam; **3 new regression tests** |

### Test coverage — 3 new regression tests

- **`test_window_jumpto_and_loading_shims_are_retired`** — asserts `typeof window.jumpTo === 'undefined'` and same for `window.loading`. Pins the retirement so a future PR can't accidentally republish them.
- **`test_qs_nav_jump_event_is_cancelable_and_carries_detail`** — documents the test seam contract: `event.type === 'qs:nav:jump'`, `event.cancelable === true`, `event.detail === {page, label}`, and `preventDefault()` actually prevents `jumpTo()` from running (verified via the form-submit side-effect that `jumpTo()` triggers).
- **`test_qs_nav_loading_event_is_cancelable_and_carries_detail`** — same for `qs:nav:loading`.

### Why other shims stay

The other shims (`showSpinner`, `hideSpinner`, `escapeHtml`, `setButtonIconAndText`, `showToast`, `showNavigationLoadingOverlay`, `hideNavigationLoadingOverlay`) still exist because their consumers are classic non-module scripts (`eventHandler.js`, `validationHandler.js`, `130-trakt.js`, `140-mal.js`, etc.). Converting those to ES modules is a separate, larger refactor on #1334's roadmap.

### Verification

| Check | Result |
|---|---|
| Vitest | 323/323 pass |
| Python tests | 80/80 pass |
| Playwright e2e | **52/52 pass** (was 49; +3 new) |
| ESLint | 0 errors |
| pre-commit | 12/12 hooks green |
| Diff stat | 3 files, +212 / -45 |

### Inline-handler sprint — definitively done

| PR | Status | Eliminated |
|---|---|---|
| #1375 | merged | 9 handlers |
| #1376 | merged | 4 handlers + **1 latent webhooks bug fix** |
| #1377 | merged | 10 handlers + `data-jumpto-page` / `data-nav-action` infra |
| #1378 | merged | 3 handlers + event delegation + `{html: true}` opt-in + **1 latent textContent bug fix** |
| #1381 | merged | 4 handlers (color-picker macro IIFEs) |
| **this** | **open** | **2 window shims + CustomEvent test seam** |

**Total: 30 inline handlers + 2 window shims gone. Zero inline handlers or cross-module nav shims remaining anywhere in the codebase.**

## Related Issues

Closes the inline-handler track of #1334. Follows #1375, #1376, #1377, #1378, #1381.

## Which Environment Did You Test On?

- [x] Local Install (Linux, Python 3.13, Vitest+jsdom, Playwright Chromium e2e)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
