### PR TITLE
Extract _pid.py from _legacy.py

### DIFF
--- a/modules/helpers/__init__.py
+++ b/modules/helpers/__init__.py
@@ -48,4 +48,5 @@ from ._qs_update import *  # noqa: F403
 from ._update_cache import *  # noqa: F403
 from ._install_mode import *  # noqa: F403
 from ._kometa_version import *  # noqa: F403
+from ._pid import *  # noqa: F403
 from ._paths import *  # noqa: F403

--- a/modules/helpers/_artifacts.py
+++ b/modules/helpers/_artifacts.py
@@ -135,10 +135,8 @@ def sync_managed_library_artifacts_to_kometa(
     kometa_config_dir: str | Path | None = None,
 ) -> dict:
     from modules.helpers._file_utils import _directory_tree_signature
-    from modules.helpers._legacy import (
-        get_kometa_config_dir,
-        handle_remove_readonly,
-    )
+    from modules.helpers._legacy import get_kometa_config_dir
+    from modules.helpers._pid import handle_remove_readonly
 
     normalized = require_config_name_for_storage(config_name, context="Managed library artifact sync")
     source_root = get_managed_config_artifact_root(normalized)

--- a/modules/helpers/_git.py
+++ b/modules/helpers/_git.py
@@ -12,7 +12,7 @@ except ImportError:
 
 
 def detect_git_branch(repo_root=None, default="develop"):
-    from modules.helpers._legacy import get_app_root
+    from modules.helpers._pid import get_app_root
 
     root = Path(repo_root or get_app_root()).resolve()
 

--- a/modules/helpers/_legacy.py
+++ b/modules/helpers/_legacy.py
@@ -1,10 +1,8 @@
 import datetime
 import io
 import os
-import psutil
 import re
 import shutil
-import stat
 import subprocess
 import sys
 import tempfile
@@ -784,11 +782,6 @@ def perform_kometa_update(kometa_root, branch="master"):
         return {"success": False, "log": logs}
 
 
-def get_app_root():
-    # Go up one directory to reach the Quickstart root
-    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-
-
 def rotate_logs():
     if not os.path.exists(LOG_FILE):
         return
@@ -888,42 +881,6 @@ def ts_log(*args, level="INFO"):
             f.write(line_file + "\n")
     except Exception:
         pass
-
-
-def handle_remove_readonly(func, path, exc_info):
-    os.chmod(path, stat.S_IWRITE)
-    func(path)
-
-
-def get_kometa_pid_file():
-    os.makedirs(CONFIG_DIR, exist_ok=True)
-    return os.path.join(CONFIG_DIR, "kometa.pid")
-
-
-def get_kometa_pid():
-    pid_file = get_kometa_pid_file()
-    if os.path.exists(pid_file):
-        try:
-            with open(pid_file, "r") as f:
-                return int(f.read().strip())
-        except Exception:
-            return None
-    return None
-
-
-def is_kometa_running():
-    pid = get_kometa_pid()
-    if not pid:
-        return False
-    try:
-        proc = psutil.Process(pid)
-        return proc.is_running() and "kometa.py" in " ".join(proc.cmdline())
-    except psutil.NoSuchProcess:
-        try:
-            os.remove(get_kometa_pid_file())
-        except Exception:
-            pass
-        return False
 
 
 def perform_quickstart_update(qs_root, branch="master"):
@@ -1654,39 +1611,3 @@ def get_kometa_log_dir() -> Path:
     if configured:
         return Path(os.path.normpath(str(configured))).resolve()
     return get_kometa_config_dir() / "logs"
-
-
-def get_imagemaid_pid_file():
-    os.makedirs(CONFIG_DIR, exist_ok=True)
-    return os.path.join(CONFIG_DIR, "imagemaid.pid")
-
-
-def get_imagemaid_launch_log_file():
-    os.makedirs(CONFIG_DIR, exist_ok=True)
-    return os.path.join(CONFIG_DIR, "imagemaid-launch.log")
-
-
-def get_imagemaid_pid():
-    pid_file = get_imagemaid_pid_file()
-    if os.path.exists(pid_file):
-        try:
-            with open(pid_file, "r", encoding="utf-8") as f:
-                return int(f.read().strip())
-        except Exception:
-            return None
-    return None
-
-
-def is_imagemaid_running():
-    pid = get_imagemaid_pid()
-    if not pid:
-        return False
-    try:
-        proc = psutil.Process(pid)
-        return proc.is_running() and "imagemaid.py" in " ".join(proc.cmdline())
-    except psutil.NoSuchProcess:
-        try:
-            os.remove(get_imagemaid_pid_file())
-        except Exception:
-            pass
-        return False

--- a/modules/helpers/_pid.py
+++ b/modules/helpers/_pid.py
@@ -1,0 +1,85 @@
+"""Process ID and runtime state utilities extracted from _legacy.py."""
+
+import os
+import stat
+
+import psutil
+
+from modules.helpers._legacy import CONFIG_DIR
+
+
+def get_app_root():
+    # Go up one directory to reach the Quickstart root
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def handle_remove_readonly(func, path, exc_info):
+    os.chmod(path, stat.S_IWRITE)
+    func(path)
+
+
+def get_kometa_pid_file():
+    os.makedirs(CONFIG_DIR, exist_ok=True)
+    return os.path.join(CONFIG_DIR, "kometa.pid")
+
+
+def get_kometa_pid():
+    pid_file = get_kometa_pid_file()
+    if os.path.exists(pid_file):
+        try:
+            with open(pid_file, "r") as f:
+                return int(f.read().strip())
+        except Exception:
+            return None
+    return None
+
+
+def is_kometa_running():
+    pid = get_kometa_pid()
+    if not pid:
+        return False
+    try:
+        proc = psutil.Process(pid)
+        return proc.is_running() and "kometa.py" in " ".join(proc.cmdline())
+    except psutil.NoSuchProcess:
+        try:
+            os.remove(get_kometa_pid_file())
+        except Exception:
+            pass
+        return False
+
+
+def get_imagemaid_pid_file():
+    os.makedirs(CONFIG_DIR, exist_ok=True)
+    return os.path.join(CONFIG_DIR, "imagemaid.pid")
+
+
+def get_imagemaid_launch_log_file():
+    os.makedirs(CONFIG_DIR, exist_ok=True)
+    return os.path.join(CONFIG_DIR, "imagemaid-launch.log")
+
+
+def get_imagemaid_pid():
+    pid_file = get_imagemaid_pid_file()
+    if os.path.exists(pid_file):
+        try:
+            with open(pid_file, "r", encoding="utf-8") as f:
+                return int(f.read().strip())
+        except Exception:
+            return None
+    return None
+
+
+def is_imagemaid_running():
+    pid = get_imagemaid_pid()
+    if not pid:
+        return False
+    try:
+        proc = psutil.Process(pid)
+        return proc.is_running() and "imagemaid.py" in " ".join(proc.cmdline())
+    except psutil.NoSuchProcess:
+        try:
+            os.remove(get_imagemaid_pid_file())
+        except Exception:
+            pass
+        return False

--- a/modules/helpers/_update_cache.py
+++ b/modules/helpers/_update_cache.py
@@ -103,7 +103,7 @@ def resolve_imagemaid_update_branch(branch_override=None):
     if branch:
         return branch
     from modules.helpers._git import detect_git_branch
-    from modules.helpers._legacy import get_app_root
+    from modules.helpers._pid import get_app_root
 
     qs_branch = detect_git_branch(get_app_root())
     return "master" if qs_branch == "master" else "develop"


### PR DESCRIPTION
Move 9 runtime state functions into _pid.py. Updates _git.py, _update_cache.py, and _artifacts.py to import from the new location.

_legacy.py: -95 lines (~1550 remaining).