### PR TITLE
Extract per-library metadata_files handling to importer_metadata

### DIFF
--- a/modules/importer.py
+++ b/modules/importer.py
@@ -251,6 +251,7 @@ from modules import importer_collections  # noqa: E402
 # Same import pattern as importer_collections -- module-level import so the
 # call site inside prepare_import_payload reads as importer_overlays.process_*.
 from modules import importer_overlays  # noqa: E402
+
 # Per-library metadata_files handling moved to modules/importer_metadata.py.
 # Same module-level import pattern as importer_collections.
 from modules import importer_metadata  # noqa: E402

--- a/modules/importer.py
+++ b/modules/importer.py
@@ -251,6 +251,9 @@ from modules import importer_collections  # noqa: E402
 # Same import pattern as importer_collections -- module-level import so the
 # call site inside prepare_import_payload reads as importer_overlays.process_*.
 from modules import importer_overlays  # noqa: E402
+# Per-library metadata_files handling moved to modules/importer_metadata.py.
+# Same module-level import pattern as importer_collections.
+from modules import importer_metadata  # noqa: E402
 
 
 def _build_attribute_sets(
@@ -469,51 +472,13 @@ def prepare_import_payload(
                 language_weight_template_keys=LANGUAGE_WEIGHT_TEMPLATE_KEYS,
             )
 
-            metadata_files = lib_cfg.get("metadata_files")
-            if isinstance(metadata_files, list):
-                imported_metadata_files = []
-                for idx, entry in enumerate(metadata_files):
-                    entry_type = None
-                    location = None
-                    if isinstance(entry, dict):
-                        if "file" in entry:
-                            entry_type = "file"
-                            location = entry.get("file")
-                        elif "folder" in entry:
-                            entry_type = "folder"
-                            location = entry.get("folder")
-                        elif "git" in entry:
-                            entry_type = "git"
-                            location = entry.get("git")
-                        elif "repo" in entry:
-                            entry_type = "repo"
-                            location = entry.get("repo")
-                        elif "url" in entry:
-                            entry_type = "url"
-                            location = entry.get("url")
-                    if entry_type not in {"file", "folder", "url", "git", "repo"}:
-                        report.add(
-                            "unmapped",
-                            f"libraries.{lib_name}.metadata_files[{idx}]",
-                            "Only file, folder, url, git, and repo metadata files are supported.",
-                        )
-                        continue
-                    location = str(location or "").strip()
-                    if not location:
-                        report.add(
-                            "unmapped",
-                            f"libraries.{lib_name}.metadata_files[{idx}]",
-                            "Metadata file location is required.",
-                        )
-                        continue
-                    imported_metadata_files.append({"type": entry_type, "location": location})
-                    report.add("imported", f"libraries.{lib_name}.metadata_files[{idx}].{entry_type}")
-
-                if imported_metadata_files:
-                    libraries_data[f"{lib_id}-metadata_files"] = json.dumps(imported_metadata_files, ensure_ascii=True)
-                    report.add("imported", f"libraries.{lib_name}.metadata_files")
-            elif metadata_files is not None:
-                report.add("unmapped", f"libraries.{lib_name}.metadata_files", "Unsupported metadata_files format.")
+            importer_metadata.process_metadata_files(
+                lib_id,
+                str(lib_name),
+                lib_cfg,
+                libraries_data=libraries_data,
+                report=report,
+            )
 
             # Library settings
             settings_section = lib_cfg.get("settings")

--- a/modules/importer_metadata.py
+++ b/modules/importer_metadata.py
@@ -1,0 +1,106 @@
+"""Per-library ``metadata_files`` handling for ``prepare_import_payload``.
+
+Split out of ``modules.importer`` following the same pattern as
+:mod:`modules.importer_collections` and :mod:`modules.importer_overlays`.
+
+Unlike collections/overlays, ``metadata_files`` entries do not support
+Quickstart-bundled ``default`` references or ``template_variables``.
+Every entry is treated as a raw file reference and just written into
+a JSON blob under ``libraries_data[lib_id-metadata_files]``.
+
+Accepted entry shapes:
+
+* ``{file: <path>}`` -- local file path
+* ``{folder: <path>}`` -- local folder path
+* ``{url: <http_url>}``
+* ``{git: <github_slug_or_url>}``
+* ``{repo: <config_repo_key>}``
+
+Any other key (or missing/empty location) records an ``unmapped``
+report entry and is skipped.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from modules.importer import ImportReport
+
+_METADATA_ENTRY_TYPES: tuple[str, ...] = ("file", "folder", "git", "repo", "url")
+
+
+def process_metadata_files(
+    lib_id: str,
+    lib_name: str,
+    lib_cfg: dict,
+    *,
+    libraries_data: dict[str, Any],
+    report: ImportReport,
+) -> None:
+    """Process ``lib_cfg['metadata_files']`` into libraries_data + report.
+
+    A no-op when the library has no ``metadata_files`` key.  Records an
+    unmapped report entry if the key is present but not a list.
+    """
+    metadata_files = lib_cfg.get("metadata_files")
+    if metadata_files is None:
+        return
+
+    if not isinstance(metadata_files, list):
+        report.add(
+            "unmapped",
+            f"libraries.{lib_name}.metadata_files",
+            "Unsupported metadata_files format.",
+        )
+        return
+
+    imported_metadata_files: list[dict[str, str]] = []
+    for idx, entry in enumerate(metadata_files):
+        parsed = _parse_metadata_entry(entry)
+        if parsed is None:
+            report.add(
+                "unmapped",
+                f"libraries.{lib_name}.metadata_files[{idx}]",
+                "Only file, folder, url, git, and repo metadata files are supported.",
+            )
+            continue
+
+        entry_type, location = parsed
+        if not location:
+            report.add(
+                "unmapped",
+                f"libraries.{lib_name}.metadata_files[{idx}]",
+                "Metadata file location is required.",
+            )
+            continue
+
+        imported_metadata_files.append({"type": entry_type, "location": location})
+        report.add(
+            "imported",
+            f"libraries.{lib_name}.metadata_files[{idx}].{entry_type}",
+        )
+
+    if imported_metadata_files:
+        libraries_data[f"{lib_id}-metadata_files"] = json.dumps(
+            imported_metadata_files, ensure_ascii=True
+        )
+        report.add("imported", f"libraries.{lib_name}.metadata_files")
+
+
+def _parse_metadata_entry(entry: Any) -> tuple[str, str] | None:
+    """Return ``(entry_type, location)`` for a single metadata entry.
+
+    Returns ``None`` when the entry is not a dict or contains no
+    recognised location key.  ``location`` is stripped but not
+    validated for non-emptiness -- the caller reports that separately
+    to distinguish "no location key" from "location key with empty
+    string" for report accuracy.
+    """
+    if not isinstance(entry, dict):
+        return None
+    for candidate in _METADATA_ENTRY_TYPES:
+        if candidate in entry:
+            return candidate, str(entry.get(candidate) or "").strip()
+    return None

--- a/modules/importer_metadata.py
+++ b/modules/importer_metadata.py
@@ -83,9 +83,7 @@ def process_metadata_files(
         )
 
     if imported_metadata_files:
-        libraries_data[f"{lib_id}-metadata_files"] = json.dumps(
-            imported_metadata_files, ensure_ascii=True
-        )
+        libraries_data[f"{lib_id}-metadata_files"] = json.dumps(imported_metadata_files, ensure_ascii=True)
         report.add("imported", f"libraries.{lib_name}.metadata_files")
 
 


### PR DESCRIPTION
**Sprint 4, PR #12.** Seventh bite of the `prepare_import_payload` monster.

## What moved

The ~46-line **Metadata** block from the per-library iteration in `prepare_import_payload`, plus a small DRY refactor.

## Why one function is enough here (unlike Collections/Overlays)

`metadata_files` entries do **NOT** support:
- Quickstart-bundled `default` references
- `template_variables` overrides

Every entry is a raw file reference that gets JSON-serialized into `libraries_data[lib_id-metadata_files]`. No template pipeline means no sub-helper needed. Single public function `process_metadata_files()` with one tiny `_parse_metadata_entry` helper to keep the entry-shape branching separate from the report/emission logic.

## Micro DRY win

The original had a 5-way if/elif chain checking for each entry type:

```python
if "file" in entry:
    entry_type = "file"
    location = entry.get("file")
elif "folder" in entry:
    entry_type = "folder"
    location = entry.get("folder")
elif "git" in entry:
    ...
```

Replaced with a single loop over the type tuple:

```python
for candidate in _METADATA_ENTRY_TYPES:
    if candidate in entry:
        return candidate, str(entry.get(candidate) or "").strip()
```

Same priority order (file wins over folder wins over url) preserved via the tuple ordering. Behavior verified byte-identical against the original via a smoke test covering:
- All 5 valid keys (`file`, `folder`, `url`, `git`, `repo`)
- Bare string entry (returns None)
- Unknown-key dict (returns None)
- Empty-string value (returns `('file', '')`, triggers report about missing location)
- `None` value (returns `('file', '')`, same path)
- Multi-key dict `{file: ..., folder: ...}` (file wins, as it did originally)

## Handler signature

```python
process_metadata_files(
    lib_id, lib_name, lib_cfg,
    *,
    libraries_data, report,
) -> None
```

Simpler than Collections/Overlays because there is no schema index or radio-group state to thread through.

## Compatibility

- No external callers touch the extracted logic (was purely inline)
- No helpers to re-export; the parsing is self-contained

## Circular-import guard

`modules/importer_metadata` imports `ImportReport` only under `TYPE_CHECKING` — no runtime cross-import between `importer` and `importer_metadata`.

## Impact

- `modules/importer.py`: **820 → 786** (**-34 / -4.1%**)
- `modules/importer_metadata.py`: NEW ~105 lines
- **`prepare_import_payload` body: 490 → 452** (**-38 / -7.8%**)

## Sprint 4 running total

| PR | Status | Δ | Ending |
|---|---|---|---|
| #1503 | merged | -238 | 1789 |
| #1504 | merged | -12 | 1777 |
| #1505 | merged | -283 | 1494 |
| #1506 | merged | -146 | 1348 |
| #1507 | merged | +15 | 1363 |
| #1510 | merged | -232 | 1131 |
| #1511 | merged | -121 | 1010 |
| #1512 | merged | -83 | 927 |
| #1513 | merged | -107 | 820 |
| #1514 | open | -91 | (836→ once rebased) |
| **#TBD (this)** | **open** | **-34** | **786** |

**Cumulative importer.py: 2027 → 786 = -61.2%**

## Verification

- All **1285 tests pass**
- Ruff + black clean
- Both modules import cleanly in either order

## Roadmap for prepare_import_payload

Remaining chunks inside the per-library loop:

- **Library settings** block (~57 lines)
- **Service-scoped fields** for radarr / sonarr (~47 lines)
- **Operations dispatch** (~57 lines, already hooks `importer_operations`)

Plus setup (~30 lines) and the handled-keys sweep (~11 lines).
