### PR TITLE
Extract per-library overlay_files handling to importer_overlays

### DIFF
--- a/modules/importer.py
+++ b/modules/importer.py
@@ -247,6 +247,11 @@ from modules.importer_simple_sections import (  # noqa: E402
 # makes it obvious this is the collection-processing pipeline.
 from modules import importer_collections  # noqa: E402
 
+# Per-library overlay_files handling moved to modules/importer_overlays.py.
+# Same import pattern as importer_collections -- module-level import so the
+# call site inside prepare_import_payload reads as importer_overlays.process_*.
+from modules import importer_overlays  # noqa: E402
+
 
 def _build_attribute_sets(
     attribute_config: dict,
@@ -451,114 +456,18 @@ def prepare_import_payload(
                 collection_by_alias=collection_by_alias,
             )
 
-            # Overlays
-            overlay_files = lib_cfg.get("overlay_files")
-            if isinstance(overlay_files, list):
-                imported_overlay_files = []
-                for idx, entry in enumerate(overlay_files):
-                    default_value = None
-                    template_values = None
-                    builder_level = builder_default
-                    raw_entry_type = None
-                    raw_entry_location = None
-                    if isinstance(entry, dict):
-                        default_value = entry.get("default")
-                        template_values = entry.get("template_variables")
-                        for candidate in ("file", "folder", "url", "git", "repo"):
-                            location = entry.get(candidate)
-                            if location:
-                                raw_entry_type = candidate
-                                raw_entry_location = str(location)
-                                break
-                        if isinstance(template_values, dict) and "builder_level" in template_values:
-                            level = template_values.get("builder_level")
-                            if level in {"show", "season", "episode"}:
-                                builder_level = level
-                    elif isinstance(entry, str):
-                        default_value = entry
-
-                    if raw_entry_type and raw_entry_location:
-                        imported_overlay_files.append({"type": raw_entry_type, "location": raw_entry_location})
-                        report.add("imported", f"libraries.{lib_name}.overlay_files[{idx}].{raw_entry_type}")
-                        continue
-
-                    if not default_value:
-                        report.add("unmapped", f"libraries.{lib_name}.overlay_files[{idx}]", "Missing default.")
-                        continue
-
-                    raw_default = str(default_value)
-                    overlay_id = _resolve_overlay_id(raw_default, overlay_by_id, overlay_by_alias)
-                    if overlay_id not in overlay_by_id:
-                        report.add(
-                            "unmapped",
-                            f"libraries.{lib_name}.overlay_files[{idx}].default",
-                            "Overlay not found in Quickstart.",
-                        )
-                        continue
-
-                    overlay_meta = overlay_by_id.get(overlay_id, {})
-                    if overlay_id == "overlay_languages" and isinstance(template_values, dict) and str(template_values.get("use_subtitles", "")).strip().lower() == "true":
-                        subtitles_id = overlay_by_alias.get("languages_subtitles")
-                        if subtitles_id:
-                            overlay_id = subtitles_id
-                            overlay_meta = overlay_by_id.get(overlay_id, {})
-                            template_values = dict(template_values)
-                            template_values.pop("use_subtitles", None)
-                            report.add(
-                                "imported",
-                                f"libraries.{lib_name}.overlay_files[{idx}].template_variables.use_subtitles",
-                            )
-                    media_types = overlay_meta.get("media_types") or []
-                    if builder_level == "movie" and media_types and "movie" not in media_types:
-                        report.add(
-                            "unmapped",
-                            f"libraries.{lib_name}.overlay_files[{idx}].default",
-                            "Overlay not available for movie libraries.",
-                        )
-                        continue
-                    if builder_level not in media_types and builder_level != "movie":
-                        if "show" in media_types:
-                            builder_level = "show"
-                        elif media_types:
-                            builder_level = media_types[0]
-
-                    radio_info = overlay_radio.get(overlay_id)
-                    if radio_info:
-                        radio_key = f"{lib_id}-{builder_level}-{radio_info['group_name']}"
-                        libraries_data[radio_key] = radio_info.get("value")
-                    else:
-                        libraries_data[f"{lib_id}-{builder_level}-{overlay_id}"] = True
-                    report.add("imported", f"libraries.{lib_name}.overlay_files[{idx}].default")
-
-                    if isinstance(template_values, dict):
-                        allowed = _collect_template_keys(overlay_meta.get("template_variables"))
-                        allowed.update(_collect_overlay_source_override_keys(overlay_meta))
-                        if overlay_id in {"overlay_languages", "overlay_languages_subtitles"}:
-                            allowed = set(allowed)
-                            allowed.update(LANGUAGE_WEIGHT_TEMPLATE_KEYS)
-                        for key, value in template_values.items():
-                            if key not in allowed:
-                                if key == "builder_level":
-                                    continue
-                                report.add(
-                                    "unmapped",
-                                    f"libraries.{lib_name}.overlay_files[{idx}].template_variables.{key}",
-                                    "Template variable not available in Quickstart.",
-                                )
-                                continue
-                            child_name = f"{lib_id}-{builder_level}-template_{overlay_id}[{key}]"
-                            libraries_data[child_name] = value
-                            report.add(
-                                "imported",
-                                f"libraries.{lib_name}.overlay_files[{idx}].template_variables.{key}",
-                            )
-
-                if imported_overlay_files:
-                    libraries_data[f"{lib_id}-overlay_files"] = json.dumps(imported_overlay_files, ensure_ascii=True)
-                    report.add("imported", f"libraries.{lib_name}.overlay_files")
-
-            elif overlay_files is not None:
-                report.add("unmapped", f"libraries.{lib_name}.overlay_files", "Unsupported overlay_files format.")
+            importer_overlays.process_overlay_files(
+                lib_id,
+                str(lib_name),
+                lib_cfg,
+                builder_default,
+                libraries_data=libraries_data,
+                report=report,
+                overlay_by_id=overlay_by_id,
+                overlay_by_alias=overlay_by_alias,
+                overlay_radio=overlay_radio,
+                language_weight_template_keys=LANGUAGE_WEIGHT_TEMPLATE_KEYS,
+            )
 
             metadata_files = lib_cfg.get("metadata_files")
             if isinstance(metadata_files, list):

--- a/modules/importer_overlays.py
+++ b/modules/importer_overlays.py
@@ -178,11 +178,7 @@ def _process_single_overlay_entry(
     overlay_meta = overlay_by_id.get(overlay_id, {})
 
     # -- Language-subtitles alias: use_subtitles: true swaps the overlay id.
-    if (
-        overlay_id == "overlay_languages"
-        and isinstance(template_values, dict)
-        and str(template_values.get("use_subtitles", "")).strip().lower() == "true"
-    ):
+    if overlay_id == "overlay_languages" and isinstance(template_values, dict) and str(template_values.get("use_subtitles", "")).strip().lower() == "true":
         subtitles_id = overlay_by_alias.get("languages_subtitles")
         if subtitles_id:
             overlay_id = subtitles_id

--- a/modules/importer_overlays.py
+++ b/modules/importer_overlays.py
@@ -1,0 +1,277 @@
+"""Per-library ``overlay_files`` handling for ``prepare_import_payload``.
+
+Split out of ``modules.importer`` following the same pattern as
+:mod:`modules.importer_collections`.  The overlay pipeline is
+structurally similar (parse entry -> resolve id -> emit templates)
+but adds three overlay-specific concerns:
+
+* **builder_level**  -- overlays can target ``movie``, ``show``,
+  ``season`` or ``episode`` scope.  Defaults to the library's
+  ``builder_default`` (movie vs. show).  Overrideable per entry
+  via ``template_variables.builder_level``.
+* **Language subtitles alias** -- when the ``overlay_languages``
+  overlay is selected and the config carries
+  ``use_subtitles: true``, we transparently swap to the
+  ``overlay_languages_subtitles`` alternate overlay.
+* **Radio groups** -- some overlays participate in mutually
+  exclusive radio groups (only one option per group can be set
+  per library).  Handled via the ``overlay_radio`` mapping from
+  :func:`modules.importer_library_types._build_overlay_index`.
+* **Language weight expansion** -- for the two language overlays
+  the allowed-template-keys set is extended with the module-level
+  ``LANGUAGE_WEIGHT_TEMPLATE_KEYS`` (81 ``weight_<code>`` keys).
+
+Each library entry's ``overlay_files:`` list can contain:
+
+* **File references** -- ``{file, url, git, repo, folder}`` pointing
+  at an external overlay YAML -- collected into a JSON blob under
+  ``libraries_data[lib_id-overlay_files]``.
+* **Default references** -- ``{default: overlay_id_or_alias}`` (or
+  a bare string) selecting one of the Quickstart-bundled overlays.
+
+Report annotations are added in place onto the caller-supplied
+``ImportReport``; ``libraries_data`` is mutated in place.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from modules.importer_library_types import _resolve_overlay_id
+from modules.importer_value_coercion import (
+    _collect_overlay_source_override_keys,
+    _collect_template_keys,
+)
+
+if TYPE_CHECKING:
+    from modules.importer import ImportReport
+
+
+def process_overlay_files(
+    lib_id: str,
+    lib_name: str,
+    lib_cfg: dict,
+    builder_default: str,
+    *,
+    libraries_data: dict[str, Any],
+    report: ImportReport,
+    overlay_by_id: dict[str, dict],
+    overlay_by_alias: dict[str, str],
+    overlay_radio: dict[str, dict],
+    language_weight_template_keys: frozenset[str],
+) -> None:
+    """Process ``lib_cfg['overlay_files']`` into libraries_data + report.
+
+    A no-op when the library has no ``overlay_files`` key.  Records an
+    unmapped report entry if the key is present but not a list.
+
+    ``language_weight_template_keys`` is passed in (not imported) so
+    this module doesn't reach back into ``modules.importer`` for the
+    constant -- keeps the dependency direction one-way.
+    """
+    overlay_files = lib_cfg.get("overlay_files")
+    if overlay_files is None:
+        return
+
+    if not isinstance(overlay_files, list):
+        report.add(
+            "unmapped",
+            f"libraries.{lib_name}.overlay_files",
+            "Unsupported overlay_files format.",
+        )
+        return
+
+    imported_overlay_files: list[dict[str, str]] = []
+    for idx, entry in enumerate(overlay_files):
+        _process_single_overlay_entry(
+            idx,
+            entry,
+            lib_id=lib_id,
+            lib_name=lib_name,
+            builder_default=builder_default,
+            libraries_data=libraries_data,
+            report=report,
+            overlay_by_id=overlay_by_id,
+            overlay_by_alias=overlay_by_alias,
+            overlay_radio=overlay_radio,
+            language_weight_template_keys=language_weight_template_keys,
+            imported_overlay_files=imported_overlay_files,
+        )
+
+    if imported_overlay_files:
+        libraries_data[f"{lib_id}-overlay_files"] = json.dumps(imported_overlay_files, ensure_ascii=True)
+        report.add("imported", f"libraries.{lib_name}.overlay_files")
+
+
+def _process_single_overlay_entry(
+    idx: int,
+    entry: Any,
+    *,
+    lib_id: str,
+    lib_name: str,
+    builder_default: str,
+    libraries_data: dict[str, Any],
+    report: ImportReport,
+    overlay_by_id: dict[str, dict],
+    overlay_by_alias: dict[str, str],
+    overlay_radio: dict[str, dict],
+    language_weight_template_keys: frozenset[str],
+    imported_overlay_files: list[dict[str, str]],
+) -> None:
+    """Dispatch a single overlay_files[] entry.
+
+    Handles file-ref short-circuit, default resolution (with the
+    ``overlay_languages`` -> ``overlay_languages_subtitles`` alias
+    when ``use_subtitles: true``), builder_level fallback against
+    the overlay's supported media_types, and radio-group vs.
+    plain-flag emission.
+    """
+    default_value: Any = None
+    template_values: Any = None
+    builder_level = builder_default
+    raw_entry_type: str | None = None
+    raw_entry_location: str | None = None
+
+    if isinstance(entry, dict):
+        default_value = entry.get("default")
+        template_values = entry.get("template_variables")
+        for candidate in ("file", "folder", "url", "git", "repo"):
+            location = entry.get(candidate)
+            if location:
+                raw_entry_type = candidate
+                raw_entry_location = str(location)
+                break
+        if isinstance(template_values, dict) and "builder_level" in template_values:
+            level = template_values.get("builder_level")
+            if level in {"show", "season", "episode"}:
+                builder_level = level
+    elif isinstance(entry, str):
+        default_value = entry
+
+    if raw_entry_type and raw_entry_location:
+        imported_overlay_files.append({"type": raw_entry_type, "location": raw_entry_location})
+        report.add(
+            "imported",
+            f"libraries.{lib_name}.overlay_files[{idx}].{raw_entry_type}",
+        )
+        return
+
+    if not default_value:
+        report.add(
+            "unmapped",
+            f"libraries.{lib_name}.overlay_files[{idx}]",
+            "Missing default.",
+        )
+        return
+
+    raw_default = str(default_value)
+    overlay_id = _resolve_overlay_id(raw_default, overlay_by_id, overlay_by_alias)
+    if overlay_id not in overlay_by_id:
+        report.add(
+            "unmapped",
+            f"libraries.{lib_name}.overlay_files[{idx}].default",
+            "Overlay not found in Quickstart.",
+        )
+        return
+
+    overlay_meta = overlay_by_id.get(overlay_id, {})
+
+    # -- Language-subtitles alias: use_subtitles: true swaps the overlay id.
+    if (
+        overlay_id == "overlay_languages"
+        and isinstance(template_values, dict)
+        and str(template_values.get("use_subtitles", "")).strip().lower() == "true"
+    ):
+        subtitles_id = overlay_by_alias.get("languages_subtitles")
+        if subtitles_id:
+            overlay_id = subtitles_id
+            overlay_meta = overlay_by_id.get(overlay_id, {})
+            template_values = dict(template_values)
+            template_values.pop("use_subtitles", None)
+            report.add(
+                "imported",
+                f"libraries.{lib_name}.overlay_files[{idx}].template_variables.use_subtitles",
+            )
+
+    # -- Media-type compatibility check + builder_level fallback.
+    media_types = overlay_meta.get("media_types") or []
+    if builder_level == "movie" and media_types and "movie" not in media_types:
+        report.add(
+            "unmapped",
+            f"libraries.{lib_name}.overlay_files[{idx}].default",
+            "Overlay not available for movie libraries.",
+        )
+        return
+    if builder_level not in media_types and builder_level != "movie":
+        if "show" in media_types:
+            builder_level = "show"
+        elif media_types:
+            builder_level = media_types[0]
+
+    # -- Radio-group vs. plain-flag emission.
+    radio_info = overlay_radio.get(overlay_id)
+    if radio_info:
+        radio_key = f"{lib_id}-{builder_level}-{radio_info['group_name']}"
+        libraries_data[radio_key] = radio_info.get("value")
+    else:
+        libraries_data[f"{lib_id}-{builder_level}-{overlay_id}"] = True
+    report.add("imported", f"libraries.{lib_name}.overlay_files[{idx}].default")
+
+    if isinstance(template_values, dict):
+        _apply_overlay_template_variables(
+            idx,
+            overlay_id,
+            overlay_meta,
+            template_values,
+            builder_level,
+            lib_id=lib_id,
+            lib_name=lib_name,
+            libraries_data=libraries_data,
+            report=report,
+            language_weight_template_keys=language_weight_template_keys,
+        )
+
+
+def _apply_overlay_template_variables(
+    idx: int,
+    overlay_id: str,
+    overlay_meta: dict,
+    template_values: dict,
+    builder_level: str,
+    *,
+    lib_id: str,
+    lib_name: str,
+    libraries_data: dict[str, Any],
+    report: ImportReport,
+    language_weight_template_keys: frozenset[str],
+) -> None:
+    """Emit template_variables overrides for one overlay entry.
+
+    For language overlays (``overlay_languages`` /
+    ``overlay_languages_subtitles``) the allowed-key set is expanded
+    with the 81 ``weight_<code>`` language-weight keys so callers can
+    supply per-language weights.
+    """
+    allowed = _collect_template_keys(overlay_meta.get("template_variables"))
+    allowed.update(_collect_overlay_source_override_keys(overlay_meta))
+    if overlay_id in {"overlay_languages", "overlay_languages_subtitles"}:
+        allowed = set(allowed)
+        allowed.update(language_weight_template_keys)
+
+    for key, value in template_values.items():
+        if key not in allowed:
+            if key == "builder_level":
+                continue
+            report.add(
+                "unmapped",
+                f"libraries.{lib_name}.overlay_files[{idx}].template_variables.{key}",
+                "Template variable not available in Quickstart.",
+            )
+            continue
+        child_name = f"{lib_id}-{builder_level}-template_{overlay_id}[{key}]"
+        libraries_data[child_name] = value
+        report.add(
+            "imported",
+            f"libraries.{lib_name}.overlay_files[{idx}].template_variables.{key}",
+        )


### PR DESCRIPTION
**Sprint 4, PR #11.** Sixth bite of the `prepare_import_payload` monster, following the same 3-function pattern established by `importer_collections` in #1513.

## What moved

The ~108-line **Overlays** block from the per-library iteration in `prepare_import_payload`, split into three named functions:

| Function | Role |
|---|---|
| `process_overlay_files` | Public entry point |
| `_process_single_overlay_entry` | Per-entry dispatch (file ref vs default ref) |
| `_apply_overlay_template_variables` | Template variable emission |

## Handler signature

Same shape as `process_collection_files` but with two extras (`builder_default` and `language_weight_template_keys`):

```python
process_overlay_files(
    lib_id, lib_name, lib_cfg, builder_default,
    *,
    libraries_data, report,
    overlay_by_id, overlay_by_alias, overlay_radio,
    language_weight_template_keys,
) -> None
```

- `builder_default` is per-library (movie or show, derived from Plex library types or inferred from config)
- `language_weight_template_keys` is **passed in** rather than imported so the dependency direction stays one-way (`importer` → `importer_overlays`), avoiding a circular import with the `LANGUAGE_WEIGHT_TEMPLATE_KEYS` constant that lives in `importer`

## Overlay-specific concerns

Beyond the parse/resolve/emit pipeline that Collections has, overlays add five additional concerns — all preserved verbatim from the original block:

1. **`builder_level` per entry** (movie/show/season/episode scope, with fallback to the library `builder_default` when unspecified)
2. **Language-subtitles alias**: `overlay_languages` + `use_subtitles: true` transparently swaps to `overlay_languages_subtitles`
3. **Media-type compatibility check**: overlays with a `media_types` allowlist skip incompatible libraries (unmapped) or auto-adjust `builder_level` to a compatible scope
4. **Radio-group emission**: overlays in mutually exclusive groups (via `overlay_radio`) write a group key rather than a plain flag
5. **Language-weight expansion**: language overlays extend the allowed template keys with the 81 `weight_<code>` language codes

## Compatibility

- No external callers touch the extracted logic (was purely inline)
- `_resolve_overlay_id`, `_collect_template_keys`, `_collect_overlay_source_override_keys` still reachable via `importer.*` re-exports for any tests/scripts that reference them

## Circular-import guard

`modules/importer_overlays` imports `ImportReport` only under `TYPE_CHECKING` — no runtime cross-import between `importer` and `importer_overlays`.

## Impact

- `modules/importer.py`: **927 → 836** (**-91 / -9.8%**)
- `modules/importer_overlays.py`: NEW ~250 lines
- **`prepare_import_payload` body: 603 → 507** (**-96 / -15.9%**)

## Sprint 4 running total

| PR | Status | Δ | Ending |
|---|---|---|---|
| #1503 | merged | -238 | 1789 |
| #1504 | merged | -12 | 1777 |
| #1505 | merged | -283 | 1494 |
| #1506 | merged | -146 | 1348 |
| #1507 | merged | +15 | 1363 |
| #1510 | merged | -232 | 1131 |
| #1511 | merged | -121 | 1010 |
| #1512 | merged | -83 | 927 |
| #1513 | open | -107 | 820 |
| **#TBD (this)** | **open** | **-91** | **836** |

**Cumulative importer.py: 2027 → 836 = -58.8%** (against develop baseline, before #1513 merges)

## Note on branch base

This PR is branched off `develop` (not off `extract/importer-collections`). Collections and Overlays touch different regions of `importer.py`, so the two PRs can merge in either order. Whichever merges second will drop cleanly onto the new develop with a trivial rebase.

## Verification

- All **1285 tests pass**
- Ruff + black clean
- Both modules import cleanly in either order

## Roadmap for prepare_import_payload

Remaining chunks inside the per-library loop:

1. **Metadata files** (~46 lines) — smallest, next up
2. **Library settings** (~57 lines)
3. **Service-scoped fields** (radarr, sonarr — ~47 lines)
4. **Operations dispatch** (~57 lines) — already hooks into `importer_operations`
5. Setup + handled-keys sweep (~30 lines)
