### PR TITLE
Extra variables

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -373,6 +373,26 @@ def _parse_string_list_mapping(value):
     return normalized
 
 
+def _parse_string_mapping(value):
+    parsed = _parse_template_mapping_dict(value)
+    if not parsed:
+        return {}
+
+    normalized = {}
+    for raw_key, raw_value in parsed.items():
+        key_text = str(raw_key or "").strip()
+        if not key_text:
+            continue
+        if isinstance(raw_value, (list, tuple, set)):
+            parts = _coerce_string_list(raw_value)
+            value_text = ", ".join(parts)
+        else:
+            value_text = str(raw_value or "").strip()
+        if value_text:
+            normalized[key_text] = value_text
+    return normalized
+
+
 def _parse_tmdb_person_window(value):
     if value is None:
         return None
@@ -451,6 +471,9 @@ def _normalize_collection_template_var_value(key, value):
         return list_values if list_values else None
     if key in {"addons", "append_addons"}:
         mapping_values = _parse_string_list_mapping(value)
+        return mapping_values if mapping_values else None
+    if key == "title_override":
+        mapping_values = _parse_string_mapping(value)
         return mapping_values if mapping_values else None
     if key in {"tmdb_birthday", "tmdb_deathday"}:
         return _parse_tmdb_person_window(value)

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -25527,6 +25527,13 @@
             "placeholder": "Custom sort title format"
           },
           {
+            "key": "build_collection",
+            "label": "Build Collection",
+            "type": "toggle",
+            "tooltip": "Build the franchise collections from this Defaults File. Turn this off if you only want the related collection actions without creating the Plex collections.",
+            "default": true
+          },
+          {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
@@ -25549,6 +25556,14 @@
             "tooltip": "Append additional franchises mappings to the default addons dictionary for this Defaults File.",
             "key_placeholder": "Base franchise (e.g. Star Wars)",
             "value_placeholder": "Add comma-separated franchises (e.g. The Clone Wars, Rebels)"
+          },
+          {
+            "key": "title_override",
+            "label": "Title Override",
+            "type": "mapping_list",
+            "tooltip": "Override the generated collection title for specific TMDb collection IDs in this Defaults File.",
+            "key_placeholder": "TMDb collection ID (e.g. 10)",
+            "value_placeholder": "Custom title (e.g. Star Wars: Skywalker Saga)"
           },
           {
             "key": "remove_suffix",
@@ -26199,6 +26214,13 @@
             "type": "text_input",
             "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
             "placeholder": "Custom sort title format"
+          },
+          {
+            "key": "build_collection",
+            "label": "Build Collection",
+            "type": "toggle",
+            "tooltip": "Build the franchise collections from this Defaults File. Turn this off if you only want the related collection actions without creating the Plex collections.",
+            "default": true
           },
           {
             "key": "addons",

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -25563,7 +25563,11 @@
             "type": "mapping_list",
             "tooltip": "Override the generated collection title for specific TMDb collection IDs in this Defaults File.",
             "key_placeholder": "TMDb collection ID (e.g. 10)",
-            "value_placeholder": "Custom title (e.g. Star Wars: Skywalker Saga)"
+            "value_placeholder": "Custom title (e.g. Star Wars: Skywalker Saga)",
+            "key_validation_preset": "tmdb_collection_id",
+            "dynamic_child_value_kind": "string",
+            "lookup_display_mode": "inline",
+            "value_display_label": "Custom title"
           },
           {
             "key": "remove_suffix",
@@ -25589,6 +25593,8 @@
             "tooltip": "Map a franchise child key to a custom collection name. Quickstart exports these as <code>name_&lt;&lt;key&gt;&gt;</code> template variables.",
             "key_placeholder": "Franchise key (e.g. 10)",
             "value_placeholder": "Custom collection name",
+            "key_validation_preset": "tmdb_collection_id",
+            "lookup_display_mode": "inline",
             "dynamic_child_prefix": "name_",
             "dynamic_child_value_kind": "string"
           },
@@ -25599,6 +25605,8 @@
             "tooltip": "Map a franchise child key to a custom collection summary. Quickstart exports these as <code>summary_&lt;&lt;key&gt;&gt;</code> template variables.",
             "key_placeholder": "Franchise key (e.g. 10)",
             "value_placeholder": "Custom collection summary",
+            "key_validation_preset": "tmdb_collection_id",
+            "lookup_display_mode": "inline",
             "dynamic_child_prefix": "summary_",
             "dynamic_child_value_kind": "string"
           },
@@ -25609,6 +25617,8 @@
             "tooltip": "Map a franchise child key to a custom sort title. Quickstart exports these as <code>sort_title_&lt;&lt;key&gt;&gt;</code> template variables.",
             "key_placeholder": "Franchise key (e.g. 10)",
             "value_placeholder": "Custom sort title",
+            "key_validation_preset": "tmdb_collection_id",
+            "lookup_display_mode": "inline",
             "dynamic_child_prefix": "sort_title_",
             "dynamic_child_value_kind": "string"
           },
@@ -25619,6 +25629,8 @@
             "tooltip": "Map a franchise child key to a sync mode override. Use <code>append</code> or <code>sync</code>. Quickstart exports these as <code>sync_mode_&lt;&lt;key&gt;&gt;</code> template variables.",
             "key_placeholder": "Franchise key (e.g. 10)",
             "value_placeholder": "append or sync",
+            "key_validation_preset": "tmdb_collection_id",
+            "lookup_display_mode": "inline",
             "dynamic_child_prefix": "sync_mode_",
             "dynamic_child_value_kind": "select"
           },
@@ -25629,6 +25641,8 @@
             "tooltip": "Map a franchise child key to a collection order override. Quickstart exports these as <code>collection_order_&lt;&lt;key&gt;&gt;</code> template variables.",
             "key_placeholder": "Franchise key (e.g. 10)",
             "value_placeholder": "release, alpha, custom, etc.",
+            "key_validation_preset": "tmdb_collection_id",
+            "lookup_display_mode": "inline",
             "dynamic_child_prefix": "collection_order_",
             "dynamic_child_value_kind": "select"
           },
@@ -25640,6 +25654,8 @@
             "key_placeholder": "Franchise key (e.g. 10)",
             "value_placeholder": "https://example.com/poster.jpg",
             "validation_preset": "url",
+            "key_validation_preset": "tmdb_collection_id",
+            "lookup_display_mode": "inline",
             "dynamic_child_prefix": "url_poster_",
             "dynamic_child_value_kind": "string"
           },
@@ -25650,6 +25666,8 @@
             "tooltip": "Map a franchise child key to a Radarr add_missing override. Use <code>true</code> or <code>false</code>. Quickstart exports these as <code>radarr_add_missing_&lt;&lt;key&gt;&gt;</code> template variables.",
             "key_placeholder": "Franchise key (e.g. 10)",
             "value_placeholder": "true or false",
+            "key_validation_preset": "tmdb_collection_id",
+            "lookup_display_mode": "inline",
             "dynamic_child_prefix": "radarr_add_missing_",
             "dynamic_child_value_kind": "boolean"
           },
@@ -25660,6 +25678,8 @@
             "tooltip": "Map a franchise child key to a Radarr root folder override. Quickstart exports these as <code>radarr_folder_&lt;&lt;key&gt;&gt;</code> template variables.",
             "key_placeholder": "Franchise key (e.g. 10)",
             "value_placeholder": "C:\\Media\\Movies",
+            "key_validation_preset": "tmdb_collection_id",
+            "lookup_display_mode": "inline",
             "dynamic_child_prefix": "radarr_folder_",
             "dynamic_child_value_kind": "string"
           },
@@ -25670,6 +25690,8 @@
             "tooltip": "Map a franchise child key to comma-separated Radarr tags. Quickstart exports these as <code>radarr_tag_&lt;&lt;key&gt;&gt;</code> template variables.",
             "key_placeholder": "Franchise key (e.g. 10)",
             "value_placeholder": "4k,franchise",
+            "key_validation_preset": "tmdb_collection_id",
+            "lookup_display_mode": "inline",
             "dynamic_child_prefix": "radarr_tag_",
             "dynamic_child_value_kind": "string_list"
           },
@@ -25680,6 +25702,8 @@
             "tooltip": "Map a franchise child key to comma-separated item Radarr tags. Quickstart exports these as <code>item_radarr_tag_&lt;&lt;key&gt;&gt;</code> template variables.",
             "key_placeholder": "Franchise key (e.g. 10)",
             "value_placeholder": "collection,tracked",
+            "key_validation_preset": "tmdb_collection_id",
+            "lookup_display_mode": "inline",
             "dynamic_child_prefix": "item_radarr_tag_",
             "dynamic_child_value_kind": "string_list"
           },
@@ -25690,6 +25714,8 @@
             "tooltip": "Map a franchise child key to a Radarr monitor override. Use <code>true</code> or <code>false</code>. Quickstart exports these as <code>radarr_monitor_&lt;&lt;key&gt;&gt;</code> template variables.",
             "key_placeholder": "Franchise key (e.g. 10)",
             "value_placeholder": "true or false",
+            "key_validation_preset": "tmdb_collection_id",
+            "lookup_display_mode": "inline",
             "dynamic_child_prefix": "radarr_monitor_",
             "dynamic_child_value_kind": "boolean"
           },
@@ -26255,6 +26281,8 @@
             "tooltip": "Map a franchise child key to a custom collection name. Quickstart exports these as <code>name_&lt;&lt;key&gt;&gt;</code> template variables.",
             "key_placeholder": "Franchise key (e.g. 1399)",
             "value_placeholder": "Custom collection name",
+            "key_validation_preset": "numeric_id",
+            "lookup_display_mode": "inline",
             "dynamic_child_prefix": "name_",
             "dynamic_child_value_kind": "string"
           },
@@ -26265,6 +26293,8 @@
             "tooltip": "Map a franchise child key to a custom collection summary. Quickstart exports these as <code>summary_&lt;&lt;key&gt;&gt;</code> template variables.",
             "key_placeholder": "Franchise key (e.g. 1399)",
             "value_placeholder": "Custom collection summary",
+            "key_validation_preset": "numeric_id",
+            "lookup_display_mode": "inline",
             "dynamic_child_prefix": "summary_",
             "dynamic_child_value_kind": "string"
           },
@@ -26275,6 +26305,8 @@
             "tooltip": "Map a franchise child key to a custom sort title. Quickstart exports these as <code>sort_title_&lt;&lt;key&gt;&gt;</code> template variables.",
             "key_placeholder": "Franchise key (e.g. 1399)",
             "value_placeholder": "Custom sort title",
+            "key_validation_preset": "numeric_id",
+            "lookup_display_mode": "inline",
             "dynamic_child_prefix": "sort_title_",
             "dynamic_child_value_kind": "string"
           },
@@ -26285,6 +26317,8 @@
             "tooltip": "Map a franchise child key to a sync mode override. Use <code>append</code> or <code>sync</code>. Quickstart exports these as <code>sync_mode_&lt;&lt;key&gt;&gt;</code> template variables.",
             "key_placeholder": "Franchise key (e.g. 1399)",
             "value_placeholder": "append or sync",
+            "key_validation_preset": "numeric_id",
+            "lookup_display_mode": "inline",
             "dynamic_child_prefix": "sync_mode_",
             "dynamic_child_value_kind": "select"
           },
@@ -26295,6 +26329,8 @@
             "tooltip": "Map a franchise child key to a collection order override. Quickstart exports these as <code>collection_order_&lt;&lt;key&gt;&gt;</code> template variables.",
             "key_placeholder": "Franchise key (e.g. 1399)",
             "value_placeholder": "release, alpha, custom, etc.",
+            "key_validation_preset": "numeric_id",
+            "lookup_display_mode": "inline",
             "dynamic_child_prefix": "collection_order_",
             "dynamic_child_value_kind": "select"
           },
@@ -26306,6 +26342,8 @@
             "key_placeholder": "Franchise key (e.g. 1399)",
             "value_placeholder": "https://example.com/poster.jpg",
             "validation_preset": "url",
+            "key_validation_preset": "numeric_id",
+            "lookup_display_mode": "inline",
             "dynamic_child_prefix": "url_poster_",
             "dynamic_child_value_kind": "string"
           },
@@ -26316,6 +26354,8 @@
             "tooltip": "Map a franchise child key to a Sonarr add_missing override. Use <code>true</code> or <code>false</code>. Quickstart exports these as <code>sonarr_add_missing_&lt;&lt;key&gt;&gt;</code> template variables.",
             "key_placeholder": "Franchise key (e.g. 1399)",
             "value_placeholder": "true or false",
+            "key_validation_preset": "numeric_id",
+            "lookup_display_mode": "inline",
             "dynamic_child_prefix": "sonarr_add_missing_",
             "dynamic_child_value_kind": "boolean"
           },
@@ -26326,6 +26366,8 @@
             "tooltip": "Map a franchise child key to a Sonarr root folder override. Quickstart exports these as <code>sonarr_folder_&lt;&lt;key&gt;&gt;</code> template variables.",
             "key_placeholder": "Franchise key (e.g. 1399)",
             "value_placeholder": "C:\\Media\\Shows",
+            "key_validation_preset": "numeric_id",
+            "lookup_display_mode": "inline",
             "dynamic_child_prefix": "sonarr_folder_",
             "dynamic_child_value_kind": "string"
           },
@@ -26336,6 +26378,8 @@
             "tooltip": "Map a franchise child key to comma-separated Sonarr tags. Quickstart exports these as <code>sonarr_tag_&lt;&lt;key&gt;&gt;</code> template variables.",
             "key_placeholder": "Franchise key (e.g. 1399)",
             "value_placeholder": "ongoing,tracked",
+            "key_validation_preset": "numeric_id",
+            "lookup_display_mode": "inline",
             "dynamic_child_prefix": "sonarr_tag_",
             "dynamic_child_value_kind": "string_list"
           },
@@ -26346,6 +26390,8 @@
             "tooltip": "Map a franchise child key to comma-separated item Sonarr tags. Quickstart exports these as <code>item_sonarr_tag_&lt;&lt;key&gt;&gt;</code> template variables.",
             "key_placeholder": "Franchise key (e.g. 1399)",
             "value_placeholder": "watched,tracked",
+            "key_validation_preset": "numeric_id",
+            "lookup_display_mode": "inline",
             "dynamic_child_prefix": "item_sonarr_tag_",
             "dynamic_child_value_kind": "string_list"
           },
@@ -26356,6 +26402,8 @@
             "tooltip": "Map a franchise child key to a Sonarr monitor override. Use <code>all</code>, <code>none</code>, <code>future</code>, <code>missing</code>, <code>existing</code>, <code>pilot</code>, <code>first</code>, or <code>latest</code>. Quickstart exports these as <code>sonarr_monitor_&lt;&lt;key&gt;&gt;</code> template variables.",
             "key_placeholder": "Franchise key (e.g. 1399)",
             "value_placeholder": "future, all, latest, etc.",
+            "key_validation_preset": "numeric_id",
+            "lookup_display_mode": "inline",
             "dynamic_child_prefix": "sonarr_monitor_",
             "dynamic_child_value_kind": "select"
           },

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -2922,6 +2922,109 @@ function setupTemplateStringListHandlers (scope) {
     return String(el?.value || '').trim().toLowerCase() === 'true'
   }
 
+  function setLookupState (target, state) {
+    if (!target) return
+    target.textContent = state?.message || ''
+    target.className = 'small mt-1'
+    if (!state?.message) {
+      target.classList.add('d-none')
+      return
+    }
+    target.classList.remove('d-none')
+    if (state.level === 'warning') {
+      target.classList.add('text-warning')
+    } else if (state.valid && state.verified) {
+      target.classList.add('text-success')
+    } else if (state.verified) {
+      target.classList.add('text-danger')
+    } else {
+      target.classList.add('text-warning')
+    }
+  }
+
+  function applyLookupState (target, presetConfig, presetName, value, context = {}) {
+    if (!target || !presetConfig?.lookupService || !value) return
+
+    if (presetConfig.lookupService === 'tmdb') {
+      if (!getServiceValidationState('tmdb')) {
+        setLookupState(target, {
+          valid: false,
+          verified: false,
+          message: 'TMDb not validated, so the collection title could not be checked.'
+        })
+        return
+      }
+
+      setLookupState(target, {
+        valid: false,
+        verified: false,
+        message: 'Checking TMDb collection title...'
+      })
+      lookupTemplateStringValue(presetName, value, context).then(result => {
+        if (!target.isConnected) return
+        if (result.valid && result.verified && result.label) {
+          const successMessage = result.message || `TMDb: ${result.label}`
+          setLookupState(target, {
+            valid: true,
+            verified: true,
+            level: result.level,
+            message: successMessage
+          })
+          return
+        }
+        setLookupState(target, {
+          valid: Boolean(result.valid),
+          verified: Boolean(result.verified),
+          message: result.message || 'TMDb lookup failed.'
+        })
+      })
+      return
+    }
+
+    if (presetConfig.lookupService === 'plex') {
+      if (!getServiceValidationState('plex')) {
+        setLookupState(target, {
+          valid: false,
+          verified: false,
+          message: 'Plex not validated, so the IMDb ID could not be checked against the active library.'
+        })
+        return
+      }
+      if (!String(context.libraryName || '').trim()) {
+        setLookupState(target, {
+          valid: false,
+          verified: false,
+          message: 'Library context is unavailable for Plex lookup.'
+        })
+        return
+      }
+
+      setLookupState(target, {
+        valid: false,
+        verified: false,
+        message: 'Checking Plex library for this IMDb ID...'
+      })
+      lookupTemplateStringValue(presetName, value, context).then(result => {
+        if (!target.isConnected) return
+        if (result.valid && result.verified && result.label) {
+          const successMessage = result.message || `Plex: ${result.label}`
+          setLookupState(target, {
+            valid: true,
+            verified: true,
+            level: result.level,
+            message: successMessage
+          })
+          return
+        }
+        setLookupState(target, {
+          valid: Boolean(result.valid),
+          verified: Boolean(result.verified),
+          message: result.message || 'Plex lookup failed.'
+        })
+      })
+    }
+  }
+
   async function lookupTemplateStringValue (presetName, value, context = {}) {
     const libraryName = String(context.libraryName || '').trim()
     const mediaType = String(context.mediaType || '').trim()
@@ -3015,26 +3118,6 @@ function setupTemplateStringListHandlers (scope) {
       const counterpartHiddenId = getCounterpartHiddenId()
       const counterpartHidden = counterpartHiddenId ? document.getElementById(counterpartHiddenId) : null
       return parseStoredStringList(counterpartHidden?.value)
-    }
-
-    function setLookupState (target, state) {
-      if (!target) return
-      target.textContent = state?.message || ''
-      target.className = 'small mt-1'
-      if (!state?.message) {
-        target.classList.add('d-none')
-        return
-      }
-      target.classList.remove('d-none')
-      if (state.level === 'warning') {
-        target.classList.add('text-warning')
-      } else if (state.valid && state.verified) {
-        target.classList.add('text-success')
-      } else if (state.verified) {
-        target.classList.add('text-danger')
-      } else {
-        target.classList.add('text-warning')
-      }
     }
 
     function setFeedback (message, persistent = false, level = 'error') {
@@ -3137,76 +3220,8 @@ function setupTemplateStringListHandlers (scope) {
           syncState(updated)
         })
 
-        if (item.valid && presetConfig.lookupService === 'tmdb') {
-          if (!getServiceValidationState('tmdb')) {
-            setLookupState(lookupMeta, {
-              valid: false,
-              verified: false,
-              message: 'TMDb not validated, so the collection title could not be checked.'
-            })
-          } else {
-            setLookupState(lookupMeta, {
-              valid: false,
-              verified: false,
-              message: 'Checking TMDb collection title...'
-            })
-            lookupTemplateStringValue(presetName, item.value, { libraryName, mediaType }).then(result => {
-              if (!lookupMeta.isConnected) return
-              if (result.valid && result.verified && result.label) {
-                const successMessage = result.message || `TMDb: ${result.label}`
-                setLookupState(lookupMeta, {
-                  valid: true,
-                  verified: true,
-                  level: result.level,
-                  message: successMessage
-                })
-                return
-              }
-              setLookupState(lookupMeta, {
-                valid: Boolean(result.valid),
-                verified: Boolean(result.verified),
-                message: result.message || 'TMDb lookup failed.'
-              })
-            })
-          }
-        } else if (item.valid && presetConfig.lookupService === 'plex') {
-          if (!getServiceValidationState('plex')) {
-            setLookupState(lookupMeta, {
-              valid: false,
-              verified: false,
-              message: 'Plex not validated, so the IMDb ID could not be checked against the active library.'
-            })
-          } else if (!libraryName) {
-            setLookupState(lookupMeta, {
-              valid: false,
-              verified: false,
-              message: 'Library context is unavailable for Plex lookup.'
-            })
-          } else {
-            setLookupState(lookupMeta, {
-              valid: false,
-              verified: false,
-              message: 'Checking Plex library for this IMDb ID...'
-            })
-            lookupTemplateStringValue(presetName, item.value, { libraryName, mediaType }).then(result => {
-              if (!lookupMeta.isConnected) return
-              if (result.valid && result.verified && result.label) {
-                const successMessage = result.message || `Plex: ${result.label}`
-                setLookupState(lookupMeta, {
-                  valid: true,
-                  verified: true,
-                  level: result.level,
-                  message: successMessage
-                })
-                return
-              }
-              setLookupState(lookupMeta, {
-                valid: Boolean(result.valid),
-                verified: Boolean(result.verified),
-                message: result.message || 'Plex lookup failed.'
-              })
-            })
-          }
+        if (item.valid && presetConfig.lookupService) {
+          applyLookupState(lookupMeta, presetConfig, presetName, item.value, { libraryName, mediaType })
         }
       })
     }
@@ -3285,6 +3300,8 @@ function setupTemplateStringListHandlers (scope) {
 }
 
 function setupTemplateMappingListHandlers (scope) {
+  const templateStringLookupCache = window.__qsTemplateStringLookupCache || new Map()
+  window.__qsTemplateStringLookupCache = templateStringLookupCache
   const root = scope || document
   root.querySelectorAll('[data-template-mapping-list]').forEach(wrapper => {
     if (wrapper.dataset.listenerAdded) return
@@ -3297,9 +3314,171 @@ function setupTemplateMappingListHandlers (scope) {
     const list = wrapper.querySelector('[data-template-mapping-items]')
     const feedback = wrapper.querySelector('[data-template-mapping-feedback]')
     const validationPreset = String(wrapper.dataset.validationPreset || '').trim().toLowerCase()
+    const keyValidationPreset = String(wrapper.dataset.keyValidationPreset || '').trim().toLowerCase()
+    const lookupDisplayMode = String(wrapper.dataset.lookupDisplayMode || 'stacked').trim().toLowerCase()
+    const valueDisplayLabel = String(wrapper.dataset.valueDisplayLabel || '').trim()
     const valueKind = String(wrapper.dataset.mappingValueKind || 'string_list').trim().toLowerCase()
+    const libraryName = String(wrapper.dataset.libraryName || '').trim()
+    const mediaType = String(wrapper.dataset.mediaType || '').trim()
+    const keyPresetConfig = keyValidationPreset && templateStringListPresetConfigs[keyValidationPreset]
+      ? templateStringListPresetConfigs[keyValidationPreset]
+      : null
 
     if (!hidden || !keyInput || !valueInput || !addBtn || !list) return
+
+    function getServiceValidationState (serviceName) {
+      const el = document.getElementById(`qs-validate-${serviceName}`)
+      return String(el?.value || '').trim().toLowerCase() === 'true'
+    }
+
+    function setLookupState (target, state) {
+      if (!target) return
+      target.textContent = state?.message || ''
+      const inlineLookup = target.dataset.lookupInline === 'true'
+      target.className = inlineLookup ? 'small ms-2' : 'small mt-1'
+      if (!state?.message) {
+        target.classList.add('d-none')
+        return
+      }
+      target.classList.remove('d-none')
+      if (state.level === 'warning') {
+        target.classList.add('text-warning')
+      } else if (state.valid && state.verified) {
+        target.classList.add('text-success')
+      } else if (state.verified) {
+        target.classList.add('text-danger')
+      } else {
+        target.classList.add('text-warning')
+      }
+    }
+
+    async function lookupTemplateStringValue (presetName, value, context = {}) {
+      const currentLibraryName = String(context.libraryName || '').trim()
+      const currentMediaType = String(context.mediaType || '').trim()
+      const cacheKey = `${presetName}:${currentLibraryName}:${currentMediaType}:${value}`
+      if (templateStringLookupCache.has(cacheKey)) {
+        return templateStringLookupCache.get(cacheKey)
+      }
+      const request = fetch('/lookup_template_string_value', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          preset: presetName,
+          value,
+          library_name: currentLibraryName,
+          media_type: currentMediaType
+        })
+      })
+        .then(async (response) => {
+          const data = await response.json().catch(() => ({}))
+          if (!response.ok) {
+            return {
+              valid: false,
+              verified: false,
+              message: data.error || data.message || `Lookup failed (${response.status})`
+            }
+          }
+          return data
+        })
+        .catch(() => ({
+          valid: false,
+          verified: false,
+          message: 'Lookup unavailable right now.'
+        }))
+      templateStringLookupCache.set(cacheKey, request)
+      return request
+    }
+
+    function applyLookupState (target, presetConfig, presetName, value, context = {}) {
+      if (!target || !presetConfig?.lookupService || !value) return
+
+      if (presetConfig.lookupService === 'tmdb') {
+        if (!getServiceValidationState('tmdb')) {
+          setLookupState(target, {
+            valid: false,
+            verified: false,
+            message: 'TMDb not validated, so the collection title could not be checked.'
+          })
+          return
+        }
+
+        setLookupState(target, {
+          valid: false,
+          verified: false,
+          message: 'Checking TMDb collection title...'
+        })
+        lookupTemplateStringValue(presetName, value, context).then(result => {
+          if (!target.isConnected) return
+          if (result.valid && result.verified && result.label) {
+            const successMessage = result.message || `TMDb: ${result.label}`
+            setLookupState(target, {
+              valid: true,
+              verified: true,
+              level: result.level,
+              message: successMessage
+            })
+            return
+          }
+          setLookupState(target, {
+            valid: Boolean(result.valid),
+            verified: Boolean(result.verified),
+            message: result.message || 'TMDb lookup failed.'
+          })
+        })
+        return
+      }
+
+      if (presetConfig.lookupService === 'plex') {
+        if (!getServiceValidationState('plex')) {
+          setLookupState(target, {
+            valid: false,
+            verified: false,
+            message: 'Plex not validated, so the IMDb ID could not be checked against the active library.'
+          })
+          return
+        }
+        if (!String(context.libraryName || '').trim()) {
+          setLookupState(target, {
+            valid: false,
+            verified: false,
+            message: 'Library context is unavailable for Plex lookup.'
+          })
+          return
+        }
+
+        setLookupState(target, {
+          valid: false,
+          verified: false,
+          message: 'Checking Plex library for this IMDb ID...'
+        })
+        lookupTemplateStringValue(presetName, value, context).then(result => {
+          if (!target.isConnected) return
+          if (result.valid && result.verified && result.label) {
+            const successMessage = result.message || `Plex: ${result.label}`
+            setLookupState(target, {
+              valid: true,
+              verified: true,
+              level: result.level,
+              message: successMessage
+            })
+            return
+          }
+          setLookupState(target, {
+            valid: Boolean(result.valid),
+            verified: Boolean(result.verified),
+            message: result.message || 'Plex lookup failed.'
+          })
+        })
+      }
+    }
+
+    if (keyValidationPreset === 'tmdb_collection_id' || keyValidationPreset === 'numeric_id' || keyValidationPreset === 'year' || keyValidationPreset === 'decade') {
+      keyInput.setAttribute('inputmode', 'numeric')
+    }
+    if (keyValidationPreset.startsWith('imdb_id')) {
+      keyInput.setAttribute('autocapitalize', 'off')
+    }
 
     function parseValuesList (rawValue) {
       if (Array.isArray(rawValue)) {
@@ -3338,6 +3517,15 @@ function setupTemplateMappingListHandlers (scope) {
       feedback.classList.toggle('d-block', Boolean(message))
     }
 
+    function setKeyInputValidity (result) {
+      if (!keyInput) return
+      if (!result || result.valid) {
+        keyInput.classList.remove('is-invalid')
+        return
+      }
+      keyInput.classList.add('is-invalid')
+    }
+
     function setValueInputValidity (result) {
       if (!valueInput) return
       if (!result || result.valid) {
@@ -3345,6 +3533,28 @@ function setupTemplateMappingListHandlers (scope) {
         return
       }
       valueInput.classList.add('is-invalid')
+    }
+
+    function normalizeMappingKey (rawKey) {
+      const keyText = String(rawKey || '').trim()
+      if (!keyText) return ''
+      return keyPresetConfig?.normalize ? keyPresetConfig.normalize(keyText) : keyText
+    }
+
+    function validateKey (rawKey) {
+      const normalized = normalizeMappingKey(rawKey)
+      if (!normalized) {
+        return { value: '', valid: false, message: 'Enter a key before adding it.' }
+      }
+      if (!keyPresetConfig?.validate) {
+        return { value: normalized, valid: true, message: '' }
+      }
+      const result = keyPresetConfig.validate(normalized)
+      return {
+        value: normalized,
+        valid: Boolean(result.valid),
+        message: result.message || 'Enter a valid key.'
+      }
     }
 
     function normalizeMappingValue (rawValue) {
@@ -3359,7 +3569,7 @@ function setupTemplateMappingListHandlers (scope) {
     function normalizeMapping (mapping) {
       const normalized = {}
       Object.entries(mapping || {}).forEach(([rawKey, rawValues]) => {
-        const key = String(rawKey || '').trim()
+        const key = normalizeMappingKey(rawKey)
         if (!key) return
         const value = normalizeMappingValue(rawValues)
         if (value == null) return
@@ -3371,19 +3581,47 @@ function setupTemplateMappingListHandlers (scope) {
     function renderList (mapping) {
       list.replaceChildren()
       Object.entries(mapping).forEach(([key, value]) => {
+        const keyResult = validateKey(key)
         const li = document.createElement('li')
         li.className = 'list-group-item d-flex justify-content-between align-items-center'
+        if (!keyResult.valid) li.classList.add('list-group-item-danger')
 
         const textWrap = document.createElement('div')
         textWrap.className = 'd-flex flex-column'
 
+        const titleRow = document.createElement('div')
+        titleRow.className = 'd-flex align-items-center gap-2'
+
         const title = document.createElement('span')
         title.textContent = key
-        textWrap.appendChild(title)
+        titleRow.appendChild(title)
+
+        if (!keyResult.valid) {
+          const badge = document.createElement('span')
+          badge.className = 'badge text-bg-danger'
+          badge.textContent = 'Invalid'
+          badge.title = keyResult.message
+          titleRow.appendChild(badge)
+        }
+
+        textWrap.appendChild(titleRow)
+
+        const lookupMeta = document.createElement('div')
+        if (lookupDisplayMode === 'inline') {
+          lookupMeta.dataset.lookupInline = 'true'
+          titleRow.appendChild(lookupMeta)
+        }
+        lookupMeta.className = 'small mt-1 d-none'
+        if (lookupDisplayMode !== 'inline') {
+          textWrap.appendChild(lookupMeta)
+        }
 
         const details = document.createElement('div')
         details.className = 'small text-muted'
-        details.textContent = Array.isArray(value) ? value.join(', ') : String(value || '')
+        const rawDetails = Array.isArray(value) ? value.join(', ') : String(value || '')
+        details.textContent = valueDisplayLabel && !Array.isArray(value)
+          ? `${valueDisplayLabel}: ${rawDetails}`
+          : rawDetails
         textWrap.appendChild(details)
 
         const button = document.createElement('button')
@@ -3396,6 +3634,10 @@ function setupTemplateMappingListHandlers (scope) {
 
         li.append(textWrap, button)
         list.appendChild(li)
+
+        if (keyResult.valid && keyPresetConfig?.lookupService) {
+          applyLookupState(lookupMeta, keyPresetConfig, keyValidationPreset, keyResult.value, { libraryName, mediaType })
+        }
 
         button.addEventListener('click', () => {
           const current = normalizeMapping(parseStoredMapping(hidden.value))
@@ -3412,18 +3654,21 @@ function setupTemplateMappingListHandlers (scope) {
       hidden.value = JSON.stringify(normalized)
       renderList(normalized)
       setFeedback(message)
+      setKeyInputValidity({ valid: true })
       setValueInputValidity({ valid: true })
       return normalized
     }
 
     function addEntry () {
-      const key = String(keyInput.value || '').trim()
-      if (!key) {
-        setFeedback('Enter a key before adding it.')
+      const keyResult = validateKey(keyInput.value)
+      if (!keyResult.valid) {
+        setKeyInputValidity(keyResult)
+        setFeedback(keyResult.message || 'Enter a valid key before adding it.')
         return
       }
       const normalizedValue = normalizeMappingValue(valueInput.value)
       if (normalizedValue == null) {
+        setKeyInputValidity({ valid: true })
         setFeedback('Enter at least one value before adding it.')
         return
       }
@@ -3431,12 +3676,13 @@ function setupTemplateMappingListHandlers (scope) {
         const validationResult = URLValidation.validateValue(normalizedValue)
         if (!validationResult.valid) {
           setValueInputValidity(validationResult)
+          setKeyInputValidity({ valid: true })
           setFeedback(validationResult.message || 'Enter a valid URL before adding it.')
           return
         }
       }
       const current = normalizeMapping(parseStoredMapping(hidden.value))
-      current[key] = normalizedValue
+      current[keyResult.value] = normalizedValue
       syncState(current)
       keyInput.value = ''
       valueInput.value = ''
@@ -3450,6 +3696,7 @@ function setupTemplateMappingListHandlers (scope) {
     })
     keyInput.addEventListener('input', () => {
       setFeedback('')
+      setKeyInputValidity({ valid: true })
     })
     valueInput.addEventListener('input', () => {
       setFeedback('')

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -2922,14 +2922,15 @@ function setupTemplateStringListHandlers (scope) {
     return String(el?.value || '').trim().toLowerCase() === 'true'
   }
 
-  function setLookupState (target, state) {
-    if (!target) return
-    target.textContent = state?.message || ''
-    target.className = 'small mt-1'
-    if (!state?.message) {
-      target.classList.add('d-none')
-      return
-    }
+    function setLookupState (target, state) {
+      if (!target) return
+      target.textContent = state?.message || ''
+      const inlineLookup = target.dataset.lookupInline === 'true'
+      target.className = inlineLookup ? 'small ms-2' : 'small mt-1'
+      if (!state?.message) {
+        target.classList.add('d-none')
+        return
+      }
     target.classList.remove('d-none')
     if (state.level === 'warning') {
       target.classList.add('text-warning')
@@ -3200,8 +3201,13 @@ function setupTemplateStringListHandlers (scope) {
         textWrap.appendChild(titleRow)
 
         const lookupMeta = document.createElement('div')
-        lookupMeta.className = 'small mt-1 d-none'
-        textWrap.appendChild(lookupMeta)
+        if (presetConfig.lookupService) {
+          lookupMeta.dataset.lookupInline = 'true'
+          titleRow.appendChild(lookupMeta)
+        } else {
+          textWrap.appendChild(lookupMeta)
+        }
+        lookupMeta.className = presetConfig.lookupService ? 'small ms-2 d-none' : 'small mt-1 d-none'
 
         const button = document.createElement('button')
         button.type = 'button'
@@ -3611,7 +3617,7 @@ function setupTemplateMappingListHandlers (scope) {
           lookupMeta.dataset.lookupInline = 'true'
           titleRow.appendChild(lookupMeta)
         }
-        lookupMeta.className = 'small mt-1 d-none'
+        lookupMeta.className = lookupDisplayMode === 'inline' ? 'small ms-2 d-none' : 'small mt-1 d-none'
         if (lookupDisplayMode !== 'inline') {
           textWrap.appendChild(lookupMeta)
         }

--- a/static/local-js/overlayHandler.js
+++ b/static/local-js/overlayHandler.js
@@ -3207,7 +3207,6 @@ const OverlayHandler = {
       buildBackdropDataUrl(cfg).then(dataUrl => {
         if (!dataUrl) return
         cfg.layer.src = dataUrl
-        applyPosition(cfg)
       })
     }
 

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -1418,7 +1418,12 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                         {% endif %}
                         {% set label_width = item.label_width if item.label_width is defined else (320 if item.label|length > 24 else 170) %}
                         <div class="mb-2" data-template-mapping-list data-hidden-input="{{ input_name }}"
+                            data-library-name="{{ library.name }}"
+                            data-media-type="{{ library.type }}"
                             data-validation-preset="{{ item.validation_preset | default('') }}"
+                            data-key-validation-preset="{{ item.key_validation_preset | default('') }}"
+                            data-lookup-display-mode="{{ item.lookup_display_mode | default('stacked') }}"
+                            data-value-display-label="{{ item.value_display_label | default('') }}"
                             data-mapping-value-kind="{{ item.dynamic_child_value_kind | default('string_list') }}">
                             <div class="input-group">
                                 <span class="input-group-text qs-template-variable-label" id="{{ input_name }}_text"

--- a/tests/fixtures/schema/config-schema.json
+++ b/tests/fixtures/schema/config-schema.json
@@ -4565,6 +4565,25 @@
             "assets_for_all_collections": {
               "type": "boolean"
             },
+            "ignore_labels": {
+              "description": "Skip item operations for items with any of these labels.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1
+                }
+              ]
+            },
+            "respect_ignore_ids": {
+              "description": "When true, this library operations run skips items listed in ignore_ids or ignore_imdb_ids.",
+              "type": "boolean"
+            },
             "update_blank_track_titles": {
               "type": "boolean"
             },
@@ -4734,6 +4753,12 @@
                   "type": "string",
                   "enum": [
                     "tmdb",
+                    "tmdb_premiere",
+                    "tmdb_theatrical",
+                    "tmdb_theatricallimited",
+                    "tmdb_digital",
+                    "tmdb_physical",
+                    "tmdb_tv",
                     "tvdb",
                     "omdb",
                     "mdb",
@@ -4759,6 +4784,12 @@
                         "type": "string",
                         "enum": [
                           "tmdb",
+                          "tmdb_premiere",
+                          "tmdb_theatrical",
+                          "tmdb_theatricallimited",
+                          "tmdb_digital",
+                          "tmdb_physical",
+                          "tmdb_tv",
                           "tvdb",
                           "omdb",
                           "mdb",
@@ -4786,6 +4817,12 @@
                   "type": "string",
                   "enum": [
                     "tmdb",
+                    "tmdb_premiere",
+                    "tmdb_theatrical",
+                    "tmdb_theatricallimited",
+                    "tmdb_digital",
+                    "tmdb_physical",
+                    "tmdb_tv",
                     "tvdb",
                     "omdb",
                     "mdb",
@@ -4811,6 +4848,12 @@
                         "type": "string",
                         "enum": [
                           "tmdb",
+                          "tmdb_premiere",
+                          "tmdb_theatrical",
+                          "tmdb_theatricallimited",
+                          "tmdb_digital",
+                          "tmdb_physical",
+                          "tmdb_tv",
                           "tvdb",
                           "omdb",
                           "mdb",
@@ -9011,6 +9054,10 @@
         "sort_title": {
           "type": "string"
         },
+        "build_collection": {
+          "description": "When false, the collection is not created but related Radarr or Sonarr actions can still run.",
+          "type": "boolean"
+        },
         "schedule": {
           "type": "string"
         },
@@ -9360,6 +9407,13 @@
         },
         "append_addons": {
           "type": "object"
+        },
+        "title_override": {
+          "description": "Override the generated collection title for specific dynamic collection keys.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "remove_addons": {
           "oneOf": [

--- a/tests/test_collection_child_override_contract.py
+++ b/tests/test_collection_child_override_contract.py
@@ -107,30 +107,30 @@ def test_name_and_summary_child_overrides_follow_child_toggles_for_shared_naming
 def test_franchise_uses_generic_dynamic_child_override_surface():
     expected_by_media = {
         ("movie",): {
-            "child_name_overrides": ("name_", "string"),
-            "child_summary_overrides": ("summary_", "string"),
-            "child_sort_title_overrides": ("sort_title_", "string"),
-            "child_sync_mode_overrides": ("sync_mode_", "select"),
-            "child_collection_order_overrides": ("collection_order_", "select"),
-            "child_url_poster_overrides": ("url_poster_", "string"),
-            "child_radarr_add_missing_overrides": ("radarr_add_missing_", "boolean"),
-            "child_radarr_folder_overrides": ("radarr_folder_", "string"),
-            "child_radarr_tag_overrides": ("radarr_tag_", "string_list"),
-            "child_item_radarr_tag_overrides": ("item_radarr_tag_", "string_list"),
-            "child_radarr_monitor_overrides": ("radarr_monitor_", "boolean"),
+            "child_name_overrides": ("name_", "string", "tmdb_collection_id"),
+            "child_summary_overrides": ("summary_", "string", "tmdb_collection_id"),
+            "child_sort_title_overrides": ("sort_title_", "string", "tmdb_collection_id"),
+            "child_sync_mode_overrides": ("sync_mode_", "select", "tmdb_collection_id"),
+            "child_collection_order_overrides": ("collection_order_", "select", "tmdb_collection_id"),
+            "child_url_poster_overrides": ("url_poster_", "string", "tmdb_collection_id"),
+            "child_radarr_add_missing_overrides": ("radarr_add_missing_", "boolean", "tmdb_collection_id"),
+            "child_radarr_folder_overrides": ("radarr_folder_", "string", "tmdb_collection_id"),
+            "child_radarr_tag_overrides": ("radarr_tag_", "string_list", "tmdb_collection_id"),
+            "child_item_radarr_tag_overrides": ("item_radarr_tag_", "string_list", "tmdb_collection_id"),
+            "child_radarr_monitor_overrides": ("radarr_monitor_", "boolean", "tmdb_collection_id"),
         },
         ("show",): {
-            "child_name_overrides": ("name_", "string"),
-            "child_summary_overrides": ("summary_", "string"),
-            "child_sort_title_overrides": ("sort_title_", "string"),
-            "child_sync_mode_overrides": ("sync_mode_", "select"),
-            "child_collection_order_overrides": ("collection_order_", "select"),
-            "child_url_poster_overrides": ("url_poster_", "string"),
-            "child_sonarr_add_missing_overrides": ("sonarr_add_missing_", "boolean"),
-            "child_sonarr_folder_overrides": ("sonarr_folder_", "string"),
-            "child_sonarr_tag_overrides": ("sonarr_tag_", "string_list"),
-            "child_item_sonarr_tag_overrides": ("item_sonarr_tag_", "string_list"),
-            "child_sonarr_monitor_overrides": ("sonarr_monitor_", "select"),
+            "child_name_overrides": ("name_", "string", "numeric_id"),
+            "child_summary_overrides": ("summary_", "string", "numeric_id"),
+            "child_sort_title_overrides": ("sort_title_", "string", "numeric_id"),
+            "child_sync_mode_overrides": ("sync_mode_", "select", "numeric_id"),
+            "child_collection_order_overrides": ("collection_order_", "select", "numeric_id"),
+            "child_url_poster_overrides": ("url_poster_", "string", "numeric_id"),
+            "child_sonarr_add_missing_overrides": ("sonarr_add_missing_", "boolean", "numeric_id"),
+            "child_sonarr_folder_overrides": ("sonarr_folder_", "string", "numeric_id"),
+            "child_sonarr_tag_overrides": ("sonarr_tag_", "string_list", "numeric_id"),
+            "child_item_sonarr_tag_overrides": ("item_sonarr_tag_", "string_list", "numeric_id"),
+            "child_sonarr_monitor_overrides": ("sonarr_monitor_", "select", "numeric_id"),
         },
     }
 
@@ -138,11 +138,27 @@ def test_franchise_uses_generic_dynamic_child_override_surface():
         collection = _find_collection("collection_franchise", media_types)
         fields = {item["key"]: item for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key")}
 
-        for field_key, (child_prefix, value_kind) in expected_fields.items():
+        for field_key, (child_prefix, value_kind, key_validation_preset) in expected_fields.items():
             assert field_key in fields
             assert fields[field_key]["type"] == "mapping_list"
             assert fields[field_key]["dynamic_child_prefix"] == child_prefix
             assert fields[field_key]["dynamic_child_value_kind"] == value_kind
+            assert fields[field_key]["key_validation_preset"] == key_validation_preset
+            assert fields[field_key]["lookup_display_mode"] == "inline"
+
+
+def test_movie_franchise_title_override_uses_tmdb_collection_key_validation():
+    collection = _find_collection("collection_franchise", ("movie",))
+    fields = {item["key"]: item for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key")}
+
+    assert "title_override" in fields
+    field = fields["title_override"]
+    assert field["type"] == "mapping_list"
+    assert field["key_validation_preset"] == "tmdb_collection_id"
+    assert field["dynamic_child_value_kind"] == "string"
+    assert field["lookup_display_mode"] == "inline"
+    assert field["value_display_label"] == "Custom title"
+    assert "validation_preset" not in field
 
 
 def test_year_collections_master_toggle_does_not_get_fake_child_name_or_summary_overrides():

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -2214,14 +2214,17 @@ def test_build_libraries_section_normalizes_collection_arr_tag_lists(app):
             {
                 "movies": {
                     "mov-library_movies-collection_franchise": True,
+                    "mov-library_movies-template_collection_franchise_build_collection": False,
                     "mov-library_movies-template_collection_franchise_radarr_folder": r"C:\Media\Movies",
                     "mov-library_movies-template_collection_franchise_radarr_tag": '["4k", "favorite"]',
                     "mov-library_movies-template_collection_franchise_item_radarr_tag": '["collected", "franchise"]',
+                    "mov-library_movies-template_collection_franchise_title_override": '{"10": "Star Wars: Skywalker Saga"}',
                 }
             },
             {
                 "shows": {
                     "sho-library_shows-collection_franchise": True,
+                    "sho-library_shows-template_collection_franchise_build_collection": False,
                     "sho-library_shows-template_collection_franchise_sonarr_folder": r"C:\Media\Shows",
                     "sho-library_shows-template_collection_franchise_sonarr_monitor": "future",
                     "sho-library_shows-template_collection_franchise_sonarr_tag": '["ongoing", "priority"]',
@@ -2253,13 +2256,46 @@ def test_build_libraries_section_normalizes_collection_arr_tag_lists(app):
 
     assert movie_entry is not None
     assert show_entry is not None
+    assert movie_entry["template_variables"]["build_collection"] is False
     assert movie_entry["template_variables"]["radarr_folder"] == r"C:\Media\Movies"
     assert movie_entry["template_variables"]["radarr_tag"] == ["4k", "favorite"]
     assert movie_entry["template_variables"]["item_radarr_tag"] == ["collected", "franchise"]
+    assert movie_entry["template_variables"]["title_override"] == {"10": "Star Wars: Skywalker Saga"}
+    assert show_entry["template_variables"]["build_collection"] is False
     assert show_entry["template_variables"]["sonarr_folder"] == r"C:\Media\Shows"
     assert show_entry["template_variables"]["sonarr_monitor"] == "future"
     assert show_entry["template_variables"]["sonarr_tag"] == ["ongoing", "priority"]
     assert show_entry["template_variables"]["item_sonarr_tag"] == ["watched", "tracked"]
+
+
+def test_runtime_config_schema_accepts_franchise_build_collection_and_title_override(isolated_config_dir):
+    import json
+
+    import jsonschema
+
+    schema_path = isolated_config_dir / ".schema" / "config-schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    sample = {
+        "plex": {"url": "http://example", "token": "x"},
+        "tmdb": {"apikey": "x"},
+        "libraries": {
+            "Movies": {
+                "collection_files": [
+                    {
+                        "default": "franchise",
+                        "template_variables": {
+                            "build_collection": False,
+                            "title_override": {"10": "Star Wars: Skywalker Saga"},
+                        },
+                    }
+                ]
+            }
+        },
+    }
+
+    errors = sorted(jsonschema.Draft7Validator(schema).iter_errors(sample), key=lambda err: list(err.path))
+
+    assert errors == []
 
 
 def test_build_libraries_section_emits_collection_hub_priority(app):
@@ -2612,6 +2648,10 @@ def test_normalize_collection_template_var_value_handles_dynamic_family_controls
         '{"Top 250": ["IMDb Top 250"]}',
     ) == {"Top 250": ["IMDb Top 250"]}
     assert output._normalize_collection_template_var_value(
+        "title_override",
+        '{"10": "Star Wars: Skywalker Saga", "535313": "Godzilla (MonsterVerse)"}',
+    ) == {"10": "Star Wars: Skywalker Saga", "535313": "Godzilla (MonsterVerse)"}
+    assert output._normalize_collection_template_var_value(
         "tmdb_birthday",
         '{"this_month": true, "before": 7, "after": "2"}',
     ) == {"this_month": True, "before": 7, "after": 2}
@@ -2630,6 +2670,7 @@ def test_dynamic_family_template_var_normalization_matches_collection_export_sha
         "addons": '{"US": ["Canada", "Mexico"], "CA": "United States"}',
         "append_addons": '{"US": ["Brazil"]}',
         "remove_suffix": '["Collection"]',
+        "title_override": '{"10": "Star Wars: Skywalker Saga"}',
     }
 
     for list_key in ("include", "exclude", "exclude_prefix"):
@@ -2659,6 +2700,9 @@ def test_dynamic_family_template_var_normalization_matches_collection_export_sha
             "US": ["Brazil"],
         },
         "remove_suffix": "Collection",
+        "title_override": {
+            "10": "Star Wars: Skywalker Saga",
+        },
     }
 
 

--- a/tests/test_importer_collection_files.py
+++ b/tests/test_importer_collection_files.py
@@ -212,6 +212,7 @@ def test_prepare_import_payload_collapses_franchise_dynamic_child_template_varia
                         {
                             "default": "franchise",
                             "template_variables": {
+                                "build_collection": False,
                                 "name_10": "Skywalker Saga",
                                 "sync_mode_10": "append",
                                 "collection_order_10": "custom",
@@ -221,6 +222,7 @@ def test_prepare_import_payload_collapses_franchise_dynamic_child_template_varia
                                 "radarr_tag_10": ["4k", "franchise"],
                                 "item_radarr_tag_10": ["collection", "tracked"],
                                 "radarr_monitor_10": False,
+                                "title_override": {"10": "Star Wars: Skywalker Saga"},
                             },
                         }
                     ]
@@ -230,6 +232,7 @@ def test_prepare_import_payload_collapses_franchise_dynamic_child_template_varia
                         {
                             "default": "franchise",
                             "template_variables": {
+                                "build_collection": False,
                                 "summary_1399": "Dragons and dynasties",
                                 "sort_title_1399": "!350_Game of Thrones",
                                 "sonarr_add_missing_1399": True,
@@ -250,6 +253,8 @@ def test_prepare_import_payload_collapses_franchise_dynamic_child_template_varia
     libraries_payload = payload["libraries"]["libraries"]
     assert libraries_payload["mov-library_movies-collection_franchise"] is True
     assert libraries_payload["sho-library_shows-collection_franchise"] is True
+    assert libraries_payload["mov-library_movies-template_collection_franchise_build_collection"] is False
+    assert libraries_payload["mov-library_movies-template_collection_franchise_title_override"] == {"10": "Star Wars: Skywalker Saga"}
     assert libraries_payload["mov-library_movies-template_collection_franchise_child_name_overrides"] == '{"10": "Skywalker Saga"}'
     assert libraries_payload["mov-library_movies-template_collection_franchise_child_sync_mode_overrides"] == '{"10": "append"}'
     assert libraries_payload["mov-library_movies-template_collection_franchise_child_collection_order_overrides"] == '{"10": "custom"}'
@@ -266,5 +271,6 @@ def test_prepare_import_payload_collapses_franchise_dynamic_child_template_varia
     assert libraries_payload["sho-library_shows-template_collection_franchise_child_sonarr_tag_overrides"] == '{"1399": "tracked,priority"}'
     assert libraries_payload["sho-library_shows-template_collection_franchise_child_item_sonarr_tag_overrides"] == '{"1399": "watched,tracked"}'
     assert libraries_payload["sho-library_shows-template_collection_franchise_child_sonarr_monitor_overrides"] == '{"1399": "future"}'
+    assert libraries_payload["sho-library_shows-template_collection_franchise_build_collection"] is False
     assert any("libraries.Movies.collection_files[0].template_variables.name_10" in line for line in report.lines)
     assert any("libraries.Shows.collection_files[0].template_variables.sonarr_monitor_1399" in line for line in report.lines)

--- a/tests/test_template_gap_analyzer.py
+++ b/tests/test_template_gap_analyzer.py
@@ -491,6 +491,8 @@ def test_build_qs_collection_map_preserves_dynamic_family_edge_cases_for_repo_fi
     assert "data_limit" in collection_map["writer"]
     assert "data_limit" not in collection_map["studio"]
     assert "data_limit" not in collection_map["network"]
+    assert "build_collection" in collection_map["franchise"]
+    assert "title_override" in collection_map["franchise"]
 
 
 def test_build_qs_library_template_keys_includes_separator_placeholder_keys_for_repo_file():
@@ -1228,11 +1230,11 @@ def test_quickstart_recommendation_summary_excludes_dynamic_collection_child_ins
             "file": "config.yml",
             "library": "Movies",
             "matched_default_files": ["movie/franchise.yml"],
-            "supported_in_quickstart": False,
-            "quickstart_declared": False,
+            "supported_in_quickstart": True,
+            "quickstart_declared": True,
             "schema_declared": False,
             "kometa_declared": True,
-            "validation_level": "works_in_kometa_missing_from_quickstart_and_schema",
+            "validation_level": "supported_in_quickstart",
             "name_verified": True,
             "value_shape_verified": True,
             "value_shape_rule": "dynamic",
@@ -1243,7 +1245,7 @@ def test_quickstart_recommendation_summary_excludes_dynamic_collection_child_ins
     ranked = module.serialize_ranked_summary(summary)
     excluded = module.build_quickstart_recommendation_exclusion_summary(rows)
 
-    assert [item["key"] for item in ranked] == ["title_override"]
+    assert ranked == []
     assert excluded[("collection", "franchise", "movie_645")]["reason"] == "dynamic_collection_child_instance_key_not_ranked"
     assert excluded[("collection", "seasonal", "trakt_list_christmas")]["reason"] == "dynamic_collection_child_instance_key_not_ranked"
 
@@ -1288,11 +1290,11 @@ def test_build_merged_fix_queue_excludes_internal_and_dynamic_instance_false_pos
             "files": ["config.yml"],
             "libraries": ["Movies"],
             "matched_default_files": ["movie/franchise.yml"],
-            "supported_in_quickstart": False,
-            "quickstart_declared": False,
+            "supported_in_quickstart": True,
+            "quickstart_declared": True,
             "schema_declared": False,
             "kometa_declared": True,
-            "validation_level": "works_in_kometa_missing_from_quickstart_and_schema",
+            "validation_level": "supported_in_quickstart",
         },
     ]
     importer_rows = [
@@ -1322,19 +1324,18 @@ def test_build_merged_fix_queue_excludes_internal_and_dynamic_instance_false_pos
             "kind": "collection",
             "default": "franchise",
             "key": "build_collection",
-            "import_status": "unmapped",
-            "reason_class": "missing_template_variable_support",
+            "import_status": "mapped",
             "occurrences": 4,
             "files": ["config.yml"],
             "libraries": ["Movies"],
-            "reasons": ["Template variable not available in Quickstart."],
+            "reasons": [],
         },
     ]
 
     ranked = module.build_merged_fix_queue(verified_rows, importer_rows)
 
     assert [item["key"] for item in ranked] == ["build_collection"]
-    assert ranked[0]["action_targets"] == ["schema", "quickstart", "importer"]
+    assert ranked[0]["action_targets"] == ["schema"]
 
 
 def test_build_merged_fix_queue_excludes_internal_library_type_metadata():


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

```md
## Summary

This PR closes the remaining verified franchise collection gaps in Quickstart and makes the related Libraries-page inputs easier to use.

It adds end-to-end support for `build_collection` and `title_override` where Quickstart needs to expose, import, emit, and validate them, while also improving the lookup UX so users get immediate feedback instead of entering blind numeric IDs.

## What Changed

- Added `build_collection` and `title_override` to the runtime schema in `config/kometa/json-schema/config-schema.json`.
- Mirrored the same schema updates into `config/.schema/config-schema.json` and `tests/fixtures/schema/config-schema.json` so the fixture copy stays aligned with the runtime schema.
- Added Quickstart Libraries-page support for:
  - movie `franchise`: `build_collection`, `title_override`
  - show `franchise`: `build_collection`
- Updated the Libraries metadata so franchise override maps can validate their keys and resolve them through lookups instead of accepting opaque IDs with no feedback.
- Added inline lookup rendering for franchise-related mapping rows so users see the entered ID and resolved title together on the same line.
- Labeled mapped values more clearly in rendered rows, such as showing `Custom title: ...` instead of leaving the second line ambiguous.
- Applied the same inline lookup treatment to existing lookup-backed list rows on the Libraries page, including fields like `ignore_ids`, `ignore_imdb_ids`, and movie franchise `exclude`.
- Updated output handling so `title_override` is emitted as the expected string mapping in the generated config.
- Kept importer/backend/test coverage aligned with the new franchise fields and UI metadata.
- Fixed the related frontend regressions encountered during this work:
  - resolved the Libraries-page lookup helper scoping issue
  - removed the stray overlay preview `applyPosition` call that was triggering the runtime error

## Why

Before this change, Quickstart could show the new franchise options in the UI only partially, and emitted configs could fail schema validation if `build_collection` or `title_override` were present without corresponding schema support.

The Libraries page also made several ID-based fields harder to use than necessary because users had to enter raw IDs without clear confirmation of what those IDs resolved to.

## Testing

- `venv\Scripts\python.exe -c "import pytest, sys; sys.exit(pytest.main(['tests/test_collection_child_override_contract.py','tests/test_core_backend.py','tests/test_importer_collection_files.py','tests/test_template_gap_analyzer.py','tests/test_config_and_library_routes.py']))"`
- Result: `288 passed`

## Notes

- This PR intentionally does not broaden other schemas beyond the required `config-schema.json` mirror chain.
- The fixture schema now mirrors the runtime schema again for the touched franchise fields instead of drifting from it.
```

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
