### PR TITLE
Cross the finish line: extract remaining small helpers (Sprint 3 finale)

### DIFF
--- a/modules/logscan.py
+++ b/modules/logscan.py
@@ -1,6 +1,5 @@
 import hashlib
 import logging
-import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -52,15 +51,7 @@ class LogscanAnalyzer:
         self.server_versions = []
 
     def remove_repeated_dividers(self, line):
-        divider = self.global_divider
-
-        # Ensure that line is a string
-        line = str(line)
-
-        # Use regular expression to find and replace repeated dividers
-        line = re.sub(f"({re.escape(divider)}){{10,}}", "", line)
-
-        return line
+        return logscan_content_extractors.remove_repeated_dividers(line, self.global_divider)
 
     async def parse_attachment_content(self, content_bytes):
         try:
@@ -128,26 +119,7 @@ class LogscanAnalyzer:
         return logscan_recommendations.format_time_value(time_value)
 
     def cleanup_content(self, content):
-        """
-        Clean up the content by removing unnecessary lines and trailing characters.
-        """
-        cleanup_regex = r"\[(202[0-9])-\d+-\d+ \d+:\d+:\d+,\d+\] \[.*\.py:\d+\] +\[[INFODEBUGWARCTL]*\] +\||^[ ]{65}\|"
-        cleaned_content = re.sub(cleanup_regex, "", content)
-
-        # mylogger.info(f"content:\n{content}")
-        # mylogger.info(f"cleaned_content:\n{cleaned_content}")
-
-        # Second pass to remove trailing '|'
-        lines = cleaned_content.splitlines()
-        cleaned_lines = [line.rstrip("|") if line.rstrip().endswith("|") else line for line in lines]
-        cleaned_content = "\n".join(cleaned_lines)
-
-        # Third pass to remove trailing spaces
-        cleaned_lines = [line.rstrip() for line in cleaned_content.splitlines()]
-        cleaned_content = "\n".join(cleaned_lines)
-        # mylogger.info(f"cleaned_content3rdpass:\n{cleaned_content}")
-
-        return cleaned_content
+        return logscan_content_extractors.cleanup_content(content)
 
     def extract_filename_from_url(self, url):
         return logscan_people.extract_filename_from_url(url)
@@ -311,45 +283,13 @@ class LogscanAnalyzer:
         return logscan_command.hash_file(path)
 
     def _parse_finished_datetime(self, value):
-        if not value:
-            return None
-        text = str(value).strip()
-        match = re.search(r"(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})", text)
-        if match:
-            try:
-                return datetime.strptime(f"{match.group(1)} {match.group(2)}", "%Y-%m-%d %H:%M:%S")
-            except Exception:
-                return None
-        match = re.search(r"(\d{2}:\d{2}:\d{2})\s+(\d{4}-\d{2}-\d{2})", text)
-        if match:
-            try:
-                return datetime.strptime(f"{match.group(2)} {match.group(1)}", "%Y-%m-%d %H:%M:%S")
-            except Exception:
-                return None
-        return None
+        return logscan_finished_runs.parse_finished_datetime(value)
 
     def _normalize_finished_at(self, finished_at, log_mtime):
-        parsed = self._parse_finished_datetime(finished_at)
-        now = datetime.now()
-        if parsed and parsed > now + timedelta(days=1):
-            parsed = None
-        if not parsed and log_mtime:
-            try:
-                parsed = datetime.fromtimestamp(log_mtime)
-            except Exception:
-                parsed = None
-        if parsed:
-            return parsed.strftime("%Y-%m-%d %H:%M:%S")
-        return finished_at
+        return logscan_finished_runs.normalize_finished_at(finished_at, log_mtime)
 
     def _normalize_started_at(self, started_at):
-        parsed = self._parse_finished_datetime(started_at)
-        now = datetime.now()
-        if parsed and parsed > now + timedelta(days=1):
-            parsed = None
-        if parsed:
-            return parsed.strftime("%Y-%m-%d %H:%M:%S")
-        return started_at
+        return logscan_finished_runs.normalize_started_at(started_at)
 
     def _parse_hms_to_seconds(self, value):
         return logscan_library_stats.parse_hms_to_seconds(value)

--- a/modules/logscan_content_extractors.py
+++ b/modules/logscan_content_extractors.py
@@ -152,6 +152,44 @@ def extract_divider(content: str, fallback: str = DEFAULT_DIVIDER) -> str:
     return fallback
 
 
+def remove_repeated_dividers(line, divider: str) -> str:
+    """Collapse long runs of *divider* into a single empty span.
+
+    Kometa banner lines can contain hundreds of divider characters in
+    a row (e.g. ``==================...``).  We drop runs of 10 or
+    more so downstream regex parsers don't choke on them.  The
+    *divider* argument is typically ``analyzer.global_divider`` and
+    is regex-escaped before use so multi-char dividers work too.
+    """
+    line = str(line)
+    return re.sub(f"({re.escape(divider)}){{10,}}", "", line)
+
+
+def cleanup_content(content: str) -> str:
+    """Strip Kometa log prefixes and trailing punctuation from *content*.
+
+    Three-pass scrub:
+
+    1. Remove the ``[YYYY-MM-DD HH:MM:SS,mmm] [file.py:NN] [LEVEL] |``
+       Kometa log prefix (or a 65-space continuation-line prefix)
+       from the front of each line.
+    2. Strip a trailing ``|`` from each line (banner pipe).
+    3. Right-strip whitespace on each line.
+
+    Returned as a single ``\n``-joined string ready for downstream
+    line-oriented parsing.
+    """
+    cleanup_regex = r"\[(202[0-9])-\d+-\d+ \d+:\d+:\d+,\d+\] \[.*\.py:\d+\] +\[[INFODEBUGWARCTL]*\] +\||^[ ]{65}\|"
+    cleaned_content = re.sub(cleanup_regex, "", content)
+
+    lines = cleaned_content.splitlines()
+    cleaned_lines = [line.rstrip("|") if line.rstrip().endswith("|") else line for line in lines]
+    cleaned_content = "\n".join(cleaned_lines)
+
+    cleaned_lines = [line.rstrip() for line in cleaned_content.splitlines()]
+    return "\n".join(cleaned_lines)
+
+
 # ---------------------------------------------------------------------------
 # Scheduled run time / maintenance window
 # ---------------------------------------------------------------------------

--- a/modules/logscan_finished_runs.py
+++ b/modules/logscan_finished_runs.py
@@ -30,7 +30,7 @@ results to ``self``.
 from __future__ import annotations
 
 import re
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Optional
 
 # ---------------------------------------------------------------------------
@@ -280,3 +280,78 @@ def format_contiguous_lines(line_numbers: list[int]) -> str:
         formatted_ranges.append(f"{start_range}-{end_range}")
 
     return ", ".join(formatted_ranges)
+
+
+# ---------------------------------------------------------------------------
+# Datetime normalizers.
+#
+# The started_at / finished_at fields in the summary payload can arrive
+# in several shapes: "2024-11-08 03:15:22", "2024-11-08T03:15:22",
+# "03:15:22 2024-11-08", or already-parsed datetimes from Kometa's
+# scheduler.  These helpers coerce them into the canonical
+# "YYYY-MM-DD HH:MM:SS" string form and reject far-future dates that
+# usually indicate a parse mistake.
+# ---------------------------------------------------------------------------
+
+
+def parse_finished_datetime(value) -> Optional[datetime]:
+    """Parse *value* into a naive datetime, or return None if it can't.
+
+    Accepts either ``YYYY-MM-DD[ T]HH:MM:SS`` or ``HH:MM:SS YYYY-MM-DD``
+    in the string form; anything else -> None.  Falsy inputs -> None.
+    """
+    if not value:
+        return None
+    text = str(value).strip()
+    match = re.search(r"(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})", text)
+    if match:
+        try:
+            return datetime.strptime(f"{match.group(1)} {match.group(2)}", "%Y-%m-%d %H:%M:%S")
+        except Exception:
+            return None
+    match = re.search(r"(\d{2}:\d{2}:\d{2})\s+(\d{4}-\d{2}-\d{2})", text)
+    if match:
+        try:
+            return datetime.strptime(f"{match.group(2)} {match.group(1)}", "%Y-%m-%d %H:%M:%S")
+        except Exception:
+            return None
+    return None
+
+
+def normalize_finished_at(finished_at, log_mtime) -> Optional[str]:
+    """Return *finished_at* as a canonical ``YYYY-MM-DD HH:MM:SS`` string.
+
+    If parsing fails or the parsed value is more than a day in the
+    future (typical when a log's clock is skewed), fall back to
+    *log_mtime* (a POSIX timestamp).  If even that fails, return the
+    original ``finished_at`` unchanged so the caller can decide what
+    to do with garbage.
+    """
+    parsed = parse_finished_datetime(finished_at)
+    now = datetime.now()
+    if parsed and parsed > now + timedelta(days=1):
+        parsed = None
+    if not parsed and log_mtime:
+        try:
+            parsed = datetime.fromtimestamp(log_mtime)
+        except Exception:
+            parsed = None
+    if parsed:
+        return parsed.strftime("%Y-%m-%d %H:%M:%S")
+    return finished_at
+
+
+def normalize_started_at(started_at) -> Optional[str]:
+    """Return *started_at* as a canonical ``YYYY-MM-DD HH:MM:SS`` string.
+
+    Same shape as :func:`normalize_finished_at` but without the
+    log-mtime fallback -- if the input can't be parsed or is too
+    far in the future, the raw input is returned unchanged.
+    """
+    parsed = parse_finished_datetime(started_at)
+    now = datetime.now()
+    if parsed and parsed > now + timedelta(days=1):
+        parsed = None
+    if parsed:
+        return parsed.strftime("%Y-%m-%d %H:%M:%S")
+    return started_at


### PR DESCRIPTION
**Sprint 3, PR #10 — THE SPRINT FINALE.** Cleans up the last five orphan methods on `LogscanAnalyzer`, pushing `logscan.py` **BELOW the 600-line target**.

## What moves where

### Moved to `modules/logscan_content_extractors`

| Old (class method) | New (module function) |
|---|---|
| `remove_repeated_dividers(line)` | `remove_repeated_dividers(line, divider)` |
| `cleanup_content(content)` | `cleanup_content(content)` |

The divider version now takes the divider explicitly instead of reading `self.global_divider`, which makes it purely functional.

### Moved to `modules/logscan_finished_runs`

| Old (class method) | New (module function) |
|---|---|
| `_parse_finished_datetime(value)` | `parse_finished_datetime(value)` |
| `_normalize_finished_at(finished_at, log_mtime)` | `normalize_finished_at(finished_at, log_mtime)` |
| `_normalize_started_at(started_at)` | `normalize_started_at(started_at)` |

## Rationale for the splits

- The divider / cleanup helpers are **content-preprocessing utilities** and belong with the rest of `logscan_content_extractors`.
- The datetime normalizers are used exclusively to **canonicalize the `started_at` / `finished_at` fields in the FINISHED-RUN summary block**, so `logscan_finished_runs` is the natural home.

## Class wrappers preserved

`LogscanAnalyzer` keeps all five methods as **1-line delegators** so existing callers (both internal and tests) see **zero API change**.

## Bonus cleanup

Ruff caught that `logscan.py` no longer imports `re` after this extraction — cleaned up as part of the same commit.

## Impact

- `modules/logscan.py`: **626 → 566** (**-60 / -9.6%**)
- `modules/logscan_content_extractors.py`: 240 → 278 (+38)
- `modules/logscan_finished_runs.py`: 282 → 357 (+75)

## Sprint 3 complete

| PR | Δ | Ending |
|---|---|---|
| #1488 PMS versions | -20 | 3271 |
| #1489 Finished runs | -104 | 3167 |
| #1490 Recommendations | -114 | 3053 |
| #1492 Content extractors | -106 | 2947 |
| #1493 Maintenance | -267 | 2680 |
| #1494 Library stats | -254 | 2426 |
| #1495 make_recommendations | -1109 | 1317 |
| #1496 extract_progress | -640 | 677 |
| #1497 rec post-processing | -51 | 626 |
| **#1498 (this) finale** | **-60** | **566** |
| **TOTAL** | **-2725 (-82.8%)** | |

**`logscan.py` is now 34 lines BELOW the 600-line ceiling.** Ten PRs. Starting size 3291. Ending 566.

## The extracted module ecosystem

The former 3291-line monolith is now a lean 566-line `LogscanAnalyzer` coordinator plus these focused modules:

| Module | Lines | Purpose |
|---|---|---|
| `logscan.py` | 566 | Coordinator + I/O + orchestration |
| `logscan_pms_versions.py` | ~90 | PMS version tuple comparisons |
| `logscan_finished_runs.py` | 357 | Finished-run summary parsing |
| `logscan_recommendations.py` | ~350 | Pre-built recommendation strings |
| `logscan_content_extractors.py` | 278 | Log preprocessing / value extraction |
| `logscan_maintenance.py` | ~450 | Maintenance / quickstart-marker parsing |
| `logscan_library_stats.py` | ~350 | Library counts / section runtimes |
| `logscan_recommendations_engine.py` | 1429 | The make_recommendations engine |
| `logscan_progress_engine.py` | 770 | Live progress payload parser |

## Verification

- All **1284 tests pass**
- Ruff + black clean
- Smoke-tested all 5 extracted functions end-to-end via the analyzer wrappers — datetimes, cleanup, dividers all behave byte-identical to the original