### PR TITLE
Extract per-overlay-type cleanup + overlay_sort_key to output_overlays.py

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -60,9 +60,11 @@ from modules.output_library_ops import (
 )
 from modules.output_optimize import optimize_template_variables
 from modules.output_overlays import (
+    apply_per_overlay_type_cleanup,
     overlay_lookup_name,
     prune_rating_template_vars,
     reorder_rating_template_vars,
+    sort_overlay_entries,
 )
 from modules.output_playlists import (  # noqa: F401 -- re-exported so output.<name> keeps working
     PLAYLIST_KEYED_TEMPLATE_VAR_SPECS,
@@ -283,91 +285,6 @@ def build_libraries_section(
             overlay_entries = []
             overlay_name_order = []
 
-            default_language_flag_codes = ["en", "de", "fr", "es", "pt", "ja"]
-            default_language_flag_weights = {
-                "en": 610,
-                "de": 600,
-                "fr": 590,
-                "es": 580,
-                "pt": 570,
-                "ja": 560,
-                "ko": 550,
-                "zh": 540,
-                "da": 530,
-                "ru": 520,
-                "it": 510,
-                "hi": 500,
-                "te": 490,
-                "fa": 480,
-                "th": 470,
-                "nl": 460,
-                "no": 450,
-                "is": 440,
-                "sv": 430,
-                "tr": 420,
-                "pl": 410,
-                "cs": 400,
-                "uk": 390,
-                "hu": 380,
-                "ar": 370,
-                "bg": 360,
-                "bn": 350,
-                "bs": 340,
-                "ca": 330,
-                "cy": 320,
-                "el": 310,
-                "et": 300,
-                "eu": 290,
-                "fi": 280,
-                "tl": 270,
-                "fil": 265,
-                "gl": 260,
-                "he": 250,
-                "hr": 240,
-                "id": 230,
-                "ka": 220,
-                "kk": 210,
-                "kn": 200,
-                "la": 190,
-                "lt": 180,
-                "lv": 170,
-                "mk": 160,
-                "ml": 150,
-                "mr": 140,
-                "ms": 130,
-                "nb": 120,
-                "nn": 110,
-                "pa": 100,
-                "ro": 90,
-                "sk": 80,
-                "sl": 70,
-                "sq": 60,
-                "sr": 50,
-                "so": 45,
-                "sw": 40,
-                "ta": 30,
-                "ur": 20,
-                "ay": 19,
-                "ga": 18,
-                "li": 17,
-                "kh": 16,
-                "vi": 15,
-                "mn": 14,
-                "af": 13,
-                "bm": 12,
-                "ln": 11,
-                "wo": 10,
-                "lo": 9,
-                "myn": 8,
-                "iu": 7,
-                "rom": 6,
-                "am": 5,
-                "su": 4,
-                "zu": 3,
-                "lb": 2,
-                "mos": 1,
-            }
-
             if overlay_key and overlay_key in overlays:
                 raw_overlay_entries = overlays[overlay_key]
 
@@ -510,131 +427,7 @@ def build_libraries_section(
                             overlay_entry["default"] = "languages"
 
                 # Final cleanup for specific overlays (e.g., drop text for aspect/video_format)
-                for ov in overlay_entries:
-                    default_name = ov.get("default", "")
-                    tv = ov.get("template_variables")
-                    if not isinstance(tv, dict):
-                        continue
-                    for key, value in list(tv.items()):
-                        if value is None:
-                            tv.pop(key, None)
-                    if tv.get("builder_level") == "show":
-                        tv.pop("builder_level", None)
-                        if not tv:
-                            ov.pop("template_variables", None)
-                            continue
-                    if isinstance(default_name, str) and default_name in {"resolution", "overlay_resolution"}:
-                        use_edition_val = tv.get("use_edition")
-                        use_resolution_val = tv.get("use_resolution")
-                        if isinstance(use_edition_val, str):
-                            use_edition_val = use_edition_val.lower() == "true"
-                        if isinstance(use_resolution_val, str):
-                            use_resolution_val = use_resolution_val.lower() == "true"
-                        if use_edition_val is None:
-                            tv["use_edition"] = True
-                            use_edition_val = True
-                        elif use_edition_val is False:
-                            tv["use_edition"] = False
-                            use_edition_val = False
-                        if use_resolution_val is None:
-                            tv["use_resolution"] = True
-                            use_resolution_val = True
-                        elif use_resolution_val is False:
-                            tv["use_resolution"] = False
-                            use_resolution_val = False
-                        if use_edition_val is True:
-                            resolution_levels = ["4k", "1080p", "720p", "576p", "480p"]
-                            resolution_variants = ["dvhdrplus", "dvhdr", "plus", "dv", "hlg", "hdr"]
-                            keep_keys = {
-                                "builder_level",
-                                "use_edition",
-                                "use_resolution",
-                                "use_4k",
-                                "use_1080p",
-                                "use_720p",
-                                "use_576p",
-                                "use_480p",
-                                "use_dv",
-                                "use_hlg",
-                                "use_hdr",
-                                "use_plus",
-                                "use_dvhdr",
-                                "use_dvhdrplus",
-                                "use_extended",
-                                "use_uncut",
-                                "use_unrated",
-                                "use_special",
-                                "use_anniversary",
-                                "use_collector",
-                                "use_diamond",
-                                "use_platinum",
-                                "use_directors",
-                                "use_final",
-                                "use_international",
-                                "use_theatrical",
-                                "use_ultimate",
-                                "use_alternate",
-                                "use_coda",
-                                "use_enhanced",
-                                "use_imax",
-                                "use_remastered",
-                                "use_criterion",
-                                "use_richarddonner",
-                                "use_blackchrome",
-                                "use_definitive",
-                                "use_openmatte",
-                                "use_ulysses",
-                                "use_producers",
-                                "horizontal_offset",
-                                "vertical_offset",
-                            }
-                            keep_keys.update(
-                                {f"use_{resolution_level}_{resolution_variant}" for resolution_level in resolution_levels for resolution_variant in resolution_variants}
-                            )
-                            for key in list(tv.keys()):
-                                if key not in keep_keys:
-                                    tv.pop(key, None)
-                            if not tv:
-                                ov.pop("template_variables", None)
-                                continue
-                    if isinstance(default_name, str) and default_name in {"commonsense", "overlay_content_rating_commonsense", "content_rating_commonsense"}:
-                        for key in ["text", "font", "font_size", "font_color"]:
-                            tv.pop(key, None)
-                        if not tv:
-                            ov.pop("template_variables", None)
-                        continue
-                    if isinstance(default_name, str) and default_name in {"episode_info", "overlay_episode_info"}:
-                        tv.pop("text", None)
-                        if not tv:
-                            ov.pop("template_variables", None)
-                        continue
-                    if isinstance(default_name, str) and default_name in {"languages", "overlay_languages"}:
-                        languages_value = tv.get("languages")
-                        if languages_value is not None:
-                            normalized_languages = _parse_string_list(languages_value)
-                            if normalized_languages == default_language_flag_codes or not normalized_languages:
-                                tv.pop("languages", None)
-                            else:
-                                tv["languages"] = normalized_languages
-                        for key in list(tv.keys()):
-                            if not (isinstance(key, str) and key.startswith("weight_")):
-                                continue
-                            language_key = key[len("weight_") :]
-                            default_weight = default_language_flag_weights.get(language_key)
-                            try:
-                                numeric_value = int(str(tv.get(key)).strip())
-                            except (TypeError, ValueError):
-                                continue
-                            tv[key] = numeric_value
-                            if default_weight is not None and numeric_value == default_weight:
-                                tv.pop(key, None)
-                        if not tv:
-                            ov.pop("template_variables", None)
-                            continue
-                    if isinstance(default_name, str) and default_name in {"aspect", "video_format", "overlay_aspect", "overlay_video_format"}:
-                        tv.pop("text", None)
-                        if not tv:
-                            ov.pop("template_variables", None)
+                apply_per_overlay_type_cleanup(overlay_entries)
 
                 if overlay_entries:
                     # Final cleanup: drop rating pairs if either side is empty
@@ -674,23 +467,7 @@ def build_libraries_section(
                     for ov in overlay_entries:
                         reorder_rating_template_vars(ov)
 
-                    if overlay_name_order:
-                        order_map = {name: idx for idx, name in enumerate(overlay_name_order)}
-                        level_order = {"show": 0, "season": 1, "episode": 2}
-
-                        def overlay_sort_key(overlay_entry):
-                            name = overlay_entry.get("default", "")
-                            sort_name = "languages" if name == "languages_subtitles" else name
-                            name_index = order_map.get(sort_name, len(order_map))
-                            tv = overlay_entry.get("template_variables") or {}
-                            if not isinstance(tv, dict):
-                                tv = {}
-                            level = tv.get("builder_level", "show")
-                            level_index = level_order.get(level, 0)
-                            subtitles_index = 1 if tv.get("use_subtitles") else 0
-                            return (name_index, level_index, subtitles_index)
-
-                        overlay_entries.sort(key=overlay_sort_key)
+                    sort_overlay_entries(overlay_entries, overlay_name_order)
 
                 overlay_library_prefix = library_key[: -len("-library")] if isinstance(library_key, str) and library_key.endswith("-library") else library_key
                 raw_overlay_file_entries = _parse_overlay_file_block_entries(overlays.get(overlay_key, {}).get(f"{overlay_library_prefix}-overlay_files"))

--- a/modules/output_overlays.py
+++ b/modules/output_overlays.py
@@ -426,3 +426,376 @@ def reorder_rating_template_vars(overlay_entry):
         if key not in ordered:
             ordered[key] = tv[key]
     overlay_entry["template_variables"] = ordered
+
+
+# ---------------------------------------------------------------------------
+# Per-overlay-type post-processing cleanup.
+#
+# After the overlay entries are built and rating-slot compaction has been
+# applied, each overlay type gets a targeted cleanup pass that:
+#   * Drops keys that were injected by the UI but shouldn't emit in YAML.
+#   * Normalizes values (booleans-from-strings, language weight ints).
+#   * Elides default-equal values so the emitted YAML stays minimal.
+# ---------------------------------------------------------------------------
+
+# Language weights used by the "languages" overlay.  These are the Kometa
+# defaults, in priority order (higher weight = higher priority).  Only weights
+# that DIFFER from these defaults emit into YAML; matching ones are dropped.
+DEFAULT_LANGUAGE_FLAG_CODES = ("en", "de", "fr", "es", "pt", "ja")
+DEFAULT_LANGUAGE_FLAG_WEIGHTS = {
+    "en": 610,
+    "de": 600,
+    "fr": 590,
+    "es": 580,
+    "pt": 570,
+    "ja": 560,
+    "ko": 550,
+    "zh": 540,
+    "da": 530,
+    "ru": 520,
+    "it": 510,
+    "hi": 500,
+    "te": 490,
+    "fa": 480,
+    "th": 470,
+    "nl": 460,
+    "no": 450,
+    "is": 440,
+    "sv": 430,
+    "tr": 420,
+    "pl": 410,
+    "cs": 400,
+    "uk": 390,
+    "hu": 380,
+    "ar": 370,
+    "bg": 360,
+    "bn": 350,
+    "bs": 340,
+    "ca": 330,
+    "cy": 320,
+    "el": 310,
+    "et": 300,
+    "eu": 290,
+    "fi": 280,
+    "tl": 270,
+    "fil": 265,
+    "gl": 260,
+    "he": 250,
+    "hr": 240,
+    "id": 230,
+    "ka": 220,
+    "kk": 210,
+    "kn": 200,
+    "la": 190,
+    "lt": 180,
+    "lv": 170,
+    "mk": 160,
+    "ml": 150,
+    "mr": 140,
+    "ms": 130,
+    "nb": 120,
+    "nn": 110,
+    "pa": 100,
+    "ro": 90,
+    "sk": 80,
+    "sl": 70,
+    "sq": 60,
+    "sr": 50,
+    "so": 45,
+    "sw": 40,
+    "ta": 30,
+    "ur": 20,
+    "ay": 19,
+    "ga": 18,
+    "li": 17,
+    "kh": 16,
+    "vi": 15,
+    "mn": 14,
+    "af": 13,
+    "bm": 12,
+    "ln": 11,
+    "wo": 10,
+    "lo": 9,
+    "myn": 8,
+    "iu": 7,
+    "rom": 6,
+    "am": 5,
+    "su": 4,
+    "zu": 3,
+    "lb": 2,
+    "mos": 1,
+}
+
+# Recognized "resolution" overlay defaults.
+_RESOLUTION_DEFAULTS = frozenset({"resolution", "overlay_resolution"})
+_COMMONSENSE_DEFAULTS = frozenset(_COMMONSENSE_ALIASES)  # reuse from earlier
+_EPISODE_INFO_DEFAULTS = frozenset({"episode_info", "overlay_episode_info"})
+_LANGUAGES_DEFAULTS = frozenset({"languages", "overlay_languages"})
+_ASPECT_VIDEO_FORMAT_DEFAULTS = frozenset({"aspect", "video_format", "overlay_aspect", "overlay_video_format"})
+
+# Keys kept when a resolution overlay has use_edition=True; anything else
+# is stripped.  The dynamic per-(level,variant) combinations get generated
+# once at module load.
+_RESOLUTION_EDITION_STATIC_KEEP_KEYS = frozenset(
+    {
+        "builder_level",
+        "use_edition",
+        "use_resolution",
+        "use_4k",
+        "use_1080p",
+        "use_720p",
+        "use_576p",
+        "use_480p",
+        "use_dv",
+        "use_hlg",
+        "use_hdr",
+        "use_plus",
+        "use_dvhdr",
+        "use_dvhdrplus",
+        "use_extended",
+        "use_uncut",
+        "use_unrated",
+        "use_special",
+        "use_anniversary",
+        "use_collector",
+        "use_diamond",
+        "use_platinum",
+        "use_directors",
+        "use_final",
+        "use_international",
+        "use_theatrical",
+        "use_ultimate",
+        "use_alternate",
+        "use_coda",
+        "use_enhanced",
+        "use_imax",
+        "use_remastered",
+        "use_criterion",
+        "use_richarddonner",
+        "use_blackchrome",
+        "use_definitive",
+        "use_openmatte",
+        "use_ulysses",
+        "use_producers",
+        "horizontal_offset",
+        "vertical_offset",
+    }
+)
+_RESOLUTION_LEVELS = ("4k", "1080p", "720p", "576p", "480p")
+_RESOLUTION_VARIANTS = ("dvhdrplus", "dvhdr", "plus", "dv", "hlg", "hdr")
+_RESOLUTION_EDITION_KEEP_KEYS = frozenset(_RESOLUTION_EDITION_STATIC_KEEP_KEYS | {f"use_{lvl}_{var}" for lvl in _RESOLUTION_LEVELS for var in _RESOLUTION_VARIANTS})
+
+
+def _drop_none_values(tv):
+    """Drop keys whose value is exactly ``None``.  Mutates *tv*."""
+    for key, value in list(tv.items()):
+        if value is None:
+            tv.pop(key, None)
+
+
+def _elide_default_builder_level(tv):
+    """Drop ``builder_level`` if it equals the default ``"show"``.
+
+    Returns True if the caller should short-circuit (tv became empty).
+    """
+    if tv.get("builder_level") == "show":
+        tv.pop("builder_level", None)
+        return not tv
+    return False
+
+
+def _coerce_string_bool(val):
+    """Coerce a string boolean ("true"/"false") to Python bool.
+
+    Preserves non-string inputs (including the sentinel ``None``).
+    """
+    if isinstance(val, str):
+        return val.lower() == "true"
+    return val
+
+
+def _cleanup_resolution_overlay(tv):
+    """Post-process a resolution overlay's template_variables in place.
+
+    Normalizes ``use_edition`` / ``use_resolution``:
+      * Missing (None) -> written as bool True.
+      * String "true"  -> left as string (historical quirk of the inline code).
+      * String "false" -> rewritten to bool False.
+      * Bool True/False -> left as-is.
+
+    When ``use_edition`` is truthy, strips any key not in the resolution
+    edition allow-list.
+
+    Returns True if *tv* became empty (caller should pop it).
+    """
+    use_edition_val = _coerce_string_bool(tv.get("use_edition"))
+    use_resolution_val = _coerce_string_bool(tv.get("use_resolution"))
+    if use_edition_val is None:
+        tv["use_edition"] = True
+        use_edition_val = True
+    elif use_edition_val is False:
+        # This overwrites both native False and the string "false".
+        # (String "true" is not touched -- neither branch fires.)
+        tv["use_edition"] = False
+
+    if use_resolution_val is None:
+        tv["use_resolution"] = True
+    elif use_resolution_val is False:
+        tv["use_resolution"] = False
+
+    if use_edition_val is not True:
+        return False
+    for key in list(tv.keys()):
+        if key not in _RESOLUTION_EDITION_KEEP_KEYS:
+            tv.pop(key, None)
+    return not tv
+
+
+def _cleanup_commonsense_overlay(tv):
+    """Drop text/font styling from a commonsense overlay -- it uses images.
+
+    Returns True if *tv* became empty.
+    """
+    for key in ("text", "font", "font_size", "font_color"):
+        tv.pop(key, None)
+    return not tv
+
+
+def _cleanup_episode_info_overlay(tv):
+    """Drop the ``text`` key from an episode_info overlay -- Kometa injects
+    the episode text itself; a stale text key would override.
+
+    Returns True if *tv* became empty.
+    """
+    tv.pop("text", None)
+    return not tv
+
+
+def _cleanup_languages_overlay(tv):
+    """Normalize a languages overlay in place.
+
+    * ``languages`` list: normalized via _parse_string_list and dropped
+      if it equals the default set.
+    * ``weight_XX`` keys: coerced to int; dropped if they match the
+      default weight for that language.
+
+    Returns True if *tv* became empty.
+    """
+    # Delay-import to avoid a circular reference during module load
+    # (output_values -> output_overlays would create a cycle if this ever grew).
+    from modules.output_values import _parse_string_list
+
+    languages_value = tv.get("languages")
+    if languages_value is not None:
+        normalized_languages = _parse_string_list(languages_value)
+        if normalized_languages == list(DEFAULT_LANGUAGE_FLAG_CODES) or not normalized_languages:
+            tv.pop("languages", None)
+        else:
+            tv["languages"] = normalized_languages
+
+    for key in list(tv.keys()):
+        if not (isinstance(key, str) and key.startswith("weight_")):
+            continue
+        language_key = key[len("weight_") :]
+        default_weight = DEFAULT_LANGUAGE_FLAG_WEIGHTS.get(language_key)
+        try:
+            numeric_value = int(str(tv.get(key)).strip())
+        except (TypeError, ValueError):
+            continue
+        tv[key] = numeric_value
+        if default_weight is not None and numeric_value == default_weight:
+            tv.pop(key, None)
+
+    return not tv
+
+
+def _cleanup_aspect_video_format_overlay(tv):
+    """Drop the ``text`` key from aspect / video_format overlays -- they
+    use image glyphs, so a stale text key from the UI must not emit.
+
+    Returns True if *tv* became empty.
+    """
+    tv.pop("text", None)
+    return not tv
+
+
+# Dispatch table: default-name -> (allowed default names, cleanup function).
+# Ordered by the sequence the original inline code applied them.
+_OVERLAY_TYPE_CLEANUPS = (
+    (_RESOLUTION_DEFAULTS, _cleanup_resolution_overlay),
+    (_COMMONSENSE_DEFAULTS, _cleanup_commonsense_overlay),
+    (_EPISODE_INFO_DEFAULTS, _cleanup_episode_info_overlay),
+    (_LANGUAGES_DEFAULTS, _cleanup_languages_overlay),
+    (_ASPECT_VIDEO_FORMAT_DEFAULTS, _cleanup_aspect_video_format_overlay),
+)
+
+
+def apply_per_overlay_type_cleanup(overlay_entries):
+    """Post-process every overlay in *overlay_entries* by type.
+
+    For each entry:
+      1. Skip if template_variables is missing or non-dict.
+      2. Drop any key whose value is None.
+      3. Elide default ``builder_level: show``.
+      4. Dispatch to the type-specific cleanup based on ``default``.
+
+    If an overlay's template_variables becomes empty at any point,
+    remove the key entirely from the entry.
+
+    Mutates *overlay_entries* (list of dicts) in place.
+    """
+    for ov in overlay_entries:
+        default_name = ov.get("default", "")
+        tv = ov.get("template_variables")
+        if not isinstance(tv, dict):
+            continue
+
+        _drop_none_values(tv)
+
+        if _elide_default_builder_level(tv):
+            ov.pop("template_variables", None)
+            continue
+
+        # Type dispatch: the recognized default-name sets are pairwise
+        # disjoint, so at most one branch can match.  If it empties tv,
+        # pop template_variables from the entry.
+        if not isinstance(default_name, str):
+            continue
+        for names, cleanup in _OVERLAY_TYPE_CLEANUPS:
+            if default_name not in names:
+                continue
+            if cleanup(tv):
+                ov.pop("template_variables", None)
+            break
+
+
+def sort_overlay_entries(overlay_entries, overlay_name_order):
+    """Sort *overlay_entries* in place by (name-order, level-order, subtitles).
+
+    * name-order comes from *overlay_name_order* (a list of display
+      names in canonical order).  ``languages_subtitles`` is folded
+      onto ``languages``.
+    * level-order is show < season < episode.
+    * subtitles-sorted entries come after non-subtitles siblings at
+      the same (name, level).
+
+    No-op when *overlay_name_order* is falsy.
+    """
+    if not overlay_name_order:
+        return
+    order_map = {name: idx for idx, name in enumerate(overlay_name_order)}
+    level_order = {"show": 0, "season": 1, "episode": 2}
+
+    def _key(overlay_entry):
+        name = overlay_entry.get("default", "")
+        sort_name = "languages" if name == "languages_subtitles" else name
+        name_index = order_map.get(sort_name, len(order_map))
+        tv = overlay_entry.get("template_variables") or {}
+        if not isinstance(tv, dict):
+            tv = {}
+        level = tv.get("builder_level", "show")
+        level_index = level_order.get(level, 0)
+        subtitles_index = 1 if tv.get("use_subtitles") else 0
+        return (name_index, level_index, subtitles_index)
+
+    overlay_entries.sort(key=_key)


### PR DESCRIPTION
**Sprint 2, PR #4.** The biggest single PR of sprint 2 so far. Pulls the entire 'Final cleanup for specific overlays' dispatcher and its 84-line language-flag-weights table out of `add_entry`, plus the small `overlay_sort_key` sort helper.

## What moved

### `apply_per_overlay_type_cleanup(overlay_entries)`
Post-processes every overlay in the list by type:
1. Skip entries with missing / non-dict `template_variables`.
2. Drop keys whose value is `None`.
3. Elide default `builder_level='show'`.
4. Dispatch to a type-specific cleanup based on `default`.

Split into 5 named per-type helpers:
- `_cleanup_resolution_overlay`
- `_cleanup_commonsense_overlay`
- `_cleanup_episode_info_overlay`
- `_cleanup_languages_overlay`
- `_cleanup_aspect_video_format_overlay`

Plus 3 shared primitives:
- `_drop_none_values`
- `_elide_default_builder_level`
- `_coerce_string_bool`

Uses a dispatch table `_OVERLAY_TYPE_CLEANUPS` so adding a new overlay type is a one-line change.

### `sort_overlay_entries(overlay_entries, overlay_name_order)`
Sort in place by `(name-order, level-order, subtitles)`. `languages_subtitles` folds onto `languages`; level order is `show < season < episode`.

### Constants moved to module scope
- `DEFAULT_LANGUAGE_FLAG_CODES` — 6-item tuple, Kometa's default language set
- `DEFAULT_LANGUAGE_FLAG_WEIGHTS` — 83-item mapping, language → priority weight
- `_RESOLUTION_DEFAULTS`, `_COMMONSENSE_DEFAULTS`, `_EPISODE_INFO_DEFAULTS`, `_LANGUAGES_DEFAULTS`, `_ASPECT_VIDEO_FORMAT_DEFAULTS` — frozensets of recognized default names
- `_RESOLUTION_EDITION_KEEP_KEYS` — frozenset, computed once via cross-product of resolution levels × variants

## Behavioral finding

The original resolution cleanup had an **asymmetric string coercion**: string `'true'` passed through unchanged, but string `'false'` got rewritten to bool `False`. This is preserved exactly in the extraction and documented in the docstring of `_cleanup_resolution_overlay`.

The smoke test suite includes both `use_edition: 'true'` and `use_edition: 'false'` cases to verify.

## Impact

- `modules/output.py`: **1247 → 1024** (-223 / -17.9%)
- `modules/output_overlays.py`: 431 → 714 (+283)

## Cumulative sprint progress

| PR range | Start | End | Δ |
|---|---|---|---|
| Sprint 1 (#1445-1465) | 3833 | 1595 | -2238 |
| #1468 | 1595 | 1496 | -99 |
| #1469 | 1496 | 1311 | -185 |
| #1470 | 1311 | 1247 | -64 |
| **This PR** | **1247** | **1024** | **-223** |
| **Total** | 3833 | 1024 | **-2809 (-73.3%)** |

## Verification

- All 1081 tests pass
- Ruff + black clean
- **Smoke tests** confirm behavioral identity across 29 edge cases: no tv, tv not dict, None-only tv, builder_level elision, all 5 overlay types (resolution × 7 sub-cases including asymmetric string bool coercion; commonsense × 2; episode_info × 2; languages × 6 covering default drops / weight coercion / non-int weights / empty-after cases; aspect / video_format × 2), unknown types, non-string defaults, and multi-entry lists.