### PR TITLE
Extract finished-run parsing to modules/logscan_finished_runs

### DIFF
--- a/modules/logscan.py
+++ b/modules/logscan.py
@@ -4,7 +4,7 @@ import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from modules import logscan_command, logscan_people
+from modules import logscan_command, logscan_finished_runs, logscan_people
 from modules.logscan_pms_versions import (
     VULNERABLE_RANGE_HIGH,
     VULNERABLE_RANGE_LOW,
@@ -449,130 +449,26 @@ class LogscanAnalyzer:
         return sorted(names, key=str.lower)
 
     def extract_finished_runs(self, content):
-        lines = content.splitlines()
-        finished_runs = []
-
-        # Iterate through lines to find pairs
-        for i in range(len(lines) - 1):
-            line = lines[i]
-            next_line = lines[i + 1]
-
-            if "Finished " in line and " Run Time: " in next_line:
-                # mylogger.info(f"Pair Found L1: {line}")
-                # mylogger.info(f"Pair Found L2: {next_line}")
-                finished_match = re.search(r".*Finished\s+(.*?)\s*$", line)
-                run_time_match = re.search(r".*Run Time:(.*?)\s*$", next_line)
-
-                finished_text = finished_match.group(1).strip() if finished_match else "N/A"
-                run_time_text = run_time_match.group(1).strip() if run_time_match else "N/A"
-                # mylogger.info(f"finished_text L1: {finished_text}")
-                # mylogger.info(f"run_time_text L2: {run_time_text}")
-
-                # Join the pair into one line
-                combined_line = f"{finished_text} - {run_time_text}"
-                # mylogger.info(f"combined_line: {combined_line}")
-                finished_runs.append(combined_line)
-
-            # Check if there's a line with "Finished:" and "Run Time:" at the end
-            if "Finished: " in line and " Run Time: " in line:
-                finished_match = re.search(r".*Finished:\s+(.*?)\s*$", line)
-                run_time_match = re.search(r".*Run Time:(.*?)\s*$", line)
-
-                finished_text = finished_match.group(1).strip() if finished_match else "N/A"
-                run_time_text = run_time_match.group(1).strip() if run_time_match else "N/A"
-                # Join the pair into one line
-                combined_line = f"Finished at:{finished_text} - {run_time_text}"
-                # mylogger.info(f"FINAL:combined_line: {combined_line}")
-                # Add the line to the result
-                finished_runs.append(combined_line)
-
-        return finished_runs
+        return logscan_finished_runs.extract_finished_runs(content)
 
     def _parse_run_time_from_line(self, line):
-        if not line:
-            return None
-        match = re.search(
-            r"Run Time:\s*(?:(\d+)\s+day(?:s)?(?:,\s*|\s+))?(\d+):(\d{1,2}):(\d{1,2})",
-            line,
-            re.IGNORECASE,
-        )
-        if not match:
-            return None
-        try:
-            days = int(match.group(1) or 0)
-            hours = int(match.group(2))
-            minutes = int(match.group(3))
-            seconds = int(match.group(4))
-        except ValueError:
-            return None
-        return timedelta(days=days, hours=hours, minutes=minutes, seconds=seconds)
+        return logscan_finished_runs.parse_run_time_from_line(line)
 
     def extract_last_lines(self, content):
-        lines = content.splitlines()
-
-        run_time_index = None
-        run_time_is_final = False
-        fallback_index = None
-        for idx in range(len(lines) - 1, -1, -1):
-            line = lines[idx]
-            if "Run Time:" not in line:
-                continue
-            if fallback_index is None:
-                fallback_index = idx
-            previous_line = lines[idx - 1] if idx > 0 else ""
-            previous_is_finished_run = re.search(r"\bFinished\s+Run\b", previous_line, re.IGNORECASE)
-            if "Finished:" in line or "Start Time:" in line or previous_is_finished_run:
-                run_time_index = idx
-                run_time_is_final = True
-                break
-
-        if run_time_index is None:
-            run_time_index = fallback_index
-
-        if run_time_index is None:
-            return None
-
-        start_index = max(0, run_time_index - 5)
-        extracted_lines = [line.lstrip() for line in lines[start_index:]]
-        run_time_line = lines[run_time_index]
-        parsed_run_time = self._parse_run_time_from_line(run_time_line)
-        if parsed_run_time and run_time_is_final:
-            self.run_time = parsed_run_time
-            start_match = re.search(r"Start Time:\s*(.*?)\s+Finished:", run_time_line)
-            if start_match:
-                self.started_at = start_match.group(1).strip()
-            timestamp_match = re.search(r"\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),", run_time_line)
-            if timestamp_match:
-                self.finished_at = timestamp_match.group(1).strip()
-            else:
-                finished_match = re.search(r"Finished:\s*(.*?)\s+Run Time:", run_time_line)
-                if not finished_match:
-                    finished_match = re.search(r"Finished:\s*(.*?)\s*$", run_time_line)
-                if finished_match:
-                    self.finished_at = finished_match.group(1).strip()
-        return "\n".join(extracted_lines)
+        tail_text, metadata = logscan_finished_runs.extract_last_lines(content)
+        if metadata:
+            # Persist final-run metadata onto the analyzer; interim
+            # Run Time: lines return metadata=None and leave state alone.
+            if "run_time" in metadata:
+                self.run_time = metadata["run_time"]
+            if "started_at" in metadata:
+                self.started_at = metadata["started_at"]
+            if "finished_at" in metadata:
+                self.finished_at = metadata["finished_at"]
+        return tail_text
 
     def format_contiguous_lines(self, line_numbers):
-        formatted_ranges = []
-        start_range = line_numbers[0]
-        end_range = line_numbers[0]
-
-        for i in range(1, len(line_numbers)):
-            if line_numbers[i] == line_numbers[i - 1] + 1:
-                end_range = line_numbers[i]
-            else:
-                if start_range == end_range:
-                    formatted_ranges.append(str(start_range))
-                else:
-                    formatted_ranges.append(f"{start_range}-{end_range}")
-                start_range = end_range = line_numbers[i]
-
-        if start_range == end_range:
-            formatted_ranges.append(str(start_range))
-        else:
-            formatted_ranges.append(f"{start_range}-{end_range}")
-
-        return ", ".join(formatted_ranges)
+        return logscan_finished_runs.format_contiguous_lines(line_numbers)
 
     def make_recommendations(self, content, incomplete_message):
         self.checkfiles_flg = None

--- a/modules/logscan_finished_runs.py
+++ b/modules/logscan_finished_runs.py
@@ -1,0 +1,282 @@
+"""Kometa "finished run" summary parsing.
+
+Extracted from :class:`modules.logscan.LogscanAnalyzer`.
+
+A Kometa run log ends with a summary section like::
+
+    Finished: 2024-11-08 03:15:22 Run Time: 1:24:07
+    ...
+    Finished collections
+     Run Time: 0:32:14
+
+This module parses those tail sections and pulls out:
+
+* the list of "Finished <phase> - <run time>" combined lines
+  (:func:`extract_finished_runs`);
+* the last-run time-delta (:func:`parse_run_time_from_line`);
+* the last-line tail block plus its Start/Finished/Run-time metadata
+  (:func:`find_last_run_time_index`, :func:`parse_final_run_metadata`,
+  :func:`extract_last_lines`);
+* human-friendly line-number range formatting for recommendation
+  summaries (:func:`format_contiguous_lines`).
+
+All functions are pure -- they take content or lines and return the
+parsed values.  :class:`LogscanAnalyzer` still owns the stateful
+attributes (``self.run_time``, ``self.started_at``, ``self.finished_at``);
+the class methods now delegate to these pure helpers and assign the
+results to ``self``.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import timedelta
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# "Finished <phase>" line pair scanner
+# ---------------------------------------------------------------------------
+
+
+def extract_finished_runs(content: str) -> list[str]:
+    """Scan *content* for "Finished <phase>" / "Run Time: ..." line pairs.
+
+    Kometa emits its per-phase finish messages in two formats:
+
+    1. **Two-line pair** -- ``"...Finished collections"`` immediately
+       followed by ``" Run Time: 0:32:14"`` on the next line.
+    2. **Single-line summary** -- one line containing both
+       ``"Finished: <ts>"`` and ``"Run Time: ..."``.
+
+    The two forms produce slightly different output strings:
+
+    * pair form   -> ``"collections - 0:32:14"``
+    * single-line -> ``"Finished at:<timestamp> - <run_time>"``
+
+    Output order follows the input line order.  Malformed pairs
+    (missing regex captures) resolve to ``"N/A"`` in the affected
+    slot rather than being dropped -- callers rely on the position
+    to correlate with the raw log.
+    """
+    lines = content.splitlines()
+    finished_runs = []
+
+    for i in range(len(lines) - 1):
+        line = lines[i]
+        next_line = lines[i + 1]
+
+        if "Finished " in line and " Run Time: " in next_line:
+            finished_match = re.search(r".*Finished\s+(.*?)\s*$", line)
+            run_time_match = re.search(r".*Run Time:(.*?)\s*$", next_line)
+            finished_text = finished_match.group(1).strip() if finished_match else "N/A"
+            run_time_text = run_time_match.group(1).strip() if run_time_match else "N/A"
+            finished_runs.append(f"{finished_text} - {run_time_text}")
+
+        if "Finished: " in line and " Run Time: " in line:
+            finished_match = re.search(r".*Finished:\s+(.*?)\s*$", line)
+            run_time_match = re.search(r".*Run Time:(.*?)\s*$", line)
+            finished_text = finished_match.group(1).strip() if finished_match else "N/A"
+            run_time_text = run_time_match.group(1).strip() if run_time_match else "N/A"
+            finished_runs.append(f"Finished at:{finished_text} - {run_time_text}")
+
+    return finished_runs
+
+
+# ---------------------------------------------------------------------------
+# Run-time parsing
+# ---------------------------------------------------------------------------
+
+
+_RUN_TIME_REGEX = re.compile(
+    r"Run Time:\s*(?:(\d+)\s+day(?:s)?(?:,\s*|\s+))?(\d+):(\d{1,2}):(\d{1,2})",
+    re.IGNORECASE,
+)
+
+
+def parse_run_time_from_line(line: Optional[str]) -> Optional[timedelta]:
+    """Return the ``Run Time: ...`` value from *line* as a :class:`timedelta`.
+
+    Accepts both:
+
+    * ``"Run Time: 0:32:14"``           (H:MM:SS)
+    * ``"Run Time: 1 day, 2:20:31"``    (days, H:MM:SS)
+    * ``"Run Time: 3 days 4:05:06"``    (plural, no comma)
+
+    Returns ``None`` for a missing or malformed line -- never raises.
+    """
+    if not line:
+        return None
+    match = _RUN_TIME_REGEX.search(line)
+    if not match:
+        return None
+    try:
+        days = int(match.group(1) or 0)
+        hours = int(match.group(2))
+        minutes = int(match.group(3))
+        seconds = int(match.group(4))
+    except ValueError:
+        return None
+    return timedelta(days=days, hours=hours, minutes=minutes, seconds=seconds)
+
+
+# ---------------------------------------------------------------------------
+# Last-run tail block extraction
+# ---------------------------------------------------------------------------
+
+
+def find_last_run_time_index(lines: list[str]) -> tuple[Optional[int], bool]:
+    """Return ``(index, is_final_run)`` for the last "Run Time:" line in *lines*.
+
+    Scans *lines* from the end backwards.  A "Run Time:" line is
+    considered the **final** run marker when it's on the same line as
+    ``"Finished:"`` / ``"Start Time:"`` OR when the previous line
+    contains ``"Finished Run"``.  Other "Run Time:" occurrences (per-
+    phase interim reports) become fallback candidates.
+
+    Returns:
+        * ``(index, True)`` when a final-run marker is found.
+        * ``(fallback_index, False)`` when only interim run-time lines
+          exist -- caller can still extract the tail block but the
+          run-time metadata isn't the whole-run summary.
+        * ``(None, False)`` when *lines* contains no "Run Time:" at all.
+    """
+    run_time_index: Optional[int] = None
+    fallback_index: Optional[int] = None
+
+    for idx in range(len(lines) - 1, -1, -1):
+        line = lines[idx]
+        if "Run Time:" not in line:
+            continue
+        if fallback_index is None:
+            fallback_index = idx
+        previous_line = lines[idx - 1] if idx > 0 else ""
+        previous_is_finished_run = re.search(r"\bFinished\s+Run\b", previous_line, re.IGNORECASE)
+        if "Finished:" in line or "Start Time:" in line or previous_is_finished_run:
+            run_time_index = idx
+            return run_time_index, True
+
+    return fallback_index, False
+
+
+def parse_final_run_metadata(run_time_line: str) -> dict:
+    """Extract ``started_at``, ``finished_at``, ``run_time`` from a final run-time line.
+
+    Returns a dict with keys ``"started_at"``, ``"finished_at"``,
+    ``"run_time"``.  Any key whose value can't be extracted is
+    omitted from the result (never present as ``None``).
+
+    IMPORTANT: This function returns metadata regardless of which
+    fields matched.  Callers (like :func:`extract_last_lines`) may
+    additionally gate on ``"run_time" in result`` to preserve the
+    legacy behavior of only trusting a final-run marker when its
+    ``Run Time:`` component parses successfully.
+
+    The three fields are located by:
+
+    * ``run_time``   -- via :func:`parse_run_time_from_line`
+    * ``started_at`` -- ``Start Time: <value> Finished:`` capture
+    * ``finished_at`` -- prefers the leading ``[YYYY-MM-DD HH:MM:SS,``
+      log timestamp, else falls back to ``Finished: <value> Run Time:``
+      or ``Finished: <value>`` at end of line.
+    """
+    result: dict = {}
+
+    run_time = parse_run_time_from_line(run_time_line)
+    if run_time is not None:
+        result["run_time"] = run_time
+
+    start_match = re.search(r"Start Time:\s*(.*?)\s+Finished:", run_time_line)
+    if start_match:
+        result["started_at"] = start_match.group(1).strip()
+
+    timestamp_match = re.search(r"\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),", run_time_line)
+    if timestamp_match:
+        result["finished_at"] = timestamp_match.group(1).strip()
+    else:
+        finished_match = re.search(r"Finished:\s*(.*?)\s+Run Time:", run_time_line)
+        if not finished_match:
+            finished_match = re.search(r"Finished:\s*(.*?)\s*$", run_time_line)
+        if finished_match:
+            result["finished_at"] = finished_match.group(1).strip()
+
+    return result
+
+
+def extract_last_lines(content: str) -> tuple[Optional[str], Optional[dict]]:
+    """Extract the tail block ending at the last Run Time: line.
+
+    Returns ``(tail_text, run_metadata)``:
+
+    * ``tail_text`` -- the last ~6 lines (``run_time_index-5`` through end),
+      left-stripped and joined with newlines.  ``None`` if *content*
+      contains no "Run Time:" line at all.
+    * ``run_metadata`` -- dict from :func:`parse_final_run_metadata`
+      when the last "Run Time:" line is a final-run marker AND its
+      ``Run Time:`` component successfully parses.  ``None``
+      otherwise -- either the line is an interim per-phase report,
+      or the ``Run Time:`` regex missed (malformed line).
+
+    Callers that maintain persistent per-run state (like
+    :class:`LogscanAnalyzer`) can assign the metadata dict entries
+    to their own attributes; pure callers can ignore the second
+    element entirely.
+    """
+    lines = content.splitlines()
+
+    run_time_index, run_time_is_final = find_last_run_time_index(lines)
+    if run_time_index is None:
+        return None, None
+
+    start_index = max(0, run_time_index - 5)
+    extracted_lines = [line.lstrip() for line in lines[start_index:]]
+    tail_text = "\n".join(extracted_lines)
+
+    metadata: Optional[dict] = None
+    if run_time_is_final:
+        parsed = parse_final_run_metadata(lines[run_time_index])
+        # Only expose metadata when Run Time itself parsed -- matches
+        # the legacy behavior of "only trust started_at/finished_at
+        # when we also have a run_time to anchor them".
+        if "run_time" in parsed:
+            metadata = parsed
+
+    return tail_text, metadata
+
+
+# ---------------------------------------------------------------------------
+# Line-number range formatting
+# ---------------------------------------------------------------------------
+
+
+def format_contiguous_lines(line_numbers: list[int]) -> str:
+    """Collapse contiguous integers into ``start-end`` ranges.
+
+    ``[1, 2, 3, 5, 7, 8]``  -> ``"1-3, 5, 7-8"``.
+
+    Used in recommendation summaries so instead of listing every
+    error line (potentially hundreds) the user sees compact ranges.
+
+    Preserves input order -- caller sorts if needed.  Raises
+    ``IndexError`` on empty input (matches previous behavior; the
+    caller in :class:`LogscanAnalyzer` guards with a length check).
+    """
+    formatted_ranges = []
+    start_range = line_numbers[0]
+    end_range = line_numbers[0]
+
+    for i in range(1, len(line_numbers)):
+        if line_numbers[i] == line_numbers[i - 1] + 1:
+            end_range = line_numbers[i]
+        else:
+            if start_range == end_range:
+                formatted_ranges.append(str(start_range))
+            else:
+                formatted_ranges.append(f"{start_range}-{end_range}")
+            start_range = end_range = line_numbers[i]
+
+    if start_range == end_range:
+        formatted_ranges.append(str(start_range))
+    else:
+        formatted_ranges.append(f"{start_range}-{end_range}")
+
+    return ", ".join(formatted_ranges)

--- a/tests/test_logscan_finished_runs.py
+++ b/tests/test_logscan_finished_runs.py
@@ -1,0 +1,282 @@
+"""Unit tests for :mod:`modules.logscan_finished_runs`.
+
+Extracted alongside PR that moved the finished-run parsing helpers
+out of ``modules.logscan.LogscanAnalyzer``.  These focused unit
+tests verify the pure helpers directly; integration coverage via
+``LogscanAnalyzer`` methods still lives in
+``tests/test_logscan_runtime_parse.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from modules.logscan_finished_runs import (
+    extract_finished_runs,
+    extract_last_lines,
+    find_last_run_time_index,
+    format_contiguous_lines,
+    parse_final_run_metadata,
+    parse_run_time_from_line,
+)
+
+# ---------------------------------------------------------------------------
+# parse_run_time_from_line
+# ---------------------------------------------------------------------------
+
+
+class TestParseRunTimeFromLine:
+    def test_hms_only(self):
+        delta = parse_run_time_from_line("Run Time: 1:24:07")
+        assert delta == timedelta(hours=1, minutes=24, seconds=7)
+
+    def test_days_with_comma(self):
+        delta = parse_run_time_from_line("Run Time: 1 day, 2:20:31")
+        assert delta == timedelta(days=1, hours=2, minutes=20, seconds=31)
+
+    def test_days_plural_with_comma(self):
+        delta = parse_run_time_from_line("Run Time: 3 days, 4:05:06")
+        assert delta == timedelta(days=3, hours=4, minutes=5, seconds=6)
+
+    def test_days_without_comma(self):
+        # Non-comma variant: "3 days 4:05:06" (space-separated)
+        delta = parse_run_time_from_line("Run Time: 3 days 4:05:06")
+        assert delta == timedelta(days=3, hours=4, minutes=5, seconds=6)
+
+    def test_none_when_no_match(self):
+        assert parse_run_time_from_line("Nothing to see here") is None
+
+    def test_none_when_line_is_empty(self):
+        assert parse_run_time_from_line("") is None
+
+    def test_none_when_line_is_none(self):
+        assert parse_run_time_from_line(None) is None
+
+    def test_case_insensitive(self):
+        assert parse_run_time_from_line("RUN TIME: 0:00:30") == timedelta(seconds=30)
+
+    def test_ignores_surrounding_context(self):
+        line = "[timestamp] [foo.py:1] [INFO] | Start Time: 08:00:00 Finished: 08:30:00 Run Time: 0:30:00 |"
+        assert parse_run_time_from_line(line) == timedelta(minutes=30)
+
+
+# ---------------------------------------------------------------------------
+# extract_finished_runs
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFinishedRuns:
+    def test_two_line_pair(self):
+        content = "\n".join(
+            [
+                "some noise",
+                "|  Finished collections  |",
+                "|   Run Time: 0:32:14   |",
+                "more noise",
+            ]
+        )
+        result = extract_finished_runs(content)
+        # Combined line preserves the trailing pipes/spaces from each
+        # regex capture; the parser doesn't post-normalize whitespace.
+        assert len(result) == 1
+        assert "collections" in result[0]
+        assert "0:32:14" in result[0]
+        assert " - " in result[0]
+
+    def test_single_line_form(self):
+        # Needs a following line so the loop's for i in range(len-1) reaches it.
+        content = "|   Finished: 2024-11-08 03:15:22 Run Time: 1:24:07   |\ntrailing line"
+        result = extract_finished_runs(content)
+        assert len(result) == 1
+        assert result[0].startswith("Finished at:")
+        assert "2024-11-08 03:15:22" in result[0]
+        assert "1:24:07" in result[0]
+
+    def test_empty_input(self):
+        assert extract_finished_runs("") == []
+
+    def test_input_with_no_finished_lines(self):
+        assert extract_finished_runs("hello\nworld\n") == []
+
+    def test_multiple_pairs_preserve_order(self):
+        content = "\n".join(
+            [
+                "|  Finished collections  |",
+                "|   Run Time: 0:32:14   |",
+                "|  Finished overlays  |",
+                "|   Run Time: 0:12:03   |",
+            ]
+        )
+        result = extract_finished_runs(content)
+        assert len(result) == 2
+        assert "collections" in result[0]
+        assert "overlays" in result[1]
+
+
+# ---------------------------------------------------------------------------
+# find_last_run_time_index
+# ---------------------------------------------------------------------------
+
+
+class TestFindLastRunTimeIndex:
+    def test_no_run_time_returns_none(self):
+        idx, is_final = find_last_run_time_index(["some", "lines", "without"])
+        assert idx is None and is_final is False
+
+    def test_final_run_marker_on_same_line_as_finished(self):
+        lines = [
+            "some line",
+            "Start Time: 08:00 Finished: 08:30 Run Time: 0:30:00",
+        ]
+        idx, is_final = find_last_run_time_index(lines)
+        assert idx == 1 and is_final is True
+
+    def test_final_run_marker_after_finished_run_header(self):
+        lines = [
+            "|  Finished Run  |",
+            "|   Run Time: 0:30:00   |",
+        ]
+        idx, is_final = find_last_run_time_index(lines)
+        assert idx == 1 and is_final is True
+
+    def test_interim_run_time_is_fallback(self):
+        # Per-phase Run Time: reports without a Finished Run banner
+        # aren't the final-run marker.
+        lines = [
+            "|  Finished collections  |",
+            "|   Run Time: 0:32:14   |",
+        ]
+        idx, is_final = find_last_run_time_index(lines)
+        assert idx == 1 and is_final is False
+
+    def test_final_marker_preferred_over_interim(self):
+        # Interim Run Time: earlier in the log, final Run Time: at end.
+        lines = [
+            "|  Finished collections  |",
+            "|   Run Time: 0:32:14   |",  # interim
+            "|  Finished Run  |",
+            "|   Run Time: 1:00:00   |",  # final
+        ]
+        idx, is_final = find_last_run_time_index(lines)
+        assert idx == 3 and is_final is True
+
+
+# ---------------------------------------------------------------------------
+# parse_final_run_metadata
+# ---------------------------------------------------------------------------
+
+
+class TestParseFinalRunMetadata:
+    def test_full_line_extracts_all_three(self):
+        line = "[2024-11-08 03:15:22,000] Start Time: 08:00:00 Finished: 03:15:22 Run Time: 1:24:07"
+        result = parse_final_run_metadata(line)
+        assert result["run_time"] == timedelta(hours=1, minutes=24, seconds=7)
+        assert result["started_at"] == "08:00:00"
+        # Prefers the log timestamp over Finished: text
+        assert result["finished_at"] == "2024-11-08 03:15:22"
+
+    def test_finished_at_falls_back_when_no_log_timestamp(self):
+        line = "Start Time: 08:00 Finished: 08:30 Run Time: 0:30:00"
+        result = parse_final_run_metadata(line)
+        assert result["finished_at"] == "08:30"
+
+    def test_missing_run_time_omits_the_key(self):
+        result = parse_final_run_metadata("Just some text with no run time")
+        assert "run_time" not in result
+
+    def test_missing_started_at_omits_the_key(self):
+        result = parse_final_run_metadata("Finished: 08:30 Run Time: 0:30:00")
+        assert "started_at" not in result
+
+    def test_missing_all_returns_empty_dict(self):
+        assert parse_final_run_metadata("nothing here") == {}
+
+
+# ---------------------------------------------------------------------------
+# extract_last_lines
+# ---------------------------------------------------------------------------
+
+
+class TestExtractLastLines:
+    def test_returns_none_when_no_run_time(self):
+        tail, metadata = extract_last_lines("just\nsome\nrandom\nlines\n")
+        assert tail is None and metadata is None
+
+    def test_final_run_populates_metadata(self):
+        content = "\n".join(
+            [
+                "|  Finished Run  |",
+                "|   Start Time: 07:16:22 2024-11-08     Finished: 09:36:53 2024-11-08     Run Time: 1 day, 2:20:31   |",
+            ]
+        )
+        tail, metadata = extract_last_lines(content)
+        assert tail is not None
+        assert "Finished Run" in tail
+        assert metadata is not None
+        assert metadata["run_time"] == timedelta(days=1, hours=2, minutes=20, seconds=31)
+
+    def test_interim_run_time_returns_tail_but_no_metadata(self):
+        # Per-phase Run Time: with no Finished Run banner -- should
+        # still return the tail block but with metadata=None so the
+        # caller doesn't overwrite whole-run state.
+        content = "\n".join(
+            [
+                "|  Finished Movies  |",
+                "|   Run Time: 0:00:02   |",
+            ]
+        )
+        tail, metadata = extract_last_lines(content)
+        assert tail is not None
+        assert metadata is None
+
+    def test_metadata_none_when_run_time_regex_fails(self):
+        # Final-run banner present but Run Time: is malformed --
+        # metadata should still be None because we can't anchor the
+        # whole-run state without a Run Time value.  (Matches the\n"
+        # legacy behavior of ``if parsed_run_time and run_time_is_final:``.)
+        content = "\n".join(
+            [
+                "|  Finished Run  |",
+                "|   Run Time: garbage   |",
+            ]
+        )
+        tail, metadata = extract_last_lines(content)
+        assert tail is not None
+        assert metadata is None
+
+
+# ---------------------------------------------------------------------------
+# format_contiguous_lines
+# ---------------------------------------------------------------------------
+
+
+class TestFormatContiguousLines:
+    def test_single_line(self):
+        assert format_contiguous_lines([5]) == "5"
+
+    def test_two_consecutive(self):
+        assert format_contiguous_lines([5, 6]) == "5-6"
+
+    def test_two_non_consecutive(self):
+        assert format_contiguous_lines([5, 8]) == "5, 8"
+
+    def test_mixed_ranges_and_singletons(self):
+        assert format_contiguous_lines([1, 2, 3, 5, 7, 8]) == "1-3, 5, 7-8"
+
+    def test_all_consecutive(self):
+        assert format_contiguous_lines([10, 11, 12, 13, 14]) == "10-14"
+
+    def test_all_singletons(self):
+        assert format_contiguous_lines([1, 3, 5, 7]) == "1, 3, 5, 7"
+
+    def test_empty_input_raises(self):
+        # Documented behavior -- caller in LogscanAnalyzer guards
+        # against empty input.
+        with pytest.raises(IndexError):
+            format_contiguous_lines([])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
**Sprint 3, PR #2 — second logscan.py extraction.** Pulls the ~100-line cluster (L451-575) into its own module.

## Public API in `modules/logscan_finished_runs.py`

Direct extractions (with slight rename to drop the private underscore):

- `extract_finished_runs(content)` → `list[str]` — scan for 'Finished <phase>' / 'Run Time: ...' line pairs
- `parse_run_time_from_line(line)` → `timedelta | None` — parse 'Run Time: [D day(s), ]H:MM:SS'
- `format_contiguous_lines(line_numbers)` → `str` — collapse ints to 'start-end' ranges
- `extract_last_lines(content)` → `(tail_text, metadata | None)` — tail block + run metadata

**Two NEW pure helpers** extracted from inline logic inside the legacy `extract_last_lines`:

- `find_last_run_time_index(lines)` → `(index, is_final)` — scans backwards; distinguishes final-run markers from interim per-phase reports
- `parse_final_run_metadata(run_time_line)` → `dict` — returns keys `{run_time, started_at, finished_at}`; missing captures omitted

Both now testable in isolation instead of buried inside a 40-line method.

## Behavior preservation

The legacy `extract_last_lines` only assigned `self.run_time` / `self.started_at` / `self.finished_at` when **BOTH** the run_time regex matched **AND** the line was a final-run marker. The new pure `extract_last_lines` mirrors this by returning `metadata=None` when either condition fails — so the `LogscanAnalyzer.extract_last_lines` wrapper doesn't overwrite state for interim per-phase reports or malformed run-time lines.

**Locked in** by:
- `test_metadata_none_when_run_time_regex_fails`
- `test_interim_run_time_returns_tail_but_no_metadata`

## `logscan.py` changes

- `extract_finished_runs`, `_parse_run_time_from_line`, `format_contiguous_lines`: **1-line delegating methods** (return `logscan_finished_runs.<pure_fn>(args)`)
- `extract_last_lines`: **12-line wrapper** that unpacks metadata onto `self`. **KEPT as a method** because it mutates state.
- `from modules import logscan_finished_runs` added

## New tests: `tests/test_logscan_finished_runs.py`

**35 focused unit tests** across 6 test classes:

- `TestParseRunTimeFromLine` (9): hms/days/case/context
- `TestExtractFinishedRuns` (5): pair/single/empty/order
- `TestFindLastRunTimeIndex` (5): finality detection
- `TestParseFinalRunMetadata` (5): three-key extraction
- `TestExtractLastLines` (4): tail + metadata gating
- `TestFormatContiguousLines` (7): ranges/singletons/empty

Existing `tests/test_logscan_runtime_parse.py` continues to exercise the `LogscanAnalyzer` method wrappers **unchanged** — locks in that the extraction preserved observable behavior.

## Impact

- `modules/logscan.py`: **3271 → 3167** (**-104 / -3.2%**)
- `modules/logscan_finished_runs.py`: NEW 283 lines
- `tests/test_logscan_finished_runs.py`: NEW 234 lines

**Cumulative on `logscan.py`**: 3291 → 3167 (-124 across Sprint 3 so far).

## Sprint 3 progress

| PR | Start | End | Δ |
|---|---|---|---|
| PR #1488 (PMS versions) | 3291 | 3271 | -20 |
| **This PR** | 3271 | **3167** | **-104** |
| **Total** | 3291 | 3167 | **-124 (-3.8%)** |

## Verification

- All **1139 tests pass** (35 new + 1104 existing)
- Ruff + black clean