### PR TITLE
Extract dump_section (YAML serializer) into output_dump.py - output.py drops below 2000 lines

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -4,17 +4,16 @@ import os
 import json
 import shutil
 import subprocess
-from datetime import datetime, timezone
+from datetime import datetime
 import platform
 import psutil
 
 import jsonschema
 from flask import current_app as app, has_request_context, session
 from ruamel.yaml import YAML
-from ruamel.yaml.scalarstring import PlainScalarString
 from ruamel.yaml.comments import CommentedSeq
 
-from modules import helpers, persistence, database
+from modules import helpers, persistence
 from modules.output_collections import (  # noqa: F401 -- re-exported so output.<name> keeps working
     FRANCHISE_DYNAMIC_CHILD_FIELD_SPECS,
     _collapse_collection_data_template_vars,
@@ -36,6 +35,7 @@ from modules.output_defaults import (  # noqa: F401 -- re-exported so output.<na
     _prune_template_variables,
     _values_match,
 )
+from modules.output_dump import dump_section
 from modules.output_file_entries import (  # noqa: F401 -- re-exported so output.<name> keeps working
     _parse_collection_file_block_entries,
     _parse_metadata_file_entries,
@@ -1907,268 +1907,6 @@ def build_config(header_style="standard", config_name=None):
         f"\n\n"
     )
 
-    def inject_section_headers(yaml_string, font):
-        lines = yaml_string.splitlines()
-        output = []
-        in_libraries_block = False
-
-        for i, line in enumerate(lines):
-            stripped = line.strip()
-
-            # Detect when we've entered the top-level libraries block
-            if stripped == "libraries:":
-                in_libraries_block = True
-                output.append(line)
-                continue
-
-            # Exit the block once indentation resets or we hit a new top-level key
-            if in_libraries_block and not line.startswith("  ") and not line.strip().startswith("#") and ":" in line:
-                in_libraries_block = False
-
-            # Only inject header for lines like "  Movies:" or "  TV Shows:" inside the libraries block
-            if in_libraries_block and line.startswith("  ") and not line.startswith("   ") and line.strip().endswith(":") and not line.strip().startswith("-"):
-                library_name = line.strip().rstrip(":")
-                output.append(render_section_header(library_name, font))
-
-            elif stripped.startswith("collection_files:"):
-                output.append(render_section_header("Collections", font))
-            elif stripped.startswith("metadata_files:"):
-                output.append(render_section_header("Metadata Files", font))
-            elif stripped.startswith("overlay_files:"):
-                output.append(render_section_header("Overlays", font))
-
-            output.append(line)
-
-        return "\n".join(output)
-
-    # Function to dump YAML sections
-    def dump_section(title, dump_name, data):
-
-        dump_yaml = YAML()
-        dump_yaml.default_flow_style = False
-        dump_yaml.sort_keys = False  # Preserve original key order
-        dump_yaml.width = 4096  # avoid folding long tokens/secrets
-
-        # Custom representation for `None` values
-        dump_yaml.representer.add_representer(
-            type(None),
-            lambda self, _: self.represent_scalar("tag:yaml.org,2002:null", ""),
-        )
-
-        def _prune_empty_output_values(obj):
-            if isinstance(obj, dict):
-                pruned = {}
-                for key, value in obj.items():
-                    if key == "valid":
-                        continue
-                    cleaned_value = _prune_empty_output_values(value)
-                    if cleaned_value is _EMPTY_OUTPUT:
-                        continue
-                    pruned[key] = cleaned_value
-                return pruned if pruned else _EMPTY_OUTPUT
-            if isinstance(obj, list):
-                cleaned_items = []
-                for value in obj:
-                    cleaned_value = _prune_empty_output_values(value)
-                    if cleaned_value is _EMPTY_OUTPUT:
-                        continue
-                    cleaned_items.append(cleaned_value)
-                return cleaned_items if cleaned_items else _EMPTY_OUTPUT
-            if obj is None:
-                return _EMPTY_OUTPUT
-            if isinstance(obj, str) and obj.strip() == "":
-                return _EMPTY_OUTPUT
-            return obj
-
-        def clean_data(obj):
-            if isinstance(obj, dict):
-                # Sort specific sections alphabetically
-                if dump_name in [
-                    "settings",
-                    "webhooks",
-                    "plex",
-                    "tmdb",
-                    "tautulli",
-                    "github",
-                    "omdb",
-                    "mdblist",
-                    "notifiarr",
-                    "gotify",
-                    "ntfy",
-                    "apprise",
-                    "anidb",
-                    "radarr",
-                    "sonarr",
-                    "trakt",
-                    "mal",
-                ]:
-                    obj = dict(sorted(obj.items()))  # Alphabetically sort keys in the section
-                cleaned_dict = {}
-                for k, v in obj.items():
-                    if k == "valid":
-                        continue
-                    cleaned_value = clean_data(v)
-                    if cleaned_value is _EMPTY_OUTPUT:
-                        continue
-                    cleaned_dict[k] = cleaned_value
-                return cleaned_dict if cleaned_dict else _EMPTY_OUTPUT
-            elif isinstance(obj, list):
-                cleaned_list = []
-                for v in obj:
-                    cleaned_value = clean_data(v)
-                    if cleaned_value is _EMPTY_OUTPUT:
-                        continue
-                    cleaned_list.append(cleaned_value)
-                return cleaned_list if cleaned_list else _EMPTY_OUTPUT
-            else:
-                return _prune_empty_output_values(obj)
-
-        # Clean the data
-        cleaned_data = clean_data(data)
-        if cleaned_data is _EMPTY_OUTPUT:
-            cleaned_data = {}
-        if dump_name == "libraries" and isinstance(cleaned_data, dict) and "libraries" not in cleaned_data:
-            cleaned_data = {"libraries": cleaned_data}
-        if dump_name == "anidb":
-            section = cleaned_data.get("anidb")
-            if isinstance(section, dict):
-                section.pop("enable", None)
-
-        # Force long/scalar strings to emit in plain style (avoid folded multi-line) for sensitive sections
-        plain_scalar_sections = {
-            "plex",
-            "tmdb",
-            "tautulli",
-            "github",
-            "omdb",
-            "mdblist",
-            "notifiarr",
-            "gotify",
-            "ntfy",
-            "apprise",
-            "anidb",
-            "radarr",
-            "sonarr",
-            "trakt",
-            "mal",
-        }
-
-        def plainify_strings(obj):
-            if isinstance(obj, dict):
-                return {k: plainify_strings(v) for k, v in obj.items()}
-            if isinstance(obj, list):
-                return [plainify_strings(v) for v in obj]
-            if isinstance(obj, str):
-                return PlainScalarString(obj)
-            return obj
-
-        if dump_name in plain_scalar_sections:
-            cleaned_data = plainify_strings(cleaned_data)
-
-        # Normalize MAL/TRAKT numeric fields
-        if dump_name in ("mal", "trakt"):
-            section = cleaned_data.get(dump_name, {})
-            auth = section.get("authorization", {})
-
-            if isinstance(auth, dict) and "expires_in" in auth:
-                try:
-                    auth["expires_in"] = int(auth["expires_in"])
-                except Exception:
-                    pass
-
-            if "cache_expiration" in section:
-                try:
-                    section["cache_expiration"] = int(section["cache_expiration"])
-                except Exception:
-                    pass
-
-        if dump_name == "trakt":
-            section = cleaned_data.get("trakt", {})
-            if isinstance(section, dict):
-                auth = section.get("authorization")
-                if isinstance(auth, dict) and "force_refresh" in auth and "force_refresh" not in section:
-                    section["force_refresh"] = auth.pop("force_refresh")
-
-                preferred_order = ["authorization", "client_id", "client_secret", "pin", "force_refresh"]
-                ordered_section = {}
-                for key in preferred_order:
-                    if key in section:
-                        ordered_section[key] = section[key]
-                for key, value in section.items():
-                    if key not in ordered_section:
-                        ordered_section[key] = value
-                cleaned_data["trakt"] = ordered_section
-
-        # Ensure settings multi-value inputs are normalized for YAML output.
-        if dump_name == "settings" and isinstance(cleaned_data.get("settings"), dict):
-            settings_block = cleaned_data["settings"]
-            for setting_key in list(settings_block.keys()):
-                normalized_value = _normalize_settings_section_value(setting_key, settings_block.get(setting_key))
-                if normalized_value is None:
-                    settings_block.pop(setting_key, None)
-                else:
-                    settings_block[setting_key] = normalized_value
-
-            if "asset_directory" in settings_block:
-                if isinstance(settings_block["asset_directory"], str):
-                    # Convert multi-line string into a list
-                    settings_block["asset_directory"] = _normalize_asset_directory_values(settings_block["asset_directory"])
-                elif isinstance(settings_block["asset_directory"], list):
-                    # Ensure all list items are strings
-                    settings_block["asset_directory"] = _normalize_asset_directory_values(settings_block["asset_directory"])
-
-        # Dump the cleaned data to YAML
-        with io.StringIO() as stream:
-            dump_yaml.dump(cleaned_data, stream)
-            section_output = stream.getvalue().strip()
-            if header_style != "none":
-                section_output = inject_section_headers(section_output, header_style)
-
-            validation_comment = build_validation_comment(dump_name)
-            blocks = []
-            if title:
-                blocks.append(title)
-            if validation_comment:
-                blocks.append(validation_comment)
-            blocks.append(section_output)
-            return "\n".join(blocks) + "\n\n"
-
-    def format_validation_timestamp(raw):
-        if not raw:
-            return ""
-        try:
-            normalized = raw.replace("Z", "+00:00")
-            parsed = datetime.fromisoformat(normalized)
-            if parsed.tzinfo is None:
-                parsed = parsed.replace(tzinfo=timezone.utc)
-            local = parsed.astimezone()
-            return local.strftime("%Y-%m-%d %H:%M:%S")
-        except Exception:
-            return raw
-
-    def build_validation_comment(section_key):
-        if not config_name:
-            return ""
-        stored = database.retrieve_section_data(config_name, section_key)
-        if not stored or not isinstance(stored[2], dict):
-            return ""
-        stored_validated = helpers.booler(stored[0])
-        payload = stored[2]
-        status = payload.get("validation_status")
-        if not status:
-            if stored_validated:
-                status = "validated"
-            else:
-                fallback_timestamp = payload.get("validated_at")
-                status = "failed" if fallback_timestamp else ""
-        if not status:
-            return ""
-        updated_at = payload.get("validation_updated_at") or payload.get("validated_at")
-        last_validated = format_validation_timestamp(updated_at)
-        if last_validated:
-            return f"# validation: {status} (last_validated: {last_validated})"
-        return f"# validation: {status}"
-
     ordered_sections = [
         ("libraries", "025-libraries"),
         ("playlist_files", "027-playlist_files"),
@@ -2210,7 +1948,7 @@ def build_config(header_style="standard", config_name=None):
         if section_key in config_data:
             section_data = config_data[section_key]
             section_art = header_for_section(section_key, helpers.user_visible_name(section_key))
-            yaml_content += dump_section(section_art, section_key, section_data)
+            yaml_content += dump_section(section_art, section_key, section_data, header_style, config_name)
 
     validated = False
     validation_error = None

--- a/modules/output_dump.py
+++ b/modules/output_dump.py
@@ -1,0 +1,450 @@
+"""YAML section serialization for build_config.
+
+Extracted from the original ``modules/output.py`` monolith.  Every
+config section (``plex``, ``tmdb``, ``libraries``, etc.) that
+``build_config`` emits is passed through ``dump_section`` -- a
+recursive cleaner + ``ruamel.yaml`` dumper + validation-comment
+prepender.
+
+Public surface: nothing here is a public API.  ``build_config`` calls
+``dump_section`` locally; everything else in this module is a helper
+of that call site.
+
+Design notes:
+
+* The ``_EMPTY_OUTPUT`` sentinel drives recursive pruning of empty
+  values (``None``, whitespace-only strings, empty containers).
+  ``dict.pop`` semantics matter -- the sentinel signals "this entry
+  should be dropped from its parent", which propagates upward through
+  the walk.
+* ``clean_data`` and ``_prune_empty_output_values`` were two separate
+  nested closures in the original code.  They stay as separate top-level
+  helpers here because their responsibilities do differ subtly:
+  ``clean_data`` also alphabetically sorts certain sections and strips
+  a ``valid`` key; ``_prune_empty_output_values`` only handles the
+  scalar leaves.
+* Section-name-set constants (``_ALPHABETICALLY_SORTED_SECTIONS``,
+  ``_PLAIN_SCALAR_SECTIONS``) are hoisted to module scope so they're
+  not recreated on every ``dump_section`` call.
+"""
+
+from __future__ import annotations
+
+import io
+from datetime import datetime, timezone
+
+from ruamel.yaml import YAML
+from ruamel.yaml.scalarstring import PlainScalarString
+
+from modules import database, helpers
+from modules.output_collections import _normalize_settings_section_value
+from modules.output_headers import render_section_header
+from modules.output_values import _normalize_asset_directory_values
+
+# Sentinel returned by pruning to say "drop this from its parent".
+# Sits at module scope so identity comparisons (`is _EMPTY_OUTPUT`)
+# stay stable across recursive calls.
+_EMPTY_OUTPUT = object()
+
+
+# Sections whose top-level keys should be emitted in alphabetical order
+# (for readability of the generated config.yml).
+_ALPHABETICALLY_SORTED_SECTIONS = frozenset(
+    {
+        "settings",
+        "webhooks",
+        "plex",
+        "tmdb",
+        "tautulli",
+        "github",
+        "omdb",
+        "mdblist",
+        "notifiarr",
+        "gotify",
+        "ntfy",
+        "apprise",
+        "anidb",
+        "radarr",
+        "sonarr",
+        "trakt",
+        "mal",
+    }
+)
+
+
+# Sections that carry secret/opaque tokens which YAML's folding logic
+# tends to line-wrap.  We coerce every string in these sections to a
+# PlainScalarString so ruamel.yaml keeps them on one line.
+_PLAIN_SCALAR_SECTIONS = frozenset(
+    {
+        "plex",
+        "tmdb",
+        "tautulli",
+        "github",
+        "omdb",
+        "mdblist",
+        "notifiarr",
+        "gotify",
+        "ntfy",
+        "apprise",
+        "anidb",
+        "radarr",
+        "sonarr",
+        "trakt",
+        "mal",
+    }
+)
+
+
+# --- pruning / cleaning ---------------------------------------------------
+
+
+def _prune_empty_output_values(obj):
+    """Walk ``obj`` and return ``_EMPTY_OUTPUT`` for empty leaves.
+
+    Empty here means:
+      * ``None``
+      * empty or whitespace-only string
+      * a dict where every value pruned to ``_EMPTY_OUTPUT``
+      * a list where every item pruned to ``_EMPTY_OUTPUT``
+
+    A ``valid`` key inside a dict is always dropped -- it's a transient
+    validation flag that should never land in the emitted YAML.
+
+    Note: in the current call graph this function only ever receives
+    scalar arguments (``clean_data`` calls it on non-dict, non-list
+    leaves), so the dict/list branches are effectively defensive.  They
+    were preserved from the original nested-closure form to keep this
+    extraction behavior-neutral.
+    """
+    if isinstance(obj, dict):
+        pruned = {}
+        for key, value in obj.items():
+            if key == "valid":
+                continue
+            cleaned_value = _prune_empty_output_values(value)
+            if cleaned_value is _EMPTY_OUTPUT:
+                continue
+            pruned[key] = cleaned_value
+        return pruned if pruned else _EMPTY_OUTPUT
+    if isinstance(obj, list):
+        cleaned_items = []
+        for value in obj:
+            cleaned_value = _prune_empty_output_values(value)
+            if cleaned_value is _EMPTY_OUTPUT:
+                continue
+            cleaned_items.append(cleaned_value)
+        return cleaned_items if cleaned_items else _EMPTY_OUTPUT
+    if obj is None:
+        return _EMPTY_OUTPUT
+    if isinstance(obj, str) and obj.strip() == "":
+        return _EMPTY_OUTPUT
+    return obj
+
+
+def _clean_data(obj, dump_name):
+    """Recursively clean a section's data dict for YAML emission.
+
+    Behaviors, applied top-down:
+      * Dicts in the ``_ALPHABETICALLY_SORTED_SECTIONS`` list get their
+        keys alphabetically sorted (readability of the emitted YAML).
+      * A ``valid`` key inside any dict is dropped.
+      * Empty values (``None``, empty string, empty containers) are
+        pruned via ``_EMPTY_OUTPUT`` sentinel semantics.
+      * Scalars go through ``_prune_empty_output_values`` for leaf-level
+        empty detection.
+    """
+    if isinstance(obj, dict):
+        if dump_name in _ALPHABETICALLY_SORTED_SECTIONS:
+            obj = dict(sorted(obj.items()))
+        cleaned_dict = {}
+        for k, v in obj.items():
+            if k == "valid":
+                continue
+            cleaned_value = _clean_data(v, dump_name)
+            if cleaned_value is _EMPTY_OUTPUT:
+                continue
+            cleaned_dict[k] = cleaned_value
+        return cleaned_dict if cleaned_dict else _EMPTY_OUTPUT
+    if isinstance(obj, list):
+        cleaned_list = []
+        for v in obj:
+            cleaned_value = _clean_data(v, dump_name)
+            if cleaned_value is _EMPTY_OUTPUT:
+                continue
+            cleaned_list.append(cleaned_value)
+        return cleaned_list if cleaned_list else _EMPTY_OUTPUT
+    return _prune_empty_output_values(obj)
+
+
+def _plainify_strings(obj):
+    """Recursively coerce every string in ``obj`` to a PlainScalarString.
+
+    Used for sections that hold API tokens / opaque strings so
+    ``ruamel.yaml`` doesn't emit them in folded style.  Structural
+    containers are re-created (fresh dicts/lists) but their scalar
+    leaves are wrapped in-place.
+    """
+    if isinstance(obj, dict):
+        return {k: _plainify_strings(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_plainify_strings(v) for v in obj]
+    if isinstance(obj, str):
+        return PlainScalarString(obj)
+    return obj
+
+
+# --- per-section post-cleaning tweaks -------------------------------------
+
+
+def _coerce_int_or_ignore(container, key):
+    """Coerce ``container[key]`` to ``int`` in place; swallow any exception."""
+    if key not in container:
+        return
+    try:
+        container[key] = int(container[key])
+    except Exception:
+        pass
+
+
+def _apply_mal_trakt_int_coercions(cleaned_data, dump_name):
+    """MAL/TRAKT sections carry ``expires_in`` and ``cache_expiration`` fields that
+    must land in YAML as ints, not strings.
+    """
+    section = cleaned_data.get(dump_name, {})
+    if not isinstance(section, dict):
+        return
+    auth = section.get("authorization")
+    if isinstance(auth, dict):
+        _coerce_int_or_ignore(auth, "expires_in")
+    _coerce_int_or_ignore(section, "cache_expiration")
+
+
+_TRAKT_PREFERRED_ORDER = ("authorization", "client_id", "client_secret", "pin", "force_refresh")
+
+
+def _apply_trakt_reorder(cleaned_data):
+    """TRAKT has a legacy ``force_refresh`` key living under ``authorization`` that
+    should be hoisted to the section root, and the section's top-level keys
+    should be emitted in a specific order.
+    """
+    section = cleaned_data.get("trakt")
+    if not isinstance(section, dict):
+        return
+    auth = section.get("authorization")
+    if isinstance(auth, dict) and "force_refresh" in auth and "force_refresh" not in section:
+        section["force_refresh"] = auth.pop("force_refresh")
+
+    ordered_section = {key: section[key] for key in _TRAKT_PREFERRED_ORDER if key in section}
+    for key, value in section.items():
+        if key not in ordered_section:
+            ordered_section[key] = value
+    cleaned_data["trakt"] = ordered_section
+
+
+def _apply_settings_normalization(cleaned_data):
+    """Normalize settings-block values, mirroring the schema shapes expected
+    by Kometa.  ``asset_directory`` in particular can arrive as a multi-line
+    string and needs list-splitting.
+    """
+    settings_block = cleaned_data.get("settings")
+    if not isinstance(settings_block, dict):
+        return
+
+    for setting_key in list(settings_block.keys()):
+        normalized_value = _normalize_settings_section_value(setting_key, settings_block.get(setting_key))
+        if normalized_value is None:
+            settings_block.pop(setting_key, None)
+        else:
+            settings_block[setting_key] = normalized_value
+
+    if "asset_directory" in settings_block and isinstance(settings_block["asset_directory"], (str, list)):
+        settings_block["asset_directory"] = _normalize_asset_directory_values(settings_block["asset_directory"])
+
+
+# --- validation comment ---------------------------------------------------
+
+
+def _format_validation_timestamp(raw):
+    """Render an ISO-8601 timestamp as ``YYYY-MM-DD HH:MM:SS`` in local time.
+
+    Returns the raw input unchanged if parsing fails, or ``""`` for
+    empty input.  Missing timezone defaults to UTC.
+    """
+    if not raw:
+        return ""
+    try:
+        normalized = raw.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        local = parsed.astimezone()
+        return local.strftime("%Y-%m-%d %H:%M:%S")
+    except Exception:
+        return raw
+
+
+def build_validation_comment(section_key, config_name):
+    """Return a ``# validation: <status> (last_validated: <ts>)`` comment,
+    or ``""`` if there's nothing on record for this section.
+    """
+    if not config_name:
+        return ""
+    stored = database.retrieve_section_data(config_name, section_key)
+    if not stored or not isinstance(stored[2], dict):
+        return ""
+    stored_validated = helpers.booler(stored[0])
+    payload = stored[2]
+    status = payload.get("validation_status")
+    if not status:
+        if stored_validated:
+            status = "validated"
+        else:
+            fallback_timestamp = payload.get("validated_at")
+            status = "failed" if fallback_timestamp else ""
+    if not status:
+        return ""
+    updated_at = payload.get("validation_updated_at") or payload.get("validated_at")
+    last_validated = _format_validation_timestamp(updated_at)
+    if last_validated:
+        return f"# validation: {status} (last_validated: {last_validated})"
+    return f"# validation: {status}"
+
+
+# --- YAML dumper factory --------------------------------------------------
+
+
+def _build_dump_yaml():
+    """Return a fresh ``YAML`` instance configured for Kometa output.
+
+    Key settings:
+      * ``default_flow_style = False`` -- always block-style
+      * ``sort_keys = False`` -- respect insertion order (post-cleaning)
+      * ``width = 4096`` -- avoid mid-string wrapping of long secrets
+      * ``None`` renders as ``""`` rather than the string ``null``
+    """
+    dump_yaml = YAML()
+    dump_yaml.default_flow_style = False
+    dump_yaml.sort_keys = False
+    dump_yaml.width = 4096
+    dump_yaml.representer.add_representer(
+        type(None),
+        lambda self, _: self.represent_scalar("tag:yaml.org,2002:null", ""),
+    )
+    return dump_yaml
+
+
+# --- the dumper -----------------------------------------------------------
+
+
+def dump_section(title, dump_name, data, header_style, config_name):
+    """Clean and YAML-dump one config section, returning the assembled string.
+
+    Returns a multi-line string of the form::
+
+        <title>
+        <validation_comment>
+        <yaml_body>
+
+    where ``<title>`` is the pre-rendered header (from
+    ``render_section_header``), ``<validation_comment>`` is a
+    ``# validation:`` line (empty if nothing stored), and
+    ``<yaml_body>`` is the ruamel-dumped output with section headers
+    injected for the ``libraries`` block.
+
+    ``header_style`` is passed through to
+    ``_inject_library_section_headers`` and drives whether ratings
+    overlays / collection-file blocks etc. get their own ASCII art
+    dividers within the libraries section.  When ``header_style ==
+    'none'`` no header injection happens.
+    """
+    cleaned_data = _clean_data(data, dump_name)
+    if cleaned_data is _EMPTY_OUTPUT:
+        cleaned_data = {}
+    if dump_name == "libraries" and isinstance(cleaned_data, dict) and "libraries" not in cleaned_data:
+        cleaned_data = {"libraries": cleaned_data}
+    if dump_name == "anidb":
+        section = cleaned_data.get("anidb")
+        if isinstance(section, dict):
+            section.pop("enable", None)
+
+    if dump_name in _PLAIN_SCALAR_SECTIONS:
+        cleaned_data = _plainify_strings(cleaned_data)
+
+    if dump_name in ("mal", "trakt"):
+        _apply_mal_trakt_int_coercions(cleaned_data, dump_name)
+
+    if dump_name == "trakt":
+        _apply_trakt_reorder(cleaned_data)
+
+    if dump_name == "settings":
+        _apply_settings_normalization(cleaned_data)
+
+    dump_yaml = _build_dump_yaml()
+    with io.StringIO() as stream:
+        dump_yaml.dump(cleaned_data, stream)
+        section_output = stream.getvalue().strip()
+
+    if header_style != "none":
+        section_output = _inject_library_section_headers(section_output, header_style)
+
+    validation_comment = build_validation_comment(dump_name, config_name)
+    blocks = []
+    if title:
+        blocks.append(title)
+    if validation_comment:
+        blocks.append(validation_comment)
+    blocks.append(section_output)
+    return "\n".join(blocks) + "\n\n"
+
+
+# --- library section header injection -------------------------------------
+#
+# When emitting the ``libraries`` block, we walk the already-dumped YAML
+# string and drop ASCII-art headers above each library name / each of
+# ``collection_files``, ``metadata_files``, ``overlay_files``.
+
+
+_LIBRARY_SUBHEADER_TITLES = {
+    "collection_files:": "Collections",
+    "metadata_files:": "Metadata Files",
+    "overlay_files:": "Overlays",
+}
+
+
+def _inject_library_section_headers(yaml_string, font):
+    """Insert ``render_section_header`` output above each library block and
+    each of its ``collection_files:`` / ``metadata_files:`` / ``overlay_files:``
+    child keys, so the emitted YAML is readable at a glance.
+    """
+    lines = yaml_string.splitlines()
+    output = []
+    in_libraries_block = False
+
+    for line in lines:
+        stripped = line.strip()
+
+        if stripped == "libraries:":
+            in_libraries_block = True
+            output.append(line)
+            continue
+
+        if in_libraries_block and not line.startswith("  ") and not stripped.startswith("#") and ":" in line:
+            in_libraries_block = False
+
+        # Only inject header for lines like "  Movies:" or "  TV Shows:" inside the libraries block
+        if in_libraries_block and line.startswith("  ") and not line.startswith("   ") and stripped.endswith(":") and not stripped.startswith("-"):
+            library_name = stripped.rstrip(":")
+            output.append(render_section_header(library_name, font))
+        else:
+            subheader_title = None
+            for prefix, title in _LIBRARY_SUBHEADER_TITLES.items():
+                if stripped.startswith(prefix):
+                    subheader_title = title
+                    break
+            if subheader_title is not None:
+                output.append(render_section_header(subheader_title, font))
+
+        output.append(line)
+
+    return "\n".join(output)


### PR DESCRIPTION
Fourteenth refactor pass on `modules/output.py` (now 2226 lines after #1457). Stacked on top of #1457.

## output.py 3833 -> 1964 (-1869 / -48.8%) - under 2000 lines!

The second-largest single-PR extraction of the sprint, after PR #1455 (optimize_template_variables).

## What

Extracted `dump_section` — the ~190-line YAML serializer that turns each config section (`plex`, `tmdb`, `libraries`, etc.) into its YAML block — into a new module `modules/output_dump.py`. Also pulled the two validation-comment helpers (`build_validation_comment`, `format_validation_timestamp`) and the `inject_section_headers` closure since they were only called from within `dump_section`.

## Before

`build_config` contained a nested `dump_section(title, dump_name, data)` closure that captured `header_style`, `config_name`, `inject_section_headers`, and `build_validation_comment` from the enclosing scope. It in turn had **three more** nested closures (`_prune_empty_output_values`, `clean_data`, `plainify_strings`) plus scattered inline logic for MAL/TRAKT/Trakt/Settings section-specific post-processing.

Total closure depth: 4 levels. Constants (`_ALPHABETICALLY_SORTED_SECTIONS`, `_PLAIN_SCALAR_SECTIONS`, `_EMPTY_OUTPUT` sentinel) were recreated on every call.

## After

Flat `modules/output_dump.py` with:

### Top-level functions (all testable in isolation)
| Function | Purpose |
|---|---|
| `dump_section(title, dump_name, data, header_style, config_name)` | The public entry point |
| `build_validation_comment(section_key, config_name)` | Re-exported |
| `_clean_data(obj, dump_name)` | Top-level walker w/ alpha-sort |
| `_prune_empty_output_values(obj)` | Scalar/container empty-value walker |
| `_plainify_strings(obj)` | PlainScalarString wrap for tokens |
| `_format_validation_timestamp(raw)` | ISO-8601 -> local |
| `_apply_mal_trakt_int_coercions(data, name)` | expires_in / cache_expiration |
| `_apply_trakt_reorder(data)` | Hoist force_refresh + reorder |
| `_apply_settings_normalization(data)` | Normalize settings values |
| `_inject_library_section_headers(yaml, font)` | ASCII art headers for libraries |
| `_build_dump_yaml()` | ruamel.yaml factory |
| `_coerce_int_or_ignore(container, key)` | Shared int coercion |

### Constants hoisted out of function-local scope
- `_EMPTY_OUTPUT` sentinel (was recreated per call!)
- `_ALPHABETICALLY_SORTED_SECTIONS` — 17-entry frozenset
- `_PLAIN_SCALAR_SECTIONS` — 15-entry frozenset
- `_TRAKT_PREFERRED_ORDER` — 5-entry tuple
- `_LIBRARY_SUBHEADER_TITLES` — 3-entry dict

## DRY wins along the way

- **MAL/TRAKT int coercion**: was 2 nearly-identical try/except blocks -> 1 `_coerce_int_or_ignore` helper
- **`_inject_library_section_headers`**: was 4 `elif stripped.startswith(...)` branches -> dict-driven `for prefix, title in _LIBRARY_SUBHEADER_TITLES.items()` loop
- **`_apply_trakt_reorder`**: uses dict-comprehension pattern (mirrors `_reorder_by_template` from output_reorder.py)

## Import cleanup bonus

Three dead imports removed from `output.py`:
- `datetime.timezone` (moved with `_format_validation_timestamp`)
- `PlainScalarString` (moved with `_plainify_strings`)
- `database` (moved with `build_validation_comment`)

## API safety

Zero external callers (verified across `tests/`, `blueprints/`, `quickstart.py`). No re-export needed — `dump_section` is now imported directly from `output_dump` for the one call site.

## Impact

- `modules/output.py`: 2226 -> **1964** (-262 / -11.8%) - **under 2000 for the first time**
- `modules/output_dump.py`: **451** lines new
- Net +189: docstrings, top-level constants, DRY helpers. Trade-off is 260 lines of tightly-coupled nested closures becoming a flat module of 12 independently-testable functions.

## Cumulative sprint progress on output.py

| PR | Size | Delta |
|---|---|---|
| Start | 3833 | — |
| #1445-1447 (MERGED) | 3343 | -490 |
| #1448-1454 | 2768 | -575 |
| #1455 (first elephant) | 2363 | -405 |
| #1456 (baby elephant) | 2252 | -111 |
| #1457 (DRY sweep) | 2226 | -26 |
| **This PR (dump_section)** | **1964** | **-262**  |
| **Total** | | **-1869 / -48.8%** |

## Verification

- All 1077 tests pass
- Ruff + black clean
- Smoke tests confirm all extracted helpers: pruning, alpha-sort, timestamp formatting, MAL/TRAKT int coercion, TRAKT reorder + force_refresh hoisting