### PR TITLE
Extract + DRY the three file-block-entry parsers from output.py

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -29,6 +29,11 @@ from modules.output_defaults import (  # noqa: F401 -- re-exported so output.<na
     _prune_template_variables,
     _values_match,
 )
+from modules.output_file_entries import (  # noqa: F401 -- re-exported so output.<name> keeps working
+    _parse_collection_file_block_entries,
+    _parse_metadata_file_entries,
+    _parse_overlay_file_block_entries,
+)
 from modules.output_playlists import (  # noqa: F401 -- re-exported so output.<name> keeps working
     PLAYLIST_KEYED_TEMPLATE_VAR_SPECS,
     PLAYLIST_SHARED_TEMPLATE_VAR_SPECS,
@@ -873,99 +878,6 @@ def _normalize_legacy_collection_template_vars(config_data):
                     continue
                 template_vars[new_key] = template_vars.pop(old_key)
     return config_data
-
-
-def _parse_metadata_file_entries(raw_value):
-    if isinstance(raw_value, list):
-        entries = raw_value
-    elif isinstance(raw_value, str):
-        text = raw_value.strip()
-        if not text:
-            return []
-        try:
-            entries = json.loads(text)
-        except Exception:
-            return []
-    else:
-        return []
-
-    if not isinstance(entries, list):
-        return []
-
-    normalized = []
-    for entry in entries:
-        if not isinstance(entry, dict):
-            continue
-        entry_type = str(entry.get("type") or "").strip().lower()
-        location = str(entry.get("location") or "").strip()
-        if entry_type not in {"file", "folder", "url", "git", "repo"} or not location:
-            continue
-        normalized.append({entry_type: location})
-
-    normalized.sort(key=lambda item: (next(iter(item.keys())), next(iter(item.values())).casefold()))
-    return normalized
-
-
-def _parse_collection_file_block_entries(raw_value):
-    if isinstance(raw_value, list):
-        entries = raw_value
-    elif isinstance(raw_value, str):
-        text = raw_value.strip()
-        if not text:
-            return []
-        try:
-            entries = json.loads(text)
-        except Exception:
-            return []
-    else:
-        return []
-
-    if not isinstance(entries, list):
-        return []
-
-    normalized = []
-    for entry in entries:
-        if not isinstance(entry, dict):
-            continue
-        entry_type = str(entry.get("type") or "").strip().lower()
-        location = str(entry.get("location") or "").strip()
-        if entry_type not in {"file", "folder", "url", "git", "repo"} or not location:
-            continue
-        normalized.append({entry_type: location})
-
-    normalized.sort(key=lambda item: (next(iter(item.keys())), next(iter(item.values())).casefold()))
-    return normalized
-
-
-def _parse_overlay_file_block_entries(raw_value):
-    if isinstance(raw_value, list):
-        entries = raw_value
-    elif isinstance(raw_value, str):
-        text = raw_value.strip()
-        if not text:
-            return []
-        try:
-            entries = json.loads(text)
-        except Exception:
-            return []
-    else:
-        return []
-
-    if not isinstance(entries, list):
-        return []
-
-    normalized = []
-    for entry in entries:
-        if not isinstance(entry, dict):
-            continue
-        entry_type = str(entry.get("type") or "").strip().lower()
-        location = str(entry.get("location") or "").strip()
-        if entry_type not in {"file", "folder", "url", "git", "repo"} or not location:
-            continue
-        normalized.append({entry_type: location})
-
-    normalized.sort(key=lambda item: (next(iter(item.keys())), next(iter(item.values())).casefold()))
-    return normalized
 
 
 def build_libraries_section(

--- a/modules/output_file_entries.py
+++ b/modules/output_file_entries.py
@@ -1,0 +1,77 @@
+"""Config-file block entry parsers for output.py.
+
+Extracted from the original ``modules/output.py`` monolith.  This module
+covers three near-identical helpers that were previously copy-pasted
+three times in output.py -- one each for the ``metadata_files``,
+``collection_files``, and ``overlay_files`` YAML blocks.
+
+All three parse the same shape of input: a list (or a JSON-encoded
+string of a list) of ``{"type": <kind>, "location": <path-or-url>}``
+dicts, filter to entries where ``type in {file, folder, url, git, repo}``,
+sort deterministically, and emit ``{<kind>: <location>}`` dicts.
+
+The single ``_parse_config_file_block_entries`` implementation does the
+work; three thin aliases preserve the historic call surface so
+``output._parse_metadata_file_entries(...)`` etc. keep working (there
+are direct test call sites for each name).
+
+Note: this is a **different** shape/concern from the parsers in
+``modules/library_file_entries.py``, which emit
+``{"type": X, "location": Y, "validated": True}`` shapes for library
+form persistence.  Do not confuse them.
+"""
+
+from __future__ import annotations
+
+import json
+
+_ACCEPTED_ENTRY_TYPES = frozenset({"file", "folder", "url", "git", "repo"})
+
+
+def _parse_config_file_block_entries(raw_value):
+    """Normalize a config-file-list block into sorted ``[{kind: location}, ...]``."""
+    if isinstance(raw_value, list):
+        entries = raw_value
+    elif isinstance(raw_value, str):
+        text = raw_value.strip()
+        if not text:
+            return []
+        try:
+            entries = json.loads(text)
+        except Exception:
+            return []
+    else:
+        return []
+
+    if not isinstance(entries, list):
+        return []
+
+    normalized = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        entry_type = str(entry.get("type") or "").strip().lower()
+        location = str(entry.get("location") or "").strip()
+        if entry_type not in _ACCEPTED_ENTRY_TYPES or not location:
+            continue
+        normalized.append({entry_type: location})
+
+    normalized.sort(key=lambda item: (next(iter(item.keys())), next(iter(item.values())).casefold()))
+    return normalized
+
+
+# Semantic aliases: each block kind gets its own name so call sites
+# stay self-documenting.  They all share one implementation today; if
+# any need to diverge later, they can be inlined without hunting.
+
+
+def _parse_metadata_file_entries(raw_value):
+    return _parse_config_file_block_entries(raw_value)
+
+
+def _parse_collection_file_block_entries(raw_value):
+    return _parse_config_file_block_entries(raw_value)
+
+
+def _parse_overlay_file_block_entries(raw_value):
+    return _parse_config_file_block_entries(raw_value)


### PR DESCRIPTION
Fifth refactor pass on `modules/output.py` (now 3207 lines after #1448). Stacked on top of #1448.

## What (with a bonus DRY win)

While scoping this extraction I found a **textbook DRY violation** — three functions in `output.py` were **byte-for-byte identical** apart from their names:

- `_parse_metadata_file_entries`
- `_parse_collection_file_block_entries`
- `_parse_overlay_file_block_entries`

Verified with the receipts:
```
awk 'NR>=879 && NR<=906' modules/output.py > /tmp/fn1.txt
awk 'NR>=910 && NR<=937' modules/output.py > /tmp/fn2.txt
awk 'NR>=941 && NR<=968' modules/output.py > /tmp/fn3.txt
diff /tmp/fn1.txt /tmp/fn2.txt  # -> no diff
diff /tmp/fn1.txt /tmp/fn3.txt  # -> no diff
```

## Solution

New module `modules/output_file_entries.py`:

- **`_parse_config_file_block_entries`** — the one real implementation
- Three thin aliases that delegate to it: `_parse_metadata_file_entries`, `_parse_collection_file_block_entries`, `_parse_overlay_file_block_entries`

Aliases are **kept** rather than collapsed because:
1. Each has direct test call sites via `output.<name>`
2. Semantic names help readability at call sites
3. If any need to diverge later, drop the alias and inline — cheap

## Not to be confused with

There's an existing `modules/library_file_entries.py` with similarly-named parsers. **These are different**:

| Module | Emits | Purpose |
|---|---|---|
| `library_file_entries.py` | `{type: X, location: Y, validated: True}` | Library form persistence |
| `output_file_entries.py` (this PR) | `{kind: location}` | YAML config rendering |

## Dependencies

`json` (stdlib only). Zero external module deps.

## Impact

- `modules/output.py`: 3207 → **3119** (-88 / -2.7%)
- `modules/output_file_entries.py`: **78** lines new
- **Net -11 lines total** across the two files (90 lines of dupe → 33-line impl + 3 aliases)

## Cumulative sprint progress on `output.py`

| PR | Size | Delta |
|---|---|---|
| Start | 3833 | — |
| #1445 | 3670 | -163 |
| #1446 | 3538 | -132 |
| #1447 | 3343 | -195 |
| #1448 | 3207 | -136 |
| **This PR** | **3119** | **-88** |
| **Total** | | **-714 / -18.6%** |

## Verification

- All 1077 tests pass
- Ruff + black clean
- Directly ran the 4 parser-focused tests (`file_entries`/`file_block` name filter): all pass