### PR TITLE
Sweep the floor: clean_section_data + _rewrite_custom_font_paths → output_postprocess.py

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -62,6 +62,10 @@ from modules.output_playlists import (  # noqa: F401 -- re-exported so output.<n
     _parse_playlist_file_entries_value,
     _playlist_libraries_from_library_toggles,
 )
+from modules.output_postprocess import (  # noqa: F401 -- re-exported so output.<name> keeps working
+    _rewrite_custom_font_paths,
+    clean_section_data,
+)
 from modules.output_values import (  # noqa: F401 -- re-exported for tests calling output._parse_string_list, etc.
     _coerce_bool,
     _coerce_string_list,
@@ -117,64 +121,6 @@ LIBRARY_SONARR_FIELDS = {
     "sonarr_path": "string",
     "plex_path": "string",
 }
-
-
-def clean_section_data(section_data, config_attribute):
-    """
-    Cleans out temporary or irrelevant data before integrating it into the final config.yml
-    """
-    clean_data = {}
-
-    for key, value in section_data.items():
-        if key == config_attribute:
-            if isinstance(value, dict):
-                clean_sub_data = {}
-                for sub_key, sub_value in value.items():
-                    if not sub_key.startswith("tmp_"):
-                        clean_sub_data[sub_key] = copy.deepcopy(sub_value)
-                clean_data[key] = clean_sub_data
-            else:
-                clean_data[key] = copy.deepcopy(value)
-
-    return clean_data
-
-
-def _rewrite_custom_font_paths(config_data):
-    available_fonts = set(helpers.list_available_fonts(include_static=True, include_custom=True))
-    if not available_fonts:
-        return config_data
-
-    def normalize_font_value(value):
-        if isinstance(value, dict):
-            raw = value.get("value")
-            if isinstance(raw, str):
-                updated = normalize_font_value(raw)
-                if updated != raw:
-                    value["value"] = updated
-            return value
-        if not isinstance(value, str):
-            return value
-        stripped = value.strip()
-        if not stripped:
-            return value
-        base = os.path.basename(stripped)
-        if base in available_fonts:
-            return f"config/fonts/{base}"
-        return value
-
-    def walk(obj):
-        if isinstance(obj, dict):
-            for key, val in obj.items():
-                if isinstance(key, str) and (key == "font" or key.endswith("_font")):
-                    obj[key] = normalize_font_value(val)
-                else:
-                    walk(val)
-        elif isinstance(obj, list):
-            for item in obj:
-                walk(item)
-
-    walk(config_data)
-    return config_data
 
 
 def optimize_template_variables(config_data, library_types=None):

--- a/modules/output_postprocess.py
+++ b/modules/output_postprocess.py
@@ -1,0 +1,101 @@
+"""Post-processing helpers for finalized config dicts.
+
+Extracted from the original ``modules/output.py`` monolith.  These two
+helpers run after ``build_libraries_section`` / ``build_config`` have
+assembled the config dict but before the YAML dump -- final cleanup
+passes over the fully-built structure.
+
+* ``clean_section_data`` -- strip transient ``tmp_*`` keys from a
+  section before it lands in the output config.
+* ``_rewrite_custom_font_paths`` -- walk the config tree and rewrite
+  bare font filenames (``MyFont.ttf``) to the on-disk
+  ``config/fonts/MyFont.ttf`` path that Kometa expects.
+
+Public surface: ``clean_section_data`` has no underscore prefix (it's
+a slightly-public helper).  Neither has external callers today, but
+both are re-exported by ``output.py`` so historical
+``output.clean_section_data(...)`` style calls keep working if any
+test reaches for them.
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+
+from modules import helpers
+
+
+def clean_section_data(section_data, config_attribute):
+    """Cleans out temporary or irrelevant data before integrating into config.yml.
+
+    Keeps only the ``config_attribute`` key from ``section_data``, and
+    when its value is a dict, strips any sub-keys prefixed with
+    ``tmp_``.  Everything retained is deep-copied so downstream mutation
+    can't leak back into the source section.
+    """
+    clean_data = {}
+
+    for key, value in section_data.items():
+        if key != config_attribute:
+            continue
+        if isinstance(value, dict):
+            clean_sub_data = {sub_key: copy.deepcopy(sub_value) for sub_key, sub_value in value.items() if not sub_key.startswith("tmp_")}
+            clean_data[key] = clean_sub_data
+        else:
+            clean_data[key] = copy.deepcopy(value)
+
+    return clean_data
+
+
+def _normalize_font_value(value, available_fonts):
+    """Rewrite one font-field value in-place, returning the (possibly-updated) value.
+
+    Handles two shapes: ``{"value": "MyFont.ttf"}`` (form-submission
+    style) and bare strings.  If the basename matches a known available
+    font, rewrite to ``config/fonts/<basename>``; otherwise leave alone.
+    """
+    if isinstance(value, dict):
+        raw = value.get("value")
+        if isinstance(raw, str):
+            updated = _normalize_font_value(raw, available_fonts)
+            if updated != raw:
+                value["value"] = updated
+        return value
+    if not isinstance(value, str):
+        return value
+    stripped = value.strip()
+    if not stripped:
+        return value
+    base = os.path.basename(stripped)
+    if base in available_fonts:
+        return f"config/fonts/{base}"
+    return value
+
+
+def _walk_config_for_fonts(obj, available_fonts):
+    """Recursively walk ``obj``, rewriting every ``font`` / ``*_font`` value."""
+    if isinstance(obj, dict):
+        for key, val in obj.items():
+            if isinstance(key, str) and (key == "font" or key.endswith("_font")):
+                obj[key] = _normalize_font_value(val, available_fonts)
+            else:
+                _walk_config_for_fonts(val, available_fonts)
+    elif isinstance(obj, list):
+        for item in obj:
+            _walk_config_for_fonts(item, available_fonts)
+
+
+def _rewrite_custom_font_paths(config_data):
+    """Rewrite bare font filenames to full ``config/fonts/<name>`` paths.
+
+    Kometa expects font references in the config to be paths under
+    ``config/fonts/``.  Users often paste just the filename
+    (``MyFont.ttf``); this walker resolves those against the set of
+    available fonts and rewrites in-place.
+    """
+    available_fonts = set(helpers.list_available_fonts(include_static=True, include_custom=True))
+    if not available_fonts:
+        return config_data
+    _walk_config_for_fonts(config_data, available_fonts)
+    return config_data


### PR DESCRIPTION
Tenth refactor pass on `modules/output.py` (now 2822 lines after #1453). Stacked on top of #1453.

##  Cumulative -1065 lines / -27.8% on `output.py`

## What

Final "floor-sweeping" PR before we start on the mega-functions. New module `modules/output_postprocess.py` houses two small helpers that both run **after** the config dict is fully assembled but before YAML serialization — the natural conceptual grouping.

| Helper | Purpose |
|---|---|
| `clean_section_data` | Strip transient `tmp_*` keys from a section before it lands in the output config |
| `_rewrite_custom_font_paths` | Walk the config tree and rewrite bare font filenames (e.g. `MyFont.ttf`) to `config/fonts/MyFont.ttf` paths that Kometa expects |

## Cleanup wins along the way

**`clean_section_data`** got a Pythonicity upgrade:
- `if key != config_attribute: continue` guard clause (was: triple-nested if/else) — Zen: "Flat is better than nested."
- Dict comprehension for the sub-key filter (was: explicit loop with append)

**`_rewrite_custom_font_paths`** got a **DRY-and-decompose**: hoisted its two nested closures (`normalize_font_value` + `walk`) into independent module-level functions:

```python
def _normalize_font_value(value, available_fonts): ...
def _walk_config_for_fonts(obj, available_fonts): ...
```

Both are now testable independently — verified against `{font: X.ttf}`, `{label_font: {value: X.ttf}}`, and unknown-font edge cases. Zero behavior change.

## YAGNI-note on constants

`LIBRARY_RADARR_FIELDS` / `LIBRARY_SONARR_FIELDS` (~37 lines) deliberately **left where they are**: only `build_libraries_section` uses them, and that function is also still in `output.py`. Move them when the big function moves. Premature-abstraction avoided.

(There's a same-named constant in `quickstart.py` — different type entirely: `list` vs `dict`. Zero coupling; confirmed via grep.)

## API safety

`output.py` re-imports both function names with `# noqa: F401`. Neither has external callers today (verified across tests/, blueprints/, quickstart.py).

## Impact

- `modules/output.py`: 2822 → **2768** (-54 / -1.9%)
- `modules/output_postprocess.py`: **101** lines new
  - Net +47 line-of-code trade: docstrings + closure decomposition were worth it

## Cumulative sprint progress on `output.py`

| PR | Size | Delta |
|---|---|---|
| Start | 3833 | — |
| #1445 (MERGED) | 3670 | -163 |
| #1446 (MERGED) | 3538 | -132 |
| #1447 (MERGED) | 3343 | -195 |
| #1448 | 3207 | -136 |
| #1449 | 3119 | -88 |
| #1450 | 2971 | -148 |
| #1451 | 2878 | -93 |
| #1452 | 2839 | -39 |
| #1453 | 2822 | -17 |
| **This PR** | **2768** | **-54** |
| **Total** | | **-1065 / -27.8%** |

## Verification

- All 1077 tests pass
- Ruff + black clean