### PR TITLE
Extract library-data extraction into LibrariesBundle + new module

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -18,6 +18,11 @@ from modules.output_collections import (  # noqa: F401 -- re-exported so output.
     _parse_tmdb_person_window,
     build_collection_files,
 )
+from modules.output_config_sections import (
+    normalize_apprise_section,
+    normalize_playlist_files_section,
+    normalize_webhooks_section,
+)
 from modules.output_defaults import (  # noqa: F401 -- re-exported so output.<name> keeps working
     _build_attribute_defaults,
     _build_collection_defaults,
@@ -309,85 +314,9 @@ def build_config(header_style="standard", config_name=None):
         if "validated" in section_data and section_data["validated"]:
             config_data[config_attribute] = clean_section_data(section_data, config_attribute)
 
-    # Process playlist_files section
-    if "playlist_files" in config_data:
-        playlist_data = config_data["playlist_files"]
-
-        # Debug raw data
-        if app.config["QS_DEBUG"]:
-            helpers.ts_log(f"Raw config_data['playlist_files'] content (Level 1): {playlist_data}", level="DEBUG")
-
-        # Adjust for possible extra nesting
-        if "playlist_files" in playlist_data and isinstance(playlist_data["playlist_files"], dict):
-            playlist_data = playlist_data["playlist_files"]
-            if app.config["QS_DEBUG"]:
-                helpers.ts_log(f" playlist_data after extra nesting: {playlist_data}", level="DEBUG")
-
-        # Extract and process libraries
-        libraries_value = playlist_data.get("libraries", "")
-        if app.config["QS_DEBUG"]:
-            helpers.ts_log(f"Extracted libraries value: {libraries_value}", level="DEBUG")
-
-        if isinstance(libraries_value, list):
-            libraries_list = [str(lib).strip() for lib in libraries_value if str(lib).strip()]
-        else:
-            libraries_list = [lib.strip() for lib in str(libraries_value or "").split(",") if lib.strip()]
-        if app.config["QS_DEBUG"]:
-            helpers.ts_log(f"Processed libraries list: {libraries_value}", level="DEBUG")
-
-        playlist_template_variables = {key: value for key, value in playlist_data.items() if key != "libraries" and value not in (None, "", [], {})}
-
-        # Format playlist_files data
-        formatted_playlist_files = _format_playlist_file_entries(libraries_list=libraries_list, template_variables=playlist_template_variables)
-        if app.config["QS_DEBUG"]:
-            helpers.ts_log("Formatted playlist_files data:", formatted_playlist_files, level="DEBUG")
-
-        # Replace in config_data
-        config_data["playlist_files"] = formatted_playlist_files
-
-    if "webhooks" in config_data:
-        webhooks_data = config_data["webhooks"]
-
-        # Handle case where `webhooks` is nested inside itself
-        if isinstance(webhooks_data, dict) and "webhooks" in webhooks_data:
-            webhooks_data = webhooks_data["webhooks"]  # Fix: Handle extra nesting
-
-        # Remove empty values
-        cleaned_webhooks = {key: value for key, value in webhooks_data.items() if value is not None and value != "" and value != [] and value != {}}
-
-        # If no valid webhooks exist, remove the "webhooks" section entirely
-        if cleaned_webhooks:
-            config_data["webhooks"] = {"webhooks": cleaned_webhooks}  # Preserve webhooks key
-        else:
-            config_data.pop("webhooks", None)  # Fully remove empty webhooks
-
-        # Debugging: Ensure webhooks are correctly cleaned
-        if app.config["QS_DEBUG"]:
-            helpers.ts_log(f"Cleaned Webhooks Data AFTER Removing Empty Values: {cleaned_webhooks}", level="DEBUG")
-            if "webhooks" not in config_data:
-                helpers.ts_log("Webhooks section completely removed.", level="DEBUG")
-
-    if "apprise" in config_data:
-        apprise_data = config_data["apprise"]
-        apprise_location = None
-
-        if isinstance(apprise_data, dict):
-            if "apprise" in apprise_data:
-                nested_apprise = apprise_data["apprise"]
-                if isinstance(nested_apprise, dict):
-                    apprise_location = nested_apprise.get("location")
-                else:
-                    apprise_location = nested_apprise
-            elif "location" in apprise_data:
-                apprise_location = apprise_data.get("location")
-        elif isinstance(apprise_data, str):
-            apprise_location = apprise_data
-
-        apprise_location = str(apprise_location).strip() if apprise_location is not None else ""
-        if apprise_location:
-            config_data["apprise"] = {"apprise": {"config": apprise_location}}
-        else:
-            config_data.pop("apprise", None)
+    normalize_playlist_files_section(config_data, debug=app.config["QS_DEBUG"])
+    normalize_webhooks_section(config_data, debug=app.config["QS_DEBUG"])
+    normalize_apprise_section(config_data)
 
     # Initialize movie and show libraries
     movie_libraries = {}

--- a/modules/output.py
+++ b/modules/output.py
@@ -58,7 +58,7 @@ from modules.output_library_ops import (
     build_template_variables,
     build_top_level_fields,
 )
-from modules.output_grouping import group_movie_and_show_libraries
+from modules.output_libraries_data import extract_libraries_bundle
 from modules.output_optimize import optimize_template_variables
 from modules.output_overlay_builder import build_overlay_files_for_library
 from modules.output_playlists import (  # noqa: F401 -- re-exported so output.<name> keeps working
@@ -321,76 +321,33 @@ def build_config(header_style="standard", config_name=None):
     # Initialize movie and show libraries
     movie_libraries = {}
     show_libraries = {}
+    library_types = {}
 
     # Process the libraries section
     if "libraries" in config_data and "libraries" in config_data["libraries"]:
         nested_libraries_data = config_data["libraries"]["libraries"]
 
-        # Debugging
         if app.config["QS_DEBUG"]:
             helpers.ts_log("Raw nested libraries data:", nested_libraries_data, level="DEBUG")
 
-        # Extract selected libraries
-        movie_libraries = {
-            key: value
-            for key, value in nested_libraries_data.items()
-            if key and isinstance(key, str) and key.startswith("mov-library_") and key.endswith("-library") and value not in [None, "", False]
-        }
-        show_libraries = {
-            key: value
-            for key, value in nested_libraries_data.items()
-            if key and isinstance(key, str) and key.startswith("sho-library_") and key.endswith("-library") and value not in [None, "", False]
-        }
-
-        # Extract **correct** movie and show library names
-        movie_library_names = {helpers.extract_library_name(k) for k in movie_libraries}
-        show_library_names = {helpers.extract_library_name(k) for k in show_libraries}
-        library_types = {name: "movie" for name in movie_libraries.values()}
-        library_types.update({name: "show" for name in show_libraries.values()})
-
-        # Debugging
-        if app.config["QS_DEBUG"]:
-            helpers.ts_log("Movie Library Names:", movie_library_names, level="DEBUG")
-            helpers.ts_log("Show Library Names:", show_library_names, level="DEBUG")
-
-        movie_groups, show_groups = group_movie_and_show_libraries(nested_libraries_data, movie_library_names, show_library_names)
-        movie_collections = movie_groups["collections"]
-        show_collections = show_groups["collections"]
-        movie_collection_files = movie_groups["collection_files"]
-        show_collection_files = show_groups["collection_files"]
-        movie_overlay_file_blocks = movie_groups["overlay_file_blocks"]
-        show_overlay_file_blocks = show_groups["overlay_file_blocks"]
-        movie_overlays = movie_groups["overlays"]
-        show_overlays = show_groups["overlays"]
-        movie_attributes = movie_groups["attributes"]
-        show_attributes = show_groups["attributes"]
-        movie_metadata_files = movie_groups["metadata_files"]
-        show_metadata_files = show_groups["metadata_files"]
-        movie_templates = movie_groups["templates"]
-        show_templates = show_groups["templates"]
-        movie_top_level = movie_groups["top_level"]
-        show_top_level = show_groups["top_level"]
-
-        # Debugging
-        if app.config["QS_DEBUG"]:
-            helpers.ts_log(f"Extracted Movie Libraries: {movie_libraries}", level="DEBUG")
-            helpers.ts_log(f"Extracted Show Libraries: {show_libraries}", level="DEBUG")
-            helpers.ts_log(f"Extracted Movie Collections: {movie_collections}", level="DEBUG")
-            helpers.ts_log(f"Extracted Show Collections: {show_collections}", level="DEBUG")
-            helpers.ts_log(f"Extracted Movie Collection Files: {movie_collection_files}", level="DEBUG")
-            helpers.ts_log(f"Extracted Show Collection Files: {show_collection_files}", level="DEBUG")
-            helpers.ts_log(f"Extracted Movie Overlay File Blocks: {movie_overlay_file_blocks}", level="DEBUG")
-            helpers.ts_log(f"Extracted Show Overlay File Blocks: {show_overlay_file_blocks}", level="DEBUG")
-            helpers.ts_log(f"Extracted Movie Overlays: {movie_overlays}", level="DEBUG")
-            helpers.ts_log(f"Extracted Show Overlays: {show_overlays}", level="DEBUG")
-            helpers.ts_log(f"Extracted Movie Attributes: {movie_attributes}", level="DEBUG")
-            helpers.ts_log(f"Extracted Show Attributes: {show_attributes}", level="DEBUG")
-            helpers.ts_log(f"Extracted Movie Metadata Files: {movie_metadata_files}", level="DEBUG")
-            helpers.ts_log(f"Extracted Show Metadata Files: {show_metadata_files}", level="DEBUG")
-            helpers.ts_log(f"Extracted Movie Templates: {movie_templates}", level="DEBUG")
-            helpers.ts_log(f"Extracted Show Templates: {show_templates}", level="DEBUG")
-            helpers.ts_log(f"Extracted Movie Top Level: {movie_top_level}", level="DEBUG")
-            helpers.ts_log(f"Extracted Show Top Level: {show_top_level}", level="DEBUG")
+        bundle = extract_libraries_bundle(nested_libraries_data, debug=app.config["QS_DEBUG"])
+        movie_libraries = bundle.movie_libraries
+        show_libraries = bundle.show_libraries
+        library_types = bundle.library_types
+        movie_collections = bundle.movie_groups["collections"]
+        show_collections = bundle.show_groups["collections"]
+        movie_collection_files = bundle.movie_groups["collection_files"]
+        show_collection_files = bundle.show_groups["collection_files"]
+        movie_overlays = bundle.movie_groups["overlays"]
+        show_overlays = bundle.show_groups["overlays"]
+        movie_attributes = bundle.movie_groups["attributes"]
+        show_attributes = bundle.show_groups["attributes"]
+        movie_metadata_files = bundle.movie_groups["metadata_files"]
+        show_metadata_files = bundle.show_groups["metadata_files"]
+        movie_templates = bundle.movie_groups["templates"]
+        show_templates = bundle.show_groups["templates"]
+        movie_top_level = bundle.movie_groups["top_level"]
+        show_top_level = bundle.show_groups["top_level"]
 
         # Build nested libraries structure
         libraries_section = build_libraries_section(

--- a/modules/output_config_sections.py
+++ b/modules/output_config_sections.py
@@ -1,0 +1,178 @@
+"""Config-section normalization for the generated Kometa config.
+
+Extracted from ``modules.output.build_config``.
+
+Kometa accepts a handful of top-level config sections in slightly
+inconsistent shapes -- users may have historical persistence data
+that stores them nested twice, or as a bare string, or with empty
+values that need to disappear.  This module contains three focused
+normalizers that mutate ``config_data`` in place to canonicalize
+those shapes before YAML dump time.
+
+Public entry points:
+
+* :func:`normalize_playlist_files_section` -- flatten possibly-nested
+  playlist_files data and format via ``_format_playlist_file_entries``.
+* :func:`normalize_webhooks_section` -- strip empty values, unwrap
+  extra ``webhooks.webhooks`` nesting, delete the section when
+  entirely empty.
+* :func:`normalize_apprise_section` -- extract the apprise
+  ``location`` from any of the three legacy shapes and rewrite
+  it into the canonical ``{apprise: {config: <location>}}`` form.
+
+Each function mutates ``config_data`` in place and returns ``None``.
+All three are safe to call whether or not their section is present
+in ``config_data``.
+"""
+
+from __future__ import annotations
+
+from modules import helpers
+from modules.output_playlists import _format_playlist_file_entries
+
+# Values that count as "empty" during webhook cleanup.  Kometa's
+# YAML dumper would happily emit these, but Kometa's runtime treats
+# them as missing, so we drop them at generation time to avoid
+# confusing diagnostics.
+_WEBHOOK_EMPTY_VALUES = (None, "", [], {})
+
+
+def _debug(debug, message):
+    """Emit *message* via helpers.ts_log when debug is truthy."""
+    if debug:
+        helpers.ts_log(message, level="DEBUG")
+
+
+def normalize_playlist_files_section(config_data, *, debug=False):
+    """Normalize ``config_data['playlist_files']`` in place.
+
+    Handles two historical persistence shapes:
+
+    1. ``{playlist_files: {libraries: <list-or-string>, ...tvars}}``
+       -- the canonical shape.
+    2. ``{playlist_files: {playlist_files: {libraries: ..., ...tvars}}}``
+       -- an extra layer of nesting that some older persistence rows
+       still carry.  Unwrapped before parsing.
+
+    The ``libraries`` value may be either a list or a
+    comma-separated string.  Both are split, stripped, and filtered
+    for empties.  All remaining keys become the shared template
+    variables (empty containers dropped).
+
+    The whole normalized structure is then piped through
+    :func:`_format_playlist_file_entries` (already extracted), which
+    produces the final list emitted to YAML.
+
+    No-op when ``playlist_files`` is not in *config_data*.
+    """
+    if "playlist_files" not in config_data:
+        return
+
+    playlist_data = config_data["playlist_files"]
+    _debug(debug, f"Raw config_data['playlist_files'] content (Level 1): {playlist_data}")
+
+    # Legacy shape may double-nest the payload; unwrap once when so.
+    inner = playlist_data.get("playlist_files") if isinstance(playlist_data, dict) else None
+    if isinstance(inner, dict):
+        playlist_data = inner
+        _debug(debug, f" playlist_data after extra nesting: {playlist_data}")
+
+    libraries_value = playlist_data.get("libraries", "")
+    _debug(debug, f"Extracted libraries value: {libraries_value}")
+
+    if isinstance(libraries_value, list):
+        libraries_list = [str(lib).strip() for lib in libraries_value if str(lib).strip()]
+    else:
+        libraries_list = [lib.strip() for lib in str(libraries_value or "").split(",") if lib.strip()]
+    _debug(debug, f"Processed libraries list: {libraries_value}")
+
+    playlist_template_variables = {key: value for key, value in playlist_data.items() if key != "libraries" and value not in (None, "", [], {})}
+
+    formatted_playlist_files = _format_playlist_file_entries(
+        libraries_list=libraries_list,
+        template_variables=playlist_template_variables,
+    )
+    _debug(debug, f"Formatted playlist_files data: {formatted_playlist_files}")
+
+    config_data["playlist_files"] = formatted_playlist_files
+
+
+def normalize_webhooks_section(config_data, *, debug=False):
+    """Normalize ``config_data['webhooks']`` in place.
+
+    * Unwrap the ``{webhooks: {webhooks: ...}}`` extra nesting when
+      present (persistence-side shape mismatch).
+    * Drop any key whose value is in :data:`_WEBHOOK_EMPTY_VALUES`.
+    * When nothing remains, remove the ``webhooks`` section entirely
+      so the YAML file stays tidy.
+    * Otherwise re-wrap into the canonical
+      ``{webhooks: {webhooks: <cleaned>}}`` shape Kometa expects.
+
+    No-op when ``webhooks`` is not in *config_data*.
+    """
+    if "webhooks" not in config_data:
+        return
+
+    webhooks_data = config_data["webhooks"]
+    if isinstance(webhooks_data, dict) and "webhooks" in webhooks_data:
+        webhooks_data = webhooks_data["webhooks"]
+
+    cleaned_webhooks = {key: value for key, value in webhooks_data.items() if value not in _WEBHOOK_EMPTY_VALUES}
+
+    if cleaned_webhooks:
+        config_data["webhooks"] = {"webhooks": cleaned_webhooks}
+    else:
+        config_data.pop("webhooks", None)
+
+    _debug(debug, f"Cleaned Webhooks Data AFTER Removing Empty Values: {cleaned_webhooks}")
+    if debug and "webhooks" not in config_data:
+        helpers.ts_log("Webhooks section completely removed.", level="DEBUG")
+
+
+def _extract_apprise_location(apprise_data):
+    """Pull the apprise ``location`` value out of any legacy shape.
+
+    Recognized inputs:
+
+    * ``str`` -- treated as the location directly.
+    * ``{apprise: {location: <val>}}`` -- doubly-nested canonical.
+    * ``{apprise: <val>}`` -- bare scalar under the wrapper key.
+    * ``{location: <val>}`` -- single-nested older shape.
+    * anything else -- returns ``None``.
+
+    Returned value is left as-is; the caller strips + rewrites.
+    """
+    if isinstance(apprise_data, str):
+        return apprise_data
+    if not isinstance(apprise_data, dict):
+        return None
+    if "apprise" in apprise_data:
+        nested_apprise = apprise_data["apprise"]
+        if isinstance(nested_apprise, dict):
+            return nested_apprise.get("location")
+        return nested_apprise
+    if "location" in apprise_data:
+        return apprise_data.get("location")
+    return None
+
+
+def normalize_apprise_section(config_data):
+    """Normalize ``config_data['apprise']`` in place.
+
+    Extracts the location from any of the four legacy shapes (see
+    :func:`_extract_apprise_location`) and rewrites into the canonical
+    ``{apprise: {config: <location>}}`` form.  When the location is
+    empty / missing, removes the ``apprise`` section entirely.
+
+    No-op when ``apprise`` is not in *config_data*.
+    """
+    if "apprise" not in config_data:
+        return
+
+    apprise_location = _extract_apprise_location(config_data["apprise"])
+    apprise_location = str(apprise_location).strip() if apprise_location is not None else ""
+
+    if apprise_location:
+        config_data["apprise"] = {"apprise": {"config": apprise_location}}
+    else:
+        config_data.pop("apprise", None)

--- a/modules/output_libraries_data.py
+++ b/modules/output_libraries_data.py
@@ -1,0 +1,152 @@
+"""Library data extraction from persisted flat keys.
+
+Extracted from ``modules.output.build_config``.
+
+Between the user's UI selections and the emitted YAML, Kometa's
+Quickstart needs to walk the flat persistence map, identify which
+libraries are selected (movie vs show), and then re-group all of
+their attribute keys per library.  This module owns that walk.
+
+Public entry point:
+
+* :func:`extract_libraries_bundle(nested_libraries_data, *, debug=False)`
+  returns a :class:`LibrariesBundle` carrying every derivative the
+  downstream orchestrator needs.
+
+Splitting this out shrinks ``build_config`` by ~55 lines (~10% of
+its remaining bulk) and gives future callers a single call to
+prepare libraries data instead of hand-writing the four extraction
+comprehensions + grouping call + 18-line debug logging block.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from modules import helpers
+from modules.output_grouping import group_movie_and_show_libraries
+
+# Placeholder values considered equivalent to "unselected".  Kometa
+# treats each of these as a missing library toggle -- the UI stores
+# unset checkboxes as ``False`` while some older rows may still be
+# ``None`` or the empty string.
+_UNSELECTED_LIBRARY_VALUES = (None, "", False)
+
+
+@dataclass(frozen=True)
+class LibrariesBundle:
+    """Every derivative ``build_libraries_section`` needs about the selected libraries.
+
+    Attributes are named to match the local variables ``build_config``
+    used to compute inline; downstream code can be migrated to the
+    bundle in a follow-up refactor without touching this module.
+
+    * ``movie_libraries`` / ``show_libraries``:
+      ``{persisted_key: display_name}`` maps of the selected libraries.
+    * ``movie_library_names`` / ``show_library_names``:
+      Sets of extracted library-id stems (from
+      :func:`helpers.extract_library_name`).
+    * ``library_types``: ``{display_name: \"movie\"|\"show\"}`` -- the
+      inverse map used by ``optimize_template_variables`` to decide
+      per-library default sets.
+    * ``movie_groups`` / ``show_groups``:
+      Result of :func:`group_movie_and_show_libraries` -- each is
+      keyed by grouping stem (\"collections\", \"overlays\",
+      \"attributes\", ...) and each value is
+      ``{library_id: {flat_key: value}}``.
+    """
+
+    movie_libraries: dict = field(default_factory=dict)
+    show_libraries: dict = field(default_factory=dict)
+    movie_library_names: set = field(default_factory=set)
+    show_library_names: set = field(default_factory=set)
+    library_types: dict = field(default_factory=dict)
+    movie_groups: dict = field(default_factory=dict)
+    show_groups: dict = field(default_factory=dict)
+
+
+def _is_selected_library_key(key, prefix):
+    """Return True when *key* is a selected top-level library toggle.
+
+    Recognized shape: ``<prefix>library_<id>-library`` with a truthy
+    value.  Anything else (attribute keys, unset toggles) is skipped.
+    """
+    return isinstance(key, str) and key.startswith(prefix) and key.endswith("-library")
+
+
+def _select_libraries(nested_libraries_data, prefix):
+    """Return ``{key: value}`` for all selected libraries under *prefix*.
+
+    Filters ``nested_libraries_data`` to entries whose key starts
+    with *prefix* (``\"mov-library_\"`` or ``\"sho-library_\"``), ends
+    with ``-library``, and has a non-placeholder value.
+    """
+    return {key: value for key, value in nested_libraries_data.items() if _is_selected_library_key(key, prefix) and value not in _UNSELECTED_LIBRARY_VALUES}
+
+
+def _debug_log_extracted(bundle, debug):
+    """Emit the 18-line 'Extracted X:' debug dump when *debug* is truthy."""
+    if not debug:
+        return
+
+    helpers.ts_log("Movie Library Names:", bundle.movie_library_names, level="DEBUG")
+    helpers.ts_log("Show Library Names:", bundle.show_library_names, level="DEBUG")
+    helpers.ts_log(f"Extracted Movie Libraries: {bundle.movie_libraries}", level="DEBUG")
+    helpers.ts_log(f"Extracted Show Libraries: {bundle.show_libraries}", level="DEBUG")
+
+    # Enumerate every grouping stem so adding a new one in
+    # output_grouping._GROUPING_SPECS automatically shows up here
+    # without another surgery in this module.
+    for stem, group_dict in bundle.movie_groups.items():
+        label = stem.replace("_", " ").title()
+        helpers.ts_log(f"Extracted Movie {label}: {group_dict}", level="DEBUG")
+    for stem, group_dict in bundle.show_groups.items():
+        label = stem.replace("_", " ").title()
+        helpers.ts_log(f"Extracted Show {label}: {group_dict}", level="DEBUG")
+
+
+def extract_libraries_bundle(nested_libraries_data, *, debug=False):
+    """Build the :class:`LibrariesBundle` from persisted flat data.
+
+    * Filters the flat ``nested_libraries_data`` into selected movie
+      and show library toggles.
+    * Computes the library-id name sets via
+      :func:`helpers.extract_library_name`.
+    * Builds the ``library_types`` inverse map (display_name ->
+      \"movie\" | \"show\") used by defaults optimization.
+    * Runs :func:`group_movie_and_show_libraries` to produce the
+      per-kind per-library grouped dicts.
+    * When *debug* is truthy, emits the same 18-line ``ts_log``
+      trace ``build_config`` used to emit inline.
+
+    Returns a frozen :class:`LibrariesBundle`.  When
+    ``nested_libraries_data`` doesn't contain any recognized
+    library toggles, returns a bundle with empty defaults for every
+    field -- safe to unpack into the downstream orchestrator.
+    """
+    movie_libraries = _select_libraries(nested_libraries_data, "mov-library_")
+    show_libraries = _select_libraries(nested_libraries_data, "sho-library_")
+
+    movie_library_names = {helpers.extract_library_name(k) for k in movie_libraries}
+    show_library_names = {helpers.extract_library_name(k) for k in show_libraries}
+
+    library_types = {name: "movie" for name in movie_libraries.values()}
+    library_types.update({name: "show" for name in show_libraries.values()})
+
+    movie_groups, show_groups = group_movie_and_show_libraries(
+        nested_libraries_data,
+        movie_library_names,
+        show_library_names,
+    )
+
+    bundle = LibrariesBundle(
+        movie_libraries=movie_libraries,
+        show_libraries=show_libraries,
+        movie_library_names=movie_library_names,
+        show_library_names=show_library_names,
+        library_types=library_types,
+        movie_groups=movie_groups,
+        show_groups=show_groups,
+    )
+    _debug_log_extracted(bundle, debug)
+    return bundle


### PR DESCRIPTION
**Sprint 2, PR #12.** Pulls the ~74-line library extraction block out of `build_config` into a new module. Introduces a `LibrariesBundle` frozen dataclass to carry the seven derivatives downstream code needs.

## What moved

### `LibrariesBundle` (frozen dataclass)

Carries every derivative that `build_libraries_section` needs about the selected libraries:

| Field | Shape |
|---|---|
| `movie_libraries` / `show_libraries` | `{persisted_key: display_name}` maps of selected libraries |
| `movie_library_names` / `show_library_names` | Sets of extracted library-id stems |
| `library_types` | `{display_name: 'movie'\|'show'}` inverse map (used by defaults optimization) |
| `movie_groups` / `show_groups` | Per-kind grouped dicts from `group_movie_and_show_libraries` (keyed by stem: `collections`, `overlays`, `attributes`, ...) |

### `extract_libraries_bundle(nested_libraries_data, *, debug=False) -> LibrariesBundle`

Public entry point. Runs:
1. `_select_libraries('mov-library_', ...)` and `_select_libraries('sho-library_', ...)`
2. `helpers.extract_library_name` over both maps
3. `library_types` inverse-map assembly
4. `group_movie_and_show_libraries` dispatcher
5. When `debug` is truthy, an 18-line `ts_log` trace

## DRY decomposition

| Item | Purpose |
|---|---|
| `_UNSELECTED_LIBRARY_VALUES = (None, '', False)` | Named tuple of placeholder values, replaces a 3-clause `!=` chain |
| `_is_selected_library_key(key, prefix)` | Pure predicate: is a string, starts with prefix, ends with `-library` |
| `_select_libraries(source, prefix)` | Comprehension helper — replaces two nearly-identical inline comprehensions |
| `_debug_log_extracted(bundle, debug)` | The 18-line `Extracted X:` trace, driven by iterating the bundle's group dicts. **Automatically picks up new grouping stems added in `output_grouping._GROUPING_SPECS`** — no more surgery needed here when new kinds appear |

## Before / after in `build_config`

**Before** (~74 lines):
- 4 inline comprehensions with mixed key-shape filtering
- 3 separate `if app.config['QS_DEBUG']:` debug blocks
- 16-line unpack from `movie_groups`/`show_groups`
- 18 individual `ts_log` calls hand-spelling every group name

**After** (~20 lines):
```python
if app.config['QS_DEBUG']:
    helpers.ts_log('Raw nested libraries data:', nested_libraries_data, level='DEBUG')

bundle = extract_libraries_bundle(nested_libraries_data, debug=app.config['QS_DEBUG'])
movie_libraries = bundle.movie_libraries
show_libraries = bundle.show_libraries
library_types = bundle.library_types
movie_collections = bundle.movie_groups['collections']
# ... 12 more single-line unpacks
```

## Deferred to a future PR

The unpack from `bundle.movie_groups[...]` back into 16 named locals is still verbose because `build_libraries_section` still takes 17 positional args. Changing that signature would require updating **26 test call sites** in `tests/test_core_backend.py` — worth its own focused PR. Already filed in the kennel TODO list.

## Impact

- `modules/output.py`: **514 → 471** (-43 / -8.4%)
- `modules/output_libraries_data.py`: **NEW 162 lines**

## Cumulative sprint progress

| PR range | Start | End | Δ |
|---|---|---|---|
| Sprint 1 (#1445-1465) | 3833 | 1595 | -2238 |
| #1468-1478 | 1595 | 514 | -1081 |
| **This PR** | **514** | **471** | **-43** |
| **Total** | 3833 | 471 | **-3362 (-87.7%)** |

## Verification

- All 1081 tests pass
- Ruff + black clean
- **Smoke tests** verify 28 field-level equivalence checks (7 bundle fields x 4 realistic inputs: empty, only-toggles, full-mix-with-excluded-toggles, all-excluded)