### PR TITLE
added npm install as part of --setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,44 +478,87 @@ Quickstart uses pytest for unit/integration tests and Playwright for E2E tests.
 
 ### Developer Testing
 
-Set up or refresh the local test environment, including runtime requirements, developer requirements, and Playwright browsers:
+The Python test runner is cross-platform:
 
-```
+- `scripts/run_tests.py` is the source-of-truth runner for Windows, macOS, and Linux.
+- `scripts/run-tests.ps1` is only a Windows PowerShell wrapper around `scripts/run_tests.py`.
+- `scripts/run_tests.py --setup` installs Python requirements, Node dependencies, and Playwright browsers.
+
+#### Windows (PowerShell)
+
+First-time setup:
+
+```powershell
+python -m venv venv
+.\venv\Scripts\Activate.ps1
 python scripts/run_tests.py --setup
-python scripts/run_tests.py --setup --all
 ```
 
-Run tests (cross-platform):
+Normal test and lint flow:
 
-```
-python scripts/run_tests.py             # Unit/integration (non-E2E)
-python scripts/run_tests.py --e2e       # End-to-end tests (Playwright)
-python scripts/run_tests.py --all       # Everything
+```powershell
+python scripts/run_tests.py --lint
 python scripts/run_tests.py --repochecks
+python scripts/run_tests.py
+python scripts/run_tests.py --e2e
+python scripts/run_tests.py --all
 ```
 
-PowerShell users can keep using the wrapper:
+If you prefer the Windows wrapper:
 
-```
+```powershell
+.\scripts\run-tests.ps1 -Lint
+.\scripts\run-tests.ps1 -RepoChecks
 .\scripts\run-tests.ps1
 .\scripts\run-tests.ps1 -E2E
 .\scripts\run-tests.ps1 -All
 ```
 
+#### macOS and Linux
+
+These steps are identical on macOS and Linux:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+python scripts/run_tests.py --setup
+```
+
+Normal test and lint flow:
+
+```bash
+python scripts/run_tests.py --lint
+python scripts/run_tests.py --repochecks
+python scripts/run_tests.py
+python scripts/run_tests.py --e2e
+python scripts/run_tests.py --all
+```
+
+#### Direct commands
+
+Use these when you want to run individual layers yourself instead of the wrapper:
+
+```bash
+npm run lint:eslint
+python -m pre_commit run --all-files
+python -m pytest -p pytest_progress_plugin tests -m "not e2e and not ratings_matrix" -vv -o console_output_style=count
+python -m pytest -p pytest_progress_plugin tests -m e2e -vv -o console_output_style=count
+```
+
 Fast focused paths:
 
-```
+```powershell
 .\venv\Scripts\python.exe -m pytest tests\test_importer_edge_cases.py
 .\venv\Scripts\python.exe -m pytest tests\test_workspace_dependency_logic.py
 .\venv\Scripts\python.exe -m pytest tests\test_core_backend.py -k final
-python scripts/run_tests.py --e2e
 ```
 
-If you prefer raw commands:
+Unix/macOS equivalents:
 
-```
-python -m pytest -m "not e2e" -vv
-python -m pytest -m e2e -vv
+```bash
+venv/bin/python -m pytest tests/test_importer_edge_cases.py
+venv/bin/python -m pytest tests/test_workspace_dependency_logic.py
+venv/bin/python -m pytest tests/test_core_backend.py -k final
 ```
 
 Notes for Playwright on Windows:

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -80,6 +81,16 @@ def detect_precommit_command(python_cmd: str) -> list[str]:
     if unix_precommit.exists():
         return [str(unix_precommit)]
     return [python_cmd, "-m", "pre_commit"]
+
+
+def detect_npm_command() -> list[str] | None:
+    npm_cmd = shutil.which("npm.cmd")
+    if npm_cmd:
+        return [npm_cmd]
+    npm_cmd = shutil.which("npm")
+    if npm_cmd:
+        return [npm_cmd]
+    return None
 
 
 def run_command(command: list[str], *, env: dict[str, str] | None = None) -> int:
@@ -192,6 +203,19 @@ def run_setup(python_cmd: str, *, skip_playwright: bool) -> int:
     )
     if exit_code != 0:
         return exit_code
+
+    if (REPO_ROOT / "package.json").exists():
+        npm_command = detect_npm_command()
+        if npm_command is None:
+            print(
+                "Node tooling is configured for this repo, but npm was not found on PATH. " "Install Node.js/npm, then rerun setup.",
+                file=sys.stderr,
+            )
+            return 1
+        print("Installing Node dependencies...")
+        exit_code = run_command([*npm_command, "install"])
+        if exit_code != 0:
+            return exit_code
 
     if not skip_playwright:
         print("Installing Playwright browsers...")


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Fix non-ratings repo-check issues and streamline cross-platform test setup.
This branch does three things outside the known ratings overlay regression area. First, it fixes the remaining repo-check failures caused by stale test expectations and Windows-specific ESLint invocation issues. Second, it improves the cross-platform test bootstrap so scripts/run_tests.py --setup now installs Python requirements, Node dependencies, and Playwright in one place. Third, it updates the README so Windows, macOS, and Linux contributors have a clear testing path that matches the actual runner behavior.
Included changes:
Fix Windows ESLint test execution by resolving the correct executable instead of tripping over the Unix shim on Windows.
Update stale backend and template-gap-analyzer tests to match current intended behavior.
Make scripts/run_tests.py --setup run npm install automatically when Node tooling is present.
Fail setup with a clear message if npm is required but missing.
Document the cross-platform setup/test flow in README.md.
Not included:
The known ratings overlay regression in tests/e2e/test_ratings_overlay_e2e.py was intentionally left untouched.
Validation:
Pre-commit / ESLint / Ruff / Black passed in repo-check flow.
RepoChecks result: only the known ratings overlay E2E failures remain.
Current failure set is limited to:test_ratings_position_changes_reset_shared_offsets
test_ratings_shared_nudge_sync_respects_anchor_math
test_ratings_edge_positions_respect_15px_margin (show and episode)
test_ratings_slot_order_across_position_combos for the single-slot episode case


## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
