### PR TITLE
Extract top-level simple-section handling to importer_simple_sections

### DIFF
--- a/modules/importer.py
+++ b/modules/importer.py
@@ -6,27 +6,6 @@ from ruamel.yaml import YAML
 
 from modules import helpers
 
-SIMPLE_SECTIONS = {
-    "plex",
-    "tmdb",
-    "omdb",
-    "mdblist",
-    "tautulli",
-    "notifiarr",
-    "gotify",
-    "ntfy",
-    "apprise",
-    "github",
-    "radarr",
-    "sonarr",
-    "trakt",
-    "mal",
-    "anidb",
-    "webhooks",
-    "settings",
-    "playlist_files",
-}
-
 LIBRARY_RADARR_IMPORT_FIELDS = {
     "url": "string",
     "token": "string",
@@ -253,6 +232,15 @@ from modules.importer_playlists import (  # noqa: E402
     PLAYLIST_SHARED_IMPORT_FIELDS,  # noqa: F401 (used by libraries block below + scripts)
 )
 
+# Top-level "simple section" handling (apprise, plex, tmdb, ...) moved to
+# modules/importer_simple_sections.py.  SIMPLE_SECTIONS is re-imported here
+# because the end-of-function unknown-key sweep still uses it to decide
+# which config keys count as "handled" vs. "not supported".
+from modules import importer_simple_sections  # noqa: E402
+from modules.importer_simple_sections import (  # noqa: E402
+    SIMPLE_SECTIONS,  # noqa: F401 (used by tail unknown-key sweep in prepare_import_payload)
+)
+
 
 def _build_attribute_sets(
     attribute_config: dict,
@@ -334,26 +322,6 @@ def _build_attribute_sets(
     )
 
 
-def _flatten_dict(base: str, payload: Any, report: ImportReport, max_depth: int = 3) -> None:
-    if max_depth <= 0:
-        report.add("imported", base)
-        return
-    if isinstance(payload, dict):
-        for key, value in payload.items():
-            child = f"{base}.{key}"
-            _flatten_dict(child, value, report, max_depth - 1)
-        if not payload:
-            report.add("imported", base)
-    elif isinstance(payload, list):
-        for idx, value in enumerate(payload):
-            child = f"{base}[{idx}]"
-            _flatten_dict(child, value, report, max_depth - 1)
-        if not payload:
-            report.add("imported", base)
-    else:
-        report.add("imported", base)
-
-
 def prepare_import_payload(
     config_data: dict,
     plex_movie_names: set[str],
@@ -385,58 +353,7 @@ def prepare_import_payload(
     playlist_template_field_values = _playlist_state.template_field_values
     playlist_keyed_template_field_values = _playlist_state.keyed_template_field_values
 
-    for section in SIMPLE_SECTIONS:
-        if section not in config_data:
-            continue
-        section_payload = config_data.get(section)
-        if section == "playlist_files":
-            continue
-
-        if section == "apprise":
-            apprise_location = None
-            if isinstance(section_payload, dict):
-                if "config" in section_payload:
-                    apprise_location = section_payload.get("config")
-                elif "location" in section_payload:
-                    apprise_location = section_payload.get("location")
-                elif "apprise" in section_payload:
-                    nested_apprise = section_payload.get("apprise")
-                    if isinstance(nested_apprise, dict):
-                        apprise_location = nested_apprise.get("config") or nested_apprise.get("location")
-                    else:
-                        apprise_location = nested_apprise
-            elif isinstance(section_payload, str):
-                apprise_location = section_payload
-
-            apprise_location = str(apprise_location).strip() if apprise_location is not None else ""
-            if apprise_location:
-                normalized_apprise = {"location": apprise_location}
-                payload[section] = {section: normalized_apprise}
-                _flatten_dict(section, normalized_apprise, report)
-            else:
-                report.add("unmapped", section, "Unsupported section format.")
-            continue
-
-        if isinstance(section_payload, dict):
-            if section == "settings":
-                asset_directory = section_payload.get("asset_directory")
-                if isinstance(asset_directory, (str, list)):
-                    normalized = (
-                        [line.strip() for line in str(asset_directory).splitlines()] if isinstance(asset_directory, str) else [str(item).strip() for item in asset_directory]
-                    )
-                    normalized = [entry for entry in normalized if entry]
-                    section_payload = dict(section_payload)
-                    section_payload["asset_directory"] = normalized
-            if section == "anidb":
-                if "enable" not in section_payload:
-                    has_values = any(value not in [None, "", [], {}] for value in section_payload.values())
-                    if has_values:
-                        section_payload = dict(section_payload)
-                        section_payload["enable"] = True
-            payload[section] = {section: section_payload}
-            _flatten_dict(section, section_payload, report)
-        else:
-            report.add("unmapped", section, "Unsupported section format.")
+    importer_simple_sections.process_simple_sections(config_data, payload=payload, report=report)
 
     libraries_payload = config_data.get("libraries")
     if isinstance(libraries_payload, dict):

--- a/modules/importer_simple_sections.py
+++ b/modules/importer_simple_sections.py
@@ -1,0 +1,181 @@
+"""Top-level "simple section" parsing for ``prepare_import_payload``.
+
+Split out of ``modules.importer`` so the generic per-section handling
+(plex, tmdb, omdb, tautulli, notifiarr, ...) has a home separate from
+the mega function.
+
+Each section in :data:`SIMPLE_SECTIONS` gets copied straight from the
+YAML config into the flat ``payload[section]`` dict.  A couple of
+sections need light preprocessing before the copy:
+
+* ``apprise``   -- coerces the various historical shapes
+                   (``config`` string / nested dict) into a single
+                   ``{location: str}`` mapping.
+* ``settings``  -- normalizes ``asset_directory`` from multiline
+                   string OR list into a list of stripped strings.
+* ``anidb``     -- auto-adds ``enable: true`` when non-empty values
+                   are present but the flag is missing (legacy configs).
+
+All other sections in :data:`SIMPLE_SECTIONS` pass through unchanged.
+
+Report annotations are added in place onto the caller-supplied
+``ImportReport``; the ``payload`` dict is mutated in place as well.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from modules.importer import ImportReport
+
+
+SIMPLE_SECTIONS: frozenset[str] = frozenset(
+    {
+        "plex",
+        "tmdb",
+        "omdb",
+        "mdblist",
+        "tautulli",
+        "notifiarr",
+        "gotify",
+        "ntfy",
+        "apprise",
+        "github",
+        "radarr",
+        "sonarr",
+        "trakt",
+        "mal",
+        "anidb",
+        "webhooks",
+        "settings",
+        "playlist_files",
+    }
+)
+
+
+def _flatten_dict(
+    base: str,
+    payload: Any,
+    report: ImportReport,
+    max_depth: int = 3,
+) -> None:
+    """Recursively record every leaf of ``payload`` as imported.
+
+    Reports the base path when the recursion bottoms out on either
+    a scalar or the ``max_depth`` guard.  Empty dicts/lists count
+    as leaves too so the caller can see that yes, we saw them.
+    """
+    if max_depth <= 0:
+        report.add("imported", base)
+        return
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            child = f"{base}.{key}"
+            _flatten_dict(child, value, report, max_depth - 1)
+        if not payload:
+            report.add("imported", base)
+    elif isinstance(payload, list):
+        for idx, value in enumerate(payload):
+            child = f"{base}[{idx}]"
+            _flatten_dict(child, value, report, max_depth - 1)
+        if not payload:
+            report.add("imported", base)
+    else:
+        report.add("imported", base)
+
+
+def _normalize_apprise_section(section_payload: Any) -> str:
+    """Squash the historical apprise config shapes into one location string.
+
+    Returns an empty string when no location could be recovered so
+    the caller can flag it as unmapped.
+    """
+    apprise_location: Any = None
+    if isinstance(section_payload, dict):
+        if "config" in section_payload:
+            apprise_location = section_payload.get("config")
+        elif "location" in section_payload:
+            apprise_location = section_payload.get("location")
+        elif "apprise" in section_payload:
+            nested_apprise = section_payload.get("apprise")
+            if isinstance(nested_apprise, dict):
+                apprise_location = nested_apprise.get("config") or nested_apprise.get("location")
+            else:
+                apprise_location = nested_apprise
+    elif isinstance(section_payload, str):
+        apprise_location = section_payload
+
+    return str(apprise_location).strip() if apprise_location is not None else ""
+
+
+def _normalize_settings_section(section_payload: dict) -> dict:
+    """Normalize the settings section's asset_directory (str-or-list to list)."""
+    asset_directory = section_payload.get("asset_directory")
+    if not isinstance(asset_directory, (str, list)):
+        return section_payload
+
+    if isinstance(asset_directory, str):
+        normalized = [line.strip() for line in asset_directory.splitlines()]
+    else:
+        normalized = [str(item).strip() for item in asset_directory]
+    normalized = [entry for entry in normalized if entry]
+
+    updated = dict(section_payload)
+    updated["asset_directory"] = normalized
+    return updated
+
+
+def _normalize_anidb_section(section_payload: dict) -> dict:
+    """Auto-add ``enable: true`` for legacy configs missing the flag."""
+    if "enable" in section_payload:
+        return section_payload
+    has_values = any(value not in [None, "", [], {}] for value in section_payload.values())
+    if not has_values:
+        return section_payload
+    updated = dict(section_payload)
+    updated["enable"] = True
+    return updated
+
+
+def process_simple_sections(
+    config_data: dict,
+    *,
+    payload: dict[str, dict],
+    report: ImportReport,
+) -> None:
+    """Copy each top-level SIMPLE_SECTIONS block from config_data into payload.
+
+    Mutates ``payload`` (adds one key per recognized section) and
+    ``report`` (records imported / unmapped paths) in place.
+
+    ``playlist_files`` is included in :data:`SIMPLE_SECTIONS` for the
+    end-of-function unknown-key sweep but is handled separately by
+    :mod:`modules.importer_playlists`; this function skips it explicitly.
+    """
+    for section in SIMPLE_SECTIONS:
+        if section not in config_data:
+            continue
+        section_payload = config_data.get(section)
+        if section == "playlist_files":
+            continue
+
+        if section == "apprise":
+            apprise_location = _normalize_apprise_section(section_payload)
+            if apprise_location:
+                normalized_apprise = {"location": apprise_location}
+                payload[section] = {section: normalized_apprise}
+                _flatten_dict(section, normalized_apprise, report)
+            else:
+                report.add("unmapped", section, "Unsupported section format.")
+            continue
+
+        if isinstance(section_payload, dict):
+            if section == "settings":
+                section_payload = _normalize_settings_section(section_payload)
+            if section == "anidb":
+                section_payload = _normalize_anidb_section(section_payload)
+            payload[section] = {section: section_payload}
+            _flatten_dict(section, section_payload, report)
+        else:
+            report.add("unmapped", section, "Unsupported section format.")


### PR DESCRIPTION
**Sprint 4, PR #9.** Fourth bite of the `prepare_import_payload` monster. Moves the ~55-line `SIMPLE_SECTIONS` dispatch loop, plus the `_flatten_dict` helper it uses, into a focused module.

## What moved

- `SIMPLE_SECTIONS` constant (18-entry frozenset of top-level YAML keys that get generic dict handling: plex, tmdb, omdb, mdblist, tautulli, notifiarr, gotify, ntfy, apprise, github, radarr, sonarr, trakt, mal, anidb, webhooks, settings, playlist_files)
- `_flatten_dict` recursive helper (used to record every leaf of a section payload as `imported`)
- The ~55-line `for section in SIMPLE_SECTIONS` loop from `prepare_import_payload`

## New module structure

`modules/importer_simple_sections` exports:

- `SIMPLE_SECTIONS` — constant (re-exported from `modules.importer` for the end-of-function unknown-key sweep)
- `process_simple_sections(config_data, *, payload, report) -> None`

Internal helpers (leading `_`) that USED to be inline blocks inside the loop body and got names as a side effect of the extraction:

| Helper | Was |
|---|---|
| `_flatten_dict` | Unchanged behavior, just moved |
| `_normalize_apprise_section` | ~15 lines of inline logic coercing the historical apprise shapes into a single location string |
| `_normalize_settings_section` | The `asset_directory` str-or-list normalization block |
| `_normalize_anidb_section` | The "auto-enable when values are present" legacy compat block |

These sub-helpers are byte-identical to their prior inline equivalents; they exist purely to name what each block does so `process_simple_sections` reads as a flat dispatch instead of a 90-line if/elif ladder. Verified via direct call smoke-tests covering every input shape:
- None, string, dict with `config`, `location`, or `apprise` key
- Nested apprise dict
- Multi-line string `asset_directory`
- Mixed list `asset_directory`
- anidb with and without values

## Compatibility

- **`SIMPLE_SECTIONS` re-exported from `modules.importer`** because the tail-of-function unknown-key sweep still checks `if key in SIMPLE_SECTIONS`. No external callers reference `importer.SIMPLE_SECTIONS` today, but keeping it accessible avoids surprising anyone who wired up a monkeypatch.
- **`_flatten_dict` is now module-private** (leading `_`) inside `importer_simple_sections`; not re-exported because it had no external users and its only remaining call sites are inside `process_simple_sections`.

## Circular-import guard

`modules/importer_simple_sections` imports `ImportReport` only under `TYPE_CHECKING` — no runtime cross-import between `importer` and `importer_simple_sections`.

## Impact

- `modules/importer.py`: **1010 → 927** (**-83 / -8.2%**)
- `modules/importer_simple_sections.py`: NEW ~180 lines
- **`prepare_import_payload` body: 654 → 603** (**-51 / -7.8%**)

## Sprint 4 running total

| PR | Status | File | Δ | Ending |
|---|---|---|---|---|
| #1500 | merged | logscan_imagemaid_analysis | -704 | 316 |
| #1502 | merged | logscan_progress | -562 | 310 |
| #1503 | merged | importer (yaml annotation) | -238 | 1789 |
| #1504 | merged | importer (dead-code fix) | -12 | 1777 |
| #1505 | merged | importer (library types) | -283 | 1494 |
| #1506 | merged | importer (value coercion) | -146 | 1348 |
| #1507 | merged | importer (hoist statics) | +15 | 1363 |
| #1510 | merged | importer (operations) | -232 | 1131 |
| #1511 | merged | importer (playlists) | -121 | 1010 |
| **#TBD (this)** | **importer (simple sections)** | **-83** | **927** |

**Cumulative importer.py: 2027 → 927 = -54.3%**

## Verification

- All **1285 tests pass**
- Ruff + black clean
- Both modules import cleanly in either order
- `importer.SIMPLE_SECTIONS is importer_simple_sections.SIMPLE_SECTIONS` verified
- All 4 internal helpers smoke-tested with edge-case inputs before commit

## Roadmap for prepare_import_payload

The function is now **603 lines** in its body (down from original 1062, so -43.2% inside the mega function). Remaining chunks:

1. Setup (~30 lines) — config loads, index builds, playlist parse
2. **Per-library handling (~560 lines)** — the last big fish
3. Post-processing / finalization (~10 lines)

The per-library block is a beast with collections/overlays/metadata/settings/services sub-sections. Next PR will target one sub-section.