### PR TITLE
Extract emit_and_validate_config from build_config's final phase

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -1,8 +1,5 @@
-import os
-
-import jsonschema
+import jsonschema  # noqa: F401 -- re-exported so tests monkeypatching output.jsonschema.Draft7Validator keep working
 from flask import current_app as app, has_request_context, session
-from ruamel.yaml import YAML
 
 from modules import helpers
 from modules import persistence  # noqa: F401 -- re-exported so tests monkeypatching output.persistence.retrieve_settings keep working
@@ -33,7 +30,6 @@ from modules.output_defaults import (  # noqa: F401 -- re-exported so output.<na
     _prune_template_variables,
     _values_match,
 )
-from modules.output_dump import dump_section
 from modules.output_file_entries import (  # noqa: F401 -- re-exported so output.<name> keeps working
     _parse_collection_file_block_entries,
     _parse_metadata_file_entries,
@@ -66,9 +62,8 @@ from modules.output_postprocess import (  # noqa: F401 -- re-exported so output.
     _rewrite_custom_font_paths,
     clean_section_data,
 )
-from modules.output_render import ORDERED_CONFIG_SECTIONS, apply_final_transformations, retrieve_config_sections
+from modules.output_render import emit_and_validate_config, retrieve_config_sections
 from modules.output_reorder import reorder_library_section  # noqa: F401 -- re-exported so tests calling output.reorder_library_section keep working
-from modules.output_yaml_header import render_yaml_header
 from modules.output_values import (  # noqa: F401 -- re-exported for tests calling output._parse_string_list, etc.
     _coerce_bool,
     _coerce_string_list,
@@ -98,11 +93,6 @@ def build_config(header_style="standard", config_name=None):
     config_data, header_art = retrieve_config_sections(header_style)
     library_types = {}
 
-    def header_for_section(section_key, display_name):
-        if section_key in header_art:
-            return header_art[section_key]
-        return render_section_header(display_name, header_style)
-
     normalize_playlist_files_section(config_data, debug=app.config["QS_DEBUG"])
     normalize_webhooks_section(config_data, debug=app.config["QS_DEBUG"])
     normalize_apprise_section(config_data)
@@ -130,39 +120,12 @@ def build_config(header_style="standard", config_name=None):
         if app.config["QS_DEBUG"]:
             helpers.ts_log(f"Final Libraries Section: {libraries_section}", level="DEBUG")
 
-    # Build YAML content
-    yaml = YAML(typ="safe", pure=True)
-    yaml.default_flow_style = False
-    yaml.sort_keys = False
-
-    helpers.ensure_json_schema()
-
-    with open(os.path.join(helpers.JSON_SCHEMA_DIR, "config-schema.json"), "r") as file:
-        schema = yaml.load(file)
-
-    # Reuse the shared update snapshot instead of re-checking on every final-page render.
-    version_info = app.config.get("VERSION_CHECK") or helpers.check_for_update()
-
-    yaml_content = render_yaml_header(header_style, config_name, movie_libraries, show_libraries, version_info)
-
-    optimize_defaults = helpers.booler(app.config.get("QS_OPTIMIZE_DEFAULTS", True))
-    config_data = apply_final_transformations(config_data, library_types, optimize_defaults=optimize_defaults)
-
-    for section_key, section_stem in ORDERED_CONFIG_SECTIONS:
-        if section_key in config_data:
-            section_data = config_data[section_key]
-            section_art = header_for_section(section_key, helpers.user_visible_name(section_key))
-            yaml_content += dump_section(section_art, section_key, section_data, header_style, config_name)
-
-    validated = False
-    validation_error = None
-    validation_errors = []
-    parsed_yaml = yaml.load(yaml_content)
-    validator = jsonschema.Draft7Validator(schema)
-    validation_errors = sorted(validator.iter_errors(parsed_yaml), key=lambda err: list(err.path))
-    if validation_errors:
-        validation_error = validation_errors[0]
-    else:
-        validated = True
-
-    return validated, validation_error, config_data, yaml_content, validation_errors
+    return emit_and_validate_config(
+        config_data,
+        header_art,
+        header_style,
+        config_name,
+        library_types,
+        movie_libraries,
+        show_libraries,
+    )

--- a/modules/output_render.py
+++ b/modules/output_render.py
@@ -24,23 +24,42 @@ Public entry points:
   Preserves the exact call order because several later steps assume
   earlier ones have already run.
 
+* :func:`emit_and_validate_config` -- final phase.  Combines
+  ``apply_final_transformations``, YAML dump per section, and
+  jsonschema validation into one call that returns the 5-tuple
+  ``build_config`` needs to return to its caller.
+
 Private helpers:
 
 * :func:`_strip_mal_code_verifier` -- one-line PKCE half-secret scrub.
+* :func:`_load_config_schema` -- open the config JSON schema once,
+  return a shared YAML parser + parsed schema dict.
+* :func:`_dump_config_sections` -- iterate
+  :data:`ORDERED_CONFIG_SECTIONS` and append each section's YAML to
+  the running text.
+* :func:`_validate_yaml_content` -- run the parsed YAML through
+  Draft7 jsonschema.
 """
 
 from __future__ import annotations
 
 import copy
+import os
+
+import jsonschema
+from flask import current_app as app
+from ruamel.yaml import YAML
 
 from modules import helpers, persistence
 from modules.output_collections import (
     _collapse_collection_data_template_vars,
     _normalize_legacy_collection_template_vars,
 )
+from modules.output_dump import dump_section
 from modules.output_headers import render_section_header
 from modules.output_optimize import optimize_template_variables
 from modules.output_postprocess import _rewrite_custom_font_paths, clean_section_data
+from modules.output_yaml_header import render_yaml_header
 
 
 def retrieve_config_sections(header_style):
@@ -164,3 +183,102 @@ def apply_final_transformations(config_data, library_types, *, optimize_defaults
     config_data = helpers.enforce_string_fields(config_data, helpers.STRING_FIELDS)
     config_data = _rewrite_custom_font_paths(config_data)
     return config_data
+
+
+def _load_config_schema():
+    """Return ``(yaml_parser, schema_dict)`` for validation.
+
+    Uses a pure/safe ``YAML`` instance since we only need JSON-like
+    parsing of a schema file we control.  ``helpers.ensure_json_schema()``
+    is a no-op after the first successful call, so calling it here on
+    every request is cheap.
+    """
+    yaml = YAML(typ="safe", pure=True)
+    yaml.default_flow_style = False
+    yaml.sort_keys = False
+
+    helpers.ensure_json_schema()
+    schema_path = os.path.join(helpers.JSON_SCHEMA_DIR, "config-schema.json")
+    with open(schema_path, "r") as file:
+        schema = yaml.load(file)
+
+    return yaml, schema
+
+
+def _dump_config_sections(config_data, header_art, header_style, config_name):
+    """Iterate :data:`ORDERED_CONFIG_SECTIONS` and dump each present section.
+
+    Returns the accumulated YAML string (no leading header).  Sections
+    with no entry in *config_data* are skipped.  The pre-rendered header
+    art from :func:`retrieve_config_sections` is preferred over a fresh
+    render so identical section names stay byte-identical between the
+    initial retrieval pass and the emission pass.
+    """
+    yaml_body = ""
+    for section_key, _section_stem in ORDERED_CONFIG_SECTIONS:
+        if section_key not in config_data:
+            continue
+        section_data = config_data[section_key]
+        # Prefer the pre-rendered header art; fall back to re-rendering
+        # for sections that didn't come from the template list.
+        if section_key in header_art:
+            section_art = header_art[section_key]
+        else:
+            section_art = render_section_header(helpers.user_visible_name(section_key), header_style)
+        yaml_body += dump_section(section_art, section_key, section_data, header_style, config_name)
+    return yaml_body
+
+
+def _validate_yaml_content(yaml_content, yaml_parser, schema):
+    """Validate *yaml_content* against *schema*.
+
+    Returns ``(validated, first_error, sorted_errors)`` where:
+
+    * ``validated`` -- bool, True when no errors
+    * ``first_error`` -- the earliest error by path (stable ordering)
+      or ``None`` when valid
+    * ``sorted_errors`` -- the full sorted-by-path list; may be empty
+    """
+    parsed_yaml = yaml_parser.load(yaml_content)
+    validator = jsonschema.Draft7Validator(schema)
+    sorted_errors = sorted(validator.iter_errors(parsed_yaml), key=lambda err: list(err.path))
+    if sorted_errors:
+        return False, sorted_errors[0], sorted_errors
+    return True, None, []
+
+
+def emit_and_validate_config(
+    config_data,
+    header_art,
+    header_style,
+    config_name,
+    library_types,
+    movie_libraries,
+    show_libraries,
+):
+    """Final phase of ``build_config``: header + transforms + dump + validate.
+
+    Composes the six-step transformation chain
+    (:func:`apply_final_transformations`, gated by
+    ``QS_OPTIMIZE_DEFAULTS``), YAML dump per ordered section
+    (:func:`_dump_config_sections`), and jsonschema validation
+    (:func:`_validate_yaml_content`) into one call.
+
+    Reuses the update snapshot cached at ``app.config['VERSION_CHECK']``
+    when available -- avoids a network call on every final-page render.
+
+    Returns the 5-tuple ``build_config`` returns to its caller:
+    ``(validated, first_error, transformed_config_data, yaml_content, sorted_errors)``.
+    """
+    yaml_parser, schema = _load_config_schema()
+
+    version_info = app.config.get("VERSION_CHECK") or helpers.check_for_update()
+    yaml_content = render_yaml_header(header_style, config_name, movie_libraries, show_libraries, version_info)
+
+    optimize_defaults = helpers.booler(app.config.get("QS_OPTIMIZE_DEFAULTS", True))
+    config_data = apply_final_transformations(config_data, library_types, optimize_defaults=optimize_defaults)
+
+    yaml_content += _dump_config_sections(config_data, header_art, header_style, config_name)
+
+    validated, first_error, sorted_errors = _validate_yaml_content(yaml_content, yaml_parser, schema)
+    return validated, first_error, config_data, yaml_content, sorted_errors


### PR DESCRIPTION
**Sprint 2, PR #19.** Pulls the entire post-libraries YAML emission + validation phase out of `build_config` into `modules/output_render.py`.

## What moved

```python
emit_and_validate_config(
    config_data, header_art, header_style, config_name,
    library_types, movie_libraries, show_libraries,
) -> (validated, first_error, config_data, yaml_content, sorted_errors)
```

The final phase of `build_config`. Composes six steps into one call:

1. Load YAML parser + JSON schema (`_load_config_schema`)
2. Render the YAML header with version info
3. Apply the final transformations chain
4. Dump each ordered section (`_dump_config_sections`)
5. Validate the assembled YAML (`_validate_yaml_content`)
6. Return the 5-tuple `build_config`'s callers expect

Reuses the update snapshot cached at `app.config['VERSION_CHECK']` when present — avoids the network call on every final-page render.

## Private helpers added

- **`_load_config_schema()`** → `(yaml_parser, schema_dict)` — opens config-schema.json once, returns a pure/safe YAML parser and the parsed schema.
- **`_dump_config_sections(config_data, header_art, header_style, config_name)`** — iterates `ORDERED_CONFIG_SECTIONS`; prefers pre-rendered `header_art` when a section is present in it; falls back to `render_section_header` for sections that didn't come from the template list.
- **`_validate_yaml_content(yaml_content, yaml_parser, schema)`** → `(validated, first_error, sorted_errors)`.

## Cleanup

- **Removed unused `header_for_section` nested closure** — previously wrapped header_art dict-lookup-or-render, now folded into `_dump_config_sections`.

## What `build_config` looks like now

45 lines — reads top-to-bottom as the 5-phase pipeline:

```python
def build_config(header_style='standard', config_name=None):
    if not config_name and has_request_context():
        config_name = session.get('config_name')

    # 1. Retrieve
    config_data, header_art = retrieve_config_sections(header_style)
    library_types = {}

    # 2. Normalize
    normalize_playlist_files_section(config_data, debug=app.config['QS_DEBUG'])
    normalize_webhooks_section(config_data, debug=app.config['QS_DEBUG'])
    normalize_apprise_section(config_data)

    # 3. Libraries
    movie_libraries, show_libraries = {}, {}
    if 'libraries' in config_data and 'libraries' in config_data['libraries']:
        nested_libraries_data = config_data['libraries']['libraries']
        ...
        bundle = extract_libraries_bundle(nested_libraries_data, ...)
        libraries_section = build_libraries_section(**bundle.to_section_kwargs())
        config_data['libraries'] = libraries_section.get('libraries', {}) ...
        apply_playlist_libraries_toggle(config_data, ...)

    # 4+5. Emit + validate
    return emit_and_validate_config(
        config_data, header_art, header_style, config_name,
        library_types, movie_libraries, show_libraries,
    )
```

## Imports that left `output.py`

- `os` (used only for `os.path.join(schema_path)`)
- `YAML` from `ruamel.yaml`
- `dump_section`
- `render_yaml_header`
- `ORDERED_CONFIG_SECTIONS`
- `apply_final_transformations`

## Imports preserved with `noqa` (tests need them via `output.<name>`)

- **`jsonschema`** — 2 tests monkey-patch `output.jsonschema.Draft7Validator.iter_errors`
- **`persistence`** — 15+ tests monkey-patch `output.persistence.retrieve_settings` (documented in prev PR #1485)

## Impact

- `modules/output.py`: **168 → 131** (**-37 / -22.0%**)
- `modules/output_render.py`: 166 → 294 (+128; adds 4 functions + expanded docstring)

**`output.py` is now under 135 lines** — down from 3833 at sprint start. That's a **96.6% reduction**.

## Cumulative sprint progress

| PR | Start | End | Δ |
|---|---|---|---|
| Sprint 1 (#1445-1465) | 3833 | 1595 | -2238 |
| #1468-1485 | 1595 | 168 | -1427 |
| **This PR** | **168** | **131** | **-37** |
| **Total** | 3833 | 131 | **-3702 (-96.6%)** |

## Verification

- All 1081 tests pass
- Ruff + black clean