### PR TITLE
Export private helper functions for test compatibility

### DIFF
--- a/modules/helpers/__init__.py
+++ b/modules/helpers/__init__.py
@@ -11,6 +11,18 @@ from __future__ import annotations
 # Import everything from the legacy module first (backward compat).
 from ._legacy import *  # noqa: F403
 
+# Private helpers used by tests and other modules.
+from ._legacy import (  # noqa: F401
+    _get_upstream_sha,
+    _download_zip,
+    _extract_zip_bytes,
+    _backup_kometa_runtime_assets,
+    _restore_kometa_runtime_assets,
+    _cleanup_kometa_backup,
+    _ensure_venv,
+    _pip_install,
+)
+
 # Then import from smaller, focused submodules.  Any names they export
 # will override legacy definitions (in case of a future rename).
 from ._paths import *  # noqa: F403


### PR DESCRIPTION
## Description

Hotfix for #1395. The `from ._legacy import *` in `__init__.py` doesn't export names starting with `_` (private convention). Several tests and monkeypatches reference these private helpers directly.

### Exported

```python
_get_upstream_sha, _download_zip, _extract_zip_bytes,
_backup_kometa_runtime_assets, _restore_kometa_runtime_assets,
_cleanup_kometa_backup, _ensure_venv, _pip_install
```

### Before/after

**Before:** 40 pytest failures (35 AttributeError + 5 pre-existing)
**After:** 5 pytest failures (all pre-existing, unrelated to helpers decomposition)

The remaining 5 failures are in `test_template_gap_analyzer.py` and `test_update_flows.py` — assertion differences in template data and SHA fixture values. Pre-existing test environment issues.