### PR TITLE
Extract section_heading + add_border_to_ascii_art from output.py

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -42,6 +42,10 @@ from modules.output_file_entries import (  # noqa: F401 -- re-exported so output
     _parse_metadata_file_entries,
     _parse_overlay_file_block_entries,
 )
+from modules.output_headers import (  # noqa: F401 -- re-exported so output.<name> and public callers keep working
+    add_border_to_ascii_art,
+    section_heading,
+)
 from modules.output_playlists import (  # noqa: F401 -- re-exported so output.<name> keeps working
     PLAYLIST_KEYED_TEMPLATE_VAR_SPECS,
     PLAYLIST_SHARED_TEMPLATE_VAR_SPECS,
@@ -113,27 +117,6 @@ LIBRARY_SONARR_FIELDS = {
     "sonarr_path": "string",
     "plex_path": "string",
 }
-
-
-def add_border_to_ascii_art(art):
-    lines = art.split("\n")
-    lines = lines[:-1]
-    width = max(len(line) for line in lines)
-    border_line = "#" * (width + 4)
-    bordered_art = [border_line] + [f"# {line.ljust(width)} #" for line in lines] + [border_line]
-    return "\n".join(bordered_art)
-
-
-def section_heading(title, font="standard"):
-    if font == "none":
-        return ""
-    elif font == "single line":
-        return f"#==================== {title} ====================#"
-    else:
-        try:
-            return add_border_to_ascii_art(pyfiglet.figlet_format(title, font=font))
-        except pyfiglet.FontNotFound:
-            return f"#==================== {title} ====================#"
 
 
 def clean_section_data(section_data, config_attribute):

--- a/modules/output_headers.py
+++ b/modules/output_headers.py
@@ -1,0 +1,37 @@
+"""ASCII art / section header helpers for output.py.
+
+Extracted from the original ``modules/output.py`` monolith.  Kometa
+config files carry decorative section headers between YAML sections --
+either single-line comments or pyfiglet-generated ASCII art wrapped in
+a hash-mark border.  These two helpers own that rendering.
+
+Public surface: ``section_heading`` is called from ``quickstart.py`` as
+``output.section_heading(...)``.  ``add_border_to_ascii_art`` is used
+in several build_config / build_libraries_section contexts to wrap a
+pre-generated pyfiglet block.  Both are re-exported from ``output.py``
+so historical call sites keep working.
+"""
+
+from __future__ import annotations
+
+import pyfiglet
+
+
+def add_border_to_ascii_art(art):
+    lines = art.split("\n")
+    lines = lines[:-1]
+    width = max(len(line) for line in lines)
+    border_line = "#" * (width + 4)
+    bordered_art = [border_line] + [f"# {line.ljust(width)} #" for line in lines] + [border_line]
+    return "\n".join(bordered_art)
+
+
+def section_heading(title, font="standard"):
+    if font == "none":
+        return ""
+    if font == "single line":
+        return f"#==================== {title} ====================#"
+    try:
+        return add_border_to_ascii_art(pyfiglet.figlet_format(title, font=font))
+    except pyfiglet.FontNotFound:
+        return f"#==================== {title} ====================#"


### PR DESCRIPTION
Ninth refactor pass on `modules/output.py` (now 2839 lines after #1452).  Stacked on top of #1452.

##  Cumulative -1011 lines / -26.4% — broke below the 1000-line-shed milestone!

## What

Two small ASCII-art helpers moved into a dedicated module `modules/output_headers.py`. Kometa config files carry decorative section headers between YAML sections — either single-line comments or pyfiglet-generated ASCII art wrapped in a hash-mark border.

**Functions moved:**
| Helper | Purpose |
|---|---|
| `add_border_to_ascii_art` | Wrap a pyfiglet block with `#`-borders |
| `section_heading` | Render a title in the chosen font style; fallback to `===...=== title ===...===` on `none` / `single line` / unknown-font |

## Minor cleanup

`section_heading`'s `elif`/`else` chain rewritten with early returns. Zen of Python: *"Flat is better than nested."*

## API safety

`quickstart.py` calls `output.section_heading("Quickstart", font=font)` directly (line 1299) — this must re-export. `output.py` imports both names without underscore, no `# noqa` needed since they're used within the same file.

## Note on `pyfiglet`

`pyfiglet` is still imported in `output.py` because six other callers use `pyfiglet.figlet_format` directly inline — mostly duplicated `section_heading`-like logic inside `build_config` and `build_libraries_section`. **Future DRY target**: replace those inline copies with `section_heading()` calls once the mega-functions are broken up.

## Impact

- `modules/output.py`: 2839 → **2822** (-17 / -0.6%)
- `modules/output_headers.py`: **37** lines new

## Cumulative sprint progress on `output.py`

| PR | Size | Delta |
|---|---|---|
| Start | 3833 | — |
| #1445 (MERGED) | 3670 | -163 |
| #1446 (MERGED) | 3538 | -132 |
| #1447 (MERGED) | 3343 | -195 |
| #1448 | 3207 | -136 |
| #1449 | 3119 | -88 |
| #1450 | 2971 | -148 |
| #1451 | 2878 | -93 |
| #1452 | 2839 | -39 |
| **This PR** | **2822** | **-17** |
| **Total** | | **-1011 / -26.4%** |

## Verification

- All 1077 tests pass
- Ruff + black clean