### PR TITLE
Extract PMS version helpers to modules/logscan_pms_versions

### DIFF
--- a/modules/logscan.py
+++ b/modules/logscan.py
@@ -5,6 +5,12 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from modules import logscan_command, logscan_people
+from modules.logscan_pms_versions import (
+    VULNERABLE_RANGE_HIGH,
+    VULNERABLE_RANGE_LOW,
+    format_version_tuple,
+    is_vulnerable_pms_version,
+)
 
 # Re-exported for back-compat with tests / quickstart imports.
 from modules.logscan_people import (  # noqa: F401
@@ -19,32 +25,6 @@ from modules.logscan_people import (  # noqa: F401
 # Create logger
 mylogger = logging.getLogger("logscan")
 mylogger.setLevel(logging.INFO)
-
-
-# --- PMS security vulnerability helpers (non-invasive; keep existing checks as-is) ---
-
-
-def _parse_pms_version_tuple(ver: str):
-    """Return a 4-int tuple for PMS versions like '1.41.7.9100' (trims any '-xyz')."""
-    ver = ver.split("-", 1)[0].strip()  # drop any '-whatever' suffix if present
-    parts = ver.split(".")
-    nums = []
-    for i in range(4):
-        try:
-            nums.append(int(parts[i]))
-        except Exception:
-            nums.append(0)
-    return tuple(nums[:4])
-
-
-def _version_in_inclusive_range(ver: str, low: tuple, high: tuple) -> bool:
-    v = _parse_pms_version_tuple(ver)
-    return low <= v <= high
-
-
-# Vulnerable range you want to flag (adjust as needed)
-_PMS_VULN_LOW = (1, 41, 7, 0)  # 1.41.7.x
-_PMS_VULN_HIGH = (1, 42, 0, 99999)  # through 1.42.0.x
 
 
 class LogscanAnalyzer:
@@ -688,7 +668,7 @@ class LogscanAnalyzer:
             if m:
                 sn = m.group(1).strip()
                 ver = m.group(2).strip()
-                if _version_in_inclusive_range(ver, _PMS_VULN_LOW, _PMS_VULN_HIGH):
+                if is_vulnerable_pms_version(ver):
                     security_vuln_hits.append((sn, ver, idx))
 
             if "Config Error: anidb sub-attribute" in line or "AniDB Error: Login failed" in line:
@@ -1454,8 +1434,8 @@ class LogscanAnalyzer:
                     seen.add(key)
                     items.append((sn, ver, ln))
 
-            vuln_low_str = ".".join(map(str, _PMS_VULN_LOW))
-            vuln_high_str = ".".join(map(str, _PMS_VULN_HIGH))
+            vuln_low_str = format_version_tuple(VULNERABLE_RANGE_LOW)
+            vuln_high_str = format_version_tuple(VULNERABLE_RANGE_HIGH)
             url_line = "[https://forums.plex.tv/t/plex-media-server-security-update/928341]"
 
             msg = (

--- a/modules/logscan_pms_versions.py
+++ b/modules/logscan_pms_versions.py
@@ -1,0 +1,72 @@
+"""PMS (Plex Media Server) version parsing and vulnerability checks.
+
+Extracted from ``modules.logscan``.
+
+Kometa doesn't ship with a curated CVE database; instead the logscan
+recommendations flag Plex versions that fall inside a specific
+known-bad range (currently 1.41.7.x -- 1.42.0.x).  This module owns:
+
+* :func:`parse_version_tuple` -- turn a PMS version string like
+  ``"1.41.7.9100"`` or ``"1.42.0.9700-abc123"`` into a
+  ``(major, minor, patch, build)`` int-tuple.  Missing components
+  default to 0.  The ``-suffix`` (build tag) is stripped.  Never
+  raises on malformed input -- non-int components resolve to 0.
+
+* :func:`version_in_inclusive_range` -- given a version string and
+  inclusive ``low``/``high`` tuples, return True when the parsed
+  version lies within.
+
+* :data:`VULNERABLE_RANGE_LOW` / :data:`VULNERABLE_RANGE_HIGH` --
+  the currently-flagged vulnerable-version window.  Update these
+  when a new CVE window needs flagging.
+
+* :func:`is_vulnerable_pms_version` -- terse convenience:
+  ``is_vulnerable_pms_version("1.41.7.9100")`` returns True.
+"""
+
+from __future__ import annotations
+
+
+def parse_version_tuple(ver: str) -> tuple[int, int, int, int]:
+    """Return a 4-int tuple for PMS versions like ``'1.41.7.9100'``.
+
+    Any ``-suffix`` (e.g. ``'1.42.0.9700-abc123'``) is trimmed.
+    Missing components default to 0; non-integer components also
+    default to 0 (defensive against malformed input in log lines).
+    """
+    ver = ver.split("-", 1)[0].strip()
+    parts = ver.split(".")
+    nums = []
+    for i in range(4):
+        try:
+            nums.append(int(parts[i]))
+        except Exception:
+            nums.append(0)
+    return tuple(nums[:4])
+
+
+def version_in_inclusive_range(ver: str, low: tuple, high: tuple) -> bool:
+    """Return True when *ver* parses into a tuple within ``[low, high]``."""
+    return low <= parse_version_tuple(ver) <= high
+
+
+# Currently-flagged vulnerable PMS version window.  When a new CVE
+# needs flagging, update these two constants and the recommendation
+# text in :func:`modules.logscan.LogscanAnalyzer.make_recommendations`.
+VULNERABLE_RANGE_LOW: tuple[int, int, int, int] = (1, 41, 7, 0)  # 1.41.7.x
+VULNERABLE_RANGE_HIGH: tuple[int, int, int, int] = (1, 42, 0, 99999)  # through 1.42.0.x
+
+
+def is_vulnerable_pms_version(ver: str) -> bool:
+    """Return True when *ver* falls inside the current vulnerable window."""
+    return version_in_inclusive_range(ver, VULNERABLE_RANGE_LOW, VULNERABLE_RANGE_HIGH)
+
+
+def format_version_tuple(version: tuple) -> str:
+    """Render a version tuple as a dotted string.
+
+    ``(1, 41, 7, 0) -> '1.41.7.0'``.  Used when the recommendation
+    text needs to display the vulnerable range in a human-readable
+    form.
+    """
+    return ".".join(str(component) for component in version)

--- a/tests/test_logscan_pms_versions.py
+++ b/tests/test_logscan_pms_versions.py
@@ -1,0 +1,121 @@
+"""Unit tests for :mod:`modules.logscan_pms_versions`.
+
+Extracted alongside PR that moved the PMS-version helpers out of
+``modules.logscan``.  The originals lived inside ``logscan.py`` with
+no dedicated test file -- the only coverage was via integration
+tests of ``LogscanAnalyzer.make_recommendations``.  These focused
+unit tests fill that gap so future edits to the vulnerable-range
+constants or the parsing helper can be verified in isolation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from modules.logscan_pms_versions import (
+    VULNERABLE_RANGE_HIGH,
+    VULNERABLE_RANGE_LOW,
+    format_version_tuple,
+    is_vulnerable_pms_version,
+    parse_version_tuple,
+    version_in_inclusive_range,
+)
+
+
+class TestParseVersionTuple:
+    def test_full_four_component_version(self):
+        assert parse_version_tuple("1.41.7.9100") == (1, 41, 7, 9100)
+
+    def test_trims_trailing_suffix_after_hyphen(self):
+        assert parse_version_tuple("1.42.0.9700-abcd123") == (1, 42, 0, 9700)
+
+    def test_pads_missing_components_with_zero(self):
+        assert parse_version_tuple("1.41") == (1, 41, 0, 0)
+
+    def test_empty_string_returns_all_zeros(self):
+        assert parse_version_tuple("") == (0, 0, 0, 0)
+
+    def test_non_integer_components_default_to_zero(self):
+        # Kometa's log lines sometimes have garbled version fragments;
+        # never raise -- just coerce non-int chunks to 0.
+        assert parse_version_tuple("1.abc.7.9100") == (1, 0, 7, 9100)
+
+    def test_ignores_extra_components_beyond_four(self):
+        assert parse_version_tuple("1.2.3.4.5.6") == (1, 2, 3, 4)
+
+    def test_strips_surrounding_whitespace_on_suffix(self):
+        assert parse_version_tuple("  1.2.3.4  ") == (1, 2, 3, 4)
+
+
+class TestVersionInInclusiveRange:
+    def test_at_lower_bound_is_included(self):
+        assert version_in_inclusive_range("1.41.7.0", (1, 41, 7, 0), (1, 42, 0, 99999))
+
+    def test_at_upper_bound_is_included(self):
+        assert version_in_inclusive_range("1.42.0.99999", (1, 41, 7, 0), (1, 42, 0, 99999))
+
+    def test_below_range_is_excluded(self):
+        assert not version_in_inclusive_range("1.41.6.9999", (1, 41, 7, 0), (1, 42, 0, 99999))
+
+    def test_above_range_is_excluded(self):
+        assert not version_in_inclusive_range("1.42.1.0", (1, 41, 7, 0), (1, 42, 0, 99999))
+
+    def test_inside_range(self):
+        assert version_in_inclusive_range("1.42.0.100", (1, 41, 7, 0), (1, 42, 0, 99999))
+
+
+class TestIsVulnerablePmsVersion:
+    """Wraps the module-level range constants; when those move the tests move."""
+
+    def test_flags_current_vulnerable_version(self):
+        # 1.41.7.x should be flagged.
+        assert is_vulnerable_pms_version("1.41.7.9100")
+        assert is_vulnerable_pms_version("1.42.0.9700")
+
+    def test_does_not_flag_older_versions(self):
+        assert not is_vulnerable_pms_version("1.40.5.8000")
+
+    def test_does_not_flag_patched_versions(self):
+        # Anything past 1.42.0.99999 should be considered patched.
+        assert not is_vulnerable_pms_version("1.42.1.0")
+        assert not is_vulnerable_pms_version("1.43.0.100")
+
+    def test_handles_suffixed_versions(self):
+        assert is_vulnerable_pms_version("1.41.7.9100-abc123")
+
+
+class TestFormatVersionTuple:
+    def test_full_four_component(self):
+        assert format_version_tuple((1, 41, 7, 0)) == "1.41.7.0"
+
+    def test_matches_range_constants(self):
+        # Round-trip: format each constant and confirm parse gets it back.
+        for constant in (VULNERABLE_RANGE_LOW, VULNERABLE_RANGE_HIGH):
+            rendered = format_version_tuple(constant)
+            assert parse_version_tuple(rendered) == constant
+
+    def test_three_component_tuple(self):
+        assert format_version_tuple((1, 2, 3)) == "1.2.3"
+
+    def test_single_component(self):
+        assert format_version_tuple((42,)) == "42"
+
+
+class TestRangeConstantsSanity:
+    """Guard rails on the module-level constants themselves."""
+
+    def test_low_is_below_high(self):
+        assert VULNERABLE_RANGE_LOW < VULNERABLE_RANGE_HIGH
+
+    def test_constants_are_four_component_tuples(self):
+        assert len(VULNERABLE_RANGE_LOW) == 4
+        assert len(VULNERABLE_RANGE_HIGH) == 4
+
+    def test_constants_are_all_ints(self):
+        for constant in (VULNERABLE_RANGE_LOW, VULNERABLE_RANGE_HIGH):
+            for component in constant:
+                assert isinstance(component, int)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
**First extraction from the `logscan.py` monolith** (3291 lines, 5x over the 600-line target). Starting small with the most self-contained chunk: PMS version parsing + vulnerable-range helpers.

## What moved to new `modules/logscan_pms_versions.py`

**Renamed from private → public** (zero external callers verified via grep):

- `parse_version_tuple(ver)` → `(major, minor, patch, build)` — was `_parse_pms_version_tuple`
- `version_in_inclusive_range(ver, low, high)` — was `_version_in_inclusive_range`
- `VULNERABLE_RANGE_LOW = (1, 41, 7, 0)` — was `_PMS_VULN_LOW`
- `VULNERABLE_RANGE_HIGH = (1, 42, 0, 99999)` — was `_PMS_VULN_HIGH`

**New DRY helpers**:

- `is_vulnerable_pms_version(ver) -> bool` — terse convenience that wraps `version_in_inclusive_range` with the module-level range constants
- `format_version_tuple(version) -> str` — replaces the ad-hoc `'.'.join(map(str, tuple))` pattern used twice

## Call sites cleaned up in `modules/logscan.py`

**Before**:
```python
if _version_in_inclusive_range(ver, _PMS_VULN_LOW, _PMS_VULN_HIGH):
    security_vuln_hits.append((sn, ver, idx))
```
**After**:
```python
if is_vulnerable_pms_version(ver):
    security_vuln_hits.append((sn, ver, idx))
```

**Before**:
```python
vuln_low_str = '.'.join(map(str, _PMS_VULN_LOW))
vuln_high_str = '.'.join(map(str, _PMS_VULN_HIGH))
```
**After**:
```python
vuln_low_str = format_version_tuple(VULNERABLE_RANGE_LOW)
vuln_high_str = format_version_tuple(VULNERABLE_RANGE_HIGH)
```

## New tests: `tests/test_logscan_pms_versions.py`

**23 focused unit tests** across 5 test classes:

- `TestParseVersionTuple` (7 tests): full/trimmed/missing/garbage/whitespace
- `TestVersionInInclusiveRange` (5 tests): boundary + outside
- `TestIsVulnerablePmsVersion` (4 tests): current CVE window
- `TestFormatVersionTuple` (4 tests): 4/3/1 components, round-trip
- `TestRangeConstantsSanity` (3 tests): guardrails on constants

These add coverage that didn't exist before — the helpers were only reached via `LogscanAnalyzer` integration tests.

## Impact

- `modules/logscan.py`: **3291 → 3271** (-20)
- `modules/logscan_pms_versions.py`: NEW 72 lines
- `tests/test_logscan_pms_versions.py`: NEW 118 lines

## Sprint context

Sprint 3 begins. **`logscan.py` is 5x over the 600-line target** and has 60+ methods. This warm-up handles the smallest self-contained chunk. Next targets:

- `extract_finished_runs` / `extract_last_lines` / `format_contiguous_lines` (~100-line cluster around L471-575)
- `extract_maintenance_summary` / `extract_quiet_period_summary` (~250 lines)
- `make_recommendations` mega-method (~1100 lines — biggest single method in the class)
- `extract_progress` (~640 lines)

## Verification

- All **1104 tests pass** (23 new + 1081 existing)
- Ruff + black clean