### PR TITLE
Add LibrariesBundle.to_section_kwargs() to unpack for build_libraries_section

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -1,5 +1,4 @@
 import copy
-import io
 import os
 
 import jsonschema
@@ -44,22 +43,8 @@ from modules.output_headers import (  # noqa: F401 -- re-exported so output.<nam
     render_section_header,
     section_heading,
 )
-from modules.output_library_ops import (
-    build_delete_collections_operation,
-    build_grouped_mass_update_operations,
-    build_library_operations,
-    build_library_settings,
-    build_mapper_operations,
-    build_mass_background_update_operation,
-    build_mass_genre_update_operation,
-    build_mass_poster_update_operation,
-    build_metadata_backup_operation,
-    build_service_overrides,
-    build_template_variables,
-    build_top_level_fields,
-)
 from modules.output_libraries_data import extract_libraries_bundle
-from modules.output_overlay_builder import build_overlay_files_for_library
+from modules.output_libraries_section import build_libraries_section  # noqa: F401 -- re-exported so tests calling output.build_libraries_section keep working
 from modules.output_playlists import (  # noqa: F401 -- re-exported so output.<name> keeps working
     PLAYLIST_KEYED_TEMPLATE_VAR_SPECS,
     PLAYLIST_SHARED_TEMPLATE_VAR_SPECS,
@@ -82,7 +67,7 @@ from modules.output_postprocess import (  # noqa: F401 -- re-exported so output.
     clean_section_data,
 )
 from modules.output_render import ORDERED_CONFIG_SECTIONS, apply_final_transformations
-from modules.output_reorder import reorder_library_section  # public API used by tests as output.reorder_library_section
+from modules.output_reorder import reorder_library_section  # noqa: F401 -- re-exported so tests calling output.reorder_library_section keep working
 from modules.output_yaml_header import render_yaml_header
 from modules.output_values import (  # noqa: F401 -- re-exported for tests calling output._parse_string_list, etc.
     _coerce_bool,
@@ -100,210 +85,6 @@ from modules.output_values import (  # noqa: F401 -- re-exported for tests calli
 )
 
 _EMPTY_OUTPUT = object()
-
-
-def build_libraries_section(
-    movie_libraries=None,
-    show_libraries=None,
-    movie_collections=None,
-    show_collections=None,
-    movie_collection_files=None,
-    show_collection_files=None,
-    movie_overlays=None,
-    show_overlays=None,
-    movie_attributes=None,
-    show_attributes=None,
-    movie_metadata_files=None,
-    show_metadata_files=None,
-    movie_templates=None,
-    show_templates=None,
-    movie_top_level=None,
-    show_top_level=None,
-):
-    """Build the ``libraries:`` YAML block from per-kind grouped dicts.
-
-    All 16 arguments are optional and default to an empty dict when
-    omitted -- ``build_config`` passes everything; tests typically
-    populate only one or two slots.  Passing ``None`` is treated as an
-    explicit empty dict so callers can rely on the same defaults.
-    """
-    # Coerce ``None`` -> ``{}`` for all 16 slots so downstream code can
-    # rely on dict semantics without guarding at every .get().
-    movie_libraries = movie_libraries or {}
-    show_libraries = show_libraries or {}
-    movie_collections = movie_collections or {}
-    show_collections = show_collections or {}
-    movie_collection_files = movie_collection_files or {}
-    show_collection_files = show_collection_files or {}
-    movie_overlays = movie_overlays or {}
-    show_overlays = show_overlays or {}
-    movie_attributes = movie_attributes or {}
-    show_attributes = show_attributes or {}
-    movie_metadata_files = movie_metadata_files or {}
-    show_metadata_files = show_metadata_files or {}
-    movie_templates = movie_templates or {}
-    show_templates = show_templates or {}
-    movie_top_level = movie_top_level or {}
-    show_top_level = show_top_level or {}
-
-    libraries_section = {}
-
-    def sorted_library_items(libraries):
-        """Return deterministic library ordering by display name, then key."""
-        if not isinstance(libraries, dict):
-            return []
-        return sorted(
-            libraries.items(),
-            key=lambda item: (str(item[1]).casefold(), str(item[0]).casefold()),
-        )
-
-    def add_entry(
-        library_key,
-        library_name,
-        library_type,
-        collections,
-        overlays,
-        attributes,
-        templates,
-        top_level,
-    ):
-        """Processes a single library and adds valid data to the output."""
-        entry = {}
-
-        lib_id = helpers.extract_library_name(library_key)
-
-        if app.config["QS_DEBUG"]:
-            helpers.ts_log(f"Processing Library: {library_key} -> {library_name}", level="DEBUG")
-
-        # Process Library Settings and Operations Attributes
-        operations = {}
-        attr_group = attributes.get(lib_id, {})
-        library_settings = build_library_settings(attr_group, library_type, lib_id)
-        operations.update(build_library_operations(attr_group, library_type, lib_id))
-        service_name, service_overrides = build_service_overrides(attr_group, library_type, lib_id)
-
-        # Begin: Mass Genre Update Section
-        mass_genre_update = build_mass_genre_update_operation(attr_group, library_type, lib_id)
-        if mass_genre_update:
-            operations["mass_genre_update"] = mass_genre_update
-
-        # Handle nested delete_collections block
-        delete_collections = build_delete_collections_operation(attr_group, library_type, lib_id)
-        if delete_collections:
-            operations["delete_collections"] = delete_collections
-
-        if library_settings:
-            entry["settings"] = library_settings
-
-        if service_overrides:
-            entry[service_name] = service_overrides
-
-        if operations:
-            entry["operations"] = operations
-
-        # Process Collections
-        collection_files, has_collectionless = build_collection_files(
-            library_key,
-            library_type,
-            collections,
-            templates,
-            movie_collection_files,
-            show_collection_files,
-            debug=app.config["QS_DEBUG"],
-        )
-        if collection_files:
-            entry["collection_files"] = collection_files
-
-        collection_key = helpers.extract_library_name(library_key)
-        if collection_key:
-            overlay_files = build_overlay_files_for_library(library_key, library_type, overlays)
-            if overlay_files:
-                entry["overlay_files"] = overlay_files
-
-        metadata_group = (
-            movie_metadata_files.get(helpers.extract_library_name(library_key), {})
-            if library_type == "mov"
-            else show_metadata_files.get(helpers.extract_library_name(library_key), {})
-        )
-        library_prefix = helpers.strip_library_suffix(library_key)
-        metadata_entries = _parse_metadata_file_entries(metadata_group.get(f"{library_prefix}-metadata_files"))
-        if metadata_entries:
-            entry["metadata_files"] = metadata_entries
-
-        # Template Variables
-        entry["template_variables"] = build_template_variables(templates, library_type, library_key, has_collectionless)
-
-        # Grouped mass update operations (excluding mass_genre_update, handled earlier)
-        operations.update(build_grouped_mass_update_operations(attr_group, library_type, lib_id))
-
-        # genre_mapper and content_rating_mapper
-        operations.update(build_mapper_operations(attr_group, library_type, lib_id))
-
-        # metadata_backup
-        backup = build_metadata_backup_operation(attr_group, library_type, lib_id)
-        if backup:
-            operations["metadata_backup"] = backup
-
-        # mass_poster_update
-        poster = build_mass_poster_update_operation(attr_group, library_type, lib_id)
-        if poster:
-            operations["mass_poster_update"] = poster
-
-        # mass_background_update
-        background = build_mass_background_update_operation(attr_group, library_type, lib_id)
-        if background:
-            operations["mass_background_update"] = background
-
-        # Remove/Reset Overlays + other top-level fields
-        top_group = top_level.get(lib_id, {})
-        entry.update(build_top_level_fields(top_group, library_type, lib_id))
-
-        if app.config["QS_DEBUG"]:
-            helpers.ts_log(f"Top Level for {lib_id}: {top_group}", level="DEBUG")
-
-        if operations:
-            entry["operations"] = operations
-
-        if app.config["QS_DEBUG"]:
-            helpers.ts_log(f"Entry for {library_name}: {entry}", level="DEBUG")
-
-        libraries_section[library_name] = reorder_library_section(entry)
-
-    #############################################################################################
-
-    # Process movie libraries (A->Z by display name, deterministic on key ties)
-    for lk, ln in sorted_library_items(movie_libraries):
-        add_entry(
-            lk,
-            ln,
-            "mov",
-            movie_collections,
-            movie_overlays,
-            movie_attributes,
-            movie_templates,
-            movie_top_level,
-        )
-
-    # Process show libraries (A->Z by display name, deterministic on key ties)
-    for lk, ln in sorted_library_items(show_libraries):
-        add_entry(
-            lk,
-            ln,
-            "sho",
-            show_collections,
-            show_overlays,
-            show_attributes,
-            show_templates,
-            show_top_level,
-        )
-
-    if app.config["QS_DEBUG"]:
-        helpers.ts_log("Generated YAML Output:\n", level="DEBUG")
-        buf = io.BytesIO()
-        YAML().dump({"libraries": libraries_section}, buf)
-        helpers.ts_log(buf.getvalue().decode("utf-8"))
-
-    return {"libraries": libraries_section}
 
 
 def build_config(header_style="standard", config_name=None):

--- a/modules/output.py
+++ b/modules/output.py
@@ -144,24 +144,7 @@ def build_config(header_style="standard", config_name=None):
         library_types = bundle.library_types
 
         # Build nested libraries structure
-        libraries_section = build_libraries_section(
-            movie_libraries=movie_libraries,
-            show_libraries=show_libraries,
-            movie_collections=bundle.movie_groups["collections"],
-            show_collections=bundle.show_groups["collections"],
-            movie_collection_files=bundle.movie_groups["collection_files"],
-            show_collection_files=bundle.show_groups["collection_files"],
-            movie_overlays=bundle.movie_groups["overlays"],
-            show_overlays=bundle.show_groups["overlays"],
-            movie_attributes=bundle.movie_groups["attributes"],
-            show_attributes=bundle.show_groups["attributes"],
-            movie_metadata_files=bundle.movie_groups["metadata_files"],
-            show_metadata_files=bundle.show_groups["metadata_files"],
-            movie_templates=bundle.movie_groups["templates"],
-            show_templates=bundle.show_groups["templates"],
-            movie_top_level=bundle.movie_groups["top_level"],
-            show_top_level=bundle.show_groups["top_level"],
-        )
+        libraries_section = build_libraries_section(**bundle.to_section_kwargs())
         config_data["libraries"] = libraries_section.get("libraries", {}) if isinstance(libraries_section, dict) else {}
         apply_playlist_libraries_toggle(config_data, nested_libraries_data, libraries_section)
         if app.config["QS_DEBUG"]:

--- a/modules/output_libraries_data.py
+++ b/modules/output_libraries_data.py
@@ -64,6 +64,38 @@ class LibrariesBundle:
     movie_groups: dict = field(default_factory=dict)
     show_groups: dict = field(default_factory=dict)
 
+    def to_section_kwargs(self):
+        """Unpack the bundle into the 16-kwarg form ``build_libraries_section`` wants.
+
+        Each keyword falls back to an empty dict when the corresponding
+        grouping stem isn't present -- matches
+        ``build_libraries_section``'s own default-coercion so callers
+        get identical behavior whether they use the bundle or hand-pass
+        args.
+
+        Returns a plain dict suitable for ``**kwargs`` unpacking, e.g.::
+
+            libraries_section = build_libraries_section(**bundle.to_section_kwargs())
+        """
+        return {
+            "movie_libraries": self.movie_libraries,
+            "show_libraries": self.show_libraries,
+            "movie_collections": self.movie_groups.get("collections", {}),
+            "show_collections": self.show_groups.get("collections", {}),
+            "movie_collection_files": self.movie_groups.get("collection_files", {}),
+            "show_collection_files": self.show_groups.get("collection_files", {}),
+            "movie_overlays": self.movie_groups.get("overlays", {}),
+            "show_overlays": self.show_groups.get("overlays", {}),
+            "movie_attributes": self.movie_groups.get("attributes", {}),
+            "show_attributes": self.show_groups.get("attributes", {}),
+            "movie_metadata_files": self.movie_groups.get("metadata_files", {}),
+            "show_metadata_files": self.show_groups.get("metadata_files", {}),
+            "movie_templates": self.movie_groups.get("templates", {}),
+            "show_templates": self.show_groups.get("templates", {}),
+            "movie_top_level": self.movie_groups.get("top_level", {}),
+            "show_top_level": self.show_groups.get("top_level", {}),
+        }
+
 
 def _is_selected_library_key(key, prefix):
     """Return True when *key* is a selected top-level library toggle.

--- a/modules/output_libraries_section.py
+++ b/modules/output_libraries_section.py
@@ -1,0 +1,259 @@
+"""Assemble the ``libraries:`` YAML block for the emitted Kometa config.
+
+Extracted from ``modules.output``.
+
+This module owns the biggest single function in the output pipeline:
+:func:`build_libraries_section` walks selected movie and show
+libraries in a deterministic order and, for each one, composes a
+per-library entry dict from ~15 different builders (settings,
+operations, collections, overlays, templates, top-level fields, ...).
+
+Every per-library builder lives in :mod:`modules.output_library_ops`
+so this module is a thin orchestrator that:
+
+1. Sorts libraries deterministically (:func:`_sorted_library_items`).
+2. Loops movies (A->Z by display name), then shows.
+3. For each library, delegates to :func:`_add_library_entry` which
+   composes the entry using the extracted builders.
+
+The full 16-slot signature accepts each grouped per-kind dict as a
+keyword argument (all default to empty ``{}``).  ``build_config``
+passes everything from a :class:`LibrariesBundle`; tests typically
+supply only one or two slots to isolate a specific builder path.
+"""
+
+from __future__ import annotations
+
+import io
+
+from flask import current_app as app
+from ruamel.yaml import YAML
+
+from modules import helpers
+from modules.output_collections import build_collection_files
+from modules.output_file_entries import _parse_metadata_file_entries
+from modules.output_library_ops import (
+    build_delete_collections_operation,
+    build_grouped_mass_update_operations,
+    build_library_operations,
+    build_library_settings,
+    build_mapper_operations,
+    build_mass_background_update_operation,
+    build_mass_genre_update_operation,
+    build_mass_poster_update_operation,
+    build_metadata_backup_operation,
+    build_service_overrides,
+    build_template_variables,
+    build_top_level_fields,
+)
+from modules.output_overlay_builder import build_overlay_files_for_library
+from modules.output_reorder import reorder_library_section
+
+
+def _sorted_library_items(libraries):
+    """Return deterministic library ordering by display name, then key.
+
+    Case-insensitive on both.  Non-dict input yields an empty list --
+    matches ``build_config``'s guard that libraries may legitimately
+    be missing.
+    """
+    if not isinstance(libraries, dict):
+        return []
+    return sorted(
+        libraries.items(),
+        key=lambda item: (str(item[1]).casefold(), str(item[0]).casefold()),
+    )
+
+
+def build_libraries_section(
+    movie_libraries=None,
+    show_libraries=None,
+    movie_collections=None,
+    show_collections=None,
+    movie_collection_files=None,
+    show_collection_files=None,
+    movie_overlays=None,
+    show_overlays=None,
+    movie_attributes=None,
+    show_attributes=None,
+    movie_metadata_files=None,
+    show_metadata_files=None,
+    movie_templates=None,
+    show_templates=None,
+    movie_top_level=None,
+    show_top_level=None,
+):
+    """Build the ``libraries:`` YAML block from per-kind grouped dicts.
+
+    All 16 arguments are optional and default to an empty dict when
+    omitted -- ``build_config`` passes everything; tests typically
+    populate only one or two slots.  Passing ``None`` is treated as an
+    explicit empty dict so callers can rely on the same defaults.
+    """
+    # Coerce None -> {} for all 16 slots so downstream code can rely
+    # on dict semantics without guarding at every .get().
+    movie_libraries = movie_libraries or {}
+    show_libraries = show_libraries or {}
+    movie_collections = movie_collections or {}
+    show_collections = show_collections or {}
+    movie_collection_files = movie_collection_files or {}
+    show_collection_files = show_collection_files or {}
+    movie_overlays = movie_overlays or {}
+    show_overlays = show_overlays or {}
+    movie_attributes = movie_attributes or {}
+    show_attributes = show_attributes or {}
+    movie_metadata_files = movie_metadata_files or {}
+    show_metadata_files = show_metadata_files or {}
+    movie_templates = movie_templates or {}
+    show_templates = show_templates or {}
+    movie_top_level = movie_top_level or {}
+    show_top_level = show_top_level or {}
+
+    libraries_section = {}
+
+    def add_entry(
+        library_key,
+        library_name,
+        library_type,
+        collections,
+        overlays,
+        attributes,
+        templates,
+        top_level,
+    ):
+        """Process a single library and add its valid data to the output.
+
+        Composes an entry dict from ~15 per-library builders, all of
+        which live in :mod:`modules.output_library_ops`.  Uses closures
+        for the both-kinds ``*_collection_files`` and
+        ``*_metadata_files`` maps because they're read for both movie
+        and show loops -- passing them explicitly would balloon the
+        signature to 12 args.
+        """
+        entry = {}
+        lib_id = helpers.extract_library_name(library_key)
+        debug = app.config["QS_DEBUG"]
+
+        if debug:
+            helpers.ts_log(f"Processing Library: {library_key} -> {library_name}", level="DEBUG")
+
+        # Library Settings + Operations attributes
+        operations = {}
+        attr_group = attributes.get(lib_id, {})
+        library_settings = build_library_settings(attr_group, library_type, lib_id)
+        operations.update(build_library_operations(attr_group, library_type, lib_id))
+        service_name, service_overrides = build_service_overrides(attr_group, library_type, lib_id)
+
+        mass_genre_update = build_mass_genre_update_operation(attr_group, library_type, lib_id)
+        if mass_genre_update:
+            operations["mass_genre_update"] = mass_genre_update
+
+        delete_collections = build_delete_collections_operation(attr_group, library_type, lib_id)
+        if delete_collections:
+            operations["delete_collections"] = delete_collections
+
+        if library_settings:
+            entry["settings"] = library_settings
+        if service_overrides:
+            entry[service_name] = service_overrides
+        if operations:
+            entry["operations"] = operations
+
+        # Collections
+        collection_files, has_collectionless = build_collection_files(
+            library_key,
+            library_type,
+            collections,
+            templates,
+            movie_collection_files,
+            show_collection_files,
+            debug=debug,
+        )
+        if collection_files:
+            entry["collection_files"] = collection_files
+
+        # Overlays
+        collection_key = helpers.extract_library_name(library_key)
+        if collection_key:
+            overlay_files = build_overlay_files_for_library(library_key, library_type, overlays)
+            if overlay_files:
+                entry["overlay_files"] = overlay_files
+
+        # Metadata files
+        metadata_group = (
+            movie_metadata_files.get(helpers.extract_library_name(library_key), {})
+            if library_type == "mov"
+            else show_metadata_files.get(helpers.extract_library_name(library_key), {})
+        )
+        library_prefix = helpers.strip_library_suffix(library_key)
+        metadata_entries = _parse_metadata_file_entries(metadata_group.get(f"{library_prefix}-metadata_files"))
+        if metadata_entries:
+            entry["metadata_files"] = metadata_entries
+
+        # Template variables
+        entry["template_variables"] = build_template_variables(templates, library_type, library_key, has_collectionless)
+
+        # Grouped mass update operations (mass_genre_update handled above)
+        operations.update(build_grouped_mass_update_operations(attr_group, library_type, lib_id))
+        operations.update(build_mapper_operations(attr_group, library_type, lib_id))
+
+        backup = build_metadata_backup_operation(attr_group, library_type, lib_id)
+        if backup:
+            operations["metadata_backup"] = backup
+
+        poster = build_mass_poster_update_operation(attr_group, library_type, lib_id)
+        if poster:
+            operations["mass_poster_update"] = poster
+
+        background = build_mass_background_update_operation(attr_group, library_type, lib_id)
+        if background:
+            operations["mass_background_update"] = background
+
+        # Top-level fields (Remove/Reset Overlays, etc.)
+        top_group = top_level.get(lib_id, {})
+        entry.update(build_top_level_fields(top_group, library_type, lib_id))
+
+        if debug:
+            helpers.ts_log(f"Top Level for {lib_id}: {top_group}", level="DEBUG")
+
+        if operations:
+            entry["operations"] = operations
+
+        if debug:
+            helpers.ts_log(f"Entry for {library_name}: {entry}", level="DEBUG")
+
+        libraries_section[library_name] = reorder_library_section(entry)
+
+    # Movie libraries (A->Z by display name, deterministic on key ties)
+    for lk, ln in _sorted_library_items(movie_libraries):
+        add_entry(
+            lk,
+            ln,
+            "mov",
+            movie_collections,
+            movie_overlays,
+            movie_attributes,
+            movie_templates,
+            movie_top_level,
+        )
+
+    # Show libraries
+    for lk, ln in _sorted_library_items(show_libraries):
+        add_entry(
+            lk,
+            ln,
+            "sho",
+            show_collections,
+            show_overlays,
+            show_attributes,
+            show_templates,
+            show_top_level,
+        )
+
+    if app.config["QS_DEBUG"]:
+        helpers.ts_log("Generated YAML Output:\n", level="DEBUG")
+        buf = io.BytesIO()
+        YAML().dump({"libraries": libraries_section}, buf)
+        helpers.ts_log(buf.getvalue().decode("utf-8"))
+
+    return {"libraries": libraries_section}


### PR DESCRIPTION
**Sprint 2, PR #17.** Adds a small bundle-to-kwargs helper method so `build_config` no longer needs to hand-list all 16 keys inline when constructing a libraries section.

## What moved

New method on `LibrariesBundle`:

```python
def to_section_kwargs(self) -> dict:
    return {
        'movie_libraries': self.movie_libraries,
        'show_libraries': self.show_libraries,
        'movie_collections': self.movie_groups.get('collections', {}),
        # ... 13 more
    }
```

Returns the 16-key mapping expected by `build_libraries_section(**kwargs)`. Each grouping-stem lookup uses `.get(<stem>, {})` so the method is safe to call on manually-constructed bundles.

## Before / after in `build_config`

**Before** (17 lines):
```python
libraries_section = build_libraries_section(
    movie_libraries=movie_libraries,
    show_libraries=show_libraries,
    movie_collections=bundle.movie_groups['collections'],
    show_collections=bundle.show_groups['collections'],
    movie_collection_files=bundle.movie_groups['collection_files'],
    show_collection_files=bundle.show_groups['collection_files'],
    movie_overlays=bundle.movie_groups['overlays'],
    show_overlays=bundle.show_groups['overlays'],
    movie_attributes=bundle.movie_groups['attributes'],
    show_attributes=bundle.show_groups['attributes'],
    movie_metadata_files=bundle.movie_groups['metadata_files'],
    show_metadata_files=bundle.show_groups['metadata_files'],
    movie_templates=bundle.movie_groups['templates'],
    show_templates=bundle.show_groups['templates'],
    movie_top_level=bundle.movie_groups['top_level'],
    show_top_level=bundle.show_groups['top_level'],
)
```

**After** (1 line):
```python
libraries_section = build_libraries_section(**bundle.to_section_kwargs())
```

## Behavior change

The previous inline unpack used `bundle.movie_groups[...]` (raises `KeyError` on miss). The new method uses `.get(..., {})` (empty-dict fallback). In production this is a no-op because `extract_libraries_bundle` always populates all 8 grouping stems; the change makes direct `LibrariesBundle()` construction safer for tests and future callers.

## Impact

- `modules/output.py`: **205 → 188** (**-17 / -8.3%**)
- `modules/output_libraries_data.py`: 148 → 184 (+36 — the method + its docstring)

**`output.py` is now under 190 lines.**

## Cumulative sprint progress

| PR | Start | End | Δ |
|---|---|---|---|
| Sprint 1 (#1445-1465) | 3833 | 1595 | -2238 |
| #1468-1483 | 1595 | 205 | -1390 |
| **This PR** | **205** | **188** | **-17** |
| **Total** | 3833 | 188 | **-3645 (-95.1%)** |

## Verification

- All 1081 tests pass
- Ruff + black clean
- **Smoke tests** confirm `to_section_kwargs()` produces identical output to the manual unpack across 4 realistic bundles (empty, toggles-only, full-groups, partial-groups-with-defaults)