### PR TITLE
Whale carve #3: extract 4 small ops (mappers, backup, poster+background)

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -48,7 +48,11 @@ from modules.output_headers import (  # noqa: F401 -- re-exported so output.<nam
 )
 from modules.output_library_ops import (
     build_delete_collections_operation,
+    build_mapper_operations,
+    build_mass_background_update_operation,
     build_mass_genre_update_operation,
+    build_mass_poster_update_operation,
+    build_metadata_backup_operation,
 )
 from modules.output_optimize import optimize_template_variables
 from modules.output_playlists import (  # noqa: F401 -- re-exported so output.<name> keeps working
@@ -1289,69 +1293,20 @@ def build_libraries_section(
                 operations[op] = seq
 
         # genre_mapper and content_rating_mapper
-        for mapper_key in ["genre_mapper", "content_rating_mapper"]:
-            full_key = f"{library_type}-library_{lib_id}-attribute_{mapper_key}"
-            mapping_value = attr_group.get(full_key)
-            if mapping_value:
-                try:
-                    parsed_mapping = json.loads(mapping_value)
-                    if isinstance(parsed_mapping, dict) and parsed_mapping:
-                        operations[mapper_key] = parsed_mapping
-                except Exception as e:
-                    helpers.ts_log(f"Skipping invalid JSON for {mapper_key}: {mapping_value} — {e}", level="ERROR")
+        operations.update(build_mapper_operations(attr_group, library_type, lib_id))
 
         # metadata_backup
-        backup = {}
-        path_key = f"{library_type}-library_{lib_id}-attribute_metadata_backup_path"
-        exclude_key = f"{library_type}-library_{lib_id}-attribute_metadata_backup_exclude"
-        sync_key = f"{library_type}-library_{lib_id}-attribute_sync_tags"
-        blank_key = f"{library_type}-library_{lib_id}-attribute_add_blank_entries"
-
-        if attr_group.get(path_key):
-            backup["path"] = attr_group.get(path_key)
-
-        # Only add exclude if it is a non-empty list
-        if attr_group.get(exclude_key):
-            val = attr_group.get(exclude_key)
-            try:
-                parsed = json.loads(val) if isinstance(val, str) else val
-                if isinstance(parsed, list) and parsed:  # non-empty list only
-                    backup["exclude"] = parsed
-            except Exception as e:
-                helpers.ts_log(f"Skipping invalid exclude value: {val} — {e}", level="ERROR")
-
-        if attr_group.get(sync_key) is True:
-            backup["sync_tags"] = True
-        if attr_group.get(blank_key) is True:
-            backup["add_blank_entries"] = True
-
-        # Only add to operations if backup has any keys
+        backup = build_metadata_backup_operation(attr_group, library_type, lib_id)
         if backup:
             operations["metadata_backup"] = backup
 
         # mass_poster_update
-        poster = {}
-        for key in [
-            "seasons",
-            "episodes",
-            "ignore_locked",
-            "ignore_overlays",
-            "source",
-        ]:
-            full_key = f"{library_type}-library_{lib_id}-attribute_mass_poster_{key}"
-            val = attr_group.get(full_key)
-            if val not in [None, False, ""]:
-                poster[key] = val
+        poster = build_mass_poster_update_operation(attr_group, library_type, lib_id)
         if poster:
             operations["mass_poster_update"] = poster
 
         # mass_background_update
-        background = {}
-        for key in ["seasons", "episodes", "ignore_locked", "source"]:
-            full_key = f"{library_type}-library_{lib_id}-attribute_mass_background_{key}"
-            val = attr_group.get(full_key)
-            if val not in [None, False, ""]:
-                background[key] = val
+        background = build_mass_background_update_operation(attr_group, library_type, lib_id)
         if background:
             operations["mass_background_update"] = background
 

--- a/modules/output_library_ops.py
+++ b/modules/output_library_ops.py
@@ -150,3 +150,123 @@ def build_mass_genre_update_operation(attr_group, library_type, lib_id):
         result.append(custom_flow_list)
 
     return result
+
+
+# Keys read from attr_group for each 'mass_<media>_update' operation.
+# Poster has one extra key (ignore_overlays) that background lacks;
+# otherwise the shape is identical, which is why they share a helper.
+_MASS_POSTER_UPDATE_KEYS = ("seasons", "episodes", "ignore_locked", "ignore_overlays", "source")
+_MASS_BACKGROUND_UPDATE_KEYS = ("seasons", "episodes", "ignore_locked", "source")
+
+# Values that the mass_poster/background 'empty' check considers
+# 'user hasn't set this field' -- distinct from _EMPTY_OVERRIDE_VALUES
+# because these two operations skip 'False' (boolean off) rather than
+# only string placeholders.
+_MASS_MEDIA_EMPTY_VALUES = frozenset({None, False, ""})
+
+
+def _build_mass_media_update_operation(attr_group, library_type, lib_id, media_kind, keys):
+    """Shared builder for the two mass_<media>_update operations.
+
+    ``media_kind`` is ``"poster"`` or ``"background"`` -- used to compose
+    the ``mass_<media>_<key>`` attribute lookup keys.  ``keys`` is the
+    tuple of subfields to check (see ``_MASS_POSTER_UPDATE_KEYS`` /
+    ``_MASS_BACKGROUND_UPDATE_KEYS``).
+
+    Returns a dict of the subfields whose value is non-empty, or an
+    empty dict when the whole operation should be skipped.
+    """
+    result = {}
+    for key in keys:
+        val = attr_group.get(_attr_key(library_type, lib_id, f"mass_{media_kind}_{key}"))
+        if val not in _MASS_MEDIA_EMPTY_VALUES:
+            result[key] = val
+    return result
+
+
+def build_mass_poster_update_operation(attr_group, library_type, lib_id):
+    """Return the ``mass_poster_update`` operations dict, or empty.
+
+    Reads five per-library attribute inputs:
+    ``mass_poster_seasons``, ``mass_poster_episodes``,
+    ``mass_poster_ignore_locked``, ``mass_poster_ignore_overlays``,
+    ``mass_poster_source``.  Any subfield with a truthy-ish value
+    (i.e. not ``None``, ``False``, or the empty string) is included.
+    """
+    return _build_mass_media_update_operation(attr_group, library_type, lib_id, "poster", _MASS_POSTER_UPDATE_KEYS)
+
+
+def build_mass_background_update_operation(attr_group, library_type, lib_id):
+    """Return the ``mass_background_update`` operations dict, or empty.
+
+    Same shape as :func:`build_mass_poster_update_operation` but reads
+    four inputs (no ``ignore_overlays``): ``mass_background_seasons``,
+    ``mass_background_episodes``, ``mass_background_ignore_locked``,
+    ``mass_background_source``.
+    """
+    return _build_mass_media_update_operation(attr_group, library_type, lib_id, "background", _MASS_BACKGROUND_UPDATE_KEYS)
+
+
+def build_mapper_operations(attr_group, library_type, lib_id):
+    """Return a dict of the enabled mapper operations.
+
+    Reads ``genre_mapper`` and ``content_rating_mapper`` attribute
+    inputs.  Each value is expected to be a JSON-encoded dict; when
+    valid and non-empty, it's copied into the returned dict under
+    the matching key.
+
+    Returns an empty dict if neither mapper is set (or both are
+    invalid/empty).  Callers should merge the result into their
+    ``operations`` dict.
+    """
+    result = {}
+    for mapper_key in ("genre_mapper", "content_rating_mapper"):
+        raw_value = attr_group.get(_attr_key(library_type, lib_id, mapper_key))
+        if not raw_value:
+            continue
+        try:
+            parsed = json.loads(raw_value)
+        except Exception as e:
+            helpers.ts_log(f"Skipping invalid JSON for {mapper_key}: {raw_value} - {e}", level="ERROR")
+            continue
+        if isinstance(parsed, dict) and parsed:
+            result[mapper_key] = parsed
+    return result
+
+
+def build_metadata_backup_operation(attr_group, library_type, lib_id):
+    """Return the ``metadata_backup`` operations dict, or empty.
+
+    Reads four attribute inputs:
+
+    * ``metadata_backup_path`` -- filesystem path (string).
+    * ``metadata_backup_exclude`` -- JSON list; only included when it
+      parses to a non-empty list.
+    * ``sync_tags`` -- included only when literally ``True``.
+    * ``add_blank_entries`` -- included only when literally ``True``.
+
+    Returns an empty dict when none of the four are set; callers
+    should treat that as 'don't emit a metadata_backup block'.
+    """
+    result = {}
+
+    path_value = attr_group.get(_attr_key(library_type, lib_id, "metadata_backup_path"))
+    if path_value:
+        result["path"] = path_value
+
+    exclude_raw = attr_group.get(_attr_key(library_type, lib_id, "metadata_backup_exclude"))
+    if exclude_raw:
+        try:
+            parsed = json.loads(exclude_raw) if isinstance(exclude_raw, str) else exclude_raw
+        except Exception as e:
+            helpers.ts_log(f"Skipping invalid exclude value: {exclude_raw} - {e}", level="ERROR")
+            parsed = None
+        if isinstance(parsed, list) and parsed:  # non-empty list only
+            result["exclude"] = parsed
+
+    if attr_group.get(_attr_key(library_type, lib_id, "sync_tags")) is True:
+        result["sync_tags"] = True
+    if attr_group.get(_attr_key(library_type, lib_id, "add_blank_entries")) is True:
+        result["add_blank_entries"] = True
+
+    return result


### PR DESCRIPTION
Seventeenth refactor pass on `modules/output.py` (now 1900 lines after #1460). Stacked on top of #1460.

## Cumulative -1978 lines / -51.6%

## What

Four small self-contained operation builders in one PR, plus one DRY collapse:

| Function | What it does |
|---|---|
| `build_mapper_operations` | Reads `genre_mapper` + `content_rating_mapper` JSON dicts and returns the enabled ones |
| `build_metadata_backup_operation` | Reads path/exclude/sync_tags/add_blank_entries → returns the backup dict |
| `build_mass_poster_update_operation` | Reads 5 subfields, drops empties |
| `build_mass_background_update_operation` | Reads 4 subfields, drops empties |

## DRY win: `_build_mass_media_update_operation`

The two `mass_<media>_update` operations were near-identical 8-line loops. Consolidated to one 5-line helper + two 1-line delegating public functions. The key lists became `_MASS_POSTER_UPDATE_KEYS` / `_MASS_BACKGROUND_UPDATE_KEYS` tuples at module scope.

## New module-level constant: `_MASS_MEDIA_EMPTY_VALUES`

`frozenset({None, False, ""})` — the values that count as 'user didn't set this' for the mass_poster and mass_background operations specifically. Distinct from the existing `_EMPTY_OVERRIDE_VALUES` because these two skip `False` (boolean off) rather than only string placeholders.

## Impact

- `modules/output.py`: 1900 → **1855** (-45 / -2.4%)
- `modules/output_library_ops.py`: 152 → 272 (+120)

## Cumulative sprint progress

| PR | Size | Delta |
|---|---|---|
| Start | 3833 | — |
| #1445-1458 | 1932 | -1901 |
| #1459 (whale carve #1) | 1932 | -32 |
| #1460 (whale carve #2) | 1900 | -32 |
| **This PR (whale carve #3)** | **1855** | **-45** |
| **Total** | | **-1978 / -51.6%** |

## Verification

- All 1077 tests pass
- Ruff + black clean
- Smoke tests confirm all four operations plus edge cases (invalid JSON, empty exclude list, sync_tags-not-literally-True, missing inputs)