### PR TITLE
Playlist vars

### DIFF
--- a/modules/importer.py
+++ b/modules/importer.py
@@ -64,6 +64,53 @@ LIBRARY_SONARR_IMPORT_FIELDS = {
     "sonarr_path": "string",
     "plex_path": "string",
 }
+PLAYLIST_SHARED_IMPORT_FIELDS = {
+    "style": "string",
+    "sync_to_users": "string_list",
+    "exclude_users": "string_list",
+    "minimum_items": "integer",
+    "hub_priority": "integer",
+    "url_poster": "string",
+    "file_poster": "string",
+    "schedule": "string",
+    "delete_not_scheduled": "boolean",
+    "limit": "integer",
+    "delete_playlist": "boolean",
+    "ignore_ids": "string_list",
+    "ignore_imdb_ids": "string_list",
+    "item_radarr_tag": "string_list",
+    "item_sonarr_tag": "string_list",
+    "radarr_add_missing": "boolean",
+    "radarr_folder": "string",
+    "radarr_tag": "string_list",
+    "sonarr_add_missing": "boolean",
+    "sonarr_folder": "string",
+    "sonarr_tag": "string_list",
+}
+PLAYLIST_KEYED_IMPORT_FIELDS = {
+    "use_": "boolean",
+    "name_": "string",
+    "summary_": "string",
+    "schedule_": "string",
+    "url_poster_": "string",
+    "file_poster_": "string",
+    "limit_": "integer",
+    "delete_playlist_": "boolean",
+    "exclude_users_": "string_list",
+    "exclude_user_": "string_list",
+    "imdb_list_": "string_list",
+    "item_radarr_tag_": "string_list",
+    "item_sonarr_tag_": "string_list",
+    "mdblist_list_": "string_list",
+    "radarr_add_missing_": "boolean",
+    "radarr_folder_": "string",
+    "radarr_tag_": "string_list",
+    "sonarr_add_missing_": "boolean",
+    "sonarr_folder_": "string",
+    "sonarr_tag_": "string_list",
+    "sync_to_users_": "string_list",
+    "trakt_list_": "string_list",
+}
 
 
 def sanitize_config_name(raw_name: str | None) -> str:
@@ -383,6 +430,54 @@ def _collect_dynamic_child_field_specs(template_vars: Any) -> list[dict[str, str
             }
         )
     return specs
+
+
+def _coerce_import_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "yes", "1"}:
+            return True
+        if lowered in {"false", "no", "0"}:
+            return False
+    return None
+
+
+def _coerce_import_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and re.fullmatch(r"-?\d+", value.strip()):
+        return int(value.strip())
+    return None
+
+
+def _coerce_import_string_list(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    text = str(value or "").strip()
+    if not text:
+        return []
+    return [item.strip() for item in text.split(",") if item.strip()]
+
+
+def _serialize_playlist_import_value(value_kind: str, value: Any) -> Any:
+    kind = str(value_kind or "string").strip().lower()
+    if kind == "boolean":
+        bool_value = _coerce_import_bool(value)
+        return None if bool_value is None else ("true" if bool_value else "false")
+    if kind == "integer":
+        int_value = _coerce_import_int(value)
+        return None if int_value is None else str(int_value)
+    if kind == "string_list":
+        values = _coerce_import_string_list(value)
+        return values if values else None
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
 
 
 def _collect_overlay_source_override_keys(overlay_meta: Any) -> set[str]:
@@ -1239,6 +1334,8 @@ def prepare_import_payload(
         return True, imported_any
 
     playlist_libraries: set[str] = set()
+    playlist_template_field_values: dict[str, Any] = {}
+    playlist_keyed_template_field_values: dict[str, dict[str, Any]] = {}
     playlist_payload = config_data.get("playlist_files")
     if playlist_payload is not None:
         if isinstance(playlist_payload, list):
@@ -1270,6 +1367,51 @@ def prepare_import_payload(
                 report.add("imported", f"playlist_files[{idx}].template_variables.libraries")
                 for lib_idx in range(len(entry_libs)):
                     report.add("imported", f"playlist_files[{idx}].template_variables.libraries[{lib_idx}]")
+                for key, value in tv.items():
+                    if key == "libraries":
+                        continue
+
+                    if key == "exclude_user":
+                        key = "exclude_users"
+                    if key == "exclude_user_":
+                        key = "exclude_users_"
+
+                    if key in PLAYLIST_SHARED_IMPORT_FIELDS:
+                        value_kind = PLAYLIST_SHARED_IMPORT_FIELDS[key]
+                        if value_kind == "boolean":
+                            normalized_value = _coerce_import_bool(value)
+                        elif value_kind == "integer":
+                            normalized_value = _coerce_import_int(value)
+                        elif value_kind == "string_list":
+                            values = _coerce_import_string_list(value)
+                            normalized_value = values if values else None
+                        else:
+                            text = str(value).strip() if value is not None else ""
+                            normalized_value = text or None
+
+                        if normalized_value is None:
+                            report.add("unmapped", f"playlist_files[{idx}].template_variables.{key}", "Unsupported playlist template variable value.")
+                            continue
+
+                        playlist_template_field_values[key] = normalized_value
+                        report.add("imported", f"playlist_files[{idx}].template_variables.{key}")
+                        continue
+
+                    matched_prefix = next((prefix for prefix in PLAYLIST_KEYED_IMPORT_FIELDS if key.startswith(prefix)), None)
+                    if matched_prefix:
+                        suffix = str(key[len(matched_prefix) :] or "").strip()
+                        if not suffix:
+                            report.add("unmapped", f"playlist_files[{idx}].template_variables.{key}", "Missing playlist key suffix.")
+                            continue
+                        serialized_value = _serialize_playlist_import_value(PLAYLIST_KEYED_IMPORT_FIELDS[matched_prefix], value)
+                        if serialized_value is None:
+                            report.add("unmapped", f"playlist_files[{idx}].template_variables.{key}", "Unsupported playlist keyed template variable value.")
+                            continue
+                        playlist_keyed_template_field_values.setdefault(matched_prefix, {})[suffix] = serialized_value
+                        report.add("imported", f"playlist_files[{idx}].template_variables.{key}")
+                        continue
+
+                    report.add("unmapped", f"playlist_files[{idx}].template_variables.{key}", "Playlist template variable not available in Quickstart.")
             if playlist_libraries:
                 report.add("imported", "playlist_files")
         else:
@@ -1837,6 +1979,17 @@ def prepare_import_payload(
                     f"libraries.{lib_name}.{key}",
                     "Field not supported for import.",
                 )
+
+        for key, value in playlist_template_field_values.items():
+            hidden_name = f"playlist-template_variables[{key}]"
+            if key in {"sync_to_users", "exclude_users", "ignore_ids", "ignore_imdb_ids", "item_radarr_tag", "item_sonarr_tag", "radarr_tag", "sonarr_tag"}:
+                libraries_data[hidden_name] = json.dumps(value, ensure_ascii=True)
+            else:
+                libraries_data[hidden_name] = value
+        for prefix, mapping in playlist_keyed_template_field_values.items():
+            canonical_prefix = "exclude_users_" if prefix == "exclude_user_" else prefix
+            if mapping:
+                libraries_data[f"playlist-template_variables[{canonical_prefix}]"] = json.dumps(mapping, ensure_ascii=True)
 
         if libraries_data:
             payload["libraries"] = {"libraries": libraries_data}

--- a/modules/importer.py
+++ b/modules/importer.py
@@ -65,16 +65,8 @@ LIBRARY_SONARR_IMPORT_FIELDS = {
     "plex_path": "string",
 }
 PLAYLIST_SHARED_IMPORT_FIELDS = {
-    "style": "string",
     "sync_to_users": "string_list",
     "exclude_users": "string_list",
-    "minimum_items": "integer",
-    "hub_priority": "integer",
-    "url_poster": "string",
-    "file_poster": "string",
-    "schedule": "string",
-    "delete_not_scheduled": "boolean",
-    "limit": "integer",
     "delete_playlist": "boolean",
     "ignore_ids": "string_list",
     "ignore_imdb_ids": "string_list",
@@ -86,15 +78,15 @@ PLAYLIST_SHARED_IMPORT_FIELDS = {
     "sonarr_add_missing": "boolean",
     "sonarr_folder": "string",
     "sonarr_tag": "string_list",
+    "trakt_list": "string_list",
+    "imdb_list": "string_list",
+    "mdblist_list": "string_list",
 }
 PLAYLIST_KEYED_IMPORT_FIELDS = {
     "use_": "boolean",
     "name_": "string",
     "summary_": "string",
-    "schedule_": "string",
     "url_poster_": "string",
-    "file_poster_": "string",
-    "limit_": "integer",
     "delete_playlist_": "boolean",
     "exclude_users_": "string_list",
     "exclude_user_": "string_list",
@@ -1334,6 +1326,7 @@ def prepare_import_payload(
         return True, imported_any
 
     playlist_libraries: set[str] = set()
+    playlist_file_entries: list[dict[str, str]] = []
     playlist_template_field_values: dict[str, Any] = {}
     playlist_keyed_template_field_values: dict[str, dict[str, Any]] = {}
     playlist_payload = config_data.get("playlist_files")
@@ -1342,6 +1335,21 @@ def prepare_import_payload(
             for idx, entry in enumerate(playlist_payload):
                 if not isinstance(entry, dict):
                     report.add("unmapped", f"playlist_files[{idx}]", "Unsupported playlist entry format.")
+                    continue
+                raw_entry_type = None
+                raw_entry_location = None
+                for candidate in ("file", "url", "git", "repo"):
+                    location = entry.get(candidate)
+                    if location:
+                        raw_entry_type = candidate
+                        raw_entry_location = str(location).strip()
+                        break
+                if raw_entry_type and raw_entry_location:
+                    playlist_file_entries.append({"type": raw_entry_type, "location": raw_entry_location})
+                    report.add("imported", f"playlist_files[{idx}]")
+                    report.add("imported", f"playlist_files[{idx}].{raw_entry_type}")
+                    if entry.get("template_variables") not in (None, {}):
+                        report.add("unmapped", f"playlist_files[{idx}].template_variables", "Template variables for direct playlist file entries are not supported in Quickstart.")
                     continue
                 tv = entry.get("template_variables", {})
                 if not isinstance(tv, dict):
@@ -1412,7 +1420,7 @@ def prepare_import_payload(
                         continue
 
                     report.add("unmapped", f"playlist_files[{idx}].template_variables.{key}", "Playlist template variable not available in Quickstart.")
-            if playlist_libraries:
+            if playlist_libraries or playlist_file_entries:
                 report.add("imported", "playlist_files")
         else:
             report.add("unmapped", "playlist_files", "Unsupported playlist_files format.")
@@ -1982,7 +1990,9 @@ def prepare_import_payload(
 
         for key, value in playlist_template_field_values.items():
             hidden_name = f"playlist-template_variables[{key}]"
-            if key in {"sync_to_users", "exclude_users", "ignore_ids", "ignore_imdb_ids", "item_radarr_tag", "item_sonarr_tag", "radarr_tag", "sonarr_tag"}:
+            if key in {"sync_to_users", "exclude_users"}:
+                libraries_data[hidden_name] = ", ".join(str(item).strip() for item in value if str(item).strip())
+            elif PLAYLIST_SHARED_IMPORT_FIELDS.get(key) == "string_list":
                 libraries_data[hidden_name] = json.dumps(value, ensure_ascii=True)
             else:
                 libraries_data[hidden_name] = value
@@ -1990,6 +2000,8 @@ def prepare_import_payload(
             canonical_prefix = "exclude_users_" if prefix == "exclude_user_" else prefix
             if mapping:
                 libraries_data[f"playlist-template_variables[{canonical_prefix}]"] = json.dumps(mapping, ensure_ascii=True)
+        if playlist_file_entries:
+            libraries_data["playlist_files_entries"] = json.dumps(playlist_file_entries, ensure_ascii=True)
 
         if libraries_data:
             payload["libraries"] = {"libraries": libraries_data}

--- a/modules/output.py
+++ b/modules/output.py
@@ -57,6 +57,53 @@ FRANCHISE_DYNAMIC_CHILD_FIELD_SPECS = {
     "child_item_sonarr_tag_overrides": ("item_sonarr_tag_", "string_list"),
     "child_sonarr_monitor_overrides": ("sonarr_monitor_", "select"),
 }
+PLAYLIST_SHARED_TEMPLATE_VAR_SPECS = {
+    "style": "string",
+    "sync_to_users": "string_list",
+    "exclude_users": "string_list",
+    "minimum_items": "integer",
+    "hub_priority": "integer",
+    "url_poster": "string",
+    "file_poster": "string",
+    "schedule": "string",
+    "delete_not_scheduled": "boolean",
+    "limit": "integer",
+    "delete_playlist": "boolean",
+    "ignore_ids": "ignore_ids",
+    "ignore_imdb_ids": "string_list",
+    "item_radarr_tag": "string_list",
+    "item_sonarr_tag": "string_list",
+    "radarr_add_missing": "boolean",
+    "radarr_folder": "string",
+    "radarr_tag": "string_list",
+    "sonarr_add_missing": "boolean",
+    "sonarr_folder": "string",
+    "sonarr_tag": "string_list",
+}
+PLAYLIST_KEYED_TEMPLATE_VAR_SPECS = {
+    "use_": "boolean",
+    "name_": "string",
+    "summary_": "string",
+    "schedule_": "string",
+    "url_poster_": "string",
+    "file_poster_": "string",
+    "limit_": "integer",
+    "delete_playlist_": "boolean",
+    "exclude_users_": "string_list",
+    "exclude_user_": "string_list",
+    "imdb_list_": "string_list",
+    "item_radarr_tag_": "string_list",
+    "item_sonarr_tag_": "string_list",
+    "mdblist_list_": "string_list",
+    "radarr_add_missing_": "boolean",
+    "radarr_folder_": "string",
+    "radarr_tag_": "string_list",
+    "sonarr_add_missing_": "boolean",
+    "sonarr_folder_": "string",
+    "sonarr_tag_": "string_list",
+    "sync_to_users_": "string_list",
+    "trakt_list_": "string_list",
+}
 LIBRARY_SONARR_FIELDS = {
     "url": "string",
     "token": "string",
@@ -189,12 +236,16 @@ def _to_number(value):
     return None
 
 
-def _format_playlist_files(libraries_list):
+def _format_playlist_files(libraries_list, template_variables=None):
+    normalized_template_variables = {}
+    if isinstance(template_variables, dict):
+        normalized_template_variables.update(template_variables)
+    normalized_template_variables["libraries"] = libraries_list
     return {
         "playlist_files": [
             {
                 "default": "playlist",
-                "template_variables": {"libraries": libraries_list},
+                "template_variables": normalized_template_variables,
             }
         ]
     }
@@ -391,6 +442,102 @@ def _parse_string_mapping(value):
         if value_text:
             normalized[key_text] = value_text
     return normalized
+
+
+def _playlist_scalar_or_list(values):
+    if not values:
+        return None
+    return values[0] if len(values) == 1 else values
+
+
+def _normalize_playlist_template_var_value(key, value):
+    if key == "ignore_ids":
+        list_values = _parse_comma_string_list(value)
+        if not list_values:
+            return None
+        if len(list_values) == 1:
+            number = _to_number(list_values[0])
+            if isinstance(number, (int, float)) and float(number).is_integer():
+                return int(number)
+            return list_values[0]
+        return ", ".join(list_values)
+    if key in {"sync_to_users", "exclude_users", "exclude_user", "ignore_imdb_ids", "item_radarr_tag", "item_sonarr_tag", "radarr_tag", "sonarr_tag"}:
+        return _playlist_scalar_or_list(_parse_comma_string_list(value))
+    if key in {"minimum_items", "hub_priority", "limit"}:
+        number = _to_number(value)
+        if isinstance(number, (int, float)) and float(number).is_integer():
+            return int(number)
+        return None
+    if key in {"delete_not_scheduled", "delete_playlist", "radarr_add_missing", "sonarr_add_missing"}:
+        return _coerce_bool(value)
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _normalize_playlist_keyed_template_var_value(value_kind, raw_value):
+    if raw_value in (None, ""):
+        return None
+    kind = str(value_kind or "string").strip().lower()
+    if kind == "string_list":
+        return _playlist_scalar_or_list(_parse_comma_string_list(raw_value))
+    if kind == "boolean":
+        return _coerce_bool(raw_value)
+    if kind == "integer":
+        number = _to_number(raw_value)
+        if isinstance(number, (int, float)) and float(number).is_integer():
+            return int(number)
+        return None
+    text = str(raw_value).strip()
+    return text or None
+
+
+def _collect_playlist_template_variables_from_libraries_data(nested_libraries_data):
+    if not isinstance(nested_libraries_data, dict):
+        return {}
+
+    template_vars = {}
+
+    for raw_key, raw_value in nested_libraries_data.items():
+        if not isinstance(raw_key, str):
+            continue
+        match = re.fullmatch(r"playlist-template_variables\[(.+)\]", raw_key)
+        if not match:
+            continue
+
+        field_key = str(match.group(1) or "").strip()
+        if not field_key or field_key == "libraries":
+            continue
+
+        if field_key == "exclude_user":
+            field_key = "exclude_users"
+        if field_key == "exclude_user_":
+            field_key = "exclude_users_"
+
+        if field_key in PLAYLIST_KEYED_TEMPLATE_VAR_SPECS:
+            mapping = _parse_template_mapping_dict(raw_value)
+            if not mapping:
+                continue
+            value_kind = PLAYLIST_KEYED_TEMPLATE_VAR_SPECS[field_key]
+            for raw_suffix, mapping_value in mapping.items():
+                suffix = str(raw_suffix or "").strip()
+                if not suffix:
+                    continue
+                normalized_value = _normalize_playlist_keyed_template_var_value(value_kind, mapping_value)
+                if normalized_value is None:
+                    continue
+                template_vars[f"{field_key}{suffix}"] = normalized_value
+            continue
+
+        if field_key not in PLAYLIST_SHARED_TEMPLATE_VAR_SPECS:
+            continue
+
+        normalized_value = _normalize_playlist_template_var_value(field_key, raw_value)
+        if normalized_value is not None:
+            template_vars[field_key] = normalized_value
+
+    return template_vars
 
 
 def _parse_tmdb_person_window(value):
@@ -2953,12 +3100,17 @@ def build_config(header_style="standard", config_name=None):
         if app.config["QS_DEBUG"]:
             helpers.ts_log(f"Extracted libraries value: {libraries_value}", level="DEBUG")
 
-        libraries_list = [lib.strip() for lib in libraries_value.split(",") if lib.strip()]
+        if isinstance(libraries_value, list):
+            libraries_list = [str(lib).strip() for lib in libraries_value if str(lib).strip()]
+        else:
+            libraries_list = [lib.strip() for lib in str(libraries_value or "").split(",") if lib.strip()]
         if app.config["QS_DEBUG"]:
             helpers.ts_log(f"Processed libraries list: {libraries_value}", level="DEBUG")
 
+        playlist_template_variables = {key: value for key, value in playlist_data.items() if key != "libraries" and value not in (None, "", [], {})}
+
         # Format playlist_files data
-        formatted_playlist_files = _format_playlist_files(libraries_list)
+        formatted_playlist_files = _format_playlist_files(libraries_list, playlist_template_variables)
         if app.config["QS_DEBUG"]:
             helpers.ts_log("Formatted playlist_files data:", formatted_playlist_files, level="DEBUG")
 
@@ -3163,9 +3315,10 @@ def build_config(header_style="standard", config_name=None):
             nested_libraries_data,
             ordered_library_names=ordered_library_names,
         )
+        playlist_template_variables = _collect_playlist_template_variables_from_libraries_data(nested_libraries_data)
         if has_playlist_toggle:
             if playlist_libraries:
-                config_data["playlist_files"] = _format_playlist_files(playlist_libraries)
+                config_data["playlist_files"] = _format_playlist_files(playlist_libraries, playlist_template_variables)
             else:
                 config_data.pop("playlist_files", None)
         else:
@@ -3174,7 +3327,7 @@ def build_config(header_style="standard", config_name=None):
                 ordered_library_names=ordered_library_names,
             )
             if legacy_playlist_libraries:
-                config_data["playlist_files"] = _format_playlist_files(legacy_playlist_libraries)
+                config_data["playlist_files"] = _format_playlist_files(legacy_playlist_libraries, playlist_template_variables)
         if app.config["QS_DEBUG"]:
             helpers.ts_log(f"Final Libraries Section: {libraries_section}", level="DEBUG")
 

--- a/modules/output.py
+++ b/modules/output.py
@@ -58,16 +58,8 @@ FRANCHISE_DYNAMIC_CHILD_FIELD_SPECS = {
     "child_sonarr_monitor_overrides": ("sonarr_monitor_", "select"),
 }
 PLAYLIST_SHARED_TEMPLATE_VAR_SPECS = {
-    "style": "string",
     "sync_to_users": "string_list",
     "exclude_users": "string_list",
-    "minimum_items": "integer",
-    "hub_priority": "integer",
-    "url_poster": "string",
-    "file_poster": "string",
-    "schedule": "string",
-    "delete_not_scheduled": "boolean",
-    "limit": "integer",
     "delete_playlist": "boolean",
     "ignore_ids": "ignore_ids",
     "ignore_imdb_ids": "string_list",
@@ -79,15 +71,15 @@ PLAYLIST_SHARED_TEMPLATE_VAR_SPECS = {
     "sonarr_add_missing": "boolean",
     "sonarr_folder": "string",
     "sonarr_tag": "string_list",
+    "trakt_list": "string_list",
+    "imdb_list": "string_list",
+    "mdblist_list": "string_list",
 }
 PLAYLIST_KEYED_TEMPLATE_VAR_SPECS = {
     "use_": "boolean",
     "name_": "string",
     "summary_": "string",
-    "schedule_": "string",
     "url_poster_": "string",
-    "file_poster_": "string",
-    "limit_": "integer",
     "delete_playlist_": "boolean",
     "exclude_users_": "string_list",
     "exclude_user_": "string_list",
@@ -237,18 +229,69 @@ def _to_number(value):
 
 
 def _format_playlist_files(libraries_list, template_variables=None):
-    normalized_template_variables = {}
-    if isinstance(template_variables, dict):
-        normalized_template_variables.update(template_variables)
-    normalized_template_variables["libraries"] = libraries_list
-    return {
-        "playlist_files": [
+    return _format_playlist_file_entries(libraries_list=libraries_list, template_variables=template_variables)
+
+
+def _normalize_playlist_file_entry_for_output(entry):
+    if not isinstance(entry, dict):
+        return None
+    direct_entry = next(((key, value) for key, value in entry.items() if key in {"file", "url", "git", "repo"}), None)
+    if direct_entry:
+        entry_type, location = direct_entry
+        location = str(location or "").strip()
+        if location:
+            return {entry_type: location}
+        return None
+    entry_type = str(entry.get("type") or "").strip().lower()
+    location = str(entry.get("location") or "").strip()
+    if entry_type not in {"file", "url", "git", "repo"} or not location:
+        return None
+    return {entry_type: location}
+
+
+def _parse_playlist_file_entries_value(value):
+    if value in [None, "", "[]"]:
+        return []
+    parsed = value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except Exception:
+            try:
+                parsed = ast.literal_eval(value)
+            except Exception:
+                return []
+    if not isinstance(parsed, list):
+        return []
+    entries = []
+    for entry in parsed:
+        normalized = _normalize_playlist_file_entry_for_output(entry)
+        if normalized:
+            entries.append(normalized)
+    return entries
+
+
+def _format_playlist_file_entries(libraries_list=None, template_variables=None, extra_entries=None):
+    entries = []
+
+    if libraries_list:
+        normalized_template_variables = {}
+        if isinstance(template_variables, dict):
+            normalized_template_variables.update(template_variables)
+        normalized_template_variables["libraries"] = libraries_list
+        entries.append(
             {
                 "default": "playlist",
                 "template_variables": normalized_template_variables,
             }
-        ]
-    }
+        )
+
+    for entry in extra_entries or []:
+        normalized_entry = _normalize_playlist_file_entry_for_output(entry)
+        if normalized_entry:
+            entries.append(normalized_entry)
+
+    return {"playlist_files": entries}
 
 
 def _ordered_selected_libraries(selected_names, ordered_library_names):
@@ -461,14 +504,21 @@ def _normalize_playlist_template_var_value(key, value):
                 return int(number)
             return list_values[0]
         return ", ".join(list_values)
-    if key in {"sync_to_users", "exclude_users", "exclude_user", "ignore_imdb_ids", "item_radarr_tag", "item_sonarr_tag", "radarr_tag", "sonarr_tag"}:
+    if key in {
+        "sync_to_users",
+        "exclude_users",
+        "exclude_user",
+        "ignore_imdb_ids",
+        "item_radarr_tag",
+        "item_sonarr_tag",
+        "radarr_tag",
+        "sonarr_tag",
+        "trakt_list",
+        "imdb_list",
+        "mdblist_list",
+    }:
         return _playlist_scalar_or_list(_parse_comma_string_list(value))
-    if key in {"minimum_items", "hub_priority", "limit"}:
-        number = _to_number(value)
-        if isinstance(number, (int, float)) and float(number).is_integer():
-            return int(number)
-        return None
-    if key in {"delete_not_scheduled", "delete_playlist", "radarr_add_missing", "sonarr_add_missing"}:
+    if key in {"delete_playlist", "radarr_add_missing", "sonarr_add_missing"}:
         return _coerce_bool(value)
     if value is None:
         return None
@@ -538,6 +588,12 @@ def _collect_playlist_template_variables_from_libraries_data(nested_libraries_da
             template_vars[field_key] = normalized_value
 
     return template_vars
+
+
+def _collect_playlist_file_entries_from_libraries_data(nested_libraries_data):
+    if not isinstance(nested_libraries_data, dict):
+        return []
+    return _parse_playlist_file_entries_value(nested_libraries_data.get("playlist_files_entries"))
 
 
 def _parse_tmdb_person_window(value):
@@ -3110,7 +3166,7 @@ def build_config(header_style="standard", config_name=None):
         playlist_template_variables = {key: value for key, value in playlist_data.items() if key != "libraries" and value not in (None, "", [], {})}
 
         # Format playlist_files data
-        formatted_playlist_files = _format_playlist_files(libraries_list, playlist_template_variables)
+        formatted_playlist_files = _format_playlist_file_entries(libraries_list=libraries_list, template_variables=playlist_template_variables)
         if app.config["QS_DEBUG"]:
             helpers.ts_log("Formatted playlist_files data:", formatted_playlist_files, level="DEBUG")
 
@@ -3316,9 +3372,14 @@ def build_config(header_style="standard", config_name=None):
             ordered_library_names=ordered_library_names,
         )
         playlist_template_variables = _collect_playlist_template_variables_from_libraries_data(nested_libraries_data)
+        playlist_file_entries = _collect_playlist_file_entries_from_libraries_data(nested_libraries_data)
         if has_playlist_toggle:
-            if playlist_libraries:
-                config_data["playlist_files"] = _format_playlist_files(playlist_libraries, playlist_template_variables)
+            if playlist_libraries or playlist_file_entries:
+                config_data["playlist_files"] = _format_playlist_file_entries(
+                    libraries_list=playlist_libraries,
+                    template_variables=playlist_template_variables,
+                    extra_entries=playlist_file_entries,
+                )
             else:
                 config_data.pop("playlist_files", None)
         else:
@@ -3326,8 +3387,12 @@ def build_config(header_style="standard", config_name=None):
                 nested_libraries_data,
                 ordered_library_names=ordered_library_names,
             )
-            if legacy_playlist_libraries:
-                config_data["playlist_files"] = _format_playlist_files(legacy_playlist_libraries, playlist_template_variables)
+            if legacy_playlist_libraries or playlist_file_entries:
+                config_data["playlist_files"] = _format_playlist_file_entries(
+                    libraries_list=legacy_playlist_libraries,
+                    template_variables=playlist_template_variables,
+                    extra_entries=playlist_file_entries,
+                )
         if app.config["QS_DEBUG"]:
             helpers.ts_log(f"Final Libraries Section: {libraries_section}", level="DEBUG")
 

--- a/modules/validations.py
+++ b/modules/validations.py
@@ -109,6 +109,10 @@ def _validate_overlay_yaml_text(raw_text, label, source_name=None):
     return _validate_required_top_level_mapping(raw_text, label, source_name, "overlays")
 
 
+def _validate_playlist_yaml_text(raw_text, label, source_name=None):
+    return _validate_required_top_level_mapping(raw_text, label, source_name, "playlists")
+
+
 def _validate_yaml_location_suffix(location, label):
     lowered = str(location or "").strip().lower()
     if not lowered.endswith((".yml", ".yaml")):
@@ -812,6 +816,45 @@ def _validate_overlay_yaml_location(location, label):
     return _validate_overlay_yaml_text(yaml_text, label, source_name)
 
 
+def _validate_playlist_yaml_location(location, label):
+    resolved_location = _resolve_managed_library_path(location)
+    valid, message = _validate_yaml_location_suffix(location, label)
+    if not valid:
+        return False, message
+
+    source_name = os.path.basename(urllib.parse.urlparse(str(location)).path) or os.path.basename(str(location)) or label
+
+    if str(location).strip().lower().startswith(("http://", "https://")):
+        valid, message = url_validation.validate_url(location, allow_local=True)
+        if not valid:
+            return False, f"{label}: {message}"
+
+        try:
+            response = requests.get(location, timeout=10)
+        except requests.RequestException as exc:
+            return False, f"Connection error: {str(exc)}"
+
+        if response.status_code >= 400:
+            return False, f"Failed to fetch {label} ({response.status_code} [{response.reason}])."
+
+        return _validate_playlist_yaml_text(response.text, label, source_name)
+
+    valid, message = path_validation.validate_path(
+        resolved_location,
+        {"allow_relative": True, "must_exist": True, "mode": "input_file"},
+    )
+    if not valid:
+        return False, f"{label}: {message}"
+
+    try:
+        with open(resolved_location, "r", encoding="utf-8") as handle:
+            yaml_text = handle.read()
+    except OSError as exc:
+        return False, f"{label}: Unable to read file. {exc}"
+
+    return _validate_playlist_yaml_text(yaml_text, label, source_name)
+
+
 def _summarize_folder_validation_failures(label, yaml_files, failures):
     scanned_files = len(yaml_files)
     invalid_files = len(failures)
@@ -1131,6 +1174,47 @@ def validate_overlay_file_payload(data):
     return _normalize_metadata_validation_result(_validate_overlay_yaml_location(resolved_repo_location, "Overlay file repo path"))
 
 
+def validate_playlist_file_payload(data):
+    playlist_file_type = str(data.get("playlist_file_type") or "").strip().lower()
+    playlist_file_location = str(data.get("playlist_file_location") or "").strip()
+
+    if playlist_file_type not in {"file", "url", "git", "repo"}:
+        return False, "Playlist file type must be file, url, git, or repo.", {}
+
+    if not playlist_file_location:
+        return False, "Playlist file location is required.", {}
+
+    if playlist_file_type == "url":
+        if not playlist_file_location.lower().startswith(("http://", "https://")):
+            return False, "Playlist file URL must start with http:// or https://.", {}
+        return _normalize_metadata_validation_result(_validate_playlist_yaml_location(playlist_file_location, "Playlist file URL"))
+
+    if playlist_file_type == "file":
+        if playlist_file_location.lower().startswith(("http://", "https://")):
+            return False, "Playlist file path must be a local file path.", {}
+        return _normalize_metadata_validation_result(_validate_playlist_yaml_location(playlist_file_location, "Playlist file path"))
+
+    if playlist_file_type == "git":
+        valid, message = _validate_yaml_location_suffix(playlist_file_location, "Playlist file git path")
+        if not valid:
+            return False, message, {}
+        return _normalize_metadata_validation_result(
+            _validate_playlist_yaml_location(
+                f"https://raw.githubusercontent.com/Kometa-Team/Community-Configs/master/{playlist_file_location}",
+                "Playlist file git path",
+            )
+        )
+
+    custom_repo_base = _saved_custom_repo_base()
+    if not custom_repo_base:
+        return False, "Playlist file repo entries require Custom Repo to be configured and saved first within the Settings page.", {}
+    valid, message = _validate_yaml_location_suffix(playlist_file_location, "Playlist file repo path")
+    if not valid:
+        return False, message, {}
+    resolved_repo_location = f"{custom_repo_base}{playlist_file_location}"
+    return _normalize_metadata_validation_result(_validate_playlist_yaml_location(resolved_repo_location, "Playlist file repo path"))
+
+
 def validate_metadata_file_server(data):
     valid, message, details = validate_metadata_file_payload(data)
     if not valid:
@@ -1171,6 +1255,25 @@ def validate_collection_file_server(data):
 
 def validate_overlay_file_server(data):
     valid, message, details = validate_overlay_file_payload(data)
+    if not valid:
+        payload = {"valid": False, "error": message}
+        if details.get("message") or isinstance(details.get("files"), list):
+            payload["error_details"] = {"text": details.get("message") or message, "files": details.get("files") if isinstance(details.get("files"), list) else []}
+        if isinstance(details.get("files"), list):
+            payload["files"] = details["files"]
+        return jsonify(payload), 400
+    payload = {"valid": True}
+    if details.get("message"):
+        payload["message"] = details["message"]
+    if "validated_files" in details:
+        payload["validated_files"] = details["validated_files"]
+    if isinstance(details.get("files"), list):
+        payload["files"] = details["files"]
+    return jsonify(payload)
+
+
+def validate_playlist_file_server(data):
+    valid, message, details = validate_playlist_file_payload(data)
     if not valid:
         payload = {"valid": False, "error": message}
         if details.get("message") or isinstance(details.get("files"), list):

--- a/quickstart.py
+++ b/quickstart.py
@@ -25,6 +25,7 @@ import requests
 from cachelib.file import FileSystemCache
 from datetime import datetime, timezone, timedelta
 from dotenv import load_dotenv
+from ruamel.yaml import YAML
 from flask import (
     Flask,
     jsonify,
@@ -458,7 +459,7 @@ VALIDATION_DOCS = {
     "webhooks": f"{VALIDATION_DOC_BASE}090-webhooks",
     "collections": f"{VALIDATION_DOC_BASE}025-libraries",
     "overlays": f"{VALIDATION_DOC_BASE}025-libraries",
-    "playlist_files": f"{VALIDATION_DOC_BASE}027-playlist_files",
+    "playlist_files": f"{VALIDATION_DOC_BASE}025-libraries",
 }
 VALIDATION_REASON_LABELS = {
     "missing_credentials": "Missing credentials",
@@ -958,6 +959,90 @@ def _validate_and_organize_library_file_request(kind, data, type_key, location_k
     return jsonify(payload)
 
 
+def _parse_shared_playlist_file_entries(raw_value):
+    if raw_value in [None, "", "[]"]:
+        return []
+    if isinstance(raw_value, list):
+        parsed = raw_value
+    else:
+        try:
+            parsed = json.loads(str(raw_value))
+        except Exception:
+            return None
+    if not isinstance(parsed, list):
+        return None
+
+    entries = []
+    for entry in parsed:
+        if not isinstance(entry, dict):
+            continue
+        entry_type = str(entry.get("type") or "").strip().lower()
+        location = str(entry.get("location") or "").strip()
+        validated = helpers.booler(entry.get("validated"))
+        if not entry_type and not location:
+            continue
+        normalized = {"type": entry_type, "location": location}
+        if validated:
+            normalized["validated"] = True
+        entries.append(normalized)
+    return entries
+
+
+def _validate_shared_playlist_files(libraries_data):
+    if not isinstance(libraries_data, dict):
+        return []
+    entries = _parse_shared_playlist_file_entries(libraries_data.get("playlist_files_entries"))
+    if entries is None:
+        return ["playlist_files_entries must be a valid list."]
+
+    errors = []
+    for idx, entry in enumerate(entries, start=1):
+        valid, message, details = validations._normalize_metadata_validation_result(
+            validations.validate_playlist_file_payload(
+                {
+                    "playlist_file_type": str(entry.get("type") or "").strip().lower(),
+                    "playlist_file_location": str(entry.get("location") or "").strip(),
+                }
+            )
+        )
+        if not valid:
+            errors.append(_format_library_file_validation_error("playlist_files", "playlist_files", idx, message, entry, details))
+    return errors
+
+
+def _normalize_shared_playlist_file_entries_payload(libraries_data, config_name, validate_local=False):
+    if not isinstance(libraries_data, dict):
+        return {}, []
+    normalized = dict(libraries_data)
+    entries = _parse_shared_playlist_file_entries(normalized.get("playlist_files_entries"))
+    if entries is None:
+        return normalized, ["playlist_files_entries must be a valid list."]
+
+    if not entries:
+        normalized["playlist_files_entries"] = "[]"
+        return normalized, []
+
+    new_entries = []
+    errors = []
+    for idx, entry in enumerate(entries, start=1):
+        normalized_entry, _changed, entry_error = _normalize_library_external_entry(
+            "playlist_files",
+            entry,
+            config_name,
+            "shared_playlist_files",
+            validate_local=validate_local,
+            require_managed_context=True,
+        )
+        if entry_error:
+            errors.append(_format_library_file_validation_error("playlist_files", "playlist_files", idx, entry_error, entry))
+            continue
+        if normalized_entry:
+            new_entries.append(normalized_entry)
+
+    normalized["playlist_files_entries"] = json.dumps(new_entries, ensure_ascii=True)
+    return normalized, errors
+
+
 DOTENV = os.path.relpath(os.path.join(helpers.CONFIG_DIR, ".env"))
 load_dotenv(DOTENV, override=True)
 
@@ -1006,12 +1091,43 @@ def start_update_thread():
 threading.Thread(target=start_update_thread, daemon=True).start()
 
 
+_PLAYLIST_DEFAULT_ENTRIES_CACHE = None
+
+
+def _load_playlist_default_entries():
+    global _PLAYLIST_DEFAULT_ENTRIES_CACHE
+    if _PLAYLIST_DEFAULT_ENTRIES_CACHE is not None:
+        return [dict(entry) for entry in _PLAYLIST_DEFAULT_ENTRIES_CACHE]
+
+    playlist_defaults_path = Path(__file__).resolve().parent / "config" / "kometa" / "defaults" / "playlist.yml"
+    entries = []
+    try:
+        parser = YAML(typ="safe", pure=True)
+        loaded = parser.load(playlist_defaults_path.read_text(encoding="utf-8")) or {}
+        for playlist_name, playlist_data in (loaded.get("playlists") or {}).items():
+            if not isinstance(playlist_data, dict):
+                continue
+            variables = playlist_data.get("variables") or {}
+            if not isinstance(variables, dict):
+                continue
+            key = str(variables.get("key") or "").strip()
+            label = str(playlist_name or "").strip()
+            if key and label:
+                entries.append({"key": key, "label": label})
+    except Exception:
+        entries = []
+
+    _PLAYLIST_DEFAULT_ENTRIES_CACHE = entries
+    return [dict(entry) for entry in entries]
+
+
 @app.context_processor
 def inject_version_info():
     """Ensure latest version info is injected dynamically in templates"""
     return {
         "version_info": app.config.get("VERSION_CHECK") or {},
         "overlay_fonts": list_overlay_fonts(),
+        "playlist_default_entries": _load_playlist_default_entries(),
         # Roadmap #1334 Step 5 (Phase B): expose the app-level config
         # dict to every template so 000-base.html can emit a single
         # ``window.QS_AppConfig = {...}`` line instead of 11 individual
@@ -1823,6 +1939,7 @@ def step(name):
             validation_errors += _validate_library_collection_files(incoming_libraries, selected_library_ids)
             validation_errors += _validate_library_metadata_files(incoming_libraries, selected_library_ids)
             validation_errors += _validate_library_overlay_files(incoming_libraries, selected_library_ids)
+            validation_errors += _validate_shared_playlist_files(incoming_libraries)
             validation_errors += _validate_library_auto_sort_hubs(incoming_libraries, selected_library_ids)
             for lib_id in selected_library_ids:
                 override_result = _validate_library_service_overrides(lib_id, incoming_libraries)
@@ -1836,6 +1953,14 @@ def step(name):
                 )
                 if normalization_errors:
                     validation_errors += normalization_errors
+                else:
+                    normalized_library_payload, playlist_file_errors = _normalize_shared_playlist_file_entries_payload(
+                        normalized_library_payload,
+                        session.get("config_name") or request.form.get("config_name") or request.form.get("configSelector"),
+                        validate_local=False,
+                    )
+                    if playlist_file_errors:
+                        validation_errors += playlist_file_errors
         elif save_source_name == "settings" and not _is_valid_auto_sort_hubs_value(request.form.get("auto_sort_hubs")):
             validation_errors.append("auto_sort_hubs must be one of: sort_title, sort_title.desc, alpha, alpha.desc, configured, configured.desc, random")
         if validation_errors:
@@ -6010,6 +6135,51 @@ def validate_overlay_file():
         "overlay_file_type",
         "overlay_file_location",
     )
+
+
+@app.route("/validate_playlist_file", methods=["POST"])
+def validate_playlist_file():
+    data = request.get_json(silent=True) or {}
+    valid, message, details = validations._normalize_metadata_validation_result(validations.validate_playlist_file_payload(data))
+    if not valid:
+        payload = {"valid": False, "error": message}
+        if details.get("message") or isinstance(details.get("files"), list):
+            payload["error_details"] = {
+                "text": details.get("message") or message,
+                "files": details.get("files") if isinstance(details.get("files"), list) else [],
+            }
+        if isinstance(details.get("files"), list):
+            payload["files"] = details["files"]
+        return jsonify(payload), 400
+
+    payload = {"valid": True}
+    if details.get("message"):
+        payload["message"] = details["message"]
+    if "validated_files" in details:
+        payload["validated_files"] = details["validated_files"]
+    if isinstance(details.get("files"), list):
+        payload["files"] = details["files"]
+
+    config_name = _resolve_request_config_name(data if isinstance(data, dict) else {})
+    entry_type = str((data or {}).get("playlist_file_type") or "").strip().lower()
+    entry_location = str((data or {}).get("playlist_file_location") or "").strip()
+    if entry_type == "file" and entry_location and config_name:
+        normalized_entry, changed, normalize_error = _normalize_library_external_entry(
+            "playlist_files",
+            {"type": entry_type, "location": entry_location},
+            config_name,
+            "shared_playlist_files",
+            validate_local=False,
+            require_managed_context=True,
+        )
+        if normalize_error:
+            return jsonify({"valid": False, "error": normalize_error}), 400
+        payload["normalized_location"] = normalized_entry["location"]
+        payload["organized"] = bool(changed)
+        if changed:
+            payload["message"] = payload.get("message") or "Source validated and organized into Quickstart playlist_files."
+
+    return jsonify(payload)
 
 
 @app.route("/restart", methods=["POST"])

--- a/scripts/analyze_uploaded_template_gaps.py
+++ b/scripts/analyze_uploaded_template_gaps.py
@@ -2314,6 +2314,9 @@ QUICKSTART_RECOMMENDATION_EXCLUSIONS: dict[tuple[str, str], str] = {
     ("library", "library_type"): "internal_importer_or_analyzer_metadata",
     ("library", "sort_by"): "library_template_variable_not_documented_for_quickstart",
     ("library", "exclude"): "library_template_variable_not_documented_for_quickstart",
+    ("library", "use_separators"): "invalid_separator_toggle_typo_not_recommended",
+    ("library", "use_seperator"): "invalid_separator_toggle_typo_not_recommended",
+    ("library", "use_sepeartor"): "invalid_separator_toggle_typo_not_recommended",
 }
 
 
@@ -2332,6 +2335,9 @@ MERGED_FIX_QUEUE_EXCLUSIONS: dict[tuple[str, str], str] = {
     ("library", "library_type"): "internal_importer_or_analyzer_metadata",
     ("library", "sort_by"): "library_template_variable_not_documented_for_quickstart",
     ("library", "exclude"): "library_template_variable_not_documented_for_quickstart",
+    ("library", "use_separators"): "invalid_separator_toggle_typo_not_recommended",
+    ("library", "use_seperator"): "invalid_separator_toggle_typo_not_recommended",
+    ("library", "use_sepeartor"): "invalid_separator_toggle_typo_not_recommended",
 }
 
 

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -103,6 +103,7 @@ const metadataCustomRepoBase = String(window.QS_SETTINGS_CUSTOM_REPO_BASE || '')
 const metadataRepoDependencyMessage = 'Metadata file repo entries require Custom Repo to be configured and saved first within the Settings page.'
 const collectionRepoDependencyMessage = 'Collection file repo entries require Custom Repo to be configured and saved first within the Settings page.'
 const overlayRepoDependencyMessage = 'Overlay file repo entries require Custom Repo to be configured and saved first within the Settings page.'
+const playlistRepoDependencyMessage = 'Playlist file repo entries require Custom Repo to be configured and saved first within the Settings page.'
 
 function appendMetadataSettingsLink (target, className = 'link-light fw-semibold text-decoration-underline') {
   const link = document.createElement('a')
@@ -135,6 +136,211 @@ function appendInlineCodeText (target, text, options = {}) {
     } else {
       target.appendChild(document.createTextNode(part))
     }
+  })
+}
+
+function ensureLibrariesModalRoot (modalEl) {
+  if (!modalEl || !document.body) return modalEl
+  const modalId = modalEl.id
+  modalEl.dataset.librariesModal = 'true'
+  if (modalId) {
+    const bodyModal = Array.from(document.body.querySelectorAll('[data-libraries-modal]'))
+      .find(el => el.id === modalId && el !== modalEl)
+    if (bodyModal) {
+      if (modalEl.parentElement) modalEl.remove()
+      return bodyModal
+    }
+  }
+  if (modalEl.parentElement !== document.body) {
+    document.body.appendChild(modalEl)
+  }
+  return modalEl
+}
+
+function syncLibrariesModalBackdrop (modalEl) {
+  if (!modalEl) return
+  modalEl.style.zIndex = '2000'
+  modalEl.style.pointerEvents = 'auto'
+  modalEl.removeAttribute('inert')
+
+  const dialog = modalEl.querySelector('.modal-dialog')
+  if (dialog) dialog.style.pointerEvents = 'auto'
+
+  const content = modalEl.querySelector('.modal-content')
+  if (content) content.style.pointerEvents = 'auto'
+
+  const latestBackdrop = Array.from(document.querySelectorAll('.modal-backdrop')).at(-1)
+  if (latestBackdrop) latestBackdrop.style.zIndex = '1990'
+}
+
+function cleanupLibrariesModalBackdrops () {
+  if (document.querySelector('.modal.show')) return
+  document.querySelectorAll('.modal-backdrop').forEach(backdrop => backdrop.remove())
+}
+
+function queueLibrariesModalBackdropSync (modalEl) {
+  if (window && typeof window.requestAnimationFrame === 'function') {
+    window.requestAnimationFrame(() => syncLibrariesModalBackdrop(modalEl))
+    return
+  }
+  syncLibrariesModalBackdrop(modalEl)
+}
+
+function prepareLibrariesModal (modalEl) {
+  if (!modalEl) return modalEl
+  modalEl = ensureLibrariesModalRoot(modalEl)
+  if (modalEl.dataset.librariesModalPrepared === 'true') return modalEl
+  modalEl.dataset.librariesModalPrepared = 'true'
+  modalEl.addEventListener('show.bs.modal', function () {
+    syncLibrariesModalBackdrop(modalEl)
+    queueLibrariesModalBackdropSync(modalEl)
+  })
+  modalEl.addEventListener('shown.bs.modal', function () {
+    syncLibrariesModalBackdrop(modalEl)
+  })
+  modalEl.addEventListener('hidden.bs.modal', function () {
+    cleanupLibrariesModalBackdrops()
+  })
+  return modalEl
+}
+
+function hideLibrariesModal (modalEl) {
+  if (!modalEl || typeof bootstrap === 'undefined' || !bootstrap.Modal) return
+  const modal = bootstrap.Modal.getInstance(modalEl)
+  if (modal) modal.hide()
+}
+
+function parsePlaylistUserInputValue (value) {
+  if (Array.isArray(value)) {
+    return value.map(item => String(item || '').trim()).filter(Boolean)
+  }
+  const text = String(value || '').trim()
+  if (!text) return []
+  if (text.startsWith('[') && text.endsWith(']')) {
+    try {
+      const parsed = JSON.parse(text)
+      if (Array.isArray(parsed)) {
+        return parsed.map(item => String(item || '').trim()).filter(Boolean)
+      }
+    } catch {}
+  }
+  return text.split(',').map(item => item.trim()).filter(Boolean)
+}
+
+function initPlaylistUserPickers (scope) {
+  const root = scope || document
+  root.querySelectorAll('[data-playlist-user-picker]').forEach(wrapper => {
+    if (wrapper.dataset.playlistUserPickerReady === 'true') return
+    const inputId = String(wrapper.dataset.inputId || '').trim()
+    const modalId = String(wrapper.dataset.modalId || '').trim()
+    const allowAll = String(wrapper.dataset.allowAll || '').trim().toLowerCase() === 'true'
+    const input = inputId ? document.getElementById(inputId) : wrapper.querySelector('[data-playlist-user-input]')
+    let modalEl = modalId ? document.getElementById(modalId) : wrapper.querySelector('.modal')
+    if (!input || !modalEl) return
+
+    modalEl = prepareLibrariesModal(modalEl)
+    const applyButton = modalEl.querySelector('[data-playlist-user-apply]')
+    const allToggle = modalEl.querySelector('[data-playlist-user-all-toggle]')
+
+    const syncTogglesFromInput = () => {
+      const selected = parsePlaylistUserInputValue(input.value)
+      const hasAll = selected.includes('all')
+      if (allowAll && allToggle) {
+        allToggle.checked = hasAll
+      }
+      modalEl.querySelectorAll('[data-playlist-user-toggle]').forEach(toggle => {
+        toggle.checked = !hasAll && selected.includes(toggle.value)
+      })
+    }
+
+    if (modalEl.dataset.playlistUserModalBound !== 'true') {
+      modalEl.addEventListener('show.bs.modal', syncTogglesFromInput)
+      modalEl.dataset.playlistUserModalBound = 'true'
+    }
+
+    if (applyButton && applyButton.dataset.playlistUserApplyBound !== 'true') {
+      applyButton.addEventListener('click', () => {
+        const values = []
+        if (allowAll && allToggle && allToggle.checked) {
+          values.push('all')
+        } else {
+          modalEl.querySelectorAll('[data-playlist-user-toggle]:checked').forEach(toggle => {
+            values.push(toggle.value)
+          })
+        }
+        input.value = values.join(', ')
+        input.dispatchEvent(new Event('input', { bubbles: true }))
+        input.dispatchEvent(new Event('change', { bubbles: true }))
+        hideLibrariesModal(modalEl)
+      })
+      applyButton.dataset.playlistUserApplyBound = 'true'
+    }
+
+    const normalizedValues = parsePlaylistUserInputValue(input.value)
+    input.value = normalizedValues.join(', ')
+    wrapper.dataset.playlistUserPickerReady = 'true'
+  })
+}
+
+function initPlaylistKeyToggleGroups (scope) {
+  const root = scope || document
+  root.querySelectorAll('[data-playlist-key-toggle-group]').forEach(wrapper => {
+    if (wrapper.dataset.playlistKeyToggleReady === 'true') return
+    const hiddenId = String(wrapper.dataset.hiddenInput || '').trim()
+    const hidden = hiddenId ? document.getElementById(hiddenId) : wrapper.querySelector('input[type="hidden"]')
+    const toggles = Array.from(wrapper.querySelectorAll('[data-playlist-key-toggle]'))
+    if (!hidden || !toggles.length) return
+
+    const parseStoredMapping = () => {
+      const raw = String(hidden.value || '').trim()
+      if (!raw) return {}
+      try {
+        const parsed = JSON.parse(raw)
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          return parsed
+        }
+      } catch {}
+      return {}
+    }
+
+    const isFalseValue = (value) => {
+      if (value === false || value === 0) return true
+      const text = String(value ?? '').trim().toLowerCase()
+      return text === 'false' || text === '0' || text === 'off' || text === 'no'
+    }
+
+    const syncFromHidden = () => {
+      const mapping = parseStoredMapping()
+      toggles.forEach(toggle => {
+        const key = String(toggle.dataset.playlistKey || '').trim()
+        if (!key) return
+        const storedValue = Object.prototype.hasOwnProperty.call(mapping, key) ? mapping[key] : undefined
+        toggle.checked = storedValue === undefined ? true : !isFalseValue(storedValue)
+      })
+    }
+
+    const syncToHidden = () => {
+      const mapping = parseStoredMapping()
+      toggles.forEach(toggle => {
+        const key = String(toggle.dataset.playlistKey || '').trim()
+        if (!key) return
+        if (toggle.checked) {
+          delete mapping[key]
+        } else {
+          mapping[key] = false
+        }
+      })
+      hidden.value = JSON.stringify(mapping)
+      hidden.dispatchEvent(new Event('input', { bubbles: true }))
+      hidden.dispatchEvent(new Event('change', { bubbles: true }))
+    }
+
+    toggles.forEach(toggle => {
+      toggle.addEventListener('change', syncToHidden)
+    })
+    hidden.addEventListener('change', syncFromHidden)
+    syncFromHidden()
+    wrapper.dataset.playlistKeyToggleReady = 'true'
   })
 }
 
@@ -1479,6 +1685,418 @@ initOverlayFilesEditors(document)
 if (libraryContainer && typeof MutationObserver !== 'undefined') {
   const overlayObserver = new MutationObserver(() => initOverlayFilesEditors(libraryContainer))
   overlayObserver.observe(libraryContainer, { childList: true, subtree: true })
+}
+
+function normalizePlaylistFileEntry (entry) {
+  if (!entry || typeof entry !== 'object') return null
+  const type = String(entry.type || '').trim().toLowerCase()
+  const location = String(entry.location || '').trim()
+  const validated = entry.validated === true || String(entry.validated || '').trim().toLowerCase() === 'true'
+  if (!type && !location) return null
+  const normalized = { type, location }
+  if (validated) normalized.validated = true
+  return normalized
+}
+
+function parsePlaylistFilesValue (rawValue) {
+  if (!rawValue) return []
+  try {
+    const parsed = JSON.parse(String(rawValue))
+    if (!Array.isArray(parsed)) return []
+    return parsed
+      .map(normalizePlaylistFileEntry)
+      .filter(Boolean)
+  } catch {
+    return []
+  }
+}
+
+function buildPlaylistFileRow (entry = {}) {
+  const wrapper = document.createElement('div')
+  wrapper.className = 'card bg-body-tertiary border-secondary'
+  wrapper.setAttribute('data-playlist-file-row', 'true')
+  wrapper.innerHTML = `
+    <div class="card-body">
+      <div class="row g-3 align-items-end">
+        <div class="col-md-2">
+          <label class="form-label small text-muted">Type</label>
+          <select class="form-select form-select-sm" data-playlist-file-type>
+            <option value="file">file</option>
+            <option value="git">git</option>
+            <option value="repo">repo</option>
+            <option value="url">url</option>
+          </select>
+        </div>
+        <div class="col-md-7">
+          <label class="form-label small text-muted">Location</label>
+          <input type="text" class="form-control form-control-sm" data-playlist-file-location placeholder="config/playlists.yml, user/playlists.yml, or https://example.com/playlists.yml">
+        </div>
+        <div class="col-md-3 d-flex gap-2 justify-content-md-end">
+          <button type="button" class="btn btn-success btn-sm" data-validate-playlist-file>Validate</button>
+          <button type="button" class="btn btn-danger btn-sm" data-remove-playlist-file>Remove</button>
+        </div>
+      </div>
+      <div class="mt-2 small d-none" data-playlist-file-status></div>
+    </div>
+  `
+  const typeSelect = wrapper.querySelector('[data-playlist-file-type]')
+  const locationInput = wrapper.querySelector('[data-playlist-file-location]')
+  if (typeSelect && ['file', 'url', 'git', 'repo'].includes(entry.type)) {
+    typeSelect.value = entry.type
+  }
+  if (locationInput && entry.location) {
+    locationInput.value = entry.location
+  }
+  if (entry.validated) {
+    wrapper.dataset.playlistFileState = 'success'
+    wrapper.dataset.playlistFileButtonState = 'success'
+  }
+  updatePlaylistFileValidateButton(wrapper, Boolean(entry.validated))
+  return wrapper
+}
+
+function updatePlaylistFileValidateButton (row, isValidated) {
+  if (!row) return
+  const button = row.querySelector('[data-validate-playlist-file]')
+  if (!button) return
+  const state = String(row.dataset.playlistFileButtonState || '').trim() || (isValidated ? 'success' : 'idle')
+  button.classList.remove('btn-success', 'btn-secondary')
+  if (state === 'success') {
+    button.disabled = true
+    button.classList.add('btn-secondary')
+    button.textContent = 'Validated'
+    return
+  }
+  if (state === 'blocked') {
+    button.disabled = true
+    button.classList.add('btn-secondary')
+    button.textContent = 'Needs Repo'
+    return
+  }
+  if (state === 'loading') {
+    button.disabled = true
+    button.classList.add('btn-secondary')
+    button.textContent = 'Validating...'
+    return
+  }
+  button.disabled = false
+  button.classList.add('btn-success')
+  button.textContent = 'Validate'
+}
+
+function setPlaylistFileButtonState (row, state) {
+  if (!row) return
+  row.dataset.playlistFileButtonState = state || 'idle'
+  updatePlaylistFileValidateButton(row, state === 'success')
+}
+
+function updatePlaylistCustomRepoStatus (editor) {
+  if (!editor) return
+  const target = editor.querySelector('[data-playlist-custom-repo-status]')
+  if (!target) return
+
+  target.replaceChildren()
+  target.className = 'alert small mb-3'
+  if (!metadataCustomRepoBase) {
+    target.classList.add('alert-warning')
+    target.append('Custom Repo is not configured. ')
+    target.append('Use ')
+    appendMetadataSettingsLink(target, 'alert-link fw-semibold')
+    target.append(' to configure and save it before using ')
+    const code = document.createElement('code')
+    code.textContent = 'repo'
+    target.appendChild(code)
+    target.append(' playlist files.')
+    return
+  }
+
+  target.classList.add('alert-secondary')
+  const label = document.createElement('div')
+  label.className = 'fw-semibold mb-1'
+  label.textContent = 'Custom Repo base used for repo entries'
+  target.appendChild(label)
+
+  const baseValue = document.createElement('code')
+  baseValue.textContent = metadataCustomRepoBase
+  target.appendChild(baseValue)
+}
+
+function applyPlaylistFileDependencyState (row, opts = {}) {
+  if (!row) return false
+  const skipStatus = Boolean(opts.skipStatus)
+  const type = row.querySelector('[data-playlist-file-type]')?.value || ''
+  if (type !== 'repo') {
+    if (row.dataset.playlistFileDependency === 'repo-missing') {
+      row.dataset.playlistFileDependency = ''
+    }
+    return false
+  }
+
+  if (metadataCustomRepoBase) {
+    if (row.dataset.playlistFileDependency === 'repo-missing') {
+      row.dataset.playlistFileDependency = ''
+    }
+    return false
+  }
+
+  row.dataset.playlistFileDependency = 'repo-missing'
+  setPlaylistFileButtonState(row, 'blocked')
+  if (!skipStatus) {
+    setPlaylistFileStatus(row, 'error', playlistRepoDependencyMessage)
+  }
+  return true
+}
+
+function renderPlaylistFileStatusMessage (target, message) {
+  target.replaceChildren()
+  if (!message) return
+
+  if (typeof message === 'object' && message !== null) {
+    const text = String(message.text || message.message || '').trim()
+    const files = Array.isArray(message.files) ? message.files.filter(Boolean) : []
+    if (text) {
+      const summary = document.createElement('div')
+      appendInlineCodeText(summary, text)
+      target.appendChild(summary)
+    }
+    if (files.length) {
+      const list = document.createElement('ul')
+      list.className = 'mb-0 mt-1 ps-3'
+      files.forEach(file => {
+        const item = document.createElement('li')
+        appendInlineCodeText(item, file, { wrapPlainInCode: true })
+        list.appendChild(item)
+      })
+      target.appendChild(list)
+    }
+    return
+  }
+
+  const text = String(message || '').trim()
+  if (!text) return
+
+  if (text === playlistRepoDependencyMessage) {
+    target.append('Playlist file repo entries require Custom Repo to be configured and saved first within the ')
+    appendMetadataSettingsLink(target)
+    target.append(' page.')
+    return
+  }
+
+  appendInlineCodeText(target, text)
+}
+
+function setPlaylistFileStatus (row, kind, message) {
+  if (!row) return
+  const target = row.querySelector('[data-playlist-file-status]')
+  if (!target) return
+  row.dataset.playlistFileState = kind || ''
+  target.className = 'mt-2 small'
+  if (!message) {
+    target.classList.add('d-none')
+    target.textContent = ''
+    if (applyPlaylistFileDependencyState(row, { skipStatus: true })) {
+      setPlaylistFileButtonState(row, 'blocked')
+    } else {
+      setPlaylistFileButtonState(row, 'idle')
+    }
+    const editor = row.closest('[data-playlist-files-editor]')
+    if (editor) updatePlaylistFilesAccordionState(editor)
+    return
+  }
+  target.classList.remove('d-none')
+  if (kind === 'success') {
+    target.classList.add('text-success')
+  } else if (kind === 'error') {
+    target.classList.add('text-danger')
+  } else {
+    target.classList.add('text-warning')
+  }
+  renderPlaylistFileStatusMessage(target, message)
+  if (kind === 'success') {
+    setPlaylistFileButtonState(row, 'success')
+  } else if (row.dataset.playlistFileDependency === 'repo-missing') {
+    setPlaylistFileButtonState(row, 'blocked')
+  } else {
+    setPlaylistFileButtonState(row, 'idle')
+  }
+  const editor = row.closest('[data-playlist-files-editor]')
+  if (editor) updatePlaylistFilesAccordionState(editor)
+}
+
+function updatePlaylistFilesAccordionState (editor) {
+  if (!editor) return
+  const accordionItem = editor.closest('.accordion-item')
+  const accordionHeader = accordionItem?.querySelector(':scope > .accordion-header')
+  if (!accordionHeader) return
+
+  const rows = Array.from(editor.querySelectorAll('[data-playlist-file-row]'))
+  const hasEntries = rows.some(row => {
+    const type = row.querySelector('[data-playlist-file-type]')?.value || ''
+    const location = row.querySelector('[data-playlist-file-location]')?.value || ''
+    return Boolean(normalizePlaylistFileEntry({ type, location }))
+  })
+  const hasInvalid = rows.some(row => {
+    const state = String(row.dataset.playlistFileState || '').trim().toLowerCase()
+    return state === 'error' || state === 'warning'
+  })
+
+  accordionHeader.classList.remove('invalid', 'warning')
+  if (hasInvalid) {
+    accordionHeader.classList.add('invalid')
+    return
+  }
+  if (hasEntries) {
+    accordionHeader.classList.add('selected')
+  } else {
+    accordionHeader.classList.remove('selected')
+  }
+}
+
+function syncPlaylistFilesEditor (editor, emitEvents = true) {
+  if (!editor) return []
+  const hidden = editor.querySelector('input[type="hidden"][name="playlist_files_entries"]')
+  if (!hidden) return []
+  const rows = Array.from(editor.querySelectorAll('[data-playlist-file-row]'))
+  const entries = rows.map(row => {
+    const type = row.querySelector('[data-playlist-file-type]')?.value
+    const location = row.querySelector('[data-playlist-file-location]')?.value
+    const validated = String(row.dataset.playlistFileState || '').trim().toLowerCase() === 'success'
+    return normalizePlaylistFileEntry({ type, location, validated })
+  }).filter(Boolean)
+  hidden.value = JSON.stringify(entries)
+  if (emitEvents) {
+    hidden.dispatchEvent(new Event('input', { bubbles: true }))
+    hidden.dispatchEvent(new Event('change', { bubbles: true }))
+  }
+  updatePlaylistFilesAccordionState(editor)
+  return entries
+}
+
+function renderPlaylistFilesEditor (editor) {
+  if (!editor) return
+  const hidden = editor.querySelector('input[type="hidden"][name="playlist_files_entries"]')
+  const list = editor.querySelector('[data-playlist-files-list]')
+  if (!hidden || !list) return
+  updatePlaylistCustomRepoStatus(editor)
+  const entries = parsePlaylistFilesValue(hidden.value)
+  list.replaceChildren()
+  entries.forEach(entry => list.appendChild(buildPlaylistFileRow(entry)))
+  list.querySelectorAll('[data-playlist-file-row]').forEach(row => {
+    if (applyPlaylistFileDependencyState(row)) return
+    if (String(row.dataset.playlistFileState || '').trim().toLowerCase() === 'success') {
+      setPlaylistFileButtonState(row, 'success')
+    } else {
+      setPlaylistFileButtonState(row, 'idle')
+    }
+  })
+  syncPlaylistFilesEditor(editor, false)
+  updatePlaylistFilesAccordionState(editor)
+}
+
+function initPlaylistFilesEditors (scope) {
+  const root = scope || document
+  root.querySelectorAll('[data-playlist-files-editor]').forEach(editor => {
+    if (editor.dataset.playlistFilesReady === 'true') return
+    renderPlaylistFilesEditor(editor)
+    editor.dataset.playlistFilesReady = 'true'
+  })
+}
+
+document.addEventListener('click', async event => {
+  const addButton = event.target.closest('[data-add-playlist-file]')
+  if (addButton) {
+    const editor = addButton.closest('[data-playlist-files-editor]')
+    const list = editor?.querySelector('[data-playlist-files-list]')
+    if (!editor || !list) return
+    list.appendChild(buildPlaylistFileRow())
+    syncPlaylistFilesEditor(editor)
+    return
+  }
+
+  const removeButton = event.target.closest('[data-remove-playlist-file]')
+  if (removeButton) {
+    const row = removeButton.closest('[data-playlist-file-row]')
+    const editor = removeButton.closest('[data-playlist-files-editor]')
+    if (!row || !editor) return
+    row.remove()
+    syncPlaylistFilesEditor(editor)
+    return
+  }
+
+  const validateButton = event.target.closest('[data-validate-playlist-file]')
+  if (validateButton) {
+    const row = validateButton.closest('[data-playlist-file-row]')
+    const editor = validateButton.closest('[data-playlist-files-editor]')
+    if (!row || !editor) return
+    const type = row.querySelector('[data-playlist-file-type]')?.value || ''
+    const location = row.querySelector('[data-playlist-file-location]')?.value || ''
+    syncPlaylistFilesEditor(editor, false)
+    setPlaylistFileStatus(row, '', 'Validating...')
+    setPlaylistFileButtonState(row, 'loading')
+    try {
+      const response = await fetch('/validate_playlist_file', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          playlist_file_type: type,
+          playlist_file_location: location,
+          config_name: getActiveConfigName()
+        })
+      })
+      const payload = await response.json().catch(() => ({}))
+      if (!response.ok || payload.valid === false) {
+        setPlaylistFileStatus(row, 'error', payload.error_details || payload.error || 'Validation failed.')
+        return
+      }
+      applyNormalizedLibraryFileLocation(row, '[data-playlist-file-location]', payload, editor, syncPlaylistFilesEditor)
+      setPlaylistFileStatus(row, 'success', payload.message || 'Validated successfully.')
+    } catch {
+      setPlaylistFileStatus(row, 'error', 'Validation failed.')
+    }
+    syncPlaylistFilesEditor(editor)
+    return
+  }
+})
+
+document.addEventListener('input', event => {
+  const target = event.target
+  if (!target || !target.closest('[data-playlist-files-editor]')) return
+  const row = target.closest('[data-playlist-file-row]')
+  const editor = target.closest('[data-playlist-files-editor]')
+  if (row) {
+    setPlaylistFileStatus(row, '', '')
+    applyPlaylistFileDependencyState(row)
+  }
+  syncPlaylistFilesEditor(editor)
+})
+
+document.addEventListener('change', event => {
+  const target = event.target
+  if (!target || !target.closest('[data-playlist-files-editor]')) return
+  const row = target.closest('[data-playlist-file-row]')
+  const editor = target.closest('[data-playlist-files-editor]')
+  if (row) {
+    setPlaylistFileStatus(row, '', '')
+    applyPlaylistFileDependencyState(row)
+  }
+  syncPlaylistFilesEditor(editor)
+})
+
+initPlaylistFilesEditors(document)
+if (libraryContainer && typeof MutationObserver !== 'undefined') {
+  const playlistFilesObserver = new MutationObserver(() => initPlaylistFilesEditors(libraryContainer))
+  playlistFilesObserver.observe(libraryContainer, { childList: true, subtree: true })
+}
+initPlaylistKeyToggleGroups(document)
+if (libraryContainer && typeof MutationObserver !== 'undefined') {
+  const playlistKeyToggleObserver = new MutationObserver(() => initPlaylistKeyToggleGroups(libraryContainer))
+  playlistKeyToggleObserver.observe(libraryContainer, { childList: true, subtree: true })
+}
+initPlaylistUserPickers(document)
+if (libraryContainer && typeof MutationObserver !== 'undefined') {
+  const playlistUserPickerObserver = new MutationObserver(() => initPlaylistUserPickers(libraryContainer))
+  playlistUserPickerObserver.observe(libraryContainer, { childList: true, subtree: true })
 }
 
 // Ensure hidden "false" inputs don't submit alongside checked checkboxes with the same name
@@ -4339,6 +4957,9 @@ function mountCard (card, libraryId) {
   card.style.display = ''
   libraryContainer.appendChild(card)
   activeLibraryId = libraryId
+  initPlaylistKeyToggleGroups(card)
+  initPlaylistUserPickers(card)
+  initPlaylistFilesEditors(card)
   initSecretVisibilityToggles(card)
   syncHiddenCheckboxPairs(card)
   wireIncludeToggle(card, libraryId)

--- a/static/local-js/eventHandler.js
+++ b/static/local-js/eventHandler.js
@@ -1,3 +1,11 @@
+function callValidationHandler (methodName, ...args) {
+  const handler = window.ValidationHandler
+  if (!handler || typeof handler[methodName] !== 'function') {
+    return
+  }
+  return handler[methodName](...args)
+}
+
 const EventHandler = {
   attachLibraryListeners: function () {
     document.querySelectorAll('.library-checkbox').forEach((checkbox) => {
@@ -9,7 +17,7 @@ const EventHandler = {
         // Attach event listener to each checkbox
         checkbox.addEventListener('change', () => {
           EventHandler.toggleLibraryVisibility(libraryId, checkbox.checked)
-          window.ValidationHandler.updateValidationState()
+          callValidationHandler('updateValidationState')
         })
         checkbox.dataset.listenerAdded = 'true'
       }
@@ -95,7 +103,7 @@ const EventHandler = {
             select.addEventListener('change', () => {
               console.log(`[DEBUG] Dropdown changed: ${select.id} -> ${select.value}`)
               EventHandler.updateAccordionHighlights()
-              window.ValidationHandler.updateValidationState()
+              callValidationHandler('updateValidationState')
 
               // Trigger preview update if template variable
               if (select.classList.contains('template-variable-select')) {
@@ -117,7 +125,7 @@ const EventHandler = {
             // Exclude preview overlay accordions from highlight updates
             if (!input.closest('.preview-accordion')) {
               EventHandler.updateAccordionHighlights()
-              window.ValidationHandler.updateValidationState()
+              callValidationHandler('updateValidationState')
             }
           })
           input.dataset.listenerAdded = true
@@ -134,7 +142,7 @@ const EventHandler = {
 
             // Ensure Highlights Update Properly
             EventHandler.updateAccordionHighlights()
-            window.ValidationHandler.updateValidationState()
+            callValidationHandler('updateValidationState')
           })
 
           dropdown.dataset.listenerAdded = 'true'
@@ -303,9 +311,7 @@ const EventHandler = {
         if (typeof EventHandler.updateAccordionHighlights === 'function') {
           EventHandler.updateAccordionHighlights()
         }
-        if (typeof window.ValidationHandler !== 'undefined' && window.ValidationHandler.updateValidationState) {
-          window.ValidationHandler.updateValidationState()
-        }
+        callValidationHandler('updateValidationState')
       }
       library.querySelectorAll('input:not([type="hidden"]), select, textarea').forEach(el => {
         if (el.dataset.highlightListener === 'true') return
@@ -618,8 +624,8 @@ console.log('[DEBUG] Initializing EventHandler...')
 
 // Run once on page load
 EventHandler.attachLibraryListeners()
-window.ValidationHandler.restoreSelectedLibraries()
-window.ValidationHandler.updateValidationState()
+callValidationHandler('restoreSelectedLibraries')
+callValidationHandler('updateValidationState')
 installRatingSubmitGuard()
 
 document.querySelectorAll('select.template-variable-select').forEach(select => {

--- a/static/local-js/validationHandler.js
+++ b/static/local-js/validationHandler.js
@@ -283,6 +283,10 @@ const ValidationHandler = {
 
   restoreSelectedLibraries: function () {
     const libraryInput = document.getElementById('libraries')
+    if (!libraryInput) {
+      console.log('[DEBUG] Libraries field not found. Skipping library restoration.')
+      return
+    }
     if (!libraryInput.value) {
       console.log('[DEBUG] Libraries field is empty. Initializing...')
       libraryInput.value = '' // Initialize if empty

--- a/templates/partials/_library_playlist_files.html
+++ b/templates/partials/_library_playlist_files.html
@@ -1,0 +1,18 @@
+<div class="d-flex flex-column gap-3 mb-4">
+    <div class="alert alert-info small mb-0" role="alert">
+        <div>Use one or more <code>file</code>, <code>url</code>, <code>git</code>, or <code>repo</code> entries to append extra top-level <code>playlist_files</code> sources alongside the generated defaults playlist entry.</div>
+        <div class="mt-1">Local <code>file</code> entries are copied into Quickstart-managed config storage after validation, so the saved path may normalize to <code>config/&lt;config_name&gt;/playlist_files/...</code>.</div>
+    </div>
+    <div class="playlist-files-editor" data-playlist-files-editor data-library-id="{{ library.id }}">
+        <div class="alert small mb-4" role="alert" data-playlist-custom-repo-status></div>
+        <input type="hidden" name="playlist_files_entries" id="{{ library.id }}-playlist_files_entries"
+            value="{{ data['libraries'].get('playlist_files_entries', '[]') }}">
+        <div class="playlist-files-list d-flex flex-column gap-3 mt-1" data-playlist-files-list></div>
+        <div class="d-flex justify-content-between align-items-center mt-3">
+            <button type="button" class="btn btn-outline-secondary btn-sm" data-add-playlist-file>
+                <i class="bi bi-plus-circle me-1"></i>Add Playlist File
+            </button>
+            <span class="text-muted small">Supports local files, raw URLs, Community-Configs git paths, and custom_repo-backed repo paths.</span>
+        </div>
+    </div>
+</div>

--- a/templates/partials/_library_playlist_template_variables.html
+++ b/templates/partials/_library_playlist_template_variables.html
@@ -13,6 +13,15 @@ playlist-template_variables[{{ field_key }}]
 {% endif %}
 {%- endmacro %}
 
+{% macro playlist_csv_value(field_key) -%}
+{% set raw_value = data['libraries'].get(playlist_hidden_name(field_key), '') %}
+{% if raw_value is sequence and raw_value is not string %}
+{{ raw_value | join(', ') }}
+{% else %}
+{{ raw_value | default('', true) }}
+{% endif %}
+{%- endmacro %}
+
 {% macro playlist_mapping_value(field_key) -%}
 {% set raw_value = data['libraries'].get(playlist_hidden_name(field_key)) %}
 {% if raw_value is string %}
@@ -24,24 +33,8 @@ playlist-template_variables[{{ field_key }}]
 {% endif %}
 {%- endmacro %}
 
-{% macro playlist_text_input(field_key, label, placeholder, tooltip='', input_type='text', min_value=None, step_value=None) -%}
-{% set input_name = playlist_hidden_name(field_key) %}
-{% set input_id = library.id ~ '-playlist-' ~ field_key %}
-<div class="input-group mb-2" data-collection-field-wrapper="true">
-  <span class="input-group-text qs-template-variable-label" id="{{ input_id }}_text" style="width: 230px;">
-    {{ label }}
-    {% if tooltip %}
-    <span class="text-info ms-2" data-bs-toggle="tooltip" data-bs-html="true" title="{{ tooltip }}">
-      <i class="bi bi-info-circle-fill"></i>
-    </span>
-    {% endif %}
-  </span>
-  <input type="{{ input_type }}" class="form-control" id="{{ input_id }}" name="{{ input_name }}"
-    aria-describedby="{{ input_id }}_text" value="{{ data['libraries'].get(input_name, '') | default('', true) }}"
-    placeholder="{{ placeholder }}"
-    {% if min_value is not none %}min="{{ min_value }}"{% endif %}
-    {% if step_value is not none %}step="{{ step_value }}"{% endif %}>
-</div>
+{% macro playlist_text_value(field_key) -%}
+{{ data['libraries'].get(playlist_hidden_name(field_key), '') | default('', true) }}
 {%- endmacro %}
 
 {% macro playlist_toggle_input(field_key, label, tooltip='') -%}
@@ -83,6 +76,25 @@ playlist-template_variables[{{ field_key }}]
 </div>
 {%- endmacro %}
 
+{% macro playlist_text_input(field_key, label, placeholder, tooltip='', validation_preset='') -%}
+{% set input_name = playlist_hidden_name(field_key) %}
+{% set input_id = library.id ~ '-playlist-' ~ field_key %}
+<div class="mb-2">
+  <div class="input-group">
+    <span class="input-group-text qs-template-variable-label" id="{{ input_id }}_text" style="width: 230px;">
+      {{ label }}
+      {% if tooltip %}
+      <span class="text-info ms-2" data-bs-toggle="tooltip" data-bs-html="true" title="{{ tooltip }}">
+        <i class="bi bi-info-circle-fill"></i>
+      </span>
+      {% endif %}
+    </span>
+    <input type="text" class="form-control" id="{{ input_id }}" name="{{ input_name }}" aria-describedby="{{ input_id }}_text"
+      value="{{ playlist_text_value(field_key) }}" placeholder="{{ placeholder }}" {% if validation_preset %}data-validation-preset="{{ validation_preset }}"{% endif %}>
+  </div>
+</div>
+{%- endmacro %}
+
 {% macro playlist_mapping_input(field_key, label, key_placeholder, value_placeholder, tooltip='', key_validation_preset='', value_display_label='', value_kind='string') -%}
 {% set input_name = playlist_hidden_name(field_key) %}
 {% set input_id = library.id ~ '-playlist-' ~ field_key|replace('_', '-') %}
@@ -114,26 +126,85 @@ playlist-template_variables[{{ field_key }}]
 </div>
 {%- endmacro %}
 
-{% macro playlist_select_input(field_key, label, tooltip, options) -%}
+{% macro playlist_use_toggle_group(field_key, label, entries, tooltip='') -%}
 {% set input_name = playlist_hidden_name(field_key) %}
-{% set input_id = library.id ~ '-playlist-' ~ field_key %}
-{% set current_value = data['libraries'].get(input_name, '') | default('', true) %}
-<div class="input-group mb-2" data-collection-field-wrapper="true">
-  <span class="input-group-text qs-template-variable-label" id="{{ input_id }}_text" style="width: 230px;">
-    {{ label }}
+{% set input_id = library.id ~ '-playlist-' ~ field_key|replace('_', '-') %}
+<div class="mb-3" data-playlist-key-toggle-group data-hidden-input="{{ input_id }}">
+  <div class="d-flex align-items-center gap-2 mb-2">
+    <div class="text-uppercase text-muted small">{{ label }}</div>
     {% if tooltip %}
-    <span class="text-info ms-2" data-bs-toggle="tooltip" data-bs-html="true" title="{{ tooltip }}">
+    <span class="text-info" data-bs-toggle="tooltip" data-bs-html="true" title="{{ tooltip }}">
       <i class="bi bi-info-circle-fill"></i>
     </span>
     {% endif %}
-  </span>
-  <select class="form-select" id="{{ input_id }}" name="{{ input_name }}" aria-describedby="{{ input_id }}_text">
-    {% for option in options %}
-    <option value="{{ option }}" {% if option == current_value %}selected{% endif %}>
-      {{ option if option else 'Default' }}
-    </option>
+  </div>
+  <div class="row g-2">
+    {% for entry in entries %}
+    <div class="col-12 col-lg-6">
+      <label class="form-check form-switch border rounded px-3 py-2 h-100 d-flex align-items-start gap-2">
+        <input class="form-check-input mt-1" type="checkbox" data-playlist-key-toggle data-playlist-key="{{ entry.key }}">
+        <span class="d-flex flex-column">
+          <span class="fw-semibold">{{ entry.label }}</span>
+          <span class="small text-muted">{{ entry.key }}</span>
+        </span>
+      </label>
+    </div>
     {% endfor %}
-  </select>
+  </div>
+  <div class="form-text mt-2">Unchecked entries export as <code>use_&lt;&lt;key&gt;&gt;: false</code>. Checked entries use the default enabled behavior.</div>
+  <input type="hidden" id="{{ input_id }}" name="{{ input_name }}" value='{{ playlist_mapping_value(field_key) }}' data-default='{}'>
+</div>
+{%- endmacro %}
+
+{% macro playlist_user_picker(field_key, label, modal_id, input_placeholder, tooltip='', allow_all=false) -%}
+{% set input_name = playlist_hidden_name(field_key) %}
+{% set input_id = library.id ~ '-playlist-' ~ field_key %}
+<div class="mb-2" data-playlist-user-picker data-modal-id="{{ modal_id }}" data-input-id="{{ input_id }}" data-allow-all="{{ 'true' if allow_all else 'false' }}">
+  <div class="input-group">
+    <span class="input-group-text qs-template-variable-label" id="{{ input_id }}_text" style="width: 230px;">
+      {{ label }}
+      {% if tooltip %}
+      <span class="text-info ms-2" data-bs-toggle="tooltip" data-bs-html="true" title="{{ tooltip }}">
+        <i class="bi bi-info-circle-fill"></i>
+      </span>
+      {% endif %}
+    </span>
+    <input type="text" class="form-control" id="{{ input_id }}" name="{{ input_name }}" aria-describedby="{{ input_id }}_text"
+      value="{{ playlist_csv_value(field_key) }}" placeholder="{{ input_placeholder }}" readonly data-playlist-user-input>
+    <button type="button" class="btn btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#{{ modal_id }}"
+      {% if not user_list %}disabled{% endif %}>Select</button>
+  </div>
+  {% if not user_list %}
+  <div class="form-text text-warning">No Plex users detected yet. Validate Plex and refresh users on Settings first.</div>
+  {% endif %}
+
+  <div class="modal fade" id="{{ modal_id }}" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-scrollable">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">{{ label }}</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          {% if allow_all %}
+          <div class="form-check form-switch mb-2">
+            <input class="form-check-input" type="checkbox" value="all" data-playlist-user-all-toggle {% if not user_list %}disabled{% endif %}>
+            <label class="form-check-label">All Users</label>
+          </div>
+          {% endif %}
+          {% for username in user_list %}
+          <div class="form-check form-switch">
+            <input class="form-check-input" type="checkbox" value="{{ username }}" data-playlist-user-toggle {% if not user_list %}disabled{% endif %}>
+            <label class="form-check-label">{{ username }}</label>
+          </div>
+          {% endfor %}
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-primary" data-playlist-user-apply {% if not user_list %}disabled{% endif %}>Apply</button>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 {%- endmacro %}
 
@@ -143,50 +214,46 @@ playlist-template_variables[{{ field_key }}]
 
 <div class="mb-3">
   <h6 class="text-uppercase text-muted small mb-2">Shared Playlist Defaults</h6>
-  {{ playlist_select_input('style', 'Poster Style', 'Image style used by defaults that support multiple poster styles.', ['', 'color', 'white', 'bw', 'diiivoy', 'diiivoycolor', 'rainier', 'signature', 'orig', 'transparent', 'default', 'standards']) }}
-  {{ playlist_string_list_input('sync_to_users', 'Sync To Users', 'Add Plex username (or all)', 'Sets the users to sync all playlists to.') }}
-  {{ playlist_string_list_input('exclude_users', 'Exclude Users', 'Add Plex username to exclude', 'Sets the users to exclude from sync for all playlists.') }}
-  {{ playlist_text_input('minimum_items', 'Minimum Items', 'Minimum items required', 'Minimum items required for any playlist to be created.', 'number', 1, 1) }}
-  {{ playlist_text_input('hub_priority', 'Hub Priority', 'Recommendation hub priority', 'Priority position for playlist hub rows. Lower numbers appear first.', 'number', 1, 1) }}
-  {{ playlist_text_input('url_poster', 'Poster URL', 'https://example.com/poster.jpg', 'Poster URL for all playlists in this defaults file.') }}
-  {{ playlist_text_input('file_poster', 'Poster File', 'config/posters/playlist.jpg', 'Poster filepath for all playlists in this defaults file.') }}
-  {{ playlist_text_input('schedule', 'Schedule', 'daily', 'Set the schedule for all playlists in this defaults file.') }}
-  {{ playlist_text_input('limit', 'Limit', 'Maximum items', 'Maximum number of items for all playlists in this defaults file.', 'number', 1, 1) }}
+  {{ playlist_user_picker('sync_to_users', 'Sync To Users', library.id ~ '-playlist-sync-users-modal', 'Select Plex usernames', 'Sets the users to sync all playlists to.', true) }}
+  {{ playlist_user_picker('exclude_users', 'Exclude Users', library.id ~ '-playlist-exclude-users-modal', 'Select Plex usernames to exclude', 'Sets the users to exclude from sync for all playlists.') }}
+  {{ playlist_toggle_input('delete_playlist', 'Delete Playlists', 'Delete all playlists for the users defined by sync_to_users.') }}
   {{ playlist_string_list_input('ignore_ids', 'Ignore IDs', 'Add TMDb or TVDb ID', 'Set TMDb or TVDb IDs to ignore in all playlists.', 'numeric_id') }}
   {{ playlist_string_list_input('ignore_imdb_ids', 'Ignore IMDb IDs', 'Add IMDb ID (e.g. tt1234567)', 'Set IMDb IDs to ignore in all playlists.', 'imdb_id_plex') }}
+  {{ playlist_toggle_input('radarr_add_missing', 'Radarr Add Missing', 'Override Radarr add_missing for all playlists in this defaults file.') }}
+  {{ playlist_text_input('radarr_folder', 'Radarr Folder', 'Set Radarr root folder path', 'Override Radarr root_folder_path for all playlists in this defaults file.') }}
+  {{ playlist_string_list_input('radarr_tag', 'Radarr Tags', 'Add Radarr tag', 'Override Radarr tags for all playlists in this defaults file.') }}
+  {{ playlist_toggle_input('sonarr_add_missing', 'Sonarr Add Missing', 'Override Sonarr add_missing for all playlists in this defaults file.') }}
+  {{ playlist_text_input('sonarr_folder', 'Sonarr Folder', 'Set Sonarr root folder path', 'Override Sonarr root_folder_path for all playlists in this defaults file.') }}
+  {{ playlist_string_list_input('sonarr_tag', 'Sonarr Tags', 'Add Sonarr tag', 'Override Sonarr tags for all playlists in this defaults file.') }}
   {{ playlist_string_list_input('item_radarr_tag', 'Item Radarr Tags', 'Add item Radarr tag', 'Append a Radarr tag to every movie found by all playlists in this defaults file.') }}
   {{ playlist_string_list_input('item_sonarr_tag', 'Item Sonarr Tags', 'Add item Sonarr tag', 'Append a Sonarr tag to every series found by all playlists in this defaults file.') }}
-  {{ playlist_toggle_input('radarr_add_missing', 'Add Missing Items To Radarr', 'Override Radarr add_missing for all playlists in this defaults file.') }}
-  {{ playlist_text_input('radarr_folder', 'Radarr Folder', 'Enter Radarr root folder path', 'Override Radarr root_folder_path for all playlists in this defaults file.') }}
-  {{ playlist_string_list_input('radarr_tag', 'Radarr Tags', 'Add Radarr tag', 'Override Radarr tag for all playlists in this defaults file.') }}
-  {{ playlist_toggle_input('sonarr_add_missing', 'Add Missing Items To Sonarr', 'Override Sonarr add_missing for all playlists in this defaults file.') }}
-  {{ playlist_text_input('sonarr_folder', 'Sonarr Folder', 'Enter Sonarr root folder path', 'Override Sonarr root_folder_path for all playlists in this defaults file.') }}
-  {{ playlist_string_list_input('sonarr_tag', 'Sonarr Tags', 'Add Sonarr tag', 'Override Sonarr tag for all playlists in this defaults file.') }}
-  {{ playlist_toggle_input('delete_not_scheduled', 'Delete When Not Scheduled', 'Delete playlists when they are skipped because they are not scheduled.') }}
-  {{ playlist_toggle_input('delete_playlist', 'Delete Playlists', 'Delete all playlists for the users defined by sync_to_users.') }}
+  {{ playlist_string_list_input('trakt_list', 'Default Trakt Lists', 'Add Trakt list URL', 'Default Trakt list URLs used when a playlist key does not provide its own builder list.') }}
+  {{ playlist_string_list_input('imdb_list', 'Default IMDb Lists', 'Add IMDb list URL', 'Default IMDb list URLs used when a playlist key does not provide its own builder list.') }}
+  {{ playlist_string_list_input('mdblist_list', 'Default MDBList Lists', 'Add MDBList URL', 'Default MDBList URLs used when a playlist key does not provide its own builder list.') }}
 </div>
 
 <div class="mb-2">
   <h6 class="text-uppercase text-muted small mb-2">Per-Playlist Overrides</h6>
+  {% if playlist_default_entries %}
+  {{ playlist_use_toggle_group('use_', 'Playlist Toggles', playlist_default_entries, 'Turn bundled default playlists on or off by key.') }}
+  {% else %}
   {{ playlist_mapping_input('use_', 'Use Overrides', 'Playlist key (e.g. mcu)', 'true or false', 'Turn an individual playlist on or off by key.', '', 'Use override', 'string') }}
+  {% endif %}
   {{ playlist_mapping_input('name_', 'Name Overrides', 'Playlist key (e.g. mcu)', 'Custom playlist name', 'Override the playlist name for a specific key.', '', 'Custom playlist name', 'string') }}
   {{ playlist_mapping_input('summary_', 'Summary Overrides', 'Playlist key (e.g. mcu)', 'Custom playlist summary', 'Override the playlist summary for a specific key.', '', 'Custom playlist summary', 'string') }}
-  {{ playlist_mapping_input('schedule_', 'Schedule Overrides', 'Playlist key (e.g. mcu)', 'Schedule expression', 'Override the schedule for a specific playlist key.', '', 'Schedule', 'string') }}
   {{ playlist_mapping_input('url_poster_', 'Poster URL Overrides', 'Playlist key (e.g. mcu)', 'https://example.com/poster.jpg', 'Override the poster URL for a specific playlist key.', '', 'Poster URL', 'string') }}
-  {{ playlist_mapping_input('file_poster_', 'Poster File Overrides', 'Playlist key (e.g. mcu)', 'config/posters/playlist.jpg', 'Override the poster filepath for a specific playlist key.', '', 'Poster file', 'string') }}
-  {{ playlist_mapping_input('limit_', 'Limit Overrides', 'Playlist key (e.g. mcu)', 'Maximum items', 'Override the builder limit for a specific playlist key.', '', 'Limit', 'string') }}
   {{ playlist_mapping_input('delete_playlist_', 'Delete Playlist Overrides', 'Playlist key (e.g. mcu)', 'true or false', 'Delete a specific playlist for the users defined by sync_to_users.', '', 'Delete playlist', 'string') }}
   {{ playlist_mapping_input('sync_to_users_', 'Sync To Users Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated usernames', 'Override synced users for a specific playlist key.', '', 'Users', 'string_list') }}
   {{ playlist_mapping_input('exclude_users_', 'Exclude Users Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated usernames', 'Override excluded users for a specific playlist key.', '', 'Excluded users', 'string_list') }}
+  {{ playlist_mapping_input('radarr_add_missing_', 'Radarr Add Missing Overrides', 'Playlist key (e.g. mcu)', 'true or false', 'Override Radarr add_missing for a specific playlist key.', '', 'Radarr add missing', 'boolean') }}
+  {{ playlist_mapping_input('radarr_folder_', 'Radarr Folder Overrides', 'Playlist key (e.g. mcu)', 'Radarr root folder path', 'Override Radarr root_folder_path for a specific playlist key.', '', 'Radarr folder', 'string') }}
+  {{ playlist_mapping_input('radarr_tag_', 'Radarr Tag Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated Radarr tags', 'Override Radarr tags for a specific playlist key.', '', 'Radarr tags', 'string_list') }}
+  {{ playlist_mapping_input('sonarr_add_missing_', 'Sonarr Add Missing Overrides', 'Playlist key (e.g. mcu)', 'true or false', 'Override Sonarr add_missing for a specific playlist key.', '', 'Sonarr add missing', 'boolean') }}
+  {{ playlist_mapping_input('sonarr_folder_', 'Sonarr Folder Overrides', 'Playlist key (e.g. mcu)', 'Sonarr root folder path', 'Override Sonarr root_folder_path for a specific playlist key.', '', 'Sonarr folder', 'string') }}
+  {{ playlist_mapping_input('sonarr_tag_', 'Sonarr Tag Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated Sonarr tags', 'Override Sonarr tags for a specific playlist key.', '', 'Sonarr tags', 'string_list') }}
   {{ playlist_mapping_input('trakt_list_', 'Trakt List Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated Trakt list URLs', 'Override the Trakt list URLs for a specific playlist key.', '', 'Trakt URLs', 'string_list') }}
   {{ playlist_mapping_input('imdb_list_', 'IMDb List Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated IMDb list URLs', 'Override the IMDb list URLs for a specific playlist key.', '', 'IMDb URLs', 'string_list') }}
   {{ playlist_mapping_input('mdblist_list_', 'MDBList Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated MDBList URLs', 'Override the MDBList URLs for a specific playlist key.', '', 'MDBList URLs', 'string_list') }}
   {{ playlist_mapping_input('item_radarr_tag_', 'Item Radarr Tag Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated item Radarr tags', 'Override item Radarr tags for a specific playlist key.', '', 'Item Radarr tags', 'string_list') }}
   {{ playlist_mapping_input('item_sonarr_tag_', 'Item Sonarr Tag Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated item Sonarr tags', 'Override item Sonarr tags for a specific playlist key.', '', 'Item Sonarr tags', 'string_list') }}
-  {{ playlist_mapping_input('radarr_add_missing_', 'Radarr Add Missing Overrides', 'Playlist key (e.g. mcu)', 'true or false', 'Override Radarr add_missing for a specific playlist key.', '', 'Radarr add_missing', 'string') }}
-  {{ playlist_mapping_input('radarr_folder_', 'Radarr Folder Overrides', 'Playlist key (e.g. mcu)', 'Radarr root folder path', 'Override the Radarr root folder path for a specific playlist key.', '', 'Radarr folder', 'string') }}
-  {{ playlist_mapping_input('radarr_tag_', 'Radarr Tag Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated Radarr tags', 'Override Radarr tags for a specific playlist key.', '', 'Radarr tags', 'string_list') }}
-  {{ playlist_mapping_input('sonarr_add_missing_', 'Sonarr Add Missing Overrides', 'Playlist key (e.g. mcu)', 'true or false', 'Override Sonarr add_missing for a specific playlist key.', '', 'Sonarr add_missing', 'string') }}
-  {{ playlist_mapping_input('sonarr_folder_', 'Sonarr Folder Overrides', 'Playlist key (e.g. mcu)', 'Sonarr root folder path', 'Override the Sonarr root folder path for a specific playlist key.', '', 'Sonarr folder', 'string') }}
-  {{ playlist_mapping_input('sonarr_tag_', 'Sonarr Tag Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated Sonarr tags', 'Override Sonarr tags for a specific playlist key.', '', 'Sonarr tags', 'string_list') }}
 </div>

--- a/templates/partials/_library_playlist_template_variables.html
+++ b/templates/partials/_library_playlist_template_variables.html
@@ -1,0 +1,192 @@
+{% macro playlist_hidden_name(field_key) -%}
+playlist-template_variables[{{ field_key }}]
+{%- endmacro %}
+
+{% macro playlist_string_list_value(field_key) -%}
+{% set raw_value = data['libraries'].get(playlist_hidden_name(field_key)) %}
+{% if raw_value is string %}
+{{ raw_value }}
+{% elif raw_value is sequence and raw_value is not string %}
+{{ raw_value | tojson }}
+{% else %}
+[]
+{% endif %}
+{%- endmacro %}
+
+{% macro playlist_mapping_value(field_key) -%}
+{% set raw_value = data['libraries'].get(playlist_hidden_name(field_key)) %}
+{% if raw_value is string %}
+{{ raw_value }}
+{% elif raw_value is mapping %}
+{{ raw_value | tojson }}
+{% else %}
+{}
+{% endif %}
+{%- endmacro %}
+
+{% macro playlist_text_input(field_key, label, placeholder, tooltip='', input_type='text', min_value=None, step_value=None) -%}
+{% set input_name = playlist_hidden_name(field_key) %}
+{% set input_id = library.id ~ '-playlist-' ~ field_key %}
+<div class="input-group mb-2" data-collection-field-wrapper="true">
+  <span class="input-group-text qs-template-variable-label" id="{{ input_id }}_text" style="width: 230px;">
+    {{ label }}
+    {% if tooltip %}
+    <span class="text-info ms-2" data-bs-toggle="tooltip" data-bs-html="true" title="{{ tooltip }}">
+      <i class="bi bi-info-circle-fill"></i>
+    </span>
+    {% endif %}
+  </span>
+  <input type="{{ input_type }}" class="form-control" id="{{ input_id }}" name="{{ input_name }}"
+    aria-describedby="{{ input_id }}_text" value="{{ data['libraries'].get(input_name, '') | default('', true) }}"
+    placeholder="{{ placeholder }}"
+    {% if min_value is not none %}min="{{ min_value }}"{% endif %}
+    {% if step_value is not none %}step="{{ step_value }}"{% endif %}>
+</div>
+{%- endmacro %}
+
+{% macro playlist_toggle_input(field_key, label, tooltip='') -%}
+{% set input_name = playlist_hidden_name(field_key) %}
+{% set input_id = library.id ~ '-playlist-' ~ field_key %}
+{% set stored_val = data['libraries'].get(input_name) %}
+{% set is_checked = stored_val|string|lower == 'true' %}
+<div class="form-check form-switch d-flex align-items-center mb-2">
+  <input class="form-check-input template-child-toggle me-2" type="checkbox" id="{{ input_id }}"
+    name="{{ input_name }}" value="true" {% if is_checked %}checked{% endif %}>
+  <input type="hidden" name="{{ input_name }}" value="false">
+  <label class="form-check-label me-2 mb-0" for="{{ input_id }}">{{ label }}</label>
+  {% if tooltip %}
+  <i class="bi bi-info-circle-fill text-info" data-bs-toggle="tooltip" data-bs-html="true" title="{{ tooltip }}"></i>
+  {% endif %}
+</div>
+{%- endmacro %}
+
+{% macro playlist_string_list_input(field_key, label, placeholder, tooltip='', validation_preset='') -%}
+{% set input_name = playlist_hidden_name(field_key) %}
+{% set input_id = library.id ~ '-playlist-' ~ field_key %}
+<div class="mb-2" data-template-string-list data-hidden-input="{{ input_id }}">
+  <div class="input-group">
+    <span class="input-group-text qs-template-variable-label" id="{{ input_id }}_text" style="width: 230px;">
+      {{ label }}
+      {% if tooltip %}
+      <span class="text-info ms-2" data-bs-toggle="tooltip" data-bs-html="true" title="{{ tooltip }}">
+        <i class="bi bi-info-circle-fill"></i>
+      </span>
+      {% endif %}
+    </span>
+    <input type="text" class="form-control" id="{{ input_id }}_input" aria-describedby="{{ input_id }}_text"
+      placeholder="{{ placeholder }}" {% if validation_preset %}data-validation-preset="{{ validation_preset }}"{% endif %}>
+    <button class="btn nav-button" type="button" data-template-string-add>Add</button>
+  </div>
+  <div class="invalid-feedback d-none" data-template-string-feedback></div>
+  <ul class="list-group mt-2" data-template-string-items></ul>
+  <input type="hidden" id="{{ input_id }}" name="{{ input_name }}" value='{{ playlist_string_list_value(field_key) }}' data-default='[]'>
+</div>
+{%- endmacro %}
+
+{% macro playlist_mapping_input(field_key, label, key_placeholder, value_placeholder, tooltip='', key_validation_preset='', value_display_label='', value_kind='string') -%}
+{% set input_name = playlist_hidden_name(field_key) %}
+{% set input_id = library.id ~ '-playlist-' ~ field_key|replace('_', '-') %}
+<div class="mb-2" data-template-mapping-list data-hidden-input="{{ input_id }}"
+  data-library-name="{{ library.name }}"
+  data-media-type="{{ library.type }}"
+  data-key-validation-preset="{{ key_validation_preset }}"
+  data-lookup-display-mode="inline"
+  data-value-display-label="{{ value_display_label }}"
+  data-mapping-value-kind="{{ value_kind }}">
+  <div class="input-group">
+    <span class="input-group-text qs-template-variable-label" id="{{ input_id }}_text" style="width: 230px;">
+      {{ label }}
+      {% if tooltip %}
+      <span class="text-info ms-2" data-bs-toggle="tooltip" data-bs-html="true" title="{{ tooltip }}">
+        <i class="bi bi-info-circle-fill"></i>
+      </span>
+      {% endif %}
+    </span>
+    <input type="text" class="form-control" data-template-mapping-key aria-describedby="{{ input_id }}_text"
+      placeholder="{{ key_placeholder }}">
+    <input type="text" class="form-control" data-template-mapping-value aria-describedby="{{ input_id }}_text"
+      placeholder="{{ value_placeholder }}">
+    <button class="btn nav-button" type="button" data-template-mapping-add>Add</button>
+  </div>
+  <div class="invalid-feedback d-none" data-template-mapping-feedback></div>
+  <ul class="list-group mt-2" data-template-mapping-items></ul>
+  <input type="hidden" id="{{ input_id }}" name="{{ input_name }}" value='{{ playlist_mapping_value(field_key) }}' data-default='{}'>
+</div>
+{%- endmacro %}
+
+{% macro playlist_select_input(field_key, label, tooltip, options) -%}
+{% set input_name = playlist_hidden_name(field_key) %}
+{% set input_id = library.id ~ '-playlist-' ~ field_key %}
+{% set current_value = data['libraries'].get(input_name, '') | default('', true) %}
+<div class="input-group mb-2" data-collection-field-wrapper="true">
+  <span class="input-group-text qs-template-variable-label" id="{{ input_id }}_text" style="width: 230px;">
+    {{ label }}
+    {% if tooltip %}
+    <span class="text-info ms-2" data-bs-toggle="tooltip" data-bs-html="true" title="{{ tooltip }}">
+      <i class="bi bi-info-circle-fill"></i>
+    </span>
+    {% endif %}
+  </span>
+  <select class="form-select" id="{{ input_id }}" name="{{ input_name }}" aria-describedby="{{ input_id }}_text">
+    {% for option in options %}
+    <option value="{{ option }}" {% if option == current_value %}selected{% endif %}>
+      {{ option if option else 'Default' }}
+    </option>
+    {% endfor %}
+  </select>
+</div>
+{%- endmacro %}
+
+<div class="alert alert-secondary small mb-3" role="alert">
+  These playlist defaults are shared across all libraries you enable for playlists on this page.
+</div>
+
+<div class="mb-3">
+  <h6 class="text-uppercase text-muted small mb-2">Shared Playlist Defaults</h6>
+  {{ playlist_select_input('style', 'Poster Style', 'Image style used by defaults that support multiple poster styles.', ['', 'color', 'white', 'bw', 'diiivoy', 'diiivoycolor', 'rainier', 'signature', 'orig', 'transparent', 'default', 'standards']) }}
+  {{ playlist_string_list_input('sync_to_users', 'Sync To Users', 'Add Plex username (or all)', 'Sets the users to sync all playlists to.') }}
+  {{ playlist_string_list_input('exclude_users', 'Exclude Users', 'Add Plex username to exclude', 'Sets the users to exclude from sync for all playlists.') }}
+  {{ playlist_text_input('minimum_items', 'Minimum Items', 'Minimum items required', 'Minimum items required for any playlist to be created.', 'number', 1, 1) }}
+  {{ playlist_text_input('hub_priority', 'Hub Priority', 'Recommendation hub priority', 'Priority position for playlist hub rows. Lower numbers appear first.', 'number', 1, 1) }}
+  {{ playlist_text_input('url_poster', 'Poster URL', 'https://example.com/poster.jpg', 'Poster URL for all playlists in this defaults file.') }}
+  {{ playlist_text_input('file_poster', 'Poster File', 'config/posters/playlist.jpg', 'Poster filepath for all playlists in this defaults file.') }}
+  {{ playlist_text_input('schedule', 'Schedule', 'daily', 'Set the schedule for all playlists in this defaults file.') }}
+  {{ playlist_text_input('limit', 'Limit', 'Maximum items', 'Maximum number of items for all playlists in this defaults file.', 'number', 1, 1) }}
+  {{ playlist_string_list_input('ignore_ids', 'Ignore IDs', 'Add TMDb or TVDb ID', 'Set TMDb or TVDb IDs to ignore in all playlists.', 'numeric_id') }}
+  {{ playlist_string_list_input('ignore_imdb_ids', 'Ignore IMDb IDs', 'Add IMDb ID (e.g. tt1234567)', 'Set IMDb IDs to ignore in all playlists.', 'imdb_id_plex') }}
+  {{ playlist_string_list_input('item_radarr_tag', 'Item Radarr Tags', 'Add item Radarr tag', 'Append a Radarr tag to every movie found by all playlists in this defaults file.') }}
+  {{ playlist_string_list_input('item_sonarr_tag', 'Item Sonarr Tags', 'Add item Sonarr tag', 'Append a Sonarr tag to every series found by all playlists in this defaults file.') }}
+  {{ playlist_toggle_input('radarr_add_missing', 'Add Missing Items To Radarr', 'Override Radarr add_missing for all playlists in this defaults file.') }}
+  {{ playlist_text_input('radarr_folder', 'Radarr Folder', 'Enter Radarr root folder path', 'Override Radarr root_folder_path for all playlists in this defaults file.') }}
+  {{ playlist_string_list_input('radarr_tag', 'Radarr Tags', 'Add Radarr tag', 'Override Radarr tag for all playlists in this defaults file.') }}
+  {{ playlist_toggle_input('sonarr_add_missing', 'Add Missing Items To Sonarr', 'Override Sonarr add_missing for all playlists in this defaults file.') }}
+  {{ playlist_text_input('sonarr_folder', 'Sonarr Folder', 'Enter Sonarr root folder path', 'Override Sonarr root_folder_path for all playlists in this defaults file.') }}
+  {{ playlist_string_list_input('sonarr_tag', 'Sonarr Tags', 'Add Sonarr tag', 'Override Sonarr tag for all playlists in this defaults file.') }}
+  {{ playlist_toggle_input('delete_not_scheduled', 'Delete When Not Scheduled', 'Delete playlists when they are skipped because they are not scheduled.') }}
+  {{ playlist_toggle_input('delete_playlist', 'Delete Playlists', 'Delete all playlists for the users defined by sync_to_users.') }}
+</div>
+
+<div class="mb-2">
+  <h6 class="text-uppercase text-muted small mb-2">Per-Playlist Overrides</h6>
+  {{ playlist_mapping_input('use_', 'Use Overrides', 'Playlist key (e.g. mcu)', 'true or false', 'Turn an individual playlist on or off by key.', '', 'Use override', 'string') }}
+  {{ playlist_mapping_input('name_', 'Name Overrides', 'Playlist key (e.g. mcu)', 'Custom playlist name', 'Override the playlist name for a specific key.', '', 'Custom playlist name', 'string') }}
+  {{ playlist_mapping_input('summary_', 'Summary Overrides', 'Playlist key (e.g. mcu)', 'Custom playlist summary', 'Override the playlist summary for a specific key.', '', 'Custom playlist summary', 'string') }}
+  {{ playlist_mapping_input('schedule_', 'Schedule Overrides', 'Playlist key (e.g. mcu)', 'Schedule expression', 'Override the schedule for a specific playlist key.', '', 'Schedule', 'string') }}
+  {{ playlist_mapping_input('url_poster_', 'Poster URL Overrides', 'Playlist key (e.g. mcu)', 'https://example.com/poster.jpg', 'Override the poster URL for a specific playlist key.', '', 'Poster URL', 'string') }}
+  {{ playlist_mapping_input('file_poster_', 'Poster File Overrides', 'Playlist key (e.g. mcu)', 'config/posters/playlist.jpg', 'Override the poster filepath for a specific playlist key.', '', 'Poster file', 'string') }}
+  {{ playlist_mapping_input('limit_', 'Limit Overrides', 'Playlist key (e.g. mcu)', 'Maximum items', 'Override the builder limit for a specific playlist key.', '', 'Limit', 'string') }}
+  {{ playlist_mapping_input('delete_playlist_', 'Delete Playlist Overrides', 'Playlist key (e.g. mcu)', 'true or false', 'Delete a specific playlist for the users defined by sync_to_users.', '', 'Delete playlist', 'string') }}
+  {{ playlist_mapping_input('sync_to_users_', 'Sync To Users Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated usernames', 'Override synced users for a specific playlist key.', '', 'Users', 'string_list') }}
+  {{ playlist_mapping_input('exclude_users_', 'Exclude Users Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated usernames', 'Override excluded users for a specific playlist key.', '', 'Excluded users', 'string_list') }}
+  {{ playlist_mapping_input('trakt_list_', 'Trakt List Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated Trakt list URLs', 'Override the Trakt list URLs for a specific playlist key.', '', 'Trakt URLs', 'string_list') }}
+  {{ playlist_mapping_input('imdb_list_', 'IMDb List Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated IMDb list URLs', 'Override the IMDb list URLs for a specific playlist key.', '', 'IMDb URLs', 'string_list') }}
+  {{ playlist_mapping_input('mdblist_list_', 'MDBList Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated MDBList URLs', 'Override the MDBList URLs for a specific playlist key.', '', 'MDBList URLs', 'string_list') }}
+  {{ playlist_mapping_input('item_radarr_tag_', 'Item Radarr Tag Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated item Radarr tags', 'Override item Radarr tags for a specific playlist key.', '', 'Item Radarr tags', 'string_list') }}
+  {{ playlist_mapping_input('item_sonarr_tag_', 'Item Sonarr Tag Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated item Sonarr tags', 'Override item Sonarr tags for a specific playlist key.', '', 'Item Sonarr tags', 'string_list') }}
+  {{ playlist_mapping_input('radarr_add_missing_', 'Radarr Add Missing Overrides', 'Playlist key (e.g. mcu)', 'true or false', 'Override Radarr add_missing for a specific playlist key.', '', 'Radarr add_missing', 'string') }}
+  {{ playlist_mapping_input('radarr_folder_', 'Radarr Folder Overrides', 'Playlist key (e.g. mcu)', 'Radarr root folder path', 'Override the Radarr root folder path for a specific playlist key.', '', 'Radarr folder', 'string') }}
+  {{ playlist_mapping_input('radarr_tag_', 'Radarr Tag Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated Radarr tags', 'Override Radarr tags for a specific playlist key.', '', 'Radarr tags', 'string_list') }}
+  {{ playlist_mapping_input('sonarr_add_missing_', 'Sonarr Add Missing Overrides', 'Playlist key (e.g. mcu)', 'true or false', 'Override Sonarr add_missing for a specific playlist key.', '', 'Sonarr add_missing', 'string') }}
+  {{ playlist_mapping_input('sonarr_folder_', 'Sonarr Folder Overrides', 'Playlist key (e.g. mcu)', 'Sonarr root folder path', 'Override the Sonarr root folder path for a specific playlist key.', '', 'Sonarr folder', 'string') }}
+  {{ playlist_mapping_input('sonarr_tag_', 'Sonarr Tag Overrides', 'Playlist key (e.g. mcu)', 'Add comma-separated Sonarr tags', 'Override Sonarr tags for a specific playlist key.', '', 'Sonarr tags', 'string_list') }}
+</div>

--- a/templates/partials/_library_playlists.html
+++ b/templates/partials/_library_playlists.html
@@ -26,6 +26,9 @@
       <div class="form-text text-muted mt-2">
         This requires the library to also be included in YAML, but by itself it is not enough to complete the Libraries page.
       </div>
+      <div class="mt-3">
+        {% include "partials/_library_playlist_template_variables.html" %}
+      </div>
     </div>
   </div>
 </div>

--- a/templates/partials/_library_playlists.html
+++ b/templates/partials/_library_playlists.html
@@ -27,6 +27,9 @@
         This requires the library to also be included in YAML, but by itself it is not enough to complete the Libraries page.
       </div>
       <div class="mt-3">
+        {% include "partials/_library_playlist_files.html" %}
+      </div>
+      <div class="mt-3">
         {% include "partials/_library_playlist_template_variables.html" %}
       </div>
     </div>

--- a/tests/fixtures/schema/config-schema.json
+++ b/tests/fixtures/schema/config-schema.json
@@ -14137,6 +14137,16 @@
             }
           ]
         },
+        "^exclude_users_.+$": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
         "^imdb_list_.+$": {},
         "^item_radarr_tag_.+$": {
           "oneOf": [

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -2298,6 +2298,32 @@ def test_runtime_config_schema_accepts_franchise_build_collection_and_title_over
     assert errors == []
 
 
+def test_runtime_config_schema_accepts_playlist_exclude_users_keyed_override(isolated_config_dir):
+    import json
+
+    import jsonschema
+
+    schema_path = isolated_config_dir / ".schema" / "config-schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    sample = {
+        "plex": {"url": "http://example", "token": "x"},
+        "tmdb": {"apikey": "x"},
+        "playlist_files": [
+            {
+                "default": "playlist",
+                "template_variables": {
+                    "libraries": ["Movies"],
+                    "exclude_users_mcu": ["guest"],
+                },
+            }
+        ],
+    }
+
+    errors = sorted(jsonschema.Draft7Validator(schema).iter_errors(sample), key=lambda err: list(err.path))
+
+    assert errors == []
+
+
 def test_build_libraries_section_emits_collection_hub_priority(app):
     from modules import output
 

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -352,6 +352,19 @@ def test_validate_overlay_file_accepts_existing_local_file(client, tmp_path):
     assert payload["valid"] is True
 
 
+def test_validate_playlist_file_accepts_existing_local_file(client, tmp_path):
+    playlist_file = tmp_path / "playlists.yml"
+    playlist_file.write_text("playlists:\n  test:\n    trakt_list:\n      - https://trakt.tv/users/example/lists/test\n", encoding="utf-8")
+
+    resp = client.post(
+        "/validate_playlist_file",
+        json={"playlist_file_type": "file", "playlist_file_location": str(playlist_file)},
+    )
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["valid"] is True
+
+
 def test_validate_metadata_file_organizes_local_file_into_managed_store(client, isolated_config_dir, tmp_path):
     from pathlib import Path
 
@@ -1591,6 +1604,17 @@ def test_validate_collection_file_rejects_repo_without_custom_repo(client):
     payload = resp.get_json()
     assert payload["valid"] is False
     assert payload["error"] == "Collection file repo entries require Custom Repo to be configured and saved first within the Settings page."
+
+
+def test_validate_playlist_file_rejects_repo_without_custom_repo(client):
+    resp = client.post(
+        "/validate_playlist_file",
+        json={"playlist_file_type": "repo", "playlist_file_location": "bullmoose20/playlists.yml"},
+    )
+    assert resp.status_code == 400
+    payload = resp.get_json()
+    assert payload["valid"] is False
+    assert payload["error"] == "Playlist file repo entries require Custom Repo to be configured and saved first within the Settings page."
 
 
 def test_validate_metadata_file_rejects_repo_without_custom_repo(client):

--- a/tests/test_importer_edge_cases.py
+++ b/tests/test_importer_edge_cases.py
@@ -1,3 +1,5 @@
+import json
+
 from modules import importer
 
 
@@ -34,6 +36,39 @@ def test_prepare_import_payload_maps_playlist_files_to_library_toggles():
     assert libraries["mov-library_movies-playlist"] == "true"
     assert "playlist_files" not in payload
     assert any("libraries.Movies.playlist_files" in line for line in report.lines)
+
+
+def test_prepare_import_payload_maps_playlist_template_variables_into_libraries_payload():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {"Movies": {}},
+            "playlist_files": [
+                {
+                    "default": "playlist",
+                    "template_variables": {
+                        "libraries": ["Movies"],
+                        "sync_to_users": ["alice", "bob"],
+                        "radarr_add_missing": True,
+                        "name_mcu": "Marvel Timeline",
+                        "delete_playlist_mcu": True,
+                        "trakt_list_mcu": ["https://trakt.tv/users/example/lists/mcu"],
+                    },
+                }
+            ],
+        },
+        {"Movies"},
+        set(),
+    )
+
+    libraries = payload["libraries"]["libraries"]
+    assert libraries["mov-library_movies-library"] == "Movies"
+    assert libraries["mov-library_movies-playlist"] == "true"
+    assert json.loads(libraries["playlist-template_variables[sync_to_users]"]) == ["alice", "bob"]
+    assert libraries["playlist-template_variables[radarr_add_missing]"] is True
+    assert json.loads(libraries["playlist-template_variables[name_]"]) == {"mcu": "Marvel Timeline"}
+    assert json.loads(libraries["playlist-template_variables[delete_playlist_]"]) == {"mcu": "true"}
+    assert json.loads(libraries["playlist-template_variables[trakt_list_]"]) == {"mcu": ["https://trakt.tv/users/example/lists/mcu"]}
+    assert any("playlist_files[0].template_variables.name_mcu" in line for line in report.lines)
 
 
 def test_annotate_yaml_with_report_unmapped_reason():

--- a/tests/test_importer_edge_cases.py
+++ b/tests/test_importer_edge_cases.py
@@ -48,9 +48,22 @@ def test_prepare_import_payload_maps_playlist_template_variables_into_libraries_
                     "template_variables": {
                         "libraries": ["Movies"],
                         "sync_to_users": ["alice", "bob"],
+                        "delete_playlist": True,
                         "radarr_add_missing": True,
+                        "radarr_folder": "/data/media/movies",
+                        "radarr_tag": ["playlist-default"],
+                        "sonarr_add_missing": False,
+                        "sonarr_folder": "/data/media/shows",
+                        "sonarr_tag": ["playlist-show"],
+                        "trakt_list": ["https://trakt.tv/users/example/lists/default"],
                         "name_mcu": "Marvel Timeline",
                         "delete_playlist_mcu": True,
+                        "radarr_add_missing_mcu": True,
+                        "radarr_folder_mcu": "/data/media/movies/mcu",
+                        "radarr_tag_mcu": ["mcu", "timeline"],
+                        "sonarr_add_missing_mcu": False,
+                        "sonarr_folder_mcu": "/data/media/shows/mcu",
+                        "sonarr_tag_mcu": ["mcu-show"],
                         "trakt_list_mcu": ["https://trakt.tv/users/example/lists/mcu"],
                     },
                 }
@@ -63,12 +76,55 @@ def test_prepare_import_payload_maps_playlist_template_variables_into_libraries_
     libraries = payload["libraries"]["libraries"]
     assert libraries["mov-library_movies-library"] == "Movies"
     assert libraries["mov-library_movies-playlist"] == "true"
-    assert json.loads(libraries["playlist-template_variables[sync_to_users]"]) == ["alice", "bob"]
+    assert libraries["playlist-template_variables[sync_to_users]"] == "alice, bob"
+    assert libraries["playlist-template_variables[delete_playlist]"] is True
     assert libraries["playlist-template_variables[radarr_add_missing]"] is True
+    assert libraries["playlist-template_variables[radarr_folder]"] == "/data/media/movies"
+    assert json.loads(libraries["playlist-template_variables[radarr_tag]"]) == ["playlist-default"]
+    assert libraries["playlist-template_variables[sonarr_add_missing]"] is False
+    assert libraries["playlist-template_variables[sonarr_folder]"] == "/data/media/shows"
+    assert json.loads(libraries["playlist-template_variables[sonarr_tag]"]) == ["playlist-show"]
+    assert json.loads(libraries["playlist-template_variables[trakt_list]"]) == ["https://trakt.tv/users/example/lists/default"]
     assert json.loads(libraries["playlist-template_variables[name_]"]) == {"mcu": "Marvel Timeline"}
     assert json.loads(libraries["playlist-template_variables[delete_playlist_]"]) == {"mcu": "true"}
+    assert json.loads(libraries["playlist-template_variables[radarr_add_missing_]"]) == {"mcu": "true"}
+    assert json.loads(libraries["playlist-template_variables[radarr_folder_]"]) == {"mcu": "/data/media/movies/mcu"}
+    assert json.loads(libraries["playlist-template_variables[radarr_tag_]"]) == {"mcu": ["mcu", "timeline"]}
+    assert json.loads(libraries["playlist-template_variables[sonarr_add_missing_]"]) == {"mcu": "false"}
+    assert json.loads(libraries["playlist-template_variables[sonarr_folder_]"]) == {"mcu": "/data/media/shows/mcu"}
+    assert json.loads(libraries["playlist-template_variables[sonarr_tag_]"]) == {"mcu": ["mcu-show"]}
     assert json.loads(libraries["playlist-template_variables[trakt_list_]"]) == {"mcu": ["https://trakt.tv/users/example/lists/mcu"]}
     assert any("playlist_files[0].template_variables.name_mcu" in line for line in report.lines)
+
+
+def test_prepare_import_payload_maps_direct_playlist_file_entries_into_libraries_payload():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {"Movies": {}},
+            "playlist_files": [
+                {
+                    "default": "playlist",
+                    "template_variables": {"libraries": ["Movies"]},
+                },
+                {
+                    "file": "config/extra_playlists.yml",
+                },
+                {
+                    "repo": "bullmoose20/playlists.yml",
+                },
+            ],
+        },
+        {"Movies"},
+        set(),
+    )
+
+    libraries = payload["libraries"]["libraries"]
+    assert json.loads(libraries["playlist_files_entries"]) == [
+        {"type": "file", "location": "config/extra_playlists.yml"},
+        {"type": "repo", "location": "bullmoose20/playlists.yml"},
+    ]
+    assert any("playlist_files[1].file" in line for line in report.lines)
+    assert any("playlist_files[2].repo" in line for line in report.lines)
 
 
 def test_annotate_yaml_with_report_unmapped_reason():

--- a/tests/test_ratings_yaml_contract.py
+++ b/tests/test_ratings_yaml_contract.py
@@ -231,3 +231,38 @@ def test_playlist_files_follow_library_output_order(monkeypatch, qs_module):
 
     assert library_order == ["A Movies", "B Movies", "Z Shows"]
     assert playlist_order == library_order
+
+
+def test_playlist_files_emit_shared_and_keyed_template_variables(monkeypatch, qs_module):
+    payload = {
+        "validated": True,
+        "libraries": {
+            "mov-library_movies-library": "Movies",
+            "mov-library_movies-playlist": "true",
+            "mov-library_movies-collection_collectionless": True,
+            "sho-library_shows-library": "Shows",
+            "sho-library_shows-playlist": "true",
+            "sho-library_shows-collection_collectionless": True,
+            "playlist-template_variables[style]": "rainier",
+            "playlist-template_variables[sync_to_users]": '["alice", "bob"]',
+            "playlist-template_variables[radarr_add_missing]": True,
+            "playlist-template_variables[sonarr_add_missing]": True,
+            "playlist-template_variables[name_]": '{"mcu": "Marvel Timeline"}',
+            "playlist-template_variables[delete_playlist_]": '{"mcu": "true"}',
+            "playlist-template_variables[trakt_list_]": '{"mcu": ["https://trakt.tv/users/example/lists/mcu"]}',
+            "playlist-template_variables[exclude_users_]": '{"mcu": ["guest"]}',
+        },
+    }
+
+    parsed = _parsed_yaml(_run_build_config_with_payload(qs_module, monkeypatch, payload))
+    template_vars = parsed["playlist_files"][0]["template_variables"]
+
+    assert template_vars["libraries"] == ["Movies", "Shows"]
+    assert template_vars["style"] == "rainier"
+    assert template_vars["sync_to_users"] == ["alice", "bob"]
+    assert template_vars["radarr_add_missing"] is True
+    assert template_vars["sonarr_add_missing"] is True
+    assert template_vars["name_mcu"] == "Marvel Timeline"
+    assert template_vars["delete_playlist_mcu"] is True
+    assert template_vars["trakt_list_mcu"] == "https://trakt.tv/users/example/lists/mcu"
+    assert template_vars["exclude_users_mcu"] == "guest"

--- a/tests/test_ratings_yaml_contract.py
+++ b/tests/test_ratings_yaml_contract.py
@@ -243,12 +243,23 @@ def test_playlist_files_emit_shared_and_keyed_template_variables(monkeypatch, qs
             "sho-library_shows-library": "Shows",
             "sho-library_shows-playlist": "true",
             "sho-library_shows-collection_collectionless": True,
-            "playlist-template_variables[style]": "rainier",
             "playlist-template_variables[sync_to_users]": '["alice", "bob"]',
+            "playlist-template_variables[delete_playlist]": True,
             "playlist-template_variables[radarr_add_missing]": True,
-            "playlist-template_variables[sonarr_add_missing]": True,
+            "playlist-template_variables[radarr_folder]": "/data/media/movies",
+            "playlist-template_variables[radarr_tag]": '["playlist-default"]',
+            "playlist-template_variables[sonarr_add_missing]": False,
+            "playlist-template_variables[sonarr_folder]": "/data/media/shows",
+            "playlist-template_variables[sonarr_tag]": '["playlist-show"]',
+            "playlist-template_variables[trakt_list]": '["https://trakt.tv/users/example/lists/default"]',
             "playlist-template_variables[name_]": '{"mcu": "Marvel Timeline"}',
             "playlist-template_variables[delete_playlist_]": '{"mcu": "true"}',
+            "playlist-template_variables[radarr_add_missing_]": '{"mcu": "true"}',
+            "playlist-template_variables[radarr_folder_]": '{"mcu": "/data/media/movies/mcu"}',
+            "playlist-template_variables[radarr_tag_]": '{"mcu": ["mcu", "timeline"]}',
+            "playlist-template_variables[sonarr_add_missing_]": '{"mcu": "false"}',
+            "playlist-template_variables[sonarr_folder_]": '{"mcu": "/data/media/shows/mcu"}',
+            "playlist-template_variables[sonarr_tag_]": '{"mcu": ["mcu-show"]}',
             "playlist-template_variables[trakt_list_]": '{"mcu": ["https://trakt.tv/users/example/lists/mcu"]}',
             "playlist-template_variables[exclude_users_]": '{"mcu": ["guest"]}',
         },
@@ -258,11 +269,39 @@ def test_playlist_files_emit_shared_and_keyed_template_variables(monkeypatch, qs
     template_vars = parsed["playlist_files"][0]["template_variables"]
 
     assert template_vars["libraries"] == ["Movies", "Shows"]
-    assert template_vars["style"] == "rainier"
     assert template_vars["sync_to_users"] == ["alice", "bob"]
+    assert template_vars["delete_playlist"] is True
     assert template_vars["radarr_add_missing"] is True
-    assert template_vars["sonarr_add_missing"] is True
+    assert template_vars["radarr_folder"] == "/data/media/movies"
+    assert template_vars["radarr_tag"] == "playlist-default"
+    assert template_vars["sonarr_add_missing"] is False
+    assert template_vars["sonarr_folder"] == "/data/media/shows"
+    assert template_vars["sonarr_tag"] == "playlist-show"
+    assert template_vars["trakt_list"] == "https://trakt.tv/users/example/lists/default"
     assert template_vars["name_mcu"] == "Marvel Timeline"
     assert template_vars["delete_playlist_mcu"] is True
+    assert template_vars["radarr_add_missing_mcu"] is True
+    assert template_vars["radarr_folder_mcu"] == "/data/media/movies/mcu"
+    assert template_vars["radarr_tag_mcu"] == ["mcu", "timeline"]
+    assert template_vars["sonarr_add_missing_mcu"] is False
+    assert template_vars["sonarr_folder_mcu"] == "/data/media/shows/mcu"
+    assert template_vars["sonarr_tag_mcu"] == "mcu-show"
     assert template_vars["trakt_list_mcu"] == "https://trakt.tv/users/example/lists/mcu"
     assert template_vars["exclude_users_mcu"] == "guest"
+
+
+def test_playlist_files_emit_direct_file_and_repo_entries(monkeypatch, qs_module):
+    payload = {
+        "validated": True,
+        "libraries": {
+            "mov-library_movies-library": "Movies",
+            "mov-library_movies-playlist": "true",
+            "mov-library_movies-collection_collectionless": True,
+            "playlist_files_entries": '[{"type":"file","location":"config/extra_playlists.yml"},{"type":"repo","location":"bullmoose20/playlists.yml"}]',
+        },
+    }
+
+    parsed = _parsed_yaml(_run_build_config_with_payload(qs_module, monkeypatch, payload))
+
+    assert parsed["playlist_files"][1] == {"file": "config/extra_playlists.yml"}
+    assert parsed["playlist_files"][2] == {"repo": "bullmoose20/playlists.yml"}


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

## Summary

Align Quickstart playlist support with the bundled Kometa playlist defaults and improve the Libraries page UX around playlist configuration.

## What changed

- Added missing playlist ARR template variable support on the Libraries page:
  - `radarr_add_missing`
  - `radarr_folder`
  - `radarr_tag`
  - `sonarr_add_missing`
  - `sonarr_folder`
  - `sonarr_tag`
  - plus keyed `_<key>` variants
- Kept existing playlist support for:
  - `use_<<key>>`
  - `name_<<key>>`
  - `summary_<<key>>`
  - `url_poster_<<key>>`
  - sync/exclude users
  - default builder lists
  - item Radarr/Sonarr tags
- Added shared playlist file source support on the Libraries page for direct `playlist_files` entries:
  - `file`
  - `url`
  - `git`
  - `repo`
- Added playlist file validation/normalization flow so those entries can be validated before final config generation.
- Fixed playlist import/export handling so supported playlist template variables round-trip correctly through Quickstart.
- Fixed emitted YAML so direct playlist file entries are preserved instead of being dropped.
- Replaced the generic playlist `use_<<key>>` key/value row with real visible toggles for the bundled default playlist keys.
- Populated those toggles from the bundled `config/kometa/defaults/playlist.yml` source of truth.
- Hardened Libraries-page JS init so `eventHandler.js` no longer crashes if `ValidationHandler` is not yet attached to `window`.
- Added a guard in `restoreSelectedLibraries()` when the `#libraries` field is absent.

## Why

The playlist docs and runtime support are broader than `playlist.yml` alone implies because the default playlist file also includes the shared `arr` template. Quickstart was missing those playlist ARR fields in the UI/import/export path, and `use_<<key>>` was technically supported but not exposed as user-friendly toggles.

## Notes

- `config-schema.json` was not changed in this pass because the playlist schema already covers these playlist ARR fields.
- The playlist toggle UI is now driven from the bundled default playlist file, so users see actual playlist keys instead of having to type them manually.

## Testing

- `venv\Scripts\python.exe -m pytest tests\test_importer_edge_cases.py -q`
- `venv\Scripts\python.exe -m pytest tests\test_ratings_yaml_contract.py -q`
- `venv\Scripts\python.exe -m pytest tests\test_core_backend.py -q -k "playlist_file or playlist_files or validate_playlist_file or exclude_users_keyed_override"`

## Follow-up

- JS lint was not used as a gate for this PR because `static/local-js/025-libraries.js` already has many pre-existing lint issues unrelated to this change.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
