### PR TITLE
Extract per-library service-override handling to importer_services

### DIFF
--- a/modules/importer.py
+++ b/modules/importer.py
@@ -6,43 +6,6 @@ from ruamel.yaml import YAML
 
 from modules import helpers
 
-LIBRARY_RADARR_IMPORT_FIELDS = {
-    "url": "string",
-    "token": "string",
-    "root_folder_path": "string",
-    "quality_profile": "string",
-    "availability": "string",
-    "tag": "string",
-    "monitor": "bool",
-    "search": "bool",
-    "add_missing": "bool",
-    "add_existing": "bool",
-    "upgrade_existing": "bool",
-    "monitor_existing": "bool",
-    "ignore_cache": "bool",
-    "radarr_path": "string",
-    "plex_path": "string",
-}
-LIBRARY_SONARR_IMPORT_FIELDS = {
-    "url": "string",
-    "token": "string",
-    "root_folder_path": "string",
-    "quality_profile": "string",
-    "language_profile": "string",
-    "series_type": "string",
-    "season_folder": "bool",
-    "monitor": "string",
-    "tag": "string",
-    "search": "bool",
-    "cutoff_search": "bool",
-    "add_missing": "bool",
-    "add_existing": "bool",
-    "upgrade_existing": "bool",
-    "monitor_existing": "bool",
-    "ignore_cache": "bool",
-    "sonarr_path": "string",
-    "plex_path": "string",
-}
 # Language codes recognized as `weight_<code>` overlay-source ordering keys.
 # Hoisted out of prepare_import_payload's ~95-line nested comprehension --
 # this is data, not logic, and belongs at module scope where it's easy to
@@ -261,6 +224,16 @@ from modules import importer_metadata  # noqa: E402
 # prioritize_assets (restricted bool coercion) -- everything else in
 # settings: is currently marked unmapped.
 from modules import importer_library_settings  # noqa: E402
+
+# Per-library service-override (radarr / sonarr) handling moved to
+# modules/importer_services.py.  The two field-map dicts are the canonical
+# definitions and re-exported here so external tooling that imports them
+# by name (importer.LIBRARY_RADARR_IMPORT_FIELDS etc.) keeps working.
+from modules import importer_services  # noqa: E402
+from modules.importer_services import (  # noqa: E402
+    LIBRARY_RADARR_IMPORT_FIELDS,  # noqa: F401 (re-export for backward compat)
+    LIBRARY_SONARR_IMPORT_FIELDS,  # noqa: F401 (re-export for backward compat)
+)
 
 
 def _build_attribute_sets(
@@ -495,52 +468,13 @@ def prepare_import_payload(
                 report=report,
             )
 
-            for service_name, field_map in (
-                ("radarr", LIBRARY_RADARR_IMPORT_FIELDS),
-                ("sonarr", LIBRARY_SONARR_IMPORT_FIELDS),
-            ):
-                service_section = lib_cfg.get(service_name)
-                if not isinstance(service_section, dict):
-                    if service_section is not None:
-                        report.add("unmapped", f"libraries.{lib_name}.{service_name}", "Unsupported service override format.")
-                    continue
-
-                imported_service = False
-                if service_name == "radarr" and not str(lib_id).startswith("mov-library_"):
-                    report.add("unmapped", f"libraries.{lib_name}.radarr", "Radarr overrides are only supported on movie libraries.")
-                    continue
-                if service_name == "sonarr" and not str(lib_id).startswith("sho-library_"):
-                    report.add("unmapped", f"libraries.{lib_name}.sonarr", "Sonarr overrides are only supported on show libraries.")
-                    continue
-
-                for key, value in service_section.items():
-                    field_type = field_map.get(str(key))
-                    if not field_type:
-                        report.add("unmapped", f"libraries.{lib_name}.{service_name}.{key}", "Library service override not supported for import.")
-                        continue
-
-                    target_key = f"{lib_id}-attribute_{service_name}_{key}"
-                    if field_type == "bool":
-                        bool_value = _coerce_import_bool(value)
-                        if bool_value is None:
-                            report.add("unmapped", f"libraries.{lib_name}.{service_name}.{key}", "Invalid boolean value.")
-                            continue
-                        libraries_data[target_key] = "true" if bool_value else "false"
-                    else:
-                        if isinstance(value, (dict, list)):
-                            report.add("unmapped", f"libraries.{lib_name}.{service_name}.{key}", "Unsupported override value format.")
-                            continue
-                        text_value = str(value).strip()
-                        if not text_value:
-                            report.add("unmapped", f"libraries.{lib_name}.{service_name}.{key}", "Override value is empty.")
-                            continue
-                        libraries_data[target_key] = text_value
-
-                    report.add("imported", f"libraries.{lib_name}.{service_name}.{key}")
-                    imported_service = True
-
-                if imported_service:
-                    report.add("imported", f"libraries.{lib_name}.{service_name}")
+            importer_services.process_service_overrides(
+                lib_id,
+                str(lib_name),
+                lib_cfg,
+                libraries_data=libraries_data,
+                report=report,
+            )
 
             importer_operations.process_operations_block(
                 lib_id,

--- a/modules/importer_services.py
+++ b/modules/importer_services.py
@@ -1,0 +1,226 @@
+"""Per-library service-override (radarr / sonarr) handling.
+
+Split out of ``modules.importer`` following the same pattern as the
+other per-library sub-handlers.  Kometa lets each library override
+Radarr / Sonarr settings via ``libraries.<name>.radarr:`` and
+``libraries.<name>.sonarr:`` blocks -- Quickstart imports a
+whitelisted subset of those keys into per-library
+``lib_id-attribute_<service>_<key>`` DB entries.
+
+Key features preserved from the inline block:
+
+* **Library-type gate**: Radarr overrides are rejected on non-movie
+  libraries; Sonarr overrides are rejected on non-show libraries.
+* **Whitelisted keys only**: :data:`LIBRARY_RADARR_IMPORT_FIELDS` and
+  :data:`LIBRARY_SONARR_IMPORT_FIELDS` define which keys are importable
+  and their expected type (``"string"`` or ``"bool"``).
+* **String coercion**: bool fields serialize as the string ``"true"``
+  or ``"false"`` (matching the DB format the form uses), non-bool
+  fields get ``str(...).strip()``.
+* **Empty string rejection**: whitespace-only overrides are recorded
+  as unmapped rather than silently written.
+
+The two field-map dicts are re-exported from ``modules.importer``
+because external tooling might import them by name; keeping the
+canonical definition in this module means ``importer`` re-imports
+them rather than duplicating.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from modules.importer_value_coercion import _coerce_import_bool
+
+if TYPE_CHECKING:
+    from modules.importer import ImportReport
+
+
+LIBRARY_RADARR_IMPORT_FIELDS: dict[str, str] = {
+    "url": "string",
+    "token": "string",
+    "root_folder_path": "string",
+    "quality_profile": "string",
+    "availability": "string",
+    "tag": "string",
+    "monitor": "bool",
+    "search": "bool",
+    "add_missing": "bool",
+    "add_existing": "bool",
+    "upgrade_existing": "bool",
+    "monitor_existing": "bool",
+    "ignore_cache": "bool",
+    "radarr_path": "string",
+    "plex_path": "string",
+}
+
+LIBRARY_SONARR_IMPORT_FIELDS: dict[str, str] = {
+    "url": "string",
+    "token": "string",
+    "root_folder_path": "string",
+    "quality_profile": "string",
+    "language_profile": "string",
+    "series_type": "string",
+    "season_folder": "bool",
+    "monitor": "string",
+    "tag": "string",
+    "search": "bool",
+    "cutoff_search": "bool",
+    "add_missing": "bool",
+    "add_existing": "bool",
+    "upgrade_existing": "bool",
+    "monitor_existing": "bool",
+    "ignore_cache": "bool",
+    "sonarr_path": "string",
+    "plex_path": "string",
+}
+
+
+# lib_id prefix -> service name mapping.  The lib_id has the shape
+# "<type>-library_<slug>" where type is "mov" or "sho".  Radarr goes
+# with movie, Sonarr with show.
+_SERVICE_LIBRARY_TYPE_PREFIX: dict[str, str] = {
+    "radarr": "mov-library_",
+    "sonarr": "sho-library_",
+}
+
+
+def process_service_overrides(
+    lib_id: str,
+    lib_name: str,
+    lib_cfg: dict,
+    *,
+    libraries_data: dict[str, Any],
+    report: ImportReport,
+) -> None:
+    """Process both ``radarr:`` and ``sonarr:`` sub-blocks in one call.
+
+    Iterates the two services, delegating each to
+    :func:`_process_single_service_override`.
+    """
+    for service_name, field_map in (
+        ("radarr", LIBRARY_RADARR_IMPORT_FIELDS),
+        ("sonarr", LIBRARY_SONARR_IMPORT_FIELDS),
+    ):
+        _process_single_service_override(
+            service_name,
+            field_map,
+            lib_id=lib_id,
+            lib_name=lib_name,
+            lib_cfg=lib_cfg,
+            libraries_data=libraries_data,
+            report=report,
+        )
+
+
+def _process_single_service_override(
+    service_name: str,
+    field_map: dict[str, str],
+    *,
+    lib_id: str,
+    lib_name: str,
+    lib_cfg: dict,
+    libraries_data: dict[str, Any],
+    report: ImportReport,
+) -> None:
+    """Handle one library's ``<service>:`` block (radarr OR sonarr).
+
+    Applies the library-type gate first, then iterates each key in
+    the service block, dispatching to ``_apply_service_field``.
+    """
+    service_section = lib_cfg.get(service_name)
+    if not isinstance(service_section, dict):
+        if service_section is not None:
+            report.add(
+                "unmapped",
+                f"libraries.{lib_name}.{service_name}",
+                "Unsupported service override format.",
+            )
+        return
+
+    expected_prefix = _SERVICE_LIBRARY_TYPE_PREFIX[service_name]
+    if not str(lib_id).startswith(expected_prefix):
+        wrong_type = "movie" if service_name == "radarr" else "show"
+        report.add(
+            "unmapped",
+            f"libraries.{lib_name}.{service_name}",
+            f"{service_name.capitalize()} overrides are only supported on {wrong_type} libraries.",
+        )
+        return
+
+    imported_service = False
+    for key, value in service_section.items():
+        if _apply_service_field(
+            service_name,
+            field_map,
+            key,
+            value,
+            lib_id=lib_id,
+            lib_name=lib_name,
+            libraries_data=libraries_data,
+            report=report,
+        ):
+            imported_service = True
+
+    if imported_service:
+        report.add("imported", f"libraries.{lib_name}.{service_name}")
+
+
+def _apply_service_field(
+    service_name: str,
+    field_map: dict[str, str],
+    key: str,
+    value: Any,
+    *,
+    lib_id: str,
+    lib_name: str,
+    libraries_data: dict[str, Any],
+    report: ImportReport,
+) -> bool:
+    """Emit one service-override key/value into libraries_data + report.
+
+    Returns ``True`` when the value was successfully written (so the
+    caller can flip its ``imported_service`` accumulator).  Bool fields
+    serialize as the string ``"true"``/``"false"`` to match the form's
+    on-disk format; string fields get stripped.
+    """
+    field_type = field_map.get(str(key))
+    if not field_type:
+        report.add(
+            "unmapped",
+            f"libraries.{lib_name}.{service_name}.{key}",
+            "Library service override not supported for import.",
+        )
+        return False
+
+    target_key = f"{lib_id}-attribute_{service_name}_{key}"
+    if field_type == "bool":
+        bool_value = _coerce_import_bool(value)
+        if bool_value is None:
+            report.add(
+                "unmapped",
+                f"libraries.{lib_name}.{service_name}.{key}",
+                "Invalid boolean value.",
+            )
+            return False
+        libraries_data[target_key] = "true" if bool_value else "false"
+    else:
+        if isinstance(value, (dict, list)):
+            report.add(
+                "unmapped",
+                f"libraries.{lib_name}.{service_name}.{key}",
+                "Unsupported override value format.",
+            )
+            return False
+        text_value = str(value).strip()
+        if not text_value:
+            report.add(
+                "unmapped",
+                f"libraries.{lib_name}.{service_name}.{key}",
+                "Override value is empty.",
+            )
+            return False
+        libraries_data[target_key] = text_value
+
+    report.add("imported", f"libraries.{lib_name}.{service_name}.{key}")
+    return True


### PR DESCRIPTION
**Sprint 4, PR #15.** Tenth bite of the `prepare_import_payload` monster. Extracts the last big self-contained chunk of the per-library iteration loop.

## What moved

The ~47-line service-override block (radarr + sonarr) from the per-library iteration, plus the two module-level whitelist dicts `LIBRARY_RADARR_IMPORT_FIELDS` and `LIBRARY_SONARR_IMPORT_FIELDS`, into a new `modules/importer_services` module.

Public API:

| Symbol | Kind | Purpose |
|---|---|---|
| `process_service_overrides` | function | Main entry, handles both services |
| `LIBRARY_RADARR_IMPORT_FIELDS` | dict | Whitelist (15 keys) |
| `LIBRARY_SONARR_IMPORT_FIELDS` | dict | Whitelist (18 keys) |

The two dicts are **re-exported from `importer.py`** for backward compat. Verified `importer.LIBRARY_*_IMPORT_FIELDS is importer_services.LIBRARY_*_IMPORT_FIELDS`.

## Internal split (mini-refactor for readability)

The original block was one for-loop containing two nested if-elif gates and another nested for-loop over field entries. Broken into three named functions with clear responsibilities:

| Function | Role |
|---|---|
| `process_service_overrides` | Outer dispatch over both services |
| `_process_single_service_override` | Library-type gate + inner loop |
| `_apply_service_field` | Coercion + emission for one field |

## Micro DRY win

The original had two very similar library-type gate blocks:

```python
if service_name == "radarr" and not str(lib_id).startswith("mov-library_"):
    report.add(..., "Radarr overrides are only supported on movie libraries.")
    continue
if service_name == "sonarr" and not str(lib_id).startswith("sho-library_"):
    report.add(..., "Sonarr overrides are only supported on show libraries.")
    continue
```

Now driven by a `_SERVICE_LIBRARY_TYPE_PREFIX` dict mapping service name to lib_id prefix, with a single gate check. Behavior verified byte-identical against the original -- message wording preserved exactly:
- radarr: `"Radarr overrides are only supported on movie libraries."` (same)
- sonarr: `"Sonarr overrides are only supported on show libraries."` (same)

## Coercion helper

`_coerce_import_bool` imported from `importer_value_coercion` (existing helper from #1506). Bool fields still serialize as the string `"true"` / `"false"` to match the DB format the form uses. String fields still get stripped and rejected when empty.

## Circular-import guard

`modules/importer_services` imports `ImportReport` only under `TYPE_CHECKING` -- no runtime cross-import.

## Impact

- `modules/importer.py`: **603 -> 537** (**-66 / -10.9%**)
- `modules/importer_services.py`: NEW ~230 lines
- **`prepare_import_payload` body: 258 -> 219** (**-39 / -15.1%**)

## Two big milestones

- **Cumulative Sprint 4 progress: 2027 -> 537 = -73.5%**
- **Inside `prepare_import_payload` specifically: 1062 -> 219 = -79.4%**

## Sprint 4 running total

| PR | Status | Delta | Ending |
|---|---|---|---|
| #1503-#1517 | merged | (see prior PRs) | 603 |
| **#TBD (this)** | **open** | **-66** | **537** |

## Verification

- All **1285 tests pass**
- Ruff + black clean via pre-commit hooks locally
- Re-exports verified: `importer.LIBRARY_*_IMPORT_FIELDS is importer_services.LIBRARY_*_IMPORT_FIELDS`
- All error message wording preserved verbatim

## Roadmap for prepare_import_payload

The per-library loop is now down to:
- Library setup / type detection (~40 lines)
- Top-level values / template variables (~30 lines)
- Handled-keys sweep at the tail (~11 lines)

These are small enough that one final PR can consolidate them into a per-library orchestrator, OR they may stay inline if the readability payoff no longer justifies the module count. Will evaluate after this PR merges.
