### PR TITLE
Hoist LANGUAGE_WEIGHT_TEMPLATE_KEYS + 3 pure helpers out of prepare_import_payload

### DIFF
--- a/modules/importer.py
+++ b/modules/importer.py
@@ -104,6 +104,125 @@ PLAYLIST_KEYED_IMPORT_FIELDS = {
     "trakt_list_": "string_list",
 }
 
+# Language codes recognized as `weight_<code>` overlay-source ordering keys.
+# Hoisted out of prepare_import_payload's ~95-line nested comprehension --
+# this is data, not logic, and belongs at module scope where it's easy to
+# review and doesn't rebuild on every import call.
+LANGUAGE_WEIGHT_TEMPLATE_KEYS: frozenset[str] = frozenset(
+    f"weight_{key}"
+    for key in (
+        "en",
+        "de",
+        "fr",
+        "es",
+        "pt",
+        "ja",
+        "ko",
+        "zh",
+        "da",
+        "ru",
+        "it",
+        "hi",
+        "te",
+        "fa",
+        "th",
+        "nl",
+        "no",
+        "is",
+        "sv",
+        "tr",
+        "pl",
+        "cs",
+        "uk",
+        "hu",
+        "ar",
+        "bg",
+        "bn",
+        "bs",
+        "ca",
+        "cy",
+        "el",
+        "et",
+        "eu",
+        "fi",
+        "tl",
+        "fil",
+        "gl",
+        "he",
+        "hr",
+        "id",
+        "ka",
+        "kk",
+        "kn",
+        "la",
+        "lt",
+        "lv",
+        "mk",
+        "ml",
+        "mr",
+        "ms",
+        "nb",
+        "nn",
+        "pa",
+        "ro",
+        "sk",
+        "sl",
+        "sq",
+        "sr",
+        "so",
+        "sw",
+        "ta",
+        "ur",
+        "ay",
+        "ga",
+        "li",
+        "kh",
+        "vi",
+        "mn",
+        "af",
+        "bm",
+        "ln",
+        "wo",
+        "lo",
+        "myn",
+        "iu",
+        "rom",
+        "am",
+        "su",
+        "zu",
+        "lb",
+        "mos",
+    )
+)
+
+
+def _encode_json(values: list) -> str:
+    """Compact JSON encoder used by the operation handlers."""
+    return json.dumps(values, ensure_ascii=True)
+
+
+def _clean_custom_value(value: Any) -> Any | None:
+    """Normalize a single custom-value entry for mass-update operations.
+
+    None/False collapse to None; numbers pass through; strings get
+    stripped and only survive if non-empty.
+    """
+    if value is None or value is False:
+        return None
+    if isinstance(value, (int, float)):
+        return value
+    text = str(value).strip()
+    return text if text else None
+
+
+def _normalize_op_items(value: Any) -> list:
+    """Coerce an operation's value into a uniform list for iteration."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
 
 def sanitize_config_name(raw_name: str | None) -> str:
     if not isinstance(raw_name, str):
@@ -300,92 +419,6 @@ def prepare_import_payload(
 
     collection_by_id, collection_by_alias = _build_collection_index(collection_config)
     overlay_by_id, overlay_by_alias, overlay_radio = _build_overlay_index(overlay_config)
-    language_weight_template_keys = {
-        f"weight_{key}"
-        for key in {
-            "en",
-            "de",
-            "fr",
-            "es",
-            "pt",
-            "ja",
-            "ko",
-            "zh",
-            "da",
-            "ru",
-            "it",
-            "hi",
-            "te",
-            "fa",
-            "th",
-            "nl",
-            "no",
-            "is",
-            "sv",
-            "tr",
-            "pl",
-            "cs",
-            "uk",
-            "hu",
-            "ar",
-            "bg",
-            "bn",
-            "bs",
-            "ca",
-            "cy",
-            "el",
-            "et",
-            "eu",
-            "fi",
-            "tl",
-            "fil",
-            "gl",
-            "he",
-            "hr",
-            "id",
-            "ka",
-            "kk",
-            "kn",
-            "la",
-            "lt",
-            "lv",
-            "mk",
-            "ml",
-            "mr",
-            "ms",
-            "nb",
-            "nn",
-            "pa",
-            "ro",
-            "sk",
-            "sl",
-            "sq",
-            "sr",
-            "so",
-            "sw",
-            "ta",
-            "ur",
-            "ay",
-            "ga",
-            "li",
-            "kh",
-            "vi",
-            "mn",
-            "af",
-            "bm",
-            "ln",
-            "wo",
-            "lo",
-            "myn",
-            "iu",
-            "rom",
-            "am",
-            "su",
-            "zu",
-            "lb",
-            "mos",
-        }
-    }
     (
         template_vars,
         simple_attrs,
@@ -394,24 +427,6 @@ def prepare_import_payload(
         mass_update_defs,
         toggle_select_defs,
     ) = _build_attribute_sets(attribute_config)
-
-    def _encode_json(values: list) -> str:
-        return json.dumps(values, ensure_ascii=True)
-
-    def _clean_custom_value(value: Any) -> Any | None:
-        if value is None or value is False:
-            return None
-        if isinstance(value, (int, float)):
-            return value
-        text = str(value).strip()
-        return text if text else None
-
-    def _normalize_op_items(value: Any) -> list:
-        if value is None:
-            return []
-        if isinstance(value, list):
-            return value
-        return [value]
 
     def _handle_mass_update_operation(
         lib_id: str,
@@ -1086,7 +1101,7 @@ def prepare_import_payload(
                         allowed.update(_collect_overlay_source_override_keys(overlay_meta))
                         if overlay_id in {"overlay_languages", "overlay_languages_subtitles"}:
                             allowed = set(allowed)
-                            allowed.update(language_weight_template_keys)
+                            allowed.update(LANGUAGE_WEIGHT_TEMPLATE_KEYS)
                         for key, value in template_values.items():
                             if key not in allowed:
                                 if key == "builder_level":


### PR DESCRIPTION
**Sprint 4, PR #6.** First bite of the 1062-line `prepare_import_payload` monster. Extracts things that were nested INSIDE the function but don't actually depend on any of its state — classic locality-of-behavior violation that made the mega function look even longer than it really is.

## What got hoisted to module scope

### 1. `LANGUAGE_WEIGHT_TEMPLATE_KEYS` (81-language frozenset)

This was an ~85-line set comprehension living inside `prepare_import_payload` that **rebuilt itself on every call**. Static data — 81 fixed language codes each prefixed with `weight_` — has no business being computed inside a function.

Moved to module-scope `frozenset` (immutability + set-membership fast path preserved).

### 2-4. Three tiny pure helpers

- `_encode_json(values)` — 2 lines
- `_clean_custom_value(value)` — 6 lines  
- `_normalize_op_items(value)` — 5 lines

Zero closure dependencies — they only take arguments, only return values. Making them module-scope means:
- No re-def every `prepare_import_payload` call
- They're testable in isolation
- They're visible to future extraction work on the operation handlers (`_handle_mass_update_operation` etc.) which is where they're actually called from

## This is a PURE MOVE + rename

The single reference to `language_weight_template_keys` inside `prepare_import_payload` was updated to the SCREAMING_SNAKE_CASE constant name (`LANGUAGE_WEIGHT_TEMPLATE_KEYS`). The three helpers keep their leading `_` (still internal API), just at module scope now.

No logic changed. No behavior changed. Every payload dict + every report line produced by the pipeline is byte-identical.

## Impact

- `modules/importer.py`: 1348 → 1363 (net **+15** after black reformatted the frozenset one-per-line, but that's cosmetic)
- **`prepare_import_payload` body: 1062 → 958** (**-104 lines / -9.8%** — the real win)
- 81-language set no longer rebuilds every call

## Sprint 4 progress

| PR | Status | File | Δ | Ending |
|---|---|---|---|---|
| #1500 | merged | logscan_imagemaid_analysis | -704 | 316 |
| #1502 | merged | logscan_progress | -562 | 310 |
| #1503 | merged | importer (yaml annotation) | -238 | 1789 |
| #1504 | merged | importer (dead-code fix) | -12 | 1777 |
| #1505 | merged | importer (library types) | -283 | 1494 |
| #1506 | merged | importer (value coercion) | -146 | 1348 |
| **#TBD (this)** | **importer (hoist statics)** | **+15** | **1363** |

Numbers wise this PR is close to flat on the file — but the internal complexity drop inside `prepare_import_payload` (-104 lines, no more nested defs and no more per-call set comprehension) is what makes the follow-up operation-handler extraction viable.

## Verification

- All **1285 tests pass**
- Ruff + black clean
- Confirmed `LANGUAGE_WEIGHT_TEMPLATE_KEYS` has exactly 81 entries after the hoist
- Confirmed each hoisted helper is callable at module scope and produces expected output

## Roadmap for prepare_import_payload

Now that the 3 pure helpers are at module scope, the 3 closure-heavy operation handlers (`_handle_mass_update_operation`, `_handle_toggle_select_operation`, `_handle_delete_collections_operation`) can be extracted next. Those 3 total ~233 lines and share only `report`, `libraries_data`, and the def-sets from `_build_attribute_sets` — much easier to parameterize now that the tiny helpers they call (`_encode_json` / `_clean_custom_value` / `_normalize_op_items`) live at module scope.