### PR TITLE
Extract library/section stats to modules/logscan_library_stats

### DIFF
--- a/modules/logscan.py
+++ b/modules/logscan.py
@@ -8,6 +8,7 @@ from modules import (
     logscan_command,
     logscan_content_extractors,
     logscan_finished_runs,
+    logscan_library_stats,
     logscan_maintenance,
     logscan_people,
     logscan_recommendations,
@@ -1492,138 +1493,19 @@ class LogscanAnalyzer:
         return started_at
 
     def _parse_hms_to_seconds(self, value):
-        if not value:
-            return None
-        parts = value.split(":")
-        try:
-            if len(parts) == 3:
-                hours = int(parts[0])
-                minutes = int(parts[1])
-                seconds = int(parts[2])
-                return hours * 3600 + minutes * 60 + seconds
-            if len(parts) == 2:
-                minutes = int(parts[0])
-                seconds = int(parts[1])
-                return minutes * 60 + seconds
-        except ValueError:
-            return None
-        return None
+        return logscan_library_stats.parse_hms_to_seconds(value)
 
     def extract_section_runtimes(self, content):
-        section_times = {}
-        if not content:
-            return section_times
-        inline_pattern = re.compile(r"Finished (?P<section>.+?) in (?P<time>\d+:\d{2}:\d{2})")
-        finished_pattern = re.compile(r"Finished (?P<section>.+?)\s*$")
-        runtime_pattern = re.compile(r"^\s*(?P<label>[A-Za-z][A-Za-z ]+?) Run Time:\s*(?P<time>\d+:\d{2}:\d{2})\s*$")
-        last_section = None
-        last_section_index = None
-        lines = content.splitlines()
-        for idx, line in enumerate(lines):
-            if not line:
-                continue
-            inline_match = inline_pattern.search(line)
-            if inline_match:
-                section = inline_match.group("section").strip()
-                if section.lower().startswith("at:"):
-                    continue
-                seconds = self._parse_hms_to_seconds(inline_match.group("time"))
-                if seconds is not None:
-                    section_times[section] = section_times.get(section, 0) + seconds
-                continue
-            finished_match = finished_pattern.search(line)
-            if finished_match:
-                section = finished_match.group("section").strip()
-                lowered = section.lower()
-                if lowered in ("run",) or lowered.startswith("run "):
-                    continue
-                last_section = section
-                last_section_index = idx
-                continue
-            runtime_match = runtime_pattern.search(line)
-            if not runtime_match:
-                continue
-            seconds = self._parse_hms_to_seconds(runtime_match.group("time"))
-            if seconds is None:
-                continue
-            section = None
-            if last_section and last_section_index is not None and (idx - last_section_index) <= 3:
-                section = last_section
-            else:
-                label = runtime_match.group("label").strip()
-                if label and label.lower() != "run":
-                    section = label
-            if section:
-                section_times[section] = section_times.get(section, 0) + seconds
-            last_section = None
-            last_section_index = None
-        return section_times
+        return logscan_library_stats.extract_section_runtimes(content)
 
     def count_log_levels(self, content):
-        counts = {
-            "debug": 0,
-            "info": 0,
-            "warning": 0,
-            "error": 0,
-            "critical": 0,
-            "trace": 0,
-        }
-        if not content:
-            return counts
-        for line in content.splitlines():
-            upper = line.upper()
-            if "[DEBUG]" in upper:
-                counts["debug"] += 1
-            if "[INFO]" in upper:
-                counts["info"] += 1
-            if "[WARNING]" in upper:
-                counts["warning"] += 1
-            if "[ERROR]" in upper:
-                counts["error"] += 1
-            if "[CRITICAL]" in upper:
-                counts["critical"] += 1
-            if "TRACEBACK" in upper:
-                counts["trace"] += 1
-        return counts
+        return logscan_library_stats.count_log_levels(content)
 
     def _normalize_library_name(self, value):
-        if not value:
-            return ""
-        text = str(value).lower()
-        text = text.replace("_", " ").replace("-", " ")
-        cleaned = []
-        for ch in text:
-            if ch.isalnum() or ch.isspace():
-                cleaned.append(ch)
-        normalized = " ".join("".join(cleaned).split())
-        return normalized
+        return logscan_library_stats.normalize_library_name(value)
 
     def _match_library_name(self, raw_name, library_entries):
-        if not raw_name:
-            return None
-        needle = self._normalize_library_name(raw_name)
-        if not needle:
-            return None
-        exact = None
-        candidates = []
-        for entry in library_entries:
-            name = entry.get("name")
-            if not name:
-                continue
-            normalized = self._normalize_library_name(name)
-            if not normalized:
-                continue
-            if needle == normalized:
-                exact = name
-                break
-            if needle in normalized or normalized in needle:
-                candidates.append((len(normalized), name))
-        if exact:
-            return exact
-        if candidates:
-            candidates.sort(reverse=True)
-            return candidates[0][1]
-        return None
+        return logscan_library_stats.match_library_name(raw_name, library_entries)
 
     def _strip_divider_wrappers(self, message):
         if not message:
@@ -2336,146 +2218,10 @@ class LogscanAnalyzer:
         return logscan_maintenance.extract_quiet_period_summary(content, maintenance_summary)
 
     def extract_config_line_count(self, content):
-        if not content:
-            return 0
-        lines = content.splitlines()
-        in_block = False
-        count = 0
-        for raw_line in lines:
-            line = raw_line.strip()
-            if not in_block:
-                if "Redacted Config" in line:
-                    in_block = True
-                continue
-            if "config.py:" not in line:
-                break
-            message = line.split("|", 1)[1].strip() if "|" in line else line
-            if not message:
-                continue
-            if "Quickstart run marker" in message:
-                break
-            if message.startswith("#"):
-                continue
-            if set(message.strip()) <= {"="}:
-                continue
-            count += 1
-        return count
+        return logscan_library_stats.extract_config_line_count(content)
 
     def extract_library_counts(self, content):
-        if not content:
-            return {}
-        lines = content.splitlines()
-        library_counts = {}
-        library_sources = {}
-        current_library = None
-        current_type = None
-
-        header_patterns = [
-            re.compile(r"Processing Library:\s*(.+)", re.IGNORECASE),
-            re.compile(r"Library:\s*(.+)", re.IGNORECASE),
-            re.compile(r"Information on library:\s*(.+)", re.IGNORECASE),
-        ]
-        type_pattern = re.compile(r"\b(Movie|Show)\b", re.IGNORECASE)
-        items_pattern = re.compile(r"Items Found:\s*(\d+)", re.IGNORECASE)
-        movies_pattern = re.compile(r"Movies Found:\s*(\d+)", re.IGNORECASE)
-        shows_pattern = re.compile(r"Shows Found:\s*(\d+)", re.IGNORECASE)
-        episodes_pattern = re.compile(r"Episodes Found:\s*(\d+)", re.IGNORECASE)
-        content_movies_pattern = re.compile(r"Content Count:\s*(\d+)\s+movies?", re.IGNORECASE)
-        content_shows_pattern = re.compile(r"Content Count:\s*(\d+)\s+shows?\s*/\s*(\d+)\s+episodes", re.IGNORECASE)
-        library_items_pattern = re.compile(r"Library\s+(.+?)\s+has\s+(\d+)\s+items", re.IGNORECASE)
-
-        for raw_line in lines:
-            line = raw_line.strip()
-            if line.startswith("#"):
-                line = line.lstrip("#").strip()
-            if not line:
-                continue
-            for pattern in header_patterns:
-                match = pattern.search(line)
-                if match:
-                    name = match.group(1).strip()
-                    if "->" in name:
-                        name = name.split("->", 1)[-1].strip()
-                    name = name.strip("- ").strip()
-                    if name:
-                        current_library = name
-                        current_type = None
-                        type_match = type_pattern.search(line)
-                        if type_match:
-                            current_type = type_match.group(1).lower()
-                    break
-
-            direct_match = library_items_pattern.search(line)
-            if direct_match:
-                name = direct_match.group(1).strip()
-                count = int(direct_match.group(2))
-                library_counts[name] = {
-                    "items": count,
-                }
-                continue
-
-            if not current_library:
-                continue
-
-            content_match = content_movies_pattern.search(line)
-            if content_match:
-                library_counts[current_library] = {
-                    "items": int(content_match.group(1)),
-                    "type": "movie",
-                }
-                library_sources[current_library] = "content_count"
-                continue
-
-            content_match = content_shows_pattern.search(line)
-            if content_match:
-                library_counts[current_library] = {
-                    "items": int(content_match.group(1)),
-                    "episodes": int(content_match.group(2)),
-                    "type": "show",
-                }
-                library_sources[current_library] = "content_count"
-                continue
-
-            items_match = items_pattern.search(line)
-            if items_match:
-                if library_sources.get(current_library) == "content_count":
-                    continue
-                library_counts[current_library] = {
-                    "items": int(items_match.group(1)),
-                    "type": current_type,
-                }
-                continue
-
-            movies_match = movies_pattern.search(line)
-            if movies_match:
-                if library_sources.get(current_library) == "content_count":
-                    continue
-                library_counts[current_library] = {
-                    "items": int(movies_match.group(1)),
-                    "type": "movie",
-                }
-                continue
-
-            shows_match = shows_pattern.search(line)
-            if shows_match:
-                if library_sources.get(current_library) == "content_count":
-                    continue
-                entry = library_counts.get(current_library, {})
-                entry["items"] = int(shows_match.group(1))
-                entry["type"] = entry.get("type") or "show"
-                library_counts[current_library] = entry
-                continue
-
-            episodes_match = episodes_pattern.search(line)
-            if episodes_match:
-                if library_sources.get(current_library) == "content_count":
-                    continue
-                entry = library_counts.get(current_library, {})
-                entry["episodes"] = int(episodes_match.group(1))
-                entry["type"] = entry.get("type") or "show"
-                library_counts[current_library] = entry
-
-        return library_counts
+        return logscan_library_stats.extract_library_counts(content)
 
     def _build_summary(
         self,

--- a/modules/logscan_library_stats.py
+++ b/modules/logscan_library_stats.py
@@ -1,0 +1,467 @@
+"""Library / section statistics extraction for LogscanAnalyzer.
+
+Extracted from :class:`modules.logscan.LogscanAnalyzer`.
+
+The functions in this module scan raw Kometa log text and pull out
+per-library and per-section statistics:
+
+* :func:`extract_library_counts` -- items/movies/shows/episodes per
+  library, tracking which "source" line each count came from so that
+  higher-priority sources (``Content Count:``) aren't overwritten by
+  lower-priority ones later in the log.
+
+* :func:`extract_section_runtimes` -- accumulates runtime seconds per
+  Kometa section (Movies, Shows, Overlays, ...).  Handles both the
+  inline ``Finished X in HH:MM:SS`` form and the older split
+  ``Finished X`` + ``Run Time:`` two-line form.
+
+* :func:`count_log_levels` -- one-pass counter for DEBUG/INFO/
+  WARNING/ERROR/CRITICAL + TRACEBACK occurrences.
+
+* :func:`extract_config_line_count` -- counts non-blank/non-comment
+  YAML lines inside the ``Redacted Config`` block that Kometa
+  echoes at the top of every log.
+
+* :func:`normalize_library_name` / :func:`match_library_name` --
+  fuzzy-ish name matcher used to reconcile library-config entries
+  with library names as they appear in logs (dashes, underscores,
+  and case can differ).
+
+* :func:`parse_hms_to_seconds` -- ``"HH:MM:SS"`` / ``"MM:SS"`` /
+  int-string parser that returns an ``int`` seconds count or None.
+  Public because :mod:`modules.logscan_progress` may benefit.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Small time-parsing helper
+# ---------------------------------------------------------------------------
+
+
+def parse_hms_to_seconds(value: object) -> Optional[int]:
+    """Parse a duration string into an int seconds count, else None.
+
+    Accepted forms:
+        * ``"HH:MM:SS"`` -- three colon-separated integers
+        * ``"MM:SS"``    -- two colon-separated integers
+        * ``"NNN"``      -- bare integer seconds (in a string)
+
+    Whitespace is stripped.  Anything else -- including negative
+    numbers or non-integer components -- returns ``None`` rather
+    than raising.
+    """
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        parts = text.split(":")
+        if len(parts) == 1:
+            return int(parts[0])
+        if len(parts) == 3:
+            hours = int(parts[0])
+            minutes = int(parts[1])
+            seconds = int(parts[2])
+            return hours * 3600 + minutes * 60 + seconds
+        if len(parts) == 2:
+            minutes = int(parts[0])
+            seconds = int(parts[1])
+            return minutes * 60 + seconds
+    except ValueError:
+        return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Section runtimes (Movies / Shows / Overlays / ...)
+# ---------------------------------------------------------------------------
+
+
+_INLINE_RUNTIME_RE = re.compile(r"Finished (?P<section>.+?) in (?P<time>\d+:\d{2}:\d{2})")
+_FINISHED_ONLY_RE = re.compile(r"Finished (?P<section>.+?)\s*$")
+_RUN_TIME_RE = re.compile(r"^\s*(?P<label>[A-Za-z][A-Za-z ]+?) Run Time:\s*(?P<time>\d+:\d{2}:\d{2})\s*$")
+
+_MAX_FINISHED_TO_RUNTIME_LINE_DISTANCE = 3
+
+
+def extract_section_runtimes(content: Optional[str]) -> dict[str, int]:
+    """Return a ``{section_name: total_seconds}`` dict.
+
+    Kometa reports section runtimes in one of two forms:
+
+    * Inline: ``"Finished Movies in 0:02:14"`` on a single line.
+    * Split : ``"Finished Movies"`` on one line, then a
+      ``"Something Run Time: 0:02:14"`` line within 3 lines.
+
+    When the inline form is present, the section name comes straight
+    from the ``Finished X`` capture.  For the split form, the
+    section from the preceding ``Finished X`` line wins over the
+    label prefix of the ``Run Time:`` line.  Multiple runtimes for
+    the same section are summed.
+    """
+    section_times: dict[str, int] = {}
+    if not content:
+        return section_times
+
+    last_section: Optional[str] = None
+    last_section_index: Optional[int] = None
+
+    for idx, line in enumerate(content.splitlines()):
+        if not line:
+            continue
+
+        # Case 1: inline "Finished X in HH:MM:SS"
+        inline_match = _INLINE_RUNTIME_RE.search(line)
+        if inline_match:
+            section = inline_match.group("section").strip()
+            if section.lower().startswith("at:"):
+                continue
+            seconds = parse_hms_to_seconds(inline_match.group("time"))
+            if seconds is not None:
+                section_times[section] = section_times.get(section, 0) + seconds
+            continue
+
+        # Case 2a: "Finished X" without a time -- remember for pairing
+        finished_match = _FINISHED_ONLY_RE.search(line)
+        if finished_match:
+            section = finished_match.group("section").strip()
+            lowered = section.lower()
+            if lowered == "run" or lowered.startswith("run "):
+                # "Finished Run" is the whole-log marker, not a section.
+                continue
+            last_section = section
+            last_section_index = idx
+            continue
+
+        # Case 2b: standalone "X Run Time: HH:MM:SS"
+        runtime_match = _RUN_TIME_RE.search(line)
+        if not runtime_match:
+            continue
+        seconds = parse_hms_to_seconds(runtime_match.group("time"))
+        if seconds is None:
+            continue
+
+        section = None
+        if last_section and last_section_index is not None and (idx - last_section_index) <= _MAX_FINISHED_TO_RUNTIME_LINE_DISTANCE:
+            section = last_section
+        else:
+            label = runtime_match.group("label").strip()
+            if label and label.lower() != "run":
+                section = label
+
+        if section:
+            section_times[section] = section_times.get(section, 0) + seconds
+
+        # Reset the pairing state whether or not we used it.
+        last_section = None
+        last_section_index = None
+
+    return section_times
+
+
+# ---------------------------------------------------------------------------
+# Log-level counting
+# ---------------------------------------------------------------------------
+
+
+_LOG_LEVEL_TAGS: tuple[tuple[str, str], ...] = (
+    ("debug", "[DEBUG]"),
+    ("info", "[INFO]"),
+    ("warning", "[WARNING]"),
+    ("error", "[ERROR]"),
+    ("critical", "[CRITICAL]"),
+    ("trace", "TRACEBACK"),
+)
+
+
+def count_log_levels(content: Optional[str]) -> dict[str, int]:
+    """Return a per-level count of log lines.
+
+    Keys: ``debug``, ``info``, ``warning``, ``error``, ``critical``,
+    ``trace`` (matches ``TRACEBACK`` anywhere in the line).
+
+    Matching is case-insensitive.  A line with multiple tags counts
+    once per tag (rare in practice).
+    """
+    counts = {key: 0 for key, _tag in _LOG_LEVEL_TAGS}
+    if not content:
+        return counts
+
+    for line in content.splitlines():
+        upper = line.upper()
+        for key, tag in _LOG_LEVEL_TAGS:
+            if tag in upper:
+                counts[key] += 1
+
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Library-name normalization + matching
+# ---------------------------------------------------------------------------
+
+
+def normalize_library_name(value: object) -> str:
+    """Return a normalized comparison key for library names.
+
+    Applies:
+    * Lower-casing.
+    * Underscore/dash -> space.
+    * Strip anything that isn't alphanumeric or whitespace.
+    * Collapse multiple spaces.
+
+    Falsy input returns the empty string.
+    """
+    if not value:
+        return ""
+    text = str(value).lower()
+    text = text.replace("_", " ").replace("-", " ")
+    cleaned = "".join(ch for ch in text if ch.isalnum() or ch.isspace())
+    return " ".join(cleaned.split())
+
+
+def match_library_name(raw_name: str, library_entries: list[dict]) -> Optional[str]:
+    """Find the config library-entry name that best matches *raw_name*.
+
+    * Exact normalized match wins.
+    * Otherwise, the LONGEST substring match wins (both directions:
+      ``needle in candidate`` and ``candidate in needle``).
+
+    Returns the entry's ``name`` field, or ``None`` when nothing
+    matches.
+    """
+    needle = normalize_library_name(raw_name)
+    if not needle:
+        return None
+
+    candidates: list[tuple[int, str]] = []
+    for entry in library_entries:
+        name = entry.get("name")
+        if not name:
+            continue
+        normalized = normalize_library_name(name)
+        if not normalized:
+            continue
+        if needle == normalized:
+            return name
+        if needle in normalized or normalized in needle:
+            candidates.append((len(normalized), name))
+
+    if candidates:
+        candidates.sort(reverse=True)
+        return candidates[0][1]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Config-line counting (Redacted Config block)
+# ---------------------------------------------------------------------------
+
+
+def extract_config_line_count(content: Optional[str]) -> int:
+    """Count effective lines in Kometa's ``Redacted Config`` block.
+
+    Skips:
+    * Blank lines.
+    * YAML comments (``# ...``).
+    * Divider lines composed entirely of ``=``.
+
+    Stops when we exit the config block (line without ``config.py:``)
+    or hit the ``Quickstart run marker``.
+    """
+    if not content:
+        return 0
+
+    in_block = False
+    count = 0
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+
+        if not in_block:
+            if "Redacted Config" in line:
+                in_block = True
+            continue
+
+        if "config.py:" not in line:
+            break
+
+        message = line.split("|", 1)[1].strip() if "|" in line else line
+        if not message:
+            continue
+        if "Quickstart run marker" in message:
+            break
+        if message.startswith("#"):
+            continue
+        if set(message.strip()) <= {"="}:
+            continue
+
+        count += 1
+
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Per-library item counts
+# ---------------------------------------------------------------------------
+
+
+# Header patterns identify "Processing Library:" style lines that
+# switch the current library context.
+_HEADER_PATTERNS: tuple[re.Pattern, ...] = (
+    re.compile(r"Processing Library:\s*(.+)", re.IGNORECASE),
+    re.compile(r"Library:\s*(.+)", re.IGNORECASE),
+    re.compile(r"Information on library:\s*(.+)", re.IGNORECASE),
+)
+
+_TYPE_PATTERN = re.compile(r"\b(Movie|Show)\b", re.IGNORECASE)
+
+# Direct pattern: "Library X has N items" -- assigns without touching context.
+_LIBRARY_ITEMS_PATTERN = re.compile(r"Library\s+(.+?)\s+has\s+(\d+)\s+items", re.IGNORECASE)
+
+# Content Count: winning pattern -- higher priority than the others,
+# and once assigned it blocks lower-priority overwrites.
+_CONTENT_MOVIES_PATTERN = re.compile(r"Content Count:\s*(\d+)\s+movies?", re.IGNORECASE)
+_CONTENT_SHOWS_PATTERN = re.compile(r"Content Count:\s*(\d+)\s+shows?\s*/\s*(\d+)\s+episodes", re.IGNORECASE)
+
+# Fallback patterns -- overwritable by anything else EXCEPT after a
+# Content Count entry has already been recorded for this library.
+_ITEMS_PATTERN = re.compile(r"Items Found:\s*(\d+)", re.IGNORECASE)
+_MOVIES_PATTERN = re.compile(r"Movies Found:\s*(\d+)", re.IGNORECASE)
+_SHOWS_PATTERN = re.compile(r"Shows Found:\s*(\d+)", re.IGNORECASE)
+_EPISODES_PATTERN = re.compile(r"Episodes Found:\s*(\d+)", re.IGNORECASE)
+
+
+def _try_switch_current_library(line: str) -> Optional[tuple[str, Optional[str]]]:
+    """Scan *line* for a library-header pattern; return (name, type) or None.
+
+    The type comes from the same line if it contains ``Movie`` or
+    ``Show``; otherwise ``type`` is None (to be filled in later).
+    """
+    for pattern in _HEADER_PATTERNS:
+        match = pattern.search(line)
+        if not match:
+            continue
+        name = match.group(1).strip()
+        # Handle "Library X -> Y" forms by taking the Y half.
+        if "->" in name:
+            name = name.split("->", 1)[-1].strip()
+        name = name.strip("- ").strip()
+        if not name:
+            return None
+        type_match = _TYPE_PATTERN.search(line)
+        current_type = type_match.group(1).lower() if type_match else None
+        return name, current_type
+    return None
+
+
+def extract_library_counts(content: Optional[str]) -> dict[str, dict]:
+    """Extract per-library item counts from a Kometa log.
+
+    Returns ``{library_name: {items: N, [type: 'movie'|'show'], [episodes: N]}}``.
+
+    Priority order for assigning counts to a library:
+
+    1. ``"Library X has N items"`` -- direct assignment, no context needed.
+    2. ``"Content Count: N movies"`` / ``"Content Count: N shows / N episodes"``
+       -- highest priority.  Locks the library so lower-priority
+       patterns won't overwrite it later.
+    3. ``"Items Found: N"`` / ``"Movies Found: N"`` -- overwrites in
+       full (single number, single type).
+    4. ``"Shows Found: N"`` / ``"Episodes Found: N"`` -- merges into
+       existing entry (keeping the other count/type).
+
+    All 3-4 require a preceding library-header line to establish context.
+    """
+    library_counts: dict[str, dict] = {}
+    if not content:
+        return library_counts
+
+    # Tracks which counts came from a Content Count line -- these
+    # are "locked" and can't be overwritten by lower-priority forms.
+    library_sources: dict[str, str] = {}
+    current_library: Optional[str] = None
+    current_type: Optional[str] = None
+
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if line.startswith("#"):
+            line = line.lstrip("#").strip()
+        if not line:
+            continue
+
+        # Header line? Switch the current library context.
+        header = _try_switch_current_library(line)
+        if header is not None:
+            current_library, current_type = header
+
+        # Direct assignment: "Library X has N items"
+        direct_match = _LIBRARY_ITEMS_PATTERN.search(line)
+        if direct_match:
+            name = direct_match.group(1).strip()
+            library_counts[name] = {"items": int(direct_match.group(2))}
+            continue
+
+        if not current_library:
+            continue
+
+        # Highest priority: Content Count lines
+        content_movies_match = _CONTENT_MOVIES_PATTERN.search(line)
+        if content_movies_match:
+            library_counts[current_library] = {
+                "items": int(content_movies_match.group(1)),
+                "type": "movie",
+            }
+            library_sources[current_library] = "content_count"
+            continue
+
+        content_shows_match = _CONTENT_SHOWS_PATTERN.search(line)
+        if content_shows_match:
+            library_counts[current_library] = {
+                "items": int(content_shows_match.group(1)),
+                "episodes": int(content_shows_match.group(2)),
+                "type": "show",
+            }
+            library_sources[current_library] = "content_count"
+            continue
+
+        # Lower-priority patterns -- skipped if Content Count already set.
+        if library_sources.get(current_library) == "content_count":
+            continue
+
+        items_match = _ITEMS_PATTERN.search(line)
+        if items_match:
+            library_counts[current_library] = {
+                "items": int(items_match.group(1)),
+                "type": current_type,
+            }
+            continue
+
+        movies_match = _MOVIES_PATTERN.search(line)
+        if movies_match:
+            library_counts[current_library] = {
+                "items": int(movies_match.group(1)),
+                "type": "movie",
+            }
+            continue
+
+        shows_match = _SHOWS_PATTERN.search(line)
+        if shows_match:
+            entry = library_counts.get(current_library, {})
+            entry["items"] = int(shows_match.group(1))
+            entry["type"] = entry.get("type") or "show"
+            library_counts[current_library] = entry
+            continue
+
+        episodes_match = _EPISODES_PATTERN.search(line)
+        if episodes_match:
+            entry = library_counts.get(current_library, {})
+            entry["episodes"] = int(episodes_match.group(1))
+            entry["type"] = entry.get("type") or "show"
+            library_counts[current_library] = entry
+
+    return library_counts

--- a/tests/test_logscan_library_stats.py
+++ b/tests/test_logscan_library_stats.py
@@ -1,0 +1,315 @@
+"""Unit tests for :mod:`modules.logscan_library_stats`.
+
+Extracted alongside the PR that moved library / section stats
+extraction out of :class:`modules.logscan.LogscanAnalyzer`.
+
+Existing coverage via the LogscanAnalyzer method wrappers still
+lives in tests/test_logscan_runtime_parse.py -- these focused
+tests target the pure helpers directly, especially the priority
+rules inside :func:`extract_library_counts` that are easy to
+regress.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from modules.logscan_library_stats import (
+    count_log_levels,
+    extract_config_line_count,
+    extract_library_counts,
+    extract_section_runtimes,
+    match_library_name,
+    normalize_library_name,
+    parse_hms_to_seconds,
+)
+
+# ---------------------------------------------------------------------------
+# parse_hms_to_seconds
+# ---------------------------------------------------------------------------
+
+
+class TestParseHmsToSeconds:
+    def test_hms(self):
+        assert parse_hms_to_seconds("1:30:45") == 5445
+
+    def test_ms(self):
+        assert parse_hms_to_seconds("5:30") == 330
+
+    def test_bare_int(self):
+        assert parse_hms_to_seconds("42") == 42
+
+    def test_whitespace_stripped(self):
+        assert parse_hms_to_seconds("  1:30:45  ") == 5445
+
+    def test_none_returns_none(self):
+        assert parse_hms_to_seconds(None) is None
+
+    def test_empty_returns_none(self):
+        assert parse_hms_to_seconds("") is None
+
+    def test_non_numeric_returns_none(self):
+        assert parse_hms_to_seconds("not a time") is None
+
+    def test_too_many_parts_returns_none(self):
+        # 4 colon-separated parts is not a supported form.
+        assert parse_hms_to_seconds("1:2:3:4") is None
+
+
+# ---------------------------------------------------------------------------
+# extract_section_runtimes
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSectionRuntimes:
+    def test_empty_content_returns_empty_dict(self):
+        assert extract_section_runtimes("") == {}
+        assert extract_section_runtimes(None) == {}
+
+    def test_inline_form(self):
+        content = "Finished Movies in 0:02:14"
+        assert extract_section_runtimes(content) == {"Movies": 134}
+
+    def test_split_form(self):
+        content = "Finished Overlays\n   Overlays Run Time: 0:00:30"
+        assert extract_section_runtimes(content) == {"Overlays": 30}
+
+    def test_sums_multiple_occurrences(self):
+        content = "Finished Movies in 0:02:14\nFinished Movies in 0:01:30"
+        # 134 + 90 = 224 seconds total
+        assert extract_section_runtimes(content) == {"Movies": 224}
+
+    def test_ignores_finished_run_banner(self):
+        # "Finished Run" is the whole-log marker, not a section.
+        content = "Finished Run\n   Run Time: 1:00:00"
+        assert extract_section_runtimes(content) == {}
+
+    def test_ignores_finished_at_lines(self):
+        # "Finished at: HH:MM:SS" -- Kometa sometimes uses this and
+        # it looks close enough to trip the inline pattern.
+        content = "Finished at: 08:30:00 in 0:00:30"
+        # 'at:' prefixed section is skipped
+        assert extract_section_runtimes(content) == {}
+
+
+# ---------------------------------------------------------------------------
+# count_log_levels
+# ---------------------------------------------------------------------------
+
+
+class TestCountLogLevels:
+    def test_all_levels(self):
+        content = "\n".join(
+            [
+                "[DEBUG] one",
+                "[INFO] two",
+                "[WARNING] three",
+                "[ERROR] four",
+                "[CRITICAL] five",
+                "TRACEBACK line",
+            ]
+        )
+        assert count_log_levels(content) == {
+            "debug": 1,
+            "info": 1,
+            "warning": 1,
+            "error": 1,
+            "critical": 1,
+            "trace": 1,
+        }
+
+    def test_empty_content(self):
+        assert count_log_levels("") == {
+            "debug": 0,
+            "info": 0,
+            "warning": 0,
+            "error": 0,
+            "critical": 0,
+            "trace": 0,
+        }
+
+    def test_case_insensitive(self):
+        # Lower/mixed case still matches (implementation upper-cases first).
+        assert count_log_levels("[debug] hi")["debug"] == 1
+        assert count_log_levels("[Info] hi")["info"] == 1
+
+    def test_traceback_matches_anywhere(self):
+        content = "some line before Traceback (most recent call last):"
+        assert count_log_levels(content)["trace"] == 1
+
+
+# ---------------------------------------------------------------------------
+# normalize_library_name
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeLibraryName:
+    def test_lowercases(self):
+        assert normalize_library_name("MyMovies") == "mymovies"
+
+    def test_underscores_and_dashes_become_spaces(self):
+        assert normalize_library_name("4K_TV-Shows") == "4k tv shows"
+
+    def test_strips_punctuation(self):
+        assert normalize_library_name("Movies!! (HD)") == "movies hd"
+
+    def test_collapses_multiple_spaces(self):
+        assert normalize_library_name("A   B") == "a b"
+
+    def test_empty_returns_empty(self):
+        assert normalize_library_name("") == ""
+
+    def test_none_returns_empty(self):
+        assert normalize_library_name(None) == ""
+
+
+# ---------------------------------------------------------------------------
+# match_library_name
+# ---------------------------------------------------------------------------
+
+
+class TestMatchLibraryName:
+    @pytest.fixture
+    def entries(self):
+        return [
+            {"name": "Movies"},
+            {"name": "TV Shows"},
+            {"name": "4K Movies"},
+        ]
+
+    def test_exact_normalized_match_wins(self, entries):
+        assert match_library_name("movies", entries) == "Movies"
+
+    def test_underscore_normalized_match(self, entries):
+        assert match_library_name("4k_movies", entries) == "4K Movies"
+
+    def test_longest_substring_wins(self, entries):
+        # "movie" is a substring of both "movies" and "4k movies".
+        # The longer match ("4k movies") should win when both are
+        # candidates.  BUT: "movies" is an EXACT match, so it wins
+        # over any substring.
+        # Try a substring that only matches longer:
+        assert match_library_name("4k movies special", entries) == "4K Movies"
+
+    def test_missing_returns_none(self, entries):
+        assert match_library_name("unknown", entries) is None
+
+    def test_empty_needle_returns_none(self, entries):
+        assert match_library_name("", entries) is None
+
+    def test_entry_without_name_skipped(self):
+        entries = [{"name": None}, {"foo": "bar"}, {"name": "Movies"}]
+        assert match_library_name("movies", entries) == "Movies"
+
+
+# ---------------------------------------------------------------------------
+# extract_config_line_count
+# ---------------------------------------------------------------------------
+
+
+class TestExtractConfigLineCount:
+    def test_empty_content(self):
+        assert extract_config_line_count("") == 0
+        assert extract_config_line_count(None) == 0
+
+    def test_no_config_block(self):
+        content = "just some log lines\nwith no redacted config"
+        assert extract_config_line_count(content) == 0
+
+    def test_counts_yaml_lines(self):
+        content = "\n".join(
+            [
+                "some noise",
+                "[XXX] Redacted Config",
+                "[XXX] [config.py:1] |  # comment line",
+                "[XXX] [config.py:1] | libraries:",
+                "[XXX] [config.py:1] |   Movies:",
+                "[XXX] [config.py:1] | =====",
+                "[XXX] [config.py:1] | ",
+                "[XXX] [config.py:1] |   type: movie",
+                "[XXX] some other line",
+            ]
+        )
+        # libraries:, Movies:, type: movie => 3 (comment, divider, blank skipped)
+        assert extract_config_line_count(content) == 3
+
+    def test_stops_at_quickstart_marker(self):
+        content = "\n".join(
+            [
+                "[XXX] Redacted Config",
+                "[XXX] [config.py:1] | libraries:",
+                "[XXX] [config.py:1] |   Quickstart run marker foo=bar",
+                "[XXX] [config.py:1] |   type: movie",  # not counted
+            ]
+        )
+        assert extract_config_line_count(content) == 1
+
+
+# ---------------------------------------------------------------------------
+# extract_library_counts -- priority rules
+# ---------------------------------------------------------------------------
+
+
+class TestExtractLibraryCounts:
+    def test_empty_content(self):
+        assert extract_library_counts("") == {}
+        assert extract_library_counts(None) == {}
+
+    def test_content_count_movies(self):
+        content = "Processing Library: Movies\nContent Count: 500 movies"
+        assert extract_library_counts(content) == {"Movies": {"items": 500, "type": "movie"}}
+
+    def test_content_count_shows_with_episodes(self):
+        content = "Processing Library: TV\nContent Count: 100 shows / 3000 episodes"
+        assert extract_library_counts(content) == {"TV": {"items": 100, "episodes": 3000, "type": "show"}}
+
+    def test_content_count_locks_against_lower_priority(self):
+        # After Content Count sets 500, Items Found: 123 should be ignored.
+        content = "\n".join(
+            [
+                "Processing Library: Movies",
+                "Content Count: 500 movies",
+                "Items Found: 123",
+                "Movies Found: 456",
+            ]
+        )
+        assert extract_library_counts(content) == {"Movies": {"items": 500, "type": "movie"}}
+
+    def test_items_found_falls_back(self):
+        content = "Processing Library: Movies\nItems Found: 100"
+        # Type is None because no Movie/Show hint on the header line.
+        assert extract_library_counts(content) == {"Movies": {"items": 100, "type": None}}
+
+    def test_shows_and_episodes_merge_into_single_entry(self):
+        content = "\n".join(
+            [
+                "Processing Library: TV",
+                "Shows Found: 100",
+                "Episodes Found: 3000",
+            ]
+        )
+        assert extract_library_counts(content) == {"TV": {"items": 100, "type": "show", "episodes": 3000}}
+
+    def test_direct_library_items_form(self):
+        # "Library X has N items" doesn't need a preceding header.
+        content = "Library Movies has 42 items"
+        assert extract_library_counts(content) == {"Movies": {"items": 42}}
+
+    def test_header_supports_arrow_form(self):
+        # "Processing Library: Old -> New" -- keep the "New" part.
+        content = "Processing Library: Old -> New\nItems Found: 5"
+        assert extract_library_counts(content) == {"New": {"items": 5, "type": None}}
+
+    def test_no_library_context_ignores_counts(self):
+        # Items Found: without a preceding library header -- ignored.
+        content = "Items Found: 100"
+        assert extract_library_counts(content) == {}
+
+    def test_header_type_hint_picked_up(self):
+        # "Processing Library: Movies (Movie)" -- Type field on same line.
+        content = "Processing Library: Movies (Movie)\nItems Found: 10"
+        assert extract_library_counts(content) == {"Movies (Movie)": {"items": 10, "type": "movie"}}
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
**Sprint 3, PR #6.** Pulls the ~270-line cluster of library and section stats extraction out of `LogscanAnalyzer`.

## Public API in `modules/logscan_library_stats.py`

- `parse_hms_to_seconds(value)` → `int | None` — accepts 'HH:MM:SS' / 'MM:SS' / bare int strings
- `extract_section_runtimes(content)` → `dict[str, int]` — per-section runtime seconds
- `count_log_levels(content)` → `dict[str, int]` — DEBUG/INFO/WARNING/ERROR/CRITICAL/TRACEBACK counts
- `normalize_library_name(value)` → `str` — lowercase/dedup-space/strip-punct
- `match_library_name(raw_name, library_entries)` → `str | None` — fuzzy matcher
- `extract_config_line_count(content)` → `int` — YAML lines in Redacted Config block
- `extract_library_counts(content)` → `dict[str, dict]` — per-library item counts

## Three DRY wins inside `extract_library_counts`

**#1 — Content-count lock check hoisted.** Legacy code repeated:
```python
if library_sources.get(current_library) == 'content_count':
    continue
```
inside **all four** fallback branches (items/movies/shows/episodes). Now **one gate check** before the fallbacks. 3 lines saved, and the priority relationship is explicit.

**#2 — Header-scan extracted.** The 12-line loop-break-inline block:
```python
for pattern in header_patterns:
    match = pattern.search(line)
    if match:
        name = match.group(1).strip()
        if '->' in name: name = name.split('->', 1)[-1].strip()
        name = name.strip('- ').strip()
        if name:
            current_library = name
            current_type = None
            type_match = type_pattern.search(line)
            if type_match:
                current_type = type_match.group(1).lower()
        break
```
becomes:
```python
header = _try_switch_current_library(line)
if header is not None:
    current_library, current_type = header
```

**#3 — Pattern list promoted to module-level named constants** with docstring-style names that document each pattern's role (headers first, direct assign next, content-count-winning, then fallbacks). No more anonymous inline regexes.

## Bonus DRY in `count_log_levels`

Was **six sequential** `if X in upper` checks. Now a data-driven loop over a `(name, tag)` tuple table:
```python
_LOG_LEVEL_TAGS = (
    ('debug', '[DEBUG]'),
    ('info', '[INFO]'),
    # ...
)

for line in content.splitlines():
    upper = line.upper()
    for key, tag in _LOG_LEVEL_TAGS:
        if tag in upper:
            counts[key] += 1
```

Adding a new level = adding a tuple, not editing the loop body.

## Class wrappers in `logscan.py`

7 methods become **1-line delegating wrappers**. `_match_library_name` is still called externally from `modules/logscan_progress.py` via a fresh `LogscanAnalyzer` instance — still works via the wrapper.

## New tests: `tests/test_logscan_library_stats.py`

**44 focused unit tests** across 7 test classes, including priority-rule coverage inside `extract_library_counts` that was previously only exercised by integration tests:

- `TestParseHmsToSeconds` (8): hms/ms/int/whitespace/None/empty/junk/4-parts
- `TestExtractSectionRuntimes` (6): empty/inline/split/sum/finished-run/at:
- `TestCountLogLevels` (4): all-levels/empty/case/traceback-anywhere
- `TestNormalizeLibraryName` (6): lowercase/underscores/punctuation/spaces/empty/None
- `TestMatchLibraryName` (6): exact/underscore/longest/missing/empty/entry-no-name
- `TestExtractConfigLineCount` (4): empty/no-block/yaml/quickstart-marker-stops
- `TestExtractLibraryCounts` (10): empty/content-count/shows-episodes/locking/fallbacks/merge/direct/arrow/no-context/type-hint

## Impact

- `modules/logscan.py`: **2680 → 2426** (**-254 / -9.5%**)
- `modules/logscan_library_stats.py`: NEW 472 lines
- `tests/test_logscan_library_stats.py`: NEW 302 lines

## Sprint 3 progress

| PR | Δ | Ending |
|---|---|---|
| #1488 (PMS versions) | -20 | 3271 |
| #1489 (finished runs) | -104 | 3167 |
| #1490 (recommendations) | -114 | 3053 |
| #1492 (content extractors) | -106 | 2947 |
| #1493 (maintenance) | -267 | 2680 |
| **This PR** | **-254** | **2426** |
| **Total** | **-865 (-26.3%)** | |

## Verification

- All **1283 tests pass** (44 new + 1239 existing)
- Ruff + black clean