### PR TITLE
Tighten ESLint config; add regression-guard tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,6 +27,24 @@ const browserGlobals = {
   Element: 'readonly'
 }
 
+// Quickstart-specific globals. Most are functions defined in 000-base.js
+// or one of the classic-script files loaded by 025-libraries.js
+// (eventHandler.js, validationHandler.js, etc.). Declaring them here
+// suppresses `no-undef` errors in classic scripts that call them bare.
+//
+// NOTE: `loading` is INTENTIONALLY NOT in this list. PR #1382 retired
+// the window.loading shim because the only external caller
+// (001-start.js) was migrated to a direct `import { loading }`. Adding
+// `loading: 'readonly'` here would silently re-enable bare `loading()`
+// calls from classic scripts that would resolve to `undefined` at
+// runtime. The `no-restricted-syntax` rule below also bans
+// `window.loading = ...` to prevent the shim being re-introduced.
+//
+// `jumpTo` IS in this list because PR #1383 restored its shim after
+// discovering static/local-js/025-libraries.js (a 4600-line classic
+// script) calls it bare. When 025-libraries.js is converted to an ES
+// module, remove `jumpTo` from this list and add it to the
+// `no-restricted-syntax` ban below.
 const quickstartGlobals = {
   $: 'readonly',
   bootstrap: 'readonly',
@@ -87,6 +105,44 @@ const moduleFiles = [
   'static/local-js/150-settings.js'
 ]
 
+// Selectors for `no-restricted-syntax`. Defined here so the rules block
+// below stays readable. ESLint AST selector reference:
+// https://eslint.org/docs/latest/extend/selectors
+//
+// Inline-handler regression guards: these patterns catch the recurring
+// foot-gun cleaned up across PRs #1375-#1381 (29 inline event handlers
+// + 4 IIFEs eliminated). The cleanup pattern:
+//
+//   BAD:  innerHTML = '<a onclick="jumpTo(\\'010-plex\\')">click</a>'
+//   GOOD: <a href="javascript:void(0);" data-jumpto-page="010-plex">click</a>
+//         + delegated click listener
+//
+// We catch the BAD pattern by inspecting Literal nodes (regular strings)
+// and TemplateElement nodes (the static text portions of template
+// literals). The regex matches the on-event-name pattern followed by
+// optional whitespace and `=`. Wrapped in `\b` so it doesn't trip on
+// e.g. `data-onclick-foo="..."` or substrings inside larger identifiers.
+const inlineHandlerPattern = '/\\bon(click|input|change|submit|key\\w*|focus|blur|mouse\\w*)\\s*=/'
+const inlineHandlerMessage =
+  'Inline event-handler attributes (onclick=, oninput=, etc.) are forbidden ' +
+  'in JS strings. Use data-attributes + delegated listeners. ' +
+  'See static/local-js/000-base.js for the data-jumpto-page / data-nav-action ' +
+  'pattern.'
+
+// Shim regression guards. These catch `window.X = ...` assignments for
+// names we have deliberately retired. AssignmentExpression selector:
+//   left.object.name === 'window' AND left.property.name === 'loading'
+// Per-name selectors are easier to read than one selector that matches
+// "any retired name".
+//
+// NOTE: window.jumpTo is INTENTIONALLY NOT in this ban list. See the
+// quickstartGlobals comment above for why.
+const retiredShimMessage = (name) =>
+  `window.${name} = ... is a retired compatibility shim. ` +
+  'See PR #1382 (chore/retire-jumpto-loading-shims). The only caller ' +
+  'was migrated to a direct ES module import. Adding the shim back ' +
+  'would re-introduce window namespace pollution.'
+
 module.exports = [
   {
     files: ['static/local-js/**/*.js'],
@@ -104,7 +160,33 @@ module.exports = [
       'no-unused-vars': ['error', { args: 'none', ignoreRestSiblings: true }],
       'no-shadow': 'error',
       'no-global-assign': 'error',
-      'no-implied-eval': 'error'
+      'no-implied-eval': 'error',
+      // Modernization rules. Already passing across the codebase; locking
+      // them in so they can't regress. The `eqeqeq` 'null' exception
+      // allows `x == null` / `x != null` as the idiomatic check for
+      // "null or undefined" -- the existing codebase uses this in 15+
+      // places, all genuinely intentional.
+      'no-var': 'error',
+      'prefer-const': 'error',
+      eqeqeq: ['error', 'always', { null: 'ignore' }],
+      // Regression guards for the inline-handler / shim cleanup sprint.
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: `Literal[value=${inlineHandlerPattern}]`,
+          message: inlineHandlerMessage
+        },
+        {
+          selector: `TemplateElement[value.raw=${inlineHandlerPattern}]`,
+          message: inlineHandlerMessage
+        },
+        {
+          selector:
+            "AssignmentExpression[left.type='MemberExpression']" +
+            "[left.object.name='window'][left.property.name='loading']",
+          message: retiredShimMessage('loading')
+        }
+      ]
     }
   },
   {

--- a/tests/test_eslint_config.py
+++ b/tests/test_eslint_config.py
@@ -1,0 +1,230 @@
+"""Regression guard for the project's ESLint config.
+
+These tests prove that the rules in `eslint.config.js` actually catch the
+regressions they were added to catch. If someone weakens or removes a
+rule, the corresponding test fails -- not at runtime, but at lint time.
+
+We invoke ESLint via npx on synthetic JS snippets written to a temp
+directory. We assert the violations show up (or don't) by checking
+ESLint's JSON output.
+
+The synthetic-snippet approach decouples the tests from the real
+codebase -- they don't depend on the production JS staying clean, only
+on the config behaving as documented.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ESLINT_CONFIG = REPO_ROOT / "eslint.config.js"
+
+
+def _eslint_available() -> bool:
+    """ESLint is only available where node_modules/.bin/eslint exists.
+
+    Skip these tests in environments that don't have the JS toolchain
+    installed (e.g. some CI matrix entries that only run Python tests).
+    """
+    return (REPO_ROOT / "node_modules" / ".bin" / "eslint").exists()
+
+
+pytestmark = pytest.mark.skipif(
+    not _eslint_available(),
+    reason="node_modules/.bin/eslint not installed (run `npm install` first)",
+)
+
+
+def _run_eslint(snippet: str, filename: str = "snippet.js") -> list[dict]:
+    """Write a snippet to a temp file under static/local-js/ and lint it.
+
+    We have to place the file under static/local-js/ because the ESLint
+    config's `files: ['static/local-js/**/*.js']` glob only matches there.
+    Returns the parsed JSON results (list of one file-result dict).
+    """
+    target_dir = REPO_ROOT / "static" / "local-js"
+    # Use a name that the moduleFiles allow-list does NOT contain so the
+    # snippet is treated as a classic (sourceType: 'script') file by
+    # default. That's what matters for the inline-handler / shim tests.
+    target = target_dir / f"__eslint_test_{filename}"
+    target.write_text(snippet, encoding="utf-8")
+    try:
+        result = subprocess.run(
+            [
+                "npx",
+                "--no-install",
+                "eslint",
+                "--format=json",
+                "--config",
+                str(ESLINT_CONFIG),
+                str(target),
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env={**os.environ, "CI": "true"},
+        )
+        # eslint exits 1 when violations exist; both 0 and 1 are valid
+        # outcomes for these tests. Anything else is a real failure.
+        if result.returncode not in (0, 1):
+            raise AssertionError(f"eslint exited {result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}")
+        return json.loads(result.stdout)
+    finally:
+        target.unlink(missing_ok=True)
+
+
+def _messages(results: list[dict]) -> list[dict]:
+    """Flatten ESLint's per-file message lists into a single list."""
+    return [msg for file_result in results for msg in file_result.get("messages", [])]
+
+
+def _rule_ids(messages: list[dict]) -> set[str]:
+    return {msg.get("ruleId") for msg in messages if msg.get("ruleId")}
+
+
+# ---------- inline-handler regression guards ----------
+
+
+@pytest.mark.parametrize(
+    "snippet",
+    [
+        # Regular string literal containing inline handler.
+        "const html = '<a onclick=\"jumpTo(\\'foo\\')\">x</a>'\nconsole.log(html)\n",
+        # Template literal containing inline handler.
+        'const html = `<button oninput="foo()">x</button>`\nconsole.log(html)\n',
+        # Inline handler with whitespace before =.
+        "const html = '<div onclick =\"x()\">y</div>'\nconsole.log(html)\n",
+        # Different event name.
+        'const html = `<form onsubmit="return false">x</form>`\nconsole.log(html)\n',
+        # onkey* family.
+        "const html = '<input onkeyup=\"f()\">' \nconsole.log(html)\n",
+        # mouse* family.
+        "const html = `<div onmouseover='x()'>y</div>`\nconsole.log(html)\n",
+    ],
+)
+def test_inline_handler_in_string_is_flagged(snippet: str) -> None:
+    results = _run_eslint(snippet)
+    msgs = _messages(results)
+    assert "no-restricted-syntax" in _rule_ids(msgs), f"expected no-restricted-syntax violation for inline handler, got messages: {msgs}"
+
+
+@pytest.mark.parametrize(
+    "snippet",
+    [
+        # Real anchor href, not an event handler -- must NOT be flagged.
+        "const html = '<a href=\"foo\">click</a>'\nconsole.log(html)\n",
+        # data-attribute that contains the substring "onclick" but isn't
+        # an event attribute -- must NOT be flagged.
+        "const html = '<div data-onclick-handler=\"x\">y</div>'\nconsole.log(html)\n",
+        # Adding event listener via JS property is fine (MemberExpression,
+        # not a Literal containing "onclick=").
+        "const el = document.createElement('div')\nel.onclick = () => console.log('hi')\n",
+        # FileReader.onload property assignment -- common idiom, fine.
+        "const reader = new FileReader()\nreader.onload = () => {}\n",
+    ],
+)
+def test_legitimate_patterns_not_flagged(snippet: str) -> None:
+    results = _run_eslint(snippet)
+    msgs = _messages(results)
+    inline_handler_msgs = [m for m in msgs if m.get("ruleId") == "no-restricted-syntax"]
+    assert not inline_handler_msgs, f"expected NO no-restricted-syntax violations for legitimate pattern, got: {inline_handler_msgs}"
+
+
+# ---------- retired-shim regression guards ----------
+
+
+def test_window_loading_assignment_is_flagged() -> None:
+    """PR #1382 retired window.loading. The rule must reject re-introducing it."""
+    snippet = "function loading () { return 1 }\n" "window.loading = loading\n"
+    results = _run_eslint(snippet)
+    msgs = _messages(results)
+    no_restricted = [m for m in msgs if m.get("ruleId") == "no-restricted-syntax"]
+    assert no_restricted, f"expected window.loading = ... to be flagged, got: {msgs}"
+    # The message body should mention 'loading' so the developer knows what they did.
+    assert any("loading" in (m.get("message") or "") for m in no_restricted)
+
+
+def test_window_jumpto_assignment_is_NOT_flagged_yet() -> None:
+    """window.jumpTo is intentionally still allowed -- PR #1383 restored
+    the shim because static/local-js/025-libraries.js (a classic script)
+    still depends on it. When that file becomes a module, this test
+    should flip to assert the assignment IS flagged.
+    """
+    snippet = "function jumpTo (page, label) { return 1 }\n" "window.jumpTo = jumpTo\n"
+    results = _run_eslint(snippet)
+    msgs = _messages(results)
+    no_restricted = [m for m in msgs if m.get("ruleId") == "no-restricted-syntax"]
+    assert not no_restricted, (
+        "window.jumpTo = ... should still be allowed (025-libraries.js depends on it). "
+        f"If you've converted 025-libraries.js to a module, flip this test and add a ban "
+        f"selector to eslint.config.js. Got violations: {no_restricted}"
+    )
+
+
+# ---------- modernization guards ----------
+
+
+def test_var_is_flagged() -> None:
+    """no-var: enforces let/const over var. Codebase is currently clean."""
+    snippet = "var x = 1\nconsole.log(x)\n"
+    results = _run_eslint(snippet)
+    rule_ids = _rule_ids(_messages(results))
+    assert "no-var" in rule_ids, f"expected no-var violation; got rules: {rule_ids}"
+
+
+def test_let_that_should_be_const_is_flagged() -> None:
+    """prefer-const: locals that are never reassigned must be const."""
+    snippet = "let x = 1\nconsole.log(x)\n"
+    results = _run_eslint(snippet)
+    rule_ids = _rule_ids(_messages(results))
+    assert "prefer-const" in rule_ids, f"expected prefer-const violation; got rules: {rule_ids}"
+
+
+def test_loose_equality_is_flagged() -> None:
+    """eqeqeq: == must be ===."""
+    snippet = "const x = 1\nif (x == '1') console.log('match')\n"
+    results = _run_eslint(snippet)
+    rule_ids = _rule_ids(_messages(results))
+    assert "eqeqeq" in rule_ids, f"expected eqeqeq violation; got rules: {rule_ids}"
+
+
+def test_eq_null_is_NOT_flagged() -> None:
+    """eqeqeq 'null' exception: `x == null` and `x != null` are idiomatic."""
+    snippet = "function foo (x) {\n" "  if (x == null) return 'nullish'\n" "  if (x != null) return 'present'\n" "  return 'other'\n" "}\n" "console.log(foo(1))\n"
+    results = _run_eslint(snippet)
+    rule_ids = _rule_ids(_messages(results))
+    assert "eqeqeq" not in rule_ids, f"x == null / x != null must be allowed (idiomatic null-or-undefined check); got: {rule_ids}"
+
+
+# ---------- pre-existing rules (don't regress these) ----------
+
+
+def test_no_shadow_is_active() -> None:
+    """The no-shadow rule already caught two bugs in PR #1382. Keep it on."""
+    snippet = "const loading = 'outer'\n" "function f () {\n" "  const loading = 'inner'\n" "  return loading\n" "}\n" "console.log(loading, f())\n"
+    results = _run_eslint(snippet)
+    rule_ids = _rule_ids(_messages(results))
+    assert "no-shadow" in rule_ids, f"expected no-shadow violation; got rules: {rule_ids}"
+
+
+def test_no_undef_is_active() -> None:
+    """no-undef catches typos / missing imports. Keep it on."""
+    snippet = "thisIsDefinitelyNotAGlobal('x')\n"
+    results = _run_eslint(snippet)
+    rule_ids = _rule_ids(_messages(results))
+    assert "no-undef" in rule_ids, f"expected no-undef violation; got rules: {rule_ids}"
+
+
+def test_no_implied_eval_is_active() -> None:
+    """no-implied-eval catches setTimeout(string, ...) etc."""
+    snippet = "setTimeout('alert(1)', 100)\n"
+    results = _run_eslint(snippet)
+    rule_ids = _rule_ids(_messages(results))
+    assert "no-implied-eval" in rule_ids, f"expected no-implied-eval; got rules: {rule_ids}"


### PR DESCRIPTION
## What type of PR is this?

- [x] **Feature/Tweak — adds regression-guard ESLint rules + tests**
- [ ] Bug Fix
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Other

## Description

Adds rules to `eslint.config.js` that lock in everything the inline-handler / shim retirement sprint achieved (PRs #1375-#1383), plus modernization guards that were trivially passing but not enforced. Includes a new `tests/test_eslint_config.py` with **19 tests** that prove every rule behaves as documented.

### Why this PR exists

PR #1383 fixed a regression I introduced in #1382 by retiring a shim that one classic script still depended on. The hotfix taught us:

1. **"Shim is undefined" tests prove absence, not safe-to-remove.**
2. **Bare references via `window.*` in classic scripts are the silent failure mode** that absence tests can't catch.
3. **An ESLint rule that bans both the assignment AND bare references to retired names** would catch this class of regression at lint time — before the bug even gets committed.

This PR delivers (1) and (3). The "bare-reference" half waits until `025-libraries.js` becomes a module (so we can ban bare `jumpTo` too).

### New rules

#### 1. `no-restricted-syntax` — inline-handler regression

Catches inline event-handler attributes inside JS string literals **and** template literals:

```js
// BAD — flagged:
innerHTML = '<a onclick="jumpTo(\'010-plex\')">click</a>'
el.innerHTML = `<button oninput="foo()">x</button>`

// GOOD — not flagged:
<a href="javascript:void(0);" data-jumpto-page="010-plex">click</a>
// + delegated click listener (the pattern from PRs #1375-#1381)
```

Pattern matched: `\bon(click|input|change|submit|key\w*|focus|blur|mouse\w*)\s*=`. Applied to both `Literal` and `TemplateElement` AST nodes. JS property assignments (`element.onclick = fn`, `reader.onload = fn`) are **NOT** flagged — the rule only matches inside string/template content.

#### 2. `no-restricted-syntax` — retired-shim regression

Catches `window.loading = ...` assignments. PR #1382 retired this shim; the only external caller (001-start.js) was migrated to a direct ES module import.

`window.jumpTo = ...` is **intentionally** still allowed — PR #1383 restored that shim after discovering 025-libraries.js still depends on it. The eslint.config.js comment explains the asymmetry and points to the future flip.

#### 3. Modernization rules (already passing, now enforced)

| Rule | Effect |
|---|---|
| `no-var` | Rejects `var x = ...` in favour of let/const |
| `prefer-const` | Rejects `let x = 1` where x is never reassigned |
| `eqeqeq` | Requires `===` / `!==` EXCEPT for `x == null` / `x != null` (idiomatic null-or-undefined check; 15 such uses in the codebase, all genuinely intentional) |

The `eqeqeq` `'null': 'ignore'` option was set after the first dry run found 15 false positives — all legitimate `== null` patterns.

### New test file — `tests/test_eslint_config.py` (19 tests)

The tests write **synthetic snippets** to a temp file under `static/local-js/` and lint them, asserting:

-  Inline-handler patterns ARE flagged (6 parametrized cases covering onclick/oninput/onchange/onsubmit/onkey\*/onmouse\*)
-  Legitimate patterns are NOT flagged (4 parametrized cases: real `href=`, `data-*` attributes, JS property assignments, `FileReader.onload`)
-  `window.loading = ...` IS flagged with a helpful message
-  `window.jumpTo = ...` is NOT flagged (with a comment that says "flip this when 025-libraries.js becomes a module")
-  `var` / non-reassigned `let` / loose equality ARE flagged
-  `== null` / `!= null` is NOT flagged
-  Pre-existing rules (`no-shadow`, `no-undef`, `no-implied-eval`) are still active

**Synthetic-snippet approach decouples these tests from the real codebase** — they don't depend on production JS staying clean, only on the config behaving as documented. If someone weakens a rule, the corresponding test fails.

Tests are skipped when `node_modules/.bin/eslint` isn't installed (Python-only CI environments). When eslint IS present they take ~14s total.

### What's next for ESLint (out of scope here)

- Once 025-libraries.js becomes a module: add `window.jumpTo` to the ban list and bare `jumpTo` to `no-restricted-globals`
- Decide whether to consolidate `eslint` and `standard` (both run in pre-commit and overlap a lot) — probably remove `standard` once the rules we want are all in `eslint.config.js`
- Custom rule to enforce `data-*` attribute usage for click handlers (catches at AST level instead of via grep)

### Verification

| Check | Result |
|---|---|
| Vitest | 323/323 pass |
| Python tests | **99/99 pass** (was 80; +19 new ESLint config tests) |
| Playwright e2e | 53/53 pass |
| ESLint on real code | 0 errors (all rules already satisfied) |
| pre-commit | 12/12 hooks green |
| Diff stat | 1 file modified (eslint.config.js, +83/-1)<br>1 file added (tests/test_eslint_config.py, +230) |

## Related Issues

Follow-up to #1382 / #1383. Locks in the inline-handler sprint outcomes (#1375-#1381). Step 1 of the #1334 frontend modernization roadmap.

## Which Environment Did You Test On?

- [x] Local Install (Linux, Python 3.13, Vitest+jsdom, Playwright Chromium e2e)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
