### PR TITLE
Extract process_libraries_block; drop dead _EMPTY_OUTPUT sentinel

### DIFF
--- a/modules/output.py
+++ b/modules/output.py
@@ -1,7 +1,7 @@
 import jsonschema  # noqa: F401 -- re-exported so tests monkeypatching output.jsonschema.Draft7Validator keep working
 from flask import current_app as app, has_request_context, session
 
-from modules import helpers
+from modules import helpers  # noqa: F401 -- re-exported so tests monkeypatching output.helpers.<name> keep working
 from modules import persistence  # noqa: F401 -- re-exported so tests monkeypatching output.persistence.retrieve_settings keep working
 from modules.output_collections import (  # noqa: F401 -- re-exported so output.<name> keeps working
     FRANCHISE_DYNAMIC_CHILD_FIELD_SPECS,
@@ -39,7 +39,6 @@ from modules.output_headers import (  # noqa: F401 -- re-exported so output.<nam
     render_section_header,
     section_heading,
 )
-from modules.output_libraries_data import extract_libraries_bundle
 from modules.output_libraries_section import build_libraries_section  # noqa: F401 -- re-exported so tests calling output.build_libraries_section keep working
 from modules.output_playlists import (  # noqa: F401 -- re-exported so output.<name> keeps working
     PLAYLIST_KEYED_TEMPLATE_VAR_SPECS,
@@ -62,7 +61,7 @@ from modules.output_postprocess import (  # noqa: F401 -- re-exported so output.
     _rewrite_custom_font_paths,
     clean_section_data,
 )
-from modules.output_render import emit_and_validate_config, retrieve_config_sections
+from modules.output_render import emit_and_validate_config, process_libraries_block, retrieve_config_sections
 from modules.output_reorder import reorder_library_section  # noqa: F401 -- re-exported so tests calling output.reorder_library_section keep working
 from modules.output_values import (  # noqa: F401 -- re-exported for tests calling output._parse_string_list, etc.
     _coerce_bool,
@@ -79,8 +78,6 @@ from modules.output_values import (  # noqa: F401 -- re-exported for tests calli
     _to_number,
 )
 
-_EMPTY_OUTPUT = object()
-
 
 def build_config(header_style="standard", config_name=None):
     """
@@ -91,34 +88,12 @@ def build_config(header_style="standard", config_name=None):
         config_name = session.get("config_name")
 
     config_data, header_art = retrieve_config_sections(header_style)
-    library_types = {}
 
     normalize_playlist_files_section(config_data, debug=app.config["QS_DEBUG"])
     normalize_webhooks_section(config_data, debug=app.config["QS_DEBUG"])
     normalize_apprise_section(config_data)
 
-    # Initialize movie and show libraries
-    movie_libraries = {}
-    show_libraries = {}
-
-    # Process the libraries section
-    if "libraries" in config_data and "libraries" in config_data["libraries"]:
-        nested_libraries_data = config_data["libraries"]["libraries"]
-
-        if app.config["QS_DEBUG"]:
-            helpers.ts_log("Raw nested libraries data:", nested_libraries_data, level="DEBUG")
-
-        bundle = extract_libraries_bundle(nested_libraries_data, debug=app.config["QS_DEBUG"])
-        movie_libraries = bundle.movie_libraries
-        show_libraries = bundle.show_libraries
-        library_types = bundle.library_types
-
-        # Build nested libraries structure
-        libraries_section = build_libraries_section(**bundle.to_section_kwargs())
-        config_data["libraries"] = libraries_section.get("libraries", {}) if isinstance(libraries_section, dict) else {}
-        apply_playlist_libraries_toggle(config_data, nested_libraries_data, libraries_section)
-        if app.config["QS_DEBUG"]:
-            helpers.ts_log(f"Final Libraries Section: {libraries_section}", level="DEBUG")
+    movie_libraries, show_libraries, library_types = process_libraries_block(config_data, debug=app.config["QS_DEBUG"])
 
     return emit_and_validate_config(
         config_data,

--- a/modules/output_render.py
+++ b/modules/output_render.py
@@ -2,12 +2,12 @@
 
 Extracted from ``modules.output.build_config``.
 
-This module owns the wrap-around orchestration that sits at both ends
-of ``build_config``: pulling per-section data out of persistence at the
-start, and running the fixed transformation chain before YAML dump
-at the end.  The library-processing phase in the middle lives in
-:mod:`modules.output_libraries_data` /
-:mod:`modules.output_libraries_section`.
+This module owns the full orchestration pipeline for ``build_config``:
+pulling per-section data out of persistence at the start, building
+the libraries subtree in the middle, and running the fixed
+transformation chain plus YAML emission at the end.  Individual
+builders (``build_libraries_section``, ``build_collection_files``,
+etc.) live in their own modules; this module composes them.
 
 Public entry points:
 
@@ -15,6 +15,10 @@ Public entry points:
   every validated section out of persistence.  Returns
   ``(config_data, header_art)`` where the latter is the pre-rendered
   header-art dict keyed by section name.
+
+* :func:`process_libraries_block` -- build the libraries subtree in
+  place and return the per-library metadata (movie/show library
+  toggles and library_types) needed for the emit phase.
 
 * :data:`ORDERED_CONFIG_SECTIONS` -- the compile-time section order
   used when writing YAML.  Loaded once at import time.
@@ -57,7 +61,10 @@ from modules.output_collections import (
 )
 from modules.output_dump import dump_section
 from modules.output_headers import render_section_header
+from modules.output_libraries_data import extract_libraries_bundle
+from modules.output_libraries_section import build_libraries_section
 from modules.output_optimize import optimize_template_variables
+from modules.output_playlists import apply_playlist_libraries_toggle
 from modules.output_postprocess import _rewrite_custom_font_paths, clean_section_data
 from modules.output_yaml_header import render_yaml_header
 
@@ -105,6 +112,43 @@ def retrieve_config_sections(header_style):
             config_data[config_attribute] = clean_section_data(section_data, config_attribute)
 
     return config_data, header_art
+
+
+def process_libraries_block(config_data, *, debug=False):
+    """Build the libraries subtree in place; return per-library metadata.
+
+    Returns ``(movie_libraries, show_libraries, library_types)``.
+    Mutates *config_data* in place: replaces its ``"libraries"`` entry
+    with the nested libraries-section structure produced by
+    :func:`build_libraries_section`, and applies the playlist-libraries
+    toggle.
+
+    When the source ``config_data`` doesn't contain a nested
+    ``libraries.libraries`` block (e.g. no libraries were selected),
+    returns three empty dicts and leaves *config_data* untouched --
+    the emit phase later dumps an empty libraries section.
+
+    The ``debug`` flag controls two ts_log dumps (raw input dict and
+    final libraries-section dict) that are extremely noisy in
+    production but useful when diagnosing library-config bugs.
+    """
+    if "libraries" not in config_data or "libraries" not in config_data["libraries"]:
+        return {}, {}, {}
+
+    nested_libraries_data = config_data["libraries"]["libraries"]
+    if debug:
+        helpers.ts_log("Raw nested libraries data:", nested_libraries_data, level="DEBUG")
+
+    bundle = extract_libraries_bundle(nested_libraries_data, debug=debug)
+    libraries_section = build_libraries_section(**bundle.to_section_kwargs())
+
+    config_data["libraries"] = libraries_section.get("libraries", {}) if isinstance(libraries_section, dict) else {}
+    apply_playlist_libraries_toggle(config_data, nested_libraries_data, libraries_section)
+
+    if debug:
+        helpers.ts_log(f"Final Libraries Section: {libraries_section}", level="DEBUG")
+
+    return bundle.movie_libraries, bundle.show_libraries, bundle.library_types
 
 
 # The order Kometa's YAML file uses for top-level sections.  Anchored


### PR DESCRIPTION
**Sprint 2, PR #20.** Pulls the last inline scaffolding out of `build_config` and deletes a dead-code sentinel.

## What moved

```python
process_libraries_block(config_data, *, debug=False)
    -> (movie_libraries, show_libraries, library_types)
```

Builds the libraries subtree in place and returns per-library metadata. Mutates `config_data`: replaces its `'libraries'` entry with the nested libraries-section structure from `build_libraries_section`, then applies the playlist-libraries toggle.

When source `config_data` lacks a nested `libraries.libraries` block (no libraries selected), returns three empty dicts and leaves `config_data` untouched.

The `debug` flag controls two `ts_log` dumps that are extremely noisy in production but useful when diagnosing library-config bugs.

## Dead code removed

- **`_EMPTY_OUTPUT`** sentinel in `output.py` — was defined but never referenced. The **real** `_EMPTY_OUTPUT` lives in `output_dump.py` where it drives the recursive pruning of empty leaves. The `output.py` copy was a copy-paste leftover from an earlier extraction; grep confirms zero callers.

## What `build_config` looks like now (25 lines)

```python
def build_config(header_style='standard', config_name=None):
    if not config_name and has_request_context():
        config_name = session.get('config_name')

    config_data, header_art = retrieve_config_sections(header_style)

    normalize_playlist_files_section(config_data, debug=app.config['QS_DEBUG'])
    normalize_webhooks_section(config_data, debug=app.config['QS_DEBUG'])
    normalize_apprise_section(config_data)

    movie_libraries, show_libraries, library_types = process_libraries_block(
        config_data, debug=app.config['QS_DEBUG']
    )

    return emit_and_validate_config(
        config_data, header_art, header_style, config_name,
        library_types, movie_libraries, show_libraries,
    )
```

Reads top-to-bottom as the 4-phase pipeline: **retrieve → normalize → libraries → emit**.

## Imports added to `output_render.py`

All guaranteed non-circular (none of these modules import `output_render`):

- `extract_libraries_bundle` (from `output_libraries_data`)
- `build_libraries_section` (from `output_libraries_section`)
- `apply_playlist_libraries_toggle` (from `output_playlists`)

## Imports that left `output.py`

- `extract_libraries_bundle` (moved with the block)

## Import upgraded with `noqa` (tests need it)

- **`helpers`** — **14 test files** monkey-patch `output.helpers.get_plex_summary`, `get_quickstart_settings_summary`, `get_library_summaries`, and `ensure_json_schema`. Module-identity semantics propagate the patch to `output_render.helpers`.

## Impact

- `modules/output.py`: **131 → 107** (**-24 / -18.3%**)
- `modules/output_render.py`: 294 → 329 (+35; adds function + docstring)

## Cumulative sprint progress

| PR | Start | End | Δ |
|---|---|---|---|
| Sprint 1 (#1445-1465) | 3833 | 1595 | -2238 |
| #1468-1486 | 1595 | 131 | -1464 |
| **This PR** | **131** | **107** | **-24** |
| **Total** | 3833 | 107 | **-3726 (-97.2%)** |

## Verification

- All 1081 tests pass
- Ruff + black clean