### PR TITLE
Implement retry logic for Docker manifest creation

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -125,7 +125,26 @@ jobs:
           fi
 
           echo "$manifest_command"
-          eval "$manifest_command"
+          
+          # Retry logic with exponential backoff
+          max_attempts=5
+          attempt=1
+          while [ $attempt -le $max_attempts ]; do
+            echo "Attempt $attempt to create manifest..."
+            if eval "$manifest_command"; then
+              echo "Manifest created successfully"
+              break
+            else
+              if [ $attempt -lt $max_attempts ]; then
+                echo "Manifest creation failed, waiting before retry..."
+                sleep $((10 * attempt))  # 10s, 20s, 30s, 40s, 50s
+              else
+                echo "Max attempts reached. Failing."
+                exit 1
+              fi
+            fi
+            attempt=$((attempt + 1))
+          done
 
           docker manifest push ${{ vars.DOCKER_TEAM }}/${{ vars.DOCKER_REPO }}:${{ inputs.tag_name }}
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -125,7 +125,7 @@ jobs:
           fi
 
           echo "$manifest_command"
-          
+
           # Retry logic with exponential backoff
           max_attempts=5
           attempt=1


### PR DESCRIPTION
Added retry logic with exponential backoff for manifest creation in the Docker build workflow.

## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [X] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Adds a backoff/retry to publishing the image to try to prevent an intermittent failure.
