### PR TITLE
Convert overlayHandler.js to ES module; last helper conversion

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -88,6 +88,7 @@ const moduleFiles = [
   'static/local-js/validationHandler.js',
   'static/local-js/imageHandler.js',
   'static/local-js/eventHandler.js',
+  'static/local-js/overlayHandler.js',
   'static/local-js/001-start.js',
   'static/local-js/010-plex.js',
   'static/local-js/020-tmdb.js',

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -5,6 +5,7 @@ document.addEventListener('DOMContentLoaded', function () {
     '/static/local-js/imageHandler.js',
     '/static/local-js/eventHandler.js',
     '/static/local-js/overlayHandler.js',
+    '/static/local-js/overlayHandler.js',
     '/static/local-js/validationHandler.js',
     '/static/local-js/imageHandler.js',
     '/static/local-js/eventHandler.js',

--- a/static/local-js/overlayHandler.js
+++ b/static/local-js/overlayHandler.js
@@ -17,7 +17,7 @@ const OverlayHandler = {
         OverlayHandler.updateSeparatorPreview(fieldId, separatorDropdown.value)
         OverlayHandler.toggleSeparatorPlaceholder(libraryId, selectedStyle)
         OverlayHandler.updateHiddenInputs(libraryId, isMovie)
-        EventHandler.updateAccordionHighlights()
+        window.EventHandler.updateAccordionHighlights()
       })
 
       separatorDropdown.dataset.listenerAdded = true
@@ -28,7 +28,7 @@ const OverlayHandler = {
       OverlayHandler.updateSeparatorPreview(fieldId, separatorDropdown.value)
       OverlayHandler.toggleSeparatorPlaceholder(libraryId, initialSelected)
       OverlayHandler.updateHiddenInputs(libraryId, isMovie)
-      EventHandler.updateAccordionHighlights()
+      window.EventHandler.updateAccordionHighlights()
     }
 
     const placeholderWrapper = OverlayHandler.getSeparatorPlaceholderWrapper(libraryId)
@@ -37,7 +37,7 @@ const OverlayHandler = {
       sourceSelect.addEventListener('change', () => {
         const separatorsEnabled = separatorDropdown ? separatorDropdown.value !== 'none' : true
         OverlayHandler.syncSeparatorPlaceholderFields(placeholderWrapper, { show: separatorsEnabled })
-        EventHandler.updateAccordionHighlights()
+        window.EventHandler.updateAccordionHighlights()
       })
       sourceSelect.dataset.listenerAdded = 'true'
     }
@@ -3886,8 +3886,8 @@ const OverlayHandler = {
         emptyState.classList.toggle('d-none', rows.length > 0)
       }
 
-      if (typeof EventHandler !== 'undefined' && typeof EventHandler.updateAccordionHighlights === 'function') {
-        EventHandler.updateAccordionHighlights()
+      if (typeof window.EventHandler !== 'undefined' && window.EventHandler.updateAccordionHighlights === 'function') {
+        window.EventHandler.updateAccordionHighlights()
       }
       if (typeof ValidationHandler !== 'undefined' && typeof ValidationHandler.updateValidationState === 'function') {
         ValidationHandler.updateValidationState()
@@ -8549,6 +8549,8 @@ const OverlayHandler = {
   }
 }
 
+window.OverlayHandler = OverlayHandler
+
 function bootstrapOverlayHandler () {
   const separatorPlaceholders = document.querySelectorAll('[data-separator-placeholder-wrapper="true"]')
 
@@ -8722,3 +8724,5 @@ function setupParentChildToggleSync () {
     })
   })
 }
+
+window.setupParentChildToggleSync = setupParentChildToggleSync

--- a/tests/e2e/test_wizard_e2e.py
+++ b/tests/e2e/test_wizard_e2e.py
@@ -1978,3 +1978,29 @@ def test_eventhandler_module_loads_via_import(page, live_server):
     assert state["hasEventHandler"], "window.EventHandler must exist after import()"
     assert state["hasAttach"], "EventHandler.attachLibraryListeners must be a function"
     assert state["hasHighlights"], "EventHandler.updateAccordionHighlights must be a function"
+
+
+# ES module conversion of overlayHandler.js (chore/convert-overlayhandler-to-module).
+# Last helper-script conversion. Publishes window.OverlayHandler and
+# window.setupParentChildToggleSync for backward compat.
+
+
+@pytest.mark.e2e
+def test_overlayhandler_module_loads_via_import(page, live_server):
+    """overlayHandler.js is now loaded via import() by 025-libraries.js.
+    Verify window.OverlayHandler is available with expected methods.
+    """
+    page.goto(f"{live_server}/step/025-libraries", wait_until="domcontentloaded")
+    page.wait_for_timeout(2000)
+    state = page.evaluate("""() => ({
+            hasOverlayHandler: typeof window.OverlayHandler !== 'undefined',
+            hasBoards: typeof window.OverlayHandler === 'object'
+                && typeof window.OverlayHandler.initializeOverlayBoards === 'function',
+            hasJumpBtns: typeof window.OverlayHandler === 'object'
+                && typeof window.OverlayHandler.initializeJumpButtons === 'function',
+            hasToggleSync: typeof window.setupParentChildToggleSync === 'function'
+        })""")
+    assert state["hasOverlayHandler"], "window.OverlayHandler must exist after import()"
+    assert state["hasBoards"], "OverlayHandler.initializeOverlayBoards must be a function"
+    assert state["hasJumpBtns"], "OverlayHandler.initializeJumpButtons must be a function"
+    assert state["hasToggleSync"], "window.setupParentChildToggleSync must be a function"


### PR DESCRIPTION
## Description

Fifth and **FINAL** helper-script module conversion (#1392), following eventHandler.js (#1391). overlayHandler.js (8724 lines) is the last of the 5 helpers dynamically loaded by 025-libraries.js.

### Different from other helpers

overlayHandler.js had **no IIFE or DOMContentLoaded wrapper** — just top-level `const OverlayHandler`, `function bootstrapOverlayHandler`, `function setupParentChildToggleSync`, plus an if/else DOMContentLoaded guard. Added `window.OverlayHandler` and `window.setupParentChildToggleSync` shims. Fixed cross-module `EventHandler` references (same pattern as #1391).

### All 5 helpers now converted

| Helper | PR | Lines |
|---|---|---|
| rgbaPicker.js | #1388 | 171 |
| validationHandler.js | #1389 | 375 |
| imageHandler.js | #1390 | 591 |
| eventHandler.js | #1391 | 763 |
| overlayHandler.js | **#1392** | 8,724 |

### Next: Convert 025-libraries.js itself

The dynamic script loader is now only loading modules (import() path). The classic-script `<script>` tag path is unused and can be removed. 025-libraries.js can be simplified to use top-level `await import()` for all 5 helpers — and then be converted to a module itself.

### Verification

| Check | Result |
|---|---|
| Vitest | 323/323 pass |
| Python tests | 99/99 pass |
| Playwright e2e | **68/68 pass** (was 67; +1) |
| ESLint | 0 errors |
| pre-commit | 12/12 hooks green |