### PR TITLE
Switch build_libraries_section to keyword args; drop 315 lines of test filler

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -103,23 +103,49 @@ _EMPTY_OUTPUT = object()
 
 
 def build_libraries_section(
-    movie_libraries,
-    show_libraries,
-    movie_collections,
-    show_collections,
-    movie_collection_files,
-    show_collection_files,
-    movie_overlays,
-    show_overlays,
-    movie_attributes,
-    show_attributes,
-    movie_metadata_files,
-    show_metadata_files,
-    movie_templates,
-    show_templates,
-    movie_top_level,
-    show_top_level,
+    movie_libraries=None,
+    show_libraries=None,
+    movie_collections=None,
+    show_collections=None,
+    movie_collection_files=None,
+    show_collection_files=None,
+    movie_overlays=None,
+    show_overlays=None,
+    movie_attributes=None,
+    show_attributes=None,
+    movie_metadata_files=None,
+    show_metadata_files=None,
+    movie_templates=None,
+    show_templates=None,
+    movie_top_level=None,
+    show_top_level=None,
 ):
+    """Build the ``libraries:`` YAML block from per-kind grouped dicts.
+
+    All 16 arguments are optional and default to an empty dict when
+    omitted -- ``build_config`` passes everything; tests typically
+    populate only one or two slots.  Passing ``None`` is treated as an
+    explicit empty dict so callers can rely on the same defaults.
+    """
+    # Coerce ``None`` -> ``{}`` for all 16 slots so downstream code can
+    # rely on dict semantics without guarding at every .get().
+    movie_libraries = movie_libraries or {}
+    show_libraries = show_libraries or {}
+    movie_collections = movie_collections or {}
+    show_collections = show_collections or {}
+    movie_collection_files = movie_collection_files or {}
+    show_collection_files = show_collection_files or {}
+    movie_overlays = movie_overlays or {}
+    show_overlays = show_overlays or {}
+    movie_attributes = movie_attributes or {}
+    show_attributes = show_attributes or {}
+    movie_metadata_files = movie_metadata_files or {}
+    show_metadata_files = show_metadata_files or {}
+    movie_templates = movie_templates or {}
+    show_templates = show_templates or {}
+    movie_top_level = movie_top_level or {}
+    show_top_level = show_top_level or {}
+
     libraries_section = {}
 
     def sorted_library_items(libraries):
@@ -335,39 +361,25 @@ def build_config(header_style="standard", config_name=None):
         movie_libraries = bundle.movie_libraries
         show_libraries = bundle.show_libraries
         library_types = bundle.library_types
-        movie_collections = bundle.movie_groups["collections"]
-        show_collections = bundle.show_groups["collections"]
-        movie_collection_files = bundle.movie_groups["collection_files"]
-        show_collection_files = bundle.show_groups["collection_files"]
-        movie_overlays = bundle.movie_groups["overlays"]
-        show_overlays = bundle.show_groups["overlays"]
-        movie_attributes = bundle.movie_groups["attributes"]
-        show_attributes = bundle.show_groups["attributes"]
-        movie_metadata_files = bundle.movie_groups["metadata_files"]
-        show_metadata_files = bundle.show_groups["metadata_files"]
-        movie_templates = bundle.movie_groups["templates"]
-        show_templates = bundle.show_groups["templates"]
-        movie_top_level = bundle.movie_groups["top_level"]
-        show_top_level = bundle.show_groups["top_level"]
 
         # Build nested libraries structure
         libraries_section = build_libraries_section(
-            movie_libraries,
-            show_libraries,
-            movie_collections,
-            show_collections,
-            movie_collection_files,
-            show_collection_files,
-            movie_overlays,
-            show_overlays,
-            movie_attributes,
-            show_attributes,
-            movie_metadata_files,
-            show_metadata_files,
-            movie_templates,
-            show_templates,
-            movie_top_level,
-            show_top_level,
+            movie_libraries=movie_libraries,
+            show_libraries=show_libraries,
+            movie_collections=bundle.movie_groups["collections"],
+            show_collections=bundle.show_groups["collections"],
+            movie_collection_files=bundle.movie_groups["collection_files"],
+            show_collection_files=bundle.show_groups["collection_files"],
+            movie_overlays=bundle.movie_groups["overlays"],
+            show_overlays=bundle.show_groups["overlays"],
+            movie_attributes=bundle.movie_groups["attributes"],
+            show_attributes=bundle.show_groups["attributes"],
+            movie_metadata_files=bundle.movie_groups["metadata_files"],
+            show_metadata_files=bundle.show_groups["metadata_files"],
+            movie_templates=bundle.movie_groups["templates"],
+            show_templates=bundle.show_groups["templates"],
+            movie_top_level=bundle.movie_groups["top_level"],
+            show_top_level=bundle.show_groups["top_level"],
         )
         config_data["libraries"] = libraries_section.get("libraries", {}) if isinstance(libraries_section, dict) else {}
         apply_playlist_libraries_toggle(config_data, nested_libraries_data, libraries_section)

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -1929,17 +1929,8 @@ def test_build_libraries_section_emits_metadata_files(app):
 
     with app.app_context():
         libraries_section = output.build_libraries_section(
-            {"mov-library_movies-library": "Movies"},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            movie_metadata_files={
                 "movies": {
                     "mov-library_movies-metadata_files": json.dumps(
                         [
@@ -1952,11 +1943,6 @@ def test_build_libraries_section_emits_metadata_files(app):
                     )
                 }
             },
-            {},
-            {},
-            {},
-            {},
-            {},
         )
 
         assert libraries_section["libraries"]["Movies"]["metadata_files"] == [
@@ -1976,13 +1962,8 @@ def test_build_libraries_section_emits_raw_overlay_files(app):
 
     with app.app_context():
         libraries_section = output.build_libraries_section(
-            {"mov-library_movies-library": "Movies"},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            movie_overlays={
                 "movies": {
                     "mov-library_movies-overlay_files": json.dumps(
                         [
@@ -1995,15 +1976,6 @@ def test_build_libraries_section_emits_raw_overlay_files(app):
                     )
                 }
             },
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
         )
 
         assert libraries_section["libraries"]["Movies"]["overlay_files"] == [
@@ -2023,11 +1995,9 @@ def test_build_libraries_section_emits_collection_files(app):
 
     with app.app_context():
         libraries_section = output.build_libraries_section(
-            {"mov-library_movies-library": "Movies"},
-            {},
-            {"movies": {"mov-library_movies-collection_collectionless": True}},
-            {},
-            {
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            movie_collections={"movies": {"mov-library_movies-collection_collectionless": True}},
+            movie_collection_files={
                 "movies": {
                     "mov-library_movies-collection_files": json.dumps(
                         [
@@ -2040,17 +2010,6 @@ def test_build_libraries_section_emits_collection_files(app):
                     )
                 }
             },
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
         )
 
         assert libraries_section["libraries"]["Movies"]["collection_files"] == [
@@ -2068,28 +2027,14 @@ def test_build_libraries_section_preserves_collection_include_and_exclude(app):
 
     with app.app_context():
         libraries_section = output.build_libraries_section(
-            {"mov-library_movies-library": "Movies"},
-            {},
-            {
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            movie_collections={
                 "movies": {
                     "mov-library_movies-collection_actor": True,
                     "mov-library_movies-template_collection_actor_include": ["Tom Hanks"],
                     "mov-library_movies-template_collection_actor_exclude": ["Morgan Freeman"],
                 }
             },
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
         )
 
     actor_entry = next(
@@ -2106,9 +2051,8 @@ def test_build_libraries_section_preserves_chart_builder_size_template_variables
 
     with app.app_context():
         libraries_section = output.build_libraries_section(
-            {"mov-library_movies-library": "Movies"},
-            {},
-            {
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            movie_collections={
                 "movies": {
                     "mov-library_movies-collection_tautulli": True,
                     "mov-library_movies-template_collection_tautulli_list_days": "14",
@@ -2160,19 +2104,6 @@ def test_build_libraries_section_preserves_chart_builder_size_template_variables
                     "mov-library_movies-template_collection_content_rating_us_limit_other": "5",
                 }
             },
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
         )
 
     collection_entries = libraries_section["libraries"]["Movies"]["collection_files"]
@@ -2233,9 +2164,9 @@ def test_build_libraries_section_normalizes_collection_arr_tag_lists(app):
 
     with app.app_context():
         libraries_section = output.build_libraries_section(
-            {"mov-library_movies-library": "Movies"},
-            {"sho-library_shows-library": "Shows"},
-            {
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            show_libraries={"sho-library_shows-library": "Shows"},
+            movie_collections={
                 "movies": {
                     "mov-library_movies-collection_franchise": True,
                     "mov-library_movies-template_collection_franchise_build_collection": False,
@@ -2245,7 +2176,7 @@ def test_build_libraries_section_normalizes_collection_arr_tag_lists(app):
                     "mov-library_movies-template_collection_franchise_title_override": '{"10": "Star Wars: Skywalker Saga"}',
                 }
             },
-            {
+            show_collections={
                 "shows": {
                     "sho-library_shows-collection_franchise": True,
                     "sho-library_shows-template_collection_franchise_build_collection": False,
@@ -2255,18 +2186,6 @@ def test_build_libraries_section_normalizes_collection_arr_tag_lists(app):
                     "sho-library_shows-template_collection_franchise_item_sonarr_tag": '["watched", "tracked"]',
                 }
             },
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
         )
 
     movie_entry = next(
@@ -2353,9 +2272,8 @@ def test_build_libraries_section_emits_collection_hub_priority(app):
 
     with app.app_context():
         libraries_section = output.build_libraries_section(
-            {"mov-library_movies-library": "Movies"},
-            {},
-            {
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            movie_collections={
                 "movies": {
                     "mov-library_movies-collection_content_rating_uk": True,
                     "mov-library_movies-template_collection_content_rating_uk_visible_home": "true",
@@ -2364,19 +2282,6 @@ def test_build_libraries_section_emits_collection_hub_priority(app):
                     "mov-library_movies-template_collection_content_rating_uk_hub_priority_12A": "1",
                 }
             },
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
         )
 
     movie_entry = next(
@@ -2396,9 +2301,9 @@ def test_build_libraries_section_expands_franchise_dynamic_child_override_maps(a
 
     with app.app_context():
         libraries_section = output.build_libraries_section(
-            {"mov-library_movies-library": "Movies"},
-            {"sho-library_shows-library": "Shows"},
-            {
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            show_libraries={"sho-library_shows-library": "Shows"},
+            movie_collections={
                 "movies": {
                     "mov-library_movies-collection_franchise": True,
                     "mov-library_movies-template_collection_franchise_child_name_overrides": '{"10": "Skywalker Saga"}',
@@ -2407,7 +2312,7 @@ def test_build_libraries_section_expands_franchise_dynamic_child_override_maps(a
                     "mov-library_movies-template_collection_franchise_child_radarr_add_missing_overrides": '{"10": "true"}',
                 }
             },
-            {
+            show_collections={
                 "shows": {
                     "sho-library_shows-collection_franchise": True,
                     "sho-library_shows-template_collection_franchise_child_summary_overrides": '{"1399": "Dragons and dynasties"}',
@@ -2416,18 +2321,6 @@ def test_build_libraries_section_expands_franchise_dynamic_child_override_maps(a
                     "sho-library_shows-template_collection_franchise_child_item_sonarr_tag_overrides": '{"1399": "tracked,priority"}',
                 }
             },
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
         )
 
     movie_entry = next(
@@ -2456,15 +2349,9 @@ def test_build_libraries_section_emits_library_arr_overrides(app):
 
     with app.app_context():
         libraries_section = output.build_libraries_section(
-            {"mov-library_movies-library": "Movies"},
-            {"sho-library_shows-library": "Shows"},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            show_libraries={"sho-library_shows-library": "Shows"},
+            movie_attributes={
                 "movies": {
                     "mov-library_movies-attribute_radarr_url": "http://radarr.local:7878",
                     "mov-library_movies-attribute_radarr_quality_profile": "HD-1080p",
@@ -2472,7 +2359,7 @@ def test_build_libraries_section_emits_library_arr_overrides(app):
                     "mov-library_movies-attribute_radarr_add_existing": "false",
                 }
             },
-            {
+            show_attributes={
                 "shows": {
                     "sho-library_shows-attribute_sonarr_url": "http://sonarr.local:8989",
                     "sho-library_shows-attribute_sonarr_language_profile": "English",
@@ -2480,12 +2367,6 @@ def test_build_libraries_section_emits_library_arr_overrides(app):
                     "sho-library_shows-attribute_sonarr_season_folder": "true",
                 }
             },
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
         )
 
     movies = libraries_section["libraries"]["Movies"]["radarr"]
@@ -4896,22 +4777,8 @@ def test_build_libraries_section_emits_schedule_overlays(app):
 
     with app.app_context():
         libraries_section = output.build_libraries_section(
-            {"mov-library_movies-library": "Movies"},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {"movies": {"mov-library_movies-top_level_schedule_overlays": "weekly(saturday)"}},
-            {},
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            movie_top_level={"movies": {"mov-library_movies-top_level_schedule_overlays": "weekly(saturday)"}},
         )
 
     movies = libraries_section["libraries"]["Movies"]
@@ -4924,22 +4791,8 @@ def test_build_libraries_section_emits_auto_sort_hubs(app):
 
     with app.app_context():
         libraries_section = output.build_libraries_section(
-            {"mov-library_movies-library": "Movies"},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {"movies": {"mov-library_movies-top_level_auto_sort_hubs": "configured.desc"}},
-            {},
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            movie_top_level={"movies": {"mov-library_movies-top_level_auto_sort_hubs": "configured.desc"}},
         )
 
     movies = libraries_section["libraries"]["Movies"]
@@ -4952,28 +4805,14 @@ def test_build_libraries_section_keeps_default_ratings_overlay_when_overlay_file
 
     with app.app_context():
         libraries_section = output.build_libraries_section(
-            {"mov-library_movies-library": "Movies"},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            movie_overlays={
                 "movies": {
                     "mov-library_movies-movie-overlay_ratings": True,
                     "mov-library_movies-movie-template_overlay_ratings[rating1]": "critic",
                     "mov-library_movies-movie-template_overlay_ratings[rating1_image]": "imdb",
                 }
             },
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
         )
 
     overlay_entries = libraries_section["libraries"]["Movies"]["overlay_files"]
@@ -4988,28 +4827,14 @@ def test_build_libraries_section_emits_languages_overlay_language_list(app):
 
     with app.app_context():
         libraries_section = output.build_libraries_section(
-            {"mov-library_movies-library": "Movies"},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            movie_overlays={
                 "movies": {
                     "mov-library_movies-movie-overlay_languages": True,
                     "mov-library_movies-movie-template_overlay_languages[languages]": ["en", "ja"],
                     "mov-library_movies-movie-template_overlay_languages[style]": "square",
                 }
             },
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
         )
 
     overlay_entries = libraries_section["libraries"]["Movies"]["overlay_files"]
@@ -5025,28 +4850,14 @@ def test_build_libraries_section_emits_subtitle_languages_overlay_language_list(
 
     with app.app_context():
         libraries_section = output.build_libraries_section(
-            {"mov-library_movies-library": "Movies"},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            movie_overlays={
                 "movies": {
                     "mov-library_movies-movie-overlay_languages_subtitles": True,
                     "mov-library_movies-movie-template_overlay_languages_subtitles[languages]": ["en", "ja"],
                     "mov-library_movies-movie-template_overlay_languages_subtitles[style]": "square",
                 }
             },
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
         )
 
     overlay_entries = libraries_section["libraries"]["Movies"]["overlay_files"]
@@ -5064,28 +4875,14 @@ def test_build_libraries_section_emits_languages_overlay_alignment_template_vari
 
     with app.app_context():
         libraries_section = output.build_libraries_section(
-            {"mov-library_movies-library": "Movies"},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            movie_overlays={
                 "movies": {
                     "mov-library_movies-movie-overlay_languages": True,
                     "mov-library_movies-movie-template_overlay_languages[flag_alignment]": "right",
                     "mov-library_movies-movie-template_overlay_languages[back_align]": "center",
                 }
             },
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
         )
 
     overlay_entries = libraries_section["libraries"]["Movies"]["overlay_files"]
@@ -5101,28 +4898,14 @@ def test_build_libraries_section_emits_subtitle_languages_overlay_alignment_temp
 
     with app.app_context():
         libraries_section = output.build_libraries_section(
-            {"mov-library_movies-library": "Movies"},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            movie_overlays={
                 "movies": {
                     "mov-library_movies-movie-overlay_languages_subtitles": True,
                     "mov-library_movies-movie-template_overlay_languages_subtitles[flag_alignment]": "left",
                     "mov-library_movies-movie-template_overlay_languages_subtitles[back_align]": "right",
                 }
             },
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
         )
 
     overlay_entries = libraries_section["libraries"]["Movies"]["overlay_files"]
@@ -5140,28 +4923,14 @@ def test_build_libraries_section_emits_streaming_overlay_region_originals_and_di
 
     with app.app_context():
         libraries_section = output.build_libraries_section(
-            {"mov-library_movies-library": "Movies"},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            movie_overlays={
                 "movies": {
                     "mov-library_movies-movie-overlay_streaming": True,
                     "mov-library_movies-movie-template_overlay_streaming[region]": "CA",
                     "mov-library_movies-movie-template_overlay_streaming[originals_only]": True,
                 }
             },
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
         )
 
     overlay_entries = libraries_section["libraries"]["Movies"]["overlay_files"]
@@ -5176,28 +4945,14 @@ def test_build_libraries_section_emits_only_non_default_language_weight_override
 
     with app.app_context():
         libraries_section = output.build_libraries_section(
-            {"mov-library_movies-library": "Movies"},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            movie_overlays={
                 "movies": {
                     "mov-library_movies-movie-overlay_languages": True,
                     "mov-library_movies-movie-template_overlay_languages[weight_en]": "610",
                     "mov-library_movies-movie-template_overlay_languages[weight_ja]": "700",
                 }
             },
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
         )
 
     overlay_entries = libraries_section["libraries"]["Movies"]["overlay_files"]
@@ -5278,19 +5033,8 @@ def test_build_libraries_section_includes_separator_placeholder_imdb_id(app):
 
     with app.app_context():
         libraries_section = output.build_libraries_section(
-            {"mov-library_movies-library": "Movies"},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            movie_templates={
                 "movies": {
                     "mov-library_movies-template_variables[use_separator]": "gray",
                     "mov-library_movies-attribute_template_variables[placeholder_imdb_id]": "tt0108052",
@@ -5298,9 +5042,6 @@ def test_build_libraries_section_includes_separator_placeholder_imdb_id(app):
                     "mov-library_movies-template_variables[collection_mode]": "hide",
                 }
             },
-            {},
-            {},
-            {},
         )
 
     template_variables = libraries_section["libraries"]["Movies"]["template_variables"]
@@ -5315,28 +5056,14 @@ def test_build_libraries_section_includes_separator_placeholder_tmdb_movie(app):
 
     with app.app_context():
         libraries_section = output.build_libraries_section(
-            {"mov-library_movies-library": "Movies"},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            movie_templates={
                 "movies": {
                     "mov-library_movies-template_variables[use_separator]": "gray",
                     "mov-library_movies-attribute_template_variables[placeholder_tmdb_movie]": "603",
                     "mov-library_movies-template_variables[language]": "en",
                 }
             },
-            {},
-            {},
-            {},
         )
 
     template_variables = libraries_section["libraries"]["Movies"]["template_variables"]
@@ -5350,28 +5077,14 @@ def test_build_libraries_section_includes_separator_placeholder_tvdb_show(app):
 
     with app.app_context():
         libraries_section = output.build_libraries_section(
-            {},
-            {"sho-library_shows-library": "Shows"},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {
+            show_libraries={"sho-library_shows-library": "Shows"},
+            show_templates={
                 "shows": {
                     "sho-library_shows-template_variables[use_separator]": "gray",
                     "sho-library_shows-attribute_template_variables[placeholder_tvdb_show]": "121361",
                     "sho-library_shows-template_variables[language]": "en",
                 }
             },
-            {},
-            {},
         )
 
     template_variables = libraries_section["libraries"]["Shows"]["template_variables"]
@@ -5419,27 +5132,13 @@ def test_build_libraries_section_omits_empty_collectionless_exclude_prefix(app):
 
     with app.app_context():
         libraries_section = output.build_libraries_section(
-            {"mov-library_movies-library": "Movies"},
-            {},
-            {
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            movie_collections={
                 "movies": {
                     "mov-library_movies-collection_collectionless": True,
                     "mov-library_movies-template_collection_collectionless_exclude_prefix": "[]",
                 }
             },
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
         )
 
     collection_entries = libraries_section["libraries"]["Movies"]["collection_files"]
@@ -5454,22 +5153,8 @@ def test_build_libraries_section_emits_schedule(app):
 
     with app.app_context():
         libraries_section = output.build_libraries_section(
-            {"mov-library_movies-library": "Movies"},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {},
-            {"movies": {"mov-library_movies-top_level_schedule": "weekly(saturday)"}},
-            {},
+            movie_libraries={"mov-library_movies-library": "Movies"},
+            movie_top_level={"movies": {"mov-library_movies-top_level_schedule": "weekly(saturday)"}},
         )
 
     movies = libraries_section["libraries"]["Movies"]


### PR DESCRIPTION
**Sprint 2, PR #15.** Migrates `build_libraries_section` from a 16-arg positional signature to fully keyword-based (all args default to `None` -> `{}`). Then mechanically rewrites all 23 test call sites to drop the `{}` filler args.

## The problem

Every test that exercised `build_libraries_section` looked like this:

```python
libraries_section = output.build_libraries_section(
    {"mov-library_movies-library": "Movies"},   # movie_libraries
    {},                                            # show_libraries
    {},                                            # movie_collections
    {},                                            # show_collections
    {},                                            # movie_collection_files
    {},                                            # show_collection_files
    {},                                            # movie_overlays
    {},                                            # show_overlays
    {},                                            # movie_attributes
    {},                                            # show_attributes
    {"movies": {...actual data...}},              # movie_metadata_files
    {},                                            # show_metadata_files
    {},                                            # movie_templates
    {},                                            # show_templates
    {},                                            # movie_top_level
    {},                                            # show_top_level
)
```

15 out of 16 args are literally empty dicts. Adding a new arg to the signature meant editing 23 test call sites. Reading a test meant counting positions to figure out which slot the real data was in.

## The change

### Signature (`modules/output.py`)

```python
def build_libraries_section(
    movie_libraries=None,
    show_libraries=None,
    movie_collections=None,
    # ...  13 more, all default None
):
    movie_libraries = movie_libraries or {}
    show_libraries = show_libraries or {}
    # ...  14 more coercions
```

**Backward-compat is preserved**: existing positional callers still work because Python's positional-arg matching is order-preserving and all 16 slots keep their positions.  The `None -> {}` coercion lets callers drop empty-dict fillers entirely.

### Tests (`tests/test_core_backend.py`)

The above 17-line test call becomes:

```python
libraries_section = output.build_libraries_section(
    movie_libraries={"mov-library_movies-library": "Movies"},
    movie_metadata_files={"movies": {...actual data...}},
)
```

Rewritten mechanically via an AST-based one-shot script that:
1. Found every `output.build_libraries_section` call (23 total)
2. Skipped positions where the AST was `ast.Dict` with no keys (empty `{}`)
3. Rewrote each non-empty positional to kwarg form using the canonical name from signature order
4. Re-parsed to verify syntactic validity before writing

### `build_config`

Removed the 16-line intermediate unpack from `bundle.movie_groups/show_groups`; the function now passes bundle attributes directly as kwargs.

## Impact

- `tests/test_core_backend.py`: **5885 → 5570** (**-315 / -5.4%**)
- `modules/output.py`: 412 → 424 (**+12** — the cost of the 16 `None` defaults + `or {}` coercions)
- **Total codebase: -303 net lines**

`output.py` grew by 12 lines. This PR is intentionally an **investment in test readability** — the caller ergonomics are dramatically better, and any future signature change will only touch `output.py` (not 23 test call sites). The next PR will extract `build_libraries_section` entirely to its own module for the big `output.py` shrinkage.

## Cumulative sprint progress

| PR | Start | End | Δ |
|---|---|---|---|
| Sprint 1 (#1445-1465) | 3833 | 1595 | -2238 |
| #1468-1481 | 1595 | 412 | -1183 |
| **This PR** | **412** | **424** | **+12** (see above) |
| **Total `output.py`** | 3833 | 424 | **-3409 (-89.0%)** |
| **Total tests** | 5885 | 5570 | **-315 (-5.4%)** |

## Verification

- All 1081 tests pass
- Ruff + black clean
- Backward-compat verified: the entire `test_build_libraries_section*` subsuite (23 tests) passes both before AND after the test-migration rewrite