### PR TITLE
Whale carve #4: extract build_top_level_fields

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -53,6 +53,7 @@ from modules.output_library_ops import (
     build_mass_genre_update_operation,
     build_mass_poster_update_operation,
     build_metadata_backup_operation,
+    build_top_level_fields,
 )
 from modules.output_optimize import optimize_template_variables
 from modules.output_playlists import (  # noqa: F401 -- re-exported so output.<name> keeps working
@@ -1310,44 +1311,12 @@ def build_libraries_section(
         if background:
             operations["mass_background_update"] = background
 
-        # Remove/Reset Overlays
+        # Remove/Reset Overlays + other top-level fields
         top_group = top_level.get(lib_id, {})
-
-        remove_key = f"{library_type}-library_{lib_id}-top_level_remove_overlays"
-        reset_key = f"{library_type}-library_{lib_id}-top_level_reset_overlays"
-        schedule_key = f"{library_type}-library_{lib_id}-top_level_schedule"
-        auto_sort_hubs_key = f"{library_type}-library_{lib_id}-top_level_auto_sort_hubs"
-        schedule_overlays_key = f"{library_type}-library_{lib_id}-top_level_schedule_overlays"
-        report_path_key = f"{library_type}-library_{lib_id}-top_level_report_path"
-
-        remove_overlays = top_group.get(remove_key)
-        reset_overlays = top_group.get(reset_key)
-        schedule = top_group.get(schedule_key)
-        auto_sort_hubs = top_group.get(auto_sort_hubs_key)
-        schedule_overlays = top_group.get(schedule_overlays_key)
-        report_path = top_group.get(report_path_key)
-
-        if report_path not in [None, ""]:
-            entry["report_path"] = report_path
-        if schedule not in [None, ""]:
-            entry["schedule"] = schedule
-        if auto_sort_hubs not in [None, ""]:
-            entry["auto_sort_hubs"] = auto_sort_hubs
-        if remove_overlays:
-            entry["remove_overlays"] = True
-        if reset_overlays not in [None, "None", ""]:
-            entry["reset_overlays"] = reset_overlays
-        if schedule_overlays not in [None, ""]:
-            entry["schedule_overlays"] = schedule_overlays
+        entry.update(build_top_level_fields(top_group, library_type, lib_id))
 
         if app.config["QS_DEBUG"]:
             helpers.ts_log(f"Top Level for {lib_id}: {top_group}", level="DEBUG")
-            helpers.ts_log(f"{report_path_key} = {report_path}", level="DEBUG")
-            helpers.ts_log(f"{schedule_key} = {schedule}", level="DEBUG")
-            helpers.ts_log(f"{auto_sort_hubs_key} = {auto_sort_hubs}", level="DEBUG")
-            helpers.ts_log(f"{remove_key} = {remove_overlays}", level="DEBUG")
-            helpers.ts_log(f"{reset_key} = {reset_overlays}", level="DEBUG")
-            helpers.ts_log(f"{schedule_overlays_key} = {schedule_overlays}", level="DEBUG")
 
         if operations:
             entry["operations"] = operations

--- a/modules/output_library_ops.py
+++ b/modules/output_library_ops.py
@@ -270,3 +270,57 @@ def build_metadata_backup_operation(attr_group, library_type, lib_id):
         result["add_blank_entries"] = True
 
     return result
+
+
+# The five 'top_level' fields whose emptiness rule is 'None or empty
+# string means user didn't set it'.  ``remove_overlays`` uses a
+# truthy check and ``reset_overlays`` also filters the literal
+# string 'None' (UI leftover), so they're handled inline below.
+_TOP_LEVEL_SIMPLE_FIELDS = (
+    "report_path",
+    "schedule",
+    "auto_sort_hubs",
+    "schedule_overlays",
+)
+
+
+def _top_level_key(library_type, lib_id, suffix):
+    """Compose a ``top_level_<suffix>`` lookup key.
+
+    Mirrors :func:`_attr_key` but for the ``top_level`` namespace so
+    ``top_group.get(_top_level_key(...))`` reads clean.
+    """
+    return f"{library_type}-library_{lib_id}-top_level_{suffix}"
+
+
+def build_top_level_fields(top_group, library_type, lib_id):
+    """Return the top-level fields dict to merge into a library's entry.
+
+    Reads six top-level inputs off ``top_group``:
+
+    * ``report_path``, ``schedule``, ``auto_sort_hubs``, ``schedule_overlays``
+      -- included when the value isn't ``None`` or empty string.
+    * ``remove_overlays`` -- included as literal ``True`` when the raw
+      value is truthy.  (The stored value is always emitted as ``True``
+      per the Kometa schema; we only care whether it was set.)
+    * ``reset_overlays`` -- included when the value isn't ``None``,
+      empty string, or the literal string ``"None"`` (a UI leftover).
+
+    Returns an empty dict when none of the six are set.  Callers merge
+    the result into their per-library entry dict via ``entry.update(...)``.
+    """
+    result = {}
+
+    for field in _TOP_LEVEL_SIMPLE_FIELDS:
+        value = top_group.get(_top_level_key(library_type, lib_id, field))
+        if value not in (None, ""):
+            result[field] = value
+
+    if top_group.get(_top_level_key(library_type, lib_id, "remove_overlays")):
+        result["remove_overlays"] = True
+
+    reset_overlays = top_group.get(_top_level_key(library_type, lib_id, "reset_overlays"))
+    if reset_overlays not in (None, "None", ""):
+        result["reset_overlays"] = reset_overlays
+
+    return result


### PR DESCRIPTION
Eighteenth refactor pass on `modules/output.py` (now 1855 lines after #1461). Stacked on top of #1461.

## Cumulative -2009 lines / -52.4%

## What

Extracted the 45-line 'Remove/Reset Overlays' block from `add_entry` (which despite its name actually handles **6 different top-level fields**): `report_path`, `schedule`, `auto_sort_hubs`, `schedule_overlays`, `remove_overlays`, `reset_overlays`.

Call site shrinks from 39 lines to **3 lines**:

```python
top_group = top_level.get(lib_id, {})
entry.update(build_top_level_fields(top_group, library_type, lib_id))
if app.config["QS_DEBUG"]:
    helpers.ts_log(f"Top Level for {lib_id}: {top_group}", level="DEBUG")
```

## DRY wins

- The four fields with matching emptiness logic (`report_path`, `schedule`, `auto_sort_hubs`, `schedule_overlays`) collapsed from four separate `if val not in [None, ""]: entry[key] = val` blocks into one loop over `_TOP_LEVEL_SIMPLE_FIELDS`.
- The two special-cased fields (`remove_overlays` truthy check, `reset_overlays` with extra `"None"` string filter) stay inline with a comment explaining **why** they're not in the loop.
- New `_top_level_key(library_type, lib_id, suffix)` helper — the companion to `_attr_key`, using the `top_level` namespace instead of `attribute`.

## Cleaned up redundant debug logging

Dropped 6 lines of per-key debug logs. The `Top Level for {lib_id}: {top_group}` log at the top already dumps the whole dict, so the per-key logs were duplicating the same information. **Zen: don't repeat yourself.**

## Impact

- `modules/output.py`: 1855 → **1824** (-31 / -1.7%)
- `modules/output_library_ops.py`: 272 → 326 (+54)

## Cumulative sprint progress

| PR | Size | Delta |
|---|---|---|
| Start | 3833 | — |
| #1445-1458 | 1932 | -1901 |
| #1459 (whale #1) | 1932 | -32 |
| #1460 (whale #2) | 1900 | -32 |
| #1461 (whale #3) | 1855 | -45 |
| **This PR (whale #4)** | **1824** | **-31** |
| **Total** | | **-2009 / -52.4%** |

## Verification

- All 1077 tests pass
- Ruff + black clean
- Smoke tests confirm all 6 inputs + edge cases (None, empty string, `'None'` literal, falsy truthy for remove_overlays)