### PR TITLE
Fix helpers package namespace drift (10 -> 0 pre-existing test failures)

### DIFF
--- a/modules/kometa_install.py
+++ b/modules/kometa_install.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import sys
 from pathlib import Path
@@ -338,10 +339,28 @@ def resolve_kometa_request_target(payload, logs=None, require_existing_root=Fals
             logs.append("❌ Existing Kometa mode requires a path.")
         return {"error": "Existing Kometa mode requires a path."}
 
+    # NOTE: ``helpers.resolve_user_dir`` returns ``None`` for BOTH syntactically
+    # invalid paths AND syntactically-valid paths that don't exist on disk. The
+    # existing-mode flow needs to distinguish them so the UI can tell the user
+    # "path missing" vs "path malformed". Pre-resolve the candidate ourselves to
+    # emit a precise error when ``require_existing_root`` is set.
+    if require_existing_root:
+        try:
+            stripped = candidate.strip()
+            expanded = os.path.expandvars(os.path.expanduser(stripped)) if stripped else ""
+            candidate_path = Path(expanded).resolve() if expanded else None
+        except Exception:
+            candidate_path = None
+        if candidate_path is not None and not candidate_path.exists():
+            missing_message = "The selected existing Kometa path does not exist in this Quickstart environment."
+            if logs is not None:
+                logs.append(chr(0x274C) + " " + missing_message)
+            return {"error": missing_message}
+
     resolved_existing = helpers.resolve_user_dir(candidate)
     if not resolved_existing:
         if logs is not None:
-            logs.append("❌ Invalid path provided.")
+            logs.append(chr(0x274C) + " Invalid path provided.")
         return {"error": "Invalid path provided."}
 
     if require_existing_root and not resolved_existing.exists():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,12 +42,21 @@ def _load_app(config_dir, kometa_root):
         sys.path.insert(0, repo_root)
 
     import modules.helpers as helpers
+    from modules.helpers import _legacy as helpers_legacy
 
     _seed_schema_files(config_dir)
-    helpers.CONFIG_DIR = str(config_dir)
-    helpers.JSON_SCHEMA_DIR = os.path.join(str(config_dir), ".schema")
-    helpers.HASH_FILE = os.path.join(str(config_dir), ".schema", "file_hashes.txt")
-    helpers.RESTART_NOTICE_FILE = os.path.join(str(config_dir), "restart_needed.flag")
+    # NOTE: After helpers.py was decomposed into a package, ``CONFIG_DIR`` (and
+    # related path constants) live as module-level globals inside ``_legacy.py``.
+    # ``from ._legacy import *`` copies them into the package namespace, but the
+    # two bindings then drift independently. Functions defined inside ``_legacy``
+    # resolve ``CONFIG_DIR`` from ``_legacy``'s own namespace at call time, so we
+    # must patch BOTH or test isolation breaks (the function will keep using the
+    # real repo's config dir).
+    for mod in (helpers, helpers_legacy):
+        mod.CONFIG_DIR = str(config_dir)
+        mod.JSON_SCHEMA_DIR = os.path.join(str(config_dir), ".schema")
+        mod.HASH_FILE = os.path.join(str(config_dir), ".schema", "file_hashes.txt")
+        mod.RESTART_NOTICE_FILE = os.path.join(str(config_dir), "restart_needed.flag")
     helpers.check_for_update = lambda: {
         "local_version": "0.0.0",
         "remote_version": "0.0.0",
@@ -147,20 +156,39 @@ def client(app):
     return app.test_client()
 
 
+def _patch_helpers_paths(monkeypatch, config_dir):
+    """Re-bind CONFIG_DIR + friends across all helpers namespaces.
+
+    After ``modules/helpers.py`` was split into ``modules/helpers/__init__.py``
+    plus submodules, path constants like ``CONFIG_DIR`` exist in BOTH the
+    package namespace and the ``_legacy`` submodule namespace -- and functions
+    inside ``_legacy`` resolve ``CONFIG_DIR`` from their own module globals at
+    call time. Patching only the package namespace silently leaves the legacy
+    functions using the real repo's config dir. So patch both.
+    """
+    import modules.helpers as helpers
+    from modules.helpers import _legacy as helpers_legacy
+
+    config_dir = str(config_dir)
+    schema_dir = os.path.join(config_dir, ".schema")
+    hash_file = os.path.join(schema_dir, "file_hashes.txt")
+    restart_notice = os.path.join(config_dir, "restart_needed.flag")
+    for mod in (helpers, helpers_legacy):
+        monkeypatch.setattr(mod, "CONFIG_DIR", config_dir)
+        monkeypatch.setattr(mod, "JSON_SCHEMA_DIR", schema_dir)
+        monkeypatch.setattr(mod, "HASH_FILE", hash_file)
+        monkeypatch.setattr(mod, "RESTART_NOTICE_FILE", restart_notice)
+
+
 @pytest.fixture()
 def isolated_config_dir(tmp_path, monkeypatch, app):
-    import modules.helpers as helpers
-
     config_dir = tmp_path / "config"
     config_dir.mkdir(parents=True, exist_ok=True)
     _seed_schema_files(config_dir)
     kometa_root = tmp_path / "_qs_test_kometa_root"
     kometa_root.mkdir(parents=True, exist_ok=True)
 
-    monkeypatch.setattr(helpers, "CONFIG_DIR", str(config_dir))
-    monkeypatch.setattr(helpers, "JSON_SCHEMA_DIR", str(config_dir / ".schema"))
-    monkeypatch.setattr(helpers, "HASH_FILE", str(config_dir / ".schema" / "file_hashes.txt"))
-    monkeypatch.setattr(helpers, "RESTART_NOTICE_FILE", str(config_dir / "restart_needed.flag"))
+    _patch_helpers_paths(monkeypatch, config_dir)
     app.config["KOMETA_ROOT"] = str(kometa_root)
 
     return config_dir
@@ -168,18 +196,13 @@ def isolated_config_dir(tmp_path, monkeypatch, app):
 
 @pytest.fixture()
 def _runtime_isolation(tmp_path, monkeypatch, app):
-    import modules.helpers as helpers
-
     config_dir = tmp_path / "config"
     config_dir.mkdir(parents=True, exist_ok=True)
     _seed_schema_files(config_dir)
     kometa_root = tmp_path / "_qs_test_kometa_root"
     kometa_root.mkdir(parents=True, exist_ok=True)
 
-    monkeypatch.setattr(helpers, "CONFIG_DIR", str(config_dir))
-    monkeypatch.setattr(helpers, "JSON_SCHEMA_DIR", str(config_dir / ".schema"))
-    monkeypatch.setattr(helpers, "HASH_FILE", str(config_dir / ".schema" / "file_hashes.txt"))
-    monkeypatch.setattr(helpers, "RESTART_NOTICE_FILE", str(config_dir / "restart_needed.flag"))
+    _patch_helpers_paths(monkeypatch, config_dir)
     app.config["KOMETA_ROOT"] = str(kometa_root)
 
     return {"config_dir": config_dir, "kometa_root": kometa_root}


### PR DESCRIPTION
## Summary

Fixes a silent namespace-drift bug in the test harness left over from the `modules/helpers.py` → `modules/helpers/` package decomposition, plus a related path-validation papercut. **Cuts pre-existing test failures from 10 to 0** on a clean `develop` checkout.

## Root cause

When `helpers.py` was split into `helpers/__init__.py` + `helpers/_legacy.py`, path constants like `CONFIG_DIR`, `JSON_SCHEMA_DIR`, `HASH_FILE`, and `RESTART_NOTICE_FILE` ended up as module-level globals **inside `_legacy.py`**. The package-level `from ._legacy import *` copies them into `modules.helpers`, but the two bindings then drift independently.

Functions defined inside `_legacy.py` (e.g. `_managed_kometa_root_default`, `get_kometa_root_path`, `get_kometa_config_dir`, `get_kometa_log_dir`, `get_kometa_pid_file`, …) resolve `CONFIG_DIR` from `_legacy`'s own module globals at call time. So when conftest patched only `helpers.CONFIG_DIR`:

```python
monkeypatch.setattr(helpers, "CONFIG_DIR", str(config_dir))
```

…the legacy functions kept using the **real repo's** config dir. Path-resolution helpers like `_managed_kometa_root_default()` returned `/home/chaz/dev/Kometa-Team/Quickstart/config/kometa` instead of the per-test `tmp_path/config/kometa`, which then short-circuited `get_kometa_root_path()`'s "is this a real override?" branches and skipped the persisted-existing-root lookup entirely.

You can reproduce the drift directly:

```python
def test_check_drift(app, tmp_path):
    from modules import helpers
    from modules.helpers import _legacy
    print(helpers.CONFIG_DIR)   # /tmp/.../tmp_path/config  (patched)
    print(_legacy.CONFIG_DIR)   # /home/chaz/.../Quickstart/config  (real repo!)
```

## What this PR does

### 1. `tests/conftest.py` — patch BOTH namespaces

Adds a `_patch_helpers_paths(monkeypatch, config_dir)` helper that rebinds `CONFIG_DIR`, `JSON_SCHEMA_DIR`, `HASH_FILE`, and `RESTART_NOTICE_FILE` on **both** `modules.helpers` and `modules.helpers._legacy`. Wired into the existing `isolated_config_dir` and `_runtime_isolation` fixtures (DRY — the two fixtures previously had the same monkey-patch block copy-pasted).

Same fix applied directly to `_load_app` (session-scoped, no monkeypatch) with a comment explaining why.

### 2. `modules/kometa_install.py` — distinguish "missing" from "malformed"

`helpers.resolve_user_dir` returns `None` for **both** syntactically-invalid paths *and* syntactically-valid paths that don't exist on disk. The existing-mode validation flow had a follow-up `if not resolved_existing.exists():` branch that was therefore **unreachable** — the user always got "Invalid path provided." instead of the more specific "does not exist" message.

Added a pre-check that resolves the candidate path ourselves and emits the right error when `require_existing_root` is set, without changing `resolve_user_dir`'s 18 callers across the codebase.

## Test results

Before this PR (clean `develop`):

```
FAILED tests/test_core_backend.py::test_sync_managed_library_artifacts_to_kometa_copies_and_prunes
FAILED tests/test_core_backend.py::test_copy_fonts_to_kometa_prefers_config_scoped_fonts
FAILED tests/test_core_backend.py::test_copy_fonts_to_kometa_adopts_legacy_font_into_config_scope
FAILED tests/test_core_backend.py::test_save_to_named_config_syncs_managed_library_artifacts_to_kometa
FAILED tests/test_core_backend.py::test_save_to_named_config_writes_to_external_kometa_config_dir
FAILED tests/test_core_backend.py::test_import_config_confirm_rehomes_bundled_library_files
FAILED tests/test_core_backend.py::test_import_config_confirm_rehomes_bundled_overlay_source_images
FAILED tests/test_core_backend.py::test_validate_kometa_root_existing_mode_does_not_create_missing_root
FAILED tests/test_core_backend.py::test_get_kometa_root_path_prefers_persisted_existing_selection
FAILED tests/test_logscan_endpoints.py::test_ingest_completed_live_logs_caches_unchanged_incomplete_live_kometa_log
```

After this PR: full suite green (excluding `tests/e2e/` which needs a live browser).

## Why this is worth merging even though the symptoms were already patched

PR #1398 patched the **symptoms** of these failures one-by-one (e.g. special-casing maintenance sidecars in `read_logscan_text`). The underlying namespace drift is still there on `develop` — any future test that touches a function in `_legacy.py` referencing `CONFIG_DIR` will silently see the real repo's config dir, not the patched test fixture. Fixing the root cause prevents the next round of mysterious failures.
