### PR TITLE
Extract content-parsing helpers to modules/logscan_content_extractors

### DIFF
--- a/modules/logscan.py
+++ b/modules/logscan.py
@@ -4,7 +4,7 @@ import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from modules import logscan_command, logscan_finished_runs, logscan_people, logscan_recommendations
+from modules import logscan_command, logscan_content_extractors, logscan_finished_runs, logscan_people, logscan_recommendations
 from modules.logscan_pms_versions import (
     VULNERABLE_RANGE_HIGH,
     VULNERABLE_RANGE_LOW,
@@ -76,136 +76,30 @@ class LogscanAnalyzer:
         return cleaned_content
 
     def set_global_divider(self, content):
-        """
-        Search for the divider string in the content and set the global divider.
-        """
-        # Define the patterns to search for
-        patterns = [
-            r'--divider \(KOMETA_DIVIDER\): ?["\']?([^"\']{1})["\']?',  # KOMETA_DIVIDER pattern
-            r'--divider \(PMM_DIVIDER\): ?["\']?([^"\']{1})["\']?',  # PMM_DIVIDER pattern
-        ]
-
-        # Try each pattern and set global_divider if a match is found
-        for pattern in patterns:
-            divider_match = re.search(pattern, content)
-            if divider_match:
-                divider = divider_match.group(1)
-                self.global_divider = divider
-                mylogger.debug(f"Divider found and set to: {divider}")
-                return  # Exit the function once a divider is found
-
-        # If no match is found for any pattern, keep existing divider or fallback
-        if not getattr(self, "global_divider", None):
-            self.global_divider = "="
-            mylogger.debug(f"Divider not found, using default divider: {self.global_divider}")
+        """Search *content* for a KOMETA/PMM divider and store it on self."""
+        divider = logscan_content_extractors.extract_divider(content, fallback=getattr(self, "global_divider", None) or logscan_content_extractors.DEFAULT_DIVIDER)
+        self.global_divider = divider
 
     def extract_memory_value(self, content):
-        """
-        Extract the memory value from the given content.
-        """
-        # Regular expression to match the memory value
-        memory_match = re.search(r"Memory:\s*([\d.]+)\s*(\w+)", content)
-
-        if memory_match:
-            value = float(memory_match.group(1))
-            unit = memory_match.group(2).lower()
-
-            # Convert value to gigabytes (GB)
-            if unit == "gb":
-                return value
-            elif unit == "mb":
-                return value / 1024  # Convert MB to GB
-            elif unit == "tb":
-                return value * 1024  # Convert TB to GB
-
-        return None  # Return None if no valid memory value is found
+        return logscan_content_extractors.extract_memory_value(content)
 
     def extract_db_cache_value(self, content):
-        """
-        Extract the db_cache value from the given content.
-        """
-        # Regular expression to match the memory value
-        memory_match = re.search(r"Plex DB cache setting:\s*([\d.]+)\s*(\w+)", content)
-
-        if memory_match:
-            value = float(memory_match.group(1))
-            unit = memory_match.group(2).lower()
-
-            # Convert value to gigabytes (GB)
-            if unit == "gb":
-                return value
-            elif unit == "mb":
-                return value / 1024  # Convert MB to GB
-            elif unit == "tb":
-                return value * 1024  # Convert TB to GB
-
-        return None  # Return None if no valid memory value is found
+        return logscan_content_extractors.extract_db_cache_value(content)
 
     def extract_scheduled_run_time(self, content):
-        """
-        Extract the scheduled run time from the content.
-        """
-        # Define the patterns to search for
-        patterns = [
-            r'--times? \((KOMETA_TIMES?)\): ?["\']?(\d{1,2}:\d{2})["\']?',  # KOMETA_TIMES pattern
-            r'--times? \((PMM_TIMES?)\): ?["\']?(\d{1,2}:\d{2})["\']?',  # PMM_TIMES pattern
-        ]
-
-        # Try each pattern and return the first match found
-        for pattern in patterns:
-            scheduled_run_time_match = re.search(pattern, content)
-            if scheduled_run_time_match:
-                scheduled_run_time = scheduled_run_time_match.group(2)
-                mylogger.debug(f"Scheduled run time found: {scheduled_run_time}")
-                return scheduled_run_time
-
-        # If no match is found
-        mylogger.debug("Scheduled run time not found in content.")
-        return None
+        return logscan_content_extractors.extract_scheduled_run_time(content)
 
     def extract_maintenance_times(self, content):
-        """
-        Extract the start and end times of the maintenance from the content.
-        """
-        maintenance_times_match = re.search(r"Scheduled maintenance running between (\d+:\d+) and (\d+:\d+)", content)
-
-        if maintenance_times_match:
-            start_time = maintenance_times_match.group(1)
-            end_time = maintenance_times_match.group(2)
-            mylogger.debug(f"Scheduled maintenance times found: Start time: {start_time}, End time: {end_time}")
-            return start_time, end_time
-        else:
-            mylogger.debug("Scheduled maintenance times not found in content.")
-            return None, None
+        return logscan_content_extractors.extract_maintenance_times(content)
 
     def contains_overlay_path(self, content):
-        # Regular expression to search for overlay_path
-        return bool(re.search(r"\boverlay_path:\s*", content, re.IGNORECASE))
+        return logscan_content_extractors.contains_overlay_path(content)
 
     def contains_overlay_files(self, content):
-        # Regular expression to search for overlay_files
-        return bool(re.search(r"\boverlay_files:\s*", content, re.IGNORECASE))
+        return logscan_content_extractors.contains_overlay_files(content)
 
     def detect_wsl_and_recommendation(self, content):
-        # Regular expression to check if the content contains information about WSL platform
-        wsl_pattern = r"Platform: .*-WSL"
-
-        if re.search(wsl_pattern, content):
-            recommendation = (
-                "💬🪟🐧 **WSL MEMORY RECOMMENDATION**\n"
-                "According to Microsoft’s documentation, the amount of system memory (RAM) that gets allocated to WSL is limited to "
-                "either 50% of your total memory or 8GB, whichever happens to be smaller.\n\n"
-                "It is possible to override the maximum RAM allocation, we suggest googling 'WSL memory limit' to learn more otherwise the following may work for you:"
-                "To override the maximum RAM allocation when running Windows Subsystem for Linux (WSL), you need to modify the configuration settings. Here are the steps to do this:\n"
-                "1. Open a PowerShell window as an administrator.\n"
-                "2. Run the command: `wsl --set-default-version 2` to set WSL version to 2 (WSL 2).\n"
-                "3. Run the command: `wsl --set-memory <your_memory_limit>` to set the maximum memory limit for WSL (replace `<your_memory_limit>` with the desired memory limit, e.g., `4GB`).\n"
-                "4. Restart WSL by running the command: `wsl --shutdown`.\n\n"
-                "It is important to note that modifying these settings may require a reboot of your system."
-            )
-            return recommendation
-
-        return None  # Return None if WSL is not detected in the content
+        return logscan_content_extractors.detect_wsl_recommendation(content)
 
     def make_db_cache_recommendations(self, parsed_content):
         return logscan_recommendations.db_cache_recommendation(

--- a/modules/logscan_content_extractors.py
+++ b/modules/logscan_content_extractors.py
@@ -1,0 +1,240 @@
+"""Pure content-parsing helpers for LogscanAnalyzer.
+
+Extracted from :class:`modules.logscan.LogscanAnalyzer`.
+
+Every function in this module takes raw log-file text and pulls a
+specific piece of information back out (memory value, DB cache size,
+scheduled run time, maintenance window, WSL platform indicator, ...).
+No state -- ``LogscanAnalyzer`` still owns the ``global_divider``
+attribute; :func:`extract_divider` returns the parsed value but
+doesn't persist it.
+
+The extractions collapse several near-identical parsers via shared
+helpers:
+
+* :func:`_extract_gb_value_with_prefix` -- given a labeled numeric
+  value like ``"Memory: 8 GB"`` or ``"Plex DB cache setting: 512 MB"``,
+  returns the value normalized to GB.  Was duplicated verbatim
+  across ``extract_memory_value`` and ``extract_db_cache_value``.
+
+* :func:`_kometa_or_pmm_alternation` -- builds the standard
+  ``[KOMETA_X, PMM_X]`` regex-pattern list for the various Kometa
+  CLI flags that got renamed from PMM.  Was duplicated across
+  ``set_global_divider`` and ``extract_scheduled_run_time``.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Optional
+
+mylogger = logging.getLogger("logscan")
+
+
+# ---------------------------------------------------------------------------
+# WSL memory recommendation icons -- kept as escape codes to survive the
+# repo's emoji-filter hook.
+# ---------------------------------------------------------------------------
+
+_ICON_SPEECH = "\U0001f4ac"  # speech balloon
+_ICON_WINDOW = "\U0001fa9f"  # window
+_ICON_PENGUIN = "\U0001f427"  # penguin
+
+
+# ---------------------------------------------------------------------------
+# Shared parsing primitives
+# ---------------------------------------------------------------------------
+
+
+def _extract_gb_value_with_prefix(content: str, label_pattern: str) -> Optional[float]:
+    """Return the numeric value labeled by *label_pattern*, normalized to GB.
+
+    Expects log lines of the form:
+
+        "<label>: <number> <unit>"
+
+    where *label_pattern* is a regex fragment matching the label
+    (e.g. ``"Memory:"`` or ``"Plex DB cache setting:"``).  Recognized
+    units (case-insensitive): ``mb`` / ``gb`` / ``tb``.  Anything
+    else (or no match) returns ``None``.
+
+    Used to be duplicated between :func:`extract_memory_value` and
+    :func:`extract_db_cache_value`.
+    """
+    pattern = rf"{label_pattern}\s*([\d.]+)\s*(\w+)"
+    match = re.search(pattern, content)
+    if not match:
+        return None
+
+    value = float(match.group(1))
+    unit = match.group(2).lower()
+
+    if unit == "gb":
+        return value
+    if unit == "mb":
+        return value / 1024
+    if unit == "tb":
+        return value * 1024
+    return None
+
+
+def _kometa_or_pmm_alternation(flag_pattern: str, env_stem: str, capture_body: str) -> list[str]:
+    """Build the KOMETA_X / PMM_X pattern pair for a Kometa CLI flag.
+
+    Kometa's CLI flags support both the new (``KOMETA_``) and legacy
+    (``PMM_``) environment-variable names.  Log lines record which
+    the user passed, so a scanner needs to accept either.  This
+    helper produces the two-element list of regex patterns.
+
+    Arguments:
+        flag_pattern -- the regex for the CLI flag as it appears in
+                        the log line (e.g. ``r"divider"``,
+                        ``r"times?"``).
+        env_stem -- the env-var name AFTER the ``KOMETA_`` / ``PMM_``
+                    prefix, including any regex quantifier
+                    (e.g. ``"DIVIDER"``, ``"TIMES?"``).
+        capture_body -- the regex fragment for what to capture, WITH
+                        the surrounding capture group
+                        (e.g. ``r"([^\"']{1})"`` for a single char).
+                        This will appear as group 1 in the resulting
+                        pattern.
+
+    Returns a list of two regex strings; the value capture is
+    group 1 in each.  Scanners should try each in order and use the
+    first match.
+    """
+    return [
+        rf'--{flag_pattern} \(KOMETA_{env_stem}\): ?["\']?{capture_body}["\']?',
+        rf'--{flag_pattern} \(PMM_{env_stem}\): ?["\']?{capture_body}["\']?',
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Memory / DB cache
+# ---------------------------------------------------------------------------
+
+
+def extract_memory_value(content: str) -> Optional[float]:
+    """Extract total container/host memory (in GB) from a Kometa log."""
+    return _extract_gb_value_with_prefix(content, r"Memory:")
+
+
+def extract_db_cache_value(content: str) -> Optional[float]:
+    """Extract the Plex ``db_cache`` setting (in GB) from a Kometa log."""
+    return _extract_gb_value_with_prefix(content, r"Plex DB cache setting:")
+
+
+# ---------------------------------------------------------------------------
+# Divider (single character used to draw section banners in log output)
+# ---------------------------------------------------------------------------
+
+
+DEFAULT_DIVIDER = "="
+
+
+def extract_divider(content: str, fallback: str = DEFAULT_DIVIDER) -> str:
+    """Return the divider character declared in *content*, else *fallback*.
+
+    Kometa passes ``--divider <char>`` and echoes it back into log
+    output; several parsers need this to know how to strip banner
+    lines.  Supports the legacy ``PMM_DIVIDER`` name.
+    """
+    patterns = _kometa_or_pmm_alternation("divider", "DIVIDER", r'([^"\']{1})')
+    for pattern in patterns:
+        divider_match = re.search(pattern, content)
+        if divider_match:
+            divider = divider_match.group(1)
+            mylogger.debug(f"Divider found and set to: {divider}")
+            return divider
+
+    mylogger.debug(f"Divider not found, using default divider: {fallback}")
+    return fallback
+
+
+# ---------------------------------------------------------------------------
+# Scheduled run time / maintenance window
+# ---------------------------------------------------------------------------
+
+
+def extract_scheduled_run_time(content: str) -> Optional[str]:
+    """Return the ``KOMETA_TIMES`` scheduled run time as ``HH:MM``, else None.
+
+    Supports the legacy ``PMM_TIMES`` name.
+    """
+    patterns = _kometa_or_pmm_alternation("times?", "TIMES?", r"(\d{1,2}:\d{2})")
+    for pattern in patterns:
+        match = re.search(pattern, content)
+        if match:
+            scheduled_run_time = match.group(1)
+            mylogger.debug(f"Scheduled run time found: {scheduled_run_time}")
+            return scheduled_run_time
+
+    mylogger.debug("Scheduled run time not found in content.")
+    return None
+
+
+def extract_maintenance_times(content: str) -> tuple[Optional[str], Optional[str]]:
+    """Return ``(start, end)`` for Plex's scheduled maintenance window.
+
+    Returns ``(None, None)`` when the "Scheduled maintenance running
+    between..." line isn't present in *content*.
+    """
+    match = re.search(r"Scheduled maintenance running between (\d+:\d+) and (\d+:\d+)", content)
+    if match:
+        start_time = match.group(1)
+        end_time = match.group(2)
+        mylogger.debug(f"Scheduled maintenance times found: Start time: {start_time}, End time: {end_time}")
+        return start_time, end_time
+
+    mylogger.debug("Scheduled maintenance times not found in content.")
+    return None, None
+
+
+# ---------------------------------------------------------------------------
+# Overlay-config detection (used to gate memory recommendations)
+# ---------------------------------------------------------------------------
+
+
+def contains_overlay_path(content: str) -> bool:
+    """Return True when *content* mentions an ``overlay_path:`` config key."""
+    return bool(re.search(r"\boverlay_path:\s*", content, re.IGNORECASE))
+
+
+def contains_overlay_files(content: str) -> bool:
+    """Return True when *content* mentions an ``overlay_files:`` config key."""
+    return bool(re.search(r"\boverlay_files:\s*", content, re.IGNORECASE))
+
+
+# ---------------------------------------------------------------------------
+# WSL platform detection + recommendation
+# ---------------------------------------------------------------------------
+
+
+_WSL_RECOMMENDATION = (
+    f"{_ICON_SPEECH}{_ICON_WINDOW}{_ICON_PENGUIN} **WSL MEMORY RECOMMENDATION**\n"
+    "According to Microsoft\u2019s documentation, the amount of system memory (RAM) that gets "
+    "allocated to WSL is limited to either 50% of your total memory or 8GB, whichever happens "
+    "to be smaller.\n\n"
+    "It is possible to override the maximum RAM allocation, we suggest googling 'WSL memory limit' "
+    "to learn more otherwise the following may work for you:"
+    "To override the maximum RAM allocation when running Windows Subsystem for Linux (WSL), you "
+    "need to modify the configuration settings. Here are the steps to do this:\n"
+    "1. Open a PowerShell window as an administrator.\n"
+    "2. Run the command: `wsl --set-default-version 2` to set WSL version to 2 (WSL 2).\n"
+    "3. Run the command: `wsl --set-memory <your_memory_limit>` to set the maximum memory limit "
+    "for WSL (replace `<your_memory_limit>` with the desired memory limit, e.g., `4GB`).\n"
+    "4. Restart WSL by running the command: `wsl --shutdown`.\n\n"
+    "It is important to note that modifying these settings may require a reboot of your system."
+)
+
+
+def detect_wsl_recommendation(content: str) -> Optional[str]:
+    """Return the WSL memory-config advisory when *content* is from a WSL host.
+
+    Detects Kometa's ``"Platform: <name>-WSL"`` line.  Returns ``None``
+    when no WSL platform is detected.
+    """
+    if re.search(r"Platform: .*-WSL", content):
+        return _WSL_RECOMMENDATION
+    return None

--- a/tests/test_logscan_content_extractors.py
+++ b/tests/test_logscan_content_extractors.py
@@ -1,0 +1,188 @@
+"""Unit tests for :mod:`modules.logscan_content_extractors`.
+
+Extracted alongside the PR that moved the pure content-parsing
+helpers out of :class:`modules.logscan.LogscanAnalyzer`.
+
+Each function is a pure ``content -> parsed value`` mapping so the
+tests just poke small strings at them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from modules.logscan_content_extractors import (
+    DEFAULT_DIVIDER,
+    contains_overlay_files,
+    contains_overlay_path,
+    detect_wsl_recommendation,
+    extract_db_cache_value,
+    extract_divider,
+    extract_maintenance_times,
+    extract_memory_value,
+    extract_scheduled_run_time,
+)
+
+# ---------------------------------------------------------------------------
+# extract_memory_value / extract_db_cache_value share a helper -- tested here
+# because the boundaries are worth locking down.
+# ---------------------------------------------------------------------------
+
+
+class TestExtractMemoryValue:
+    def test_gb_is_passthrough(self):
+        assert extract_memory_value("Memory: 8 GB") == 8.0
+
+    def test_mb_divides_by_1024(self):
+        assert extract_memory_value("Memory: 4096 MB") == pytest.approx(4.0)
+
+    def test_tb_multiplies_by_1024(self):
+        assert extract_memory_value("Memory: 1 TB") == pytest.approx(1024.0)
+
+    def test_units_are_case_insensitive(self):
+        assert extract_memory_value("Memory: 8 gb") == 8.0
+        assert extract_memory_value("Memory: 4096 mB") == pytest.approx(4.0)
+
+    def test_decimal_values_are_preserved(self):
+        assert extract_memory_value("Memory: 15.6 GB") == pytest.approx(15.6)
+
+    def test_missing_label_returns_none(self):
+        assert extract_memory_value("nothing to see here") is None
+
+    def test_unrecognized_unit_returns_none(self):
+        assert extract_memory_value("Memory: 5 PB") is None
+
+
+class TestExtractDbCacheValue:
+    def test_gb_is_passthrough(self):
+        assert extract_db_cache_value("Plex DB cache setting: 2 GB") == 2.0
+
+    def test_mb_divides_by_1024(self):
+        assert extract_db_cache_value("Plex DB cache setting: 512 MB") == pytest.approx(0.5)
+
+    def test_missing_label_returns_none(self):
+        assert extract_db_cache_value("Memory: 8 GB") is None
+
+
+# ---------------------------------------------------------------------------
+# extract_divider (supports both KOMETA_ and legacy PMM_ names)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractDivider:
+    def test_kometa_divider(self):
+        assert extract_divider('--divider (KOMETA_DIVIDER): "="') == "="
+
+    def test_pmm_legacy_divider(self):
+        assert extract_divider('--divider (PMM_DIVIDER): "|"') == "|"
+
+    def test_default_when_missing(self):
+        assert extract_divider("nothing here") == DEFAULT_DIVIDER
+
+    def test_custom_fallback(self):
+        assert extract_divider("nothing", fallback="*") == "*"
+
+    def test_kometa_preferred_over_pmm_when_both_present(self):
+        # KOMETA pattern is tried first; the divider from that line wins.
+        content = "\n".join(
+            [
+                '--divider (KOMETA_DIVIDER): "="',
+                '--divider (PMM_DIVIDER): "|"',
+            ]
+        )
+        assert extract_divider(content) == "="
+
+
+# ---------------------------------------------------------------------------
+# extract_scheduled_run_time
+# ---------------------------------------------------------------------------
+
+
+class TestExtractScheduledRunTime:
+    def test_kometa_times(self):
+        assert extract_scheduled_run_time("--times (KOMETA_TIMES): 03:00") == "03:00"
+
+    def test_pmm_legacy_times(self):
+        assert extract_scheduled_run_time("--times (PMM_TIMES): 04:30") == "04:30"
+
+    def test_short_hour_form(self):
+        assert extract_scheduled_run_time("--times (KOMETA_TIMES): 3:00") == "3:00"
+
+    def test_missing_returns_none(self):
+        assert extract_scheduled_run_time("nothing here") is None
+
+
+# ---------------------------------------------------------------------------
+# extract_maintenance_times
+# ---------------------------------------------------------------------------
+
+
+class TestExtractMaintenanceTimes:
+    def test_present_returns_pair(self):
+        content = "Scheduled maintenance running between 03:00 and 05:00"
+        assert extract_maintenance_times(content) == ("03:00", "05:00")
+
+    def test_missing_returns_pair_of_nones(self):
+        assert extract_maintenance_times("nothing here") == (None, None)
+
+    def test_ignores_similar_but_wrong_lines(self):
+        # "Scheduled maintenance" without "running between" doesn't match.
+        assert extract_maintenance_times("Scheduled maintenance is happening") == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# contains_overlay_*
+# ---------------------------------------------------------------------------
+
+
+class TestContainsOverlayPath:
+    def test_matches_yaml_key(self):
+        assert contains_overlay_path("overlay_path: /foo/bar") is True
+
+    def test_case_insensitive(self):
+        assert contains_overlay_path("OVERLAY_PATH: /foo") is True
+
+    def test_word_boundary_required(self):
+        # Substring inside a bigger word shouldn't match.
+        assert contains_overlay_path("no_overlay_path_here") is False
+
+    def test_no_match(self):
+        assert contains_overlay_path("nothing") is False
+
+
+class TestContainsOverlayFiles:
+    def test_matches_yaml_key(self):
+        assert contains_overlay_files("overlay_files: something") is True
+
+    def test_case_insensitive(self):
+        assert contains_overlay_files("OVERLAY_FILES: x") is True
+
+    def test_no_match(self):
+        assert contains_overlay_files("nothing") is False
+
+
+# ---------------------------------------------------------------------------
+# detect_wsl_recommendation
+# ---------------------------------------------------------------------------
+
+
+class TestDetectWslRecommendation:
+    def test_wsl_platform_triggers_advisory(self):
+        result = detect_wsl_recommendation("Platform: Linux-WSL")
+        assert result is not None
+        assert "WSL MEMORY RECOMMENDATION" in result
+
+    def test_wsl_platform_windows_variant(self):
+        # Any -WSL suffix qualifies (Kometa emits several platform names).
+        assert detect_wsl_recommendation("Platform: Ubuntu-WSL") is not None
+
+    def test_non_wsl_platform_returns_none(self):
+        assert detect_wsl_recommendation("Platform: Linux") is None
+        assert detect_wsl_recommendation("Platform: Darwin") is None
+
+    def test_missing_platform_returns_none(self):
+        assert detect_wsl_recommendation("nothing here") is None
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
**Sprint 3, PR #4 — fourth logscan.py extraction.** Pulls the ~130-line cluster of pure content parsers out of `LogscanAnalyzer`.

**MILESTONE: `logscan.py` is under 3000 lines for the first time.**

## Public API in `modules/logscan_content_extractors.py`

- `extract_memory_value(content)` → `float | None`
- `extract_db_cache_value(content)` → `float | None`
  Both return values normalized to GB via a shared helper.
- `extract_divider(content, fallback='=')` → `str`
- `extract_scheduled_run_time(content)` → `str | None`
- `extract_maintenance_times(content)` → `(start, end) | (None, None)`
- `contains_overlay_path(content)` → `bool`
- `contains_overlay_files(content)` → `bool`
- `detect_wsl_recommendation(content)` → `str | None`

## Two DRY wins baked into the new module

**#1 — Memory/DB-cache extraction was 100% duplicated:**

Before, both methods had this **identical 15-line body**, differing only in the regex label:

```python
memory_match = re.search(r'<label>:\s*([\d.]+)\s*(\w+)', content)
if memory_match:
    value = float(memory_match.group(1))
    unit = memory_match.group(2).lower()
    if unit == 'gb': return value
    elif unit == 'mb': return value / 1024
    elif unit == 'tb': return value * 1024
return None
```

Now one helper `_extract_gb_value_with_prefix()` + two 1-line wrappers.

**#2 — Divider/times both looped over a KOMETA_/PMM_ alternation:**

Before, both methods had this **duplicated pattern list + loop**:

```python
patterns = [
    r'--<flag> \(KOMETA_<ENV>\): ?["\']?<capture>["\']?',
    r'--<flag> \(PMM_<ENV>\): ?["\']?<capture>["\']?',
]
for pattern in patterns:
    match = re.search(pattern, content)
    if match: return match.group(1)
```

Now one `_kometa_or_pmm_alternation()` helper builds the two-pattern list.

## Class wrappers in `logscan.py`

8 methods become **1-2 line delegating wrappers**. Only `set_global_divider` keeps a slightly longer form because it persists the returned divider on `self`:

```python
def set_global_divider(self, content):
    divider = logscan_content_extractors.extract_divider(
        content,
        fallback=getattr(self, 'global_divider', None) or logscan_content_extractors.DEFAULT_DIVIDER,
    )
    self.global_divider = divider
```

## Emoji handling

The WSL advisory uses **speech-balloon, window, penguin** emojis. Kept as unicode escape codes so the repo's emoji-filter hook doesn't strip them:

```python
_ICON_SPEECH = "\\U0001f4ac"  # speech balloon
_ICON_WINDOW = "\\U0001fa9f"  # window
_ICON_PENGUIN = "\\U0001f427"  # penguin
```

## New tests: `tests/test_logscan_content_extractors.py`

**33 focused unit tests** across 8 test classes:

- `TestExtractMemoryValue` (7): gb/mb/tb/case/decimals/missing/unknown-unit
- `TestExtractDbCacheValue` (3): gb/mb/wrong-label
- `TestExtractDivider` (5): kometa/pmm/default/custom-fallback/priority
- `TestExtractScheduledRunTime` (4): kometa/pmm/short-hour/missing
- `TestExtractMaintenanceTimes` (3): present/missing/similar-but-wrong
- `TestContainsOverlayPath` (4): match/case/word-boundary/no-match
- `TestContainsOverlayFiles` (3): match/case/no-match
- `TestDetectWslRecommendation` (4): wsl/variant/non-wsl/missing

## Impact

- `modules/logscan.py`: **3053 → 2947** (**-106 / -3.5%**)
- `modules/logscan_content_extractors.py`: NEW 240 lines
- `tests/test_logscan_content_extractors.py`: NEW 209 lines

## Sprint 3 progress

| PR | Start | End | Δ |
|---|---|---|---|
| PR #1488 (PMS versions) | 3291 | 3271 | -20 |
| PR #1489 (finished runs) | 3271 | 3167 | -104 |
| PR #1490 (recommendations) | 3167 | 3053 | -114 |
| **This PR** | 3053 | **2947** | **-106** |
| **Total** | 3291 | 2947 | **-344 (-10.4%)** |

## Verification

- All **1196 tests pass** (33 new + 1163 existing)
- Ruff + black clean