### PR TITLE
Extract per-library operations dispatch loop into importer_operations

### DIFF
--- a/modules/importer.py
+++ b/modules/importer.py
@@ -542,63 +542,16 @@ def prepare_import_payload(
                 if imported_service:
                     report.add("imported", f"libraries.{lib_name}.{service_name}")
 
-            # Operations
-            operations = lib_cfg.get("operations")
-            if isinstance(operations, dict):
-                imported_ops = False
-                for key, value in operations.items():
-                    if key in simple_attrs and not isinstance(value, (dict, list)):
-                        libraries_data[f"{lib_id}-attribute_{key}"] = value
-                        report.add("imported", f"libraries.{lib_name}.operations.{key}")
-                        imported_ops = True
-                        continue
-
-                    handled, imported = importer_operations.handle_delete_collections_operation(
-                        lib_id,
-                        str(lib_name),
-                        key,
-                        value,
-                        libraries_data=libraries_data,
-                        report=report,
-                    )
-                    if handled:
-                        imported_ops = imported_ops or imported
-                        continue
-
-                    handled, imported = importer_operations.handle_mass_update_operation(
-                        lib_id,
-                        str(lib_name),
-                        key,
-                        value,
-                        mass_update_defs=mass_update_defs,
-                        libraries_data=libraries_data,
-                        report=report,
-                    )
-                    if handled:
-                        imported_ops = imported_ops or imported
-                        continue
-
-                    handled, imported = importer_operations.handle_toggle_select_operation(
-                        lib_id,
-                        str(lib_name),
-                        key,
-                        value,
-                        toggle_select_defs=toggle_select_defs,
-                        libraries_data=libraries_data,
-                        report=report,
-                    )
-                    if handled:
-                        imported_ops = imported_ops or imported
-                        continue
-                    report.add(
-                        "unmapped",
-                        f"libraries.{lib_name}.operations.{key}",
-                        "Complex operation not supported for import.",
-                    )
-                if imported_ops:
-                    report.add("imported", f"libraries.{lib_name}.operations")
-            elif operations is not None:
-                report.add("unmapped", f"libraries.{lib_name}.operations", "Unsupported operations format.")
+            importer_operations.process_operations_block(
+                lib_id,
+                str(lib_name),
+                lib_cfg,
+                libraries_data=libraries_data,
+                report=report,
+                simple_attrs=simple_attrs,
+                mass_update_defs=mass_update_defs,
+                toggle_select_defs=toggle_select_defs,
+            )
 
             handled_keys = {"collection_files", "overlay_files", "metadata_files", "template_variables", "settings", "operations", "radarr", "sonarr"}
             handled_keys.update(top_level_map.keys())

--- a/modules/importer_operations.py
+++ b/modules/importer_operations.py
@@ -331,3 +331,101 @@ def handle_delete_collections_operation(
     else:
         report.add("unmapped", f"libraries.{lib_name}.operations.{op_key}", "No importable values found.")
     return True, imported_any
+
+
+def process_operations_block(
+    lib_id: str,
+    lib_name: str,
+    lib_cfg: dict,
+    *,
+    libraries_data: dict[str, Any],
+    report: ImportReport,
+    simple_attrs: set[str],
+    mass_update_defs: dict[str, dict],
+    toggle_select_defs: dict[str, dict],
+) -> None:
+    """Process ``lib_cfg['operations']`` into libraries_data + report.
+
+    Dispatches each operation key to the appropriate handler:
+
+    1. **Simple scalar attributes** (``simple_attrs``) get written
+       directly as ``libraries_data[lib_id-attribute_<key>]``.
+    2. **``delete_collections`` operation** -- handled specially via
+       :func:`handle_delete_collections_operation`.
+    3. **Mass-update operations** (``mass_update_defs``) -- dispatched
+       to :func:`handle_mass_update_operation`.
+    4. **Toggle/select operations** (``toggle_select_defs``) --
+       dispatched to :func:`handle_toggle_select_operation`.
+    5. Anything else records an ``unmapped`` "Complex operation" note.
+
+    A no-op when the library has no ``operations`` key.  Records an
+    unmapped report entry if the key is present but not a dict.
+    Emits a top-level ``libraries.<name>.operations`` imported entry
+    when at least one operation inside was importable.
+    """
+    operations = lib_cfg.get("operations")
+    if operations is None:
+        return
+
+    if not isinstance(operations, dict):
+        report.add(
+            "unmapped",
+            f"libraries.{lib_name}.operations",
+            "Unsupported operations format.",
+        )
+        return
+
+    imported_ops = False
+    for key, value in operations.items():
+        if key in simple_attrs and not isinstance(value, (dict, list)):
+            libraries_data[f"{lib_id}-attribute_{key}"] = value
+            report.add("imported", f"libraries.{lib_name}.operations.{key}")
+            imported_ops = True
+            continue
+
+        handled, imported = handle_delete_collections_operation(
+            lib_id,
+            lib_name,
+            key,
+            value,
+            libraries_data=libraries_data,
+            report=report,
+        )
+        if handled:
+            imported_ops = imported_ops or imported
+            continue
+
+        handled, imported = handle_mass_update_operation(
+            lib_id,
+            lib_name,
+            key,
+            value,
+            mass_update_defs=mass_update_defs,
+            libraries_data=libraries_data,
+            report=report,
+        )
+        if handled:
+            imported_ops = imported_ops or imported
+            continue
+
+        handled, imported = handle_toggle_select_operation(
+            lib_id,
+            lib_name,
+            key,
+            value,
+            toggle_select_defs=toggle_select_defs,
+            libraries_data=libraries_data,
+            report=report,
+        )
+        if handled:
+            imported_ops = imported_ops or imported
+            continue
+
+        report.add(
+            "unmapped",
+            f"libraries.{lib_name}.operations.{key}",
+            "Complex operation not supported for import.",
+        )
+
+    if imported_ops:
+        report.add("imported", f"libraries.{lib_name}.operations")


### PR DESCRIPTION
**Sprint 4, PR #14.** Ninth bite of the `prepare_import_payload` monster, and the last big self-contained chunk of the per-library iteration.

## What moved

The ~57-line operations dispatch loop from `prepare_import_payload` folded into the **existing** `modules/importer_operations` module (which already had the three underlying handler functions from #1510).

New public function: `process_operations_block()`

It receives `lib_id`, `lib_name`, `lib_cfg` positionally and the shared mutable/derived state (`libraries_data`, `report`, `simple_attrs`, `mass_update_defs`, `toggle_select_defs`) as keyword-only arguments -- matching the convention set by Collections/Overlays/Metadata/Settings.

## Why co-locate instead of new module

`process_operations_block` is a **thin dispatcher** over the three existing handlers in the same module:

| Handler | Set by |
|---|---|
| `handle_delete_collections_operation` | #1510 |
| `handle_mass_update_operation` | #1510 |
| `handle_toggle_select_operation` | #1510 |
| `process_operations_block` | **this PR** |

Adding the dispatcher to the same module keeps operation-related code together and only grows `importer_operations` from 333 to 431 lines (well under the 600-line budget).

## Behavior preserved verbatim

The dispatch order is identical:

1. `simple_attrs` scalar attribute
2. `delete_collections` handler
3. `mass_update` handler
4. `toggle/select` handler
5. `unmapped` ("Complex operation not supported")

## Handler signature

```python
process_operations_block(
    lib_id, lib_name, lib_cfg,
    *,
    libraries_data, report,
    simple_attrs, mass_update_defs, toggle_select_defs,
) -> None
```

## Circular-import guard

No changes needed -- `importer_operations` already imports `ImportReport` under `TYPE_CHECKING`.

## Impact

- `modules/importer.py`: **650 -> 603** (**-47 / -7.2%**)
- `modules/importer_operations.py`: 333 -> 431 (+98)
- **`prepare_import_payload` body: 305 -> 258** (**-47 / -15.4%**)

The mega-function is now **258 lines** vs the original **1062**. That is a **75.7% reduction** inside `prepare_import_payload` alone across Sprint 4.

## Sprint 4 running total

| PR | Status | Delta | Ending |
|---|---|---|---|
| #1503 | merged | -238 | 1789 |
| #1504 | merged | -12 | 1777 |
| #1505 | merged | -283 | 1494 |
| #1506 | merged | -146 | 1348 |
| #1507 | merged | +15 | 1363 |
| #1510 | merged | -232 | 1131 |
| #1511 | merged | -121 | 1010 |
| #1512 | merged | -83 | 927 |
| #1513 | merged | -107 | 820 |
| #1514 | merged | -91 | 729 |
| #1515 | merged | -35 | 694 |
| #1516 | merged | -44 | 650 |
| **#TBD (this)** | **open** | **-47** | **603** |

**Cumulative importer.py: 2027 -> 603 = -70.3%**

## Verification

- All **1285 tests pass**
- Ruff + black clean via pre-commit hooks locally
- `importer_operations.py` under 600-line budget (431)
- No changes to any of the three underlying `handle_*` functions

## Roadmap for prepare_import_payload

Remaining chunks inside the per-library loop:
- **Service-scoped fields** for radarr / sonarr (~47 lines) -- last big chunk

Plus setup (~30 lines), library-type/id assignment (~40 lines), top-level values + template variables (~30 lines), and the handled-keys sweep (~11 lines) -- these are smaller and may be consolidated into one final "per-library orchestrator" module.
