### PR TITLE
Delete dead duplicate _coerce_import_bool + add regression test

### DIFF
--- a/modules/importer.py
+++ b/modules/importer.py
@@ -424,18 +424,6 @@ def _collect_dynamic_child_field_specs(template_vars: Any) -> list[dict[str, str
     return specs
 
 
-def _coerce_import_bool(value: Any) -> bool | None:
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        lowered = value.strip().lower()
-        if lowered in {"true", "yes", "1"}:
-            return True
-        if lowered in {"false", "no", "0"}:
-            return False
-    return None
-
-
 def _coerce_import_int(value: Any) -> int | None:
     if isinstance(value, bool):
         return None

--- a/tests/test_importer_edge_cases.py
+++ b/tests/test_importer_edge_cases.py
@@ -139,3 +139,38 @@ def test_prepare_import_payload_maps_apprise_config_to_location():
 
     assert payload["apprise"]["apprise"]["location"] == "/config/apprise.yml"
     assert report.counts["imported"] >= 1
+
+
+def test_coerce_import_bool_accepts_yaml_wide_truthy_and_falsy_values():
+    """Regression guard for the duplicate `_coerce_import_bool` bug.
+
+    Prior to develop #TBD, importer.py had TWO `_coerce_import_bool`
+    definitions.  Python's last-def-wins meant callers got the "wide"
+    version that accepts YAML-native `on`/`off` alongside the usual
+    `true`/`false`/`yes`/`no`/`1`/`0`.
+
+    The narrow (dead-code) def has been removed; this test locks
+    in the wide semantics so a future refactor can't silently
+    re-narrow the accepted set and break config imports that use
+    `field: on` / `field: off`.
+    """
+    assert importer._coerce_import_bool("true") is True
+    assert importer._coerce_import_bool("yes") is True
+    assert importer._coerce_import_bool("1") is True
+    assert importer._coerce_import_bool("on") is True
+    assert importer._coerce_import_bool("True") is True  # case-insensitive
+    assert importer._coerce_import_bool(" YES ") is True  # whitespace-tolerant
+
+    assert importer._coerce_import_bool("false") is False
+    assert importer._coerce_import_bool("no") is False
+    assert importer._coerce_import_bool("0") is False
+    assert importer._coerce_import_bool("off") is False
+    assert importer._coerce_import_bool("False") is False
+
+    assert importer._coerce_import_bool("maybe") is None
+    assert importer._coerce_import_bool("") is None
+    assert importer._coerce_import_bool(None) is None
+    assert importer._coerce_import_bool(42) is None
+
+    assert importer._coerce_import_bool(True) is True
+    assert importer._coerce_import_bool(False) is False


### PR DESCRIPTION
## The bug

`modules/importer.py` had **TWO** top-level definitions of `_coerce_import_bool`:

| Line | Truthy set | Falsy set |
|---|---|---|
| **L427** (narrow) | `{'true', 'yes', '1'}` | `{'false', 'no', '0'}` |
| **L954** (wide) | `{'true', 'yes', '1', 'on'}` | `{'false', 'no', '0', 'off'}` |

Python's last-def-wins meant the **L427 def was dead code** from the moment the module finished loading. All three call sites — L461 in `_serialize_playlist_import_value`, L1390 in `prepare_import_payload`'s playlist branch, L1924 in the dynamic child branch — actually invoked the L954 version.

## Why the wide version is the correct one

YAML 1.1 treats `on` / `off` as native boolean literals. Accepting them matches user expectation when they hand-edit `config.yml` — a user who writes `no_verify_ssl: on` shouldn't get their intent silently coerced to `None`.

## What this PR does

1. **Deletes the dead L427 def.** Zero runtime behavior changes — every caller was already resolving to the wide version.
2. **Adds `test_coerce_import_bool_accepts_yaml_wide_truthy_and_falsy_values`** in `tests/test_importer_edge_cases.py`. Locks in wide semantics (`true/yes/1/on` → True, `false/no/0/off` → False, case-insensitive, whitespace-tolerant, bogus values → None) so a future refactor can't accidentally re-narrow the accepted set and break config imports that use `field: on` / `field: off`.

## Verification

- `grep -rn '_coerce_import_bool' tests/ scripts/ --include='*.py'` → **zero external references**. Nothing depended on the narrow semantics.
- `grep -n '"on"|"off"' tests/test_importer_edge_cases.py` → no existing test exercised those values either way.
- All **1285 tests pass** (was 1284, +1 new guard).
- Ruff + black clean.

## Impact

- `modules/importer.py`: 2027 → **2015** (-12 lines, one dead def)
- `tests/test_importer_edge_cases.py`: **+36 lines** (regression guard)

## Discovery credit

Found while mapping `importer.py` for the Sprint 4 extraction work (#1503). Kept as a separate PR to keep the extraction diffs pure moves.