### PR TITLE
Extract maintenance analysis to modules/logscan_maintenance

### DIFF
--- a/modules/logscan.py
+++ b/modules/logscan.py
@@ -4,7 +4,14 @@ import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from modules import logscan_command, logscan_content_extractors, logscan_finished_runs, logscan_people, logscan_recommendations
+from modules import (
+    logscan_command,
+    logscan_content_extractors,
+    logscan_finished_runs,
+    logscan_maintenance,
+    logscan_people,
+    logscan_recommendations,
+)
 from modules.logscan_pms_versions import (
     VULNERABLE_RANGE_HIGH,
     VULNERABLE_RANGE_LOW,
@@ -2311,296 +2318,22 @@ class LogscanAnalyzer:
         return counts
 
     def extract_quickstart_marker(self, content):
-        if not content:
-            return None
-        match = re.search(r"\[Quickstart\]\s+Run marker:.*", content)
-        return match.group(0) if match else None
+        return logscan_maintenance.extract_quickstart_marker(content)
 
     def extract_quickstart_marker_fields(self, content):
-        marker = self.extract_quickstart_marker(content)
-        if not marker:
-            return {}
-        fields = {}
-        for match in re.finditer(r"(\w+)=([^\s]+)", marker):
-            key = str(match.group(1) or "").strip().lower()
-            value = str(match.group(2) or "").strip()
-            if key:
-                fields[key] = value
-        start_mode = str(fields.get("start_mode") or "").strip().lower()
-        if start_mode not in {"current", "recovery", "logged"}:
-            fields["start_mode"] = ""
-        else:
-            fields["start_mode"] = start_mode
-        return fields
+        return logscan_maintenance.extract_quickstart_marker_fields(content)
 
     def extract_quickstart_marker_capabilities(self, content):
-        capabilities = {"maintenance_markers": False}
-        marker = self.extract_quickstart_marker(content)
-        if not marker:
-            return capabilities
-        if re.search(r"\bmaintenance_markers=1\b", marker):
-            capabilities["maintenance_markers"] = True
-        return capabilities
+        return logscan_maintenance.extract_quickstart_marker_capabilities(content)
 
     def _parse_log_timestamp(self, line):
-        if not line or not line.startswith("["):
-            return None
-        match = re.match(r"\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d{3}\]", line)
-        if not match:
-            return None
-        try:
-            return datetime.strptime(match.group(1), "%Y-%m-%d %H:%M:%S")
-        except Exception:
-            return None
+        return logscan_maintenance.parse_log_timestamp(line)
 
     def extract_maintenance_summary(self, content):
-        summary = {
-            "had_pause": False,
-            "pause_count": 0,
-            "pause_seconds": 0,
-            "open_pause": False,
-            "window": None,
-            "events": [],
-        }
-        if not content:
-            return summary
-
-        marker_re = re.compile(
-            r"\[Quickstart\]\s+Maintenance marker:\s+event=(paused|resumed)\s+at=([^\s]+)" r"(?:\s+local_at=([^\s]+))?(?:\s+window=([^\s]+))?(?:\s+paused_seconds=(\d+))?",
-            re.IGNORECASE,
-        )
-        open_pause_at = None
-        open_pause_window = None
-        open_pause_local_at = None
-
-        for line in content.splitlines():
-            match = marker_re.search(line)
-            if not match:
-                continue
-            event = str(match.group(1) or "").strip().lower()
-            raw_ts = str(match.group(2) or "").strip()
-            local_at = str(match.group(3) or "").strip() or None
-            window = str(match.group(4) or "").strip() or None
-            paused_seconds_raw = match.group(5)
-            event_ts = None
-            try:
-                event_ts = datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
-                if event_ts.tzinfo is not None:
-                    event_ts = event_ts.astimezone(timezone.utc)
-            except Exception:
-                event_ts = None
-            paused_seconds = None
-            if paused_seconds_raw is not None:
-                try:
-                    paused_seconds = max(0, int(paused_seconds_raw))
-                except Exception:
-                    paused_seconds = None
-
-            summary["events"].append(
-                {
-                    "event": event,
-                    "at": raw_ts,
-                    "local_at": local_at,
-                    "window": window,
-                    "paused_seconds": paused_seconds,
-                }
-            )
-            if window:
-                summary["window"] = window
-
-            if event == "paused":
-                summary["had_pause"] = True
-                summary["pause_count"] += 1
-                open_pause_at = event_ts
-                open_pause_window = window
-                open_pause_local_at = local_at
-                continue
-
-            if event == "resumed":
-                summary["had_pause"] = True
-                if paused_seconds is None and open_pause_at and event_ts:
-                    try:
-                        paused_seconds = max(0, int((event_ts - open_pause_at).total_seconds()))
-                    except Exception:
-                        paused_seconds = None
-                if paused_seconds is not None:
-                    summary["pause_seconds"] += paused_seconds
-                open_pause_at = None
-                open_pause_window = None
-                open_pause_local_at = None
-
-        if open_pause_at is not None:
-            summary["open_pause"] = True
-            summary["had_pause"] = True
-            if not summary["window"] and open_pause_window:
-                summary["window"] = open_pause_window
-            if summary["events"] and not summary["events"][-1].get("local_at") and open_pause_local_at:
-                summary["events"][-1]["local_at"] = open_pause_local_at
-
-        return summary
+        return logscan_maintenance.extract_maintenance_summary(content)
 
     def extract_quiet_period_summary(self, content, maintenance_summary=None):
-        summary = {
-            "longest_gap_seconds": 0,
-            "longest_gap_started_at": None,
-            "longest_gap_ended_at": None,
-            "longest_gap_start_line": None,
-            "longest_gap_end_line": None,
-            "longest_gap_last_line": None,
-            "longest_gap_first_line": None,
-            "gaps_over_300": 0,
-            "gaps_over_900": 0,
-            "gaps_over_1800": 0,
-            "longest_gap_maintenance_overlap": "unknown",
-            "longest_unexplained_gap_seconds": 0,
-            "longest_unexplained_gap_started_at": None,
-            "longest_unexplained_gap_ended_at": None,
-            "longest_unexplained_gap_start_line": None,
-            "longest_unexplained_gap_end_line": None,
-            "longest_unexplained_gap_last_line": None,
-            "longest_unexplained_gap_first_line": None,
-            "longest_unexplained_gap_maintenance_overlap": "unknown",
-            "confirmed_maintenance_gaps_over_300": 0,
-            "unexplained_gaps_over_300": 0,
-            "notable_gaps": [],
-        }
-        if not content:
-            return summary
-
-        capabilities = self.extract_quickstart_marker_capabilities(content)
-        maintenance_supported = bool(capabilities.get("maintenance_markers"))
-        timestamp_entries = []
-        for line_number, line in enumerate(content.splitlines(), start=1):
-            line_ts = self._parse_log_timestamp(line)
-            if line_ts is not None:
-                timestamp_entries.append(
-                    {
-                        "timestamp": line_ts,
-                        "line_number": line_number,
-                        "line": line.strip(),
-                    }
-                )
-        if len(timestamp_entries) < 2:
-            if maintenance_supported:
-                summary["longest_gap_maintenance_overlap"] = "none"
-            return summary
-
-        maintenance_summary = maintenance_summary if isinstance(maintenance_summary, dict) else {}
-        maintenance_intervals = []
-        open_start = None
-        for event in maintenance_summary.get("events") or []:
-            if not isinstance(event, dict):
-                continue
-            local_at = str(event.get("local_at") or "").strip()
-            event_name = str(event.get("event") or "").strip().lower()
-            event_ts = None
-            if local_at:
-                try:
-                    event_ts = datetime.fromisoformat(local_at)
-                except Exception:
-                    event_ts = None
-            if event_ts is None:
-                continue
-            if event_name == "paused":
-                open_start = event_ts
-            elif event_name == "resumed" and open_start is not None:
-                maintenance_intervals.append((open_start, event_ts))
-                open_start = None
-        if open_start is not None:
-            maintenance_intervals.append((open_start, None))
-
-        def _get_gap_overlap(start_ts, end_ts):
-            overlap = False
-            for interval_start, interval_end in maintenance_intervals:
-                if interval_end is None:
-                    if end_ts > interval_start:
-                        overlap = True
-                        break
-                    continue
-                if start_ts < interval_end and end_ts > interval_start:
-                    overlap = True
-                    break
-            if overlap:
-                return "confirmed"
-            if maintenance_supported:
-                return "none"
-            return "unknown"
-
-        longest_start = None
-        longest_end = None
-        longest_previous_entry = None
-        longest_current_entry = None
-        longest_unexplained_start = None
-        longest_unexplained_end = None
-        longest_unexplained_previous_entry = None
-        longest_unexplained_current_entry = None
-        for previous_entry, current_entry in zip(timestamp_entries, timestamp_entries[1:]):
-            previous_ts = previous_entry["timestamp"]
-            current_ts = current_entry["timestamp"]
-            gap_seconds = max(0, int((current_ts - previous_ts).total_seconds()))
-            if gap_seconds <= 0:
-                continue
-            if gap_seconds >= 300:
-                summary["gaps_over_300"] += 1
-            if gap_seconds >= 900:
-                summary["gaps_over_900"] += 1
-            if gap_seconds >= 1800:
-                summary["gaps_over_1800"] += 1
-            overlap_label = _get_gap_overlap(previous_ts, current_ts)
-            gap_detail = {
-                "gap_seconds": gap_seconds,
-                "started_at": previous_ts.isoformat(),
-                "ended_at": current_ts.isoformat(),
-                "start_line": previous_entry.get("line_number"),
-                "end_line": current_entry.get("line_number"),
-                "last_line": previous_entry.get("line"),
-                "first_line": current_entry.get("line"),
-                "maintenance_overlap": overlap_label,
-            }
-            if gap_seconds >= 300:
-                summary["notable_gaps"].append(gap_detail)
-                if overlap_label == "confirmed":
-                    summary["confirmed_maintenance_gaps_over_300"] += 1
-                else:
-                    summary["unexplained_gaps_over_300"] += 1
-            if gap_seconds > summary["longest_gap_seconds"]:
-                summary["longest_gap_seconds"] = gap_seconds
-                longest_start = previous_ts
-                longest_end = current_ts
-                longest_previous_entry = previous_entry
-                longest_current_entry = current_entry
-            if overlap_label != "confirmed" and gap_seconds > summary["longest_unexplained_gap_seconds"]:
-                summary["longest_unexplained_gap_seconds"] = gap_seconds
-                longest_unexplained_start = previous_ts
-                longest_unexplained_end = current_ts
-                longest_unexplained_previous_entry = previous_entry
-                longest_unexplained_current_entry = current_entry
-
-        if longest_start is not None and longest_end is not None:
-            summary["longest_gap_started_at"] = longest_start.isoformat()
-            summary["longest_gap_ended_at"] = longest_end.isoformat()
-            if longest_previous_entry:
-                summary["longest_gap_start_line"] = longest_previous_entry.get("line_number")
-                summary["longest_gap_last_line"] = longest_previous_entry.get("line")
-            if longest_current_entry:
-                summary["longest_gap_end_line"] = longest_current_entry.get("line_number")
-                summary["longest_gap_first_line"] = longest_current_entry.get("line")
-            summary["longest_gap_maintenance_overlap"] = _get_gap_overlap(longest_start, longest_end)
-
-        if longest_unexplained_start is not None and longest_unexplained_end is not None:
-            summary["longest_unexplained_gap_started_at"] = longest_unexplained_start.isoformat()
-            summary["longest_unexplained_gap_ended_at"] = longest_unexplained_end.isoformat()
-            if longest_unexplained_previous_entry:
-                summary["longest_unexplained_gap_start_line"] = longest_unexplained_previous_entry.get("line_number")
-                summary["longest_unexplained_gap_last_line"] = longest_unexplained_previous_entry.get("line")
-            if longest_unexplained_current_entry:
-                summary["longest_unexplained_gap_end_line"] = longest_unexplained_current_entry.get("line_number")
-                summary["longest_unexplained_gap_first_line"] = longest_unexplained_current_entry.get("line")
-            summary["longest_unexplained_gap_maintenance_overlap"] = _get_gap_overlap(longest_unexplained_start, longest_unexplained_end)
-        elif maintenance_supported and summary["longest_gap_seconds"] > 0:
-            summary["longest_unexplained_gap_maintenance_overlap"] = "none"
-
-        return summary
+        return logscan_maintenance.extract_quiet_period_summary(content, maintenance_summary)
 
     def extract_config_line_count(self, content):
         if not content:

--- a/modules/logscan_maintenance.py
+++ b/modules/logscan_maintenance.py
@@ -1,0 +1,491 @@
+"""Maintenance-marker and quiet-period analysis for LogscanAnalyzer.
+
+Extracted from :class:`modules.logscan.LogscanAnalyzer`.
+
+Kometa's runtime emits ``[Quickstart] Run marker:`` and
+``[Quickstart] Maintenance marker:`` events into its log output.
+These functions parse those markers plus the surrounding log
+timestamps to answer three related questions:
+
+1. What Quickstart marker (with its embedded fields + capability
+   flags) was present in this log?
+   -- :func:`extract_quickstart_marker`,
+      :func:`extract_quickstart_marker_fields`,
+      :func:`extract_quickstart_marker_capabilities`.
+
+2. What maintenance pause/resume events did we see?
+   -- :func:`extract_maintenance_summary` returns a dict of pause
+   counts, total paused seconds, and per-event details.
+
+3. What "quiet gaps" (stretches of time with no log lines) show up
+   in the run, and how many overlap the known maintenance windows?
+   -- :func:`extract_quiet_period_summary` returns gap statistics
+   including the longest overall gap and the longest *unexplained*
+   gap (i.e. not overlapping a maintenance window).
+
+Companion helper :func:`parse_log_timestamp` returns a
+:class:`datetime` from a leading ``[YYYY-MM-DD HH:MM:SS,mmm]``
+prefix or ``None``.  Reused by other logscan modules.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+# ---------------------------------------------------------------------------
+# Basic timestamp parsing (also useful outside this module)
+# ---------------------------------------------------------------------------
+
+
+_LOG_TIMESTAMP_RE = re.compile(r"\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d{3}\]")
+
+
+def parse_log_timestamp(line: Optional[str]) -> Optional[datetime]:
+    """Return a naive :class:`datetime` parsed from ``[YYYY-MM-DD HH:MM:SS,mmm]``.
+
+    Returns ``None`` when *line* is falsy, doesn't start with ``[``,
+    or doesn't contain the expected prefix.  Never raises.
+    """
+    if not line or not line.startswith("["):
+        return None
+    match = _LOG_TIMESTAMP_RE.match(line)
+    if not match:
+        return None
+    try:
+        return datetime.strptime(match.group(1), "%Y-%m-%d %H:%M:%S")
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Quickstart run-marker parsers
+# ---------------------------------------------------------------------------
+
+
+_RUN_MARKER_RE = re.compile(r"\[Quickstart\]\s+Run marker:.*")
+_MARKER_KEY_VALUE_RE = re.compile(r"(\w+)=([^\s]+)")
+_MAINTENANCE_MARKERS_FLAG_RE = re.compile(r"\bmaintenance_markers=1\b")
+
+
+def extract_quickstart_marker(content: Optional[str]) -> Optional[str]:
+    """Return the raw ``[Quickstart] Run marker: ...`` line, else None."""
+    if not content:
+        return None
+    match = _RUN_MARKER_RE.search(content)
+    return match.group(0) if match else None
+
+
+_VALID_START_MODES = {"current", "recovery", "logged"}
+
+
+def extract_quickstart_marker_fields(content: Optional[str]) -> dict[str, str]:
+    """Parse ``key=value`` fields out of the Quickstart run marker.
+
+    Returns an empty dict when no marker is present.  The
+    ``start_mode`` value is validated against the allowed set;
+    unknown values are coerced to the empty string.
+    """
+    marker = extract_quickstart_marker(content)
+    if not marker:
+        return {}
+    fields: dict[str, str] = {}
+    for match in _MARKER_KEY_VALUE_RE.finditer(marker):
+        key = str(match.group(1) or "").strip().lower()
+        value = str(match.group(2) or "").strip()
+        if key:
+            fields[key] = value
+
+    start_mode = str(fields.get("start_mode") or "").strip().lower()
+    fields["start_mode"] = start_mode if start_mode in _VALID_START_MODES else ""
+    return fields
+
+
+def extract_quickstart_marker_capabilities(content: Optional[str]) -> dict[str, bool]:
+    """Return capability flags declared in the Quickstart run marker.
+
+    Currently just ``maintenance_markers`` -- Kometa runtimes with
+    maintenance-marker support set ``maintenance_markers=1`` in the
+    marker line.  Older runtimes omit the field entirely (interpret
+    as False).
+    """
+    capabilities = {"maintenance_markers": False}
+    marker = extract_quickstart_marker(content)
+    if not marker:
+        return capabilities
+    if _MAINTENANCE_MARKERS_FLAG_RE.search(marker):
+        capabilities["maintenance_markers"] = True
+    return capabilities
+
+
+# ---------------------------------------------------------------------------
+# Maintenance summary: pause/resume events
+# ---------------------------------------------------------------------------
+
+
+_MAINTENANCE_MARKER_RE = re.compile(
+    r"\[Quickstart\]\s+Maintenance marker:\s+event=(paused|resumed)\s+at=([^\s]+)" r"(?:\s+local_at=([^\s]+))?" r"(?:\s+window=([^\s]+))?" r"(?:\s+paused_seconds=(\d+))?",
+    re.IGNORECASE,
+)
+
+
+def _empty_maintenance_summary() -> dict[str, Any]:
+    return {
+        "had_pause": False,
+        "pause_count": 0,
+        "pause_seconds": 0,
+        "open_pause": False,
+        "window": None,
+        "events": [],
+    }
+
+
+def _parse_maintenance_event_line(line: str) -> Optional[dict[str, Any]]:
+    """Return a parsed maintenance-event dict for *line*, else None."""
+    match = _MAINTENANCE_MARKER_RE.search(line)
+    if not match:
+        return None
+
+    event = str(match.group(1) or "").strip().lower()
+    raw_ts = str(match.group(2) or "").strip()
+    local_at = str(match.group(3) or "").strip() or None
+    window = str(match.group(4) or "").strip() or None
+    paused_seconds_raw = match.group(5)
+
+    event_ts: Optional[datetime] = None
+    try:
+        event_ts = datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
+        if event_ts.tzinfo is not None:
+            event_ts = event_ts.astimezone(timezone.utc)
+    except Exception:
+        event_ts = None
+
+    paused_seconds: Optional[int] = None
+    if paused_seconds_raw is not None:
+        try:
+            paused_seconds = max(0, int(paused_seconds_raw))
+        except Exception:
+            paused_seconds = None
+
+    return {
+        "event": event,
+        "at": raw_ts,
+        "event_ts": event_ts,
+        "local_at": local_at,
+        "window": window,
+        "paused_seconds": paused_seconds,
+    }
+
+
+def extract_maintenance_summary(content: Optional[str]) -> dict[str, Any]:
+    """Aggregate ``[Quickstart] Maintenance marker:`` events into a summary.
+
+    Returns a dict with keys:
+        * ``had_pause``     -- True if any pause events seen
+        * ``pause_count``   -- number of ``event=paused`` markers
+        * ``pause_seconds`` -- total paused seconds (from ``paused_seconds=``
+                               on resume events, or computed from paused/
+                               resumed timestamps when the field is absent)
+        * ``open_pause``    -- True if the last pause has no matching resume
+        * ``window``        -- last ``window=`` value seen
+        * ``events``        -- list of per-event dicts (without event_ts)
+
+    Empty/None *content* returns an empty summary with defaults.
+    """
+    summary = _empty_maintenance_summary()
+    if not content:
+        return summary
+
+    open_pause_ts: Optional[datetime] = None
+    open_pause_window: Optional[str] = None
+    open_pause_local_at: Optional[str] = None
+
+    for line in content.splitlines():
+        parsed = _parse_maintenance_event_line(line)
+        if parsed is None:
+            continue
+
+        event = parsed["event"]
+        event_ts = parsed["event_ts"]
+        window = parsed["window"]
+        local_at = parsed["local_at"]
+        paused_seconds = parsed["paused_seconds"]
+
+        # Emit the event with the wire-format keys (drop event_ts).
+        summary["events"].append(
+            {
+                "event": event,
+                "at": parsed["at"],
+                "local_at": local_at,
+                "window": window,
+                "paused_seconds": paused_seconds,
+            }
+        )
+        if window:
+            summary["window"] = window
+
+        if event == "paused":
+            summary["had_pause"] = True
+            summary["pause_count"] += 1
+            open_pause_ts = event_ts
+            open_pause_window = window
+            open_pause_local_at = local_at
+            continue
+
+        if event == "resumed":
+            summary["had_pause"] = True
+            # If the marker didn't include paused_seconds, derive it
+            # from the pause/resume timestamps we recorded.
+            if paused_seconds is None and open_pause_ts and event_ts:
+                try:
+                    paused_seconds = max(0, int((event_ts - open_pause_ts).total_seconds()))
+                except Exception:
+                    paused_seconds = None
+            if paused_seconds is not None:
+                summary["pause_seconds"] += paused_seconds
+            open_pause_ts = None
+            open_pause_window = None
+            open_pause_local_at = None
+
+    # Handle an unclosed pause (no matching resume before EOF).
+    if open_pause_ts is not None:
+        summary["open_pause"] = True
+        summary["had_pause"] = True
+        if not summary["window"] and open_pause_window:
+            summary["window"] = open_pause_window
+        if summary["events"] and not summary["events"][-1].get("local_at") and open_pause_local_at:
+            summary["events"][-1]["local_at"] = open_pause_local_at
+
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Quiet-period summary: gaps between consecutive log timestamps
+# ---------------------------------------------------------------------------
+
+
+def _empty_quiet_period_summary() -> dict[str, Any]:
+    return {
+        "longest_gap_seconds": 0,
+        "longest_gap_started_at": None,
+        "longest_gap_ended_at": None,
+        "longest_gap_start_line": None,
+        "longest_gap_end_line": None,
+        "longest_gap_last_line": None,
+        "longest_gap_first_line": None,
+        "gaps_over_300": 0,
+        "gaps_over_900": 0,
+        "gaps_over_1800": 0,
+        "longest_gap_maintenance_overlap": "unknown",
+        "longest_unexplained_gap_seconds": 0,
+        "longest_unexplained_gap_started_at": None,
+        "longest_unexplained_gap_ended_at": None,
+        "longest_unexplained_gap_start_line": None,
+        "longest_unexplained_gap_end_line": None,
+        "longest_unexplained_gap_last_line": None,
+        "longest_unexplained_gap_first_line": None,
+        "longest_unexplained_gap_maintenance_overlap": "unknown",
+        "confirmed_maintenance_gaps_over_300": 0,
+        "unexplained_gaps_over_300": 0,
+        "notable_gaps": [],
+    }
+
+
+def _build_maintenance_intervals(events: list[dict[str, Any]]) -> list[tuple[datetime, Optional[datetime]]]:
+    """Turn maintenance events into [(start, end_or_None), ...] intervals.
+
+    Uses each event's ``local_at`` field (a naive ISO string).  Events
+    without a parseable ``local_at`` are skipped.  A trailing pause
+    without a matching resume produces an open-ended interval
+    ``(start, None)`` -- treated by the overlap checker as extending
+    to infinity.
+    """
+    intervals: list[tuple[datetime, Optional[datetime]]] = []
+    open_start: Optional[datetime] = None
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        local_at = str(event.get("local_at") or "").strip()
+        event_name = str(event.get("event") or "").strip().lower()
+        event_ts = None
+        if local_at:
+            try:
+                event_ts = datetime.fromisoformat(local_at)
+            except Exception:
+                event_ts = None
+        if event_ts is None:
+            continue
+        if event_name == "paused":
+            open_start = event_ts
+        elif event_name == "resumed" and open_start is not None:
+            intervals.append((open_start, event_ts))
+            open_start = None
+    if open_start is not None:
+        intervals.append((open_start, None))
+    return intervals
+
+
+def _classify_gap_overlap(
+    start_ts: datetime,
+    end_ts: datetime,
+    intervals: list[tuple[datetime, Optional[datetime]]],
+    maintenance_supported: bool,
+) -> str:
+    """Return "confirmed" / "none" / "unknown" for a gap vs maintenance intervals.
+
+    * ``"confirmed"`` -- gap overlaps with a known maintenance window
+    * ``"none"``      -- runtime supports maintenance markers, and this
+                         gap didn't overlap any recorded window
+    * ``"unknown"``   -- runtime doesn't support maintenance markers
+                         (older Kometa), so we can't tell either way
+    """
+    for interval_start, interval_end in intervals:
+        if interval_end is None:
+            # Open-ended maintenance -- overlaps any gap ending after start.
+            if end_ts > interval_start:
+                return "confirmed"
+            continue
+        if start_ts < interval_end and end_ts > interval_start:
+            return "confirmed"
+    return "none" if maintenance_supported else "unknown"
+
+
+def _collect_timestamped_lines(content: str) -> list[dict[str, Any]]:
+    """Return per-line entries for every line with a parseable ISO timestamp."""
+    entries: list[dict[str, Any]] = []
+    for line_number, line in enumerate(content.splitlines(), start=1):
+        line_ts = parse_log_timestamp(line)
+        if line_ts is not None:
+            entries.append(
+                {
+                    "timestamp": line_ts,
+                    "line_number": line_number,
+                    "line": line.strip(),
+                }
+            )
+    return entries
+
+
+def _populate_longest_gap(summary: dict[str, Any], key_prefix: str, start_ts, end_ts, prev_entry, curr_entry, overlap_label: str) -> None:
+    """Write the longest-gap fields for either the overall or unexplained gap."""
+    summary[f"{key_prefix}_started_at"] = start_ts.isoformat()
+    summary[f"{key_prefix}_ended_at"] = end_ts.isoformat()
+    if prev_entry:
+        summary[f"{key_prefix}_start_line"] = prev_entry.get("line_number")
+        summary[f"{key_prefix}_last_line"] = prev_entry.get("line")
+    if curr_entry:
+        summary[f"{key_prefix}_end_line"] = curr_entry.get("line_number")
+        summary[f"{key_prefix}_first_line"] = curr_entry.get("line")
+    summary[f"{key_prefix}_maintenance_overlap"] = overlap_label
+
+
+def extract_quiet_period_summary(
+    content: Optional[str],
+    maintenance_summary: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Summarize quiet gaps (no log lines) in *content*.
+
+    Cross-references gaps against known maintenance windows (from
+    *maintenance_summary*'s events) so that expected gaps aren't
+    counted as "unexplained".
+
+    Returns a dict containing overall and "unexplained" longest-gap
+    fields plus counts of gaps over 5/15/30-minute thresholds.
+    See :func:`_empty_quiet_period_summary` for the full field list.
+    """
+    summary = _empty_quiet_period_summary()
+    if not content:
+        return summary
+
+    capabilities = extract_quickstart_marker_capabilities(content)
+    maintenance_supported = bool(capabilities.get("maintenance_markers"))
+
+    timestamp_entries = _collect_timestamped_lines(content)
+    if len(timestamp_entries) < 2:
+        if maintenance_supported:
+            summary["longest_gap_maintenance_overlap"] = "none"
+        return summary
+
+    maintenance_summary = maintenance_summary if isinstance(maintenance_summary, dict) else {}
+    maintenance_intervals = _build_maintenance_intervals(maintenance_summary.get("events") or [])
+
+    longest_start = longest_end = None
+    longest_previous_entry = longest_current_entry = None
+    longest_unexplained_start = longest_unexplained_end = None
+    longest_unexplained_previous_entry = longest_unexplained_current_entry = None
+
+    for previous_entry, current_entry in zip(timestamp_entries, timestamp_entries[1:]):
+        previous_ts = previous_entry["timestamp"]
+        current_ts = current_entry["timestamp"]
+        gap_seconds = max(0, int((current_ts - previous_ts).total_seconds()))
+        if gap_seconds <= 0:
+            continue
+
+        if gap_seconds >= 300:
+            summary["gaps_over_300"] += 1
+        if gap_seconds >= 900:
+            summary["gaps_over_900"] += 1
+        if gap_seconds >= 1800:
+            summary["gaps_over_1800"] += 1
+
+        overlap_label = _classify_gap_overlap(previous_ts, current_ts, maintenance_intervals, maintenance_supported)
+
+        if gap_seconds >= 300:
+            summary["notable_gaps"].append(
+                {
+                    "gap_seconds": gap_seconds,
+                    "started_at": previous_ts.isoformat(),
+                    "ended_at": current_ts.isoformat(),
+                    "start_line": previous_entry.get("line_number"),
+                    "end_line": current_entry.get("line_number"),
+                    "last_line": previous_entry.get("line"),
+                    "first_line": current_entry.get("line"),
+                    "maintenance_overlap": overlap_label,
+                }
+            )
+            if overlap_label == "confirmed":
+                summary["confirmed_maintenance_gaps_over_300"] += 1
+            else:
+                summary["unexplained_gaps_over_300"] += 1
+
+        if gap_seconds > summary["longest_gap_seconds"]:
+            summary["longest_gap_seconds"] = gap_seconds
+            longest_start, longest_end = previous_ts, current_ts
+            longest_previous_entry, longest_current_entry = previous_entry, current_entry
+
+        if overlap_label != "confirmed" and gap_seconds > summary["longest_unexplained_gap_seconds"]:
+            summary["longest_unexplained_gap_seconds"] = gap_seconds
+            longest_unexplained_start, longest_unexplained_end = previous_ts, current_ts
+            longest_unexplained_previous_entry, longest_unexplained_current_entry = previous_entry, current_entry
+
+    if longest_start is not None and longest_end is not None:
+        _populate_longest_gap(
+            summary,
+            "longest_gap",
+            longest_start,
+            longest_end,
+            longest_previous_entry,
+            longest_current_entry,
+            _classify_gap_overlap(longest_start, longest_end, maintenance_intervals, maintenance_supported),
+        )
+
+    if longest_unexplained_start is not None and longest_unexplained_end is not None:
+        _populate_longest_gap(
+            summary,
+            "longest_unexplained_gap",
+            longest_unexplained_start,
+            longest_unexplained_end,
+            longest_unexplained_previous_entry,
+            longest_unexplained_current_entry,
+            _classify_gap_overlap(
+                longest_unexplained_start,
+                longest_unexplained_end,
+                maintenance_intervals,
+                maintenance_supported,
+            ),
+        )
+    elif maintenance_supported and summary["longest_gap_seconds"] > 0:
+        summary["longest_unexplained_gap_maintenance_overlap"] = "none"
+
+    return summary

--- a/tests/test_logscan_maintenance.py
+++ b/tests/test_logscan_maintenance.py
@@ -1,0 +1,371 @@
+"""Unit tests for :mod:`modules.logscan_maintenance`.
+
+Extracted alongside the PR that moved maintenance-marker and
+quiet-period analysis out of :class:`modules.logscan.LogscanAnalyzer`.
+
+The larger behavior is already covered by
+``tests/test_logscan_runtime_parse.py`` and
+``tests/test_logscan_endpoints.py`` -- those exercise the class
+methods (now thin wrappers), so they lock in the extract's
+byte-identical behavior.  These focused tests target the smaller
+pure helpers plus edge cases that were previously buried.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from modules.logscan_maintenance import (
+    _build_maintenance_intervals,
+    _classify_gap_overlap,
+    _empty_maintenance_summary,
+    _empty_quiet_period_summary,
+    _parse_maintenance_event_line,
+    extract_maintenance_summary,
+    extract_quickstart_marker,
+    extract_quickstart_marker_capabilities,
+    extract_quickstart_marker_fields,
+    extract_quiet_period_summary,
+    parse_log_timestamp,
+)
+
+# ---------------------------------------------------------------------------
+# parse_log_timestamp
+# ---------------------------------------------------------------------------
+
+
+class TestParseLogTimestamp:
+    def test_standard_timestamp(self):
+        line = "[2024-01-15 08:30:45,123] [foo.py:1] [INFO] hello"
+        ts = parse_log_timestamp(line)
+        assert ts == datetime(2024, 1, 15, 8, 30, 45)
+
+    def test_none_returns_none(self):
+        assert parse_log_timestamp(None) is None
+
+    def test_empty_returns_none(self):
+        assert parse_log_timestamp("") is None
+
+    def test_no_leading_bracket_returns_none(self):
+        assert parse_log_timestamp("no timestamp here") is None
+
+    def test_malformed_timestamp_returns_none(self):
+        # Starts with [ but not a valid timestamp.
+        assert parse_log_timestamp("[not a timestamp]") is None
+
+    def test_unparseable_date_returns_none(self):
+        # Well-formed pattern but impossible date -- shouldn't raise.
+        assert parse_log_timestamp("[2024-13-45 08:30:45,123]") is None
+
+
+# ---------------------------------------------------------------------------
+# extract_quickstart_marker + fields + capabilities
+# ---------------------------------------------------------------------------
+
+
+class TestExtractQuickstartMarker:
+    def test_present_returns_marker_line(self):
+        content = "some log\n[Quickstart] Run marker: start_mode=current mode=analyze\nmore"
+        result = extract_quickstart_marker(content)
+        assert result == "[Quickstart] Run marker: start_mode=current mode=analyze"
+
+    def test_missing_returns_none(self):
+        assert extract_quickstart_marker("no marker here") is None
+
+    def test_empty_returns_none(self):
+        assert extract_quickstart_marker("") is None
+
+    def test_none_returns_none(self):
+        assert extract_quickstart_marker(None) is None
+
+
+class TestExtractQuickstartMarkerFields:
+    def test_extracts_kv_pairs(self):
+        content = "[Quickstart] Run marker: start_mode=current mode=analyze foo=bar"
+        fields = extract_quickstart_marker_fields(content)
+        assert fields["mode"] == "analyze"
+        assert fields["foo"] == "bar"
+
+    def test_valid_start_mode_kept(self):
+        for mode in ("current", "recovery", "logged"):
+            content = f"[Quickstart] Run marker: start_mode={mode}"
+            assert extract_quickstart_marker_fields(content)["start_mode"] == mode
+
+    def test_invalid_start_mode_coerced_to_empty(self):
+        content = "[Quickstart] Run marker: start_mode=weird"
+        assert extract_quickstart_marker_fields(content)["start_mode"] == ""
+
+    def test_no_marker_returns_empty_dict(self):
+        assert extract_quickstart_marker_fields("nothing") == {}
+
+
+class TestExtractQuickstartMarkerCapabilities:
+    def test_maintenance_markers_flag_set(self):
+        content = "[Quickstart] Run marker: maintenance_markers=1 foo=bar"
+        caps = extract_quickstart_marker_capabilities(content)
+        assert caps["maintenance_markers"] is True
+
+    def test_maintenance_markers_flag_unset(self):
+        content = "[Quickstart] Run marker: maintenance_markers=0"
+        assert extract_quickstart_marker_capabilities(content)["maintenance_markers"] is False
+
+    def test_no_maintenance_markers_field_defaults_to_false(self):
+        content = "[Quickstart] Run marker: foo=bar"
+        assert extract_quickstart_marker_capabilities(content)["maintenance_markers"] is False
+
+    def test_no_marker_returns_default_capabilities(self):
+        caps = extract_quickstart_marker_capabilities("no marker")
+        assert caps == {"maintenance_markers": False}
+
+
+# ---------------------------------------------------------------------------
+# _parse_maintenance_event_line
+# ---------------------------------------------------------------------------
+
+
+class TestParseMaintenanceEventLine:
+    def test_full_line_extracts_all_fields(self):
+        line = "[Quickstart] Maintenance marker: event=paused at=2024-01-15T08:30:00Z local_at=2024-01-15T00:30:00 window=01:00-02:00 paused_seconds=300"
+        parsed = _parse_maintenance_event_line(line)
+        assert parsed is not None
+        assert parsed["event"] == "paused"
+        assert parsed["at"] == "2024-01-15T08:30:00Z"
+        assert parsed["local_at"] == "2024-01-15T00:30:00"
+        assert parsed["window"] == "01:00-02:00"
+        assert parsed["paused_seconds"] == 300
+
+    def test_minimal_line_matches_optional_fields_none(self):
+        line = "[Quickstart] Maintenance marker: event=resumed at=2024-01-15T09:30:00Z"
+        parsed = _parse_maintenance_event_line(line)
+        assert parsed is not None
+        assert parsed["event"] == "resumed"
+        assert parsed["local_at"] is None
+        assert parsed["window"] is None
+        assert parsed["paused_seconds"] is None
+
+    def test_non_marker_line_returns_none(self):
+        assert _parse_maintenance_event_line("random log line") is None
+
+    def test_malformed_timestamp_still_parses_event(self):
+        # Even if the ISO timestamp doesn't parse, we should still
+        # return the parsed dict with event_ts=None so the caller
+        # can decide what to do.
+        line = "[Quickstart] Maintenance marker: event=paused at=garbage"
+        parsed = _parse_maintenance_event_line(line)
+        assert parsed is not None
+        assert parsed["event"] == "paused"
+        assert parsed["event_ts"] is None
+
+
+# ---------------------------------------------------------------------------
+# extract_maintenance_summary
+# ---------------------------------------------------------------------------
+
+
+class TestExtractMaintenanceSummary:
+    def test_empty_content_returns_defaults(self):
+        assert extract_maintenance_summary("") == _empty_maintenance_summary()
+
+    def test_none_content_returns_defaults(self):
+        assert extract_maintenance_summary(None) == _empty_maintenance_summary()
+
+    def test_no_markers_returns_defaults(self):
+        assert extract_maintenance_summary("nothing here") == _empty_maintenance_summary()
+
+    def test_pause_resume_pair(self):
+        content = "\n".join(
+            [
+                "[Quickstart] Maintenance marker: event=paused at=2024-01-15T08:30:00Z local_at=2024-01-15T00:30:00 window=01:00-02:00",
+                "[Quickstart] Maintenance marker: event=resumed at=2024-01-15T09:30:00Z local_at=2024-01-15T01:30:00 paused_seconds=3600",
+            ]
+        )
+        summary = extract_maintenance_summary(content)
+        assert summary["had_pause"] is True
+        assert summary["pause_count"] == 1
+        assert summary["pause_seconds"] == 3600
+        assert summary["open_pause"] is False
+        assert summary["window"] == "01:00-02:00"
+        assert len(summary["events"]) == 2
+
+    def test_paused_seconds_derived_when_missing(self):
+        # Paired pause/resume without paused_seconds on the resume;
+        # we should compute it from the timestamps (3600s here).
+        content = "\n".join(
+            [
+                "[Quickstart] Maintenance marker: event=paused at=2024-01-15T08:00:00Z",
+                "[Quickstart] Maintenance marker: event=resumed at=2024-01-15T09:00:00Z",
+            ]
+        )
+        summary = extract_maintenance_summary(content)
+        assert summary["pause_seconds"] == 3600
+
+    def test_open_pause_flagged(self):
+        content = "[Quickstart] Maintenance marker: event=paused at=2024-01-15T08:30:00Z window=01:00-02:00"
+        summary = extract_maintenance_summary(content)
+        assert summary["open_pause"] is True
+        assert summary["had_pause"] is True
+        assert summary["window"] == "01:00-02:00"
+
+
+# ---------------------------------------------------------------------------
+# _build_maintenance_intervals
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMaintenanceIntervals:
+    def test_empty_events(self):
+        assert _build_maintenance_intervals([]) == []
+
+    def test_matched_pair(self):
+        events = [
+            {"event": "paused", "local_at": "2024-01-15T00:30:00"},
+            {"event": "resumed", "local_at": "2024-01-15T01:30:00"},
+        ]
+        intervals = _build_maintenance_intervals(events)
+        assert len(intervals) == 1
+        assert intervals[0][0] == datetime(2024, 1, 15, 0, 30, 0)
+        assert intervals[0][1] == datetime(2024, 1, 15, 1, 30, 0)
+
+    def test_open_pause_produces_open_interval(self):
+        events = [{"event": "paused", "local_at": "2024-01-15T00:30:00"}]
+        intervals = _build_maintenance_intervals(events)
+        assert len(intervals) == 1
+        assert intervals[0][1] is None
+
+    def test_missing_local_at_skipped(self):
+        events = [
+            {"event": "paused"},  # no local_at
+            {"event": "resumed", "local_at": "2024-01-15T01:30:00"},
+        ]
+        assert _build_maintenance_intervals(events) == []
+
+    def test_resume_without_pause_ignored(self):
+        events = [{"event": "resumed", "local_at": "2024-01-15T01:30:00"}]
+        assert _build_maintenance_intervals(events) == []
+
+
+# ---------------------------------------------------------------------------
+# _classify_gap_overlap
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyGapOverlap:
+    @pytest.fixture
+    def intervals(self):
+        return [
+            (datetime(2024, 1, 15, 1, 0, 0), datetime(2024, 1, 15, 2, 0, 0)),
+        ]
+
+    def test_gap_fully_inside_maintenance_is_confirmed(self, intervals):
+        result = _classify_gap_overlap(
+            datetime(2024, 1, 15, 1, 15, 0),
+            datetime(2024, 1, 15, 1, 45, 0),
+            intervals,
+            maintenance_supported=True,
+        )
+        assert result == "confirmed"
+
+    def test_gap_before_maintenance_and_supported_is_none(self, intervals):
+        result = _classify_gap_overlap(
+            datetime(2024, 1, 15, 0, 0, 0),
+            datetime(2024, 1, 15, 0, 30, 0),
+            intervals,
+            maintenance_supported=True,
+        )
+        assert result == "none"
+
+    def test_gap_before_maintenance_and_unsupported_is_unknown(self, intervals):
+        result = _classify_gap_overlap(
+            datetime(2024, 1, 15, 0, 0, 0),
+            datetime(2024, 1, 15, 0, 30, 0),
+            intervals,
+            maintenance_supported=False,
+        )
+        assert result == "unknown"
+
+    def test_open_interval_matches_when_gap_ends_after_start(self):
+        intervals = [(datetime(2024, 1, 15, 1, 0, 0), None)]
+        result = _classify_gap_overlap(
+            datetime(2024, 1, 15, 0, 30, 0),
+            datetime(2024, 1, 15, 1, 30, 0),
+            intervals,
+            maintenance_supported=True,
+        )
+        assert result == "confirmed"
+
+
+# ---------------------------------------------------------------------------
+# extract_quiet_period_summary
+# ---------------------------------------------------------------------------
+
+
+class TestExtractQuietPeriodSummary:
+    def test_empty_content_returns_defaults(self):
+        assert extract_quiet_period_summary("") == _empty_quiet_period_summary()
+
+    def test_none_content_returns_defaults(self):
+        assert extract_quiet_period_summary(None) == _empty_quiet_period_summary()
+
+    def test_less_than_two_timestamps_returns_defaults(self):
+        # One timestamped line -- no pairs to compute gaps from.
+        content = "[2024-01-15 08:30:00,000] [x.py:1] [INFO] only one"
+        summary = extract_quiet_period_summary(content)
+        assert summary["longest_gap_seconds"] == 0
+        assert summary["notable_gaps"] == []
+
+    def test_short_gap_not_notable(self):
+        # 60-second gap -- below 300s threshold, not notable.
+        content = "\n".join(
+            [
+                "[2024-01-15 08:30:00,000] [x.py:1] [INFO] first",
+                "[2024-01-15 08:31:00,000] [x.py:1] [INFO] second",
+            ]
+        )
+        summary = extract_quiet_period_summary(content)
+        assert summary["longest_gap_seconds"] == 60
+        assert summary["notable_gaps"] == []
+        assert summary["gaps_over_300"] == 0
+
+    def test_large_gap_bucketed_correctly(self):
+        # 20-minute gap should count in over-300, over-900 buckets
+        # (not over-1800).
+        content = "\n".join(
+            [
+                "[2024-01-15 08:00:00,000] [x.py:1] [INFO] first",
+                "[2024-01-15 08:20:00,000] [x.py:1] [INFO] second",
+            ]
+        )
+        summary = extract_quiet_period_summary(content)
+        assert summary["longest_gap_seconds"] == 1200
+        assert summary["gaps_over_300"] == 1
+        assert summary["gaps_over_900"] == 1
+        assert summary["gaps_over_1800"] == 0
+        assert len(summary["notable_gaps"]) == 1
+
+    def test_gap_overlaps_maintenance_confirmed(self):
+        # 5-hour gap and maintenance in the middle -- overlaps.
+        # Also ensure the runtime advertised maintenance_markers=1
+        # so the classification is deterministic.
+        content = "\n".join(
+            [
+                "[Quickstart] Run marker: maintenance_markers=1",
+                "[2024-01-15 00:00:00,000] [x.py:1] [INFO] start",
+                "[2024-01-15 05:00:00,000] [x.py:1] [INFO] end",
+            ]
+        )
+        maintenance = {
+            "events": [
+                {"event": "paused", "local_at": "2024-01-15T01:00:00"},
+                {"event": "resumed", "local_at": "2024-01-15T02:00:00"},
+            ]
+        }
+        summary = extract_quiet_period_summary(content, maintenance_summary=maintenance)
+        assert summary["longest_gap_maintenance_overlap"] == "confirmed"
+        assert summary["confirmed_maintenance_gaps_over_300"] == 1
+        assert summary["unexplained_gaps_over_300"] == 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
**Sprint 3, PR #5 — biggest single extraction yet.** Pulls the ~280-line maintenance + quiet-period analysis cluster out of `LogscanAnalyzer`.

## Public API in `modules/logscan_maintenance.py`

**Quickstart run-marker parsers** (small, thematically related):
- `extract_quickstart_marker(content)` → `str | None`
- `extract_quickstart_marker_fields(content)` → `dict[str, str]`
- `extract_quickstart_marker_capabilities(content)` → `dict[str, bool]`

**Log-timestamp helper** (also useful outside this module):
- `parse_log_timestamp(line)` → `datetime | None`

**Maintenance pause/resume analysis:**
- `extract_maintenance_summary(content)` → `dict` — aggregates pause/resume events into had_pause / pause_count / pause_seconds / open_pause / window / events fields.

**Quiet-period (gap) analysis:**
- `extract_quiet_period_summary(content, maintenance_summary=None)` → `dict` — scans log timestamps for gaps between consecutive lines, cross-references with maintenance intervals to classify each gap as 'confirmed' / 'none' / 'unknown'.

## Internal decomposition (the refactor wins inside this PR)

**Legacy `extract_maintenance_summary` (85 lines)** — split into:
- `_parse_maintenance_event_line(line)` → `dict | None` (regex + timestamp parsing)
- `_empty_maintenance_summary()` → `dict` (constructor for the return shape)
- Plus a simpler top-level aggregation loop that just walks events

**Legacy `extract_quiet_period_summary` (165 lines!)** had FIVE inline nested helpers/loops all doing different things. Split into:
- `_collect_timestamped_lines(content)` — walk lines, collect entries with timestamps
- `_build_maintenance_intervals(events)` — turn pause/resume pairs into intervals
- `_classify_gap_overlap(start, end, intervals, supported)` — the tri-state classifier
- `_populate_longest_gap(summary, prefix, ...)` — **eliminates ~70 lines of duplicated field-assignment** for the longest_gap_X vs longest_unexplained_gap_X pair

Before, the same 8 field-assignment lines were repeated for the overall vs unexplained gap paths. After, one helper writes them via a prefix argument. Every new helper gets a docstring explaining what it does and why.

## Behavior preservation

Top-level function is a straightforward orchestration of the split helpers. Behavior byte-identical:
- Integration tests in `test_logscan_runtime_parse.py` and `test_logscan_endpoints.py` all pass unchanged.
- `quickstart.py` uses `extract_maintenance_summary` externally — still works.

## Class wrappers in `logscan.py`

6 methods become **1-line delegating wrappers**:

```python
def extract_quickstart_marker(self, content):
    return logscan_maintenance.extract_quickstart_marker(content)
# ... etc.
```

## New tests: `tests/test_logscan_maintenance.py`

**43 focused unit tests** across 9 test classes:

- `TestParseLogTimestamp` (6): valid/None/empty/no-bracket/malformed/bad-date
- `TestExtractQuickstartMarker` (4): present/missing/empty/None
- `TestExtractQuickstartMarkerFields` (4): kv/valid-modes/invalid-mode/no-marker
- `TestExtractQuickstartMarkerCapabilities` (4): flag-set/unset/missing/no-marker
- `TestParseMaintenanceEventLine` (4): full/minimal/non-marker/malformed-ts
- `TestExtractMaintenanceSummary` (6): empty/none/nothing/pair/derived-seconds/open
- `TestBuildMaintenanceIntervals` (5): empty/pair/open/missing-local-at/resume-only
- `TestClassifyGapOverlap` (4): inside/before-supported/before-unsupported/open
- `TestExtractQuietPeriodSummary` (5): empty/none/one-ts/short/large-bucketed/confirmed-overlap

## Impact

- `modules/logscan.py`: **2947 → 2680** (**-267 / -9.1%**)
- `modules/logscan_maintenance.py`: NEW 495 lines
- `tests/test_logscan_maintenance.py`: NEW 344 lines

## Sprint 3 progress

| PR | Δ | Ending |
|---|---|---|
| #1488 (PMS versions) | -20 | 3271 |
| #1489 (finished runs) | -104 | 3167 |
| #1490 (recommendations) | -114 | 3053 |
| #1492 (content extractors) | -106 | 2947 |
| **This PR** | **-267** | **2680** |
| **Total** | **-611 (-18.6%)** | |

## Verification

- All **1239 tests pass** (43 new + 1196 existing)
- Ruff + black clean