### PR TITLE
Extract retrieve_config_sections into output_render (was inline in build_config)

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -1,11 +1,11 @@
-import copy
 import os
 
 import jsonschema
 from flask import current_app as app, has_request_context, session
 from ruamel.yaml import YAML
 
-from modules import helpers, persistence
+from modules import helpers
+from modules import persistence  # noqa: F401 -- re-exported so tests monkeypatching output.persistence.retrieve_settings keep working
 from modules.output_collections import (  # noqa: F401 -- re-exported so output.<name> keeps working
     FRANCHISE_DYNAMIC_CHILD_FIELD_SPECS,
     _collapse_collection_data_template_vars,
@@ -66,7 +66,7 @@ from modules.output_postprocess import (  # noqa: F401 -- re-exported so output.
     _rewrite_custom_font_paths,
     clean_section_data,
 )
-from modules.output_render import ORDERED_CONFIG_SECTIONS, apply_final_transformations
+from modules.output_render import ORDERED_CONFIG_SECTIONS, apply_final_transformations, retrieve_config_sections
 from modules.output_reorder import reorder_library_section  # noqa: F401 -- re-exported so tests calling output.reorder_library_section keep working
 from modules.output_yaml_header import render_yaml_header
 from modules.output_values import (  # noqa: F401 -- re-exported for tests calling output._parse_string_list, etc.
@@ -95,32 +95,13 @@ def build_config(header_style="standard", config_name=None):
     if not config_name and has_request_context():
         config_name = session.get("config_name")
 
-    sections = helpers.get_template_list()
-    config_data = {}
-    header_art = {}
+    config_data, header_art = retrieve_config_sections(header_style)
     library_types = {}
 
     def header_for_section(section_key, display_name):
         if section_key in header_art:
             return header_art[section_key]
         return render_section_header(display_name, header_style)
-
-    # Process sections and generate header art
-    for name in sections:
-        item = sections[name]
-        persistence_key = item["stem"]
-        config_attribute = item["raw_name"]
-
-        # Handle all header styles
-        header_art[config_attribute] = render_section_header(item["name"], header_style)
-
-        # Retrieve settings for each section.
-        # Deep-copy here so YAML normalization cannot mutate the in-memory
-        # structure returned from persistence for this request lifecycle.
-        section_data = copy.deepcopy(persistence.retrieve_settings(persistence_key))
-
-        if "validated" in section_data and section_data["validated"]:
-            config_data[config_attribute] = clean_section_data(section_data, config_attribute)
 
     normalize_playlist_files_section(config_data, debug=app.config["QS_DEBUG"])
     normalize_webhooks_section(config_data, debug=app.config["QS_DEBUG"])
@@ -129,7 +110,6 @@ def build_config(header_style="standard", config_name=None):
     # Initialize movie and show libraries
     movie_libraries = {}
     show_libraries = {}
-    library_types = {}
 
     # Process the libraries section
     if "libraries" in config_data and "libraries" in config_data["libraries"]:

--- a/modules/output_render.py
+++ b/modules/output_render.py
@@ -1,33 +1,92 @@
-"""Final-phase orchestration for ``build_config``.
+"""Orchestration helpers for ``build_config``.
 
 Extracted from ``modules.output.build_config``.
 
-After all sections have been retrieved, normalized, and the libraries
-section built, ``build_config`` runs a fixed sequence of final
-transformations before dumping YAML.  This module owns:
+This module owns the wrap-around orchestration that sits at both ends
+of ``build_config``: pulling per-section data out of persistence at the
+start, and running the fixed transformation chain before YAML dump
+at the end.  The library-processing phase in the middle lives in
+:mod:`modules.output_libraries_data` /
+:mod:`modules.output_libraries_section`.
+
+Public entry points:
+
+* :func:`retrieve_config_sections` -- walk the template list and pull
+  every validated section out of persistence.  Returns
+  ``(config_data, header_art)`` where the latter is the pre-rendered
+  header-art dict keyed by section name.
 
 * :data:`ORDERED_CONFIG_SECTIONS` -- the compile-time section order
-  used when writing YAML.  Moving it to module scope means it's read
-  once at import time instead of allocated fresh on every request.
+  used when writing YAML.  Loaded once at import time.
 
-* :func:`apply_final_transformations` -- the five-step chain that
+* :func:`apply_final_transformations` -- the six-step chain that
   scrubs, optimizes, and reshapes ``config_data`` before dump.
   Preserves the exact call order because several later steps assume
   earlier ones have already run.
 
-* :func:`_strip_mal_code_verifier` -- private helper for a specific
-  one-line security scrub that ``build_config`` had inline.
+Private helpers:
+
+* :func:`_strip_mal_code_verifier` -- one-line PKCE half-secret scrub.
 """
 
 from __future__ import annotations
 
-from modules import helpers
+import copy
+
+from modules import helpers, persistence
 from modules.output_collections import (
     _collapse_collection_data_template_vars,
     _normalize_legacy_collection_template_vars,
 )
+from modules.output_headers import render_section_header
 from modules.output_optimize import optimize_template_variables
-from modules.output_postprocess import _rewrite_custom_font_paths
+from modules.output_postprocess import _rewrite_custom_font_paths, clean_section_data
+
+
+def retrieve_config_sections(header_style):
+    """Walk the template list and pull every validated section into memory.
+
+    Returns ``(config_data, header_art)``:
+
+    * ``config_data`` -- ``{config_attribute: cleaned_section_data}``
+      for every section whose persistence row has ``validated=True``.
+      Deep-copied at read time so any downstream normalization can
+      mutate freely without corrupting the persistence-layer cache
+      for the rest of the request lifecycle.
+    * ``header_art`` -- ``{config_attribute: rendered_header_string}``
+      pre-rendered once per section using *header_style*.  The dump
+      loop later re-uses these instead of re-rendering per section.
+
+    Reads section data via :mod:`modules.persistence`, so must be
+    called within a Flask app context (persistence depends on
+    ``current_app`` for its DB handle).
+
+    A section that isn't validated is skipped for ``config_data`` but
+    still gets its header art rendered -- ``build_config``'s dump loop
+    won't emit it (guarded by ``section_key in config_data``) but the
+    header would be available if a future caller wanted to render
+    an empty-but-present section.
+    """
+    sections = helpers.get_template_list()
+    config_data = {}
+    header_art = {}
+
+    for name in sections:
+        item = sections[name]
+        persistence_key = item["stem"]
+        config_attribute = item["raw_name"]
+
+        header_art[config_attribute] = render_section_header(item["name"], header_style)
+
+        # Deep-copy here so YAML normalization can't mutate the
+        # in-memory persistence cache for this request lifecycle.
+        section_data = copy.deepcopy(persistence.retrieve_settings(persistence_key))
+
+        if "validated" in section_data and section_data["validated"]:
+            config_data[config_attribute] = clean_section_data(section_data, config_attribute)
+
+    return config_data, header_art
+
 
 # The order Kometa's YAML file uses for top-level sections.  Anchored
 # alongside the render logic so both live in the same module.  Second


### PR DESCRIPTION
**Sprint 2, PR #18.** Pulls the 17-line section-retrieval loop out of `build_config` into a new orchestrator function in `modules/output_render.py`.

## What moved

```python
retrieve_config_sections(header_style) -> (config_data, header_art)
```

Walks the template list and pulls every validated section out of persistence. Returns:

- **`config_data`**: `{config_attribute: cleaned_section_data}` for every section whose persistence row has `validated=True`. Deep-copied at read time so any downstream normalization can mutate freely without corrupting the persistence-layer cache.
- **`header_art`**: `{config_attribute: rendered_header_string}` pre-rendered once per section using `header_style`.

A section that isn't validated is skipped for `config_data` but still gets header art rendered — keeps the header available to future callers.

## Before / after in `build_config`

**Before** (17 lines):
```python
sections = helpers.get_template_list()
config_data = {}
header_art = {}
library_types = {}

def header_for_section(section_key, display_name):
    if section_key in header_art:
        return header_art[section_key]
    return render_section_header(display_name, header_style)

# Process sections and generate header art
for name in sections:
    item = sections[name]
    persistence_key = item['stem']
    config_attribute = item['raw_name']

    header_art[config_attribute] = render_section_header(item['name'], header_style)

    section_data = copy.deepcopy(persistence.retrieve_settings(persistence_key))

    if 'validated' in section_data and section_data['validated']:
        config_data[config_attribute] = clean_section_data(section_data, config_attribute)
```

**After** (7 lines):
```python
config_data, header_art = retrieve_config_sections(header_style)
library_types = {}

def header_for_section(section_key, display_name):
    if section_key in header_art:
        return header_art[section_key]
    return render_section_header(display_name, header_style)
```

## Imports that moved

- `copy` — was `import copy` in output.py, only used for the persistence deep-copy
- `render_section_header` — added directly to output_render (still re-exported from output.py via output_headers)

**`persistence`** stays imported and **re-exported** from `output.py` with a `noqa` comment because **15+ test files** monkey-patch `output.persistence.retrieve_settings`. Python module-identity semantics mean that `monkeypatch.setattr(output.persistence, ...)` propagates to `output_render.persistence` (they're the same imported module object). All persistence-patching tests pass identically after the extraction.

## Cleanup

- **Removed duplicate `library_types = {}`** initializer that was leftover from an earlier extraction. Was initialized once at the top of `build_config` and again 10 lines later in the libraries-processing block.

## Impact

- `modules/output.py`: **188 → 168** (**-20 / -10.6%**)
- `modules/output_render.py`: 107 → 165 (+58, well under 600)

**`output.py` is now under 170 lines** — down from 3833 at sprint start. That's a **96% reduction**.

## Cumulative sprint progress

| PR | Start | End | Δ |
|---|---|---|---|
| Sprint 1 (#1445-1465) | 3833 | 1595 | -2238 |
| #1468-1484 | 1595 | 188 | -1407 |
| **This PR** | **188** | **168** | **-20** |
| **Total** | 3833 | 168 | **-3665 (-95.6%)** |

## Verification

- All 1081 tests pass
- Ruff + black clean
- Monkey-patch propagation verified: `tests/test_language_count_yaml_contract.py` (which patches `output.persistence.retrieve_settings`) passes identically after the extraction