### PR TITLE
fix aggressive cleanup

### DIFF
--- a/modules/helpers/_artifacts.py
+++ b/modules/helpers/_artifacts.py
@@ -12,6 +12,7 @@ MANAGED_LIBRARY_FILE_DIRS = ("metadata_files", "collection_files", "overlay_file
 MANAGED_OVERLAY_IMAGE_DIR = "overlay_images"
 MANAGED_SYNC_ARTIFACT_DIRS = MANAGED_LIBRARY_FILE_DIRS + (MANAGED_OVERLAY_IMAGE_DIR,)
 MANAGED_CONFIG_ARTIFACT_DIRS = ("fonts",) + MANAGED_SYNC_ARTIFACT_DIRS
+RESERVED_RUNTIME_BUNDLE_NAMES = frozenset({"kometa", "imagemaid"})
 
 
 def migrate_config_archives(history_limit: int | None = None) -> dict:
@@ -106,6 +107,10 @@ def require_config_name_for_storage(config_name: str | None, context: str = "Art
     if not normalized:
         raise ValueError(f"{context} requires an explicit config name.")
     return normalized
+
+
+def is_reserved_runtime_bundle_name(config_name: str | None) -> bool:
+    return normalize_config_name_for_storage(config_name) in RESERVED_RUNTIME_BUNDLE_NAMES
 
 
 def get_managed_config_artifact_root(config_name: str | None) -> Path:
@@ -204,6 +209,12 @@ def delete_config_artifacts(
     from modules.helpers._legacy import get_kometa_config_dir
 
     normalized = require_config_name_for_storage(config_name, context="Config artifact cleanup")
+    if is_reserved_runtime_bundle_name(normalized):
+        return {
+            "removed": [],
+            "errors": [f"Refusing to remove reserved runtime bundle: {normalized}"],
+            "config_name": normalized,
+        }
     config_dir = Path(CONFIG_DIR)
     archive_root = config_dir / "archives"
     removed: list[str] = []
@@ -242,6 +253,12 @@ def delete_config_artifacts(
 def delete_orphaned_artifact_bundle(bundle: dict | None) -> dict:
     bundle = bundle if isinstance(bundle, dict) else {}
     bundle_name = normalize_config_name_for_storage(bundle.get("name"))
+    if is_reserved_runtime_bundle_name(bundle_name):
+        return {
+            "removed": [],
+            "errors": [f"Refusing to remove reserved runtime bundle: {bundle_name}"],
+            "config_name": bundle_name,
+        }
     removed: list[str] = []
     errors: list[str] = []
     raw_paths = bundle.get("paths")
@@ -327,12 +344,16 @@ def list_orphaned_config_artifacts(
         match = current_pattern.match(path.name)
         if not match:
             continue
+        if is_reserved_runtime_bundle_name(match.group("name")):
+            continue
         bundle = ensure_bundle(match.group("name"))
         bundle["has_current_file"] = True
         bundle["paths"].append(str(path))
 
     for path in config_dir.iterdir():
         if not path.is_dir():
+            continue
+        if is_reserved_runtime_bundle_name(path.name):
             continue
         if any((path / folder_name).exists() and (path / folder_name).is_dir() for folder_name in MANAGED_CONFIG_ARTIFACT_DIRS):
             bundle = ensure_bundle(path.name)
@@ -347,6 +368,8 @@ def list_orphaned_config_artifacts(
         for path in managed_root.iterdir():
             if not path.is_dir():
                 continue
+            if is_reserved_runtime_bundle_name(path.name):
+                continue
             bundle = ensure_bundle(path.name)
             path_text = str(path)
             if path_text not in bundle["paths"]:
@@ -355,6 +378,8 @@ def list_orphaned_config_artifacts(
     if archive_root.exists():
         for path in archive_root.iterdir():
             if not path.is_dir():
+                continue
+            if is_reserved_runtime_bundle_name(path.name):
                 continue
             bundle = ensure_bundle(path.name)
             bundle["has_archive_dir"] = True
@@ -376,6 +401,8 @@ def list_orphaned_config_artifacts(
             match = current_pattern.match(path.name)
             if not match:
                 continue
+            if is_reserved_runtime_bundle_name(match.group("name")):
+                continue
             bundle = ensure_bundle(match.group("name"))
             bundle["has_kometa_copy"] = True
             bundle["paths"].append(str(path))
@@ -383,6 +410,8 @@ def list_orphaned_config_artifacts(
     for bundle in bundles.values():
         name = bundle.get("name")
         if not name:
+            continue
+        if is_reserved_runtime_bundle_name(name):
             continue
         current_file = config_dir / f"{name}_config.yml"
         if current_file.exists() and current_file.is_file():
@@ -423,7 +452,7 @@ def list_orphaned_config_artifacts(
                 if path_text not in bundle["paths"]:
                     bundle["paths"].append(path_text)
 
-    orphans = [bundle for name, bundle in sorted(bundles.items()) if name not in active_names]
+    orphans = [bundle for name, bundle in sorted(bundles.items()) if name not in active_names and not is_reserved_runtime_bundle_name(name)]
     return {"orphans": orphans, "errors": [], "active_names": sorted(active_names)}
 
 

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -4080,6 +4080,23 @@ def test_orphaned_config_artifacts_route_lists_font_only_default_bundle(client, 
     assert any(path.endswith("\\default") or path.endswith("/default") for path in orphan["paths"])
 
 
+def test_orphaned_config_artifacts_route_skips_reserved_runtime_roots(client, isolated_config_dir):
+    kometa_runtime_dir = isolated_config_dir / "kometa" / "metadata_files" / "mov-library_movies"
+    imagemaid_runtime_dir = isolated_config_dir / "imagemaid" / "fonts"
+    kometa_runtime_dir.mkdir(parents=True, exist_ok=True)
+    imagemaid_runtime_dir.mkdir(parents=True, exist_ok=True)
+    (kometa_runtime_dir / "movies.yml").write_text("metadata:\n  test:\n    title: Example\n", encoding="utf-8")
+    (imagemaid_runtime_dir / "Poster.ttf").write_bytes(b"font")
+
+    resp = client.get("/orphaned-config-artifacts")
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["success"] is True
+    orphan_names = {item["name"] for item in payload["orphans"]}
+    assert "kometa" not in orphan_names
+    assert "imagemaid" not in orphan_names
+
+
 def test_delete_orphaned_config_artifacts_route_removes_selected_bundle(client, isolated_config_dir, app):
     from pathlib import Path
 
@@ -4145,6 +4162,28 @@ def test_prune_unrecoverable_orphaned_config_artifacts_removes_archive_backed_or
     assert not (isolated_config_dir / font_only_name).exists()
     assert not (isolated_config_dir / archive_only_name).exists()
     assert not (isolated_config_dir / "archives" / archive_only_name).exists()
+
+
+def test_prune_unrecoverable_orphaned_config_artifacts_skips_reserved_runtime_roots(isolated_config_dir, app):
+    from modules import helpers
+
+    kometa_runtime_dir = isolated_config_dir / "kometa" / "metadata_files" / "mov-library_movies"
+    imagemaid_runtime_dir = isolated_config_dir / "imagemaid" / "fonts"
+    kometa_runtime_dir.mkdir(parents=True, exist_ok=True)
+    imagemaid_runtime_dir.mkdir(parents=True, exist_ok=True)
+    (kometa_runtime_dir / "movies.yml").write_text("metadata:\n  test:\n    title: Example\n", encoding="utf-8")
+    (imagemaid_runtime_dir / "Poster.ttf").write_bytes(b"font")
+
+    result = helpers.prune_unrecoverable_orphaned_config_artifacts(
+        active_config_names=[],
+        kometa_root=app.config.get("KOMETA_ROOT", "."),
+    )
+
+    assert result["errors"] == []
+    assert result["removed"] == []
+    assert result["skipped"] == []
+    assert (isolated_config_dir / "kometa").exists()
+    assert (isolated_config_dir / "imagemaid").exists()
 
 
 def test_delete_orphaned_config_artifacts_route_removes_copy_named_yaml(client, isolated_config_dir):


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

## Summary

Prevent the orphan-config cleanup from treating `config/kometa` and `config/imagemaid` as removable Quickstart config bundles.

## Problem

The generic artifact cleanup logic was scanning every top-level directory under `config/` and classifying any folder with managed-style subdirectories like `fonts`, `metadata_files`, `collection_files`, `overlay_files`, or `overlay_images` as a config bundle.

That meant runtime/support directories like:

- `config/kometa`
- `config/imagemaid`

could be surfaced as orphaned config artifacts and then deleted during restart/startup cleanup.

## What Changed

- Added reserved runtime bundle names for `kometa` and `imagemaid` in `modules/helpers/_artifacts.py`
- Excluded those reserved names from orphan bundle discovery
- Added hard guards so artifact deletion paths refuse to remove those reserved runtime bundles even if they are passed in directly
- Kept the change narrowly scoped to cleanup behavior only

## Tests

Added regression coverage in `tests/test_core_backend.py` to verify:

- `/orphaned-config-artifacts` does not list `kometa` or `imagemaid` as orphan bundles
- `prune_unrecoverable_orphaned_config_artifacts()` does not delete those reserved runtime roots during startup cleanup

## Verification

```text
venv\Scripts\python.exe -m pytest tests\test_core_backend.py -k orphaned_config_artifacts
8 passed, 192 deselected
```

## Notes

- No schema files were changed in this PR
- This is a cleanup-safety fix only

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [x] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
