### PR TITLE
Whale carve #2: extract build_mass_genre_update_operation

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -46,7 +46,10 @@ from modules.output_headers import (  # noqa: F401 -- re-exported so output.<nam
     render_section_header,
     section_heading,
 )
-from modules.output_library_ops import build_delete_collections_operation
+from modules.output_library_ops import (
+    build_delete_collections_operation,
+    build_mass_genre_update_operation,
+)
 from modules.output_optimize import optimize_template_variables
 from modules.output_playlists import (  # noqa: F401 -- re-exported so output.<name> keeps working
     PLAYLIST_KEYED_TEMPLATE_VAR_SPECS,
@@ -194,42 +197,7 @@ def build_libraries_section(
         operations = {}
         attr_group = attributes.get(lib_id, {})
         # Begin: Mass Genre Update Section
-        mass_genre_update = []
-
-        # Grab the full reordered list from hidden input
-        custom_key = f"{library_type}-library_{lib_id}-attribute_mass_genre_update_order"
-        order_value = attr_group.get(custom_key)
-
-        if order_value:
-            try:
-                parsed = json.loads(order_value)
-                if isinstance(parsed, list):
-                    for item in parsed:
-                        if isinstance(item, str) and item.startswith("[") and item.endswith("]"):
-                            # Probably malformed nested list — skip
-                            continue
-                        elif isinstance(item, str):
-                            mass_genre_update.append(item)
-                        elif isinstance(item, list):  # rare case
-                            mass_genre_update.extend(item)
-            except Exception as e:
-                helpers.ts_log(f"Skipping invalid JSON in custom genre: {order_value} — {e}", level="ERROR")
-
-        # Also include custom genre strings (if any) from the other hidden input
-        custom_strings_key = f"{library_type}-library_{lib_id}-attribute_mass_genre_update_custom"
-        custom_strings_value = attr_group.get(custom_strings_key)
-
-        if custom_strings_value:
-            try:
-                parsed_custom = json.loads(custom_strings_value)
-                if isinstance(parsed_custom, list) and parsed_custom:
-                    # Wrap it in a CommentedSeq to enforce flow style
-                    custom_flow_list = CommentedSeq(parsed_custom)
-                    custom_flow_list.fa.set_flow_style()  # Force [ "Thriller", "Action" ] formatting
-                    mass_genre_update.append(custom_flow_list)
-            except Exception as e:
-                helpers.ts_log(f"Skipping invalid JSON in custom genre strings: {custom_strings_value} — {e}", level="ERROR")
-
+        mass_genre_update = build_mass_genre_update_operation(attr_group, library_type, lib_id)
         if mass_genre_update:
             operations["mass_genre_update"] = mass_genre_update
 

--- a/modules/output_library_ops.py
+++ b/modules/output_library_ops.py
@@ -17,6 +17,10 @@ package.
 
 from __future__ import annotations
 
+import json
+
+from ruamel.yaml.comments import CommentedSeq
+
 from modules import helpers
 from modules.output_values import _coerce_bool
 
@@ -29,12 +33,28 @@ _EMPTY_OVERRIDE_VALUES = frozenset({None, "", "None", "none"})
 def _attr_key(library_type, lib_id, suffix):
     """Compose the per-library attribute lookup key.
 
-    Consolidates the ``f\"{library_type}-library_{lib_id}-attribute_{...}\"``
+    Consolidates the ``f"{library_type}-library_{lib_id}-attribute_{...}"``
     string builder that appears literally dozens of times inside
     ``add_entry``.  Not exported for now -- callers stay within this
     module.
     """
     return f"{library_type}-library_{lib_id}-attribute_{suffix}"
+
+
+def _parse_json_list(raw_value, context_label):
+    """Best-effort ``json.loads`` returning a list, or ``None`` on failure.
+
+    ``context_label`` is used purely for the debug/error log message so
+    callers can distinguish which input misbehaved.
+    """
+    if not raw_value:
+        return None
+    try:
+        parsed = json.loads(raw_value)
+    except Exception as e:
+        helpers.ts_log(f"Skipping invalid JSON in {context_label}: {raw_value} - {e}", level="ERROR")
+        return None
+    return parsed if isinstance(parsed, list) else None
 
 
 def build_delete_collections_operation(attr_group, library_type, lib_id):
@@ -83,4 +103,50 @@ def build_delete_collections_operation(attr_group, library_type, lib_id):
         result["less"] = less_value
     if ignore_value is True:
         result["ignore_empty_smart_collections"] = True
+    return result
+
+
+def build_mass_genre_update_operation(attr_group, library_type, lib_id):
+    """Return the ``mass_genre_update`` operations value, or an empty list.
+
+    Two attribute inputs feed this operation:
+
+    * ``mass_genre_update_order``  -- JSON list of sortable source strings.
+      Each string becomes a top-level entry.  Items shaped like
+      ``"[foo]"`` are treated as malformed UI leftovers and skipped.
+      Nested-list items get flattened.
+    * ``mass_genre_update_custom`` -- JSON list of custom genre strings
+      (e.g. ``["Thriller", "Action"]``).  The whole list is appended as
+      a single nested flow-style sequence so the emitted YAML reads
+      ``- [Thriller, Action]``.
+
+    Returns the assembled list (order + optional nested-custom).  An
+    empty list means the operation is disabled and shouldn't be emitted.
+    """
+    result = []
+
+    order_items = _parse_json_list(
+        attr_group.get(_attr_key(library_type, lib_id, "mass_genre_update_order")),
+        "custom genre",
+    )
+    if order_items is not None:
+        for item in order_items:
+            if isinstance(item, str) and item.startswith("[") and item.endswith("]"):
+                # Probably malformed nested list -- skip
+                continue
+            if isinstance(item, str):
+                result.append(item)
+            elif isinstance(item, list):  # rare case: nested list, flatten
+                result.extend(item)
+
+    custom_items = _parse_json_list(
+        attr_group.get(_attr_key(library_type, lib_id, "mass_genre_update_custom")),
+        "custom genre strings",
+    )
+    if custom_items:  # non-empty list only
+        # Wrap in a flow-style CommentedSeq so YAML emits `[a, b]` inline.
+        custom_flow_list = CommentedSeq(custom_items)
+        custom_flow_list.fa.set_flow_style()
+        result.append(custom_flow_list)
+
     return result


### PR DESCRIPTION
Sixteenth refactor pass on `modules/output.py` (now 1932 lines after #1459). Stacked on top of #1459.

## Cumulative -1933 lines / -50.4% - PAST HALFWAY

## What

Extracted `build_mass_genre_update_operation` — the ~40 lines of `add_entry` that read the two `mass_genre_update_order` and `mass_genre_update_custom` attribute inputs and produce the `operations.mass_genre_update` list.

Call site shrinks from ~40 lines to **4 lines**:

```python
mass_genre_update = build_mass_genre_update_operation(attr_group, library_type, lib_id)
if mass_genre_update:
    operations["mass_genre_update"] = mass_genre_update
```

## Why mass_genre first?

It's the **only** mass-update block with unique behavior — it wraps its custom list in a flow-style `CommentedSeq` and appends it as a **nested** entry (`- [Thriller, Action]`) rather than flattening. This uniqueness is why it's NOT in the generic `grouped_operations` loop.

The other two dedicated mass-update blocks (`mass_content_rating_update`, `mass_original_title_update`) DO overlap with the generic loop — extracting them requires resolving the overlap, which is a bigger design conversation. Saving those for a follow-up PR.

## New DRY primitive seeded for future carves

`_parse_json_list(raw_value, context_label)` — best-effort `json.loads` returning a list or `None`, with error logging. This exact try/except/log-and-continue pattern appears **8+ times** in the remaining `add_entry` mass-update blocks. Every future carve in the operation-builder series will use this instead of copy-pasting the try/except structure.

## Small clarity wins in the extraction

- The redundant `if isinstance(item, str) ... elif isinstance(item, str)` chain flattened (was accidentally checking the same type twice with only one branch reachable)
- Docstring explains **why** the `"[foo]"` malformed-bracket check exists ("probably UI leftovers")
- Function returns the assembled list rather than mutating an outer variable

## Impact

- `modules/output.py`: 1932 → **1900** (-32 / -1.7%)
- `modules/output_library_ops.py`: 87 → 152 (+65)

## Cumulative sprint progress

| PR | Size | Delta |
|---|---|---|
| Start | 3833 | — |
| #1445-1458 | 1932 | -1901 |
| #1459 (whale carve #1) | 1932 | -32 |
| **This PR (whale carve #2)** | **1900** | **-32** |
| **Total** | | **-1933 / -50.4%**  |

## Verification

- All 1077 tests pass
- Ruff + black clean
- Smoke tests: empty, order-only, order+custom (with CommentedSeq wrap), bracketed items skipped, invalid JSON tolerated