### PR TITLE
Extract playlist config parser to importer_playlists

### DIFF
--- a/modules/importer.py
+++ b/modules/importer.py
@@ -64,46 +64,6 @@ LIBRARY_SONARR_IMPORT_FIELDS = {
     "sonarr_path": "string",
     "plex_path": "string",
 }
-PLAYLIST_SHARED_IMPORT_FIELDS = {
-    "sync_to_users": "string_list",
-    "exclude_users": "string_list",
-    "delete_playlist": "boolean",
-    "ignore_ids": "string_list",
-    "ignore_imdb_ids": "string_list",
-    "item_radarr_tag": "string_list",
-    "item_sonarr_tag": "string_list",
-    "radarr_add_missing": "boolean",
-    "radarr_folder": "string",
-    "radarr_tag": "string_list",
-    "sonarr_add_missing": "boolean",
-    "sonarr_folder": "string",
-    "sonarr_tag": "string_list",
-    "trakt_list": "string_list",
-    "imdb_list": "string_list",
-    "mdblist_list": "string_list",
-}
-PLAYLIST_KEYED_IMPORT_FIELDS = {
-    "use_": "boolean",
-    "name_": "string",
-    "summary_": "string",
-    "url_poster_": "string",
-    "delete_playlist_": "boolean",
-    "exclude_users_": "string_list",
-    "exclude_user_": "string_list",
-    "imdb_list_": "string_list",
-    "item_radarr_tag_": "string_list",
-    "item_sonarr_tag_": "string_list",
-    "mdblist_list_": "string_list",
-    "radarr_add_missing_": "boolean",
-    "radarr_folder_": "string",
-    "radarr_tag_": "string_list",
-    "sonarr_add_missing_": "boolean",
-    "sonarr_folder_": "string",
-    "sonarr_tag_": "string_list",
-    "sync_to_users_": "string_list",
-    "trakt_list_": "string_list",
-}
-
 # Language codes recognized as `weight_<code>` overlay-source ordering keys.
 # Hoisted out of prepare_import_payload's ~95-line nested comprehension --
 # this is data, not logic, and belongs at module scope where it's easy to
@@ -280,6 +240,19 @@ from modules.importer_value_coercion import (  # noqa: E402
 # makes it obvious these are the operation-handler cluster.
 from modules import importer_operations  # noqa: E402
 
+# Playlist section parser moved to modules/importer_playlists.py.
+# Both PLAYLIST_*_IMPORT_FIELDS constants are re-exported here because:
+#   * scripts/analyze_uploaded_template_gaps.py reads them as
+#     importer.PLAYLIST_SHARED_IMPORT_FIELDS / importer.PLAYLIST_KEYED_IMPORT_FIELDS
+#     (guarded by tests/test_template_gap_analyzer)
+#   * The libraries block downstream still uses PLAYLIST_SHARED_IMPORT_FIELDS
+#     for one type-check on playlist template values.
+from modules import importer_playlists  # noqa: E402
+from modules.importer_playlists import (  # noqa: E402
+    PLAYLIST_KEYED_IMPORT_FIELDS,  # noqa: F401 (scripts/analyze_uploaded_template_gaps.py)
+    PLAYLIST_SHARED_IMPORT_FIELDS,  # noqa: F401 (used by libraries block below + scripts)
+)
+
 
 def _build_attribute_sets(
     attribute_config: dict,
@@ -406,105 +379,11 @@ def prepare_import_payload(
         toggle_select_defs,
     ) = _build_attribute_sets(attribute_config)
 
-    playlist_libraries: set[str] = set()
-    playlist_file_entries: list[dict[str, str]] = []
-    playlist_template_field_values: dict[str, Any] = {}
-    playlist_keyed_template_field_values: dict[str, dict[str, Any]] = {}
-    playlist_payload = config_data.get("playlist_files")
-    if playlist_payload is not None:
-        if isinstance(playlist_payload, list):
-            for idx, entry in enumerate(playlist_payload):
-                if not isinstance(entry, dict):
-                    report.add("unmapped", f"playlist_files[{idx}]", "Unsupported playlist entry format.")
-                    continue
-                raw_entry_type = None
-                raw_entry_location = None
-                for candidate in ("file", "url", "git", "repo"):
-                    location = entry.get(candidate)
-                    if location:
-                        raw_entry_type = candidate
-                        raw_entry_location = str(location).strip()
-                        break
-                if raw_entry_type and raw_entry_location:
-                    playlist_file_entries.append({"type": raw_entry_type, "location": raw_entry_location})
-                    report.add("imported", f"playlist_files[{idx}]")
-                    report.add("imported", f"playlist_files[{idx}].{raw_entry_type}")
-                    if entry.get("template_variables") not in (None, {}):
-                        report.add("unmapped", f"playlist_files[{idx}].template_variables", "Template variables for direct playlist file entries are not supported in Quickstart.")
-                    continue
-                tv = entry.get("template_variables", {})
-                if not isinstance(tv, dict):
-                    report.add("unmapped", f"playlist_files[{idx}].template_variables", "Unsupported template_variables format.")
-                    continue
-                libs = tv.get("libraries")
-                if not isinstance(libs, list):
-                    report.add("unmapped", f"playlist_files[{idx}].template_variables.libraries", "Missing playlist library entries.")
-                    continue
-                entry_libs = [str(lib).strip() for lib in libs if str(lib).strip()]
-                if not entry_libs:
-                    report.add("unmapped", f"playlist_files[{idx}].template_variables.libraries", "Missing playlist library entries.")
-                    continue
-
-                playlist_libraries.update(entry_libs)
-                report.add("imported", f"playlist_files[{idx}]")
-                default_value = entry.get("default")
-                if default_value == "playlist":
-                    report.add("imported", f"playlist_files[{idx}].default")
-                elif default_value is not None:
-                    report.add("unmapped", f"playlist_files[{idx}].default", "Unsupported playlist default.")
-                report.add("imported", f"playlist_files[{idx}].template_variables")
-                report.add("imported", f"playlist_files[{idx}].template_variables.libraries")
-                for lib_idx in range(len(entry_libs)):
-                    report.add("imported", f"playlist_files[{idx}].template_variables.libraries[{lib_idx}]")
-                for key, value in tv.items():
-                    if key == "libraries":
-                        continue
-
-                    if key == "exclude_user":
-                        key = "exclude_users"
-                    if key == "exclude_user_":
-                        key = "exclude_users_"
-
-                    if key in PLAYLIST_SHARED_IMPORT_FIELDS:
-                        value_kind = PLAYLIST_SHARED_IMPORT_FIELDS[key]
-                        if value_kind == "boolean":
-                            normalized_value = _coerce_import_bool(value)
-                        elif value_kind == "integer":
-                            normalized_value = _coerce_import_int(value)
-                        elif value_kind == "string_list":
-                            values = _coerce_import_string_list(value)
-                            normalized_value = values if values else None
-                        else:
-                            text = str(value).strip() if value is not None else ""
-                            normalized_value = text or None
-
-                        if normalized_value is None:
-                            report.add("unmapped", f"playlist_files[{idx}].template_variables.{key}", "Unsupported playlist template variable value.")
-                            continue
-
-                        playlist_template_field_values[key] = normalized_value
-                        report.add("imported", f"playlist_files[{idx}].template_variables.{key}")
-                        continue
-
-                    matched_prefix = next((prefix for prefix in PLAYLIST_KEYED_IMPORT_FIELDS if key.startswith(prefix)), None)
-                    if matched_prefix:
-                        suffix = str(key[len(matched_prefix) :] or "").strip()
-                        if not suffix:
-                            report.add("unmapped", f"playlist_files[{idx}].template_variables.{key}", "Missing playlist key suffix.")
-                            continue
-                        serialized_value = _serialize_playlist_import_value(PLAYLIST_KEYED_IMPORT_FIELDS[matched_prefix], value)
-                        if serialized_value is None:
-                            report.add("unmapped", f"playlist_files[{idx}].template_variables.{key}", "Unsupported playlist keyed template variable value.")
-                            continue
-                        playlist_keyed_template_field_values.setdefault(matched_prefix, {})[suffix] = serialized_value
-                        report.add("imported", f"playlist_files[{idx}].template_variables.{key}")
-                        continue
-
-                    report.add("unmapped", f"playlist_files[{idx}].template_variables.{key}", "Playlist template variable not available in Quickstart.")
-            if playlist_libraries or playlist_file_entries:
-                report.add("imported", "playlist_files")
-        else:
-            report.add("unmapped", "playlist_files", "Unsupported playlist_files format.")
+    _playlist_state = importer_playlists.parse_playlist_config(config_data, report)
+    playlist_libraries = _playlist_state.libraries
+    playlist_file_entries = _playlist_state.file_entries
+    playlist_template_field_values = _playlist_state.template_field_values
+    playlist_keyed_template_field_values = _playlist_state.keyed_template_field_values
 
     for section in SIMPLE_SECTIONS:
         if section not in config_data:

--- a/modules/importer_playlists.py
+++ b/modules/importer_playlists.py
@@ -1,0 +1,255 @@
+"""Playlist section parsing for ``prepare_import_payload``.
+
+Split out of ``modules.importer`` so the ~100-line playlist parsing
+block can live next to its own supporting constants (the two
+``PLAYLIST_*_IMPORT_FIELDS`` dispatch maps) instead of drowning in
+the middle of the mega function.
+
+The parser reads ``config_data["playlist_files"]`` and produces a
+:class:`PlaylistImportState` -- four collections that downstream
+library-processing code needs to know about:
+
+* ``libraries``                     -- library names that appear in
+                                       any playlist entry's
+                                       template_variables.libraries.
+* ``file_entries``                  -- entries that point at a
+                                       file/url/git/repo location
+                                       instead of a template block.
+* ``template_field_values``         -- flat playlist-scoped template
+                                       overrides keyed by field name.
+* ``keyed_template_field_values``   -- prefix->suffix->value nested
+                                       overrides for keyed fields
+                                       (``use_*``, ``name_*``, ...).
+
+Report annotations for imported / unmapped playlist paths are added
+in-place onto the caller-supplied ``ImportReport``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from modules.importer_value_coercion import (
+    _coerce_import_bool,
+    _coerce_import_int,
+    _coerce_import_string_list,
+    _serialize_playlist_import_value,
+)
+
+if TYPE_CHECKING:
+    from modules.importer import ImportReport
+
+
+PLAYLIST_SHARED_IMPORT_FIELDS: dict[str, str] = {
+    "sync_to_users": "string_list",
+    "exclude_users": "string_list",
+    "delete_playlist": "boolean",
+    "ignore_ids": "string_list",
+    "ignore_imdb_ids": "string_list",
+    "item_radarr_tag": "string_list",
+    "item_sonarr_tag": "string_list",
+    "radarr_add_missing": "boolean",
+    "radarr_folder": "string",
+    "radarr_tag": "string_list",
+    "sonarr_add_missing": "boolean",
+    "sonarr_folder": "string",
+    "sonarr_tag": "string_list",
+    "trakt_list": "string_list",
+    "imdb_list": "string_list",
+    "mdblist_list": "string_list",
+}
+
+PLAYLIST_KEYED_IMPORT_FIELDS: dict[str, str] = {
+    "use_": "boolean",
+    "name_": "string",
+    "summary_": "string",
+    "url_poster_": "string",
+    "delete_playlist_": "boolean",
+    "exclude_users_": "string_list",
+    "exclude_user_": "string_list",
+    "imdb_list_": "string_list",
+    "item_radarr_tag_": "string_list",
+    "item_sonarr_tag_": "string_list",
+    "mdblist_list_": "string_list",
+    "radarr_add_missing_": "boolean",
+    "radarr_folder_": "string",
+    "radarr_tag_": "string_list",
+    "sonarr_add_missing_": "boolean",
+    "sonarr_folder_": "string",
+    "sonarr_tag_": "string_list",
+    "sync_to_users_": "string_list",
+    "trakt_list_": "string_list",
+}
+
+
+@dataclass
+class PlaylistImportState:
+    """Aggregate output of :func:`parse_playlist_config`."""
+
+    libraries: set[str] = field(default_factory=set)
+    file_entries: list[dict[str, str]] = field(default_factory=list)
+    template_field_values: dict[str, Any] = field(default_factory=dict)
+    keyed_template_field_values: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    @property
+    def has_any_data(self) -> bool:
+        """True if the parser found at least one usable playlist entry."""
+        return bool(self.libraries or self.file_entries)
+
+
+def parse_playlist_config(config_data: dict, report: ImportReport) -> PlaylistImportState:
+    """Read ``config_data['playlist_files']`` into a :class:`PlaylistImportState`.
+
+    Mutates ``report`` in place to record imported / unmapped playlist
+    YAML paths.  Returns an empty state (with the same object identity
+    for each field) if no ``playlist_files`` key exists.
+    """
+    state = PlaylistImportState()
+    playlist_payload = config_data.get("playlist_files")
+    if playlist_payload is None:
+        return state
+
+    if not isinstance(playlist_payload, list):
+        report.add("unmapped", "playlist_files", "Unsupported playlist_files format.")
+        return state
+
+    for idx, entry in enumerate(playlist_payload):
+        if not isinstance(entry, dict):
+            report.add("unmapped", f"playlist_files[{idx}]", "Unsupported playlist entry format.")
+            continue
+
+        # -- File-reference entry (file/url/git/repo) short-circuits --
+        raw_entry_type = None
+        raw_entry_location = None
+        for candidate in ("file", "url", "git", "repo"):
+            location = entry.get(candidate)
+            if location:
+                raw_entry_type = candidate
+                raw_entry_location = str(location).strip()
+                break
+        if raw_entry_type and raw_entry_location:
+            state.file_entries.append({"type": raw_entry_type, "location": raw_entry_location})
+            report.add("imported", f"playlist_files[{idx}]")
+            report.add("imported", f"playlist_files[{idx}].{raw_entry_type}")
+            if entry.get("template_variables") not in (None, {}):
+                report.add(
+                    "unmapped",
+                    f"playlist_files[{idx}].template_variables",
+                    "Template variables for direct playlist file entries are not supported in Quickstart.",
+                )
+            continue
+
+        # -- Template-based entry: needs template_variables.libraries --
+        tv = entry.get("template_variables", {})
+        if not isinstance(tv, dict):
+            report.add(
+                "unmapped",
+                f"playlist_files[{idx}].template_variables",
+                "Unsupported template_variables format.",
+            )
+            continue
+        libs = tv.get("libraries")
+        if not isinstance(libs, list):
+            report.add(
+                "unmapped",
+                f"playlist_files[{idx}].template_variables.libraries",
+                "Missing playlist library entries.",
+            )
+            continue
+        entry_libs = [str(lib).strip() for lib in libs if str(lib).strip()]
+        if not entry_libs:
+            report.add(
+                "unmapped",
+                f"playlist_files[{idx}].template_variables.libraries",
+                "Missing playlist library entries.",
+            )
+            continue
+
+        state.libraries.update(entry_libs)
+        report.add("imported", f"playlist_files[{idx}]")
+
+        default_value = entry.get("default")
+        if default_value == "playlist":
+            report.add("imported", f"playlist_files[{idx}].default")
+        elif default_value is not None:
+            report.add("unmapped", f"playlist_files[{idx}].default", "Unsupported playlist default.")
+
+        report.add("imported", f"playlist_files[{idx}].template_variables")
+        report.add("imported", f"playlist_files[{idx}].template_variables.libraries")
+        for lib_idx in range(len(entry_libs)):
+            report.add("imported", f"playlist_files[{idx}].template_variables.libraries[{lib_idx}]")
+
+        for key, value in tv.items():
+            if key == "libraries":
+                continue
+
+            # Fold legacy singular aliases onto the plural canonical form.
+            if key == "exclude_user":
+                key = "exclude_users"
+            if key == "exclude_user_":
+                key = "exclude_users_"
+
+            if key in PLAYLIST_SHARED_IMPORT_FIELDS:
+                value_kind = PLAYLIST_SHARED_IMPORT_FIELDS[key]
+                if value_kind == "boolean":
+                    normalized_value = _coerce_import_bool(value)
+                elif value_kind == "integer":
+                    normalized_value = _coerce_import_int(value)
+                elif value_kind == "string_list":
+                    values = _coerce_import_string_list(value)
+                    normalized_value = values if values else None
+                else:
+                    text = str(value).strip() if value is not None else ""
+                    normalized_value = text or None
+
+                if normalized_value is None:
+                    report.add(
+                        "unmapped",
+                        f"playlist_files[{idx}].template_variables.{key}",
+                        "Unsupported playlist template variable value.",
+                    )
+                    continue
+
+                state.template_field_values[key] = normalized_value
+                report.add("imported", f"playlist_files[{idx}].template_variables.{key}")
+                continue
+
+            matched_prefix = next(
+                (prefix for prefix in PLAYLIST_KEYED_IMPORT_FIELDS if key.startswith(prefix)),
+                None,
+            )
+            if matched_prefix:
+                suffix = str(key[len(matched_prefix) :] or "").strip()
+                if not suffix:
+                    report.add(
+                        "unmapped",
+                        f"playlist_files[{idx}].template_variables.{key}",
+                        "Missing playlist key suffix.",
+                    )
+                    continue
+                serialized_value = _serialize_playlist_import_value(
+                    PLAYLIST_KEYED_IMPORT_FIELDS[matched_prefix],
+                    value,
+                )
+                if serialized_value is None:
+                    report.add(
+                        "unmapped",
+                        f"playlist_files[{idx}].template_variables.{key}",
+                        "Unsupported playlist keyed template variable value.",
+                    )
+                    continue
+                state.keyed_template_field_values.setdefault(matched_prefix, {})[suffix] = serialized_value
+                report.add("imported", f"playlist_files[{idx}].template_variables.{key}")
+                continue
+
+            report.add(
+                "unmapped",
+                f"playlist_files[{idx}].template_variables.{key}",
+                "Playlist template variable not available in Quickstart.",
+            )
+
+    if state.has_any_data:
+        report.add("imported", "playlist_files")
+
+    return state


### PR DESCRIPTION
**Sprint 4, PR #8.** Third bite of the `prepare_import_payload` monster. Moves the ~100-line playlist section parsing block, plus its two supporting constants, into a focused module.

## What moved

- The playlist parsing block from `prepare_import_payload` (previously ~100 lines of nested-loop parsing over `config_data['playlist_files']`)
- `PLAYLIST_SHARED_IMPORT_FIELDS` (16 field→kind entries)
- `PLAYLIST_KEYED_IMPORT_FIELDS` (19 prefix→kind entries)

Along with them a new dataclass `PlaylistImportState` that bundles the four output collections the parser produces:

| Field | Type |
|---|---|
| `libraries` | `set[str]` |
| `file_entries` | `list[dict]` |
| `template_field_values` | `dict[str, Any]` |
| `keyed_template_field_values` | `dict[str, dict[str, Any]]` |

Previously these were four separate locals inside the mega function; now they're one return value with a `.has_any_data` property that replaces the ad-hoc `playlist_libraries or playlist_file_entries` check.

## New public API

`modules/importer_playlists` exports:

- `PLAYLIST_SHARED_IMPORT_FIELDS`
- `PLAYLIST_KEYED_IMPORT_FIELDS`
- `PlaylistImportState` (dataclass)
- `parse_playlist_config(config_data, report) -> PlaylistImportState`

The parser mutates `report` in place (same behavior as before — the report always was a shared collector for the whole import pipeline).

## Compatibility

- **Both `PLAYLIST_*_IMPORT_FIELDS` re-exported from `modules.importer`:**
  - `scripts/analyze_uploaded_template_gaps.py` reads them as `importer.PLAYLIST_SHARED_IMPORT_FIELDS` and `importer.PLAYLIST_KEYED_IMPORT_FIELDS` (regression-guarded by `tests/test_template_gap_analyzer`)
  - The libraries block downstream still uses `PLAYLIST_SHARED_IMPORT_FIELDS` for one type-check on template values

- **Local variable names inside `prepare_import_payload` preserved** (`playlist_libraries`, `playlist_file_entries`, etc.) by re-aliasing from the returned dataclass. Keeps the ~11 downstream references churn-free.

## Circular-import guard

`modules/importer_playlists` imports `ImportReport` only under `TYPE_CHECKING` — no runtime cross-import between `importer` and `importer_playlists`.

## Notable process learning

Initial extraction missed that `scripts/analyze_uploaded_template_gaps.py` needed BOTH constants (I only re-exported `SHARED`). Caught by `tests/test_template_gap_analyzer` on first test run. Fixed by re-exporting `KEYED` too. This is exactly why the test suite exists — the tests found a real external caller that my grep missed.

## Impact

- `modules/importer.py`: **1131 → 1010** (**-121 / -10.7%**)
- `modules/importer_playlists.py`: NEW ~260 lines
- **`prepare_import_payload` body: 748 → 654** (**-94 / -12.6%**)

## Sprint 4 running total

| PR | Status | File | Δ | Ending |
|---|---|---|---|---|
| #1500 | merged | logscan_imagemaid_analysis | -704 | 316 |
| #1502 | merged | logscan_progress | -562 | 310 |
| #1503 | merged | importer (yaml annotation) | -238 | 1789 |
| #1504 | merged | importer (dead-code fix) | -12 | 1777 |
| #1505 | merged | importer (library types) | -283 | 1494 |
| #1506 | merged | importer (value coercion) | -146 | 1348 |
| #1507 | merged | importer (hoist statics) | +15 | 1363 |
| #1510 | merged | importer (operations) | -232 | 1131 |
| **#TBD (this)** | **importer (playlists)** | **-121** | **1010** |

**Cumulative importer.py: 2027 → 1010 = -50.2%** — past the halfway point on the original file.

## Verification

- All **1285 tests pass**
- Ruff + black clean
- Both modules import cleanly in either order
- Both `importer.PLAYLIST_SHARED_IMPORT_FIELDS` and `importer.PLAYLIST_KEYED_IMPORT_FIELDS` still accessible

## Roadmap for prepare_import_payload

The function is now **654 lines** in its body (down from original 1062). Remaining chunks:
1. Simple sections loop (~50 lines)
2. Per-library handling (~500+ lines — the last big fish)
3. Post-processing / finalization

The per-library block is a beast with collections/overlays/metadata/settings/services sub-sections. Could tackle one sub-section at a time.