### PR TITLE
Extract per-library settings block to importer_library_settings

### DIFF
--- a/modules/importer.py
+++ b/modules/importer.py
@@ -256,6 +256,12 @@ from modules import importer_overlays  # noqa: E402
 # Same module-level import pattern as importer_collections.
 from modules import importer_metadata  # noqa: E402
 
+# Per-library settings block handling moved to modules/importer_library_settings.py.
+# Handles asset_directory (list/multiline-string -> stripped list) and
+# prioritize_assets (restricted bool coercion) -- everything else in
+# settings: is currently marked unmapped.
+from modules import importer_library_settings  # noqa: E402
+
 
 def _build_attribute_sets(
     attribute_config: dict,
@@ -481,64 +487,13 @@ def prepare_import_payload(
                 report=report,
             )
 
-            # Library settings
-            settings_section = lib_cfg.get("settings")
-            if isinstance(settings_section, dict):
-                imported_settings = False
-                for key, value in settings_section.items():
-                    if key == "asset_directory":
-                        if isinstance(value, list):
-                            normalized = [str(item).strip() for item in value if str(item).strip()]
-                        elif isinstance(value, str):
-                            normalized = [line.strip() for line in value.splitlines() if line.strip()]
-                        else:
-                            normalized = []
-
-                        if normalized:
-                            libraries_data[f"{lib_id}-attribute_{key}"] = normalized
-                            report.add("imported", f"libraries.{lib_name}.settings.{key}")
-                            imported_settings = True
-                        else:
-                            report.add(
-                                "unmapped",
-                                f"libraries.{lib_name}.settings.{key}",
-                                "No importable asset directory entries found.",
-                            )
-                        continue
-
-                    if key == "prioritize_assets" and not isinstance(value, (dict, list)):
-                        bool_value = None
-                        if isinstance(value, bool):
-                            bool_value = value
-                        elif isinstance(value, str):
-                            lowered = value.strip().lower()
-                            if lowered in {"true", "yes", "1"}:
-                                bool_value = True
-                            elif lowered in {"false", "no", "0"}:
-                                bool_value = False
-
-                        if bool_value is None:
-                            report.add(
-                                "unmapped",
-                                f"libraries.{lib_name}.settings.{key}",
-                                "Invalid boolean value.",
-                            )
-                        else:
-                            libraries_data[f"{lib_id}-attribute_{key}"] = bool_value
-                            report.add("imported", f"libraries.{lib_name}.settings.{key}")
-                            imported_settings = True
-                        continue
-
-                    report.add(
-                        "unmapped",
-                        f"libraries.{lib_name}.settings.{key}",
-                        "Library setting not supported for import.",
-                    )
-
-                if imported_settings:
-                    report.add("imported", f"libraries.{lib_name}.settings")
-            elif settings_section is not None:
-                report.add("unmapped", f"libraries.{lib_name}.settings", "Unsupported settings format.")
+            importer_library_settings.process_library_settings(
+                lib_id,
+                str(lib_name),
+                lib_cfg,
+                libraries_data=libraries_data,
+                report=report,
+            )
 
             for service_name, field_map in (
                 ("radarr", LIBRARY_RADARR_IMPORT_FIELDS),

--- a/modules/importer_library_settings.py
+++ b/modules/importer_library_settings.py
@@ -1,0 +1,174 @@
+"""Per-library ``settings`` handling for ``prepare_import_payload``.
+
+Split out of ``modules.importer`` following the same pattern as the
+other per-library sub-handlers.  Kometa's ``libraries.<name>.settings:``
+block accepts many keys but only two are importable into Quickstart's
+form-oriented model today:
+
+* ``asset_directory`` -- accepts either a list of paths or a
+  multi-line string; both shapes normalize to a stripped list.
+  Emitted as ``libraries_data[lib_id-attribute_asset_directory]``.
+* ``prioritize_assets`` -- boolean.  Accepts native ``bool`` or
+  the string variants ``"true" / "yes" / "1"`` / ``"false" / "no" / "0"``
+  (all case-insensitive).  Note this is intentionally MORE
+  RESTRICTIVE than :func:`modules.importer_value_coercion._coerce_import_bool`,
+  which also accepts ``"on"``/``"off"`` -- the settings section
+  historically did not, and this module preserves that behavior.
+
+Everything else in the ``settings`` block is currently marked as
+unmapped.  ``asset_directory`` with no importable entries is also
+marked unmapped so users see an explicit "empty" report entry.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from modules.importer import ImportReport
+
+
+def process_library_settings(
+    lib_id: str,
+    lib_name: str,
+    lib_cfg: dict,
+    *,
+    libraries_data: dict[str, Any],
+    report: ImportReport,
+) -> None:
+    """Process ``lib_cfg['settings']`` into libraries_data + report.
+
+    A no-op when the library has no ``settings`` key.  Records an
+    unmapped report entry if the key is present but not a dict.
+    Emits a top-level ``libraries.<name>.settings`` imported entry
+    when at least one setting inside was importable.
+    """
+    settings_section = lib_cfg.get("settings")
+    if settings_section is None:
+        return
+
+    if not isinstance(settings_section, dict):
+        report.add(
+            "unmapped",
+            f"libraries.{lib_name}.settings",
+            "Unsupported settings format.",
+        )
+        return
+
+    imported_settings = False
+    for key, value in settings_section.items():
+        if key == "asset_directory":
+            imported = _handle_asset_directory(
+                key,
+                value,
+                lib_id=lib_id,
+                lib_name=lib_name,
+                libraries_data=libraries_data,
+                report=report,
+            )
+            imported_settings = imported_settings or imported
+            continue
+
+        if key == "prioritize_assets" and not isinstance(value, (dict, list)):
+            imported = _handle_prioritize_assets(
+                key,
+                value,
+                lib_id=lib_id,
+                lib_name=lib_name,
+                libraries_data=libraries_data,
+                report=report,
+            )
+            imported_settings = imported_settings or imported
+            continue
+
+        report.add(
+            "unmapped",
+            f"libraries.{lib_name}.settings.{key}",
+            "Library setting not supported for import.",
+        )
+
+    if imported_settings:
+        report.add("imported", f"libraries.{lib_name}.settings")
+
+
+def _handle_asset_directory(
+    key: str,
+    value: Any,
+    *,
+    lib_id: str,
+    lib_name: str,
+    libraries_data: dict[str, Any],
+    report: ImportReport,
+) -> bool:
+    """Normalize an ``asset_directory`` value to a stripped list.
+
+    Accepts a list of path-like items or a multi-line string.  Empty
+    lists / all-empty strings record an unmapped report.  Returns
+    ``True`` when a non-empty list was written to ``libraries_data``.
+    """
+    if isinstance(value, list):
+        normalized = [str(item).strip() for item in value if str(item).strip()]
+    elif isinstance(value, str):
+        normalized = [line.strip() for line in value.splitlines() if line.strip()]
+    else:
+        normalized = []
+
+    if normalized:
+        libraries_data[f"{lib_id}-attribute_{key}"] = normalized
+        report.add("imported", f"libraries.{lib_name}.settings.{key}")
+        return True
+
+    report.add(
+        "unmapped",
+        f"libraries.{lib_name}.settings.{key}",
+        "No importable asset directory entries found.",
+    )
+    return False
+
+
+def _handle_prioritize_assets(
+    key: str,
+    value: Any,
+    *,
+    lib_id: str,
+    lib_name: str,
+    libraries_data: dict[str, Any],
+    report: ImportReport,
+) -> bool:
+    """Coerce ``prioritize_assets`` to bool via the settings-specific rules.
+
+    Accepts native ``bool`` or ``"true"/"yes"/"1"/"false"/"no"/"0"``
+    (case-insensitive, stripped).  Intentionally does NOT accept
+    ``"on"``/``"off"`` -- the settings section historically has been
+    stricter than the generic ``_coerce_import_bool`` used elsewhere.
+    Returns ``True`` when a bool was written to ``libraries_data``.
+    """
+    bool_value = _coerce_settings_bool(value)
+    if bool_value is None:
+        report.add(
+            "unmapped",
+            f"libraries.{lib_name}.settings.{key}",
+            "Invalid boolean value.",
+        )
+        return False
+
+    libraries_data[f"{lib_id}-attribute_{key}"] = bool_value
+    report.add("imported", f"libraries.{lib_name}.settings.{key}")
+    return True
+
+
+def _coerce_settings_bool(value: Any) -> bool | None:
+    """Restricted boolean coercion used only inside library settings.
+
+    Distinct from :func:`modules.importer_value_coercion._coerce_import_bool`
+    because ``settings`` values do not accept ``"on"``/``"off"``.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "yes", "1"}:
+            return True
+        if lowered in {"false", "no", "0"}:
+            return False
+    return None


### PR DESCRIPTION
**Sprint 4, PR #13.** Eighth bite of the `prepare_import_payload` monster.

##  Milestone: importer.py drops below 700 lines

- **modules/importer.py: 694 → 650** (**-44 / -6.3%**)
- **`prepare_import_payload` body: 358 → 305** (**-53 / -14.8%**)
- **Cumulative Sprint 4: 2027 → 650 = -67.9%**

## What moved

The ~58-line **Library settings** block from the per-library iteration in `prepare_import_payload`, split into a small handler module with three functions:

| Function | Role |
|---|---|
| `process_library_settings` | Public entry point |
| `_handle_asset_directory` | List/multiline-string normalization |
| `_handle_prioritize_assets` | Restricted bool coercion |

Plus a private `_coerce_settings_bool` helper that intentionally does **NOT** match the more permissive `_coerce_import_bool` used elsewhere.

## The subtle bool-coercion difference (preserved verbatim)

| Function | Accepts strings |
|---|---|
| `_coerce_import_bool` (module-wide) | `true` `yes` `1` `on` / `false` `no` `0` `off` |
| `_coerce_settings_bool` (this PR) | `true` `yes` `1` / `false` `no` `0` (no on/off) |

I kept these separate rather than unifying because:

1. The original settings code was clearly restrictive on purpose — the schema says `prioritize_assets` is a bool, and Kometa users overwhelmingly write native YAML bools for it.
2. Unifying would silently expand what the settings importer accepts, which is a behavior change I cannot regression-test today (no existing coverage for `on`/`off` in this field).
3. If anyone ever **does** want to unify these, doing it as a follow-up in one focused commit is safer than smuggling it into an extraction PR.

## Handler signature

```python
process_library_settings(
    lib_id, lib_name, lib_cfg,
    *,
    libraries_data, report,
) -> None
```

## Compatibility

- No external callers touch the extracted logic (was purely inline)
- `_coerce_import_bool` remains reachable via `importer._coerce_import_bool`

## Circular-import guard

`modules/importer_library_settings` imports `ImportReport` only under `TYPE_CHECKING` — no runtime cross-import between `importer` and `importer_library_settings`.

## Sprint 4 running total

| PR | Status | Δ | Ending |
|---|---|---|---|
| #1503 | merged | -238 | 1789 |
| #1504 | merged | -12 | 1777 |
| #1505 | merged | -283 | 1494 |
| #1506 | merged | -146 | 1348 |
| #1507 | merged | +15 | 1363 |
| #1510 | merged | -232 | 1131 |
| #1511 | merged | -121 | 1010 |
| #1512 | merged | -83 | 927 |
| #1513 | merged | -107 | 820 |
| #1514 | merged | -91 | 729 |
| #1515 | merged | -35 | 694 |
| **#TBD (this)** | **open** | **-44** | **650** |

**Cumulative importer.py: 2027 → 650 = -67.9%**

## Verification

- All **1285 tests pass**
- Ruff + black clean via **pre-commit hooks locally** (no `--no-verify` this time)
- Both modules import cleanly in either order
- `_coerce_settings_bool` behavior verified byte-identical against the original inline code across 15 edge cases (native bool True/False, string `true`/`TRUE`/`yes`/`1`/`false`/`no`/`0`, string `on`/`off` returning None, invalid string, non-string non-bool value)

## Roadmap for prepare_import_payload

Remaining chunks inside the per-library loop:
- **Service-scoped fields** for radarr / sonarr (~47 lines)
- **Operations dispatch** (~57 lines, already hooks `importer_operations` from #1510)

Plus setup (~30 lines), library-type/id assignment (~40 lines), top-level values + template variables (~30 lines), and the handled-keys sweep (~11 lines).
