### PR TITLE
Extract process-metric calculators from process_control.py

### DIFF
--- a/modules/process_control.py
+++ b/modules/process_control.py
@@ -13,9 +13,19 @@ from flask import current_app as app, has_app_context, has_request_context, sess
 
 from modules import database, helpers, imagemaid, persistence
 
-KOMETA_CPU_CACHE = {}
-SYSTEM_CPU_CACHE = {"total": None, "idle": None}
-PROCESS_IO_CACHE = {"kometa": {}, "imagemaid": {}}
+# Process-metric calculators (CPU / IO stats) extracted to modules.process_metrics.
+# Re-exported here so callers using ``from modules.process_control import ...``
+# and ``modules.process_control.<name>`` continue to work.
+from modules.process_metrics import (  # noqa: F401
+    KOMETA_CPU_CACHE,
+    PROCESS_IO_CACHE,
+    SYSTEM_CPU_CACHE,
+    calculate_process_cpu_percent,
+    calculate_process_io_stats,
+    calculate_system_cpu_percent,
+    clear_process_metric_cache,
+)
+
 MAINTENANCE_STATE = {
     "paused": False,
     "paused_since": None,
@@ -59,120 +69,6 @@ def _get_version_info():
     if not has_app_context():
         return {}
     return app.config.get("VERSION_CHECK") or {}
-
-
-def calculate_process_cpu_percent(proc):
-    try:
-        cpu_times = proc.cpu_times()
-    except Exception:
-        return None
-    total_cpu = cpu_times.user + cpu_times.system
-    try:
-        for child in proc.children(recursive=True):
-            try:
-                child_times = child.cpu_times()
-                total_cpu += child_times.user + child_times.system
-            except Exception:
-                continue
-    except Exception:
-        pass
-    now = time.time()
-    entry = KOMETA_CPU_CACHE.get(proc.pid)
-    KOMETA_CPU_CACHE[proc.pid] = {"time": now, "cpu": total_cpu}
-    if not entry:
-        return None
-    elapsed = now - entry.get("time", now)
-    if elapsed <= 0:
-        return None
-    delta_cpu = total_cpu - entry.get("cpu", total_cpu)
-    if delta_cpu < 0:
-        return None
-    percent = (delta_cpu / elapsed) * 100.0
-    return max(0.0, percent)
-
-
-def calculate_system_cpu_percent():
-    try:
-        cpu_times = psutil.cpu_times()
-    except Exception:
-        return None
-    total = sum(cpu_times)
-    idle = getattr(cpu_times, "idle", 0)
-    last_total = SYSTEM_CPU_CACHE.get("total")
-    last_idle = SYSTEM_CPU_CACHE.get("idle")
-    SYSTEM_CPU_CACHE["total"] = total
-    SYSTEM_CPU_CACHE["idle"] = idle
-    if last_total is None or last_idle is None:
-        return None
-    delta_total = total - last_total
-    if delta_total <= 0:
-        return None
-    delta_idle = idle - last_idle
-    busy = max(0.0, delta_total - delta_idle)
-    percent = (busy / delta_total) * 100.0
-    return max(0.0, min(100.0, percent))
-
-
-def calculate_process_io_stats(proc, cache_name):
-    bucket = PROCESS_IO_CACHE.setdefault(cache_name, {})
-    total_read = 0
-    total_write = 0
-    saw_counters = False
-
-    def _accumulate_io(target_proc):
-        nonlocal total_read, total_write, saw_counters
-        try:
-            counters = target_proc.io_counters()
-        except Exception:
-            return
-        read_bytes = getattr(counters, "read_bytes", None)
-        write_bytes = getattr(counters, "write_bytes", None)
-        if read_bytes is None or write_bytes is None:
-            return
-        saw_counters = True
-        total_read += max(0, int(read_bytes))
-        total_write += max(0, int(write_bytes))
-
-    _accumulate_io(proc)
-    try:
-        for child in proc.children(recursive=True):
-            _accumulate_io(child)
-    except Exception:
-        pass
-
-    if not saw_counters:
-        return None
-
-    now = time.time()
-    entry = bucket.get(proc.pid)
-    bucket[proc.pid] = {"time": now, "read": total_read, "write": total_write}
-
-    read_rate_mb_s = None
-    write_rate_mb_s = None
-    if entry:
-        elapsed = now - entry.get("time", now)
-        if elapsed > 0:
-            delta_read = total_read - entry.get("read", total_read)
-            delta_write = total_write - entry.get("write", total_write)
-            if delta_read >= 0:
-                read_rate_mb_s = delta_read / (1024 * 1024) / elapsed
-            if delta_write >= 0:
-                write_rate_mb_s = delta_write / (1024 * 1024) / elapsed
-
-    return {
-        "disk_read_mb": total_read / (1024 * 1024),
-        "disk_write_mb": total_write / (1024 * 1024),
-        "disk_read_rate_mb_s": read_rate_mb_s,
-        "disk_write_rate_mb_s": write_rate_mb_s,
-    }
-
-
-def clear_process_metric_cache(pid, cache_name=None):
-    if pid is None:
-        return
-    KOMETA_CPU_CACHE.pop(pid, None)
-    if cache_name:
-        PROCESS_IO_CACHE.setdefault(cache_name, {}).pop(pid, None)
 
 
 def parse_maintenance_window_minutes(window_str):

--- a/modules/process_metrics.py
+++ b/modules/process_metrics.py
@@ -1,0 +1,164 @@
+"""Process-metric calculators (CPU / IO) for Kometa & ImageMaid subprocesses.
+
+Split out of ``modules.process_control`` -- this cluster owns the
+"how busy is the Kometa subprocess right now?" logic used by the
+runtime status API and the maintenance-guard loop.
+
+## What lives here
+
+* ``calculate_process_cpu_percent(proc)`` -- returns 0-100+ CPU% for
+  a psutil.Process and all its children, computed as a delta over
+  the previous call.  First call for a given PID returns ``None``
+  because there's no baseline yet.
+* ``calculate_system_cpu_percent()`` -- returns 0-100 system-wide
+  CPU% as a delta over the previous call.
+* ``calculate_process_io_stats(proc, cache_name)`` -- returns a dict
+  with cumulative and per-second disk read/write for a process tree.
+* ``clear_process_metric_cache(pid, cache_name=None)`` -- drops
+  cached counters for a PID (called after a process ends).
+
+## Module-level caches
+
+Three per-module dicts hold the previous-sample state so deltas can
+be computed on the next call:
+
+* ``KOMETA_CPU_CACHE`` -- PID -> {"time": t, "cpu": total_cpu_secs}
+* ``SYSTEM_CPU_CACHE`` -- {"total": t, "idle": i} (global, single entry)
+* ``PROCESS_IO_CACHE`` -- {"kometa": {pid -> ...}, "imagemaid": {pid -> ...}}
+
+These are internal state; nothing outside this module references them
+directly (verified by grep across the codebase during extraction).
+
+## Backward compatibility
+
+``modules.process_control`` re-exports every public name so callers
+in ``quickstart.py`` (which imports via alias, e.g.
+``calculate_process_cpu_percent as _calculate_process_cpu_percent``)
+keep working unchanged.  6 test-suite monkeypatches that target
+``qs_module._calculate_process_cpu_percent`` etc. also stay valid
+because they mutate ``quickstart.__dict__``, not this module.
+"""
+
+from __future__ import annotations
+
+import time
+
+import psutil
+
+KOMETA_CPU_CACHE: dict = {}
+SYSTEM_CPU_CACHE: dict = {"total": None, "idle": None}
+PROCESS_IO_CACHE: dict = {"kometa": {}, "imagemaid": {}}
+
+
+def calculate_process_cpu_percent(proc):
+    try:
+        cpu_times = proc.cpu_times()
+    except Exception:
+        return None
+    total_cpu = cpu_times.user + cpu_times.system
+    try:
+        for child in proc.children(recursive=True):
+            try:
+                child_times = child.cpu_times()
+                total_cpu += child_times.user + child_times.system
+            except Exception:
+                continue
+    except Exception:
+        pass
+    now = time.time()
+    entry = KOMETA_CPU_CACHE.get(proc.pid)
+    KOMETA_CPU_CACHE[proc.pid] = {"time": now, "cpu": total_cpu}
+    if not entry:
+        return None
+    elapsed = now - entry.get("time", now)
+    if elapsed <= 0:
+        return None
+    delta_cpu = total_cpu - entry.get("cpu", total_cpu)
+    if delta_cpu < 0:
+        return None
+    percent = (delta_cpu / elapsed) * 100.0
+    return max(0.0, percent)
+
+
+def calculate_system_cpu_percent():
+    try:
+        cpu_times = psutil.cpu_times()
+    except Exception:
+        return None
+    total = sum(cpu_times)
+    idle = getattr(cpu_times, "idle", 0)
+    last_total = SYSTEM_CPU_CACHE.get("total")
+    last_idle = SYSTEM_CPU_CACHE.get("idle")
+    SYSTEM_CPU_CACHE["total"] = total
+    SYSTEM_CPU_CACHE["idle"] = idle
+    if last_total is None or last_idle is None:
+        return None
+    delta_total = total - last_total
+    if delta_total <= 0:
+        return None
+    delta_idle = idle - last_idle
+    busy = max(0.0, delta_total - delta_idle)
+    percent = (busy / delta_total) * 100.0
+    return max(0.0, min(100.0, percent))
+
+
+def calculate_process_io_stats(proc, cache_name):
+    bucket = PROCESS_IO_CACHE.setdefault(cache_name, {})
+    total_read = 0
+    total_write = 0
+    saw_counters = False
+
+    def _accumulate_io(target_proc):
+        nonlocal total_read, total_write, saw_counters
+        try:
+            counters = target_proc.io_counters()
+        except Exception:
+            return
+        read_bytes = getattr(counters, "read_bytes", None)
+        write_bytes = getattr(counters, "write_bytes", None)
+        if read_bytes is None or write_bytes is None:
+            return
+        saw_counters = True
+        total_read += max(0, int(read_bytes))
+        total_write += max(0, int(write_bytes))
+
+    _accumulate_io(proc)
+    try:
+        for child in proc.children(recursive=True):
+            _accumulate_io(child)
+    except Exception:
+        pass
+
+    if not saw_counters:
+        return None
+
+    now = time.time()
+    entry = bucket.get(proc.pid)
+    bucket[proc.pid] = {"time": now, "read": total_read, "write": total_write}
+
+    read_rate_mb_s = None
+    write_rate_mb_s = None
+    if entry:
+        elapsed = now - entry.get("time", now)
+        if elapsed > 0:
+            delta_read = total_read - entry.get("read", total_read)
+            delta_write = total_write - entry.get("write", total_write)
+            if delta_read >= 0:
+                read_rate_mb_s = delta_read / (1024 * 1024) / elapsed
+            if delta_write >= 0:
+                write_rate_mb_s = delta_write / (1024 * 1024) / elapsed
+
+    return {
+        "disk_read_mb": total_read / (1024 * 1024),
+        "disk_write_mb": total_write / (1024 * 1024),
+        "disk_read_rate_mb_s": read_rate_mb_s,
+        "disk_write_rate_mb_s": write_rate_mb_s,
+    }
+
+
+def clear_process_metric_cache(pid, cache_name=None):
+    if pid is None:
+        return
+    KOMETA_CPU_CACHE.pop(pid, None)
+    if cache_name:
+        PROCESS_IO_CACHE.setdefault(cache_name, {}).pop(pid, None)


### PR DESCRIPTION
First thematic extraction from `modules/process_control.py`.

## Summary

**`modules/process_control.py`: 1259 -> 1155 (-104 / -8.3%)** in this PR.

Creates **`modules/process_metrics.py`** (~165 lines).

## What moved

**4 functions + 3 module-level caches** for computing CPU% and disk-IO stats over the Kometa / ImageMaid subprocess trees:

- `calculate_process_cpu_percent(proc)` -- delta-based CPU% over one Kometa/ImageMaid process tree
- `calculate_system_cpu_percent()` -- delta-based system-wide CPU%
- `calculate_process_io_stats(proc, cache_name)` -- disk read/write MB + rates per process tree
- `clear_process_metric_cache(pid, cache_name=None)` -- drops cached counters after a process ends

Plus the three module-level state dicts that hold previous-sample data:

- `KOMETA_CPU_CACHE` (PID -> {time, cpu})
- `SYSTEM_CPU_CACHE` (single global entry {total, idle})
- `PROCESS_IO_CACHE` (per-cache-name PID -> {time, read, write})

## Why start here

This is a small, safe first PR to establish the pattern for the `process_control.py` split. The cluster was chosen first because:

1. **Fully self-contained** -- zero dependencies on other functions inside `process_control.py`
2. **Private state** -- the three caches have zero external references (verified via grep)
3. **Only stdlib + psutil deps** -- no cross-cluster import issues
4. **Tests patch through aliases** -- 6 test-suite monkeypatches on `qs_module._calculate_*` work through `quickstart.__dict__` aliases, so they continue to work unchanged across the module boundary

## Verification

- **AST-verified**: all 4 functions are byte-for-byte identical to `origin/develop`.
- **All 1300+ tests pass**.
- **Ruff clean.**
- **Black clean** (pre-commit reformatted long lines, re-committed).

## What's next?

`process_control.py` at 1155 lines still has plenty of clusters to extract:

- **Maintenance-window helpers** (~165 lines, 9 functions) -- `parse_maintenance_window_minutes`, `is_within_maintenance_window`, `get_maintenance_window_from_db`, etc.
- **Pending Kometa-start queue** (~35 lines, 5 functions) -- `normalize_kometa_start_mode`, `set/peek/pop/clear_pending_kometa_start`
- **Process discovery** (~75 lines, 4 functions) -- `find_running_kometa_processes`, `find_running_imagemaid_processes`, etc.
- **Process lifecycle** (~180 lines, 4 functions) -- `stop_process_tree`, `launch_kometa_command`, `launch_imagemaid_command`, `reset_imagemaid_runtime_env`
- **Run-context state** (~110 lines, 11 functions) -- `extract_selected_libraries`, `update/get/clear_run_context`, `suspend/resume_process_tree`
- **Maintenance guard loop** (~203 lines, 1 function) -- `maintenance_guard_loop` (background thread; largest single function)
- **Marker-file writers** (~304 lines, 15+ functions) -- `write_quickstart_*_marker`, sidecar path helpers, log-line appenders