### PR TITLE
Extract library-type inference to importer_library_types

### DIFF
--- a/modules/importer.py
+++ b/modules/importer.py
@@ -150,6 +150,22 @@ from modules.importer_yaml_annotation import (  # noqa: E402
     annotate_yaml_with_report,  # noqa: F401 (public API, called as importer.annotate_yaml_with_report)
 )
 
+# Library-type inference + collection/overlay index builders moved to
+# modules/importer_library_types.py.  Re-exported here because
+# blueprints/import_config_routes.py calls `importer.build_library_type_plan`
+# and the mega prepare_import_payload (which stayed in this module)
+# still calls `_build_collection_index` / `_build_overlay_index`.
+from modules.importer_library_types import (  # noqa: E402
+    _build_collection_index,  # noqa: F401 (used below by prepare_import_payload)
+    _build_overlay_index,  # noqa: F401 (used below by prepare_import_payload)
+    _normalize_library_type,  # noqa: F401 (kept accessible via importer._normalize_library_type)
+    _resolve_collection_id,  # noqa: F401 (kept accessible via importer._resolve_collection_id)
+    _resolve_overlay_id,  # noqa: F401 (kept accessible via importer._resolve_overlay_id)
+    build_library_type_plan,  # noqa: F401 (public API, called as importer.build_library_type_plan)
+    infer_library_types,  # noqa: F401 (public API, called as importer.infer_library_types)
+    normalize_library_type,  # noqa: F401 (public API, called as importer.normalize_library_type)
+)
+
 
 def _collect_template_keys(template_vars: Any) -> set[str]:
     keys = set()
@@ -318,108 +334,6 @@ def _has_template_string_list_values(value: Any) -> bool:
     return bool(value)
 
 
-def _build_collection_index(collection_config: list[dict]) -> tuple[dict[str, dict], dict[str, str]]:
-    by_id: dict[str, dict] = {}
-    by_alias: dict[str, str] = {}
-    for group in collection_config or []:
-        for collection in group.get("collections", []) if isinstance(group, dict) else []:
-            cid = collection.get("id")
-            if not cid:
-                continue
-            if cid in by_id:
-                existing = by_id[cid]
-                if isinstance(existing, dict):
-                    existing_media = existing.get("media_types")
-                    new_media = collection.get("media_types")
-                    if isinstance(existing_media, list) or isinstance(new_media, list):
-                        merged_media = []
-                        for entry in existing_media or []:
-                            if entry not in merged_media:
-                                merged_media.append(entry)
-                        for entry in new_media or []:
-                            if entry not in merged_media:
-                                merged_media.append(entry)
-                        existing["media_types"] = merged_media
-
-                    existing_templates = existing.get("template_variables")
-                    new_templates = collection.get("template_variables")
-                    if isinstance(existing_templates, list) and isinstance(new_templates, list):
-                        seen_keys = {str(item.get("key")) for item in existing_templates if isinstance(item, dict) and item.get("key")}
-                        for item in new_templates:
-                            if not isinstance(item, dict):
-                                continue
-                            key = str(item.get("key") or "").strip()
-                            if key and key in seen_keys:
-                                continue
-                            existing_templates.append(item)
-                            if key:
-                                seen_keys.add(key)
-                    elif existing.get("template_variables") in (None, [], {}):
-                        existing["template_variables"] = new_templates
-                alias = cid.replace("collection_", "", 1)
-                by_alias[alias] = cid
-                continue
-
-            by_id[cid] = collection
-            alias = cid.replace("collection_", "", 1)
-            by_alias[alias] = cid
-    return by_id, by_alias
-
-
-def _build_overlay_index(overlay_config: list[dict]) -> tuple[dict[str, dict], dict[str, str], dict[str, dict]]:
-    by_id: dict[str, dict] = {}
-    by_alias: dict[str, str] = {}
-    radio_map: dict[str, dict] = {}
-    for group in overlay_config or []:
-        if not isinstance(group, dict):
-            continue
-        input_type = group.get("input_type")
-        radio_group = group.get("radio_group_name")
-        for overlay in group.get("overlays", []):
-            if not isinstance(overlay, dict):
-                continue
-            oid = overlay.get("id")
-            if not oid:
-                continue
-            if oid in by_id:
-                existing = by_id[oid]
-                if isinstance(existing, dict):
-                    existing_media = existing.get("media_types")
-                    new_media = overlay.get("media_types")
-                    if isinstance(existing_media, list) or isinstance(new_media, list):
-                        merged = []
-                        for entry in existing_media or []:
-                            if entry not in merged:
-                                merged.append(entry)
-                        for entry in new_media or []:
-                            if entry not in merged:
-                                merged.append(entry)
-                        existing["media_types"] = merged
-                    existing_templates = existing.get("template_variables")
-                    new_templates = overlay.get("template_variables")
-                    if isinstance(existing_templates, dict) and isinstance(new_templates, dict):
-                        for key, value in new_templates.items():
-                            if key not in existing_templates:
-                                existing_templates[key] = value
-                    elif isinstance(new_templates, dict) and not isinstance(existing_templates, dict):
-                        existing["template_variables"] = new_templates
-            else:
-                by_id[oid] = overlay
-            alias = oid.replace("overlay_", "", 1)
-            by_alias[alias] = oid
-            if input_type == "radio" and radio_group and "value" in overlay:
-                radio_value = overlay.get("value")
-                radio_map[oid] = {
-                    "group_name": str(radio_group),
-                    "value": radio_value,
-                }
-                if isinstance(radio_value, str):
-                    radio_alias = radio_value.strip()
-                    if radio_alias:
-                        by_alias[radio_alias] = oid
-    return by_id, by_alias, radio_map
-
-
 def _build_attribute_sets(
     attribute_config: dict,
 ) -> tuple[set[str], set[str], dict[str, str], set[str], dict[str, dict], dict[str, dict]]:
@@ -498,187 +412,6 @@ def _build_attribute_sets(
         mass_update_defs,
         toggle_select_defs,
     )
-
-
-def _normalize_library_type(value: Any) -> tuple[str | None, str | None]:
-    if value is None:
-        return None, None
-    text = str(value).strip().lower()
-    if text in {"movie", "mov"}:
-        return "mov", "movie"
-    if text in {"show", "sho", "series"}:
-        return "sho", "show"
-    return None, None
-
-
-def normalize_library_type(value: Any) -> str | None:
-    _, label = _normalize_library_type(value)
-    return label
-
-
-def _resolve_collection_id(raw_default: str, collection_by_id: dict, collection_by_alias: dict) -> str | None:
-    if raw_default.startswith("collection_") and raw_default in collection_by_id:
-        return raw_default
-    return collection_by_alias.get(raw_default)
-
-
-def _resolve_overlay_id(raw_default: str, overlay_by_id: dict, overlay_by_alias: dict) -> str | None:
-    if raw_default.startswith("overlay_") and raw_default in overlay_by_id:
-        return raw_default
-    if raw_default.startswith("content_rating_"):
-        candidate = f"overlay_{raw_default}"
-        return candidate if candidate in overlay_by_id else None
-    return overlay_by_alias.get(raw_default)
-
-
-def infer_library_types(config_data: dict) -> tuple[dict[str, str], list[dict]]:
-    collection_config = helpers.load_quickstart_config("quickstart_collections.json") or []
-    overlay_config = helpers.load_quickstart_overlay_config() or []
-    collection_by_id, collection_by_alias = _build_collection_index(collection_config)
-    overlay_by_id, overlay_by_alias, _ = _build_overlay_index(overlay_config)
-
-    inferred_types: dict[str, str] = {}
-    details: list[dict] = []
-
-    libraries_payload = config_data.get("libraries")
-    if not isinstance(libraries_payload, dict):
-        return inferred_types, details
-
-    for lib_name, lib_cfg in libraries_payload.items():
-        if not isinstance(lib_cfg, dict):
-            continue
-        movie_score = 0
-        show_score = 0
-
-        collection_files = lib_cfg.get("collection_files")
-        if isinstance(collection_files, list):
-            for entry in collection_files:
-                default_value = None
-                if isinstance(entry, dict):
-                    default_value = entry.get("default")
-                elif isinstance(entry, str):
-                    default_value = entry
-                if not default_value:
-                    continue
-                raw_default = str(default_value)
-                collection_id = _resolve_collection_id(raw_default, collection_by_id, collection_by_alias)
-                if not collection_id:
-                    continue
-                media_types = collection_by_id.get(collection_id, {}).get("media_types") or []
-                is_movie = "movie" in media_types
-                is_show = "show" in media_types
-                if is_movie and not is_show:
-                    movie_score += 2
-                elif is_show and not is_movie:
-                    show_score += 2
-                elif is_movie and is_show:
-                    movie_score += 1
-                    show_score += 1
-
-        overlay_files = lib_cfg.get("overlay_files")
-        if isinstance(overlay_files, list):
-            for entry in overlay_files:
-                default_value = None
-                template_values = None
-                if isinstance(entry, dict):
-                    default_value = entry.get("default")
-                    template_values = entry.get("template_variables")
-                elif isinstance(entry, str):
-                    default_value = entry
-                if not default_value:
-                    continue
-                if isinstance(template_values, dict):
-                    builder_level = template_values.get("builder_level")
-                    if builder_level in {"show", "season", "episode"}:
-                        show_score += 2
-                    elif builder_level == "movie":
-                        movie_score += 2
-
-                raw_default = str(default_value)
-                overlay_id = _resolve_overlay_id(raw_default, overlay_by_id, overlay_by_alias)
-                if not overlay_id:
-                    continue
-                media_types = overlay_by_id.get(overlay_id, {}).get("media_types") or []
-                movie_types = "movie" in media_types
-                show_types = any(t in {"show", "season", "episode"} for t in media_types)
-                if movie_types and not show_types:
-                    movie_score += 1
-                elif show_types and not movie_types:
-                    show_score += 1
-                elif movie_types and show_types:
-                    movie_score += 1
-                    show_score += 1
-
-        inferred = None
-        if show_score > movie_score:
-            inferred = "show"
-        elif movie_score > show_score:
-            inferred = "movie"
-
-        if movie_score == 0 and show_score == 0:
-            confidence = "unknown"
-        else:
-            confidence = "high" if abs(movie_score - show_score) >= 2 else "low"
-
-        if inferred:
-            inferred_types[str(lib_name)] = inferred
-
-        details.append(
-            {
-                "name": str(lib_name),
-                "inferred_type": inferred,
-                "movie_score": movie_score,
-                "show_score": show_score,
-                "confidence": confidence,
-            }
-        )
-
-    return inferred_types, details
-
-
-def build_library_type_plan(
-    config_data: dict,
-    plex_movie_names: set[str],
-    plex_show_names: set[str],
-) -> tuple[dict[str, str], list[dict], bool]:
-    inferred_types, details = infer_library_types(config_data)
-    detail_map = {d.get("name"): d for d in details}
-    library_types: dict[str, str] = {}
-    inference_list: list[dict] = []
-    libraries_payload = config_data.get("libraries")
-    if not isinstance(libraries_payload, dict):
-        return library_types, inference_list, False
-
-    for lib_name in libraries_payload.keys():
-        name = str(lib_name)
-        if name in plex_movie_names:
-            inferred_type = "movie"
-            source = "plex"
-            confidence = "confirmed"
-        elif name in plex_show_names:
-            inferred_type = "show"
-            source = "plex"
-            confidence = "confirmed"
-        else:
-            inferred_type = inferred_types.get(name)
-            source = "inferred" if inferred_type else "unknown"
-            confidence = detail_map.get(name, {}).get("confidence", "unknown")
-        if inferred_type:
-            library_types[name] = inferred_type
-        detail = detail_map.get(name, {})
-        inference_list.append(
-            {
-                "name": name,
-                "source": source,
-                "type": inferred_type,
-                "confidence": confidence,
-                "movie_score": detail.get("movie_score", 0),
-                "show_score": detail.get("show_score", 0),
-            }
-        )
-
-    needs_confirmation = any(item.get("source") != "plex" for item in inference_list)
-    return library_types, inference_list, needs_confirmation
 
 
 def _flatten_dict(base: str, payload: Any, report: ImportReport, max_depth: int = 3) -> None:

--- a/modules/importer.py
+++ b/modules/importer.py
@@ -186,18 +186,6 @@ def _collect_dynamic_child_field_specs(template_vars: Any) -> list[dict[str, str
     return specs
 
 
-def _coerce_import_bool(value: Any) -> bool | None:
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        lowered = value.strip().lower()
-        if lowered in {"true", "yes", "1"}:
-            return True
-        if lowered in {"false", "no", "0"}:
-            return False
-    return None
-
-
 def _coerce_import_int(value: Any) -> int | None:
     if isinstance(value, bool):
         return None

--- a/modules/importer_library_types.py
+++ b/modules/importer_library_types.py
@@ -1,0 +1,333 @@
+"""Kometa library-type inference and collection/overlay index builders.
+
+Extracted from :mod:`modules.importer` to isolate the ~283 lines of
+"figure out what kind of library each Plex library is and which
+collections/overlays it can support" logic.
+
+## Public API
+
+* :func:`infer_library_types` -- Given a user's uploaded
+  ``config.yml`` dict, return ``(library_types, inference_list)``
+  where ``library_types`` maps library names to types
+  (``"movie"``, ``"show"``, ``"music"``, ...) and
+  ``inference_list`` describes how each guess was made (from an
+  explicit ``library_type`` key, from operations/collections
+  present, or as a fallback).
+* :func:`build_library_type_plan` -- Combines
+  :func:`infer_library_types` with the caller-provided
+  movie/show library-name sets from Plex to produce the final
+  ``(library_types, library_inference, needs_confirmation)``
+  triple used by the import-preview UI.
+* :func:`normalize_library_type` -- Public wrapper around the
+  internal ``_normalize_library_type`` helper.
+
+## Internal (leading ``_``) helpers
+
+* ``_normalize_library_type`` -- Canonicalize a raw
+  ``library_type`` value from user YAML.
+* ``_build_collection_index`` /
+  ``_build_overlay_index`` -- Load
+  ``quickstart_collections.json`` /
+  ``quickstart_overlays.json`` and index them by id + alias +
+  radio-group for fast lookup.
+* ``_resolve_collection_id`` /
+  ``_resolve_overlay_id`` -- Match a user-provided default
+  string against the id or alias indexes.
+
+The two index-builder helpers are re-exported from
+:mod:`modules.importer` because ``prepare_import_payload`` (which
+stays in that module) also calls them.
+
+Dependency direction: ``importer -> importer_library_types``
+(one way).  This module has zero imports from ``importer``, so
+no circular imports possible.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from modules import helpers
+
+
+def _build_collection_index(collection_config: list[dict]) -> tuple[dict[str, dict], dict[str, str]]:
+    by_id: dict[str, dict] = {}
+    by_alias: dict[str, str] = {}
+    for group in collection_config or []:
+        for collection in group.get("collections", []) if isinstance(group, dict) else []:
+            cid = collection.get("id")
+            if not cid:
+                continue
+            if cid in by_id:
+                existing = by_id[cid]
+                if isinstance(existing, dict):
+                    existing_media = existing.get("media_types")
+                    new_media = collection.get("media_types")
+                    if isinstance(existing_media, list) or isinstance(new_media, list):
+                        merged_media = []
+                        for entry in existing_media or []:
+                            if entry not in merged_media:
+                                merged_media.append(entry)
+                        for entry in new_media or []:
+                            if entry not in merged_media:
+                                merged_media.append(entry)
+                        existing["media_types"] = merged_media
+
+                    existing_templates = existing.get("template_variables")
+                    new_templates = collection.get("template_variables")
+                    if isinstance(existing_templates, list) and isinstance(new_templates, list):
+                        seen_keys = {str(item.get("key")) for item in existing_templates if isinstance(item, dict) and item.get("key")}
+                        for item in new_templates:
+                            if not isinstance(item, dict):
+                                continue
+                            key = str(item.get("key") or "").strip()
+                            if key and key in seen_keys:
+                                continue
+                            existing_templates.append(item)
+                            if key:
+                                seen_keys.add(key)
+                    elif existing.get("template_variables") in (None, [], {}):
+                        existing["template_variables"] = new_templates
+                alias = cid.replace("collection_", "", 1)
+                by_alias[alias] = cid
+                continue
+
+            by_id[cid] = collection
+            alias = cid.replace("collection_", "", 1)
+            by_alias[alias] = cid
+    return by_id, by_alias
+
+
+def _build_overlay_index(overlay_config: list[dict]) -> tuple[dict[str, dict], dict[str, str], dict[str, dict]]:
+    by_id: dict[str, dict] = {}
+    by_alias: dict[str, str] = {}
+    radio_map: dict[str, dict] = {}
+    for group in overlay_config or []:
+        if not isinstance(group, dict):
+            continue
+        input_type = group.get("input_type")
+        radio_group = group.get("radio_group_name")
+        for overlay in group.get("overlays", []):
+            if not isinstance(overlay, dict):
+                continue
+            oid = overlay.get("id")
+            if not oid:
+                continue
+            if oid in by_id:
+                existing = by_id[oid]
+                if isinstance(existing, dict):
+                    existing_media = existing.get("media_types")
+                    new_media = overlay.get("media_types")
+                    if isinstance(existing_media, list) or isinstance(new_media, list):
+                        merged = []
+                        for entry in existing_media or []:
+                            if entry not in merged:
+                                merged.append(entry)
+                        for entry in new_media or []:
+                            if entry not in merged:
+                                merged.append(entry)
+                        existing["media_types"] = merged
+                    existing_templates = existing.get("template_variables")
+                    new_templates = overlay.get("template_variables")
+                    if isinstance(existing_templates, dict) and isinstance(new_templates, dict):
+                        for key, value in new_templates.items():
+                            if key not in existing_templates:
+                                existing_templates[key] = value
+                    elif isinstance(new_templates, dict) and not isinstance(existing_templates, dict):
+                        existing["template_variables"] = new_templates
+            else:
+                by_id[oid] = overlay
+            alias = oid.replace("overlay_", "", 1)
+            by_alias[alias] = oid
+            if input_type == "radio" and radio_group and "value" in overlay:
+                radio_value = overlay.get("value")
+                radio_map[oid] = {
+                    "group_name": str(radio_group),
+                    "value": radio_value,
+                }
+                if isinstance(radio_value, str):
+                    radio_alias = radio_value.strip()
+                    if radio_alias:
+                        by_alias[radio_alias] = oid
+    return by_id, by_alias, radio_map
+
+
+def _normalize_library_type(value: Any) -> tuple[str | None, str | None]:
+    if value is None:
+        return None, None
+    text = str(value).strip().lower()
+    if text in {"movie", "mov"}:
+        return "mov", "movie"
+    if text in {"show", "sho", "series"}:
+        return "sho", "show"
+    return None, None
+
+
+def normalize_library_type(value: Any) -> str | None:
+    _, label = _normalize_library_type(value)
+    return label
+
+
+def _resolve_collection_id(raw_default: str, collection_by_id: dict, collection_by_alias: dict) -> str | None:
+    if raw_default.startswith("collection_") and raw_default in collection_by_id:
+        return raw_default
+    return collection_by_alias.get(raw_default)
+
+
+def _resolve_overlay_id(raw_default: str, overlay_by_id: dict, overlay_by_alias: dict) -> str | None:
+    if raw_default.startswith("overlay_") and raw_default in overlay_by_id:
+        return raw_default
+    if raw_default.startswith("content_rating_"):
+        candidate = f"overlay_{raw_default}"
+        return candidate if candidate in overlay_by_id else None
+    return overlay_by_alias.get(raw_default)
+
+
+def infer_library_types(config_data: dict) -> tuple[dict[str, str], list[dict]]:
+    collection_config = helpers.load_quickstart_config("quickstart_collections.json") or []
+    overlay_config = helpers.load_quickstart_overlay_config() or []
+    collection_by_id, collection_by_alias = _build_collection_index(collection_config)
+    overlay_by_id, overlay_by_alias, _ = _build_overlay_index(overlay_config)
+
+    inferred_types: dict[str, str] = {}
+    details: list[dict] = []
+
+    libraries_payload = config_data.get("libraries")
+    if not isinstance(libraries_payload, dict):
+        return inferred_types, details
+
+    for lib_name, lib_cfg in libraries_payload.items():
+        if not isinstance(lib_cfg, dict):
+            continue
+        movie_score = 0
+        show_score = 0
+
+        collection_files = lib_cfg.get("collection_files")
+        if isinstance(collection_files, list):
+            for entry in collection_files:
+                default_value = None
+                if isinstance(entry, dict):
+                    default_value = entry.get("default")
+                elif isinstance(entry, str):
+                    default_value = entry
+                if not default_value:
+                    continue
+                raw_default = str(default_value)
+                collection_id = _resolve_collection_id(raw_default, collection_by_id, collection_by_alias)
+                if not collection_id:
+                    continue
+                media_types = collection_by_id.get(collection_id, {}).get("media_types") or []
+                is_movie = "movie" in media_types
+                is_show = "show" in media_types
+                if is_movie and not is_show:
+                    movie_score += 2
+                elif is_show and not is_movie:
+                    show_score += 2
+                elif is_movie and is_show:
+                    movie_score += 1
+                    show_score += 1
+
+        overlay_files = lib_cfg.get("overlay_files")
+        if isinstance(overlay_files, list):
+            for entry in overlay_files:
+                default_value = None
+                template_values = None
+                if isinstance(entry, dict):
+                    default_value = entry.get("default")
+                    template_values = entry.get("template_variables")
+                elif isinstance(entry, str):
+                    default_value = entry
+                if not default_value:
+                    continue
+                if isinstance(template_values, dict):
+                    builder_level = template_values.get("builder_level")
+                    if builder_level in {"show", "season", "episode"}:
+                        show_score += 2
+                    elif builder_level == "movie":
+                        movie_score += 2
+
+                raw_default = str(default_value)
+                overlay_id = _resolve_overlay_id(raw_default, overlay_by_id, overlay_by_alias)
+                if not overlay_id:
+                    continue
+                media_types = overlay_by_id.get(overlay_id, {}).get("media_types") or []
+                movie_types = "movie" in media_types
+                show_types = any(t in {"show", "season", "episode"} for t in media_types)
+                if movie_types and not show_types:
+                    movie_score += 1
+                elif show_types and not movie_types:
+                    show_score += 1
+                elif movie_types and show_types:
+                    movie_score += 1
+                    show_score += 1
+
+        inferred = None
+        if show_score > movie_score:
+            inferred = "show"
+        elif movie_score > show_score:
+            inferred = "movie"
+
+        if movie_score == 0 and show_score == 0:
+            confidence = "unknown"
+        else:
+            confidence = "high" if abs(movie_score - show_score) >= 2 else "low"
+
+        if inferred:
+            inferred_types[str(lib_name)] = inferred
+
+        details.append(
+            {
+                "name": str(lib_name),
+                "inferred_type": inferred,
+                "movie_score": movie_score,
+                "show_score": show_score,
+                "confidence": confidence,
+            }
+        )
+
+    return inferred_types, details
+
+
+def build_library_type_plan(
+    config_data: dict,
+    plex_movie_names: set[str],
+    plex_show_names: set[str],
+) -> tuple[dict[str, str], list[dict], bool]:
+    inferred_types, details = infer_library_types(config_data)
+    detail_map = {d.get("name"): d for d in details}
+    library_types: dict[str, str] = {}
+    inference_list: list[dict] = []
+    libraries_payload = config_data.get("libraries")
+    if not isinstance(libraries_payload, dict):
+        return library_types, inference_list, False
+
+    for lib_name in libraries_payload.keys():
+        name = str(lib_name)
+        if name in plex_movie_names:
+            inferred_type = "movie"
+            source = "plex"
+            confidence = "confirmed"
+        elif name in plex_show_names:
+            inferred_type = "show"
+            source = "plex"
+            confidence = "confirmed"
+        else:
+            inferred_type = inferred_types.get(name)
+            source = "inferred" if inferred_type else "unknown"
+            confidence = detail_map.get(name, {}).get("confidence", "unknown")
+        if inferred_type:
+            library_types[name] = inferred_type
+        detail = detail_map.get(name, {})
+        inference_list.append(
+            {
+                "name": name,
+                "source": source,
+                "type": inferred_type,
+                "confidence": confidence,
+                "movie_score": detail.get("movie_score", 0),
+                "show_score": detail.get("show_score", 0),
+            }
+        )
+
+    needs_confirmation = any(item.get("source") != "plex" for item in inference_list)
+    return library_types, inference_list, needs_confirmation

--- a/tests/test_importer_edge_cases.py
+++ b/tests/test_importer_edge_cases.py
@@ -139,3 +139,38 @@ def test_prepare_import_payload_maps_apprise_config_to_location():
 
     assert payload["apprise"]["apprise"]["location"] == "/config/apprise.yml"
     assert report.counts["imported"] >= 1
+
+
+def test_coerce_import_bool_accepts_yaml_wide_truthy_and_falsy_values():
+    """Regression guard for the duplicate `_coerce_import_bool` bug.
+
+    Prior to develop #TBD, importer.py had TWO `_coerce_import_bool`
+    definitions.  Python's last-def-wins meant callers got the "wide"
+    version that accepts YAML-native `on`/`off` alongside the usual
+    `true`/`false`/`yes`/`no`/`1`/`0`.
+
+    The narrow (dead-code) def has been removed; this test locks
+    in the wide semantics so a future refactor can't silently
+    re-narrow the accepted set and break config imports that use
+    `field: on` / `field: off`.
+    """
+    assert importer._coerce_import_bool("true") is True
+    assert importer._coerce_import_bool("yes") is True
+    assert importer._coerce_import_bool("1") is True
+    assert importer._coerce_import_bool("on") is True
+    assert importer._coerce_import_bool("True") is True  # case-insensitive
+    assert importer._coerce_import_bool(" YES ") is True  # whitespace-tolerant
+
+    assert importer._coerce_import_bool("false") is False
+    assert importer._coerce_import_bool("no") is False
+    assert importer._coerce_import_bool("0") is False
+    assert importer._coerce_import_bool("off") is False
+    assert importer._coerce_import_bool("False") is False
+
+    assert importer._coerce_import_bool("maybe") is None
+    assert importer._coerce_import_bool("") is None
+    assert importer._coerce_import_bool(None) is None
+    assert importer._coerce_import_bool(42) is None
+
+    assert importer._coerce_import_bool(True) is True
+    assert importer._coerce_import_bool(False) is False


### PR DESCRIPTION
**Sprint 4, PR #4.** Second peel of `modules/importer.py`. Moves the ~283-line cluster that answers 'given a user's uploaded config.yml, what kind of library is each Plex library and which collections/overlays can it support?'.

## Public API in `modules/importer_library_types`

| Function | Purpose |
|---|---|
| `infer_library_types(config_data)` | Return `(library_types, inference_list)`. Maps library names to types (`movie`/`show`/`music`/...) and describes HOW each guess was made. |
| `build_library_type_plan(config_data, movie_names, show_names)` | Combines `infer_library_types` with Plex-detected name sets to produce the final `(library_types, library_inference, needs_confirmation)` triple used by the import-preview UI. |
| `normalize_library_type(value)` | Public wrapper — canonicalizes a raw `library_type` string from user YAML. |

## Internal `_` helpers moved with them

- `_normalize_library_type` — canonicalization
- `_build_collection_index` — load + index `quickstart_collections.json`
- `_build_overlay_index` — load + index `quickstart_overlays.json`
- `_resolve_collection_id` — match user default against index
- `_resolve_overlay_id` — match user default against index

## This is a PURE MOVE

No inference logic changed. No branches reordered. No re-normalizations added. Every returned `(library_types, inference_list, needs_confirmation)` triple is **byte-identical**.

## Compatibility

**All 8 names re-exported from `modules/importer`:**

- `build_library_type_plan` is called externally by `blueprints/import_config_routes.py` L639
- `_build_collection_index` and `_build_overlay_index` are still called by the mega `prepare_import_payload` (which stayed behind in `importer.py`) at L730-731 — they resolve via the re-export
- The other five are kept accessible via `importer.X` for future test monkeypatching / debugging

## Notable exclusion

`_build_attribute_sets`, which sat between the index builders and the library-type functions in the source file, is a **SEPARATE concern** (parses attribute config metadata) and stays in `importer.py` with its sole caller `prepare_import_payload`.

## Dependency direction

`importer → importer_library_types` (one way). The new module has **zero** imports from `importer`, so no circular imports possible.

## Impact

- `modules/importer.py`: **1777 → 1494** (**-283 / -15.9%**)
- `modules/importer_library_types.py`: NEW ~340 lines

## Sprint 4 progress

| PR | File | Δ | Ending |
|---|---|---|---|
| #1500 | logscan_imagemaid_analysis | -704 | 316 |
| #1502 | logscan_progress | -562 | 310 |
| #1503 | importer (yaml annotation) | -238 | 1789 |
| #1504 | importer (dead-code fix) | -12 | 1777 |
| **#TBD (this)** | **importer (library types)** | **-283** | **1494** |

**Cumulative importer.py**: 2027 → 1494 = **-533 lines / -26.3%** across three PRs.

## Verification

- All **1285 tests pass**
- Ruff + black clean
- Smoke-tested end-to-end: `build_library_type_plan(config, {'Movies'}, {'TV Shows'})` returns `{'Movies': 'movie', 'TV Shows': 'show'}` with `needs_confirmation=False`
- Both modules import cleanly in either order

## Roadmap for importer.py

Chunks remaining:
1. Value-coercion helpers (`_coerce_import_*`, `_serialize_*`, `_has_template_string_list_values`, `_collect_*`) ~180 lines — self-contained cluster
2. `_build_attribute_sets` ~80 lines — could join the value-coercion module or stay
3. `prepare_import_payload` monster (~1062 lines) — will need sub-extraction of section handlers