### PR TITLE
Whale carve #7: extract 3 walker loops (settings, ops, service overrides) - biggest single carve

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -49,11 +49,14 @@ from modules.output_headers import (  # noqa: F401 -- re-exported so output.<nam
 from modules.output_library_ops import (
     build_delete_collections_operation,
     build_grouped_mass_update_operations,
+    build_library_operations,
+    build_library_settings,
     build_mapper_operations,
     build_mass_background_update_operation,
     build_mass_genre_update_operation,
     build_mass_poster_update_operation,
     build_metadata_backup_operation,
+    build_service_overrides,
     build_template_variables,
     build_top_level_fields,
 )
@@ -95,45 +98,6 @@ from modules.output_values import (  # noqa: F401 -- re-exported for tests calli
 )
 
 _EMPTY_OUTPUT = object()
-
-LIBRARY_RADARR_FIELDS = {
-    "url": "string",
-    "token": "string",
-    "root_folder_path": "string",
-    "quality_profile": "string",
-    "availability": "string",
-    "tag": "string",
-    "monitor": "bool",
-    "search": "bool",
-    "add_missing": "bool",
-    "add_existing": "bool",
-    "upgrade_existing": "bool",
-    "monitor_existing": "bool",
-    "ignore_cache": "bool",
-    "radarr_path": "string",
-    "plex_path": "string",
-}
-
-LIBRARY_SONARR_FIELDS = {
-    "url": "string",
-    "token": "string",
-    "root_folder_path": "string",
-    "quality_profile": "string",
-    "language_profile": "string",
-    "series_type": "string",
-    "season_folder": "bool",
-    "monitor": "string",
-    "tag": "string",
-    "search": "bool",
-    "cutoff_search": "bool",
-    "add_missing": "bool",
-    "add_existing": "bool",
-    "upgrade_existing": "bool",
-    "monitor_existing": "bool",
-    "ignore_cache": "bool",
-    "sonarr_path": "string",
-    "plex_path": "string",
-}
 
 
 def build_libraries_section(
@@ -184,25 +148,12 @@ def build_libraries_section(
             helpers.ts_log(f"Processing Library: {library_key} -> {library_name}", level="DEBUG")
 
         # Process Library Settings and Operations Attributes
-        library_settings_fields = [
-            "asset_directory",
-            "prioritize_assets",
-        ]
-        operations_fields = [
-            "assets_for_all",
-            "assets_for_all_collections",
-            "mass_imdb_parental_labels",
-            "mass_collection_mode",
-            "update_blank_track_titles",
-            "remove_title_parentheses",
-            "split_duplicates",
-            "radarr_add_all",
-            "sonarr_add_all",
-        ]
-        library_settings = {}
-        service_overrides = {}
         operations = {}
         attr_group = attributes.get(lib_id, {})
+        library_settings = build_library_settings(attr_group, library_type, lib_id)
+        operations.update(build_library_operations(attr_group, library_type, lib_id))
+        service_name, service_overrides = build_service_overrides(attr_group, library_type, lib_id)
+
         # Begin: Mass Genre Update Section
         mass_genre_update = build_mass_genre_update_operation(attr_group, library_type, lib_id)
         if mass_genre_update:
@@ -304,50 +255,6 @@ def build_libraries_section(
             motu_list = CommentedSeq(mass_original_title_update)
             motu_list.fa.set_block_style()
             operations["mass_original_title_update"] = motu_list
-
-        for field in library_settings_fields:
-            attr_key = f"{library_type}-library_{lib_id}-attribute_{field}"
-            value = attr_group.get(attr_key, None)
-            if value in [None, ""] and field == "asset_directory":
-                legacy_attr_key = f"{library_type}-library_{lib_id}-{field}"
-                value = attr_group.get(legacy_attr_key, None)
-
-            if field == "asset_directory":
-                normalized = _normalize_asset_directory_values(value)
-
-                if normalized:
-                    asset_dirs = CommentedSeq(normalized)
-                    asset_dirs.fa.set_block_style()
-                    library_settings[field] = asset_dirs
-                continue
-
-            if field == "prioritize_assets":
-                bool_value = _coerce_bool(value)
-                if bool_value is not None:
-                    library_settings[field] = bool_value
-                continue
-
-            if value not in [None, "", False]:
-                library_settings[field] = value
-
-        for field in operations_fields:
-            attr_key = f"{library_type}-library_{lib_id}-attribute_{field}"
-            value = attr_group.get(attr_key, None)
-            if value not in [None, "", False]:
-                operations[field] = value
-
-        service_field_map = LIBRARY_RADARR_FIELDS if library_type == "mov" else LIBRARY_SONARR_FIELDS
-        service_name = "radarr" if library_type == "mov" else "sonarr"
-        for field, field_type in service_field_map.items():
-            attr_key = f"{library_type}-library_{lib_id}-attribute_{service_name}_{field}"
-            value = attr_group.get(attr_key, None)
-            if field_type == "bool":
-                bool_value = _coerce_bool(value)
-                if bool_value is not None:
-                    service_overrides[field] = bool_value
-                continue
-            if value not in [None, "", False]:
-                service_overrides[field] = value
 
         # Handle nested delete_collections block
         delete_collections = build_delete_collections_operation(attr_group, library_type, lib_id)

--- a/modules/output_library_ops.py
+++ b/modules/output_library_ops.py
@@ -25,7 +25,7 @@ import json
 from ruamel.yaml.comments import CommentedSeq
 
 from modules import helpers
-from modules.output_values import _coerce_bool
+from modules.output_values import _coerce_bool, _normalize_asset_directory_values
 
 # Values that we treat as "no override provided" for the numeric-ish
 # knobs inside operation blocks.  Users can wipe a field by clearing
@@ -560,3 +560,150 @@ def build_grouped_mass_update_operations(attr_group, library_type, lib_id):
             result[op] = _format_grouped_op_sequence(values)
 
     return result
+
+
+# The two per-library-type Radarr/Sonarr field maps.  Values are
+# either "string" (pass-through if non-empty) or "bool" (coerce via
+# _coerce_bool, include only if the coercion yielded a real bool).
+_LIBRARY_RADARR_FIELDS = {
+    "url": "string",
+    "token": "string",
+    "root_folder_path": "string",
+    "quality_profile": "string",
+    "availability": "string",
+    "tag": "string",
+    "monitor": "bool",
+    "search": "bool",
+    "add_missing": "bool",
+    "add_existing": "bool",
+    "upgrade_existing": "bool",
+    "monitor_existing": "bool",
+    "ignore_cache": "bool",
+    "radarr_path": "string",
+    "plex_path": "string",
+}
+
+_LIBRARY_SONARR_FIELDS = {
+    "url": "string",
+    "token": "string",
+    "root_folder_path": "string",
+    "quality_profile": "string",
+    "language_profile": "string",
+    "series_type": "string",
+    "season_folder": "bool",
+    "monitor": "string",
+    "tag": "string",
+    "search": "bool",
+    "cutoff_search": "bool",
+    "add_missing": "bool",
+    "add_existing": "bool",
+    "upgrade_existing": "bool",
+    "monitor_existing": "bool",
+    "ignore_cache": "bool",
+    "sonarr_path": "string",
+    "plex_path": "string",
+}
+
+# Values treated as 'user did not set this' for the simple field
+# walkers.  Broader than _EMPTY_OVERRIDE_VALUES because ``False`` is
+# also considered empty here (boolean toggle turned off).
+_SETTINGS_EMPTY_VALUES = frozenset({None, "", False})
+
+# Simple pass-through operation fields on ``entry.operations``.
+_LIBRARY_OPERATIONS_FIELDS = (
+    "assets_for_all",
+    "assets_for_all_collections",
+    "mass_imdb_parental_labels",
+    "mass_collection_mode",
+    "update_blank_track_titles",
+    "remove_title_parentheses",
+    "split_duplicates",
+    "radarr_add_all",
+    "sonarr_add_all",
+)
+
+
+def build_library_settings(attr_group, library_type, lib_id):
+    """Return the ``entry.settings`` dict for a library.
+
+    Reads the two per-library settings fields:
+
+    * ``asset_directory`` -- normalized via
+      :func:`output_values._normalize_asset_directory_values` and
+      wrapped in a block-style ``CommentedSeq``.  Also falls back to
+      the legacy ``<type>-library_<id>-asset_directory`` key (without
+      the ``attribute_`` prefix) when the primary key is empty --
+      preserves compatibility with older form submissions.
+    * ``prioritize_assets`` -- coerced via :func:`_coerce_bool`.
+
+    Returns an empty dict when neither field is set.
+    """
+    result = {}
+
+    # asset_directory (with legacy-key fallback)
+    value = attr_group.get(_attr_key(library_type, lib_id, "asset_directory"))
+    if value in (None, ""):
+        legacy_key = f"{library_type}-library_{lib_id}-asset_directory"
+        value = attr_group.get(legacy_key)
+    normalized = _normalize_asset_directory_values(value)
+    if normalized:
+        asset_dirs = CommentedSeq(normalized)
+        asset_dirs.fa.set_block_style()
+        result["asset_directory"] = asset_dirs
+
+    # prioritize_assets (bool coerce)
+    prioritize_raw = attr_group.get(_attr_key(library_type, lib_id, "prioritize_assets"))
+    prioritize_bool = _coerce_bool(prioritize_raw)
+    if prioritize_bool is not None:
+        result["prioritize_assets"] = prioritize_bool
+
+    return result
+
+
+def build_library_operations(attr_group, library_type, lib_id):
+    """Return the pass-through library operations dict.
+
+    Reads each field in :data:`_LIBRARY_OPERATIONS_FIELDS` and
+    passes the raw value through when it's not in
+    :data:`_SETTINGS_EMPTY_VALUES`.  Callers merge into
+    ``operations`` via ``operations.update(result)``.
+    """
+    result = {}
+    for field in _LIBRARY_OPERATIONS_FIELDS:
+        value = attr_group.get(_attr_key(library_type, lib_id, field))
+        if value not in _SETTINGS_EMPTY_VALUES:
+            result[field] = value
+    return result
+
+
+def build_service_overrides(attr_group, library_type, lib_id):
+    """Return ``(service_name, overrides_dict)`` for the library type.
+
+    Movie libraries get Radarr overrides, show libraries get Sonarr.
+    Fields marked ``"bool"`` in the field-map are coerced via
+    :func:`_coerce_bool` (included only when the coercion yields a
+    real bool -- not for missing/blank inputs).  String fields are
+    passed through unless empty.
+
+    Returns ``(name, {})`` when the user set no overrides; callers
+    should treat the empty dict as "don't emit a service block".
+    """
+    if library_type == "mov":
+        field_map = _LIBRARY_RADARR_FIELDS
+        service_name = "radarr"
+    else:
+        field_map = _LIBRARY_SONARR_FIELDS
+        service_name = "sonarr"
+
+    overrides = {}
+    for field, field_type in field_map.items():
+        value = attr_group.get(_attr_key(library_type, lib_id, f"{service_name}_{field}"))
+        if field_type == "bool":
+            bool_value = _coerce_bool(value)
+            if bool_value is not None:
+                overrides[field] = bool_value
+            continue
+        if value not in _SETTINGS_EMPTY_VALUES:
+            overrides[field] = value
+
+    return service_name, overrides


### PR DESCRIPTION
Twenty-first refactor pass on `modules/output.py` (now 1688 lines after #1464). Stacked on top of #1464.

## Cumulative -2239 lines / -58.4% - NEW BIGGEST SINGLE CARVE

**Three walker loops extracted in one PR: -94 lines** — the largest single-PR reduction of the sprint, edging out #1455's -405 as a % of the file at the time.

## What

Three near-identical walker loops carved out of `add_entry`. Each was 12-18 lines of `for field in <fields>: read; filter; assign;` boilerplate:

| Extracted function | What it does |
|---|---|
| `build_library_settings` | Reads `asset_directory` (with legacy-key fallback) + `prioritize_assets` |
| `build_library_operations` | Reads 9 pass-through operation fields |
| `build_service_overrides` | Reads Radarr (mov) or Sonarr (sho) overrides — returns `(service_name, overrides_dict)` |

Call site drops from 45 lines to **3 lines**:

```python
library_settings = build_library_settings(attr_group, library_type, lib_id)
operations.update(build_library_operations(attr_group, library_type, lib_id))
service_name, service_overrides = build_service_overrides(attr_group, library_type, lib_id)
```

## Constants moved out of `output.py`

- `LIBRARY_RADARR_FIELDS` (15 fields) → `_LIBRARY_RADARR_FIELDS` (module-private in output_library_ops)
- `LIBRARY_SONARR_FIELDS` (18 fields) → `_LIBRARY_SONARR_FIELDS`
- Local `operations_fields` list per-call → `_LIBRARY_OPERATIONS_FIELDS` module-level tuple
- Repeated `[None, "", False]` check → `_SETTINGS_EMPTY_VALUES` frozenset

**Note:** `quickstart.py` has its own `LIBRARY_RADARR_FIELDS`/`LIBRARY_SONARR_FIELDS` (lists, not dicts) — different data, different purpose. Not affected.

## DRY wins

- The `service_field_map / service_name` dispatch (3 lines of ternary + assign) collapses into a clean tuple return from the helper: `service_name, service_overrides = build_service_overrides(...)`
- The `prioritize_assets` and `asset_directory` special-case handling that used `continue` statements to skip the fall-through `if value not in [None, "", False]` block flattens into direct dict assignments
- The `if value in [None, ""] and field == "asset_directory"` legacy-key fallback becomes an explicit two-line lookup

## Impact

- `modules/output.py`: 1688 → **1594** (-94 / -5.6%)
- `modules/output_library_ops.py`: 560 → 709 (+149)

## Cumulative sprint progress

| PR | Size | Delta |
|---|---|---|
| Start | 3833 | — |
| #1445-1458 | 1932 | -1901 |
| #1459-1463 (whale #1-5) | 1770 | -162 |
| #1464 (whale #6) | 1688 | -82 |
| **This PR (whale #7)** | **1594** | **-94** |
| **Total** | | **-2239 / -58.4%** |

## Verification

- All 1077 tests pass
- Ruff + black clean
- Smoke tests confirm all three builders + edge cases (legacy asset_directory fallback, bool coercion, empty-value filtering, mov→radarr vs sho→sonarr service dispatch)