### PR TITLE
Extract 3 library-operation handlers to importer_operations

### DIFF
--- a/modules/importer.py
+++ b/modules/importer.py
@@ -196,34 +196,6 @@ LANGUAGE_WEIGHT_TEMPLATE_KEYS: frozenset[str] = frozenset(
 )
 
 
-def _encode_json(values: list) -> str:
-    """Compact JSON encoder used by the operation handlers."""
-    return json.dumps(values, ensure_ascii=True)
-
-
-def _clean_custom_value(value: Any) -> Any | None:
-    """Normalize a single custom-value entry for mass-update operations.
-
-    None/False collapse to None; numbers pass through; strings get
-    stripped and only survive if non-empty.
-    """
-    if value is None or value is False:
-        return None
-    if isinstance(value, (int, float)):
-        return value
-    text = str(value).strip()
-    return text if text else None
-
-
-def _normalize_op_items(value: Any) -> list:
-    """Coerce an operation's value into a uniform list for iteration."""
-    if value is None:
-        return []
-    if isinstance(value, list):
-        return value
-    return [value]
-
-
 def sanitize_config_name(raw_name: str | None) -> str:
     if not isinstance(raw_name, str):
         return ""
@@ -301,6 +273,12 @@ from modules.importer_value_coercion import (  # noqa: E402
     _serialize_dynamic_child_mapping_value,  # noqa: F401 (kept accessible via importer._serialize_dynamic_child_mapping_value)
     _serialize_playlist_import_value,  # noqa: F401 (kept accessible via importer._serialize_playlist_import_value)
 )
+
+# Library-operation dispatch handlers moved to modules/importer_operations.py.
+# Imported as a module (not name-by-name) because the call sites inside
+# prepare_import_payload pass kwargs and the `importer_operations.` prefix
+# makes it obvious these are the operation-handler cluster.
+from modules import importer_operations  # noqa: E402
 
 
 def _build_attribute_sets(
@@ -427,239 +405,6 @@ def prepare_import_payload(
         mass_update_defs,
         toggle_select_defs,
     ) = _build_attribute_sets(attribute_config)
-
-    def _handle_mass_update_operation(
-        lib_id: str,
-        lib_name: str,
-        op_key: str,
-        op_value: Any,
-    ) -> tuple[bool, bool]:
-        definition = mass_update_defs.get(op_key)
-        if not definition:
-            return False, False
-
-        sources = definition.get("sources", set())
-        has_custom = definition.get("has_custom_string")
-        custom_behavior = definition.get("custom_string_behavior") or "string"
-        order: list[str] = []
-        custom_values: list[Any] = []
-        items = _normalize_op_items(op_value)
-
-        for idx, item in enumerate(items):
-            item_path = f"libraries.{lib_name}.operations.{op_key}[{idx}]" if isinstance(op_value, list) else f"libraries.{lib_name}.operations.{op_key}"
-            if isinstance(item, list):
-                for entry in item:
-                    custom_value = _clean_custom_value(entry)
-                    if custom_value is not None:
-                        custom_values.append(custom_value)
-                if has_custom and item:
-                    report.add("imported", item_path)
-                else:
-                    report.add("unmapped", item_path, "Unsupported mass update list entry.")
-                continue
-            if isinstance(item, dict):
-                report.add("unmapped", item_path, "Unsupported mass update format.")
-                continue
-
-            if isinstance(item, (int, float)):
-                if has_custom:
-                    custom_values.append(item)
-                    report.add("imported", item_path)
-                else:
-                    report.add("unmapped", item_path, "Custom values are not supported.")
-                continue
-
-            text = str(item).strip()
-            if not text:
-                continue
-            if text in sources:
-                if text not in order:
-                    order.append(text)
-                libraries_data[f"{lib_id}-attribute_{op_key}_{text}"] = True
-                report.add("imported", item_path)
-            elif has_custom:
-                custom_values.append(text)
-                report.add("imported", item_path)
-            else:
-                report.add("unmapped", item_path, "Custom values are not supported.")
-
-        if order:
-            libraries_data[f"{lib_id}-attribute_{op_key}_order"] = _encode_json(order)
-
-        if custom_values:
-            if custom_behavior == "list":
-                libraries_data[f"{lib_id}-attribute_{op_key}_custom"] = _encode_json(custom_values)
-            else:
-                libraries_data[f"{lib_id}-attribute_{op_key}_custom_string"] = _clean_custom_value(custom_values[0])
-                if len(custom_values) > 1:
-                    libraries_data[f"{lib_id}-attribute_{op_key}_custom"] = _encode_json(custom_values[1:])
-
-        if order or custom_values:
-            report.add("imported", f"libraries.{lib_name}.operations.{op_key}")
-            return True, True
-
-        report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}", "No importable values found.")
-        return True, False
-
-    def _handle_toggle_select_operation(
-        lib_id: str,
-        lib_name: str,
-        op_key: str,
-        op_value: Any,
-    ) -> tuple[bool, bool]:
-        definition = toggle_select_defs.get(op_key)
-        if not definition:
-            return False, False
-
-        select_key = definition.get("select_key")
-        select_options = set(definition.get("select_options") or [])
-        toggle_keys = set(definition.get("toggle_keys") or [])
-        toggle_aliases = {}
-        for key in toggle_keys:
-            toggle_aliases[key] = key
-            if key.startswith(f"{op_key}_"):
-                toggle_aliases[key.replace(f"{op_key}_", "", 1)] = key
-
-        def resolve_toggle_key(raw_key: str) -> str | None:
-            return toggle_aliases.get(raw_key)
-
-        source = None
-        imported_any = False
-
-        if isinstance(op_value, dict):
-            for raw_key, raw_value in op_value.items():
-                key = str(raw_key)
-                if key == "source":
-                    candidate = str(raw_value).strip()
-                    if candidate in select_options:
-                        source = candidate
-                        report.add("imported", f"libraries.{lib_name}.operations.{op_key}.source")
-                        imported_any = True
-                    else:
-                        report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}.source")
-                    continue
-                resolved = resolve_toggle_key(key)
-                if resolved:
-                    if helpers.booler(raw_value):
-                        libraries_data[f"{lib_id}-attribute_{resolved}"] = True
-                    report.add("imported", f"libraries.{lib_name}.operations.{op_key}.{key}")
-                    imported_any = True
-                else:
-                    report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}.{key}")
-            if source and select_key:
-                libraries_data[f"{lib_id}-attribute_{select_key}"] = source
-            return True, imported_any
-
-        if isinstance(op_value, list):
-            for idx, item in enumerate(op_value):
-                item_path = f"libraries.{lib_name}.operations.{op_key}[{idx}]"
-                if isinstance(item, str):
-                    text = item.strip()
-                    if text in select_options:
-                        source = text
-                        report.add("imported", item_path)
-                        imported_any = True
-                        continue
-                    resolved = resolve_toggle_key(text)
-                    if resolved:
-                        libraries_data[f"{lib_id}-attribute_{resolved}"] = True
-                        report.add("imported", item_path)
-                        imported_any = True
-                        continue
-                report.add("unmapped", item_path, "Unsupported option.")
-            if source and select_key:
-                libraries_data[f"{lib_id}-attribute_{select_key}"] = source
-            if imported_any:
-                report.add("imported", f"libraries.{lib_name}.operations.{op_key}")
-            return True, imported_any
-
-        if isinstance(op_value, str):
-            candidate = op_value.strip()
-            if candidate in select_options and select_key:
-                libraries_data[f"{lib_id}-attribute_{select_key}"] = candidate
-                report.add("imported", f"libraries.{lib_name}.operations.{op_key}")
-                return True, True
-            else:
-                report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}", "Unsupported option.")
-                return True, False
-
-        report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}", "Unsupported operation format.")
-        return True, False
-
-    def _handle_delete_collections_operation(
-        lib_id: str,
-        lib_name: str,
-        op_key: str,
-        op_value: Any,
-    ) -> tuple[bool, bool]:
-        if op_key != "delete_collections":
-            return False, False
-        if not isinstance(op_value, dict):
-            report.add(
-                "unmapped",
-                f"libraries.{lib_name}.operations.{op_key}",
-                "Unsupported delete_collections format.",
-            )
-            return True, False
-
-        mapping = {
-            "configured": "delete_collections_configured",
-            "managed": "delete_collections_managed",
-            "ignore_empty_smart_collections": "delete_collections_ignore_empty_smart_collections",
-            "less": "delete_collections_less",
-        }
-        imported_any = False
-
-        for raw_key, raw_value in op_value.items():
-            key = str(raw_key)
-            target = mapping.get(key)
-            if not target:
-                report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}.{key}")
-                continue
-            if key == "less":
-                try:
-                    if raw_value is None or raw_value == "":
-                        report.add(
-                            "unmapped",
-                            f"libraries.{lib_name}.operations.{op_key}.{key}",
-                            "Missing numeric value.",
-                        )
-                        continue
-                    libraries_data[f"{lib_id}-attribute_{target}"] = int(raw_value)
-                    report.add("imported", f"libraries.{lib_name}.operations.{op_key}.{key}")
-                    imported_any = True
-                except Exception:
-                    report.add(
-                        "unmapped",
-                        f"libraries.{lib_name}.operations.{op_key}.{key}",
-                        "Invalid numeric value.",
-                    )
-                continue
-            bool_value = None
-            if isinstance(raw_value, bool):
-                bool_value = raw_value
-            elif isinstance(raw_value, str):
-                lowered = raw_value.strip().lower()
-                if lowered in {"true", "yes", "1"}:
-                    bool_value = True
-                elif lowered in {"false", "no", "0"}:
-                    bool_value = False
-            if bool_value is None:
-                report.add(
-                    "unmapped",
-                    f"libraries.{lib_name}.operations.{op_key}.{key}",
-                    "Invalid boolean value.",
-                )
-                continue
-            libraries_data[f"{lib_id}-attribute_{target}"] = bool_value
-            report.add("imported", f"libraries.{lib_name}.operations.{op_key}.{key}")
-            imported_any = True
-
-        if imported_any:
-            report.add("imported", f"libraries.{lib_name}.operations.{op_key}")
-        else:
-            report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}", "No importable values found.")
-        return True, imported_any
 
     playlist_libraries: set[str] = set()
     playlist_file_entries: list[dict[str, str]] = []
@@ -1289,17 +1034,40 @@ def prepare_import_payload(
                         imported_ops = True
                         continue
 
-                    handled, imported = _handle_delete_collections_operation(lib_id, str(lib_name), key, value)
+                    handled, imported = importer_operations.handle_delete_collections_operation(
+                        lib_id,
+                        str(lib_name),
+                        key,
+                        value,
+                        libraries_data=libraries_data,
+                        report=report,
+                    )
                     if handled:
                         imported_ops = imported_ops or imported
                         continue
 
-                    handled, imported = _handle_mass_update_operation(lib_id, str(lib_name), key, value)
+                    handled, imported = importer_operations.handle_mass_update_operation(
+                        lib_id,
+                        str(lib_name),
+                        key,
+                        value,
+                        mass_update_defs=mass_update_defs,
+                        libraries_data=libraries_data,
+                        report=report,
+                    )
                     if handled:
                         imported_ops = imported_ops or imported
                         continue
 
-                    handled, imported = _handle_toggle_select_operation(lib_id, str(lib_name), key, value)
+                    handled, imported = importer_operations.handle_toggle_select_operation(
+                        lib_id,
+                        str(lib_name),
+                        key,
+                        value,
+                        toggle_select_defs=toggle_select_defs,
+                        libraries_data=libraries_data,
+                        report=report,
+                    )
                     if handled:
                         imported_ops = imported_ops or imported
                         continue

--- a/modules/importer_operations.py
+++ b/modules/importer_operations.py
@@ -1,0 +1,333 @@
+"""Library-operation import handlers.
+
+Split out of ``modules.importer.prepare_import_payload`` so the 237
+lines of operation-dispatch logic can be reviewed in isolation from
+the surrounding mega-function.
+
+Each handler translates one entry from a library's ``operations:``
+YAML block into the flat ``lib_id-attribute_*`` keys the DB expects
+and records success / failure in the shared ``ImportReport``.
+
+The handlers were nested closures inside ``prepare_import_payload``
+that reached into the surrounding scope for:
+
+* ``libraries_data`` -- the per-library flat dict being populated.
+* ``report``         -- the ``ImportReport`` collecting mapped /
+                        unmapped paths.
+* ``*_defs``         -- the operation-type dispatch tables from
+                        ``_build_attribute_sets``.
+
+That closure state is now passed in as keyword-only arguments so the
+handlers can live at module scope, be tested independently, and stop
+inflating the mega-function.
+
+Return convention (unchanged from the closures):
+
+* ``(handled, imported)`` tuple.
+* ``handled = True`` -- this handler recognised the op_key.  Caller
+  should NOT try later handlers.
+* ``handled = False`` -- op_key belongs to a different handler.
+  Caller should keep dispatching.
+* ``imported = True`` -- at least one importable value found.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from modules import helpers
+
+if TYPE_CHECKING:
+    from modules.importer import ImportReport
+
+
+def _encode_json(values: list) -> str:
+    """Compact JSON encoder used by the operation handlers."""
+    return json.dumps(values, ensure_ascii=True)
+
+
+def _clean_custom_value(value: Any) -> Any | None:
+    """Normalize a single custom-value entry for mass-update operations.
+
+    None/False collapse to None; numbers pass through; strings get
+    stripped and only survive if non-empty.
+    """
+    if value is None or value is False:
+        return None
+    if isinstance(value, (int, float)):
+        return value
+    text = str(value).strip()
+    return text if text else None
+
+
+def _normalize_op_items(value: Any) -> list:
+    """Coerce an operation's value into a uniform list for iteration."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def handle_mass_update_operation(
+    lib_id: str,
+    lib_name: str,
+    op_key: str,
+    op_value: Any,
+    *,
+    mass_update_defs: dict,
+    libraries_data: dict[str, Any],
+    report: ImportReport,
+) -> tuple[bool, bool]:
+    """Dispatch mass-update-style operation values into libraries_data.
+
+    Mass-update operations combine a set of preset "source" toggles
+    (``libraries_data[lib_id-attribute_op_key_source] = True``) with
+    optional free-form custom strings (``..._custom`` / ``..._custom_string``).
+    """
+    definition = mass_update_defs.get(op_key)
+    if not definition:
+        return False, False
+
+    sources = definition.get("sources", set())
+    has_custom = definition.get("has_custom_string")
+    custom_behavior = definition.get("custom_string_behavior") or "string"
+    order: list[str] = []
+    custom_values: list[Any] = []
+    items = _normalize_op_items(op_value)
+
+    for idx, item in enumerate(items):
+        item_path = f"libraries.{lib_name}.operations.{op_key}[{idx}]" if isinstance(op_value, list) else f"libraries.{lib_name}.operations.{op_key}"
+        if isinstance(item, list):
+            for entry in item:
+                custom_value = _clean_custom_value(entry)
+                if custom_value is not None:
+                    custom_values.append(custom_value)
+            if has_custom and item:
+                report.add("imported", item_path)
+            else:
+                report.add("unmapped", item_path, "Unsupported mass update list entry.")
+            continue
+        if isinstance(item, dict):
+            report.add("unmapped", item_path, "Unsupported mass update format.")
+            continue
+
+        if isinstance(item, (int, float)):
+            if has_custom:
+                custom_values.append(item)
+                report.add("imported", item_path)
+            else:
+                report.add("unmapped", item_path, "Custom values are not supported.")
+            continue
+
+        text = str(item).strip()
+        if not text:
+            continue
+        if text in sources:
+            if text not in order:
+                order.append(text)
+            libraries_data[f"{lib_id}-attribute_{op_key}_{text}"] = True
+            report.add("imported", item_path)
+        elif has_custom:
+            custom_values.append(text)
+            report.add("imported", item_path)
+        else:
+            report.add("unmapped", item_path, "Custom values are not supported.")
+
+    if order:
+        libraries_data[f"{lib_id}-attribute_{op_key}_order"] = _encode_json(order)
+
+    if custom_values:
+        if custom_behavior == "list":
+            libraries_data[f"{lib_id}-attribute_{op_key}_custom"] = _encode_json(custom_values)
+        else:
+            libraries_data[f"{lib_id}-attribute_{op_key}_custom_string"] = _clean_custom_value(custom_values[0])
+            if len(custom_values) > 1:
+                libraries_data[f"{lib_id}-attribute_{op_key}_custom"] = _encode_json(custom_values[1:])
+
+    if order or custom_values:
+        report.add("imported", f"libraries.{lib_name}.operations.{op_key}")
+        return True, True
+
+    report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}", "No importable values found.")
+    return True, False
+
+
+def handle_toggle_select_operation(
+    lib_id: str,
+    lib_name: str,
+    op_key: str,
+    op_value: Any,
+    *,
+    toggle_select_defs: dict,
+    libraries_data: dict[str, Any],
+    report: ImportReport,
+) -> tuple[bool, bool]:
+    """Dispatch operations that pair a select_key with a set of toggle_keys.
+
+    Handles dict, list, and bare-string YAML shapes for the same operation.
+    """
+    definition = toggle_select_defs.get(op_key)
+    if not definition:
+        return False, False
+
+    select_key = definition.get("select_key")
+    select_options = set(definition.get("select_options") or [])
+    toggle_keys = set(definition.get("toggle_keys") or [])
+    toggle_aliases = {}
+    for key in toggle_keys:
+        toggle_aliases[key] = key
+        if key.startswith(f"{op_key}_"):
+            toggle_aliases[key.replace(f"{op_key}_", "", 1)] = key
+
+    def resolve_toggle_key(raw_key: str) -> str | None:
+        return toggle_aliases.get(raw_key)
+
+    source = None
+    imported_any = False
+
+    if isinstance(op_value, dict):
+        for raw_key, raw_value in op_value.items():
+            key = str(raw_key)
+            if key == "source":
+                candidate = str(raw_value).strip()
+                if candidate in select_options:
+                    source = candidate
+                    report.add("imported", f"libraries.{lib_name}.operations.{op_key}.source")
+                    imported_any = True
+                else:
+                    report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}.source")
+                continue
+            resolved = resolve_toggle_key(key)
+            if resolved:
+                if helpers.booler(raw_value):
+                    libraries_data[f"{lib_id}-attribute_{resolved}"] = True
+                report.add("imported", f"libraries.{lib_name}.operations.{op_key}.{key}")
+                imported_any = True
+            else:
+                report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}.{key}")
+        if source and select_key:
+            libraries_data[f"{lib_id}-attribute_{select_key}"] = source
+        return True, imported_any
+
+    if isinstance(op_value, list):
+        for idx, item in enumerate(op_value):
+            item_path = f"libraries.{lib_name}.operations.{op_key}[{idx}]"
+            if isinstance(item, str):
+                text = item.strip()
+                if text in select_options:
+                    source = text
+                    report.add("imported", item_path)
+                    imported_any = True
+                    continue
+                resolved = resolve_toggle_key(text)
+                if resolved:
+                    libraries_data[f"{lib_id}-attribute_{resolved}"] = True
+                    report.add("imported", item_path)
+                    imported_any = True
+                    continue
+            report.add("unmapped", item_path, "Unsupported option.")
+        if source and select_key:
+            libraries_data[f"{lib_id}-attribute_{select_key}"] = source
+        if imported_any:
+            report.add("imported", f"libraries.{lib_name}.operations.{op_key}")
+        return True, imported_any
+
+    if isinstance(op_value, str):
+        candidate = op_value.strip()
+        if candidate in select_options and select_key:
+            libraries_data[f"{lib_id}-attribute_{select_key}"] = candidate
+            report.add("imported", f"libraries.{lib_name}.operations.{op_key}")
+            return True, True
+        else:
+            report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}", "Unsupported option.")
+            return True, False
+
+    report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}", "Unsupported operation format.")
+    return True, False
+
+
+def handle_delete_collections_operation(
+    lib_id: str,
+    lib_name: str,
+    op_key: str,
+    op_value: Any,
+    *,
+    libraries_data: dict[str, Any],
+    report: ImportReport,
+) -> tuple[bool, bool]:
+    """Dispatch the delete_collections operation.
+
+    Unlike the other handlers this one only claims a single op_key
+    ("delete_collections") -- for anything else it returns
+    (False, False) so the caller keeps dispatching.
+    """
+    if op_key != "delete_collections":
+        return False, False
+    if not isinstance(op_value, dict):
+        report.add(
+            "unmapped",
+            f"libraries.{lib_name}.operations.{op_key}",
+            "Unsupported delete_collections format.",
+        )
+        return True, False
+
+    mapping = {
+        "configured": "delete_collections_configured",
+        "managed": "delete_collections_managed",
+        "ignore_empty_smart_collections": "delete_collections_ignore_empty_smart_collections",
+        "less": "delete_collections_less",
+    }
+    imported_any = False
+
+    for raw_key, raw_value in op_value.items():
+        key = str(raw_key)
+        target = mapping.get(key)
+        if not target:
+            report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}.{key}")
+            continue
+        if key == "less":
+            try:
+                if raw_value is None or raw_value == "":
+                    report.add(
+                        "unmapped",
+                        f"libraries.{lib_name}.operations.{op_key}.{key}",
+                        "Missing numeric value.",
+                    )
+                    continue
+                libraries_data[f"{lib_id}-attribute_{target}"] = int(raw_value)
+                report.add("imported", f"libraries.{lib_name}.operations.{op_key}.{key}")
+                imported_any = True
+            except Exception:
+                report.add(
+                    "unmapped",
+                    f"libraries.{lib_name}.operations.{op_key}.{key}",
+                    "Invalid numeric value.",
+                )
+            continue
+        bool_value = None
+        if isinstance(raw_value, bool):
+            bool_value = raw_value
+        elif isinstance(raw_value, str):
+            lowered = raw_value.strip().lower()
+            if lowered in {"true", "yes", "1"}:
+                bool_value = True
+            elif lowered in {"false", "no", "0"}:
+                bool_value = False
+        if bool_value is None:
+            report.add(
+                "unmapped",
+                f"libraries.{lib_name}.operations.{op_key}.{key}",
+                "Invalid boolean value.",
+            )
+            continue
+        libraries_data[f"{lib_id}-attribute_{target}"] = bool_value
+        report.add("imported", f"libraries.{lib_name}.operations.{op_key}.{key}")
+        imported_any = True
+
+    if imported_any:
+        report.add("imported", f"libraries.{lib_name}.operations.{op_key}")
+    else:
+        report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}", "No importable values found.")
+    return True, imported_any


### PR DESCRIPTION
**Sprint 4, PR #7.** Second bite of the `prepare_import_payload` monster. Moves the trio of nested-closure operation handlers (mass update, toggle-select, delete-collections) out to their own module.

## What moved

Three nested closures inside `prepare_import_payload` → module-scope functions in `modules/importer_operations.py`:

| Handler | Size |
|---|---|
| `handle_mass_update_operation` | 73 lines |
| `handle_toggle_select_operation` | 85 lines |
| `handle_delete_collections_operation` | 79 lines |
| **Total** | **237 lines lifted out** |

## Handler signatures

Each was previously reaching into enclosing scope for:
- `libraries_data` — per-library flat dict being populated
- `report` — `ImportReport` collecting mapped/unmapped paths
- `mass_update_defs` / `toggle_select_defs` — op-type dispatch tables

Those are now **explicit keyword-only arguments**. Positional args are still the four per-call values (`lib_id`, `lib_name`, `op_key`, `op_value`), keeping call sites readable.

Leading `_` stripped from the extracted names because the handlers are now the public API of `importer_operations` (still module-internal, just not per-function-internal).

Return convention **unchanged**: `(handled, imported)` tuple where:
- `handled=True` means "this handler owned the op_key, stop dispatching"
- `imported=True` means at least one value was mapped into `libraries_data`

## Tiny helpers moved with them

`_encode_json`, `_clean_custom_value`, `_normalize_op_items` were also pulled into `importer_operations`. They're only called from the operation handlers, so DRY says single source of truth beats "accessible from `importer.py`" — the module-scope copies in `importer.py` (hoisted in PR #1507) are **deleted** as part of this PR.

## Import strategy

`modules/importer.py` now imports `importer_operations` as a **module** (not name-by-name). Call sites use `importer_operations.handle_X(...)` which makes the operation-handler cluster visually obvious and keeps the three fat kwargs from cluttering the import list.

`modules/importer_operations.py` imports `ImportReport` only for the `TYPE_CHECKING` type-hint — no runtime import of `modules.importer`, so **zero risk of circular imports**.

## No behavior changes

Byte-identical mapping of every op_key + op_value combination. No test changes required — the handlers were nested closures that could only be reached through `prepare_import_payload`, so no test targeted them directly and none needed updating.

## Impact

- `modules/importer.py`: **1363 → 1131** (**-232 / -17.0%**)
- `modules/importer_operations.py`: NEW 333 lines
- **`prepare_import_payload` body: 958 → 748** (**-210 / -21.9%**)

## Sprint 4 running total

| PR | Status | File | Δ | Ending |
|---|---|---|---|---|
| #1500 | merged | logscan_imagemaid_analysis | -704 | 316 |
| #1502 | merged | logscan_progress | -562 | 310 |
| #1503 | merged | importer (yaml annotation) | -238 | 1789 |
| #1504 | merged | importer (dead-code fix) | -12 | 1777 |
| #1505 | merged | importer (library types) | -283 | 1494 |
| #1506 | merged | importer (value coercion) | -146 | 1348 |
| #1507 | merged | importer (hoist statics) | +15 | 1363 |
| **#TBD (this)** | **importer (operations)** | **-232** | **1131** |

**Cumulative importer.py: 2027 → 1131 = -896 / -44.2%** — roughly half the original file gone.

## Verification

- All **1285 tests pass**
- Ruff + black clean
- Both modules import cleanly in either order
- `importer_operations` has all 3 handlers accessible at module scope

## Roadmap for prepare_import_payload

The function is now **748 lines** in its body (down from 1062). Remaining chunks:
1. Playlist section handling (~90 lines)
2. Simple sections loop (~60 lines)
3. Per-library handling (~500+ lines — the bulk of what's left)
4. Post-processing / finalization

The per-library block is the last big fish. It handles collections, overlays, metadata, settings, etc. Extraction there gets harder because those sections are more entangled with each other, but there are still clear seams to target.