### PR TITLE
Move asset directory normalizers into output_values.py

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -2,7 +2,6 @@ import io
 import copy
 import os
 import json
-import re
 import shutil
 import subprocess
 from datetime import datetime, timezone
@@ -62,6 +61,8 @@ from modules.output_playlists import (  # noqa: F401 -- re-exported so output.<n
 from modules.output_values import (  # noqa: F401 -- re-exported for tests calling output._parse_string_list, etc.
     _coerce_bool,
     _coerce_string_list,
+    _normalize_asset_directory_entry,
+    _normalize_asset_directory_values,
     _normalize_template_value,
     _parse_comma_string_list,
     _parse_string_list,
@@ -191,46 +192,6 @@ def _rewrite_custom_font_paths(config_data):
 
     walk(config_data)
     return config_data
-
-
-def _normalize_asset_directory_entry(value):
-    if value is None:
-        return None
-
-    text = str(value).strip()
-    if not text:
-        return None
-
-    # Convert YAML-style escaped Windows paths back to plain paths while preserving UNC prefixes.
-    if re.match(r"^[A-Za-z]:\\\\", text):
-        while "\\\\" in text:
-            text = text.replace("\\\\", "\\")
-        return text
-
-    if text.startswith("\\\\"):
-        prefix = "\\\\"
-        remainder = text[2:]
-        while "\\\\" in remainder:
-            remainder = remainder.replace("\\\\", "\\")
-        return prefix + remainder
-
-    return text
-
-
-def _normalize_asset_directory_values(value):
-    normalized = []
-    if isinstance(value, str):
-        items = value.splitlines()
-    elif isinstance(value, list):
-        items = value
-    else:
-        items = []
-
-    for item in items:
-        cleaned = _normalize_asset_directory_entry(item)
-        if cleaned:
-            normalized.append(cleaned)
-    return normalized
 
 
 def optimize_template_variables(config_data, library_types=None):

--- a/modules/output_values.py
+++ b/modules/output_values.py
@@ -1,9 +1,9 @@
 """Pure value-coercion and parsing primitives for config-YAML generation.
 
-Extracted from the original ``modules/output.py`` monolith.  All ten
-helpers here are small (< 30 lines) and dependency-free -- they take
-raw config values (strings, dicts, lists, ints, floats, ``None``) and
-return a normalized shape.  Nothing here touches Flask, the database,
+Extracted from the original ``modules/output.py`` monolith.  Each helper
+is small (< 40 lines) and dependency-free -- they take raw config
+values (strings, dicts, lists, ints, floats, ``None``) and return a
+normalized shape.  Nothing here touches Flask, the database,
 persistence, helpers, or any other repo state.
 
 Public surface (nothing here is a public API -- each name starts with
@@ -19,6 +19,8 @@ Groups:
   * ``_parse_string_list_mapping`` / ``_parse_string_mapping`` /
     ``_parse_template_mapping_dict`` -- dict-shaped normalizers
   * ``_playlist_scalar_or_list`` -- collapse 1-element lists to scalars
+  * ``_normalize_asset_directory_entry`` /
+    ``_normalize_asset_directory_values`` -- unescape Windows/UNC paths
 """
 
 from __future__ import annotations
@@ -201,3 +203,51 @@ def _playlist_scalar_or_list(values):
     if not values:
         return None
     return values[0] if len(values) == 1 else values
+
+
+# --- asset directory path normalization -----------------------------------
+#
+# Kometa's ``asset_directory:`` config accepts multi-line strings or lists.
+# On Windows, users often paste YAML-escaped paths like ``C:\\Users\\me``
+# where the double-backslashes are the YAML wire form of a single one.
+# UNC paths keep their leading ``\\`` prefix (that's the UNC marker).
+
+
+def _normalize_asset_directory_entry(value):
+    if value is None:
+        return None
+
+    text = str(value).strip()
+    if not text:
+        return None
+
+    # Convert YAML-style escaped Windows paths back to plain paths while preserving UNC prefixes.
+    if re.match(r"^[A-Za-z]:\\\\", text):
+        while "\\\\" in text:
+            text = text.replace("\\\\", "\\")
+        return text
+
+    if text.startswith("\\\\"):
+        prefix = "\\\\"
+        remainder = text[2:]
+        while "\\\\" in remainder:
+            remainder = remainder.replace("\\\\", "\\")
+        return prefix + remainder
+
+    return text
+
+
+def _normalize_asset_directory_values(value):
+    normalized = []
+    if isinstance(value, str):
+        items = value.splitlines()
+    elif isinstance(value, list):
+        items = value
+    else:
+        items = []
+
+    for item in items:
+        cleaned = _normalize_asset_directory_entry(item)
+        if cleaned:
+            normalized.append(cleaned)
+    return normalized


### PR DESCRIPTION
Eighth refactor pass on `modules/output.py` (now 2878 lines after #1451). Stacked on top of #1451.

## What

Two small path-normalization helpers moved from `output.py` into `output_values.py`, joining the family of pure stdlib-only value-coercion primitives:

| Helper | Purpose |
|---|---|
| `_normalize_asset_directory_entry` | Unescape a single Windows/UNC path (handles YAML-escaped backslashes, preserves UNC `\\\\` prefix) |
| `_normalize_asset_directory_values` | Normalize a list or multi-line string of paths |

Both are pure functions (only `re` from stdlib) and only used inside `output.py`. Zero external callers.

## Why extend `output_values.py`?

Same philosophical fit: "take a raw config value, return a normalized shape." Windows path handling is niche but the primitive spirit matches. No new module needed.

##  Bonus cleanup

**Removed `import re` from `output.py`** — no longer used! Both remaining `re` users left `output.py` in earlier PRs:
- `_parse_tmdb_person_window` → `output_collections.py` in #1450
- `_normalize_asset_directory_entry` → `output_values.py` in this PR
- Nothing else in `output.py` needed `re`.

## API safety

`output.py` re-imports both names with `# noqa: F401`. Both are only referenced internally (no test or blueprint uses them).

## Impact

- `modules/output.py`: 2878 → **2839** (-39 / -1.4%) — plus one dead import gone
- `modules/output_values.py`: 203 → **253** (+50)
- Net +11 lines total (docstring + comment explaining the Windows/UNC edge cases)

## Cumulative sprint progress on `output.py`

| PR | Size | Delta |
|---|---|---|
| Start | 3833 | — |
| #1445 (MERGED) | 3670 | -163 |
| #1446 (MERGED) | 3538 | -132 |
| #1447 | 3343 | -195 |
| #1448 | 3207 | -136 |
| #1449 | 3119 | -88 |
| #1450 | 2971 | -148 |
| #1451 | 2878 | -93 |
| **This PR** | **2839** | **-39** |
| **Total** | | **-994 / -25.9%** |

## Verification

- All 1077 tests pass
- Ruff + black clean