### PR TITLE
Whale carve #5: extract build_template_variables + kill 6 redundant if-blocks

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -53,6 +53,7 @@ from modules.output_library_ops import (
     build_mass_genre_update_operation,
     build_mass_poster_update_operation,
     build_metadata_backup_operation,
+    build_template_variables,
     build_top_level_fields,
 )
 from modules.output_optimize import optimize_template_variables
@@ -1150,62 +1151,7 @@ def build_libraries_section(
             entry["metadata_files"] = metadata_entries
 
         # Template Variables
-        template_key = helpers.extract_library_name(library_key)
-        template_data = templates.get(template_key, {})
-
-        sep_color_key = None
-        placeholder_imdb_key = None
-        placeholder_tmdb_movie_key = None
-        placeholder_tvdb_show_key = None
-        language_key = None
-        collection_mode_key = None
-
-        for key in template_data.keys():
-            if key.endswith("-template_variables[use_separator]") and key.startswith(f"{library_type}-library_{template_key}"):
-                sep_color_key = key
-            if key.endswith("-attribute_template_variables[placeholder_imdb_id]") and key.startswith(f"{library_type}-library_{template_key}"):
-                placeholder_imdb_key = key
-            if key.endswith("-attribute_template_variables[placeholder_tmdb_movie]") and key.startswith(f"{library_type}-library_{template_key}"):
-                placeholder_tmdb_movie_key = key
-            if key.endswith("-attribute_template_variables[placeholder_tvdb_show]") and key.startswith(f"{library_type}-library_{template_key}"):
-                placeholder_tvdb_show_key = key
-            if key.endswith("-template_variables[language]") and key.startswith(f"{library_type}-library_{template_key}"):
-                language_key = key
-            if key.endswith("-template_variables[collection_mode]") and key.startswith(f"{library_type}-library_{template_key}"):
-                collection_mode_key = key
-
-        sep_color = template_data.get(sep_color_key)
-        placeholder_imdb_id = template_data.get(placeholder_imdb_key)
-        placeholder_tmdb_movie = template_data.get(placeholder_tmdb_movie_key)
-        placeholder_tvdb_show = template_data.get(placeholder_tvdb_show_key)
-        language_value = template_data.get(language_key)
-        collection_mode_value = template_data.get(collection_mode_key)
-
-        template_vars = {"use_separator": True if sep_color else False}
-
-        if sep_color:
-            template_vars["sep_style"] = sep_color
-
-        if library_type == "mov":
-            if placeholder_tmdb_movie:
-                template_vars["placeholder_tmdb_movie"] = placeholder_tmdb_movie
-            elif placeholder_imdb_id:
-                template_vars["placeholder_imdb_id"] = placeholder_imdb_id
-        else:
-            if placeholder_tvdb_show:
-                template_vars["placeholder_tvdb_show"] = placeholder_tvdb_show
-            elif placeholder_imdb_id:
-                template_vars["placeholder_imdb_id"] = placeholder_imdb_id
-
-        if language_value:
-            template_vars["language"] = language_value
-        if collection_mode_value:
-            template_vars["collection_mode"] = collection_mode_value
-
-        if has_collectionless:
-            template_vars["collection_mode"] = "hide"
-
-        entry["template_variables"] = template_vars
+        entry["template_variables"] = build_template_variables(templates, library_type, library_key, has_collectionless)
 
         # Grouped mass update operations (excluding mass_genre_update, handled earlier)
         grouped_operations = [

--- a/modules/output_library_ops.py
+++ b/modules/output_library_ops.py
@@ -1,13 +1,16 @@
-"""Per-library operation builders for build_libraries_section.
+"""Per-library builders for build_libraries_section.
 
 Extracted incrementally from the giant ``add_entry`` closure inside
-``modules/output.py``.  Each function here takes the raw
-``attr_group`` dict for one library plus a couple of identity keys,
-and returns the operation's YAML-ready value (or ``None`` when the
-operation is disabled).
+``modules/output.py``.  Each function here takes the raw form-input
+dict (``attr_group``, ``top_group``, or ``template_data``) plus a
+couple of identity keys, and returns the operation / entry-field
+value ready for YAML serialization (or an empty container when the
+input is disabled/absent).
 
-The naming convention is ``build_<operation_name>_operation`` so it's
-obvious what shape the return type matches.
+Naming conventions:
+  * ``build_<operation_name>_operation`` -- goes under ``entry.operations``
+  * ``build_<field_group>_fields``       -- merged into ``entry`` directly
+  * ``build_template_variables``         -- goes under ``entry.template_variables``
 
 Public surface: none.  These helpers are called from the
 ``build_libraries_section`` orchestrator; ``output.py`` imports each
@@ -324,3 +327,92 @@ def build_top_level_fields(top_group, library_type, lib_id):
         result["reset_overlays"] = reset_overlays
 
     return result
+
+
+# Suffix -> template_variables output key.  We iterate template_data
+# looking for keys ending in one of these six suffixes with the
+# matching library prefix, and stash the value under the mapped key.
+# The prefix is checked so a movie library doesn't accidentally pick
+# up template variables meant for a show library with the same lib_id.
+_TEMPLATE_VAR_SUFFIXES = {
+    "-template_variables[use_separator]": "use_separator",
+    "-attribute_template_variables[placeholder_imdb_id]": "placeholder_imdb_id",
+    "-attribute_template_variables[placeholder_tmdb_movie]": "placeholder_tmdb_movie",
+    "-attribute_template_variables[placeholder_tvdb_show]": "placeholder_tvdb_show",
+    "-template_variables[language]": "language",
+    "-template_variables[collection_mode]": "collection_mode",
+}
+
+
+def _discover_template_variables(template_data, library_type, template_key):
+    """Walk ``template_data`` and pull out the six known template-variable inputs.
+
+    Returns a dict keyed by the output name (``use_separator``,
+    ``placeholder_imdb_id``, ...).  Missing inputs are simply absent
+    from the returned dict.
+    """
+    prefix = f"{library_type}-library_{template_key}"
+    discovered = {}
+    for key, value in template_data.items():
+        if not key.startswith(prefix):
+            continue
+        for suffix, output_name in _TEMPLATE_VAR_SUFFIXES.items():
+            if key.endswith(suffix):
+                discovered[output_name] = value
+                break
+    return discovered
+
+
+def build_template_variables(templates, library_type, library_key, has_collectionless):
+    """Return the ``template_variables`` dict for a library entry.
+
+    Extracts the template-key from ``library_key`` (via
+    :func:`helpers.extract_library_name`), looks up the matching
+    template-data dict in ``templates``, and walks it for the six
+    known template-variable inputs.  Assembles the result into the
+    shape Kometa expects.
+
+    Rules:
+      * ``use_separator`` is always emitted (defaults ``False``).
+      * ``sep_style`` is emitted only when a separator color is set --
+        the raw value from the form doubles as the style.
+      * For movie libraries (``library_type == "mov"``), the
+        ``placeholder_tmdb_movie`` input wins over ``placeholder_imdb_id``.
+        For show libraries, ``placeholder_tvdb_show`` wins.
+      * ``language`` and ``collection_mode`` are passed through when set.
+      * If the library has a collectionless entry (``has_collectionless``),
+        ``collection_mode`` is forced to ``"hide"`` (overriding any
+        user-set value).
+    """
+    template_key = helpers.extract_library_name(library_key)
+    template_data = templates.get(template_key, {})
+    discovered = _discover_template_variables(template_data, library_type, template_key)
+
+    sep_color = discovered.get("use_separator")
+    template_vars = {"use_separator": bool(sep_color)}
+    if sep_color:
+        template_vars["sep_style"] = sep_color
+
+    # Placeholder selection: media-specific placeholder wins over the
+    # generic IMDB fallback.
+    imdb_fallback = discovered.get("placeholder_imdb_id")
+    if library_type == "mov":
+        primary = discovered.get("placeholder_tmdb_movie")
+        primary_key = "placeholder_tmdb_movie"
+    else:
+        primary = discovered.get("placeholder_tvdb_show")
+        primary_key = "placeholder_tvdb_show"
+    if primary:
+        template_vars[primary_key] = primary
+    elif imdb_fallback:
+        template_vars["placeholder_imdb_id"] = imdb_fallback
+
+    for optional_key in ("language", "collection_mode"):
+        value = discovered.get(optional_key)
+        if value:
+            template_vars[optional_key] = value
+
+    if has_collectionless:
+        template_vars["collection_mode"] = "hide"
+
+    return template_vars


### PR DESCRIPTION
Nineteenth refactor pass on `modules/output.py` (now 1824 lines after #1462). Stacked on top of #1462.

## Cumulative -2063 lines / -53.8%

## What

Extracted the 58-line "Template Variables" block from `add_entry` into `build_template_variables`. Call site drops from ~50 lines to **one line**:

```python
entry["template_variables"] = build_template_variables(
    templates, library_type, library_key, has_collectionless,
)
```

## Big DRY win: six redundant if-blocks -> one dict-driven loop

The old code had SIX near-identical discovery branches inside one `for key in template_data.keys()` loop:

```python
if key.endswith('-template_variables[use_separator]') and key.startswith(f'{library_type}-library_{template_key}'):
    sep_color_key = key
if key.endswith('-attribute_template_variables[placeholder_imdb_id]') and key.startswith(...):
    placeholder_imdb_key = key
# ... four more copies ...
```

Now consolidated to a dict-driven loop over `_TEMPLATE_VAR_SUFFIXES` (suffix -> output_name mapping), with the prefix check hoisted outside:

```python
prefix = f"{library_type}-library_{template_key}"
for key, value in template_data.items():
    if not key.startswith(prefix):
        continue
    for suffix, output_name in _TEMPLATE_VAR_SUFFIXES.items():
        if key.endswith(suffix):
            discovered[output_name] = value
            break
```

## Other DRY wins

- The 4-branch nested `if-elif` for placeholder selection (mov/tmdb, mov/imdb, sho/tvdb, sho/imdb) flattened to a type-dispatch that picks the primary key and one shared `elif` for the fallback
- The two identical `if language_value: ...` / `if collection_mode_value: ...` blocks consolidated to a for-loop over `('language', 'collection_mode')`
- `True if x else False` -> `bool(x)` (Zen: "flat is better than nested")

## Impact

- `modules/output.py`: 1824 → **1770** (-54 / -3.0%)
- `modules/output_library_ops.py`: 326 → 418 (+92)

## Cumulative sprint progress

| PR | Size | Delta |
|---|---|---|
| Start | 3833 | — |
| #1445-1458 | 1932 | -1901 |
| #1459 (whale #1) | 1932 | -32 |
| #1460 (whale #2) | 1900 | -32 |
| #1461 (whale #3) | 1855 | -45 |
| #1462 (whale #4) | 1824 | -31 |
| **This PR (whale #5)** | **1770** | **-54** |
| **Total** | | **-2063 / -53.8%** |

## Verification

- All 1077 tests pass
- Ruff + black clean
- Smoke tests confirm all placeholder combinations (mov/tmdb, mov/imdb, sho/tvdb, sho/imdb), plus collectionless override, cross-library prefix filter, cross-type prefix filter