### PR TITLE
Convert eventHandler.js to ES module

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -87,6 +87,7 @@ const moduleFiles = [
   'static/local-js/rgbaPicker.js',
   'static/local-js/validationHandler.js',
   'static/local-js/imageHandler.js',
+  'static/local-js/eventHandler.js',
   'static/local-js/001-start.js',
   'static/local-js/010-plex.js',
   'static/local-js/020-tmdb.js',

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -3,6 +3,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   const scriptsToLoad = [
     '/static/local-js/imageHandler.js',
+    '/static/local-js/eventHandler.js',
     '/static/local-js/overlayHandler.js',
     '/static/local-js/validationHandler.js',
     '/static/local-js/imageHandler.js',

--- a/static/local-js/eventHandler.js
+++ b/static/local-js/eventHandler.js
@@ -9,7 +9,7 @@ const EventHandler = {
         // Attach event listener to each checkbox
         checkbox.addEventListener('change', () => {
           EventHandler.toggleLibraryVisibility(libraryId, checkbox.checked)
-          ValidationHandler.updateValidationState()
+          window.ValidationHandler.updateValidationState()
         })
         checkbox.dataset.listenerAdded = 'true'
       }
@@ -95,7 +95,7 @@ const EventHandler = {
             select.addEventListener('change', () => {
               console.log(`[DEBUG] Dropdown changed: ${select.id} -> ${select.value}`)
               EventHandler.updateAccordionHighlights()
-              ValidationHandler.updateValidationState()
+              window.ValidationHandler.updateValidationState()
 
               // Trigger preview update if template variable
               if (select.classList.contains('template-variable-select')) {
@@ -117,7 +117,7 @@ const EventHandler = {
             // Exclude preview overlay accordions from highlight updates
             if (!input.closest('.preview-accordion')) {
               EventHandler.updateAccordionHighlights()
-              ValidationHandler.updateValidationState()
+              window.ValidationHandler.updateValidationState()
             }
           })
           input.dataset.listenerAdded = true
@@ -134,7 +134,7 @@ const EventHandler = {
 
             // Ensure Highlights Update Properly
             EventHandler.updateAccordionHighlights()
-            ValidationHandler.updateValidationState()
+            window.ValidationHandler.updateValidationState()
           })
 
           dropdown.dataset.listenerAdded = 'true'
@@ -303,8 +303,8 @@ const EventHandler = {
         if (typeof EventHandler.updateAccordionHighlights === 'function') {
           EventHandler.updateAccordionHighlights()
         }
-        if (typeof ValidationHandler !== 'undefined' && ValidationHandler.updateValidationState) {
-          ValidationHandler.updateValidationState()
+        if (typeof window.ValidationHandler !== 'undefined' && window.ValidationHandler.updateValidationState) {
+          window.ValidationHandler.updateValidationState()
         }
       }
       library.querySelectorAll('input:not([type="hidden"]), select, textarea').forEach(el => {
@@ -574,6 +574,8 @@ const EventHandler = {
   }
 }
 
+window.EventHandler = EventHandler
+
 // MutationObserver for dynamically added elements
 const shouldReattachForNode = (node) => {
   if (!node || node.nodeType !== 1) return false
@@ -612,16 +614,13 @@ const observer = new MutationObserver((mutations) => {
 observer.observe(document.body, { childList: true, subtree: true })
 
 // Initial call on page load
-document.addEventListener('DOMContentLoaded', () => {
-  console.log('[DEBUG] Initializing EventHandler...')
+console.log('[DEBUG] Initializing EventHandler...')
 
-  // Run once on page load
-  EventHandler.attachLibraryListeners()
-  ValidationHandler.restoreSelectedLibraries()
-  ValidationHandler.updateValidationState()
-
-  installRatingSubmitGuard()
-})
+// Run once on page load
+EventHandler.attachLibraryListeners()
+window.ValidationHandler.restoreSelectedLibraries()
+window.ValidationHandler.updateValidationState()
+installRatingSubmitGuard()
 
 document.querySelectorAll('select.template-variable-select').forEach(select => {
   const selectedValue = select.dataset.selected

--- a/tests/e2e/test_wizard_e2e.py
+++ b/tests/e2e/test_wizard_e2e.py
@@ -1954,3 +1954,27 @@ def test_imagehandler_module_loads_via_import(page, live_server):
     assert state["hasImageHandler"], "window.ImageHandler must exist after import()"
     assert state["isPreview"], "ImageHandler.isBuiltinPreviewImage must be a function"
     assert state["genPreview"], "ImageHandler.generateSinglePreview must be a function"
+
+
+# ES module conversion of eventHandler.js (chore/convert-eventhandler-to-module).
+# Loaded by 025-libraries.js via dynamic import(). Publishes
+# window.EventHandler for backward compat.
+
+
+@pytest.mark.e2e
+def test_eventhandler_module_loads_via_import(page, live_server):
+    """eventHandler.js is now loaded via import() by 025-libraries.js.
+    Verify window.EventHandler is available with expected methods.
+    """
+    page.goto(f"{live_server}/step/025-libraries", wait_until="domcontentloaded")
+    page.wait_for_timeout(2000)
+    state = page.evaluate("""() => ({
+            hasEventHandler: typeof window.EventHandler !== 'undefined',
+            hasAttach: typeof window.EventHandler === 'object'
+                && typeof window.EventHandler.attachLibraryListeners === 'function',
+            hasHighlights: typeof window.EventHandler === 'object'
+                && typeof window.EventHandler.updateAccordionHighlights === 'function'
+        })""")
+    assert state["hasEventHandler"], "window.EventHandler must exist after import()"
+    assert state["hasAttach"], "EventHandler.attachLibraryListeners must be a function"
+    assert state["hasHighlights"], "EventHandler.updateAccordionHighlights must be a function"


### PR DESCRIPTION
## Description

Fourth **helper-script** module conversion (#1391), following imageHandler.js (#1390). eventHandler.js (763 lines) publishes `window.EventHandler` and references `ValidationHandler` via `window.*` for backward compat.

### Cross-module reference fix

eventHandler.js uses `ValidationHandler.restoreSelectedLibraries()` and `ValidationHandler.updateValidationState()` at module top level. Since `ValidationHandler` is now module-scoped in validationHandler.js, these calls must go through `window.ValidationHandler`. All 8 references were updated to use the `window.*` prefix.

### Remaining

Just **overlayHandler.js** (8,713 lines) left before 025-libraries.js itself can be converted to a module.

### Verification

| Check | Result |
|---|---|
| Vitest | 323/323 pass |
| Python tests | 99/99 pass |
| Playwright e2e | **67/67 pass** (was 66; +1) |
| ESLint | 0 errors |
| pre-commit | 12/12 hooks green |