### PR TITLE
Extract _redact.py + _file_utils.py from _legacy.py

### DIFF
--- a/modules/helpers/__init__.py
+++ b/modules/helpers/__init__.py
@@ -23,6 +23,9 @@ from ._legacy import (  # noqa: F401
     _pip_install,
 )
 
+# Private helpers from other submodules (not re-exported via `*` due to underscore prefix).
+from ._file_utils import _directory_tree_signature  # noqa: F401
+
 # Then import from smaller, focused submodules.  Any names they export
 # will override legacy definitions (in case of a future rename).
 from ._cli import *  # noqa: F403
@@ -33,4 +36,6 @@ from ._artifacts import *  # noqa: F403
 from ._plex_cache import *  # noqa: F403
 from ._misc import *  # noqa: F403
 from ._restart import *  # noqa: F403
+from ._redact import *  # noqa: F403
+from ._file_utils import *  # noqa: F403
 from ._paths import *  # noqa: F403

--- a/modules/helpers/_artifacts.py
+++ b/modules/helpers/_artifacts.py
@@ -129,8 +129,8 @@ def sync_managed_library_artifacts_to_kometa(
     kometa_root: str | Path | None = None,
     kometa_config_dir: str | Path | None = None,
 ) -> dict:
+    from modules.helpers._file_utils import _directory_tree_signature
     from modules.helpers._legacy import (
-        _directory_tree_signature,
         get_kometa_config_dir,
         handle_remove_readonly,
     )

--- a/modules/helpers/_file_utils.py
+++ b/modules/helpers/_file_utils.py
@@ -1,0 +1,34 @@
+"""File utility functions extracted from _legacy.py."""
+
+import re
+
+from pathlib import Path
+
+
+def contains_non_latin(text):
+    return bool(re.search(r"[^\x00-\x7F]", text))
+
+
+def _read_text_if_exists(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8")
+    except Exception:
+        return None
+
+
+def _directory_tree_signature(root: Path) -> list[tuple[str, int, int]]:
+    if not root.exists() or not root.is_dir():
+        return []
+
+    entries: list[tuple[str, int, int]] = []
+    for path in sorted(root.rglob("*")):
+        relative = path.relative_to(root).as_posix()
+        if path.is_dir():
+            entries.append((f"{relative}/", 0, 0))
+            continue
+        try:
+            stats = path.stat()
+            entries.append((relative, int(stats.st_size), int(stats.st_mtime_ns)))
+        except Exception:
+            entries.append((relative, -1, -1))
+    return entries

--- a/modules/helpers/_legacy.py
+++ b/modules/helpers/_legacy.py
@@ -698,27 +698,6 @@ def get_quickstart_settings_summary():
     return lines
 
 
-def redact_sensitive_data(yaml_content):
-    import re
-
-    # Split the YAML content into lines for line-by-line processing
-    lines = yaml_content.splitlines()
-
-    # Process each line to redact sensitive data
-    redacted_lines = [
-        re.sub(
-            r"(token|client.*|url|api_*key|secret|error|delete|run_start|run_end|version|changes|username|password): .+",
-            r"\1: (redacted)",
-            line.strip("\r\n"),
-        )
-        for line in lines
-    ]
-
-    # Join the lines back together to form the redacted YAML content
-    redacted_content = "\n".join(redacted_lines)
-    return redacted_content
-
-
 def get_top_imdb_items(library_id, media_type, placeholder_id=None):
     ts_log("Fetching Plex credentials for '010-plex'", level="DEBUG")
     plex_url, plex_token = persistence.get_stored_plex_credentials("010-plex")
@@ -1093,35 +1072,6 @@ def get_library_metadata(plex=None, sections=None, plex_url=None, plex_token=Non
         return {"error": str(e)}
 
 
-def contains_non_latin(text):
-    return bool(re.search(r"[^\x00-\x7F]", text))
-
-
-def _read_text_if_exists(path: Path) -> str | None:
-    try:
-        return path.read_text(encoding="utf-8")
-    except Exception:
-        return None
-
-
-def _directory_tree_signature(root: Path) -> list[tuple[str, int, int]]:
-    if not root.exists() or not root.is_dir():
-        return []
-
-    entries: list[tuple[str, int, int]] = []
-    for path in sorted(root.rglob("*")):
-        relative = path.relative_to(root).as_posix()
-        if path.is_dir():
-            entries.append((f"{relative}/", 0, 0))
-            continue
-        try:
-            stats = path.stat()
-            entries.append((relative, int(stats.st_size), int(stats.st_mtime_ns)))
-        except Exception:
-            entries.append((relative, -1, -1))
-    return entries
-
-
 def save_to_named_config(yaml_text, config_name, font_refs=None):
     config_dir = Path(CONFIG_DIR)
     kometa_root = get_kometa_root_path()
@@ -1139,6 +1089,8 @@ def save_to_named_config(yaml_text, config_name, font_refs=None):
         history_limit = 0
     if history_limit < 0:
         history_limit = 0
+
+    from modules.helpers._file_utils import _read_text_if_exists
 
     existing_local_yaml = _read_text_if_exists(latest_path)
     local_needs_write = existing_local_yaml != yaml_text

--- a/modules/helpers/_redact.py
+++ b/modules/helpers/_redact.py
@@ -1,0 +1,22 @@
+"""Data redaction utility extracted from _legacy.py."""
+
+import re
+
+
+def redact_sensitive_data(yaml_content):
+    # Split the YAML content into lines for line-by-line processing
+    lines = yaml_content.splitlines()
+
+    # Process each line to redact sensitive data
+    redacted_lines = [
+        re.sub(
+            r"(token|client.*|url|api_*key|secret|error|delete|run_start|run_end|version|changes|username|password): .+",
+            r"\1: (redacted)",
+            line.strip("\r\n"),
+        )
+        for line in lines
+    ]
+
+    # Join the lines back together to form the redacted YAML content
+    redacted_content = "\n".join(redacted_lines)
+    return redacted_content


### PR DESCRIPTION
Move redact_sensitive_data into _redact.py and contains_non_latin, _read_text_if_exists, _directory_tree_signature into _file_utils.py.

_legacy.py: -45 lines (2396 remaining).