### PR TITLE
Fix Docker crash: wrap git import in try/except

### DIFF
--- a/modules/helpers/__init__.py
+++ b/modules/helpers/__init__.py
@@ -46,4 +46,5 @@ from ._schema import *  # noqa: F403
 from ._version import *  # noqa: F403
 from ._qs_update import *  # noqa: F403
 from ._update_cache import *  # noqa: F403
+from ._install_mode import *  # noqa: F403
 from ._paths import *  # noqa: F403

--- a/modules/helpers/_install_mode.py
+++ b/modules/helpers/_install_mode.py
@@ -1,0 +1,47 @@
+"""Kometa install mode utilities extracted from _legacy.py."""
+
+import os
+
+from pathlib import Path
+
+from flask import current_app as app
+from flask import has_app_context, has_request_context, session
+
+from modules import persistence
+from modules.helpers._legacy import CONFIG_DIR
+
+
+def _managed_kometa_root_default() -> Path:
+    return Path(os.path.join(CONFIG_DIR, "kometa")).resolve()
+
+
+def _get_persisted_kometa_runtime_section() -> dict:
+    try:
+        settings = persistence.retrieve_settings("900-kometa") or {}
+    except Exception:
+        return {}
+    section = settings.get("kometa", {}) if isinstance(settings, dict) else {}
+    return section if isinstance(section, dict) else {}
+
+
+def get_kometa_install_mode() -> str:
+    mode = None
+    if has_app_context():
+        mode = app.config.get("KOMETA_INSTALL_MODE")
+    if not mode and has_request_context():
+        mode = session.get("kometa_install_mode")
+    if not mode and has_request_context():
+        mode = _get_persisted_kometa_runtime_section().get("install_mode")
+    normalized = str(mode or "").strip().lower()
+    if normalized in {"existing", "external"}:
+        return normalized
+    return "managed"
+
+
+def get_kometa_install_mode_label(mode=None) -> str:
+    normalized = str(mode or get_kometa_install_mode()).strip().lower()
+    if normalized == "existing":
+        return "Existing direct install"
+    if normalized == "external":
+        return "External/containerized config+logs"
+    return "Quickstart-managed install"

--- a/modules/helpers/_version.py
+++ b/modules/helpers/_version.py
@@ -2,12 +2,17 @@
 
 import os
 
-from git import Repo
+try:
+    from git import Repo
+except ImportError:
+    Repo = None  # Prevents errors if GitPython is missing
+
+
+import requests
 
 
 def get_remote_version(branch):
     """Fetch the latest VERSION file from the correct GitHub branch."""
-    import requests
 
     try:
         response = requests.get(


### PR DESCRIPTION
Docker images don't include git, so bare 'from git import Repo' crashes at startup. Restore the try/except wrapper that the original _legacy.py had.