### PR TITLE
Restore window.jumpTo shim; fix regression from PR #1382

### DIFF
--- a/static/local-js/000-base.js
+++ b/static/local-js/000-base.js
@@ -4336,13 +4336,22 @@ document.addEventListener('DOMContentLoaded', () => {
 // names that other files reference until those files are themselves modules.
 // Remove each entry as its consumers are converted.
 //
-// jumpTo + loading are NO LONGER shimmed -- the delegated nav listener
-// above no longer routes through window.* (uses CustomEvent as the test
-// seam instead) and 001-start.js imports `loading` directly. See PR
-// #1383 (chore/retire-jumpto-loading-shims) for the migration.
+// jumpTo: restored in PR #1384 after PR #1382 missed a remaining classic-
+// script consumer. static/local-js/025-libraries.js (a 4600-line classic
+// script) has a `qs:before-step-navigation` listener that calls
+// `jumpTo(detail.targetPage, detail.targetLabel)` after autosaving. That
+// call relied on the shim; without it, navigating away from a library
+// throws ReferenceError. The shim stays until 025-libraries.js is
+// converted to an ES module (separate roadmap item).
+//
+// loading: NOT shimmed. PR #1382 successfully migrated the only external
+// caller (001-start.js) to a direct `import { loading }`. Don't republish
+// it here -- that's the regression-prevention regression test in
+// tests/e2e/test_wizard_e2e.py (test_window_loading_shim_is_retired).
 window.escapeHtml = escapeHtml
 window.hideNavigationLoadingOverlay = hideNavigationLoadingOverlay
 window.hideSpinner = hideSpinner
+window.jumpTo = jumpTo
 window.setButtonIconAndText = setButtonIconAndText
 window.showNavigationLoadingOverlay = showNavigationLoadingOverlay
 window.showSpinner = showSpinner

--- a/tests/e2e/test_wizard_e2e.py
+++ b/tests/e2e/test_wizard_e2e.py
@@ -1499,17 +1499,42 @@ def test_macros_html_contains_no_inline_event_handlers(page, live_server):
 
 
 @pytest.mark.e2e
-def test_window_jumpto_and_loading_shims_are_retired(page, live_server):
-    """window.jumpTo and window.loading must NOT be set by 000-base.js."""
+def test_window_loading_shim_is_retired(page, live_server):
+    """window.loading must NOT be set by 000-base.js. The only external
+    caller (001-start.js) was migrated to a direct ES module import in
+    PR #1382. window.jumpTo is INTENTIONALLY still shimmed because
+    static/local-js/025-libraries.js (a 4600-line classic script) still
+    relies on it. See PR #1384 (fix/restore-jumpto-shim-for-classic-scripts)
+    for the regression that motivated the restoration.
+    """
     page.goto(f"{live_server}/step/001-start", wait_until="domcontentloaded")
     # Give the module a beat to finish executing.
     page.wait_for_timeout(200)
+    state = page.evaluate("() => typeof window.loading")
+    assert state == "undefined", f"window.loading should be undefined (retired shim), got {state}"
+
+
+@pytest.mark.e2e
+def test_window_jumpto_shim_is_present_on_libraries_page(page, live_server):
+    """Regression guard for the bug introduced by PR #1382 and fixed in
+    PR #1384: static/local-js/025-libraries.js calls `jumpTo(...)` as a
+    bare reference inside its `qs:before-step-navigation` listener. That
+    classic script depends on the `window.jumpTo` shim being published
+    by 000-base.js. Without the shim, autosave-then-navigate from a
+    library throws ReferenceError.
+    """
+    page.goto(f"{live_server}/step/025-libraries", wait_until="domcontentloaded")
+    # Sequential script loader is async; wait for it to finish.
+    page.wait_for_timeout(2000)
     state = page.evaluate("""() => ({
-            jumpTo: typeof window.jumpTo,
-            loading: typeof window.loading
-        })""")
-    assert state["jumpTo"] == "undefined", f"window.jumpTo should be undefined (retired shim), got {state['jumpTo']}"
-    assert state["loading"] == "undefined", f"window.loading should be undefined (retired shim), got {state['loading']}"
+        jumpToType: typeof window.jumpTo,
+        bareJumpToType: typeof jumpTo,
+        librariesLoaded: !!document.querySelector('#libraryPicker')
+    })""")
+    assert state["librariesLoaded"], "expected the libraries page to actually render (precondition for the test)"
+    assert state["jumpToType"] == "function", f"window.jumpTo MUST be a function on the libraries page so 025-libraries.js can call it; got {state['jumpToType']}"
+    # Bare `jumpTo` resolves via window in non-strict classic scripts.
+    assert state["bareJumpToType"] == "function", f"bare jumpTo MUST resolve (via window) on the libraries page; got {state['bareJumpToType']}"
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
## What type of PR is this?

- [x] **Bug Fix — fixes a regression introduced by PR #1382**
- [ ] Feature/Tweak
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Other

## Description

PR #1382 (Retire window.jumpTo / window.loading shims) retired both shims based on an audit that found only one external caller of `loading` (in 001-start.js) and **zero** external callers of `jumpTo`.

**That audit missed one.** `static/local-js/025-libraries.js` (line 4627) calls `jumpTo(...)` as a bare reference inside its `qs:before-step-navigation` listener:

```js
document.addEventListener('qs:before-step-navigation', (event) => {
  ...
  autosaveActiveLibrary()
    .then(() => {
      allowNextStepNavigation = true
      jumpTo(detail.targetPage, detail.targetLabel)   // <-- BROKEN
    })
})
```

`025-libraries.js` is a 4600-line **classic** script (not an ES module). In a classic non-strict script, bare `jumpTo` resolves via `window.jumpTo`. After #1382, `window.jumpTo === undefined`, so any attempt to autosave-then-navigate from an active library throws `ReferenceError: jumpTo is not defined`.

The bug is silent unless the user actually triggers the autosave path — which our e2e suite didn't.

### Fix

Restore `window.jumpTo = jumpTo` in 000-base.js's compatibility-shims block. Keep `loading` retired (that migration was correct — `001-start.js` does import it).

### Test changes

Replace the over-broad `test_window_jumpto_and_loading_shims_are_retired` with two focused tests:

- **`test_window_loading_shim_is_retired`** — pins #1382's actual success: `typeof window.loading === 'undefined'`.
- **`test_window_jumpto_shim_is_present_on_libraries_page`** — pins THIS fix. Asserts `typeof window.jumpTo === 'function'` AND `typeof jumpTo === 'function'` (bare reference) on `/step/025-libraries`. The bare check is the important one — that's exactly the resolution path 025-libraries.js depends on.

### Why not convert 025-libraries.js to a module?

It's 4600 lines with deep coupling to `imageHandler.js`, `overlayHandler.js`, `validationHandler.js`, and `eventHandler.js` — which are also classic scripts loaded via a sequential `<script>` tag loader **inside** 025-libraries.js itself. Converting all five to ES modules is a real refactor, tracked as part of #1334's roadmap. Out of scope for a hotfix.

### Lessons learned (saved in the kennel)

1. **I ran the right grep but read it wrong.** `grep -rnE '\bjumpTo\b' static/local-js/` would have caught the 025-libraries.js call — I ran that exact grep but my output filter removed `// ` lines too aggressively, hiding actual call sites. Should have read every hit.
2. **#1382's "regression test" only asserted absence**, not behaviour. It checked `typeof window.jumpTo === 'undefined'` but didn't exercise any classic-script consumer. A real load-bearing e2e (like the ones the inline-handler sprint shipped) would have caught this.
3. **The planned ESLint tightening PR should include a `no-restricted-globals` rule** for previously-retired shim names so this class of regression gets caught at lint time. That PR is up next.

### Verification

| Check | Result |
|---|---|
| Vitest | 323/323 pass |
| Python tests | 80/80 pass |
| Playwright e2e | **53/53 pass** (was 52; +1 net from the test split) |
| ESLint | 0 errors |
| pre-commit | 12/12 hooks green |
| Diff stat | 2 files, +45 / -11 |

## Related Issues

Fixes a regression introduced by #1382. Continues inline-handler sprint cleanup.

## Which Environment Did You Test On?

- [x] Local Install (Linux, Python 3.13, Playwright Chromium e2e)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
