### PR TITLE
Move 2 collection-config walkers into output_collections.py + bonus DRY

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -19,9 +19,11 @@ from ruamel.yaml.comments import CommentedSeq
 from modules import helpers, persistence, database
 from modules.output_collections import (  # noqa: F401 -- re-exported so output.<name> keeps working
     FRANCHISE_DYNAMIC_CHILD_FIELD_SPECS,
+    _collapse_collection_data_template_vars,
     _expand_franchise_dynamic_child_overrides,
     _normalize_collection_template_var_value,
     _normalize_dynamic_child_override_value,
+    _normalize_legacy_collection_template_vars,
     _normalize_settings_section_value,
     _parse_tmdb_person_window,
 )
@@ -634,101 +636,6 @@ def optimize_template_variables(config_data, library_types=None):
                 else:
                     entry.pop("template_variables", None)
 
-    return config_data
-
-
-def _collapse_collection_data_template_vars(config_data):
-    if not isinstance(config_data, dict):
-        return config_data
-    libraries_section = config_data.get("libraries", {})
-    libraries = None
-    if isinstance(libraries_section, dict):
-        nested = libraries_section.get("libraries")
-        if isinstance(nested, dict):
-            libraries = nested
-        else:
-            libraries = libraries_section
-    if not isinstance(libraries, dict):
-        return config_data
-    for library_data in libraries.values():
-        if not isinstance(library_data, dict):
-            continue
-        collection_files = library_data.get("collection_files")
-        if not isinstance(collection_files, list):
-            continue
-        for entry in collection_files:
-            if not isinstance(entry, dict):
-                continue
-            template_vars = entry.get("template_variables")
-            if not isinstance(template_vars, dict):
-                continue
-            data_block = {}
-            for key in list(template_vars.keys()):
-                if not isinstance(key, str) or not key.startswith("data_"):
-                    continue
-                subkey = key[5:]
-                if not subkey:
-                    continue
-                value = template_vars.pop(key)
-                if value is None:
-                    continue
-                if isinstance(value, str):
-                    cleaned = value.strip()
-                    if not cleaned:
-                        continue
-                    if cleaned.isdigit():
-                        value = int(cleaned)
-                data_block[subkey] = value
-            if not data_block:
-                continue
-            existing = template_vars.get("data")
-            if isinstance(existing, dict):
-                existing.update(data_block)
-                template_vars["data"] = existing
-            else:
-                template_vars["data"] = data_block
-    return config_data
-
-
-def _normalize_legacy_collection_template_vars(config_data):
-    if not isinstance(config_data, dict):
-        return config_data
-    libraries_section = config_data.get("libraries", {})
-    libraries = None
-    if isinstance(libraries_section, dict):
-        nested = libraries_section.get("libraries")
-        if isinstance(nested, dict):
-            libraries = nested
-        else:
-            libraries = libraries_section
-    if not isinstance(libraries, dict):
-        return config_data
-
-    letterboxd_key_map = {
-        "use_top_250": "use_top_500",
-        "radarr_add_missing_top_250": "radarr_add_missing_top_500",
-        "visible_home_top_250": "visible_home_top_500",
-        "visible_library_top_250": "visible_library_top_500",
-        "visible_shared_top_250": "visible_shared_top_500",
-        "limit_top_250": "limit_top_500",
-    }
-
-    for library_data in libraries.values():
-        if not isinstance(library_data, dict):
-            continue
-        collection_files = library_data.get("collection_files")
-        if not isinstance(collection_files, list):
-            continue
-        for entry in collection_files:
-            if not isinstance(entry, dict) or entry.get("default") != "letterboxd":
-                continue
-            template_vars = entry.get("template_variables")
-            if not isinstance(template_vars, dict):
-                continue
-            for old_key, new_key in letterboxd_key_map.items():
-                if old_key not in template_vars or new_key in template_vars:
-                    continue
-                template_vars[new_key] = template_vars.pop(old_key)
     return config_data
 
 

--- a/modules/output_collections.py
+++ b/modules/output_collections.py
@@ -221,3 +221,96 @@ def _normalize_settings_section_value(key, value):
         list_values = _parse_string_list(value)
         return ",".join(list_values) if list_values else None
     return value
+
+
+# --- whole-config-tree walks over collection template variables -----------
+
+
+def _iter_collection_file_template_vars(config_data):
+    """Yield every ``template_variables`` dict on every collection_file entry.
+
+    Handles both nested (``config["libraries"]["libraries"][name]``) and
+    flat (``config["libraries"][name]``) shapes that appear at different
+    stages of the build pipeline.  Yields nothing if the shape doesn't
+    match -- callers rely on that behaviour.
+    """
+    if not isinstance(config_data, dict):
+        return
+    libraries_section = config_data.get("libraries", {})
+    libraries = None
+    if isinstance(libraries_section, dict):
+        nested = libraries_section.get("libraries")
+        libraries = nested if isinstance(nested, dict) else libraries_section
+    if not isinstance(libraries, dict):
+        return
+    for library_data in libraries.values():
+        if not isinstance(library_data, dict):
+            continue
+        collection_files = library_data.get("collection_files")
+        if not isinstance(collection_files, list):
+            continue
+        for entry in collection_files:
+            if not isinstance(entry, dict):
+                continue
+            template_vars = entry.get("template_variables")
+            if isinstance(template_vars, dict):
+                yield entry, template_vars
+
+
+def _collapse_collection_data_template_vars(config_data):
+    """Fold flat ``data_<sub>`` keys into a nested ``data:`` mapping.
+
+    Kometa's collection defaults accept a ``data:`` mapping (e.g. actors,
+    genres) but the quickstart form emits flat ``data_actors``,
+    ``data_genres``, ... keys.  This walker collapses them.
+    """
+    for _entry, template_vars in _iter_collection_file_template_vars(config_data):
+        data_block = {}
+        for key in list(template_vars.keys()):
+            if not isinstance(key, str) or not key.startswith("data_"):
+                continue
+            subkey = key[5:]
+            if not subkey:
+                continue
+            value = template_vars.pop(key)
+            if value is None:
+                continue
+            if isinstance(value, str):
+                cleaned = value.strip()
+                if not cleaned:
+                    continue
+                if cleaned.isdigit():
+                    value = int(cleaned)
+            data_block[subkey] = value
+        if not data_block:
+            continue
+        existing = template_vars.get("data")
+        if isinstance(existing, dict):
+            existing.update(data_block)
+            template_vars["data"] = existing
+        else:
+            template_vars["data"] = data_block
+    return config_data
+
+
+# Historic letterboxd rename: the top_250 lists became top_500 upstream.
+_LETTERBOXD_LEGACY_KEY_MAP = {
+    "use_top_250": "use_top_500",
+    "radarr_add_missing_top_250": "radarr_add_missing_top_500",
+    "visible_home_top_250": "visible_home_top_500",
+    "visible_library_top_250": "visible_library_top_500",
+    "visible_shared_top_250": "visible_shared_top_500",
+    "limit_top_250": "limit_top_500",
+}
+
+
+def _normalize_legacy_collection_template_vars(config_data):
+    """Rename legacy letterboxd ``*_top_250`` keys to ``*_top_500``."""
+    for entry, template_vars in _iter_collection_file_template_vars(config_data):
+        if entry.get("default") != "letterboxd":
+            continue
+        for old_key, new_key in _LETTERBOXD_LEGACY_KEY_MAP.items():
+            if old_key not in template_vars or new_key in template_vars:
+                continue
+            template_vars[new_key] = template_vars.pop(old_key)
+    return config_data


### PR DESCRIPTION
Seventh refactor pass on `modules/output.py` (now 2971 lines after #1450). Stacked on top of #1450.

## What

Two closely-related whole-config-tree walkers over collection template variables were sitting in `output.py`, doing near-identical "unwrap libraries dict, walk collection_files, find template_variables" boilerplate.

Moved to `modules/output_collections.py` where they belong logically:

| Helper | Purpose |
|---|---|
| `_collapse_collection_data_template_vars` | Fold flat `data_<sub>` keys into a nested `data:` mapping |
| `_normalize_legacy_collection_template_vars` | Rename legacy letterboxd `*_top_250` keys to `*_top_500` |

## Bonus DRY win

While moving, I noticed both functions had **~15 lines of identical boilerplate** for "unwrap the libraries section (handling both nested and flat shapes), walk collection_files, find template_variables". Extracted that into a helper generator:

```python
def _iter_collection_file_template_vars(config_data):
    """Yield every template_variables dict on every collection_file entry."""
    # ... unwrap ... walk ... yield entry, template_vars
```

Both callers now share the walking logic; each carries only its own transform. If a third walker is ever needed (e.g. for overlay files), the pattern is right there.

Also promoted the letterboxd rename map from a local dict inside `_normalize_legacy_collection_template_vars` to a module-level `_LETTERBOXD_LEGACY_KEY_MAP` constant. Same visibility, easier to find and update when the next `_top_XXX` rebrand hits.

## API safety

`output.py` re-imports both names with `# noqa: F401`. Three test functions in `test_core_backend.py` call `output._collapse_collection_data_template_vars` directly — all still pass.

## Impact

- `modules/output.py`: 2971 → **2878** (-93 / -3.1%)
- `modules/output_collections.py`: 226 → **316** (+90)
- **Net -3 lines** total (DRY: ~30 lines of boilerplate collapsed into 20-line generator)

## Cumulative sprint progress on `output.py`

| PR | Size | Delta |
|---|---|---|
| Start | 3833 | — |
| #1445 (MERGED) | 3670 | -163 |
| #1446 | 3538 | -132 |
| #1447 | 3343 | -195 |
| #1448 | 3207 | -136 |
| #1449 | 3119 | -88 |
| #1450 | 2971 | -148 |
| **This PR** | **2878** | **-93** |
| **Total** | | **-955 / -24.9%** |

## Verification

- All 1077 tests pass
- Ruff + black clean