### PR TITLE
First carve of the whale: extract build_delete_collections_operation

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -4,17 +4,16 @@ import os
 import json
 import shutil
 import subprocess
-from datetime import datetime, timezone
+from datetime import datetime
 import platform
 import psutil
 
 import jsonschema
 from flask import current_app as app, has_request_context, session
 from ruamel.yaml import YAML
-from ruamel.yaml.scalarstring import PlainScalarString
 from ruamel.yaml.comments import CommentedSeq
 
-from modules import helpers, persistence, database
+from modules import helpers, persistence
 from modules.output_collections import (  # noqa: F401 -- re-exported so output.<name> keeps working
     FRANCHISE_DYNAMIC_CHILD_FIELD_SPECS,
     _collapse_collection_data_template_vars,
@@ -36,6 +35,7 @@ from modules.output_defaults import (  # noqa: F401 -- re-exported so output.<na
     _prune_template_variables,
     _values_match,
 )
+from modules.output_dump import dump_section
 from modules.output_file_entries import (  # noqa: F401 -- re-exported so output.<name> keeps working
     _parse_collection_file_block_entries,
     _parse_metadata_file_entries,
@@ -1907,268 +1907,6 @@ def build_config(header_style="standard", config_name=None):
         f"\n\n"
     )
 
-    def inject_section_headers(yaml_string, font):
-        lines = yaml_string.splitlines()
-        output = []
-        in_libraries_block = False
-
-        for i, line in enumerate(lines):
-            stripped = line.strip()
-
-            # Detect when we've entered the top-level libraries block
-            if stripped == "libraries:":
-                in_libraries_block = True
-                output.append(line)
-                continue
-
-            # Exit the block once indentation resets or we hit a new top-level key
-            if in_libraries_block and not line.startswith("  ") and not line.strip().startswith("#") and ":" in line:
-                in_libraries_block = False
-
-            # Only inject header for lines like "  Movies:" or "  TV Shows:" inside the libraries block
-            if in_libraries_block and line.startswith("  ") and not line.startswith("   ") and line.strip().endswith(":") and not line.strip().startswith("-"):
-                library_name = line.strip().rstrip(":")
-                output.append(render_section_header(library_name, font))
-
-            elif stripped.startswith("collection_files:"):
-                output.append(render_section_header("Collections", font))
-            elif stripped.startswith("metadata_files:"):
-                output.append(render_section_header("Metadata Files", font))
-            elif stripped.startswith("overlay_files:"):
-                output.append(render_section_header("Overlays", font))
-
-            output.append(line)
-
-        return "\n".join(output)
-
-    # Function to dump YAML sections
-    def dump_section(title, dump_name, data):
-
-        dump_yaml = YAML()
-        dump_yaml.default_flow_style = False
-        dump_yaml.sort_keys = False  # Preserve original key order
-        dump_yaml.width = 4096  # avoid folding long tokens/secrets
-
-        # Custom representation for `None` values
-        dump_yaml.representer.add_representer(
-            type(None),
-            lambda self, _: self.represent_scalar("tag:yaml.org,2002:null", ""),
-        )
-
-        def _prune_empty_output_values(obj):
-            if isinstance(obj, dict):
-                pruned = {}
-                for key, value in obj.items():
-                    if key == "valid":
-                        continue
-                    cleaned_value = _prune_empty_output_values(value)
-                    if cleaned_value is _EMPTY_OUTPUT:
-                        continue
-                    pruned[key] = cleaned_value
-                return pruned if pruned else _EMPTY_OUTPUT
-            if isinstance(obj, list):
-                cleaned_items = []
-                for value in obj:
-                    cleaned_value = _prune_empty_output_values(value)
-                    if cleaned_value is _EMPTY_OUTPUT:
-                        continue
-                    cleaned_items.append(cleaned_value)
-                return cleaned_items if cleaned_items else _EMPTY_OUTPUT
-            if obj is None:
-                return _EMPTY_OUTPUT
-            if isinstance(obj, str) and obj.strip() == "":
-                return _EMPTY_OUTPUT
-            return obj
-
-        def clean_data(obj):
-            if isinstance(obj, dict):
-                # Sort specific sections alphabetically
-                if dump_name in [
-                    "settings",
-                    "webhooks",
-                    "plex",
-                    "tmdb",
-                    "tautulli",
-                    "github",
-                    "omdb",
-                    "mdblist",
-                    "notifiarr",
-                    "gotify",
-                    "ntfy",
-                    "apprise",
-                    "anidb",
-                    "radarr",
-                    "sonarr",
-                    "trakt",
-                    "mal",
-                ]:
-                    obj = dict(sorted(obj.items()))  # Alphabetically sort keys in the section
-                cleaned_dict = {}
-                for k, v in obj.items():
-                    if k == "valid":
-                        continue
-                    cleaned_value = clean_data(v)
-                    if cleaned_value is _EMPTY_OUTPUT:
-                        continue
-                    cleaned_dict[k] = cleaned_value
-                return cleaned_dict if cleaned_dict else _EMPTY_OUTPUT
-            elif isinstance(obj, list):
-                cleaned_list = []
-                for v in obj:
-                    cleaned_value = clean_data(v)
-                    if cleaned_value is _EMPTY_OUTPUT:
-                        continue
-                    cleaned_list.append(cleaned_value)
-                return cleaned_list if cleaned_list else _EMPTY_OUTPUT
-            else:
-                return _prune_empty_output_values(obj)
-
-        # Clean the data
-        cleaned_data = clean_data(data)
-        if cleaned_data is _EMPTY_OUTPUT:
-            cleaned_data = {}
-        if dump_name == "libraries" and isinstance(cleaned_data, dict) and "libraries" not in cleaned_data:
-            cleaned_data = {"libraries": cleaned_data}
-        if dump_name == "anidb":
-            section = cleaned_data.get("anidb")
-            if isinstance(section, dict):
-                section.pop("enable", None)
-
-        # Force long/scalar strings to emit in plain style (avoid folded multi-line) for sensitive sections
-        plain_scalar_sections = {
-            "plex",
-            "tmdb",
-            "tautulli",
-            "github",
-            "omdb",
-            "mdblist",
-            "notifiarr",
-            "gotify",
-            "ntfy",
-            "apprise",
-            "anidb",
-            "radarr",
-            "sonarr",
-            "trakt",
-            "mal",
-        }
-
-        def plainify_strings(obj):
-            if isinstance(obj, dict):
-                return {k: plainify_strings(v) for k, v in obj.items()}
-            if isinstance(obj, list):
-                return [plainify_strings(v) for v in obj]
-            if isinstance(obj, str):
-                return PlainScalarString(obj)
-            return obj
-
-        if dump_name in plain_scalar_sections:
-            cleaned_data = plainify_strings(cleaned_data)
-
-        # Normalize MAL/TRAKT numeric fields
-        if dump_name in ("mal", "trakt"):
-            section = cleaned_data.get(dump_name, {})
-            auth = section.get("authorization", {})
-
-            if isinstance(auth, dict) and "expires_in" in auth:
-                try:
-                    auth["expires_in"] = int(auth["expires_in"])
-                except Exception:
-                    pass
-
-            if "cache_expiration" in section:
-                try:
-                    section["cache_expiration"] = int(section["cache_expiration"])
-                except Exception:
-                    pass
-
-        if dump_name == "trakt":
-            section = cleaned_data.get("trakt", {})
-            if isinstance(section, dict):
-                auth = section.get("authorization")
-                if isinstance(auth, dict) and "force_refresh" in auth and "force_refresh" not in section:
-                    section["force_refresh"] = auth.pop("force_refresh")
-
-                preferred_order = ["authorization", "client_id", "client_secret", "pin", "force_refresh"]
-                ordered_section = {}
-                for key in preferred_order:
-                    if key in section:
-                        ordered_section[key] = section[key]
-                for key, value in section.items():
-                    if key not in ordered_section:
-                        ordered_section[key] = value
-                cleaned_data["trakt"] = ordered_section
-
-        # Ensure settings multi-value inputs are normalized for YAML output.
-        if dump_name == "settings" and isinstance(cleaned_data.get("settings"), dict):
-            settings_block = cleaned_data["settings"]
-            for setting_key in list(settings_block.keys()):
-                normalized_value = _normalize_settings_section_value(setting_key, settings_block.get(setting_key))
-                if normalized_value is None:
-                    settings_block.pop(setting_key, None)
-                else:
-                    settings_block[setting_key] = normalized_value
-
-            if "asset_directory" in settings_block:
-                if isinstance(settings_block["asset_directory"], str):
-                    # Convert multi-line string into a list
-                    settings_block["asset_directory"] = _normalize_asset_directory_values(settings_block["asset_directory"])
-                elif isinstance(settings_block["asset_directory"], list):
-                    # Ensure all list items are strings
-                    settings_block["asset_directory"] = _normalize_asset_directory_values(settings_block["asset_directory"])
-
-        # Dump the cleaned data to YAML
-        with io.StringIO() as stream:
-            dump_yaml.dump(cleaned_data, stream)
-            section_output = stream.getvalue().strip()
-            if header_style != "none":
-                section_output = inject_section_headers(section_output, header_style)
-
-            validation_comment = build_validation_comment(dump_name)
-            blocks = []
-            if title:
-                blocks.append(title)
-            if validation_comment:
-                blocks.append(validation_comment)
-            blocks.append(section_output)
-            return "\n".join(blocks) + "\n\n"
-
-    def format_validation_timestamp(raw):
-        if not raw:
-            return ""
-        try:
-            normalized = raw.replace("Z", "+00:00")
-            parsed = datetime.fromisoformat(normalized)
-            if parsed.tzinfo is None:
-                parsed = parsed.replace(tzinfo=timezone.utc)
-            local = parsed.astimezone()
-            return local.strftime("%Y-%m-%d %H:%M:%S")
-        except Exception:
-            return raw
-
-    def build_validation_comment(section_key):
-        if not config_name:
-            return ""
-        stored = database.retrieve_section_data(config_name, section_key)
-        if not stored or not isinstance(stored[2], dict):
-            return ""
-        stored_validated = helpers.booler(stored[0])
-        payload = stored[2]
-        status = payload.get("validation_status")
-        if not status:
-            if stored_validated:
-                status = "validated"
-            else:
-                fallback_timestamp = payload.get("validated_at")
-                status = "failed" if fallback_timestamp else ""
-        if not status:
-            return ""
-        updated_at = payload.get("validation_updated_at") or payload.get("validated_at")
-        last_validated = format_validation_timestamp(updated_at)
-        if last_validated:
-            return f"# validation: {status} (last_validated: {last_validated})"
-        return f"# validation: {status}"
-
     ordered_sections = [
         ("libraries", "025-libraries"),
         ("playlist_files", "027-playlist_files"),
@@ -2210,7 +1948,7 @@ def build_config(header_style="standard", config_name=None):
         if section_key in config_data:
             section_data = config_data[section_key]
             section_art = header_for_section(section_key, helpers.user_visible_name(section_key))
-            yaml_content += dump_section(section_art, section_key, section_data)
+            yaml_content += dump_section(section_art, section_key, section_data, header_style, config_name)
 
     validated = False
     validation_error = None

--- a/modules/output.py
+++ b/modules/output.py
@@ -46,6 +46,7 @@ from modules.output_headers import (  # noqa: F401 -- re-exported so output.<nam
     render_section_header,
     section_heading,
 )
+from modules.output_library_ops import build_delete_collections_operation
 from modules.output_optimize import optimize_template_variables
 from modules.output_playlists import (  # noqa: F401 -- re-exported so output.<name> keeps working
     PLAYLIST_KEYED_TEMPLATE_VAR_SPECS,
@@ -374,40 +375,7 @@ def build_libraries_section(
                 service_overrides[field] = value
 
         # Handle nested delete_collections block
-        delete_collections = {}
-        configured_key = f"{library_type}-library_{lib_id}-attribute_delete_collections_configured"
-        managed_key = f"{library_type}-library_{lib_id}-attribute_delete_collections_managed"
-        ignore_key = f"{library_type}-library_{lib_id}-attribute_delete_collections_ignore_empty_smart_collections"
-        less_key = f"{library_type}-library_{lib_id}-attribute_delete_collections_less"
-
-        configured_value = _coerce_bool(attr_group.get(configured_key, None))
-        managed_value = _coerce_bool(attr_group.get(managed_key, None))
-        ignore_value = _coerce_bool(attr_group.get(ignore_key, None))
-        less_value = None
-        raw_less = attr_group.get(less_key, None)
-        if raw_less not in [None, "", "None", "none"]:
-            try:
-                less_value = int(raw_less)
-            except Exception:
-                helpers.ts_log(f"Skipping invalid delete_collections_less value: {raw_less}", level="DEBUG")
-
-        delete_collections_enabled = any(
-            [
-                configured_value is True,
-                managed_value is True,
-                ignore_value is True,
-                less_value is not None,
-            ]
-        )
-
-        if delete_collections_enabled:
-            delete_collections["configured"] = configured_value if configured_value is not None else False
-            delete_collections["managed"] = managed_value if managed_value is not None else False
-            if less_value is not None:
-                delete_collections["less"] = less_value
-            if ignore_value is True:
-                delete_collections["ignore_empty_smart_collections"] = True
-
+        delete_collections = build_delete_collections_operation(attr_group, library_type, lib_id)
         if delete_collections:
             operations["delete_collections"] = delete_collections
 

--- a/modules/output_dump.py
+++ b/modules/output_dump.py
@@ -1,0 +1,450 @@
+"""YAML section serialization for build_config.
+
+Extracted from the original ``modules/output.py`` monolith.  Every
+config section (``plex``, ``tmdb``, ``libraries``, etc.) that
+``build_config`` emits is passed through ``dump_section`` -- a
+recursive cleaner + ``ruamel.yaml`` dumper + validation-comment
+prepender.
+
+Public surface: nothing here is a public API.  ``build_config`` calls
+``dump_section`` locally; everything else in this module is a helper
+of that call site.
+
+Design notes:
+
+* The ``_EMPTY_OUTPUT`` sentinel drives recursive pruning of empty
+  values (``None``, whitespace-only strings, empty containers).
+  ``dict.pop`` semantics matter -- the sentinel signals "this entry
+  should be dropped from its parent", which propagates upward through
+  the walk.
+* ``clean_data`` and ``_prune_empty_output_values`` were two separate
+  nested closures in the original code.  They stay as separate top-level
+  helpers here because their responsibilities do differ subtly:
+  ``clean_data`` also alphabetically sorts certain sections and strips
+  a ``valid`` key; ``_prune_empty_output_values`` only handles the
+  scalar leaves.
+* Section-name-set constants (``_ALPHABETICALLY_SORTED_SECTIONS``,
+  ``_PLAIN_SCALAR_SECTIONS``) are hoisted to module scope so they're
+  not recreated on every ``dump_section`` call.
+"""
+
+from __future__ import annotations
+
+import io
+from datetime import datetime, timezone
+
+from ruamel.yaml import YAML
+from ruamel.yaml.scalarstring import PlainScalarString
+
+from modules import database, helpers
+from modules.output_collections import _normalize_settings_section_value
+from modules.output_headers import render_section_header
+from modules.output_values import _normalize_asset_directory_values
+
+# Sentinel returned by pruning to say "drop this from its parent".
+# Sits at module scope so identity comparisons (`is _EMPTY_OUTPUT`)
+# stay stable across recursive calls.
+_EMPTY_OUTPUT = object()
+
+
+# Sections whose top-level keys should be emitted in alphabetical order
+# (for readability of the generated config.yml).
+_ALPHABETICALLY_SORTED_SECTIONS = frozenset(
+    {
+        "settings",
+        "webhooks",
+        "plex",
+        "tmdb",
+        "tautulli",
+        "github",
+        "omdb",
+        "mdblist",
+        "notifiarr",
+        "gotify",
+        "ntfy",
+        "apprise",
+        "anidb",
+        "radarr",
+        "sonarr",
+        "trakt",
+        "mal",
+    }
+)
+
+
+# Sections that carry secret/opaque tokens which YAML's folding logic
+# tends to line-wrap.  We coerce every string in these sections to a
+# PlainScalarString so ruamel.yaml keeps them on one line.
+_PLAIN_SCALAR_SECTIONS = frozenset(
+    {
+        "plex",
+        "tmdb",
+        "tautulli",
+        "github",
+        "omdb",
+        "mdblist",
+        "notifiarr",
+        "gotify",
+        "ntfy",
+        "apprise",
+        "anidb",
+        "radarr",
+        "sonarr",
+        "trakt",
+        "mal",
+    }
+)
+
+
+# --- pruning / cleaning ---------------------------------------------------
+
+
+def _prune_empty_output_values(obj):
+    """Walk ``obj`` and return ``_EMPTY_OUTPUT`` for empty leaves.
+
+    Empty here means:
+      * ``None``
+      * empty or whitespace-only string
+      * a dict where every value pruned to ``_EMPTY_OUTPUT``
+      * a list where every item pruned to ``_EMPTY_OUTPUT``
+
+    A ``valid`` key inside a dict is always dropped -- it's a transient
+    validation flag that should never land in the emitted YAML.
+
+    Note: in the current call graph this function only ever receives
+    scalar arguments (``clean_data`` calls it on non-dict, non-list
+    leaves), so the dict/list branches are effectively defensive.  They
+    were preserved from the original nested-closure form to keep this
+    extraction behavior-neutral.
+    """
+    if isinstance(obj, dict):
+        pruned = {}
+        for key, value in obj.items():
+            if key == "valid":
+                continue
+            cleaned_value = _prune_empty_output_values(value)
+            if cleaned_value is _EMPTY_OUTPUT:
+                continue
+            pruned[key] = cleaned_value
+        return pruned if pruned else _EMPTY_OUTPUT
+    if isinstance(obj, list):
+        cleaned_items = []
+        for value in obj:
+            cleaned_value = _prune_empty_output_values(value)
+            if cleaned_value is _EMPTY_OUTPUT:
+                continue
+            cleaned_items.append(cleaned_value)
+        return cleaned_items if cleaned_items else _EMPTY_OUTPUT
+    if obj is None:
+        return _EMPTY_OUTPUT
+    if isinstance(obj, str) and obj.strip() == "":
+        return _EMPTY_OUTPUT
+    return obj
+
+
+def _clean_data(obj, dump_name):
+    """Recursively clean a section's data dict for YAML emission.
+
+    Behaviors, applied top-down:
+      * Dicts in the ``_ALPHABETICALLY_SORTED_SECTIONS`` list get their
+        keys alphabetically sorted (readability of the emitted YAML).
+      * A ``valid`` key inside any dict is dropped.
+      * Empty values (``None``, empty string, empty containers) are
+        pruned via ``_EMPTY_OUTPUT`` sentinel semantics.
+      * Scalars go through ``_prune_empty_output_values`` for leaf-level
+        empty detection.
+    """
+    if isinstance(obj, dict):
+        if dump_name in _ALPHABETICALLY_SORTED_SECTIONS:
+            obj = dict(sorted(obj.items()))
+        cleaned_dict = {}
+        for k, v in obj.items():
+            if k == "valid":
+                continue
+            cleaned_value = _clean_data(v, dump_name)
+            if cleaned_value is _EMPTY_OUTPUT:
+                continue
+            cleaned_dict[k] = cleaned_value
+        return cleaned_dict if cleaned_dict else _EMPTY_OUTPUT
+    if isinstance(obj, list):
+        cleaned_list = []
+        for v in obj:
+            cleaned_value = _clean_data(v, dump_name)
+            if cleaned_value is _EMPTY_OUTPUT:
+                continue
+            cleaned_list.append(cleaned_value)
+        return cleaned_list if cleaned_list else _EMPTY_OUTPUT
+    return _prune_empty_output_values(obj)
+
+
+def _plainify_strings(obj):
+    """Recursively coerce every string in ``obj`` to a PlainScalarString.
+
+    Used for sections that hold API tokens / opaque strings so
+    ``ruamel.yaml`` doesn't emit them in folded style.  Structural
+    containers are re-created (fresh dicts/lists) but their scalar
+    leaves are wrapped in-place.
+    """
+    if isinstance(obj, dict):
+        return {k: _plainify_strings(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_plainify_strings(v) for v in obj]
+    if isinstance(obj, str):
+        return PlainScalarString(obj)
+    return obj
+
+
+# --- per-section post-cleaning tweaks -------------------------------------
+
+
+def _coerce_int_or_ignore(container, key):
+    """Coerce ``container[key]`` to ``int`` in place; swallow any exception."""
+    if key not in container:
+        return
+    try:
+        container[key] = int(container[key])
+    except Exception:
+        pass
+
+
+def _apply_mal_trakt_int_coercions(cleaned_data, dump_name):
+    """MAL/TRAKT sections carry ``expires_in`` and ``cache_expiration`` fields that
+    must land in YAML as ints, not strings.
+    """
+    section = cleaned_data.get(dump_name, {})
+    if not isinstance(section, dict):
+        return
+    auth = section.get("authorization")
+    if isinstance(auth, dict):
+        _coerce_int_or_ignore(auth, "expires_in")
+    _coerce_int_or_ignore(section, "cache_expiration")
+
+
+_TRAKT_PREFERRED_ORDER = ("authorization", "client_id", "client_secret", "pin", "force_refresh")
+
+
+def _apply_trakt_reorder(cleaned_data):
+    """TRAKT has a legacy ``force_refresh`` key living under ``authorization`` that
+    should be hoisted to the section root, and the section's top-level keys
+    should be emitted in a specific order.
+    """
+    section = cleaned_data.get("trakt")
+    if not isinstance(section, dict):
+        return
+    auth = section.get("authorization")
+    if isinstance(auth, dict) and "force_refresh" in auth and "force_refresh" not in section:
+        section["force_refresh"] = auth.pop("force_refresh")
+
+    ordered_section = {key: section[key] for key in _TRAKT_PREFERRED_ORDER if key in section}
+    for key, value in section.items():
+        if key not in ordered_section:
+            ordered_section[key] = value
+    cleaned_data["trakt"] = ordered_section
+
+
+def _apply_settings_normalization(cleaned_data):
+    """Normalize settings-block values, mirroring the schema shapes expected
+    by Kometa.  ``asset_directory`` in particular can arrive as a multi-line
+    string and needs list-splitting.
+    """
+    settings_block = cleaned_data.get("settings")
+    if not isinstance(settings_block, dict):
+        return
+
+    for setting_key in list(settings_block.keys()):
+        normalized_value = _normalize_settings_section_value(setting_key, settings_block.get(setting_key))
+        if normalized_value is None:
+            settings_block.pop(setting_key, None)
+        else:
+            settings_block[setting_key] = normalized_value
+
+    if "asset_directory" in settings_block and isinstance(settings_block["asset_directory"], (str, list)):
+        settings_block["asset_directory"] = _normalize_asset_directory_values(settings_block["asset_directory"])
+
+
+# --- validation comment ---------------------------------------------------
+
+
+def _format_validation_timestamp(raw):
+    """Render an ISO-8601 timestamp as ``YYYY-MM-DD HH:MM:SS`` in local time.
+
+    Returns the raw input unchanged if parsing fails, or ``""`` for
+    empty input.  Missing timezone defaults to UTC.
+    """
+    if not raw:
+        return ""
+    try:
+        normalized = raw.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        local = parsed.astimezone()
+        return local.strftime("%Y-%m-%d %H:%M:%S")
+    except Exception:
+        return raw
+
+
+def build_validation_comment(section_key, config_name):
+    """Return a ``# validation: <status> (last_validated: <ts>)`` comment,
+    or ``""`` if there's nothing on record for this section.
+    """
+    if not config_name:
+        return ""
+    stored = database.retrieve_section_data(config_name, section_key)
+    if not stored or not isinstance(stored[2], dict):
+        return ""
+    stored_validated = helpers.booler(stored[0])
+    payload = stored[2]
+    status = payload.get("validation_status")
+    if not status:
+        if stored_validated:
+            status = "validated"
+        else:
+            fallback_timestamp = payload.get("validated_at")
+            status = "failed" if fallback_timestamp else ""
+    if not status:
+        return ""
+    updated_at = payload.get("validation_updated_at") or payload.get("validated_at")
+    last_validated = _format_validation_timestamp(updated_at)
+    if last_validated:
+        return f"# validation: {status} (last_validated: {last_validated})"
+    return f"# validation: {status}"
+
+
+# --- YAML dumper factory --------------------------------------------------
+
+
+def _build_dump_yaml():
+    """Return a fresh ``YAML`` instance configured for Kometa output.
+
+    Key settings:
+      * ``default_flow_style = False`` -- always block-style
+      * ``sort_keys = False`` -- respect insertion order (post-cleaning)
+      * ``width = 4096`` -- avoid mid-string wrapping of long secrets
+      * ``None`` renders as ``""`` rather than the string ``null``
+    """
+    dump_yaml = YAML()
+    dump_yaml.default_flow_style = False
+    dump_yaml.sort_keys = False
+    dump_yaml.width = 4096
+    dump_yaml.representer.add_representer(
+        type(None),
+        lambda self, _: self.represent_scalar("tag:yaml.org,2002:null", ""),
+    )
+    return dump_yaml
+
+
+# --- the dumper -----------------------------------------------------------
+
+
+def dump_section(title, dump_name, data, header_style, config_name):
+    """Clean and YAML-dump one config section, returning the assembled string.
+
+    Returns a multi-line string of the form::
+
+        <title>
+        <validation_comment>
+        <yaml_body>
+
+    where ``<title>`` is the pre-rendered header (from
+    ``render_section_header``), ``<validation_comment>`` is a
+    ``# validation:`` line (empty if nothing stored), and
+    ``<yaml_body>`` is the ruamel-dumped output with section headers
+    injected for the ``libraries`` block.
+
+    ``header_style`` is passed through to
+    ``_inject_library_section_headers`` and drives whether ratings
+    overlays / collection-file blocks etc. get their own ASCII art
+    dividers within the libraries section.  When ``header_style ==
+    'none'`` no header injection happens.
+    """
+    cleaned_data = _clean_data(data, dump_name)
+    if cleaned_data is _EMPTY_OUTPUT:
+        cleaned_data = {}
+    if dump_name == "libraries" and isinstance(cleaned_data, dict) and "libraries" not in cleaned_data:
+        cleaned_data = {"libraries": cleaned_data}
+    if dump_name == "anidb":
+        section = cleaned_data.get("anidb")
+        if isinstance(section, dict):
+            section.pop("enable", None)
+
+    if dump_name in _PLAIN_SCALAR_SECTIONS:
+        cleaned_data = _plainify_strings(cleaned_data)
+
+    if dump_name in ("mal", "trakt"):
+        _apply_mal_trakt_int_coercions(cleaned_data, dump_name)
+
+    if dump_name == "trakt":
+        _apply_trakt_reorder(cleaned_data)
+
+    if dump_name == "settings":
+        _apply_settings_normalization(cleaned_data)
+
+    dump_yaml = _build_dump_yaml()
+    with io.StringIO() as stream:
+        dump_yaml.dump(cleaned_data, stream)
+        section_output = stream.getvalue().strip()
+
+    if header_style != "none":
+        section_output = _inject_library_section_headers(section_output, header_style)
+
+    validation_comment = build_validation_comment(dump_name, config_name)
+    blocks = []
+    if title:
+        blocks.append(title)
+    if validation_comment:
+        blocks.append(validation_comment)
+    blocks.append(section_output)
+    return "\n".join(blocks) + "\n\n"
+
+
+# --- library section header injection -------------------------------------
+#
+# When emitting the ``libraries`` block, we walk the already-dumped YAML
+# string and drop ASCII-art headers above each library name / each of
+# ``collection_files``, ``metadata_files``, ``overlay_files``.
+
+
+_LIBRARY_SUBHEADER_TITLES = {
+    "collection_files:": "Collections",
+    "metadata_files:": "Metadata Files",
+    "overlay_files:": "Overlays",
+}
+
+
+def _inject_library_section_headers(yaml_string, font):
+    """Insert ``render_section_header`` output above each library block and
+    each of its ``collection_files:`` / ``metadata_files:`` / ``overlay_files:``
+    child keys, so the emitted YAML is readable at a glance.
+    """
+    lines = yaml_string.splitlines()
+    output = []
+    in_libraries_block = False
+
+    for line in lines:
+        stripped = line.strip()
+
+        if stripped == "libraries:":
+            in_libraries_block = True
+            output.append(line)
+            continue
+
+        if in_libraries_block and not line.startswith("  ") and not stripped.startswith("#") and ":" in line:
+            in_libraries_block = False
+
+        # Only inject header for lines like "  Movies:" or "  TV Shows:" inside the libraries block
+        if in_libraries_block and line.startswith("  ") and not line.startswith("   ") and stripped.endswith(":") and not stripped.startswith("-"):
+            library_name = stripped.rstrip(":")
+            output.append(render_section_header(library_name, font))
+        else:
+            subheader_title = None
+            for prefix, title in _LIBRARY_SUBHEADER_TITLES.items():
+                if stripped.startswith(prefix):
+                    subheader_title = title
+                    break
+            if subheader_title is not None:
+                output.append(render_section_header(subheader_title, font))
+
+        output.append(line)
+
+    return "\n".join(output)

--- a/modules/output_library_ops.py
+++ b/modules/output_library_ops.py
@@ -1,0 +1,86 @@
+"""Per-library operation builders for build_libraries_section.
+
+Extracted incrementally from the giant ``add_entry`` closure inside
+``modules/output.py``.  Each function here takes the raw
+``attr_group`` dict for one library plus a couple of identity keys,
+and returns the operation's YAML-ready value (or ``None`` when the
+operation is disabled).
+
+The naming convention is ``build_<operation_name>_operation`` so it's
+obvious what shape the return type matches.
+
+Public surface: none.  These helpers are called from the
+``build_libraries_section`` orchestrator; ``output.py`` imports each
+name without underscore because they're consumed inside the same
+package.
+"""
+
+from __future__ import annotations
+
+from modules import helpers
+from modules.output_values import _coerce_bool
+
+# Values that we treat as "no override provided" for the numeric-ish
+# knobs inside operation blocks.  Users can wipe a field by clearing
+# the form input, which arrives as one of these placeholders.
+_EMPTY_OVERRIDE_VALUES = frozenset({None, "", "None", "none"})
+
+
+def _attr_key(library_type, lib_id, suffix):
+    """Compose the per-library attribute lookup key.
+
+    Consolidates the ``f\"{library_type}-library_{lib_id}-attribute_{...}\"``
+    string builder that appears literally dozens of times inside
+    ``add_entry``.  Not exported for now -- callers stay within this
+    module.
+    """
+    return f"{library_type}-library_{lib_id}-attribute_{suffix}"
+
+
+def build_delete_collections_operation(attr_group, library_type, lib_id):
+    """Return the ``delete_collections`` operations dict, or an empty dict.
+
+    Reads four attribute inputs off ``attr_group``:
+
+    * ``delete_collections_configured`` -- bool
+    * ``delete_collections_managed`` -- bool
+    * ``delete_collections_ignore_empty_smart_collections`` -- bool
+    * ``delete_collections_less`` -- int (or empty)
+
+    Returns an empty dict when none of the four are actually set --
+    callers should treat that as "don't emit a delete_collections
+    block".  When at least one input is set, returns a dict shaped
+    like the Kometa ``operations.delete_collections`` schema:
+
+        {
+            "configured": bool,
+            "managed": bool,
+            "less": int,                              # if provided
+            "ignore_empty_smart_collections": True,   # if enabled
+        }
+    """
+    configured_value = _coerce_bool(attr_group.get(_attr_key(library_type, lib_id, "delete_collections_configured")))
+    managed_value = _coerce_bool(attr_group.get(_attr_key(library_type, lib_id, "delete_collections_managed")))
+    ignore_value = _coerce_bool(attr_group.get(_attr_key(library_type, lib_id, "delete_collections_ignore_empty_smart_collections")))
+
+    less_value = None
+    raw_less = attr_group.get(_attr_key(library_type, lib_id, "delete_collections_less"))
+    if raw_less not in _EMPTY_OVERRIDE_VALUES:
+        try:
+            less_value = int(raw_less)
+        except Exception:
+            helpers.ts_log(f"Skipping invalid delete_collections_less value: {raw_less}", level="DEBUG")
+
+    enabled = configured_value is True or managed_value is True or ignore_value is True or less_value is not None
+    if not enabled:
+        return {}
+
+    result = {
+        "configured": configured_value if configured_value is not None else False,
+        "managed": managed_value if managed_value is not None else False,
+    }
+    if less_value is not None:
+        result["less"] = less_value
+    if ignore_value is True:
+        result["ignore_empty_smart_collections"] = True
+    return result


### PR DESCRIPTION
Fifteenth refactor pass on `modules/output.py` (now 1964 lines after #1458). Stacked on top of #1458.

## Cumulative -1901 lines / -49.6% - HALF-WAY

Just barely past the halfway mark on the original 3833-line `output.py`.

## Strategy: Path A - carve the whale one piece at a time

`build_libraries_section` contains a 1300-line `add_entry` closure that does everything for one library: settings, operations, collections, overlays, template variables, remove/reset. Rather than one giant extraction (Path B - high risk), this PR series pulls out one bounded piece at a time.

**This is Path A extraction #1 - proof of concept for the pattern.**

## What moved

`build_delete_collections_operation(attr_group, library_type, lib_id)` — Reads the four `delete_collections_*` attribute inputs off `attr_group` and returns the `operations.delete_collections` YAML dict (or empty dict if the operation is disabled).

Was **47 lines of inline logic** inside `add_entry`. Now **3 lines** at the call site:

```python
delete_collections = build_delete_collections_operation(attr_group, library_type, lib_id)
if delete_collections:
    operations["delete_collections"] = delete_collections
```

## New module: `modules/output_library_ops.py`

Will incrementally host all the per-library operation builders currently trapped inside `add_entry`. Seeded this PR with **two DRY primitives** that future extractions will reuse:

- `_attr_key(library_type, lib_id, suffix)` — consolidates the `f"{library_type}-library_{lib_id}-attribute_{suffix}"` string builder. Currently appears **dozens** of times in `add_entry`; each future extraction will replace another handful.
- `_EMPTY_OVERRIDE_VALUES` — the `frozenset({None, "", "None", "none"})` used all over `add_entry` to detect wiped fields.

## Small clarity wins in the extraction

- `.get(key, None)` redundancy dropped (dict.get already defaults to None)
- 4-item `any([...])` collapsed to a flat boolean expression (Zen: "flat is better")
- Return-early on empty case; construct the dict inline rather than mutating step-by-step
- Docstrings on both public and private helpers

## Preview of coming attractions

Future PRs in this series will pull out:
- The three near-identical `mass_X_update` sections (~180 lines - biggest DRY win of the whole sprint)
- The generic `grouped_operations` loop cleanup
- `genre_mapper` / `content_rating_mapper` (12 lines)
- `metadata_backup` (29 lines)
- The top-level fields extraction (report_path, schedule, etc. - ~50 lines)

## Impact

- `modules/output.py`: 1964 → **1932** (-32 / -1.6%)
- `modules/output_library_ops.py`: **87** lines new

## Cumulative sprint progress

| PR | Size | Delta |
|---|---|---|
| Start | 3833 | — |
| #1445-1447 (MERGED) | 3343 | -490 |
| #1448-1454 | 2768 | -575 |
| #1455 (first elephant) | 2363 | -405 |
| #1456 (baby elephant) | 2252 | -111 |
| #1457 (DRY sweep) | 2226 | -26 |
| #1458 (dump_section) | 1964 | -262 |
| **This PR (whale carve #1)** | **1932** | **-32** |
| **Total** | | **-1901 / -49.6%**  |

## Verification

- All 1077 tests pass
- Ruff + black clean
- Smoke tests confirm all four input combinations plus invalid-int / empty-override edge cases