### PR TITLE
Rename modules/helpers/_legacy.py to _constants.py

### DIFF
--- a/modules/helpers/__init__.py
+++ b/modules/helpers/__init__.py
@@ -8,8 +8,8 @@ via ``from modules import helpers``.  Submodules are loaded on demand;
 
 from __future__ import annotations
 
-# Import everything from the legacy module first (backward compat).
-from ._legacy import *  # noqa: F403
+# Foundational constants (paths, TTLs, cache dicts, extension sets).
+from ._constants import *  # noqa: F403
 
 # Private helpers used by tests and other modules.
 from ._zip_update import (  # noqa: F401

--- a/modules/helpers/_artifacts.py
+++ b/modules/helpers/_artifacts.py
@@ -1,4 +1,4 @@
-"""Config artifact management utilities extracted from _legacy.py."""
+"""Config artifact management utilities extracted from the original helpers.py monolith."""
 
 import datetime
 import re
@@ -6,7 +6,7 @@ import shutil
 
 from pathlib import Path
 
-from modules.helpers._legacy import CONFIG_DIR
+from modules.helpers._constants import CONFIG_DIR
 
 MANAGED_LIBRARY_FILE_DIRS = ("metadata_files", "collection_files", "overlay_files")
 MANAGED_OVERLAY_IMAGE_DIR = "overlay_images"

--- a/modules/helpers/_cli.py
+++ b/modules/helpers/_cli.py
@@ -1,4 +1,4 @@
-"""CLI argument normalization utilities extracted from _legacy.py."""
+"""CLI argument normalization utilities extracted from the original helpers.py monolith."""
 
 
 def _unwrap_doublewrap(s: str) -> str:

--- a/modules/helpers/_constants.py
+++ b/modules/helpers/_constants.py
@@ -1,3 +1,22 @@
+"""Foundational constants shared across the helpers package.
+
+Owns the small pieces of shared state that many submodules read at
+import time:
+
+- Filesystem layout: ``BASE_DIR``, ``WORKING_DIR``, ``MEIPASS_DIR``,
+  ``CONFIG_DIR``, ``JSON_SETTINGS``, ``VERSION_FILE``, ``BUILDNUM_FILE``,
+  ``RESTART_NOTICE_FILE``
+- Upstream URLs: ``GITHUB_BASE_URL``, ``IMAGEMAID_GITHUB_BASE_URL``
+- Redaction hint: ``STRING_FIELDS``
+- File type sets: ``ALLOWED_EXTENSIONS``, ``FONT_EXTENSIONS``
+- Update-cache TTLs and in-memory dicts for Quickstart, Kometa, and ImageMaid
+- Branch-override sets: ``KOMETA_BRANCH_OVERRIDES``, ``IMAGEMAID_BRANCH_OVERRIDES``
+
+Historically named ``_legacy.py`` — this module was the last surviving
+chunk of the original monolithic ``helpers.py``. All functions have been
+extracted into dedicated submodules; what remains here is pure constants.
+"""
+
 import os
 import sys
 

--- a/modules/helpers/_file_utils.py
+++ b/modules/helpers/_file_utils.py
@@ -1,4 +1,4 @@
-"""File utility functions extracted from _legacy.py."""
+"""File utility functions extracted from the original helpers.py monolith."""
 
 import re
 

--- a/modules/helpers/_fonts.py
+++ b/modules/helpers/_fonts.py
@@ -1,4 +1,4 @@
-"""Font management utilities extracted from _legacy.py."""
+"""Font management utilities extracted from the original helpers.py monolith."""
 
 import os
 import shutil
@@ -6,7 +6,7 @@ import sys
 
 from pathlib import Path
 
-from modules.helpers._legacy import CONFIG_DIR, FONT_EXTENSIONS, MEIPASS_DIR, BASE_DIR, WORKING_DIR
+from modules.helpers._constants import CONFIG_DIR, FONT_EXTENSIONS, MEIPASS_DIR, BASE_DIR, WORKING_DIR
 
 
 def get_pyfiglet_fonts():

--- a/modules/helpers/_forms.py
+++ b/modules/helpers/_forms.py
@@ -1,6 +1,6 @@
-"""Form-building utilities extracted from _legacy.py."""
+"""Form-building utilities extracted from the original helpers.py monolith."""
 
-from modules.helpers._legacy import STRING_FIELDS
+from modules.helpers._constants import STRING_FIELDS
 
 
 def enforce_string_fields(data, enforce=False):

--- a/modules/helpers/_git.py
+++ b/modules/helpers/_git.py
@@ -1,4 +1,4 @@
-"""Git branch detection utility extracted from _legacy.py."""
+"""Git branch detection utility extracted from the original helpers.py monolith."""
 
 import shutil
 import subprocess

--- a/modules/helpers/_install_mode.py
+++ b/modules/helpers/_install_mode.py
@@ -1,4 +1,4 @@
-"""Kometa install mode utilities extracted from _legacy.py."""
+"""Kometa install mode utilities extracted from the original helpers.py monolith."""
 
 import os
 
@@ -8,7 +8,7 @@ from flask import current_app as app
 from flask import has_app_context, has_request_context, session
 
 from modules import persistence
-from modules.helpers._legacy import CONFIG_DIR
+from modules.helpers._constants import CONFIG_DIR
 
 
 def _managed_kometa_root_default() -> Path:

--- a/modules/helpers/_kometa_paths.py
+++ b/modules/helpers/_kometa_paths.py
@@ -1,4 +1,4 @@
-"""Install-mode-aware Kometa path resolvers — extracted from _legacy.py.
+"""Install-mode-aware Kometa path resolvers — extracted from the original helpers.py monolith.
 
 Resolve Kometa's on-disk locations, honoring:
 

--- a/modules/helpers/_kometa_version.py
+++ b/modules/helpers/_kometa_version.py
@@ -1,4 +1,4 @@
-"""Kometa and ImageMaid version/update check utilities extracted from _legacy.py."""
+"""Kometa and ImageMaid version/update check utilities extracted from the original helpers.py monolith."""
 
 import os
 
@@ -7,7 +7,7 @@ from pathlib import Path
 from flask import current_app as app
 from flask import has_app_context, has_request_context, session
 
-from modules.helpers._legacy import CONFIG_DIR, IMAGEMAID_GITHUB_BASE_URL
+from modules.helpers._constants import CONFIG_DIR, IMAGEMAID_GITHUB_BASE_URL
 from modules.helpers._zip_update import IMAGEMAID_GITHUB_API_BRANCH
 
 

--- a/modules/helpers/_logging.py
+++ b/modules/helpers/_logging.py
@@ -1,4 +1,4 @@
-"""Log rotation, initialization, and timestamped logging extracted from _legacy.py.
+"""Log rotation, initialization, and timestamped logging extracted from the original helpers.py monolith.
 
 Contains the core write-to-file logging plumbing used by the entire Quickstart
 codebase via ``helpers.ts_log()``. The output includes stderr-safe console

--- a/modules/helpers/_misc.py
+++ b/modules/helpers/_misc.py
@@ -1,4 +1,4 @@
-"""Miscellaneous utility functions extracted from _legacy.py."""
+"""Miscellaneous utility functions extracted from the original helpers.py monolith."""
 
 import re
 

--- a/modules/helpers/_named_config.py
+++ b/modules/helpers/_named_config.py
@@ -1,6 +1,6 @@
 """Persist a generated YAML config under a named identity.
 
-Extracted from _legacy.py. Handles:
+Extracted from the original helpers.py monolith. Handles:
 
 - Archiving previous versions (with optional history-limit pruning)
 - Writing to both the Quickstart-owned config dir and the Kometa-owned one
@@ -15,7 +15,7 @@ from pathlib import Path
 from flask import current_app as app
 
 from modules.helpers._kometa_paths import get_kometa_config_dir, get_kometa_root_path
-from modules.helpers._legacy import CONFIG_DIR
+from modules.helpers._constants import CONFIG_DIR
 from modules.helpers._logging import ts_log
 
 

--- a/modules/helpers/_os.py
+++ b/modules/helpers/_os.py
@@ -1,4 +1,4 @@
-"""OS detection utility extracted from _legacy.py."""
+"""OS detection utility extracted from the original helpers.py monolith."""
 
 import os
 import platform

--- a/modules/helpers/_overlays.py
+++ b/modules/helpers/_overlays.py
@@ -1,11 +1,11 @@
-"""Overlay configuration enrichment utilities extracted from _legacy.py."""
+"""Overlay configuration enrichment utilities extracted from the original helpers.py monolith."""
 
 import copy
 import json
 import os
 import re
 
-from modules.helpers._legacy import JSON_SETTINGS
+from modules.helpers._constants import JSON_SETTINGS
 
 
 def load_quickstart_config(filename: str):

--- a/modules/helpers/_pid.py
+++ b/modules/helpers/_pid.py
@@ -1,11 +1,11 @@
-"""Process ID and runtime state utilities extracted from _legacy.py."""
+"""Process ID and runtime state utilities extracted from the original helpers.py monolith."""
 
 import os
 import stat
 
 import psutil
 
-from modules.helpers._legacy import CONFIG_DIR
+from modules.helpers._constants import CONFIG_DIR
 
 
 def get_app_root():

--- a/modules/helpers/_plex.py
+++ b/modules/helpers/_plex.py
@@ -1,4 +1,4 @@
-"""Plex query and metadata helpers extracted from _legacy.py.
+"""Plex query and metadata helpers extracted from the original helpers.py monolith.
 
 Wraps plexapi for read-only operations against the user's Plex server:
 top-N IMDb picks, library summaries, per-library metadata, and item lookups

--- a/modules/helpers/_plex_cache.py
+++ b/modules/helpers/_plex_cache.py
@@ -1,10 +1,10 @@
-"""Plex discovery cache utilities extracted from _legacy.py."""
+"""Plex discovery cache utilities extracted from the original helpers.py monolith."""
 
 import copy
 import hashlib
 import time
 
-from modules.helpers._legacy import PLEX_DISCOVERY_CACHE_TTL_SECONDS
+from modules.helpers._constants import PLEX_DISCOVERY_CACHE_TTL_SECONDS
 
 _PLEX_DISCOVERY_CACHE: dict = {}
 

--- a/modules/helpers/_qs_update.py
+++ b/modules/helpers/_qs_update.py
@@ -1,4 +1,4 @@
-"""Quickstart version and update detection utilities extracted from _legacy.py."""
+"""Quickstart version and update detection utilities extracted from the original helpers.py monolith."""
 
 import copy
 import os
@@ -8,7 +8,7 @@ import time
 
 from pathlib import Path
 
-from modules.helpers._legacy import BUILDNUM_FILE, QS_UPDATE_CACHE_TTL_SECONDS, VERSION_FILE, _QS_UPDATE_CACHE
+from modules.helpers._constants import BUILDNUM_FILE, QS_UPDATE_CACHE_TTL_SECONDS, VERSION_FILE, _QS_UPDATE_CACHE
 
 
 def get_kometa_branch():

--- a/modules/helpers/_redact.py
+++ b/modules/helpers/_redact.py
@@ -1,4 +1,4 @@
-"""Data redaction utility extracted from _legacy.py."""
+"""Data redaction utility extracted from the original helpers.py monolith."""
 
 import re
 

--- a/modules/helpers/_restart.py
+++ b/modules/helpers/_restart.py
@@ -1,10 +1,10 @@
-"""Restart notice and environment variable utilities extracted from _legacy.py."""
+"""Restart notice and environment variable utilities extracted from the original helpers.py monolith."""
 
 import datetime
 import json
 import os
 
-from modules.helpers._legacy import CONFIG_DIR, RESTART_NOTICE_FILE
+from modules.helpers._constants import CONFIG_DIR, RESTART_NOTICE_FILE
 from modules.helpers._logging import ts_log
 
 

--- a/modules/helpers/_schema.py
+++ b/modules/helpers/_schema.py
@@ -1,4 +1,4 @@
-"""Schema/hash utilities and json-schema sync — extracted from _legacy.py.
+"""Schema/hash utilities and json-schema sync — extracted from the original helpers.py monolith.
 
 Owns the on-disk JSON-schema mirror under ``config/.schema/``:
 
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import requests
 
-from modules.helpers._legacy import ALLOWED_EXTENSIONS, CONFIG_DIR, GITHUB_BASE_URL
+from modules.helpers._constants import ALLOWED_EXTENSIONS, CONFIG_DIR, GITHUB_BASE_URL
 from modules.helpers._logging import ts_log
 
 JSON_SCHEMA_DIR = os.path.join(CONFIG_DIR, ".schema")

--- a/modules/helpers/_settings.py
+++ b/modules/helpers/_settings.py
@@ -1,4 +1,4 @@
-"""Quickstart settings utilities extracted from _legacy.py."""
+"""Quickstart settings utilities extracted from the original helpers.py monolith."""
 
 import os
 

--- a/modules/helpers/_templates.py
+++ b/modules/helpers/_templates.py
@@ -1,4 +1,4 @@
-"""Template file listing and menu utilities extracted from _legacy.py."""
+"""Template file listing and menu utilities extracted from the original helpers.py monolith."""
 
 import os
 import re

--- a/modules/helpers/_update_cache.py
+++ b/modules/helpers/_update_cache.py
@@ -1,11 +1,11 @@
-"""Kometa and ImageMaid update caching utilities extracted from _legacy.py."""
+"""Kometa and ImageMaid update caching utilities extracted from the original helpers.py monolith."""
 
 import copy
 import time
 
 from pathlib import Path
 
-from modules.helpers._legacy import (
+from modules.helpers._constants import (
     IMAGEMAID_BRANCH_OVERRIDES,
     IMAGEMAID_UPDATE_CACHE_TTL_SECONDS,
     KOMETA_BRANCH_OVERRIDES,

--- a/modules/helpers/_version.py
+++ b/modules/helpers/_version.py
@@ -1,4 +1,4 @@
-"""Version/branch detection utilities extracted from _legacy.py."""
+"""Version/branch detection utilities extracted from the original helpers.py monolith."""
 
 import os
 

--- a/modules/helpers/_zip_update.py
+++ b/modules/helpers/_zip_update.py
@@ -1,4 +1,4 @@
-"""Kometa/ImageMaid ZIP-based update primitives extracted from _legacy.py.
+"""Kometa/ImageMaid ZIP-based update primitives extracted from the original helpers.py monolith.
 
 Small, composable helpers used by the ``perform_kometa_update_zip_only``,
 ``perform_kometa_update_zip_only_at_root`` and ``perform_imagemaid_update_zip_only``
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import requests
 
-from modules.helpers._legacy import CONFIG_DIR
+from modules.helpers._constants import CONFIG_DIR
 
 GITHUB_API_BRANCH = "https://api.github.com/repos/kometa-team/Kometa/branches/{branch}"
 GITHUB_ZIP_URL = "https://codeload.github.com/kometa-team/Kometa/zip/refs/heads/{branch}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ def _load_app(config_dir, kometa_root):
 
     _seed_schema_files(config_dir)
     # NOTE: After helpers.py was decomposed into a package, path constants
-    # like ``CONFIG_DIR`` live as module-level globals inside ``_legacy.py``.
+    # like ``CONFIG_DIR`` live as module-level globals inside ``_constants.py``.
     # Extracted submodules (``_fonts`` etc.) import these at load time, so
     # their bindings drift independently from the package. Patch every loaded
     # submodule that carries the constant.
@@ -171,7 +171,7 @@ def _patch_helpers_paths(monkeypatch, config_dir):
 
     After ``modules/helpers.py`` was split into a package, path constants
     like ``CONFIG_DIR`` are imported at module load time by extracted
-    submodules (``_fonts``, ``_paths``, etc.) from ``_legacy``.  Those
+    submodules (``_fonts``, ``_paths``, etc.) from ``_constants``.  Those
     import-time bindings then drift independently from the package-level
     ``helpers.CONFIG_DIR``.  Functions inside any submodule resolve the
     constant from *their own* module globals, so we must patch every


### PR DESCRIPTION
**Truth in labeling.** After the 11-PR extraction sprint, `_legacy.py` is 32 lines of pure constants (paths, TTLs, cache dicts, extension sets, branch overrides) — **no functions, no logic**. 'Legacy' was accurate when it was 1613 lines of mixed responsibilities; it isn't now.

## What changed

- `git mv modules/helpers/_legacy.py → modules/helpers/_constants.py`
- Update **15 helpers submodules + 1 test file** to import from `modules.helpers._constants` (mechanical sed rewrite of `from modules.helpers._legacy import ...` and `from ._legacy import ...`)
- Update `helpers/__init__.py`: `from ._constants import *` plus a fresher comment ('Foundational constants ...')
- Add a module-level docstring to `_constants.py` listing what it owns
- Update **all 25 'extracted from _legacy.py' docstrings** across the helpers submodules to say **'extracted from the original helpers.py monolith'** — historically accurate and doesn't reference a filename that will keep evolving
- Update two `conftest.py` comments that mentioned `_legacy.py`

## What did NOT change

- No behavior changes anywhere
- No public API changes — every symbol still resolves via `helpers.foo` because the star re-export in `helpers/__init__.py` just changed source file name
- The unrelated identifiers like `_migrate_legacy_playlist_libraries_to_library_toggles`, `pmm_legacy_errors`, `get_legacy_custom_fonts_dir`, etc. were **not** touched — those refer to legacy Plex/PMM behavior, not the legacy helpers file

## Verified

- Full test suite passes (1077 tests) except the pre-existing `test_runtime_config_schema_accepts_playlist_exclude_users_keyed_override` (also fails on `develop`)
- All pre-commit hooks green (ruff, black)
- Git detected the rename as a rename (63% similarity — the docstring addition is the diff), not a delete-plus-add

## The sprint, complete

| Milestone | `_legacy.py` size |
|---|---|
| Sprint start | **1613 lines** (mixed functions + constants) |
| After 11 extraction PRs (#1403 … #1441) | **32 lines** (pure constants) |
| After this rename | **50 lines** (constants + module docstring), now named `_constants.py` |

Total reduction from monolithic responsibilities: **~98%**. The helpers package is now a coherent collection of focused submodules with no misleading names.