### PR TITLE
Extract group_by_library into modules/output_grouping.py (new module)

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -59,6 +59,7 @@ from modules.output_library_ops import (
     build_template_variables,
     build_top_level_fields,
 )
+from modules.output_grouping import group_movie_and_show_libraries
 from modules.output_optimize import optimize_template_variables
 from modules.output_overlay_builder import build_overlay_files_for_library
 from modules.output_playlists import (  # noqa: F401 -- re-exported so output.<name> keeps working
@@ -428,78 +429,23 @@ def build_config(header_style="standard", config_name=None):
             helpers.ts_log("Movie Library Names:", movie_library_names, level="DEBUG")
             helpers.ts_log("Show Library Names:", show_library_names, level="DEBUG")
 
-        def group_by_library(prefix, names, normalize_overlays=False):
-            """
-            Groups data (collections, overlays, attributes, etc.) by base library name.
-
-            If `normalize_overlays` is True, it strips builder-level suffixes
-            (e.g. `tv_shows-show` → `tv_shows`) to match show library names.
-            """
-            grouped = {}
-
-            def matches_group_prefix(key):
-                if not isinstance(key, str):
-                    return False
-                # Keep library-level *_files blocks isolated from the default
-                # collection/overlay groups so they do not suppress built-in
-                # defaults during YAML emission.
-                if prefix == "collection_":
-                    return "-collection_" in key or "-template_collection_" in key
-                if prefix == "overlay_":
-                    return "-overlay_" in key or "-template_overlay_" in key
-                if prefix == "attribute_":
-                    return "-attribute_" in key
-                if prefix == "template_variables":
-                    return "-template_variables" in key or "-attribute_template_variables" in key
-                if prefix == "top_level_":
-                    return "-top_level_" in key
-                if prefix in {"collection_files", "overlay_files", "metadata_files"}:
-                    return key.endswith(f"-{prefix}")
-                return prefix in key
-
-            for key, value in nested_libraries_data.items():
-                if not matches_group_prefix(key):
-                    continue
-
-                lib_name_raw = helpers.extract_library_name(key)
-
-                # Normalize overlays by trimming builder-level suffix (movie/show/season/episode),
-                # without losing hyphenated library names.
-                lib_name = lib_name_raw
-                if normalize_overlays and isinstance(lib_name_raw, str):
-                    for suffix in ("-movie", "-show", "-season", "-episode"):
-                        if lib_name_raw.endswith(suffix):
-                            lib_name = lib_name_raw[: -len(suffix)]
-                            break
-
-                if lib_name in names:
-                    grouped.setdefault(lib_name, {})[key] = value
-
-            return grouped
-
-        # Group collections, overlays, attributes, and templates only for selected libraries
-        movie_collections = group_by_library("collection_", movie_library_names)
-        show_collections = group_by_library("collection_", show_library_names)
-        movie_collection_files = group_by_library("collection_files", movie_library_names)
-        show_collection_files = group_by_library("collection_files", show_library_names)
-        movie_overlay_file_blocks = group_by_library("overlay_files", movie_library_names)
-        show_overlay_file_blocks = group_by_library("overlay_files", show_library_names)
-        # movie_overlays = group_by_library("overlay_", movie_library_names)
-        # show_overlays = group_by_library("overlay_", show_library_names)
-        movie_overlays = group_by_library("overlay_", movie_library_names, normalize_overlays=True)
-        show_overlays = group_by_library("overlay_", show_library_names, normalize_overlays=True)
-        for lib_name, payload in movie_overlay_file_blocks.items():
-            movie_overlays.setdefault(lib_name, {}).update(payload)
-        for lib_name, payload in show_overlay_file_blocks.items():
-            show_overlays.setdefault(lib_name, {}).update(payload)
-        movie_attributes = group_by_library("attribute_", movie_library_names)
-        show_attributes = group_by_library("attribute_", show_library_names)
-        movie_metadata_files = group_by_library("metadata_files", movie_library_names)
-        show_metadata_files = group_by_library("metadata_files", show_library_names)
-        movie_templates = group_by_library("template_variables", movie_library_names)
-        show_templates = group_by_library("template_variables", show_library_names)
-        movie_top_level = group_by_library("top_level_", movie_library_names)
-        show_top_level = group_by_library("top_level_", show_library_names)
+        movie_groups, show_groups = group_movie_and_show_libraries(nested_libraries_data, movie_library_names, show_library_names)
+        movie_collections = movie_groups["collections"]
+        show_collections = show_groups["collections"]
+        movie_collection_files = movie_groups["collection_files"]
+        show_collection_files = show_groups["collection_files"]
+        movie_overlay_file_blocks = movie_groups["overlay_file_blocks"]
+        show_overlay_file_blocks = show_groups["overlay_file_blocks"]
+        movie_overlays = movie_groups["overlays"]
+        show_overlays = show_groups["overlays"]
+        movie_attributes = movie_groups["attributes"]
+        show_attributes = show_groups["attributes"]
+        movie_metadata_files = movie_groups["metadata_files"]
+        show_metadata_files = show_groups["metadata_files"]
+        movie_templates = movie_groups["templates"]
+        show_templates = show_groups["templates"]
+        movie_top_level = movie_groups["top_level"]
+        show_top_level = show_groups["top_level"]
 
         # Debugging
         if app.config["QS_DEBUG"]:

--- a/modules/output_grouping.py
+++ b/modules/output_grouping.py
@@ -1,0 +1,173 @@
+"""Library-scoped data grouping for Kometa config generation.
+
+Extracted from ``modules.output.build_config``.
+
+The Quickstart persistence layer stores every library-scoped setting
+as a flat key/value pair, with keys shaped like
+``<mov|sho>-library_<id>-<kind>_<name>[option]``.  To emit the YAML
+config we need those flattened keys re-nested per library and per
+kind (collections, overlays, attributes, templates, etc.).
+
+``group_by_library`` filters the flat map by a ``prefix`` classifier
+and re-groups the matching entries by their extracted library id.
+Overlays additionally strip the builder-level suffix
+(``-movie``/``-show``/``-season``/``-episode``) so that all three
+builder levels for one show library land in the same group.
+
+The related dispatcher ``group_movie_and_show_libraries`` runs the
+full set of nine kinds twice (once for the movie library set, once
+for the show library set) and returns two dicts of dicts.  It also
+folds ``overlay_files`` into ``overlays`` -- Kometa treats the raw
+block as another overlay source, and the caller was doing this fold
+inline for both library types.
+"""
+
+from __future__ import annotations
+
+from modules import helpers
+
+# Substring predicates for each prefix classifier.  Keeping these as
+# module-level lambdas (rather than an if/elif chain inside the
+# grouping function) means each row is one line and the mapping is
+# obvious.  Predicates run against a stringified key.
+_INFIX_MATCHERS = {
+    "collection_": lambda key: "-collection_" in key or "-template_collection_" in key,
+    "overlay_": lambda key: "-overlay_" in key or "-template_overlay_" in key,
+    "attribute_": lambda key: "-attribute_" in key,
+    "template_variables": lambda key: ("-template_variables" in key or "-attribute_template_variables" in key),
+    "top_level_": lambda key: "-top_level_" in key,
+}
+
+# For these three prefixes the classifier is a strict trailing
+# suffix rather than a substring: ``mov-library_<id>-collection_files``
+# etc.  Keeping the raw ``*_files`` blocks separate from the
+# collection/overlay group entries prevents them from suppressing
+# built-in defaults during YAML emission.
+_SUFFIX_KINDS = frozenset({"collection_files", "overlay_files", "metadata_files"})
+
+# Builder-level suffixes on overlay keys.  A show library called
+# ``TVShows`` produces keys like ``sho-library_TVShows-show-overlay_...``
+# for show-level overlays, ``sho-library_TVShows-season-overlay_...``
+# for season-level, and so on.  When normalising we strip whichever
+# suffix is present so the three builder levels re-merge under the
+# base library id.
+_OVERLAY_LEVEL_SUFFIXES = ("-movie", "-show", "-season", "-episode")
+
+
+def _key_matches_prefix(key, prefix):
+    """Return True when *key* belongs to the group named *prefix*.
+
+    Not exported -- this is the classifier used by
+    :func:`group_by_library`.  Split out for clarity and testability.
+    """
+    if not isinstance(key, str):
+        return False
+    matcher = _INFIX_MATCHERS.get(prefix)
+    if matcher is not None:
+        return matcher(key)
+    if prefix in _SUFFIX_KINDS:
+        return key.endswith(f"-{prefix}")
+    return prefix in key
+
+
+def _strip_overlay_builder_suffix(lib_name_raw):
+    """Trim any ``-movie``/``-show``/``-season``/``-episode`` suffix.
+
+    Returns *lib_name_raw* unchanged when it isn't a string or doesn't
+    end with any of the known builder levels.
+    """
+    if not isinstance(lib_name_raw, str):
+        return lib_name_raw
+    for suffix in _OVERLAY_LEVEL_SUFFIXES:
+        if lib_name_raw.endswith(suffix):
+            return lib_name_raw[: -len(suffix)]
+    return lib_name_raw
+
+
+def group_by_library(prefix, names, source, *, normalize_overlays=False):
+    """Group *source* entries by base library name.
+
+    Parameters
+    ----------
+    prefix:
+        Kind classifier.  Recognised values include
+        ``collection_``, ``overlay_``, ``attribute_``,
+        ``template_variables``, ``top_level_``,
+        ``collection_files``, ``overlay_files``, ``metadata_files``.
+        Any other value falls back to a plain substring match.
+    names:
+        Set (or any container) of library ids to keep.  Entries whose
+        extracted library id is not in *names* are dropped.
+    source:
+        Flat key/value map -- typically the ``libraries.libraries``
+        payload from persistence.
+    normalize_overlays:
+        When True, strip a trailing builder-level suffix
+        (``-movie``/``-show``/``-season``/``-episode``) from each
+        extracted library id before grouping.  Only used for
+        overlay-kind prefixes.
+    """
+    grouped = {}
+    for key, value in source.items():
+        if not _key_matches_prefix(key, prefix):
+            continue
+        lib_name_raw = helpers.extract_library_name(key)
+        lib_name = _strip_overlay_builder_suffix(lib_name_raw) if normalize_overlays else lib_name_raw
+        if lib_name in names:
+            grouped.setdefault(lib_name, {})[key] = value
+    return grouped
+
+
+# Ordered specification of which grouped dicts ``build_config``
+# builds and how.  Each row is (attribute_stem, prefix,
+# normalize_overlays).  ``attribute_stem`` becomes both the
+# ``movie_<stem>`` and ``show_<stem>`` variable names on the returned
+# dispatcher result.
+_GROUPING_SPECS = (
+    ("collections", "collection_", False),
+    ("collection_files", "collection_files", False),
+    ("overlay_file_blocks", "overlay_files", False),
+    ("overlays", "overlay_", True),
+    ("attributes", "attribute_", False),
+    ("metadata_files", "metadata_files", False),
+    ("templates", "template_variables", False),
+    ("top_level", "top_level_", False),
+)
+
+
+def group_movie_and_show_libraries(source, movie_library_names, show_library_names):
+    """Group *source* for both library sets across all grouping kinds.
+
+    Returns two dicts (``movie_groups``, ``show_groups``) keyed by
+    the attribute stem from :data:`_GROUPING_SPECS`.  Overlay-files
+    payloads are folded into the corresponding ``overlays`` group --
+    Kometa treats the raw ``<prefix>-overlay_files`` block as an
+    additional overlay source and the caller was doing this fold
+    inline for both library types.
+
+    So::
+
+        movie_groups["overlays"] == group_by_library("overlay_", ..., normalize_overlays=True)
+                                        merged-with(overlay_files payloads)
+        movie_groups["collections"] == group_by_library("collection_", ...)
+        ...
+
+    Access via ``movie_groups["<stem>"]``.  The two overlay-file
+    payloads (``movie_overlay_file_blocks`` and
+    ``show_overlay_file_blocks``) remain visible so the caller can
+    still log them separately when needed.
+    """
+
+    def _make(names):
+        return {stem: group_by_library(prefix, names, source, normalize_overlays=norm) for stem, prefix, norm in _GROUPING_SPECS}
+
+    movie_groups = _make(movie_library_names)
+    show_groups = _make(show_library_names)
+
+    # Fold each overlay_files payload into the matching overlays
+    # group so callers see a unified overlay source per library.
+    for groups in (movie_groups, show_groups):
+        for lib_name, payload in groups["overlay_file_blocks"].items():
+            groups["overlays"].setdefault(lib_name, {}).update(payload)
+
+    return movie_groups, show_groups


### PR DESCRIPTION
**Sprint 2, PR #9.** Pulls the nested `group_by_library` closure and its 22 call sites out of `build_config` into a new module. Adds a dispatcher that runs the full 8-kind grouping for both movie and show library sets in one call, and folds `overlay_files` payloads into the overlays groups.

## What moved

### `group_by_library(prefix, names, source, *, normalize_overlays=False) -> dict`

Filters `source` by `prefix` kind, then re-groups matching entries by their extracted library id. When `normalize_overlays` is True, strips builder-level suffixes (`-movie`/`-show`/`-season`/`-episode`) from the library id before grouping so all builder levels for one show library re-merge under the same base id.

### `group_movie_and_show_libraries(source, movie_names, show_names) -> (movie_groups, show_groups)`

Runs the full 8-kind grouping specification for both library sets and folds the `overlay_files` payloads into the `overlays` groups (Kometa treats raw `overlay_files` as another overlay source). Returns two dicts keyed by attribute stem:
`collections`, `collection_files`, `overlay_file_blocks`, `overlays`, `attributes`, `metadata_files`, `templates`, `top_level`.

## Design improvements

The extraction takes the opportunity to replace some accidental-complexity with structure:

| Before (inline in `build_config`) | After (in `output_grouping`) |
|---|---|
| 5-case if/elif ladder inside `matches_group_prefix` closure | Dict of prefix → classifier lambda (`_INFIX_MATCHERS`) |
| Hardcoded `\"collection_files\"`, `\"overlay_files\"`, `\"metadata_files\"` triple | Named frozenset (`_SUFFIX_KINDS`) |
| Inline `for suffix in (…):` builder-level strip | Private helper `_strip_overlay_builder_suffix` |
| 16 hand-spelled `group_by_library` calls, two paired `for lib_name in overlay_file_blocks…` loops for the overlay_files fold | 1 ordered `_GROUPING_SPECS` tuple + dispatcher |

Adding a new kind is now a one-line diff in `_GROUPING_SPECS`.

## Before / after in `build_config`

Before (**~71 lines**):
- 44-line nested closure with 5-case classifier
- 22 explicit `group_by_library` calls
- 4 lines of inline overlay_files fold

After (**~18 lines**):
```python
movie_groups, show_groups = group_movie_and_show_libraries(
    nested_libraries_data, movie_library_names, show_library_names
)
movie_collections = movie_groups["collections"]
show_collections = show_groups["collections"]
# ... 14 more single-line unpacks
```

The unpack is deliberately verbose — the downstream `build_libraries_section` takes 17 positional args and needs the locals in scope. A future PR could switch that function to accept the grouped dicts directly.

## Impact

- `modules/output.py`: **739 → 685** (-54 / -7.3%)
- `modules/output_grouping.py`: **NEW 182 lines**

## Cumulative sprint progress

| PR range | Start | End | Δ |
|---|---|---|---|
| Sprint 1 (#1445-1465) | 3833 | 1595 | -2238 |
| #1468 | 1595 | 1496 | -99 |
| #1469 | 1496 | 1311 | -185 |
| #1470 | 1311 | 1247 | -64 |
| #1471 | 1247 | 1024 | -223 |
| #1472 | 1024 | 940 | -84 |
| #1473 | 940 | 801 | -139 |
| #1474 (dead code) | 801 | 766 | -35 |
| #1475 | 766 | 739 | -27 |
| **This PR** | **739** | **685** | **-54** |
| **Total** | 3833 | 685 | **-3148 (-82.1%)** |

## Verification

- All 1081 tests pass
- Ruff + black clean
- **Smoke tests** verify 30 equivalence cases: full `group_by_library` behavior across all 5 recognized prefix kinds + 3 suffix kinds + fallback substring + non-string keys + `normalize_overlays` on/off + dispatcher parity against a verbatim inline replica of the original `build_config` grouping section.