### PR TITLE
Fix xtra folders

### DIFF
--- a/modules/assets.py
+++ b/modules/assets.py
@@ -51,10 +51,6 @@ def clear_font_cache():
 def list_overlay_fonts() -> list[str]:
     """Font discovery (TTF/OTF) across common static dirs."""
     config_name = session.get("config_name") if has_request_context() else None
-    if config_name:
-        migration = helpers.migrate_legacy_custom_fonts_to_config(config_name)
-        if migration.get("copied"):
-            clear_font_cache()
     cache_key = helpers.normalize_config_name_for_storage(config_name) if config_name else "__default__"
     cached = _FONT_CACHE.get(cache_key)
     if cached:

--- a/modules/database.py
+++ b/modules/database.py
@@ -199,12 +199,23 @@ def reset_data(name, section=None):
                 cursor.execute(sql, (name,))
 
 
+def prune_invalid_section_rows():
+    with sqlite3.connect(get_database_path(), detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES) as connection:
+        connection.row_factory = sqlite3.Row
+        with closing(connection.cursor()) as cursor:
+            cursor.execute(persisted_section_table_create())
+            cursor.execute("""DELETE FROM section_data
+                   WHERE TRIM(COALESCE(name, '')) == ''
+                      OR TRIM(COALESCE(section, '')) == ''""")
+            return cursor.rowcount
+
+
 def get_unique_config_names():
     with sqlite3.connect(get_database_path(), detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES) as connection:
         connection.row_factory = sqlite3.Row
         with closing(connection.cursor()) as cursor:
             cursor.execute(persisted_section_table_create())
-            cursor.execute("SELECT DISTINCT name FROM section_data ORDER BY name ASC")
+            cursor.execute("SELECT DISTINCT name FROM section_data WHERE TRIM(COALESCE(name, '')) != '' ORDER BY name ASC")
             return [row["name"] for row in cursor.fetchall()]
 
 

--- a/modules/helpers/_artifacts.py
+++ b/modules/helpers/_artifacts.py
@@ -469,6 +469,45 @@ def list_orphaned_config_versions(config_name: str | None) -> dict:
     return {"name": normalized, "versions": versions}
 
 
+def prune_unrecoverable_orphaned_config_artifacts(
+    active_config_names: list[str] | None = None,
+    kometa_root: str | Path | None = None,
+    kometa_config_dir: str | Path | None = None,
+) -> dict:
+    inventory = list_orphaned_config_artifacts(
+        active_config_names=active_config_names,
+        kometa_root=kometa_root,
+        kometa_config_dir=kometa_config_dir,
+    )
+    if inventory.get("errors"):
+        return {
+            "removed": [],
+            "skipped": [],
+            "errors": list(inventory.get("errors", [])),
+        }
+
+    removed: list[str] = []
+    skipped: list[str] = []
+    errors: list[str] = []
+
+    for bundle in inventory.get("orphans", []):
+        if not isinstance(bundle, dict):
+            continue
+        name = normalize_config_name_for_storage(bundle.get("name"))
+        if not name:
+            continue
+        if bundle.get("has_current_file") or bundle.get("has_archive_dir") or bundle.get("has_kometa_copy"):
+            skipped.append(name)
+            continue
+        result = delete_orphaned_artifact_bundle(bundle)
+        if result.get("errors"):
+            errors.extend(result["errors"])
+            continue
+        removed.append(name)
+
+    return {"removed": removed, "skipped": skipped, "errors": errors}
+
+
 def prune_orphaned_config_archives(
     active_config_names: list[str] | None = None,
 ) -> dict:

--- a/modules/helpers/_artifacts.py
+++ b/modules/helpers/_artifacts.py
@@ -496,9 +496,6 @@ def prune_unrecoverable_orphaned_config_artifacts(
         name = normalize_config_name_for_storage(bundle.get("name"))
         if not name:
             continue
-        if bundle.get("has_current_file") or bundle.get("has_archive_dir") or bundle.get("has_kometa_copy"):
-            skipped.append(name)
-            continue
         result = delete_orphaned_artifact_bundle(bundle)
         if result.get("errors"):
             errors.extend(result["errors"])

--- a/quickstart.py
+++ b/quickstart.py
@@ -1059,6 +1059,16 @@ if cleanup_flag not in {"1", "true", "yes"}:
         helpers.update_env_variable("QS_CONFIG_CLEANUP_DONE", "1")
         os.environ["QS_CONFIG_CLEANUP_DONE"] = "1"
 
+orphan_prune_result = helpers.prune_unrecoverable_orphaned_config_artifacts(kometa_root=app.config.get("KOMETA_ROOT", "."))
+if orphan_prune_result.get("removed"):
+    helpers.ts_log(
+        f"Config cleanup removed {len(orphan_prune_result['removed'])} unrecoverable orphaned config bundle(s).",
+        level="INFO",
+    )
+if orphan_prune_result.get("errors"):
+    for msg in orphan_prune_result["errors"]:
+        helpers.ts_log(msg, level="WARNING")
+
 
 def _load_or_create_secret_key():
     env_key = os.getenv("QS_SECRET_KEY", "").strip()

--- a/quickstart.py
+++ b/quickstart.py
@@ -1062,12 +1062,19 @@ if cleanup_flag not in {"1", "true", "yes"}:
 orphan_prune_result = helpers.prune_unrecoverable_orphaned_config_artifacts(kometa_root=app.config.get("KOMETA_ROOT", "."))
 if orphan_prune_result.get("removed"):
     helpers.ts_log(
-        f"Config cleanup removed {len(orphan_prune_result['removed'])} unrecoverable orphaned config bundle(s).",
+        f"Config cleanup removed {len(orphan_prune_result['removed'])} orphaned config bundle(s).",
         level="INFO",
     )
 if orphan_prune_result.get("errors"):
     for msg in orphan_prune_result["errors"]:
         helpers.ts_log(msg, level="WARNING")
+
+invalid_section_rows_removed = database.prune_invalid_section_rows()
+if invalid_section_rows_removed:
+    helpers.ts_log(
+        f"Config cleanup removed {invalid_section_rows_removed} invalid SQLite config row(s).",
+        level="INFO",
+    )
 
 
 def _load_or_create_secret_key():

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -4120,34 +4120,31 @@ def test_delete_orphaned_config_artifacts_route_removes_font_only_default_bundle
     assert not (isolated_config_dir / "default").exists()
 
 
-def test_prune_unrecoverable_orphaned_config_artifacts_removes_font_only_bundle_but_keeps_yaml_backed_bundle(isolated_config_dir, app):
+def test_prune_unrecoverable_orphaned_config_artifacts_removes_archive_backed_orphan_bundle(isolated_config_dir, app):
     from pathlib import Path
     from modules import helpers
 
     font_only_name = "font_only_orphan"
-    recoverable_name = "recoverable_orphan"
+    archive_only_name = "archive_only_orphan"
 
     font_only_dir = isolated_config_dir / font_only_name / "fonts"
     font_only_dir.mkdir(parents=True, exist_ok=True)
     (font_only_dir / "Poster.ttf").write_bytes(b"font-only")
 
-    archive_dir = isolated_config_dir / "archives" / recoverable_name
+    archive_dir = isolated_config_dir / "archives" / archive_only_name
     archive_dir.mkdir(parents=True, exist_ok=True)
-    (archive_dir / f"{recoverable_name}_config_1.yml").write_text("archive: true\n", encoding="utf-8")
-    (isolated_config_dir / f"{recoverable_name}_config.yml").write_text("current: true\n", encoding="utf-8")
+    (archive_dir / f"{archive_only_name}_config_1.yml").write_text("archive: true\n", encoding="utf-8")
     kometa_path = Path(app.config["KOMETA_ROOT"]) / "config"
     kometa_path.mkdir(parents=True, exist_ok=True)
-    (kometa_path / f"{recoverable_name}_config.yml").write_text("kometa: true\n", encoding="utf-8")
 
     result = helpers.prune_unrecoverable_orphaned_config_artifacts(active_config_names=[], kometa_root=app.config.get("KOMETA_ROOT", "."))
 
     assert result["errors"] == []
-    assert result["removed"] == [font_only_name]
-    assert recoverable_name in result["skipped"]
+    assert set(result["removed"]) == {font_only_name, archive_only_name}
+    assert result["skipped"] == []
     assert not (isolated_config_dir / font_only_name).exists()
-    assert (isolated_config_dir / f"{recoverable_name}_config.yml").exists()
-    assert (isolated_config_dir / "archives" / recoverable_name).exists()
-    assert (kometa_path / f"{recoverable_name}_config.yml").exists()
+    assert not (isolated_config_dir / archive_only_name).exists()
+    assert not (isolated_config_dir / "archives" / archive_only_name).exists()
 
 
 def test_delete_orphaned_config_artifacts_route_removes_copy_named_yaml(client, isolated_config_dir):
@@ -4265,6 +4262,24 @@ def test_rename_config_moves_managed_library_file_directories(client, isolated_c
 
     assert new_name in database.get_unique_config_names()
     assert old_name not in database.get_unique_config_names()
+
+
+def test_prune_invalid_section_rows_removes_blank_config_entries(isolated_config_dir):
+    import sqlite3
+    from modules import database
+
+    with sqlite3.connect(database.get_database_path()) as connection:
+        cursor = connection.cursor()
+        cursor.execute(database.persisted_section_table_create())
+        cursor.execute(
+            "INSERT OR REPLACE INTO section_data(name, section, validated, user_entered, data) VALUES (?, ?, ?, ?, ?)",
+            ("", "", False, False, None),
+        )
+
+    removed = database.prune_invalid_section_rows()
+
+    assert removed == 1
+    assert "" not in database.get_unique_config_names()
 
 
 def test_list_uploaded_images_includes_builtin_guides(client):

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -3664,6 +3664,24 @@ def test_download_bundle_places_fonts_under_config_name(client, isolated_config_
         assert f"{config_name}/fonts/Poster.ttf" in names
 
 
+def test_list_overlay_fonts_does_not_create_config_scoped_font_dir_when_listing(client, isolated_config_dir, app):
+    from flask import session
+    from modules.assets import clear_font_cache, list_overlay_fonts
+
+    config_name = "random_session_name"
+    legacy_font_dir = isolated_config_dir / "fonts"
+    legacy_font_dir.mkdir(parents=True, exist_ok=True)
+    (legacy_font_dir / "Poster.ttf").write_bytes(b"legacy-font")
+
+    with app.test_request_context("/"):
+        session["config_name"] = config_name
+        clear_font_cache()
+        fonts = list_overlay_fonts()
+
+    assert "Poster.ttf" in fonts
+    assert not (isolated_config_dir / config_name).exists()
+
+
 def test_import_config_preview_rejects_zip_with_unsupported_entries(client):
     import io
     import zipfile
@@ -4100,6 +4118,36 @@ def test_delete_orphaned_config_artifacts_route_removes_font_only_default_bundle
     assert payload["success"] is True
     assert payload["deleted"] == ["default"]
     assert not (isolated_config_dir / "default").exists()
+
+
+def test_prune_unrecoverable_orphaned_config_artifacts_removes_font_only_bundle_but_keeps_yaml_backed_bundle(isolated_config_dir, app):
+    from pathlib import Path
+    from modules import helpers
+
+    font_only_name = "font_only_orphan"
+    recoverable_name = "recoverable_orphan"
+
+    font_only_dir = isolated_config_dir / font_only_name / "fonts"
+    font_only_dir.mkdir(parents=True, exist_ok=True)
+    (font_only_dir / "Poster.ttf").write_bytes(b"font-only")
+
+    archive_dir = isolated_config_dir / "archives" / recoverable_name
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    (archive_dir / f"{recoverable_name}_config_1.yml").write_text("archive: true\n", encoding="utf-8")
+    (isolated_config_dir / f"{recoverable_name}_config.yml").write_text("current: true\n", encoding="utf-8")
+    kometa_path = Path(app.config["KOMETA_ROOT"]) / "config"
+    kometa_path.mkdir(parents=True, exist_ok=True)
+    (kometa_path / f"{recoverable_name}_config.yml").write_text("kometa: true\n", encoding="utf-8")
+
+    result = helpers.prune_unrecoverable_orphaned_config_artifacts(active_config_names=[], kometa_root=app.config.get("KOMETA_ROOT", "."))
+
+    assert result["errors"] == []
+    assert result["removed"] == [font_only_name]
+    assert recoverable_name in result["skipped"]
+    assert not (isolated_config_dir / font_only_name).exists()
+    assert (isolated_config_dir / f"{recoverable_name}_config.yml").exists()
+    assert (isolated_config_dir / "archives" / recoverable_name).exists()
+    assert (kometa_path / f"{recoverable_name}_config.yml").exists()
 
 
 def test_delete_orphaned_config_artifacts_route_removes_copy_named_yaml(client, isolated_config_dir):


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

```md
## Summary

This PR fixes Quickstart's extra config-folder cleanup behavior and closes the loop on the underlying causes.

It removes the stray config-scoped folder creation side effect, expands startup cleanup so orphaned config bundles are actually pruned, and hardens the SQLite config list against malformed blank rows.

## What Changed

- Removed the read-time side effect in `modules/assets.py` where font discovery could create `config/<random>/fonts/` for a session-backed config name during normal page rendering.
- Expanded config cleanup in `modules/helpers/_artifacts.py` so startup pruning removes orphaned config bundles, including archive-backed orphan bundles that no longer belong to any saved DB config.
- Updated startup cleanup in `quickstart.py` to run the orphan-bundle prune automatically and log how many orphaned config bundles were removed.
- Added SQLite cleanup in `modules/database.py` to prune invalid `section_data` rows where the config name or section is blank.
- Tightened `get_unique_config_names()` in `modules/database.py` so blank config names are no longer treated as valid configs in the UI.
- Updated startup cleanup in `quickstart.py` to run the invalid-row SQLite prune automatically and log how many malformed rows were removed.
- Added regression coverage in `tests/test_core_backend.py` for:
  - font listing no longer creating config-scoped font folders
  - orphan cleanup removing archive-backed orphan bundles
  - invalid blank SQLite rows being removed and excluded from config lists

## Root Cause

There were two separate issues:

1. `list_overlay_fonts()` was performing config-scoped font migration during page rendering. If the current session had a random/generated config name, Quickstart could create `config/<name>/fonts/` even when the user had not actually saved a real config.

2. Cleanup was too narrow. It removed only unrecoverable orphan bundles at first, while archive-backed orphan bundles were still being preserved even when they no longer belonged to any DB-backed config. SQLite also allowed a malformed blank config row to remain in `section_data`.

## Result

- Orphaned managed config bundles are now cleaned up correctly.
- Blank/malformed config rows are removed automatically.
- Legitimate in-progress DB-backed configs are preserved.
- `config/archives/` remains only for real saved workspace history, not stray junk bundles.

## Testing

- `venv\Scripts\python.exe -c "import pytest, sys; sys.exit(pytest.main(['tests/test_core_backend.py','tests/test_config_and_library_routes.py']))"`
- Result: `225 passed`

## Notes

- No schema files were changed in this PR.
- This PR does not auto-delete legitimate DB-backed configs that simply have no current emitted YAML yet.
```

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
