### PR TITLE
Extract ORDERED_CONFIG_SECTIONS and apply_final_transformations to new module

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -59,7 +59,6 @@ from modules.output_library_ops import (
     build_top_level_fields,
 )
 from modules.output_libraries_data import extract_libraries_bundle
-from modules.output_optimize import optimize_template_variables
 from modules.output_overlay_builder import build_overlay_files_for_library
 from modules.output_playlists import (  # noqa: F401 -- re-exported so output.<name> keeps working
     PLAYLIST_KEYED_TEMPLATE_VAR_SPECS,
@@ -82,6 +81,7 @@ from modules.output_postprocess import (  # noqa: F401 -- re-exported so output.
     _rewrite_custom_font_paths,
     clean_section_data,
 )
+from modules.output_render import ORDERED_CONFIG_SECTIONS, apply_final_transformations
 from modules.output_reorder import reorder_library_section  # public API used by tests as output.reorder_library_section
 from modules.output_yaml_header import render_yaml_header
 from modules.output_values import (  # noqa: F401 -- re-exported for tests calling output._parse_string_list, etc.
@@ -389,44 +389,10 @@ def build_config(header_style="standard", config_name=None):
 
     yaml_content = render_yaml_header(header_style, config_name, movie_libraries, show_libraries, version_info)
 
-    ordered_sections = [
-        ("libraries", "025-libraries"),
-        ("playlist_files", "027-playlist_files"),
-        ("settings", "150-settings"),
-        ("webhooks", "140-webhooks"),
-        ("plex", "010-plex"),
-        ("tmdb", "020-tmdb"),
-        ("tautulli", "030-tautulli"),
-        ("github", "040-github"),
-        ("omdb", "050-omdb"),
-        ("mdblist", "060-mdblist"),
-        ("notifiarr", "070-notifiarr"),
-        ("gotify", "080-gotify"),
-        ("ntfy", "085-ntfy"),
-        ("apprise", "087-apprise"),
-        ("anidb", "090-anidb"),
-        ("radarr", "100-radarr"),
-        ("sonarr", "110-sonarr"),
-        ("trakt", "120-trakt"),
-        ("mal", "130-mal"),
-    ]
-
-    # Ensure `code_verifier` is removed from mal.authorization (wherever it exists)
-    if "mal" in config_data and "mal" in config_data["mal"]:
-        authorization_data = config_data["mal"]["mal"].get("authorization", {})
-        authorization_data.pop("code_verifier", None)  # Remove safely
-
-    config_data = _normalize_legacy_collection_template_vars(config_data)
     optimize_defaults = helpers.booler(app.config.get("QS_OPTIMIZE_DEFAULTS", True))
-    if optimize_defaults:
-        config_data = optimize_template_variables(config_data, library_types)
-    config_data = _collapse_collection_data_template_vars(config_data)
+    config_data = apply_final_transformations(config_data, library_types, optimize_defaults=optimize_defaults)
 
-    # Apply enforce_string_fields to ensure proper formatting
-    config_data = helpers.enforce_string_fields(config_data, helpers.STRING_FIELDS)
-    config_data = _rewrite_custom_font_paths(config_data)
-
-    for section_key, section_stem in ordered_sections:
+    for section_key, section_stem in ORDERED_CONFIG_SECTIONS:
         if section_key in config_data:
             section_data = config_data[section_key]
             section_art = header_for_section(section_key, helpers.user_visible_name(section_key))

--- a/modules/output_render.py
+++ b/modules/output_render.py
@@ -1,0 +1,107 @@
+"""Final-phase orchestration for ``build_config``.
+
+Extracted from ``modules.output.build_config``.
+
+After all sections have been retrieved, normalized, and the libraries
+section built, ``build_config`` runs a fixed sequence of final
+transformations before dumping YAML.  This module owns:
+
+* :data:`ORDERED_CONFIG_SECTIONS` -- the compile-time section order
+  used when writing YAML.  Moving it to module scope means it's read
+  once at import time instead of allocated fresh on every request.
+
+* :func:`apply_final_transformations` -- the five-step chain that
+  scrubs, optimizes, and reshapes ``config_data`` before dump.
+  Preserves the exact call order because several later steps assume
+  earlier ones have already run.
+
+* :func:`_strip_mal_code_verifier` -- private helper for a specific
+  one-line security scrub that ``build_config`` had inline.
+"""
+
+from __future__ import annotations
+
+from modules import helpers
+from modules.output_collections import (
+    _collapse_collection_data_template_vars,
+    _normalize_legacy_collection_template_vars,
+)
+from modules.output_optimize import optimize_template_variables
+from modules.output_postprocess import _rewrite_custom_font_paths
+
+# The order Kometa's YAML file uses for top-level sections.  Anchored
+# alongside the render logic so both live in the same module.  Second
+# element is the persistence stem (used only when a section is present).
+#
+# Kometa doesn't care about section order but this ordering keeps
+# generated files stable and diff-friendly across regenerations.
+ORDERED_CONFIG_SECTIONS = (
+    ("libraries", "025-libraries"),
+    ("playlist_files", "027-playlist_files"),
+    ("settings", "150-settings"),
+    ("webhooks", "140-webhooks"),
+    ("plex", "010-plex"),
+    ("tmdb", "020-tmdb"),
+    ("tautulli", "030-tautulli"),
+    ("github", "040-github"),
+    ("omdb", "050-omdb"),
+    ("mdblist", "060-mdblist"),
+    ("notifiarr", "070-notifiarr"),
+    ("gotify", "080-gotify"),
+    ("ntfy", "085-ntfy"),
+    ("apprise", "087-apprise"),
+    ("anidb", "090-anidb"),
+    ("radarr", "100-radarr"),
+    ("sonarr", "110-sonarr"),
+    ("trakt", "120-trakt"),
+    ("mal", "130-mal"),
+)
+
+
+def _strip_mal_code_verifier(config_data):
+    """Remove ``code_verifier`` from ``config_data['mal']['mal']['authorization']``.
+
+    The ``code_verifier`` is the client-side half of a PKCE flow and
+    should never be persisted to the emitted config -- it's a short-
+    lived request-time secret.  Best-effort: silently no-ops when
+    the surrounding structure isn't present.
+    """
+    if "mal" not in config_data or "mal" not in config_data["mal"]:
+        return
+    authorization_data = config_data["mal"]["mal"].get("authorization", {})
+    authorization_data.pop("code_verifier", None)
+
+
+def apply_final_transformations(config_data, library_types, *, optimize_defaults=True):
+    """Run the fixed pre-dump transformation chain.
+
+    Order matters -- each step assumes its predecessor's shape.
+
+    1. Strip ``code_verifier`` from any ``mal.authorization`` block.
+    2. Normalize legacy collection template variables.  Turns older
+       persistence shapes into the canonical shape expected by
+       ``optimize_template_variables``.
+    3. (Optional) Optimize template variables against defaults so
+       explicit values matching the default set are dropped.  Skipped
+       when *optimize_defaults* is falsy (used by tests that need to
+       inspect the un-optimized values).
+    4. Collapse ``collection_data`` template variables into their
+       canonical single-line shape.
+    5. Enforce string typing for every field in
+       :data:`helpers.STRING_FIELDS`.
+    6. Rewrite user-supplied custom font paths to their config-relative
+       equivalents.
+
+    Returns the transformed ``config_data``.  Steps 2-6 return new
+    dicts (some are functional; others mutate and return).  Step 1
+    mutates the input.  Callers should not rely on ``id(config_data)``
+    staying stable.
+    """
+    _strip_mal_code_verifier(config_data)
+    config_data = _normalize_legacy_collection_template_vars(config_data)
+    if optimize_defaults:
+        config_data = optimize_template_variables(config_data, library_types)
+    config_data = _collapse_collection_data_template_vars(config_data)
+    config_data = helpers.enforce_string_fields(config_data, helpers.STRING_FIELDS)
+    config_data = _rewrite_custom_font_paths(config_data)
+    return config_data


### PR DESCRIPTION
**Sprint 2, PR #14.** Pulls the tail transformation phase of `build_config` into a new `modules/output_render.py`. Extracts two things.

## What moved

### 1. `ORDERED_CONFIG_SECTIONS` (module-level tuple constant)

The 19-entry `(section_key, persistence_stem)` ordering used when emitting YAML. Previously reallocated as a **list** on every `build_config` call; now loaded **once at import** as an immutable **tuple of tuples**.

### 2. `apply_final_transformations(config_data, library_types, *, optimize_defaults=True) -> dict`

The fixed pre-dump transformation chain, six steps in order — each assumes its predecessor's shape:

| Step | Purpose |
|---|---|
| 1. `_strip_mal_code_verifier` | Remove PKCE half-secret from `mal.authorization` — never persist to emitted YAML |
| 2. `_normalize_legacy_collection_template_vars` | Turn older persistence shapes into canonical shape expected by step 3 |
| 3. `optimize_template_variables` (optional, gated by `QS_OPTIMIZE_DEFAULTS`) | Drop explicit values matching default sets |
| 4. `_collapse_collection_data_template_vars` | Collapse `collection_data` template vars into canonical single-line shape |
| 5. `helpers.enforce_string_fields` | Enforce string typing for every field in `helpers.STRING_FIELDS` |
| 6. `_rewrite_custom_font_paths` | Rewrite user-supplied custom font paths to their config-relative equivalents |

Returns the transformed `config_data` since some steps are functional (return new) and some mutate. Callers should not rely on `id(config_data)` staying stable.

### Private helper: `_strip_mal_code_verifier`

Replaces an inlined 3-line guard-and-pop pattern for the PKCE half-secret scrub. Silently no-ops when the `mal.authorization` structure isn't present.

## Side effect: import cleanup

`optimize_template_variables` was imported by `output.py` but only used inline in this transformation chain. Since it's not re-exported for tests and no callers depend on `output.optimize_template_variables`, the import moved to `output_render.py` where it's actually used. `_normalize_legacy_collection_template_vars`, `_collapse_collection_data_template_vars`, and `_rewrite_custom_font_paths` stay in `output.py`'s `# noqa: F401` re-export blocks because tests do use `output.X` for those.

## Before / after in `build_config`

**Before** (~40 lines):
```python
ordered_sections = [
    ('libraries', '025-libraries'),
    ('playlist_files', '027-playlist_files'),
    # ... 17 more entries ...
]

# Ensure code_verifier is removed from mal.authorization
if 'mal' in config_data and 'mal' in config_data['mal']:
    authorization_data = config_data['mal']['mal'].get('authorization', {})
    authorization_data.pop('code_verifier', None)

config_data = _normalize_legacy_collection_template_vars(config_data)
optimize_defaults = helpers.booler(app.config.get('QS_OPTIMIZE_DEFAULTS', True))
if optimize_defaults:
    config_data = optimize_template_variables(config_data, library_types)
config_data = _collapse_collection_data_template_vars(config_data)

config_data = helpers.enforce_string_fields(config_data, helpers.STRING_FIELDS)
config_data = _rewrite_custom_font_paths(config_data)

for section_key, section_stem in ordered_sections:
    ...
```

**After** (~7 lines + module-scope constant):
```python
optimize_defaults = helpers.booler(app.config.get('QS_OPTIMIZE_DEFAULTS', True))
config_data = apply_final_transformations(config_data, library_types, optimize_defaults=optimize_defaults)

for section_key, section_stem in ORDERED_CONFIG_SECTIONS:
    ...
```

## Impact

- `modules/output.py`: **446 → 412** (-34 / -7.6%)
- `modules/output_render.py`: **NEW 108 lines**

## Cumulative sprint progress

| PR | Start | End | Δ |
|---|---|---|---|
| Sprint 1 (#1445-1465) | 3833 | 1595 | -2238 |
| #1468-1480 | 1595 | 446 | -1149 |
| **This PR** | **446** | **412** | **-34** |
| **Total** | 3833 | 412 | **-3421 (-89.3%)** |

## Verification

- All 1081 tests pass
- Ruff + black clean