### PR TITLE
Extract _update_cache.py from _legacy.py

### DIFF
--- a/modules/helpers/__init__.py
+++ b/modules/helpers/__init__.py
@@ -45,4 +45,5 @@ from ._os import *  # noqa: F403
 from ._schema import *  # noqa: F403
 from ._version import *  # noqa: F403
 from ._qs_update import *  # noqa: F403
+from ._update_cache import *  # noqa: F403
 from ._paths import *  # noqa: F403

--- a/modules/helpers/_legacy.py
+++ b/modules/helpers/_legacy.py
@@ -10,7 +10,6 @@ import sys
 import tempfile
 import time
 import zipfile
-import copy
 
 from pathlib import Path
 from plexapi.server import PlexServer
@@ -103,64 +102,6 @@ JSON_SCHEMA_SYNC_FILES = (
 )
 
 
-def _kometa_update_cache_key(kometa_root, branch, local_version, local_sha=None, local_branch=None):
-    try:
-        root = str(Path(kometa_root).resolve())
-    except Exception:
-        root = str(kometa_root or "")
-    return root, str(branch or "").strip(), str(local_version or "").strip(), str(local_sha or "").strip(), str(local_branch or "").strip()
-
-
-def normalize_kometa_branch_override(value):
-    branch = str(value or "").strip().lower()
-    return branch if branch in KOMETA_BRANCH_OVERRIDES else ""
-
-
-def resolve_kometa_update_branch(branch_override=None):
-    branch = normalize_kometa_branch_override(branch_override)
-    from modules.helpers._qs_update import get_kometa_branch
-
-    return branch or get_kometa_branch()
-
-
-def get_cached_kometa_update(kometa_root=None, force_refresh=False, branch_override=None):
-    branch = resolve_kometa_update_branch(branch_override)
-    local_version = get_kometa_local_version(kometa_root)
-    local_sha = get_kometa_local_sha(kometa_root)
-    local_branch = get_kometa_local_branch(kometa_root)
-    key = _kometa_update_cache_key(kometa_root or ".", branch, local_version, local_sha=local_sha, local_branch=local_branch)
-
-    if not force_refresh:
-        entry = _KOMETA_UPDATE_CACHE.get(key)
-        if entry:
-            age = time.monotonic() - entry.get("created_at", 0)
-            if age <= KOMETA_UPDATE_CACHE_TTL_SECONDS:
-                payload = copy.deepcopy(entry.get("payload") or {})
-                payload["cached"] = True
-                return payload
-            _KOMETA_UPDATE_CACHE.pop(key, None)
-
-    payload = check_kometa_update(kometa_root, branch_override=branch_override)
-    if isinstance(payload, dict):
-        payload = copy.deepcopy(payload)
-        payload["cached"] = False
-        _KOMETA_UPDATE_CACHE[key] = {
-            "created_at": time.monotonic(),
-            "payload": copy.deepcopy(payload),
-        }
-        return payload
-    return {
-        "local_version": local_version,
-        "local_sha": local_sha,
-        "local_branch": local_branch,
-        "remote_version": None,
-        "remote_sha": None,
-        "branch": branch,
-        "update_available": False,
-        "cached": False,
-    }
-
-
 def _managed_kometa_root_default() -> Path:
     return Path(os.path.join(CONFIG_DIR, "kometa")).resolve()
 
@@ -195,93 +136,6 @@ def get_kometa_install_mode_label(mode=None) -> str:
     if normalized == "external":
         return "External/containerized config+logs"
     return "Quickstart-managed install"
-
-
-def invalidate_cached_kometa_update(kometa_root=None):
-    if kometa_root is None:
-        _KOMETA_UPDATE_CACHE.clear()
-        return
-    try:
-        target_root = str(Path(kometa_root).resolve())
-    except Exception:
-        target_root = str(kometa_root or "")
-    for key in list(_KOMETA_UPDATE_CACHE.keys()):
-        if key[0] == target_root:
-            _KOMETA_UPDATE_CACHE.pop(key, None)
-
-
-def _imagemaid_update_cache_key(imagemaid_root, branch, local_version=None, local_sha=None, local_branch=None):
-    try:
-        root = str(Path(imagemaid_root).resolve())
-    except Exception:
-        root = str(imagemaid_root or "")
-    return root, str(branch or "").strip(), str(local_version or "").strip(), str(local_sha or "").strip(), str(local_branch or "").strip()
-
-
-def normalize_imagemaid_branch_override(value):
-    branch = str(value or "").strip().lower()
-    return branch if branch in IMAGEMAID_BRANCH_OVERRIDES else ""
-
-
-def resolve_imagemaid_update_branch(branch_override=None):
-    branch = normalize_imagemaid_branch_override(branch_override)
-    if branch:
-        return branch
-    from modules.helpers._git import detect_git_branch
-
-    qs_branch = detect_git_branch(get_app_root())
-    return "master" if qs_branch == "master" else "develop"
-
-
-def get_cached_imagemaid_update(imagemaid_root=None, force_refresh=False, branch_override=None):
-    branch = resolve_imagemaid_update_branch(branch_override)
-    local_version = get_imagemaid_local_version(imagemaid_root)
-    local_sha = get_imagemaid_local_sha(imagemaid_root)
-    local_branch = get_imagemaid_local_branch(imagemaid_root)
-    key = _imagemaid_update_cache_key(imagemaid_root or ".", branch, local_version=local_version, local_sha=local_sha, local_branch=local_branch)
-
-    if not force_refresh:
-        entry = _IMAGEMAID_UPDATE_CACHE.get(key)
-        if entry:
-            age = time.monotonic() - entry.get("created_at", 0)
-            if age <= IMAGEMAID_UPDATE_CACHE_TTL_SECONDS:
-                payload = copy.deepcopy(entry.get("payload") or {})
-                payload["cached"] = True
-                return payload
-            _IMAGEMAID_UPDATE_CACHE.pop(key, None)
-
-    payload = check_imagemaid_update(imagemaid_root, branch_override=branch_override)
-    if isinstance(payload, dict):
-        payload = copy.deepcopy(payload)
-        payload["cached"] = False
-        _IMAGEMAID_UPDATE_CACHE[key] = {
-            "created_at": time.monotonic(),
-            "payload": copy.deepcopy(payload),
-        }
-        return payload
-    return {
-        "local_version": local_version,
-        "local_sha": local_sha,
-        "local_branch": local_branch,
-        "remote_version": None,
-        "remote_sha": None,
-        "branch": branch,
-        "update_available": False,
-        "cached": False,
-    }
-
-
-def invalidate_cached_imagemaid_update(imagemaid_root=None):
-    if imagemaid_root is None:
-        _IMAGEMAID_UPDATE_CACHE.clear()
-        return
-    try:
-        target_root = str(Path(imagemaid_root).resolve())
-    except Exception:
-        target_root = str(imagemaid_root or "")
-    for key in list(_IMAGEMAID_UPDATE_CACHE.keys()):
-        if key[0] == target_root:
-            _IMAGEMAID_UPDATE_CACHE.pop(key, None)
 
 
 def ensure_json_schema():
@@ -865,6 +719,8 @@ def get_kometa_local_branch(kometa_root=None):
     else:
         kometa_root = Path(kometa_root)
 
+    from modules.helpers._update_cache import normalize_kometa_branch_override
+
     return normalize_kometa_branch_override(_read_text(kometa_root / ".kometa_branch"))
 
 
@@ -907,6 +763,8 @@ def get_imagemaid_local_branch(imagemaid_root=None):
         imagemaid_root = get_imagemaid_root_path()
     else:
         imagemaid_root = Path(imagemaid_root)
+    from modules.helpers._update_cache import normalize_imagemaid_branch_override
+
     return normalize_imagemaid_branch_override(_read_text(imagemaid_root / ".imagemaid_branch"))
 
 
@@ -925,6 +783,8 @@ def get_imagemaid_remote_version(branch="develop"):
 
 
 def check_imagemaid_update(imagemaid_root=None, branch_override=None):
+    from modules.helpers._update_cache import resolve_imagemaid_update_branch
+
     branch = resolve_imagemaid_update_branch(branch_override)
     local_version = get_imagemaid_local_version(imagemaid_root)
     local_sha = get_imagemaid_local_sha(imagemaid_root)
@@ -954,6 +814,8 @@ def check_imagemaid_update(imagemaid_root=None, branch_override=None):
 
 
 def check_kometa_update(kometa_root=None, branch_override=None):
+    from modules.helpers._update_cache import resolve_kometa_update_branch
+
     branch = resolve_kometa_update_branch(branch_override)
     local_version = get_kometa_local_version(kometa_root)
     local_sha = get_kometa_local_sha(kometa_root)

--- a/modules/helpers/_update_cache.py
+++ b/modules/helpers/_update_cache.py
@@ -1,0 +1,159 @@
+"""Kometa and ImageMaid update caching utilities extracted from _legacy.py."""
+
+import copy
+import time
+
+from pathlib import Path
+
+from modules.helpers._legacy import (
+    IMAGEMAID_BRANCH_OVERRIDES,
+    IMAGEMAID_UPDATE_CACHE_TTL_SECONDS,
+    KOMETA_BRANCH_OVERRIDES,
+    KOMETA_UPDATE_CACHE_TTL_SECONDS,
+    _IMAGEMAID_UPDATE_CACHE,
+    _KOMETA_UPDATE_CACHE,
+)
+
+
+def _kometa_update_cache_key(kometa_root, branch, local_version, local_sha=None, local_branch=None):
+    try:
+        root = str(Path(kometa_root).resolve())
+    except Exception:
+        root = str(kometa_root or "")
+    return root, str(branch or "").strip(), str(local_version or "").strip(), str(local_sha or "").strip(), str(local_branch or "").strip()
+
+
+def normalize_kometa_branch_override(value):
+    branch = str(value or "").strip().lower()
+    return branch if branch in KOMETA_BRANCH_OVERRIDES else ""
+
+
+def resolve_kometa_update_branch(branch_override=None):
+    branch = normalize_kometa_branch_override(branch_override)
+    from modules.helpers._qs_update import get_kometa_branch
+
+    return branch or get_kometa_branch()
+
+
+def get_cached_kometa_update(kometa_root=None, force_refresh=False, branch_override=None):
+    from modules.helpers._legacy import check_kometa_update, get_kometa_local_branch, get_kometa_local_sha, get_kometa_local_version
+
+    branch = resolve_kometa_update_branch(branch_override)
+    local_version = get_kometa_local_version(kometa_root)
+    local_sha = get_kometa_local_sha(kometa_root)
+    local_branch = get_kometa_local_branch(kometa_root)
+    key = _kometa_update_cache_key(kometa_root or ".", branch, local_version, local_sha=local_sha, local_branch=local_branch)
+
+    if not force_refresh:
+        entry = _KOMETA_UPDATE_CACHE.get(key)
+        if entry:
+            age = time.monotonic() - entry.get("created_at", 0)
+            if age <= KOMETA_UPDATE_CACHE_TTL_SECONDS:
+                payload = copy.deepcopy(entry.get("payload") or {})
+                payload["cached"] = True
+                return payload
+            _KOMETA_UPDATE_CACHE.pop(key, None)
+
+    payload = check_kometa_update(kometa_root, branch_override=branch_override)
+    if isinstance(payload, dict):
+        payload = copy.deepcopy(payload)
+        payload["cached"] = False
+        _KOMETA_UPDATE_CACHE[key] = {"created_at": time.monotonic(), "payload": copy.deepcopy(payload)}
+        return payload
+    return {
+        "local_version": local_version,
+        "local_sha": local_sha,
+        "local_branch": local_branch,
+        "remote_version": None,
+        "remote_sha": None,
+        "branch": branch,
+        "update_available": False,
+        "cached": False,
+    }
+
+
+def invalidate_cached_kometa_update(kometa_root=None):
+    if kometa_root is None:
+        _KOMETA_UPDATE_CACHE.clear()
+        return
+    try:
+        target_root = str(Path(kometa_root).resolve())
+    except Exception:
+        target_root = str(kometa_root or "")
+    for key in list(_KOMETA_UPDATE_CACHE.keys()):
+        if key[0] == target_root:
+            _KOMETA_UPDATE_CACHE.pop(key, None)
+
+
+def _imagemaid_update_cache_key(imagemaid_root, branch, local_version=None, local_sha=None, local_branch=None):
+    try:
+        root = str(Path(imagemaid_root).resolve())
+    except Exception:
+        root = str(imagemaid_root or "")
+    return root, str(branch or "").strip(), str(local_version or "").strip(), str(local_sha or "").strip(), str(local_branch or "").strip()
+
+
+def normalize_imagemaid_branch_override(value):
+    branch = str(value or "").strip().lower()
+    return branch if branch in IMAGEMAID_BRANCH_OVERRIDES else ""
+
+
+def resolve_imagemaid_update_branch(branch_override=None):
+    branch = normalize_imagemaid_branch_override(branch_override)
+    if branch:
+        return branch
+    from modules.helpers._git import detect_git_branch
+    from modules.helpers._legacy import get_app_root
+
+    qs_branch = detect_git_branch(get_app_root())
+    return "master" if qs_branch == "master" else "develop"
+
+
+def get_cached_imagemaid_update(imagemaid_root=None, force_refresh=False, branch_override=None):
+    from modules.helpers._legacy import check_imagemaid_update, get_imagemaid_local_branch, get_imagemaid_local_sha, get_imagemaid_local_version
+
+    branch = resolve_imagemaid_update_branch(branch_override)
+    local_version = get_imagemaid_local_version(imagemaid_root)
+    local_sha = get_imagemaid_local_sha(imagemaid_root)
+    local_branch = get_imagemaid_local_branch(imagemaid_root)
+    key = _imagemaid_update_cache_key(imagemaid_root or ".", branch, local_version=local_version, local_sha=local_sha, local_branch=local_branch)
+
+    if not force_refresh:
+        entry = _IMAGEMAID_UPDATE_CACHE.get(key)
+        if entry:
+            age = time.monotonic() - entry.get("created_at", 0)
+            if age <= IMAGEMAID_UPDATE_CACHE_TTL_SECONDS:
+                payload = copy.deepcopy(entry.get("payload") or {})
+                payload["cached"] = True
+                return payload
+            _IMAGEMAID_UPDATE_CACHE.pop(key, None)
+
+    payload = check_imagemaid_update(imagemaid_root, branch_override=branch_override)
+    if isinstance(payload, dict):
+        payload = copy.deepcopy(payload)
+        payload["cached"] = False
+        _IMAGEMAID_UPDATE_CACHE[key] = {"created_at": time.monotonic(), "payload": copy.deepcopy(payload)}
+        return payload
+    return {
+        "local_version": local_version,
+        "local_sha": local_sha,
+        "local_branch": local_branch,
+        "remote_version": None,
+        "remote_sha": None,
+        "branch": branch,
+        "update_available": False,
+        "cached": False,
+    }
+
+
+def invalidate_cached_imagemaid_update(imagemaid_root=None):
+    if imagemaid_root is None:
+        _IMAGEMAID_UPDATE_CACHE.clear()
+        return
+    try:
+        target_root = str(Path(imagemaid_root).resolve())
+    except Exception:
+        target_root = str(imagemaid_root or "")
+    for key in list(_IMAGEMAID_UPDATE_CACHE.keys()):
+        if key[0] == target_root:
+            _IMAGEMAID_UPDATE_CACHE.pop(key, None)


### PR DESCRIPTION
Move Kometa/ImageMaid update caching functions into _update_cache.py.

_legacy.py: -168 lines (1680 remaining).