### PR TITLE
Extract build_overlay_files_for_library + helpers.strip_library_suffix

### DIFF
--- a/modules/helpers/_misc.py
+++ b/modules/helpers/_misc.py
@@ -54,3 +54,22 @@ def extract_library_name(key):
         key,
     )
     return match.group(1) if match else None
+
+
+def strip_library_suffix(library_key):
+    """Return *library_key* with its trailing ``-library`` suffix removed.
+
+    Kometa uses two closely related shapes for library-scoped keys:
+
+    * ``mov-library_<id>-library`` -- the top-level library selection key.
+    * ``mov-library_<id>-collection_<name>`` etc. -- attribute keys within
+      that library, all of which share the ``mov-library_<id>`` prefix.
+
+    Building filenames such as ``<prefix>-collection_files``,
+    ``<prefix>-overlay_files`` or ``<prefix>-metadata_files`` requires the
+    library-prefix form.  When the input isn't a string or doesn't end with
+    ``-library`` we return it unchanged so callers can pass either shape.
+    """
+    if isinstance(library_key, str) and library_key.endswith("-library"):
+        return library_key[: -len("-library")]
+    return library_key

--- a/modules/output.py
+++ b/modules/output.py
@@ -60,12 +60,7 @@ from modules.output_library_ops import (
     build_top_level_fields,
 )
 from modules.output_optimize import optimize_template_variables
-from modules.output_overlay_builder import build_overlay_entries
-from modules.output_overlays import (
-    apply_per_overlay_type_cleanup,
-    reorder_rating_template_vars,
-    sort_overlay_entries,
-)
+from modules.output_overlay_builder import build_overlay_files_for_library
 from modules.output_playlists import (  # noqa: F401 -- re-exported so output.<name> keeps working
     PLAYLIST_KEYED_TEMPLATE_VAR_SPECS,
     PLAYLIST_SHARED_TEMPLATE_VAR_SPECS,
@@ -193,38 +188,16 @@ def build_libraries_section(
 
         collection_key = helpers.extract_library_name(library_key)
         if collection_key:
-
-            # Process Overlays
-            overlay_key = helpers.extract_library_name(library_key)
-            overlay_entries = []
-            overlay_name_order = []
-
-            if overlay_key and overlay_key in overlays:
-                raw_overlay_entries = overlays[overlay_key]
-                overlay_entries, overlay_name_order = build_overlay_entries(library_type, overlay_key, raw_overlay_entries)
-
-                # Final cleanup for specific overlays (e.g., drop text for aspect/video_format)
-                apply_per_overlay_type_cleanup(overlay_entries)
-
-                if overlay_entries:
-                    for ov in overlay_entries:
-                        reorder_rating_template_vars(ov)
-                    sort_overlay_entries(overlay_entries, overlay_name_order)
-
-                overlay_library_prefix = library_key[: -len("-library")] if isinstance(library_key, str) and library_key.endswith("-library") else library_key
-                raw_overlay_file_entries = _parse_overlay_file_block_entries(overlays.get(overlay_key, {}).get(f"{overlay_library_prefix}-overlay_files"))
-                if raw_overlay_file_entries:
-                    overlay_entries.extend(raw_overlay_file_entries)
-
-                if overlay_entries:
-                    entry["overlay_files"] = overlay_entries
+            overlay_files = build_overlay_files_for_library(library_key, library_type, overlays)
+            if overlay_files:
+                entry["overlay_files"] = overlay_files
 
         metadata_group = (
             movie_metadata_files.get(helpers.extract_library_name(library_key), {})
             if library_type == "mov"
             else show_metadata_files.get(helpers.extract_library_name(library_key), {})
         )
-        library_prefix = library_key[: -len("-library")] if isinstance(library_key, str) and library_key.endswith("-library") else library_key
+        library_prefix = helpers.strip_library_suffix(library_key)
         metadata_entries = _parse_metadata_file_entries(metadata_group.get(f"{library_prefix}-metadata_files"))
         if metadata_entries:
             entry["metadata_files"] = metadata_entries

--- a/modules/output_collections.py
+++ b/modules/output_collections.py
@@ -505,7 +505,7 @@ def build_collection_files(
         collection_files.append(file_entry)
 
     raw_collection_group = movie_collection_files.get(collection_key, {}) if library_type == "mov" else show_collection_files.get(collection_key, {})
-    library_prefix = library_key[: -len("-library")] if isinstance(library_key, str) and library_key.endswith("-library") else library_key
+    library_prefix = helpers.strip_library_suffix(library_key)
     raw_collection_entries = _parse_collection_file_block_entries(raw_collection_group.get(f"{library_prefix}-collection_files"))
 
     if collection_files:

--- a/modules/output_overlay_builder.py
+++ b/modules/output_overlay_builder.py
@@ -22,9 +22,14 @@ from cleanup keeps each module cohesive and under ~600 lines.
 
 from __future__ import annotations
 
+from modules import helpers
+from modules.output_file_entries import _parse_overlay_file_block_entries
 from modules.output_overlays import (
+    apply_per_overlay_type_cleanup,
     overlay_lookup_name,
     prune_rating_template_vars,
+    reorder_rating_template_vars,
+    sort_overlay_entries,
 )
 from modules.output_values import _parse_string_list
 
@@ -243,3 +248,43 @@ def build_overlay_entries(library_type, overlay_key, raw_overlay_entries):
         return _build_show_overlay_entries(overlay_key, raw_overlay_entries, library_type)
     # Unknown library type -- return empty result rather than crash.
     return [], []
+
+
+def build_overlay_files_for_library(library_key, library_type, overlays):
+    """Assemble the final ``overlay_files`` list for a single library.
+
+    Wraps the four-stage overlay pipeline into one call:
+
+    1. ``build_overlay_entries`` -- classify + populate template vars.
+    2. ``apply_per_overlay_type_cleanup`` -- per-type field normalization.
+    3. Per-entry ``reorder_rating_template_vars`` + list-level
+       ``sort_overlay_entries`` -- final field / entry ordering.
+    4. ``_parse_overlay_file_block_entries`` on the raw
+       ``<library_prefix>-overlay_files`` value -- appended verbatim.
+
+    Returns the final list.  When the library has no overlay data
+    (no matching key in *overlays* and no raw overlay_files block)
+    returns an empty list.  Caller is responsible for whether to
+    assign to ``entry['overlay_files']``.
+    """
+    overlay_key = helpers.extract_library_name(library_key)
+    if not overlay_key:
+        return []
+
+    library_overlay_group = overlays.get(overlay_key, {}) if overlay_key in overlays else None
+    if library_overlay_group is None:
+        return []
+
+    overlay_entries, overlay_name_order = build_overlay_entries(library_type, overlay_key, library_overlay_group)
+    apply_per_overlay_type_cleanup(overlay_entries)
+    if overlay_entries:
+        for ov in overlay_entries:
+            reorder_rating_template_vars(ov)
+        sort_overlay_entries(overlay_entries, overlay_name_order)
+
+    overlay_library_prefix = helpers.strip_library_suffix(library_key)
+    raw_overlay_file_entries = _parse_overlay_file_block_entries(library_overlay_group.get(f"{overlay_library_prefix}-overlay_files"))
+    if raw_overlay_file_entries:
+        overlay_entries.extend(raw_overlay_file_entries)
+
+    return overlay_entries


### PR DESCRIPTION
**Sprint 2, PR #8.** Collapses the 4-stage overlay pipeline in `add_entry` into a single function call, and DRYs up the `-library` suffix strip pattern duplicated across 3 sites.

## What moved

### New: `build_overlay_files_for_library(library_key, library_type, overlays) -> list`

In `modules/output_overlay_builder.py`. Wraps the four-stage overlay pipeline:

1. `build_overlay_entries` — classify + populate template vars
2. `apply_per_overlay_type_cleanup` — per-type field normalization
3. Per-entry `reorder_rating_template_vars` + list-level `sort_overlay_entries` — final field / entry ordering
4. `_parse_overlay_file_block_entries` on the raw `<library_prefix>-overlay_files` value — appended verbatim

Returns the final `overlay_files` list. When the library has no overlay data (no matching key in `overlays`, no raw block) returns an empty list. Caller decides whether to assign to `entry['overlay_files']`.

### New: `modules/helpers/_misc.py::strip_library_suffix(library_key)`

Return `library_key` with its trailing `-library` suffix removed. Returns unchanged when the input isn't a string or doesn't end with `-library` — callers can pass either shape safely.

Replaces 3 verbatim inline copies of the same conditional suffix-strip:
- `modules/output.py:214` (`overlay_library_prefix`) — now DRY'd inside the new fn
- `modules/output.py:227` (metadata files `library_prefix`)
- `modules/output_collections.py:508` (`library_prefix`)

## Before / after in `add_entry`

Before (**21 lines**):

```python
if collection_key:

    # Process Overlays
    overlay_key = helpers.extract_library_name(library_key)
    overlay_entries = []
    overlay_name_order = []

    if overlay_key and overlay_key in overlays:
        raw_overlay_entries = overlays[overlay_key]
        overlay_entries, overlay_name_order = build_overlay_entries(library_type, overlay_key, raw_overlay_entries)

        # Final cleanup for specific overlays (e.g., drop text for aspect/video_format)
        apply_per_overlay_type_cleanup(overlay_entries)

        if overlay_entries:
            for ov in overlay_entries:
                reorder_rating_template_vars(ov)
            sort_overlay_entries(overlay_entries, overlay_name_order)

        overlay_library_prefix = library_key[: -len("-library")] if isinstance(library_key, str) and library_key.endswith("-library") else library_key
        raw_overlay_file_entries = _parse_overlay_file_block_entries(overlays.get(overlay_key, {}).get(f"{overlay_library_prefix}-overlay_files"))
        if raw_overlay_file_entries:
            overlay_entries.extend(raw_overlay_file_entries)

        if overlay_entries:
            entry["overlay_files"] = overlay_entries
```

After (**5 lines**):

```python
if collection_key:
    overlay_files = build_overlay_files_for_library(library_key, library_type, overlays)
    if overlay_files:
        entry["overlay_files"] = overlay_files
```

## Impact

- `modules/output.py`: **766 → 739** (-27 / -3.5%)
- `modules/output_overlay_builder.py`: 245 → 294 (+49)
- `modules/helpers/_misc.py`: 56 → 75 (+19)

## Cumulative sprint progress

| PR range | Start | End | Δ |
|---|---|---|---|
| Sprint 1 (#1445-1465) | 3833 | 1595 | -2238 |
| #1468 | 1595 | 1496 | -99 |
| #1469 | 1496 | 1311 | -185 |
| #1470 | 1311 | 1247 | -64 |
| #1471 | 1247 | 1024 | -223 |
| #1472 | 1024 | 940 | -84 |
| #1473 | 940 | 801 | -139 |
| #1474 (dead code) | 801 | 766 | -35 |
| **This PR** | **766** | **739** | **-27** |
| **Total** | 3833 | 739 | **-3094 (-80.7%)** |

The remaining ~110 lines of `add_entry` are essentially a straight sequence of `build_X` calls — one line per operation, each with a clear name.

## Verification

- All 1081 tests pass
- Ruff + black clean