### PR TITLE
Extract deferred playlist_files toggle orchestration into output_playlists

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -76,6 +76,7 @@ from modules.output_playlists import (  # noqa: F401 -- re-exported so output.<n
     _ordered_selected_libraries,
     _parse_playlist_file_entries_value,
     _playlist_libraries_from_library_toggles,
+    apply_playlist_libraries_toggle,
 )
 from modules.output_postprocess import (  # noqa: F401 -- re-exported so output.<name> keeps working
     _rewrite_custom_font_paths,
@@ -369,33 +370,7 @@ def build_config(header_style="standard", config_name=None):
             show_top_level,
         )
         config_data["libraries"] = libraries_section.get("libraries", {}) if isinstance(libraries_section, dict) else {}
-        ordered_library_names = _library_names_in_output_order(libraries_section)
-        has_playlist_toggle, playlist_libraries = _playlist_libraries_from_library_toggles(
-            nested_libraries_data,
-            ordered_library_names=ordered_library_names,
-        )
-        playlist_template_variables = _collect_playlist_template_variables_from_libraries_data(nested_libraries_data)
-        playlist_file_entries = _collect_playlist_file_entries_from_libraries_data(nested_libraries_data)
-        if has_playlist_toggle:
-            if playlist_libraries or playlist_file_entries:
-                config_data["playlist_files"] = _format_playlist_file_entries(
-                    libraries_list=playlist_libraries,
-                    template_variables=playlist_template_variables,
-                    extra_entries=playlist_file_entries,
-                )
-            else:
-                config_data.pop("playlist_files", None)
-        else:
-            legacy_playlist_libraries = _legacy_playlist_libraries_for_selected_libraries(
-                nested_libraries_data,
-                ordered_library_names=ordered_library_names,
-            )
-            if legacy_playlist_libraries or playlist_file_entries:
-                config_data["playlist_files"] = _format_playlist_file_entries(
-                    libraries_list=legacy_playlist_libraries,
-                    template_variables=playlist_template_variables,
-                    extra_entries=playlist_file_entries,
-                )
+        apply_playlist_libraries_toggle(config_data, nested_libraries_data, libraries_section)
         if app.config["QS_DEBUG"]:
             helpers.ts_log(f"Final Libraries Section: {libraries_section}", level="DEBUG")
 

--- a/modules/output_playlists.py
+++ b/modules/output_playlists.py
@@ -334,3 +334,57 @@ def _collect_playlist_file_entries_from_libraries_data(nested_libraries_data):
     if not isinstance(nested_libraries_data, dict):
         return []
     return _parse_playlist_file_entries_value(nested_libraries_data.get("playlist_files_entries"))
+
+
+def apply_playlist_libraries_toggle(config_data, nested_libraries_data, libraries_section):
+    """Compute ``config_data['playlist_files']`` from library-level toggles.
+
+    Runs AFTER :func:`build_libraries_section` has produced the ordered
+    library set.  Two branches:
+
+    * **New shape** (``has_playlist_toggle`` is True) -- the user
+      opted into playlists via per-library ``playlist_files`` toggles.
+      Use the toggle-derived library list.  When neither libraries
+      nor raw file-block entries exist, the playlist_files section
+      is stripped entirely (any stale value from the earlier
+      ``normalize_playlist_files_section`` pass is discarded).
+
+    * **Legacy shape** (no toggle present) -- fall back to the older
+      ``_legacy_playlist_libraries_for_selected_libraries`` derivation.
+      When neither libraries nor raw entries exist, leaves any earlier
+      normalize result in place (legacy configs may still populate
+      the section without a library-level toggle).
+
+    Mutates *config_data* in place.  No-op when
+    *nested_libraries_data* isn't a dict.
+    """
+    ordered_library_names = _library_names_in_output_order(libraries_section)
+    has_playlist_toggle, playlist_libraries = _playlist_libraries_from_library_toggles(
+        nested_libraries_data,
+        ordered_library_names=ordered_library_names,
+    )
+    playlist_template_variables = _collect_playlist_template_variables_from_libraries_data(nested_libraries_data)
+    playlist_file_entries = _collect_playlist_file_entries_from_libraries_data(nested_libraries_data)
+
+    if has_playlist_toggle:
+        if playlist_libraries or playlist_file_entries:
+            config_data["playlist_files"] = _format_playlist_file_entries(
+                libraries_list=playlist_libraries,
+                template_variables=playlist_template_variables,
+                extra_entries=playlist_file_entries,
+            )
+        else:
+            config_data.pop("playlist_files", None)
+        return
+
+    # Legacy: no library-toggle present.
+    legacy_libraries = _legacy_playlist_libraries_for_selected_libraries(
+        nested_libraries_data,
+        ordered_library_names=ordered_library_names,
+    )
+    if legacy_libraries or playlist_file_entries:
+        config_data["playlist_files"] = _format_playlist_file_entries(
+            libraries_list=legacy_libraries,
+            template_variables=playlist_template_variables,
+            extra_entries=playlist_file_entries,
+        )


### PR DESCRIPTION
**Sprint 2, PR #13.** Pulls the ~26-line deferred playlist_files generation block out of `build_config` into a new orchestrator function in `modules/output_playlists.py`.

## What moved

```python
apply_playlist_libraries_toggle(config_data, nested_libraries_data, libraries_section)
```

Runs AFTER `build_libraries_section` has produced the ordered library set. Two branches:

### New shape (`has_playlist_toggle=True`)

The user opted into playlists via per-library `playlist_files` toggles. Use the toggle-derived library list. When neither libraries nor raw file-block entries exist, **strips `playlist_files` entirely** — any stale value from the earlier `normalize_playlist_files_section` pass is discarded.

### Legacy shape (no toggle)

Fall back to `_legacy_playlist_libraries_for_selected_libraries`. When empty, leaves any earlier normalize result in place (legacy configs may populate the section without a library-level toggle).

Mutates `config_data` in place.

## Placement

Added next to the six existing playlist-files primitives it orchestrates, all already in `output_playlists.py`:
- `_library_names_in_output_order`
- `_playlist_libraries_from_library_toggles`
- `_collect_playlist_template_variables_from_libraries_data`
- `_collect_playlist_file_entries_from_libraries_data`
- `_format_playlist_file_entries`
- `_legacy_playlist_libraries_for_selected_libraries`

**Zero new external dependencies** — pure internal composition. `output_playlists.py` stays under 400 lines (394 total).

## Before / after in `build_config`

**Before** (26 lines, 3 levels of nesting):
```python
ordered_library_names = _library_names_in_output_order(libraries_section)
has_playlist_toggle, playlist_libraries = _playlist_libraries_from_library_toggles(
    nested_libraries_data,
    ordered_library_names=ordered_library_names,
)
playlist_template_variables = _collect_playlist_template_variables_from_libraries_data(nested_libraries_data)
playlist_file_entries = _collect_playlist_file_entries_from_libraries_data(nested_libraries_data)
if has_playlist_toggle:
    if playlist_libraries or playlist_file_entries:
        config_data['playlist_files'] = _format_playlist_file_entries(
            libraries_list=playlist_libraries,
            template_variables=playlist_template_variables,
            extra_entries=playlist_file_entries,
        )
    else:
        config_data.pop('playlist_files', None)
else:
    legacy_playlist_libraries = _legacy_playlist_libraries_for_selected_libraries(
        nested_libraries_data,
        ordered_library_names=ordered_library_names,
    )
    if legacy_playlist_libraries or playlist_file_entries:
        config_data['playlist_files'] = _format_playlist_file_entries(
            libraries_list=legacy_playlist_libraries,
            template_variables=playlist_template_variables,
            extra_entries=playlist_file_entries,
        )
```

**After** (1 line):
```python
apply_playlist_libraries_toggle(config_data, nested_libraries_data, libraries_section)
```

## Impact

- `modules/output.py`: **471 → 446** (-25 / -5.3%)
- `modules/output_playlists.py`: 336 → 394 (+58, well under 600)

## Cumulative sprint progress

| PR | Start | End | Δ |
|---|---|---|---|
| Sprint 1 (#1445-1465) | 3833 | 1595 | -2238 |
| #1468-1479 | 1595 | 471 | -1124 |
| **This PR** | **471** | **446** | **-25** |
| **Total** | 3833 | 446 | **-3387 (-88.4%)** |

## Verification

- All 1081 tests pass
- Ruff + black clean