### PR TITLE
Extract per-library collection_files handling to importer_collections

### DIFF
--- a/modules/importer.py
+++ b/modules/importer.py
@@ -241,6 +241,12 @@ from modules.importer_simple_sections import (  # noqa: E402
     SIMPLE_SECTIONS,  # noqa: F401 (used by tail unknown-key sweep in prepare_import_payload)
 )
 
+# Per-library collection_files handling moved to modules/importer_collections.py.
+# Imported as a module (not name-by-name) because the call site inside
+# prepare_import_payload passes kwargs and the `importer_collections.` prefix
+# makes it obvious this is the collection-processing pipeline.
+from modules import importer_collections  # noqa: E402
+
 
 def _build_attribute_sets(
     attribute_config: dict,
@@ -435,128 +441,15 @@ def prepare_import_payload(
             elif lib_template_vars is not None:
                 report.add("unmapped", f"libraries.{lib_name}.template_variables", "Unsupported template_variables format.")
 
-            # Collections
-            collection_files = lib_cfg.get("collection_files")
-            if isinstance(collection_files, list):
-                imported_collection_files = []
-                for idx, entry in enumerate(collection_files):
-                    default_value = None
-                    template_values = None
-                    raw_entry_type = None
-                    raw_entry_location = None
-                    if isinstance(entry, dict):
-                        default_value = entry.get("default")
-                        template_values = entry.get("template_variables")
-                        for candidate in ("file", "folder", "url", "git", "repo"):
-                            location = entry.get(candidate)
-                            if location:
-                                raw_entry_type = candidate
-                                raw_entry_location = str(location)
-                                break
-                    elif isinstance(entry, str):
-                        default_value = entry
-                    if raw_entry_type and raw_entry_location:
-                        imported_collection_files.append({"type": raw_entry_type, "location": raw_entry_location})
-                        report.add("imported", f"libraries.{lib_name}.collection_files[{idx}].{raw_entry_type}")
-                        continue
-                    if not default_value:
-                        report.add("unmapped", f"libraries.{lib_name}.collection_files[{idx}]", "Missing default.")
-                        continue
-
-                    raw_default = str(default_value)
-                    collection_id = _resolve_collection_id(raw_default, collection_by_id, collection_by_alias)
-                    if not collection_id or collection_id not in collection_by_id:
-                        report.add(
-                            "unmapped",
-                            f"libraries.{lib_name}.collection_files[{idx}].default",
-                            "Collection not found in Quickstart.",
-                        )
-                        continue
-
-                    libraries_data[f"{lib_id}-{collection_id}"] = True
-                    report.add("imported", f"libraries.{lib_name}.collection_files[{idx}].default")
-
-                    if isinstance(template_values, dict):
-                        allowed = _collect_template_keys(collection_by_id[collection_id].get("template_variables"))
-                        dynamic_child_fields = _collect_dynamic_child_field_specs(collection_by_id[collection_id].get("template_variables"))
-                        clean_id = collection_id.replace("collection_", "", 1)
-                        expanded_template_values = dict(template_values)
-                        data_block = expanded_template_values.get("data")
-                        data_reported = set()
-                        pending_dynamic_child_maps: dict[str, dict[str, str]] = {}
-                        if isinstance(data_block, dict):
-                            for subkey, subval in data_block.items():
-                                flat_key = f"data_{subkey}"
-                                if flat_key in allowed and flat_key not in expanded_template_values:
-                                    expanded_template_values[flat_key] = subval
-                                if flat_key in allowed:
-                                    report.add(
-                                        "imported",
-                                        f"libraries.{lib_name}.collection_files[{idx}].template_variables.data.{subkey}",
-                                    )
-                                    data_reported.add(subkey)
-                            if "data" in expanded_template_values and "data" not in allowed:
-                                expanded_template_values.pop("data", None)
-                            if data_reported:
-                                report.add(
-                                    "imported",
-                                    f"libraries.{lib_name}.collection_files[{idx}].template_variables.data",
-                                )
-                        if _has_template_string_list_values(expanded_template_values.get("include")) and _has_template_string_list_values(expanded_template_values.get("exclude")):
-                            report.add(
-                                "skipped",
-                                f"libraries.{lib_name}.collection_files[{idx}].template_variables.include_exclude_warning",
-                                "Warning - include and exclude were both imported. Kometa code allows this, but the wiki says not to combine them.",
-                            )
-                        for key, value in expanded_template_values.items():
-                            if key in allowed:
-                                child_name = f"{lib_id}-template_collection_{clean_id}_{key}"
-                                if isinstance(value, list):
-                                    libraries_data[child_name] = json.dumps(value, ensure_ascii=True)
-                                else:
-                                    libraries_data[child_name] = value
-                                report.add(
-                                    "imported",
-                                    f"libraries.{lib_name}.collection_files[{idx}].template_variables.{key}",
-                                )
-                            else:
-                                matched_dynamic_child = next(
-                                    (spec for spec in dynamic_child_fields if key.startswith(spec["child_prefix"]) and key != spec["child_prefix"]),
-                                    None,
-                                )
-                                if matched_dynamic_child:
-                                    suffix = key[len(matched_dynamic_child["child_prefix"]) :].strip()
-                                    serialized_value = _serialize_dynamic_child_mapping_value(
-                                        value,
-                                        matched_dynamic_child["value_kind"],
-                                    )
-                                    if suffix and serialized_value:
-                                        pending_dynamic_child_maps.setdefault(
-                                            matched_dynamic_child["field_key"],
-                                            {},
-                                        )[suffix] = serialized_value
-                                        report.add(
-                                            "imported",
-                                            f"libraries.{lib_name}.collection_files[{idx}].template_variables.{key}",
-                                        )
-                                        continue
-                                report.add(
-                                    "unmapped",
-                                    f"libraries.{lib_name}.collection_files[{idx}].template_variables.{key}",
-                                    "Template variable not available in Quickstart.",
-                                )
-
-                        for field_key, field_map in pending_dynamic_child_maps.items():
-                            if not field_map:
-                                continue
-                            libraries_data[f"{lib_id}-template_collection_{clean_id}_{field_key}"] = json.dumps(field_map, ensure_ascii=True)
-
-                if imported_collection_files:
-                    libraries_data[f"{lib_id}-collection_files"] = json.dumps(imported_collection_files, ensure_ascii=True)
-                    report.add("imported", f"libraries.{lib_name}.collection_files")
-
-            elif collection_files is not None:
-                report.add("unmapped", f"libraries.{lib_name}.collection_files", "Unsupported collection_files format.")
+            importer_collections.process_collection_files(
+                lib_id,
+                str(lib_name),
+                lib_cfg,
+                libraries_data=libraries_data,
+                report=report,
+                collection_by_id=collection_by_id,
+                collection_by_alias=collection_by_alias,
+            )
 
             # Overlays
             overlay_files = lib_cfg.get("overlay_files")

--- a/modules/importer_collections.py
+++ b/modules/importer_collections.py
@@ -1,0 +1,275 @@
+"""Per-library ``collection_files`` handling for ``prepare_import_payload``.
+
+Split out of ``modules.importer`` so the ~120-line collection-file
+processing block for each library lives next to the constants and
+helpers it uses, instead of buried inside the mega function.
+
+Each library entry in the YAML config can carry a ``collection_files``
+list.  Entries in that list can be either:
+
+* **File references** -- ``{file: ...}`` / ``{url: ...}`` / ``{git: ...}``
+  / ``{repo: ...}`` / ``{folder: ...}`` mappings that point at an
+  external collection definition file.  These are collected into a
+  JSON blob under ``libraries_data[lib_id-collection_files]``.
+
+* **Default references** -- ``{default: <collection_id_or_alias>}``
+  mappings (or bare strings) that select one of the Quickstart-bundled
+  collection templates.  Each resolves to a specific
+  ``libraries_data[lib_id-<collection_id>] = True`` flag plus optional
+  ``template_variables`` overrides written to
+  ``libraries_data[lib_id-template_collection_<clean_id>_<key>]``.
+
+Template-variable overrides support:
+
+* Flat overrides (top-level keys that appear in the collection's
+  ``template_variables`` schema).
+* Nested ``data.*`` overrides, promoted to ``data_*`` flat keys
+  when the schema allows them.
+* Dynamic-child mappings (e.g. ``ratings_<suffix>``) that get
+  collected into a single JSON blob per parent field.
+* Include/exclude "both set" warning (Kometa allows it, wiki says
+  don't) surfaced as a ``skipped`` report line.
+
+Report annotations are added in place onto the caller-supplied
+``ImportReport``; ``libraries_data`` is mutated in place.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from modules.importer_library_types import _resolve_collection_id
+from modules.importer_value_coercion import (
+    _collect_dynamic_child_field_specs,
+    _collect_template_keys,
+    _has_template_string_list_values,
+    _serialize_dynamic_child_mapping_value,
+)
+
+if TYPE_CHECKING:
+    from modules.importer import ImportReport
+
+
+def process_collection_files(
+    lib_id: str,
+    lib_name: str,
+    lib_cfg: dict,
+    *,
+    libraries_data: dict[str, Any],
+    report: ImportReport,
+    collection_by_id: dict[str, dict],
+    collection_by_alias: dict[str, str],
+) -> None:
+    """Process ``lib_cfg['collection_files']`` into libraries_data + report.
+
+    A no-op when the library has no ``collection_files`` key.  When
+    the key is present but not a list, records an unmapped report entry.
+    """
+    collection_files = lib_cfg.get("collection_files")
+    if collection_files is None:
+        return
+
+    if not isinstance(collection_files, list):
+        report.add(
+            "unmapped",
+            f"libraries.{lib_name}.collection_files",
+            "Unsupported collection_files format.",
+        )
+        return
+
+    imported_collection_files: list[dict[str, str]] = []
+    for idx, entry in enumerate(collection_files):
+        _process_single_collection_entry(
+            idx,
+            entry,
+            lib_id=lib_id,
+            lib_name=lib_name,
+            libraries_data=libraries_data,
+            report=report,
+            collection_by_id=collection_by_id,
+            collection_by_alias=collection_by_alias,
+            imported_collection_files=imported_collection_files,
+        )
+
+    if imported_collection_files:
+        libraries_data[f"{lib_id}-collection_files"] = json.dumps(imported_collection_files, ensure_ascii=True)
+        report.add("imported", f"libraries.{lib_name}.collection_files")
+
+
+def _process_single_collection_entry(
+    idx: int,
+    entry: Any,
+    *,
+    lib_id: str,
+    lib_name: str,
+    libraries_data: dict[str, Any],
+    report: ImportReport,
+    collection_by_id: dict[str, dict],
+    collection_by_alias: dict[str, str],
+    imported_collection_files: list[dict[str, str]],
+) -> None:
+    """Dispatch a single collection_files[] entry.
+
+    Populates ``imported_collection_files`` for file-ref entries and
+    writes into ``libraries_data`` for default-based entries.
+    """
+    default_value: Any = None
+    template_values: Any = None
+    raw_entry_type: str | None = None
+    raw_entry_location: str | None = None
+
+    if isinstance(entry, dict):
+        default_value = entry.get("default")
+        template_values = entry.get("template_variables")
+        for candidate in ("file", "folder", "url", "git", "repo"):
+            location = entry.get(candidate)
+            if location:
+                raw_entry_type = candidate
+                raw_entry_location = str(location)
+                break
+    elif isinstance(entry, str):
+        default_value = entry
+
+    if raw_entry_type and raw_entry_location:
+        imported_collection_files.append({"type": raw_entry_type, "location": raw_entry_location})
+        report.add(
+            "imported",
+            f"libraries.{lib_name}.collection_files[{idx}].{raw_entry_type}",
+        )
+        return
+
+    if not default_value:
+        report.add(
+            "unmapped",
+            f"libraries.{lib_name}.collection_files[{idx}]",
+            "Missing default.",
+        )
+        return
+
+    raw_default = str(default_value)
+    collection_id = _resolve_collection_id(raw_default, collection_by_id, collection_by_alias)
+    if not collection_id or collection_id not in collection_by_id:
+        report.add(
+            "unmapped",
+            f"libraries.{lib_name}.collection_files[{idx}].default",
+            "Collection not found in Quickstart.",
+        )
+        return
+
+    libraries_data[f"{lib_id}-{collection_id}"] = True
+    report.add(
+        "imported",
+        f"libraries.{lib_name}.collection_files[{idx}].default",
+    )
+
+    if isinstance(template_values, dict):
+        _apply_collection_template_variables(
+            idx,
+            collection_id,
+            template_values,
+            lib_id=lib_id,
+            lib_name=lib_name,
+            libraries_data=libraries_data,
+            report=report,
+            collection_by_id=collection_by_id,
+        )
+
+
+def _apply_collection_template_variables(
+    idx: int,
+    collection_id: str,
+    template_values: dict,
+    *,
+    lib_id: str,
+    lib_name: str,
+    libraries_data: dict[str, Any],
+    report: ImportReport,
+    collection_by_id: dict[str, dict],
+) -> None:
+    """Write template_variables overrides for one collection entry.
+
+    Handles data-block promotion, include/exclude "both set" warning,
+    schema-matching flat overrides, and dynamic-child prefix mappings.
+    """
+    allowed = _collect_template_keys(collection_by_id[collection_id].get("template_variables"))
+    dynamic_child_fields = _collect_dynamic_child_field_specs(collection_by_id[collection_id].get("template_variables"))
+    clean_id = collection_id.replace("collection_", "", 1)
+
+    expanded_template_values = dict(template_values)
+    data_block = expanded_template_values.get("data")
+    data_reported: set = set()
+    pending_dynamic_child_maps: dict[str, dict[str, str]] = {}
+
+    # -- Promote data.<subkey> to data_<subkey> when the schema allows it.
+    if isinstance(data_block, dict):
+        for subkey, subval in data_block.items():
+            flat_key = f"data_{subkey}"
+            if flat_key in allowed and flat_key not in expanded_template_values:
+                expanded_template_values[flat_key] = subval
+            if flat_key in allowed:
+                report.add(
+                    "imported",
+                    f"libraries.{lib_name}.collection_files[{idx}].template_variables.data.{subkey}",
+                )
+                data_reported.add(subkey)
+        if "data" in expanded_template_values and "data" not in allowed:
+            expanded_template_values.pop("data", None)
+        if data_reported:
+            report.add(
+                "imported",
+                f"libraries.{lib_name}.collection_files[{idx}].template_variables.data",
+            )
+
+    # -- Warn on the include+exclude combo (Kometa allows, wiki says no).
+    if _has_template_string_list_values(expanded_template_values.get("include")) and _has_template_string_list_values(expanded_template_values.get("exclude")):
+        report.add(
+            "skipped",
+            f"libraries.{lib_name}.collection_files[{idx}].template_variables.include_exclude_warning",
+            "Warning - include and exclude were both imported. Kometa code allows this, but the wiki says not to combine them.",
+        )
+
+    # -- Emit each override into libraries_data if the schema allows it.
+    for key, value in expanded_template_values.items():
+        if key in allowed:
+            child_name = f"{lib_id}-template_collection_{clean_id}_{key}"
+            if isinstance(value, list):
+                libraries_data[child_name] = json.dumps(value, ensure_ascii=True)
+            else:
+                libraries_data[child_name] = value
+            report.add(
+                "imported",
+                f"libraries.{lib_name}.collection_files[{idx}].template_variables.{key}",
+            )
+        else:
+            matched_dynamic_child = next(
+                (spec for spec in dynamic_child_fields if key.startswith(spec["child_prefix"]) and key != spec["child_prefix"]),
+                None,
+            )
+            if matched_dynamic_child:
+                suffix = key[len(matched_dynamic_child["child_prefix"]) :].strip()
+                serialized_value = _serialize_dynamic_child_mapping_value(
+                    value,
+                    matched_dynamic_child["value_kind"],
+                )
+                if suffix and serialized_value:
+                    pending_dynamic_child_maps.setdefault(
+                        matched_dynamic_child["field_key"],
+                        {},
+                    )[suffix] = serialized_value
+                    report.add(
+                        "imported",
+                        f"libraries.{lib_name}.collection_files[{idx}].template_variables.{key}",
+                    )
+                    continue
+            report.add(
+                "unmapped",
+                f"libraries.{lib_name}.collection_files[{idx}].template_variables.{key}",
+                "Template variable not available in Quickstart.",
+            )
+
+    # -- Collapse any accumulated dynamic-child maps into JSON blobs.
+    for field_key, field_map in pending_dynamic_child_maps.items():
+        if not field_map:
+            continue
+        libraries_data[f"{lib_id}-template_collection_{clean_id}_{field_key}"] = json.dumps(field_map, ensure_ascii=True)


### PR DESCRIPTION
**Sprint 4, PR #10.** Fifth bite of the `prepare_import_payload` monster, and the **first slice** of the ~560-line per-library iteration loop.

## What moved

The ~122-line **Collections** block from the per-library iteration in `prepare_import_payload`, plus a mini-refactor to break it into three named functions:

| Function | Role |
|---|---|
| `process_collection_files` | Public entry point (replaces the inline block) |
| `_process_single_collection_entry` | Per-entry dispatch (file ref vs default ref) |
| `_apply_collection_template_variables` | Template-variable emission |

The original code was one 122-line block with two nested for-loops inside one big if. Splitting it into three functions with named responsibilities makes it readable (and reviewable) instead of a wall of nested conditionals.

## Handler signature

`process_collection_files` takes the per-library values as positional args and the shared state as keyword-only kwargs:

```python
process_collection_files(
    lib_id, lib_name, lib_cfg,
    *,
    libraries_data, report,
    collection_by_id, collection_by_alias,
) -> None
```

Same pattern as `importer_operations` from PR #1510 — positional per-call values, kwargs for shared state — so all extracted per-library sub-handlers can follow the same convention.

## What `collection_files` does

Each entry in a library's `collection_files:` list can be either:

1. A **file reference** (`{file, url, git, repo, folder}` pointing at an external YAML) — collected into a JSON blob under `libraries_data[lib_id-collection_files]`.

2. A **default reference** (`{default: <collection_id_or_alias>}`, or a bare string) — resolves to a specific Quickstart-bundled collection template and sets `libraries_data[lib_id-<collection_id>]` plus optional `template_variables` overrides.

Template-variable overrides support:
- Flat overrides (top-level schema keys)
- Nested `data.<subkey>` overrides, promoted to `data_<subkey>` flat keys when the schema allows them
- Dynamic-child prefix mappings collapsed into single JSON blobs per parent field
- Include/exclude "both set" warning surfaced as a `skipped` report line

## Compatibility

- No external callers touch the extracted logic (was purely inline)
- All 5 helpers the extracted code depends on already live in their respective `importer_*` modules and remain reachable via `importer.*` re-exports for any tests/scripts that reference them:
  - `_resolve_collection_id` (importer_library_types)
  - `_collect_template_keys` (importer_value_coercion)
  - `_collect_dynamic_child_field_specs` (importer_value_coercion)
  - `_has_template_string_list_values` (importer_value_coercion)
  - `_serialize_dynamic_child_mapping_value` (importer_value_coercion)

## Circular-import guard

`modules/importer_collections` imports `ImportReport` only under `TYPE_CHECKING` — no runtime cross-import between `importer` and `importer_collections`.

## Impact

- `modules/importer.py`: **927 → 820** (**-107 / -11.5%**)
- `modules/importer_collections.py`: NEW ~275 lines
- **`prepare_import_payload` body: 603 → 490** (**-113 / -18.7%**)

## Sprint 4 running total

| PR | Status | File | Δ | Ending |
|---|---|---|---|---|
| #1500 | merged | logscan_imagemaid_analysis | -704 | 316 |
| #1502 | merged | logscan_progress | -562 | 310 |
| #1503 | merged | importer (yaml annotation) | -238 | 1789 |
| #1504 | merged | importer (dead-code fix) | -12 | 1777 |
| #1505 | merged | importer (library types) | -283 | 1494 |
| #1506 | merged | importer (value coercion) | -146 | 1348 |
| #1507 | merged | importer (hoist statics) | +15 | 1363 |
| #1510 | merged | importer (operations) | -232 | 1131 |
| #1511 | merged | importer (playlists) | -121 | 1010 |
| #1512 | merged | importer (simple sections) | -83 | 927 |
| **#TBD (this)** | **importer (collections)** | **-107** | **820** |

**Cumulative importer.py: 2027 → 820 = -59.5%**

## Verification

- All **1285 tests pass**
- Ruff + black clean
- Both modules import cleanly in either order

## Roadmap for prepare_import_payload

The function body is now **490 lines** (down from original 1062). Remaining chunks inside the per-library loop:

1. **Overlays** (~107 lines) — very similar shape to Collections
2. **Metadata files** (~46 lines)
3. **Library settings** (~57 lines)
4. **Service-scoped fields** (radarr, sonarr — ~47 lines)
5. **Operations dispatch** (~57 lines) — hooks into `importer_operations` already
6. Setup + handled-keys sweep (~30 lines)

Overlays is the natural next target — same shape, same closure vars.
