### PR TITLE
Whale carve #6: extract build_grouped_mass_update_operations (17 ops in one loop)

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -48,6 +48,7 @@ from modules.output_headers import (  # noqa: F401 -- re-exported so output.<nam
 )
 from modules.output_library_ops import (
     build_delete_collections_operation,
+    build_grouped_mass_update_operations,
     build_mapper_operations,
     build_mass_background_update_operation,
     build_mass_genre_update_operation,
@@ -1154,90 +1155,7 @@ def build_libraries_section(
         entry["template_variables"] = build_template_variables(templates, library_type, library_key, has_collectionless)
 
         # Grouped mass update operations (excluding mass_genre_update, handled earlier)
-        grouped_operations = [
-            "mass_content_rating_update",
-            "mass_original_title_update",
-            "mass_studio_update",
-            "mass_tagline_update",
-            "mass_originally_available_update",
-            "mass_added_at_update",
-            "mass_audience_rating_update",
-            "mass_critic_rating_update",
-            "mass_user_rating_update",
-            "mass_episode_audience_rating_update",
-            "mass_episode_critic_rating_update",
-            "mass_episode_user_rating_update",
-            "mass_background_update",
-            "mass_poster_update",
-            "radarr_remove_by_tag",
-            "sonarr_remove_by_tag",
-        ]
-
-        for op in grouped_operations:
-            custom_list_key = f"{library_type}-library_{lib_id}-attribute_{op}_custom"
-            custom_string_key = f"{library_type}-library_{lib_id}-attribute_{op}_custom_string"
-            order_key = f"{library_type}-library_{lib_id}-attribute_{op}_order"
-
-            op_values = []
-
-            # 1. Ordered source list (sortable)
-            order_value = attr_group.get(order_key)
-            if order_value:
-                try:
-                    parsed = json.loads(order_value)
-                    if isinstance(parsed, list):
-                        for item in parsed:
-                            if isinstance(item, (int, float)):
-                                op_values.append(item)
-                            elif isinstance(item, str) and item.strip():
-                                # Preserve valid date strings (e.g. "2023-01-01")
-                                op_values.append(item.strip())
-                except Exception as e:
-                    helpers.ts_log(f"Skipping invalid JSON in {op}_order: {order_value} — {e}", level="ERROR")
-
-            # 2. Custom list (JSON array from UI)
-            custom_list_value = attr_group.get(custom_list_key)
-            if custom_list_value:
-                try:
-                    parsed_custom = json.loads(custom_list_value)
-                    if isinstance(parsed_custom, list):
-                        for item in parsed_custom:
-                            if isinstance(item, (int, float)):
-                                op_values.append(item)
-                            elif isinstance(item, str) and item.strip():
-                                op_values.append(item.strip())
-                except Exception as e:
-                    helpers.ts_log(f"Skipping invalid JSON in {op}_custom: {custom_list_value} — {e}", level="ERROR")
-
-            # 3. Fallback to single custom string (if defined)
-            elif custom_string_key in attr_group:
-                raw_value = attr_group.get(custom_string_key)
-                if isinstance(raw_value, str) and raw_value.strip():
-                    if op in [
-                        "mass_critic_rating_update",
-                        "mass_user_rating_update",
-                        "mass_audience_rating_update",
-                        "mass_episode_critic_rating_update",
-                        "mass_episode_user_rating_update",
-                        "mass_episode_audience_rating_update",
-                    ]:
-                        try:
-                            op_values.append(float(raw_value.strip()))
-                        except ValueError:
-                            pass  # Invalid float, skip
-                    else:
-                        op_values.append(raw_value.strip())
-                elif isinstance(raw_value, (int, float)):
-                    op_values.append(raw_value)
-
-            # 4. Output formatting
-            if op_values:
-                seq = CommentedSeq(op_values)
-                seq.fa.set_block_style()
-                for i in range(len(seq)):
-                    if isinstance(seq[i], float) and seq[i].is_integer():
-                        seq[i] = float(f"{seq[i]:.1f}")
-                operations[op] = seq
+        operations.update(build_grouped_mass_update_operations(attr_group, library_type, lib_id))
 
         # genre_mapper and content_rating_mapper
         operations.update(build_mapper_operations(attr_group, library_type, lib_id))

--- a/modules/output_library_ops.py
+++ b/modules/output_library_ops.py
@@ -416,3 +416,147 @@ def build_template_variables(templates, library_type, library_key, has_collectio
         template_vars["collection_mode"] = "hide"
 
     return template_vars
+
+
+# The 17 operations that share the same order/custom/custom_string
+# tri-input shape.  Each one is emitted as a block-style YAML list of
+# strings / numbers.  mass_genre_update is deliberately excluded --
+# its custom-list is wrapped in a nested flow-style sequence and its
+# builder lives in build_mass_genre_update_operation.
+_GROUPED_OPERATIONS = (
+    "mass_content_rating_update",
+    "mass_original_title_update",
+    "mass_studio_update",
+    "mass_tagline_update",
+    "mass_originally_available_update",
+    "mass_added_at_update",
+    "mass_audience_rating_update",
+    "mass_critic_rating_update",
+    "mass_user_rating_update",
+    "mass_episode_audience_rating_update",
+    "mass_episode_critic_rating_update",
+    "mass_episode_user_rating_update",
+    "mass_background_update",
+    "mass_poster_update",
+    "radarr_remove_by_tag",
+    "sonarr_remove_by_tag",
+)
+
+# Rating operations whose ``custom_string`` fallback must be coerced
+# to float instead of string.  Frozen so callers can't mutate it.
+_RATING_OPERATIONS_FLOAT_COERCE = frozenset(
+    {
+        "mass_critic_rating_update",
+        "mass_user_rating_update",
+        "mass_audience_rating_update",
+        "mass_episode_critic_rating_update",
+        "mass_episode_user_rating_update",
+        "mass_episode_audience_rating_update",
+    }
+)
+
+
+def _collect_grouped_op_items(parsed_list, values):
+    """Append valid items from ``parsed_list`` to ``values`` in place.
+
+    Numeric items pass through untouched; strings get whitespace-
+    stripped and skipped if empty.  Anything else is ignored.
+    Shared by the ``_order`` and ``_custom`` list handlers so both
+    apply identical filtering.
+    """
+    for item in parsed_list:
+        if isinstance(item, (int, float)):
+            values.append(item)
+        elif isinstance(item, str) and item.strip():
+            values.append(item.strip())
+
+
+def _coerce_custom_string_fallback(raw_value, op):
+    """Convert the single-value ``custom_string`` fallback to a list item.
+
+    * Rating operations (see ``_RATING_OPERATIONS_FLOAT_COERCE``) get
+      float-coerced; a ``ValueError`` yields no item.
+    * Everything else keeps the string (whitespace-stripped).
+    * Numeric inputs pass through directly.
+
+    Returns a single-element list, or an empty list if the raw value
+    couldn't be turned into anything useful.
+    """
+    if isinstance(raw_value, (int, float)):
+        return [raw_value]
+    if not isinstance(raw_value, str) or not raw_value.strip():
+        return []
+    stripped = raw_value.strip()
+    if op in _RATING_OPERATIONS_FLOAT_COERCE:
+        try:
+            return [float(stripped)]
+        except ValueError:
+            return []
+    return [stripped]
+
+
+def _format_grouped_op_sequence(values):
+    """Wrap ``values`` in a block-style CommentedSeq for YAML emission.
+
+    Float values that happen to be whole numbers (e.g. ``5.0``) get
+    re-rendered as ``5.0`` explicitly (via ``f"{v:.1f}"``) so ruamel.yaml
+    doesn't drop the decimal point.  This preserves the visual hint
+    that the field is a rating, not a count.
+    """
+    seq = CommentedSeq(values)
+    seq.fa.set_block_style()
+    for i, v in enumerate(seq):
+        if isinstance(v, float) and v.is_integer():
+            seq[i] = float(f"{v:.1f}")
+    return seq
+
+
+def build_grouped_mass_update_operations(attr_group, library_type, lib_id):
+    """Return a dict of the 17 grouped mass_update operations.
+
+    For each operation name in ``_GROUPED_OPERATIONS``, reads three
+    attribute inputs:
+
+    1. ``<op>_order``          -- JSON list of sortable source strings
+    2. ``<op>_custom``         -- JSON list of custom values
+    3. ``<op>_custom_string``  -- single fallback value used when
+                                  no ``_custom`` list was provided
+
+    Combines the order + (custom OR custom_string) into one list.
+    Rating operations coerce the custom_string fallback to float;
+    everything else preserves the string.  Non-empty results are
+    wrapped in a block-style ``CommentedSeq``.
+
+    Returns a dict that the caller merges into ``operations`` via
+    ``operations.update(result)``.  Empty when none of the 17 have
+    any input.
+    """
+    result = {}
+    for op in _GROUPED_OPERATIONS:
+        values = []
+
+        # 1. Ordered source list (sortable)
+        order_items = _parse_json_list(
+            attr_group.get(_attr_key(library_type, lib_id, f"{op}_order")),
+            f"{op}_order",
+        )
+        if order_items is not None:
+            _collect_grouped_op_items(order_items, values)
+
+        # 2. Custom list (JSON array from UI) -- takes precedence over
+        #    the single-value custom_string fallback.
+        custom_list_key = _attr_key(library_type, lib_id, f"{op}_custom")
+        custom_list_raw = attr_group.get(custom_list_key)
+        if custom_list_raw:
+            custom_items = _parse_json_list(custom_list_raw, f"{op}_custom")
+            if custom_items is not None:
+                _collect_grouped_op_items(custom_items, values)
+        elif _attr_key(library_type, lib_id, f"{op}_custom_string") in attr_group:
+            # 3. Fallback to single custom_string when _custom is absent.
+            raw_value = attr_group.get(_attr_key(library_type, lib_id, f"{op}_custom_string"))
+            values.extend(_coerce_custom_string_fallback(raw_value, op))
+
+        if values:
+            result[op] = _format_grouped_op_sequence(values)
+
+    return result


### PR DESCRIPTION
Twentieth refactor pass on `modules/output.py` (now 1770 lines after #1463). Stacked on top of #1463.

## Cumulative -2145 lines / -56.0% - BIGGEST SINGLE CARVE

**The largest single-PR line reduction of this whale-carving series (-82).**

## What

Extracted the 86-line "Grouped mass update operations" loop that handles **17 different operations** sharing the same order/custom/custom_string tri-input shape.

Call site drops from 86 lines to **one line**:

```python
operations.update(build_grouped_mass_update_operations(attr_group, library_type, lib_id))
```

## Three private helpers extracted for testability

| Helper | What it does |
|---|---|
| `_collect_grouped_op_items(parsed_list, values)` | Appends valid numeric or stripped-string items to `values`. Used by both the `_order` and `_custom` list-processing paths. |
| `_coerce_custom_string_fallback(raw_value, op)` | Handles the single-value `_custom_string` fallback. Float-coerces for rating ops, keeps-string for others, passes-through numerics. |
| `_format_grouped_op_sequence(values)` | Wraps in block-style `CommentedSeq`, preserves integer-valued floats as `X.0` so ruamel.yaml doesn't drop the decimal. |

## Module-level constants hoisted

- `_GROUPED_OPERATIONS` — 17-item tuple (was a local list built fresh on every `add_entry` call)
- `_RATING_OPERATIONS_FLOAT_COERCE` — 6-item frozenset (was a local list of 6 rating op names for the float-coerce check)

## DRY wins

- **Two `try/except json.loads` blocks** (for `_order` and `_custom`) consolidated to use `_parse_json_list` (introduced in whale carve #2) + `_collect_grouped_op_items`. Was ~30 lines, now ~10.
- **The `_custom_string` branch's 12-line "is string? strip? is rating? float? or fallback to numeric?" logic** collapsed into `_coerce_custom_string_fallback` which returns a 1-or-0-element list. Cleaner control flow: no more nested `if/elif` inside `if`.
- **The rating-ops list literal** replaced with the frozenset constant.
- **`for i in range(len(seq)): seq[i]`** replaced with `for i, v in enumerate(seq)` (Zen: iterate over values, not indices).

## Behavior preservation note

The pre-existing **overlap with dedicated blocks** (`mass_content_rating_update`, `mass_original_title_update`, `mass_poster_update`, `mass_background_update` — all set by hand blocks earlier in `add_entry` and then potentially overwritten by this loop) is **preserved verbatim**. If the user has `_order`/`_custom`/`_custom_string` inputs, this loop's output overwrites the dedicated dict/list value from the earlier block. If they don't, the dedicated block's value survives. This is pre-existing behavior and should not be fixed during a refactor.

## Impact

- `modules/output.py`: 1770 → **1688** (-82 / -4.6%)
- `modules/output_library_ops.py`: 418 → 560 (+142)

## Cumulative sprint progress

| PR | Size | Delta |
|---|---|---|
| Start | 3833 | — |
| #1445-1458 | 1932 | -1901 |
| #1459-1463 (whale #1-5) | 1770 | -162 |
| **This PR (whale #6)** | **1688** | **-82** |
| **Total** | | **-2145 / -56.0%** |

## Verification

- All 1077 tests pass
- Ruff + black clean
- Smoke tests confirm all 12 tricky scenarios: empty, order-only, order+custom, order+custom_string, custom-wins-over-string, rating float coerce, integer float preservation, non-numeric rating skipped, whitespace stripping, int+str mixed types, invalid JSON tolerated, module-level constants sanity check