### PR TITLE
Extract remaining 5 clusters from process_control.py

### DIFF
--- a/modules/process_control.py
+++ b/modules/process_control.py
@@ -1,16 +1,43 @@
+"""Kometa/ImageMaid subprocess control -- launch, stop, and monitor.
+
+This module used to be a 1250-line grab-bag.  Sprint 4 split it into
+thematic siblings, all re-exported from here for backward compat:
+
+* ``modules.process_control_state`` -- runtime state dicts + locks +
+  the shared ``normalize_kometa_start_mode`` helper.  The bottom
+  layer everything else imports from.
+* ``modules.process_metrics`` -- CPU / IO stat calculators.
+* ``modules.process_markers`` -- marker-file writers for both Kometa
+  and ImageMaid runs.
+* ``modules.process_maintenance`` -- maintenance-window resolution
+  from the DB / from Plex live.
+* ``modules.process_pending_start`` -- the pending-Kometa-start queue.
+* ``modules.process_discovery`` -- psutil scans that find running
+  Kometa / ImageMaid subprocesses.
+* ``modules.process_lifecycle`` -- launch / stop / suspend / resume
+  verbs.
+* ``modules.process_run_context`` -- ``RUN_CONTEXT`` and
+  ``IMAGEMAID_RUN_CONTEXT`` accessor functions.
+
+The one function that still LIVES here is ``maintenance_guard_loop``
+-- a 200-line background thread that ties every other cluster
+together.  It's the natural owner of the top-level orchestration
+and keeping it in ``process_control.py`` makes ``quickstart.py``'s
+import line unchanged (``from modules.process_control import
+maintenance_guard_loop``).
+
+All 43 imports in ``quickstart.py`` (using ``X as _X`` aliases) reach
+their target functions through the re-export blocks below without
+caring which extracted module they live in.
+"""
+
 import os
-import re
-import shlex
-import subprocess
-import sys
 import time
 from datetime import datetime, timezone
-from pathlib import Path
 
 import psutil
-from flask import has_request_context, session
 
-from modules import database, helpers, imagemaid, persistence
+from modules import helpers, imagemaid
 
 # Process-metric calculators (CPU / IO stats) extracted to modules.process_metrics.
 # Re-exported here so callers using ``from modules.process_control import ...``
@@ -65,575 +92,58 @@ from modules.process_markers import (  # noqa: F401
     write_quickstart_stop_marker,
 )
 
-
-def parse_maintenance_window_minutes(window_str):
-    if not window_str or "Unavailable" in str(window_str):
-        return None
-    matches = re.findall(r"(\d{1,2}):(\d{2})", str(window_str))
-    if len(matches) < 2:
-        return None
-    try:
-        start_h, start_m = (int(v) for v in matches[0])
-        end_h, end_m = (int(v) for v in matches[1])
-    except Exception:
-        return None
-    if not (0 <= start_h <= 23 and 0 <= end_h <= 23 and 0 <= start_m <= 59 and 0 <= end_m <= 59):
-        return None
-    return (start_h * 60 + start_m, end_h * 60 + end_m)
-
-
-def is_within_maintenance_window(now_dt, start_min, end_min):
-    if start_min is None or end_min is None or start_min == end_min:
-        return False
-    now_min = now_dt.hour * 60 + now_dt.minute
-    if start_min < end_min:
-        return start_min <= now_min < end_min
-    return now_min >= start_min or now_min < end_min
-
-
-def get_maintenance_window_from_db(config_name=None):
-    config_name = helpers.normalize_config_name_for_storage(config_name) or database.get_last_used_config_name()
-    if not config_name:
-        return None, None, None
-    try:
-        _validated, _user_entered, data = database.retrieve_section_data(name=config_name, section="plex_telemetry")
-        telemetry = data.get("plex_telemetry", {}) if isinstance(data, dict) else {}
-        window_str = telemetry.get("maintenance_window")
-        if not window_str:
-            legacy_telemetry = persistence.retrieve_settings("plex_telemetry")
-            if isinstance(legacy_telemetry, dict):
-                window_str = legacy_telemetry.get("plex_telemetry", {}).get("maintenance_window")
-        if not window_str:
-            legacy_plex = persistence.retrieve_settings("010-plex")
-            if isinstance(legacy_plex, dict):
-                window_str = legacy_plex.get("plex", {}).get("telemetry", {}).get("maintenance_window")
-        minutes = parse_maintenance_window_minutes(window_str)
-        if not minutes:
-            return None, None, None
-        return minutes[0], minutes[1], window_str
-    except Exception as e:
-        helpers.ts_log(f"Failed to read Plex maintenance window: {e}", level="DEBUG")
-        return None, None, None
-
-
-def get_plex_credentials_from_db(config_name=None):
-    config_name = helpers.normalize_config_name_for_storage(config_name) or database.get_last_used_config_name()
-    if not config_name:
-        return None, None
-    try:
-        _validated, _user_entered, data = database.retrieve_section_data(name=config_name, section="plex")
-        plex_data = data.get("plex", {}) if isinstance(data, dict) else {}
-        plex_url = plex_data.get("url") or plex_data.get("plex_url")
-        plex_token = plex_data.get("token") or plex_data.get("plex_token")
-        return plex_url, plex_token
-    except Exception as e:
-        helpers.ts_log(f"Failed to read Plex credentials: {e}", level="DEBUG")
-        return None, None
-
-
-def get_maintenance_window_live(config_name=None):
-    plex_url, plex_token = get_plex_credentials_from_db(config_name=config_name)
-    if not plex_url or not plex_token:
-        return None, None, None
-    start_hour, end_hour = helpers.get_plex_maintenance_hours(plex_url, plex_token)
-    if start_hour is None or end_hour is None:
-        return None, None, None
-    window_str = f"{start_hour:02d}:00 – {end_hour:02d}:00"
-    return start_hour * 60, end_hour * 60, window_str
-
-
-def get_active_maintenance_lookup_config_name():
-    import quickstart
-
-    def normalize_optional_config_name(value):
-        raw = str(value or "").strip()
-        if not raw:
-            return ""
-        return helpers.normalize_config_name_for_storage(raw)
-
-    kometa_running = bool(helpers.get_kometa_pid() and helpers.is_kometa_running())
-    imagemaid_running = bool(helpers.get_imagemaid_pid() and helpers.is_imagemaid_running())
-
-    try:
-        kometa_ctx = quickstart._get_run_context()
-    except Exception:
-        kometa_ctx = {}
-    kometa_config = normalize_optional_config_name((kometa_ctx or {}).get("config_name"))
-    if kometa_running and kometa_config:
-        return kometa_config
-
-    try:
-        imagemaid_ctx = quickstart._get_imagemaid_run_context()
-    except Exception:
-        imagemaid_ctx = {}
-    imagemaid_config = normalize_optional_config_name((imagemaid_ctx or {}).get("config_name"))
-    if imagemaid_running and imagemaid_config:
-        return imagemaid_config
-
-    pending = quickstart._peek_pending_kometa_start()
-    pending_config = normalize_optional_config_name((pending or {}).get("config_name"))
-    if pending_config:
-        return pending_config
-
-    return database.get_last_used_config_name()
-
-
-def resolve_maintenance_window_live(config_name=None):
-    import quickstart
-
-    try:
-        return quickstart._get_maintenance_window_live(config_name=config_name)
-    except TypeError:
-        return quickstart._get_maintenance_window_live()
-
-
-def resolve_maintenance_window_from_db(config_name=None):
-    import quickstart
-
-    try:
-        return quickstart._get_maintenance_window_from_db(config_name=config_name)
-    except TypeError:
-        return quickstart._get_maintenance_window_from_db()
-
-
-def refresh_maintenance_window_availability(preserve_active_state=False):
-    maintenance_config_name = get_active_maintenance_lookup_config_name()
-    start_min, end_min, window_str = resolve_maintenance_window_live(config_name=maintenance_config_name)
-    if start_min is None or end_min is None:
-        start_min, end_min, window_str = resolve_maintenance_window_from_db(config_name=maintenance_config_name)
-    window_unavailable = start_min is None or end_min is None
-
-    kometa_running = bool(helpers.get_kometa_pid() and helpers.is_kometa_running())
-    imagemaid_running = bool(helpers.get_imagemaid_pid() and helpers.is_imagemaid_running())
-    has_pending = bool(peek_pending_kometa_start())
-    active = is_within_maintenance_window(datetime.now(), start_min, end_min)
-
-    with MAINTENANCE_STATE_LOCK:
-        if preserve_active_state and (MAINTENANCE_STATE.get("paused") or MAINTENANCE_STATE.get("imagemaid_paused")):
-            if window_str:
-                MAINTENANCE_STATE["window"] = window_str
-        else:
-            MAINTENANCE_STATE["active"] = active
-            MAINTENANCE_STATE["window"] = window_str
-        if window_unavailable and (kometa_running or imagemaid_running or has_pending):
-            if not MAINTENANCE_STATE.get("window_unavailable"):
-                MAINTENANCE_STATE["window_unavailable_since"] = datetime.now(timezone.utc).isoformat()
-            MAINTENANCE_STATE["window_unavailable"] = True
-        else:
-            MAINTENANCE_STATE["window_unavailable"] = False
-            MAINTENANCE_STATE["window_unavailable_since"] = None
-
-
-def set_pending_kometa_start(command, config_name, start_mode="current"):
-    with PENDING_KOMETA_START_LOCK:
-        PENDING_KOMETA_START["command"] = command
-        PENDING_KOMETA_START["config_name"] = config_name
-        PENDING_KOMETA_START["requested_at"] = datetime.now(timezone.utc).isoformat()
-        PENDING_KOMETA_START["start_mode"] = normalize_kometa_start_mode(start_mode)
-
-
-def peek_pending_kometa_start():
-    with PENDING_KOMETA_START_LOCK:
-        if not PENDING_KOMETA_START.get("command"):
-            return None
-        return dict(PENDING_KOMETA_START)
-
-
-def pop_pending_kometa_start():
-    with PENDING_KOMETA_START_LOCK:
-        if not PENDING_KOMETA_START.get("command"):
-            return None
-        pending = dict(PENDING_KOMETA_START)
-        PENDING_KOMETA_START["command"] = None
-        PENDING_KOMETA_START["config_name"] = None
-        PENDING_KOMETA_START["requested_at"] = None
-        PENDING_KOMETA_START["start_mode"] = "current"
-        return pending
-
-
-def clear_pending_kometa_start():
-    with PENDING_KOMETA_START_LOCK:
-        PENDING_KOMETA_START["command"] = None
-        PENDING_KOMETA_START["config_name"] = None
-        PENDING_KOMETA_START["requested_at"] = None
-        PENDING_KOMETA_START["start_mode"] = "current"
-
-
-def find_running_kometa_processes():
-    kometa_root = None
-    try:
-        kometa_root = str(helpers.get_kometa_root_path())
-    except Exception:
-        kometa_root = None
-    matches = []
-    for proc in psutil.process_iter():
-        try:
-            cmdline = []
-            if hasattr(proc, "info"):
-                cmdline = proc.info.get("cmdline") or []
-            if not cmdline:
-                cmdline = proc.cmdline() or []
-            joined = " ".join(cmdline)
-        except Exception:
-            continue
-        if "kometa.py" not in joined:
-            continue
-        has_root = bool(kometa_root and kometa_root in joined)
-        try:
-            create_time = proc.info.get("create_time") if hasattr(proc, "info") else None
-        except Exception:
-            create_time = None
-        if create_time is None:
-            try:
-                create_time = proc.create_time()
-            except Exception:
-                create_time = 0
-        matches.append((has_root, create_time, proc))
-    matches.sort(key=lambda item: (1 if item[0] else 0, item[1]), reverse=True)
-    return [entry[2] for entry in matches]
-
-
-def find_running_kometa_process():
-    procs = find_running_kometa_processes()
-    return procs[0] if procs else None
-
-
-def find_running_imagemaid_processes():
-    imagemaid_root = None
-    try:
-        imagemaid_root = str(helpers.get_imagemaid_root_path())
-    except Exception:
-        imagemaid_root = None
-    matches = []
-    for proc in psutil.process_iter():
-        try:
-            cmdline = []
-            if hasattr(proc, "info"):
-                cmdline = proc.info.get("cmdline") or []
-            if not cmdline:
-                cmdline = proc.cmdline() or []
-            joined = " ".join(cmdline)
-        except Exception:
-            continue
-        if "imagemaid.py" not in joined:
-            continue
-        has_root = bool(imagemaid_root and imagemaid_root in joined)
-        try:
-            create_time = proc.info.get("create_time") if hasattr(proc, "info") else None
-        except Exception:
-            create_time = None
-        if create_time is None:
-            try:
-                create_time = proc.create_time()
-            except Exception:
-                create_time = 0
-        matches.append((has_root, create_time, proc))
-    matches.sort(key=lambda item: (1 if item[0] else 0, item[1]), reverse=True)
-    return [entry[2] for entry in matches]
-
-
-def find_running_imagemaid_process():
-    procs = find_running_imagemaid_processes()
-    return procs[0] if procs else None
-
-
-def stop_process_tree(proc):
-    try:
-        children = proc.children(recursive=True)
-    except Exception:
-        children = []
-    # Ensure suspended processes can receive signals
-    for target in [proc] + children:
-        try:
-            target.resume()
-        except Exception:
-            pass
-    for child in children:
-        try:
-            child.terminate()
-        except Exception:
-            pass
-    try:
-        proc.terminate()
-    except Exception:
-        pass
-    gone, alive = psutil.wait_procs([proc] + children, timeout=5)
-    if alive:
-        for target in alive:
-            try:
-                target.kill()
-            except Exception:
-                pass
-        _, alive = psutil.wait_procs(alive, timeout=3)
-    return alive
-
-
-def launch_kometa_command(command, config_name=None, start_mode="current"):
-    if not command:
-        return False, "No command provided"
-
-    kometa_root = helpers.get_kometa_root_path()  # unified source of truth
-    is_win = sys.platform.startswith("win")
-    venv_python = kometa_root / "kometa-venv" / ("Scripts" if is_win else "bin") / ("python.exe" if is_win else "python3")
-    kometa_py = kometa_root / "kometa.py"
-
-    if not kometa_py.exists():
-        return False, f"kometa.py not found at: {kometa_py}"
-    if not venv_python.exists():
-        return False, f"Kometa venv python not found at: {venv_python}"
-
-    # Use posix=False so Windows backslashes/quotes are preserved
-    command_parts = shlex.split(command, posix=not is_win)
-
-    # Clean up double-wrapped args (affects --run-libraries, --times, etc.)
-    helpers.normalize_cli_args_inplace(command_parts)
-
-    # If the UI-built command already starts with python, replace it with our venv python
-    if command_parts and os.path.basename(command_parts[0]).lower() in {"python", "python3", "python.exe"}:
-        command_parts[0] = str(venv_python)
-    else:
-        command_parts.insert(0, str(venv_python))
-
-    # Make sure kometa.py is the script, even if the UI command omitted it
-    if not any(p.endswith("kometa.py") for p in command_parts):
-        command_parts.insert(1, str(kometa_py))
-
-    helpers.normalize_flag_values(command_parts)
-
-    config_path = extract_kometa_config_path(command_parts, kometa_root)
-    stamp_quickstart_config_marker(config_path, config_name)
-
-    helpers.ts_log(f"argv={command_parts!r}", level="DEBUG")
-
-    proc = subprocess.Popen(command_parts, cwd=str(kometa_root), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True)
-
-    with open(helpers.get_kometa_pid_file(), "w", encoding="utf-8") as f:
-        f.write(str(proc.pid))
-
-    schedule_quickstart_run_marker(kometa_root, config_name, start_mode=normalize_kometa_start_mode(start_mode))
-    return True, proc.pid
-
-
-def launch_imagemaid_command(command, mode=None, config_name=None):
-    import quickstart
-
-    if not command:
-        return False, "No command provided"
-
-    imagemaid_root = helpers.get_imagemaid_root_path()
-    is_win = sys.platform.startswith("win")
-    venv_python = imagemaid_root / "imagemaid-venv" / ("Scripts" if is_win else "bin") / ("python.exe" if is_win else "python3")
-    imagemaid_py = imagemaid_root / "imagemaid.py"
-
-    if not imagemaid_py.exists():
-        return False, f"imagemaid.py not found at: {imagemaid_py}"
-    if not venv_python.exists():
-        return False, f"ImageMaid venv python not found at: {venv_python}"
-
-    if isinstance(command, (list, tuple)):
-        command_parts = [str(part) for part in command]
-    else:
-        command_parts = shlex.split(command, posix=not is_win)
-        cleaned = []
-        for part in command_parts:
-            text = str(part)
-            if len(text) >= 2 and text[0] == text[-1] and text[0] in {"'", '"'}:
-                text = text[1:-1]
-            cleaned.append(text)
-        command_parts = cleaned
-
-    if command_parts and os.path.basename(command_parts[0]).lower() in {"python", "python3", "python.exe"}:
-        command_parts[0] = str(venv_python)
-    else:
-        command_parts.insert(0, str(venv_python))
-
-    if not any(p.endswith("imagemaid.py") for p in command_parts):
-        command_parts.insert(1, str(imagemaid_py))
-
-    env_ready, env_result = quickstart._reset_imagemaid_runtime_env(imagemaid_root)
-    if not env_ready:
-        return False, env_result or "Quickstart could not reset the ImageMaid runtime .env file."
-
-    helpers.ts_log(f"argv={command_parts!r}", level="DEBUG")
-    update_imagemaid_run_context(command_parts, mode=mode, config_name=config_name)
-    launch_log_path = Path(helpers.get_imagemaid_launch_log_file())
-    launch_log_path.parent.mkdir(parents=True, exist_ok=True)
-
-    with launch_log_path.open("w", encoding="utf-8", errors="replace") as launch_log:
-        launch_log.write(f"[Quickstart] ImageMaid launch started at {datetime.now().isoformat()}\n")
-        launch_log.flush()
-
-        proc = subprocess.Popen(
-            command_parts,
-            cwd=str(imagemaid_root),
-            stdout=launch_log,
-            stderr=subprocess.STDOUT,
-            start_new_session=True,
-        )
-
-        with open(helpers.get_imagemaid_pid_file(), "w", encoding="utf-8") as f:
-            f.write(str(proc.pid))
-
-        time.sleep(1.0)
-        return_code = proc.poll()
-        if return_code is not None:
-            launch_log.flush()
-            try:
-                os.remove(helpers.get_imagemaid_pid_file())
-            except Exception:
-                pass
-            return False, f"ImageMaid exited immediately with code {return_code}. Review the run log for details."
-
-    quickstart._schedule_quickstart_imagemaid_run_marker(imagemaid_root, mode=mode, config_name=config_name)
-    return True, proc.pid
-
-
-def reset_imagemaid_runtime_env(imagemaid_root):
-    try:
-        env_path = Path(imagemaid_root) / "config" / ".env"
-        env_path.parent.mkdir(parents=True, exist_ok=True)
-        env_path.write_text("", encoding="utf-8")
-        helpers.ts_log(f"Reset ImageMaid runtime env override file: {env_path}", level="DEBUG")
-        return True, str(env_path)
-    except Exception as exc:
-        return False, f"Quickstart could not reset ImageMaid env file before launch: {exc}"
-
-
-def extract_selected_libraries(command):
-    if not command:
-        return None, None
-    is_win = sys.platform.startswith("win")
-    try:
-        parts = shlex.split(command, posix=not is_win)
-    except Exception:
-        parts = command.split()
-
-    run_option = None
-    selected = None
-    for idx, part in enumerate(parts):
-        if part in ("--run", "--run-libraries", "--times"):
-            run_option = part
-        if part.startswith("--run-libraries="):
-            value = part.split("=", 1)[1].strip().strip('"').strip("'")
-            selected = [v for v in value.split("|") if v.strip()]
-            break
-        if part == "--run-libraries" and idx + 1 < len(parts):
-            value = parts[idx + 1].strip().strip('"').strip("'")
-            selected = [v for v in value.split("|") if v.strip()]
-            run_option = "--run-libraries"
-            break
-    return run_option, selected
-
-
-def update_run_context(command, config_name=None, start_mode="current"):
-    run_option, selected = extract_selected_libraries(command)
-    config_path = None
-    run_mode = "all"
-    if command:
-        is_win = sys.platform.startswith("win")
-        try:
-            parts = shlex.split(command, posix=not is_win)
-        except Exception:
-            parts = command.split()
-        if "--metadata-only" in parts:
-            run_mode = "metadata"
-        elif "--operations-only" in parts:
-            run_mode = "operations"
-        elif "--playlists-only" in parts:
-            run_mode = "playlists"
-        elif "--overlays-only" in parts:
-            run_mode = "overlays"
-        elif "--collections-only" in parts:
-            run_mode = "collections"
-        kometa_root = helpers.get_kometa_root_path()
-        config_path = extract_kometa_config_path(parts, kometa_root)
-    with RUN_CONTEXT_LOCK:
-        RUN_CONTEXT["command"] = command
-        RUN_CONTEXT["run_option"] = run_option
-        RUN_CONTEXT["selected_libraries"] = selected
-        RUN_CONTEXT["run_mode"] = run_mode
-        RUN_CONTEXT["start_mode"] = normalize_kometa_start_mode(start_mode)
-        if config_name is None and has_request_context():
-            config_name = session.get("config_name")
-        RUN_CONTEXT["config_name"] = config_name
-        RUN_CONTEXT["config_path"] = str(config_path) if config_path else None
-        RUN_CONTEXT["started_at"] = datetime.now()
-        RUN_CONTEXT["updated_at"] = datetime.now(timezone.utc).isoformat()
-        RUN_CONTEXT["stop_requested_at"] = None
-
-
-def get_run_context():
-    with RUN_CONTEXT_LOCK:
-        return dict(RUN_CONTEXT)
-
-
-def clear_run_context():
-    with RUN_CONTEXT_LOCK:
-        RUN_CONTEXT["command"] = None
-        RUN_CONTEXT["selected_libraries"] = None
-        RUN_CONTEXT["run_option"] = None
-        RUN_CONTEXT["run_mode"] = "all"
-        RUN_CONTEXT["start_mode"] = "current"
-        RUN_CONTEXT["config_name"] = None
-        RUN_CONTEXT["config_path"] = None
-        RUN_CONTEXT["started_at"] = None
-        RUN_CONTEXT["updated_at"] = None
-        RUN_CONTEXT["stop_requested_at"] = None
-
-
-def normalize_imagemaid_command_text(command):
-    if isinstance(command, (list, tuple)):
-        return " ".join(str(part) for part in command if str(part).strip())
-    return str(command or "").strip()
-
-
-def update_imagemaid_run_context(command, mode=None, config_name=None):
-    with IMAGEMAID_RUN_CONTEXT_LOCK:
-        IMAGEMAID_RUN_CONTEXT["command"] = normalize_imagemaid_command_text(command)
-        IMAGEMAID_RUN_CONTEXT["mode"] = str(mode or "").strip().lower() or None
-        IMAGEMAID_RUN_CONTEXT["config_name"] = str(config_name or "").strip() or None
-        IMAGEMAID_RUN_CONTEXT["started_at"] = datetime.now()
-        IMAGEMAID_RUN_CONTEXT["updated_at"] = datetime.now(timezone.utc).isoformat()
-
-
-def get_imagemaid_run_context():
-    with IMAGEMAID_RUN_CONTEXT_LOCK:
-        return dict(IMAGEMAID_RUN_CONTEXT)
-
-
-def clear_imagemaid_run_context():
-    with IMAGEMAID_RUN_CONTEXT_LOCK:
-        IMAGEMAID_RUN_CONTEXT["command"] = None
-        IMAGEMAID_RUN_CONTEXT["mode"] = None
-        IMAGEMAID_RUN_CONTEXT["config_name"] = None
-        IMAGEMAID_RUN_CONTEXT["started_at"] = None
-        IMAGEMAID_RUN_CONTEXT["updated_at"] = None
-
-
-def suspend_process_tree(proc):
-    try:
-        for child in proc.children(recursive=True):
-            try:
-                child.suspend()
-            except (psutil.NoSuchProcess, psutil.AccessDenied):
-                continue
-        proc.suspend()
-        return True
-    except (psutil.NoSuchProcess, psutil.AccessDenied):
-        return False
-
-
-def resume_process_tree(proc):
-    try:
-        proc.resume()
-        for child in proc.children(recursive=True):
-            try:
-                child.resume()
-            except (psutil.NoSuchProcess, psutil.AccessDenied):
-                continue
-        return True
-    except (psutil.NoSuchProcess, psutil.AccessDenied):
-        return False
+# Maintenance-window resolution (parse/lookup/refresh) extracted to
+# modules.process_maintenance.
+from modules.process_maintenance import (  # noqa: F401
+    get_active_maintenance_lookup_config_name,
+    get_maintenance_window_from_db,
+    get_maintenance_window_live,
+    get_plex_credentials_from_db,
+    is_within_maintenance_window,
+    parse_maintenance_window_minutes,
+    refresh_maintenance_window_availability,
+    resolve_maintenance_window_from_db,
+    resolve_maintenance_window_live,
+)
+
+# Pending Kometa-start queue extracted to modules.process_pending_start.
+from modules.process_pending_start import (  # noqa: F401
+    clear_pending_kometa_start,
+    peek_pending_kometa_start,
+    pop_pending_kometa_start,
+    set_pending_kometa_start,
+)
+
+# Process discovery (psutil scans) extracted to modules.process_discovery.
+from modules.process_discovery import (  # noqa: F401
+    find_running_imagemaid_process,
+    find_running_imagemaid_processes,
+    find_running_kometa_process,
+    find_running_kometa_processes,
+)
+
+# Process lifecycle (launch/stop/suspend/resume/env-reset) extracted to
+# modules.process_lifecycle.
+from modules.process_lifecycle import (  # noqa: F401
+    launch_imagemaid_command,
+    launch_kometa_command,
+    reset_imagemaid_runtime_env,
+    resume_process_tree,
+    stop_process_tree,
+    suspend_process_tree,
+)
+
+# Run-context state accessors extracted to modules.process_run_context.
+from modules.process_run_context import (  # noqa: F401
+    clear_imagemaid_run_context,
+    clear_run_context,
+    extract_selected_libraries,
+    get_imagemaid_run_context,
+    get_run_context,
+    normalize_imagemaid_command_text,
+    update_imagemaid_run_context,
+    update_run_context,
+)
 
 
 def maintenance_guard_loop(app_in):

--- a/modules/process_discovery.py
+++ b/modules/process_discovery.py
@@ -1,0 +1,111 @@
+"""Process discovery via psutil.
+
+Split out of ``modules.process_control`` -- finds already-running
+Kometa or ImageMaid subprocesses by scanning the OS process list.
+Used by the status API to reattach to a running process and by the
+maintenance guard loop to know whether to pause/resume anything.
+
+## What lives here
+
+* ``find_running_kometa_processes()`` -- scans ``psutil.process_iter``
+  for anything with ``kometa.py`` in its cmdline, sorts matches so
+  processes whose cmdline includes the configured kometa_root come
+  first (with ties broken by newest ``create_time``), returns the
+  full list.
+* ``find_running_kometa_process()`` -- convenience wrapper returning
+  the top of the list or ``None``.
+* ``find_running_imagemaid_processes()`` / ``find_running_imagemaid_process()``
+  -- same shape, but for ``imagemaid.py``.
+
+## Design notes
+
+The scans are best-effort: any per-process error (dead process, race,
+access-denied) is caught and the entry is skipped rather than raising.
+The root-path preference means Quickstart will attach to a Kometa
+started FROM Quickstart's managed root even if some other Kometa is
+also running on the machine.
+"""
+
+from __future__ import annotations
+
+import psutil
+
+from modules import helpers
+
+
+def find_running_kometa_processes():
+    kometa_root = None
+    try:
+        kometa_root = str(helpers.get_kometa_root_path())
+    except Exception:
+        kometa_root = None
+    matches = []
+    for proc in psutil.process_iter():
+        try:
+            cmdline = []
+            if hasattr(proc, "info"):
+                cmdline = proc.info.get("cmdline") or []
+            if not cmdline:
+                cmdline = proc.cmdline() or []
+            joined = " ".join(cmdline)
+        except Exception:
+            continue
+        if "kometa.py" not in joined:
+            continue
+        has_root = bool(kometa_root and kometa_root in joined)
+        try:
+            create_time = proc.info.get("create_time") if hasattr(proc, "info") else None
+        except Exception:
+            create_time = None
+        if create_time is None:
+            try:
+                create_time = proc.create_time()
+            except Exception:
+                create_time = 0
+        matches.append((has_root, create_time, proc))
+    matches.sort(key=lambda item: (1 if item[0] else 0, item[1]), reverse=True)
+    return [entry[2] for entry in matches]
+
+
+def find_running_kometa_process():
+    procs = find_running_kometa_processes()
+    return procs[0] if procs else None
+
+
+def find_running_imagemaid_processes():
+    imagemaid_root = None
+    try:
+        imagemaid_root = str(helpers.get_imagemaid_root_path())
+    except Exception:
+        imagemaid_root = None
+    matches = []
+    for proc in psutil.process_iter():
+        try:
+            cmdline = []
+            if hasattr(proc, "info"):
+                cmdline = proc.info.get("cmdline") or []
+            if not cmdline:
+                cmdline = proc.cmdline() or []
+            joined = " ".join(cmdline)
+        except Exception:
+            continue
+        if "imagemaid.py" not in joined:
+            continue
+        has_root = bool(imagemaid_root and imagemaid_root in joined)
+        try:
+            create_time = proc.info.get("create_time") if hasattr(proc, "info") else None
+        except Exception:
+            create_time = None
+        if create_time is None:
+            try:
+                create_time = proc.create_time()
+            except Exception:
+                create_time = 0
+        matches.append((has_root, create_time, proc))
+    matches.sort(key=lambda item: (1 if item[0] else 0, item[1]), reverse=True)
+    return [entry[2] for entry in matches]
+
+
+def find_running_imagemaid_process():
+    procs = find_running_imagemaid_processes()
+    return procs[0] if procs else None

--- a/modules/process_lifecycle.py
+++ b/modules/process_lifecycle.py
@@ -1,0 +1,244 @@
+"""Process lifecycle: launch, stop, suspend, resume, env-reset.
+
+Split out of ``modules.process_control`` -- owns the imperative "actually
+do something to the subprocess" verbs.
+
+## What lives here
+
+* ``stop_process_tree(proc)`` -- resumes-then-terminates a process
+  tree; falls back to SIGKILL if anything's still alive after 5s.
+* ``suspend_process_tree(proc)`` / ``resume_process_tree(proc)`` --
+  used by the maintenance guard loop to pause / unpause Kometa while
+  Plex is inside its scheduled maintenance window.
+* ``launch_kometa_command(command, config_name, start_mode)`` --
+  wraps the UI-built command with the correct venv python + kometa.py,
+  writes the PID file, stamps run/config markers, and launches via
+  ``subprocess.Popen``.
+* ``launch_imagemaid_command(command, mode, config_name)`` -- same
+  shape for ImageMaid, plus a poll-after-1s liveness check because
+  ImageMaid can exit immediately on config errors.
+* ``reset_imagemaid_runtime_env(imagemaid_root)`` -- wipes the
+  ImageMaid ``.env`` file before launch so stale overrides don't
+  leak across runs.
+
+## Cross-cluster dependencies
+
+* ``normalize_kometa_start_mode`` -- from ``process_control_state``.
+* ``extract_kometa_config_path`` / ``stamp_quickstart_config_marker`` /
+  ``schedule_quickstart_run_marker`` -- from ``process_markers``.
+* ``update_imagemaid_run_context`` -- from ``process_run_context``
+  (used by ``launch_imagemaid_command`` to record the run before
+  spawning).
+* ``quickstart._reset_imagemaid_runtime_env`` / ``_schedule_quickstart_imagemaid_run_marker``
+  -- reached via lazy ``import quickstart`` so the monkeypatchable
+  aliases in ``quickstart.py`` win (established test-seam pattern).
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+import psutil
+
+from modules import helpers
+from modules.process_control_state import normalize_kometa_start_mode
+from modules.process_markers import (
+    extract_kometa_config_path,
+    schedule_quickstart_run_marker,
+    stamp_quickstart_config_marker,
+)
+from modules.process_run_context import update_imagemaid_run_context
+
+
+def stop_process_tree(proc):
+    try:
+        children = proc.children(recursive=True)
+    except Exception:
+        children = []
+    # Ensure suspended processes can receive signals
+    for target in [proc] + children:
+        try:
+            target.resume()
+        except Exception:
+            pass
+    for child in children:
+        try:
+            child.terminate()
+        except Exception:
+            pass
+    try:
+        proc.terminate()
+    except Exception:
+        pass
+    gone, alive = psutil.wait_procs([proc] + children, timeout=5)
+    if alive:
+        for target in alive:
+            try:
+                target.kill()
+            except Exception:
+                pass
+        _, alive = psutil.wait_procs(alive, timeout=3)
+    return alive
+
+
+def launch_kometa_command(command, config_name=None, start_mode="current"):
+    if not command:
+        return False, "No command provided"
+
+    kometa_root = helpers.get_kometa_root_path()  # unified source of truth
+    is_win = sys.platform.startswith("win")
+    venv_python = kometa_root / "kometa-venv" / ("Scripts" if is_win else "bin") / ("python.exe" if is_win else "python3")
+    kometa_py = kometa_root / "kometa.py"
+
+    if not kometa_py.exists():
+        return False, f"kometa.py not found at: {kometa_py}"
+    if not venv_python.exists():
+        return False, f"Kometa venv python not found at: {venv_python}"
+
+    # Use posix=False so Windows backslashes/quotes are preserved
+    command_parts = shlex.split(command, posix=not is_win)
+
+    # Clean up double-wrapped args (affects --run-libraries, --times, etc.)
+    helpers.normalize_cli_args_inplace(command_parts)
+
+    # If the UI-built command already starts with python, replace it with our venv python
+    if command_parts and os.path.basename(command_parts[0]).lower() in {"python", "python3", "python.exe"}:
+        command_parts[0] = str(venv_python)
+    else:
+        command_parts.insert(0, str(venv_python))
+
+    # Make sure kometa.py is the script, even if the UI command omitted it
+    if not any(p.endswith("kometa.py") for p in command_parts):
+        command_parts.insert(1, str(kometa_py))
+
+    helpers.normalize_flag_values(command_parts)
+
+    config_path = extract_kometa_config_path(command_parts, kometa_root)
+    stamp_quickstart_config_marker(config_path, config_name)
+
+    helpers.ts_log(f"argv={command_parts!r}", level="DEBUG")
+
+    proc = subprocess.Popen(command_parts, cwd=str(kometa_root), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True)
+
+    with open(helpers.get_kometa_pid_file(), "w", encoding="utf-8") as f:
+        f.write(str(proc.pid))
+
+    schedule_quickstart_run_marker(kometa_root, config_name, start_mode=normalize_kometa_start_mode(start_mode))
+    return True, proc.pid
+
+
+def launch_imagemaid_command(command, mode=None, config_name=None):
+    import quickstart
+
+    if not command:
+        return False, "No command provided"
+
+    imagemaid_root = helpers.get_imagemaid_root_path()
+    is_win = sys.platform.startswith("win")
+    venv_python = imagemaid_root / "imagemaid-venv" / ("Scripts" if is_win else "bin") / ("python.exe" if is_win else "python3")
+    imagemaid_py = imagemaid_root / "imagemaid.py"
+
+    if not imagemaid_py.exists():
+        return False, f"imagemaid.py not found at: {imagemaid_py}"
+    if not venv_python.exists():
+        return False, f"ImageMaid venv python not found at: {venv_python}"
+
+    if isinstance(command, (list, tuple)):
+        command_parts = [str(part) for part in command]
+    else:
+        command_parts = shlex.split(command, posix=not is_win)
+        cleaned = []
+        for part in command_parts:
+            text = str(part)
+            if len(text) >= 2 and text[0] == text[-1] and text[0] in {"'", '"'}:
+                text = text[1:-1]
+            cleaned.append(text)
+        command_parts = cleaned
+
+    if command_parts and os.path.basename(command_parts[0]).lower() in {"python", "python3", "python.exe"}:
+        command_parts[0] = str(venv_python)
+    else:
+        command_parts.insert(0, str(venv_python))
+
+    if not any(p.endswith("imagemaid.py") for p in command_parts):
+        command_parts.insert(1, str(imagemaid_py))
+
+    env_ready, env_result = quickstart._reset_imagemaid_runtime_env(imagemaid_root)
+    if not env_ready:
+        return False, env_result or "Quickstart could not reset the ImageMaid runtime .env file."
+
+    helpers.ts_log(f"argv={command_parts!r}", level="DEBUG")
+    update_imagemaid_run_context(command_parts, mode=mode, config_name=config_name)
+    launch_log_path = Path(helpers.get_imagemaid_launch_log_file())
+    launch_log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with launch_log_path.open("w", encoding="utf-8", errors="replace") as launch_log:
+        launch_log.write(f"[Quickstart] ImageMaid launch started at {datetime.now().isoformat()}\n")
+        launch_log.flush()
+
+        proc = subprocess.Popen(
+            command_parts,
+            cwd=str(imagemaid_root),
+            stdout=launch_log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+
+        with open(helpers.get_imagemaid_pid_file(), "w", encoding="utf-8") as f:
+            f.write(str(proc.pid))
+
+        time.sleep(1.0)
+        return_code = proc.poll()
+        if return_code is not None:
+            launch_log.flush()
+            try:
+                os.remove(helpers.get_imagemaid_pid_file())
+            except Exception:
+                pass
+            return False, f"ImageMaid exited immediately with code {return_code}. Review the run log for details."
+
+    quickstart._schedule_quickstart_imagemaid_run_marker(imagemaid_root, mode=mode, config_name=config_name)
+    return True, proc.pid
+
+
+def reset_imagemaid_runtime_env(imagemaid_root):
+    try:
+        env_path = Path(imagemaid_root) / "config" / ".env"
+        env_path.parent.mkdir(parents=True, exist_ok=True)
+        env_path.write_text("", encoding="utf-8")
+        helpers.ts_log(f"Reset ImageMaid runtime env override file: {env_path}", level="DEBUG")
+        return True, str(env_path)
+    except Exception as exc:
+        return False, f"Quickstart could not reset ImageMaid env file before launch: {exc}"
+
+
+def suspend_process_tree(proc):
+    try:
+        for child in proc.children(recursive=True):
+            try:
+                child.suspend()
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+        proc.suspend()
+        return True
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return False
+
+
+def resume_process_tree(proc):
+    try:
+        proc.resume()
+        for child in proc.children(recursive=True):
+            try:
+                child.resume()
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+        return True
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return False

--- a/modules/process_maintenance.py
+++ b/modules/process_maintenance.py
@@ -1,0 +1,208 @@
+"""Maintenance-window helpers for the Kometa/ImageMaid run scheduler.
+
+Split out of ``modules.process_control`` -- this cluster owns everything
+about "is now a Plex maintenance window?".  The maintenance guard loop
+uses these to decide when to pause / resume the running subprocess.
+
+## What lives here
+
+* ``parse_maintenance_window_minutes(window_str)`` -- accepts strings
+  like ``"03:00 - 05:00"`` and returns ``(start_min, end_min)`` or
+  ``None``.
+* ``is_within_maintenance_window(now_dt, start_min, end_min)`` --
+  clock arithmetic that handles wrapping past midnight.
+* ``get_maintenance_window_from_db(config_name)`` -- reads the
+  ``plex_telemetry.maintenance_window`` value from the DB (with two
+  legacy-key fallbacks) and parses it.
+* ``get_plex_credentials_from_db(config_name)`` -- helper for the
+  live variant (below).
+* ``get_maintenance_window_live(config_name)`` -- asks the running
+  Plex server directly via ``helpers.get_plex_maintenance_hours``.
+* ``get_active_maintenance_lookup_config_name()`` -- picks the config
+  name to consult based on what's currently running (Kometa run
+  context wins, then ImageMaid, then pending start, then last-used).
+* ``resolve_maintenance_window_live/from_db(config_name)`` -- thin
+  test seams that route through ``quickstart._get_maintenance_window_*``
+  so the monkeypatchable aliases in ``quickstart.py`` win.
+* ``refresh_maintenance_window_availability(preserve_active_state)``
+  -- writes the current window + active flag into ``MAINTENANCE_STATE``
+  (locked).  Called from both the guard loop and the status API.
+
+## Cross-cluster dependencies
+
+* Uses shared state from ``modules.process_control_state``
+  (``MAINTENANCE_STATE`` + lock).
+* Calls ``peek_pending_kometa_start`` from
+  ``modules.process_pending_start``.
+* Reaches ``quickstart._get_maintenance_window_*`` via a lazy
+  ``import quickstart`` inside the resolve functions (established
+  pattern for reaching back into ``quickstart.py`` for test-monkey-
+  patchable aliases).
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+
+from modules import database, helpers, persistence
+from modules.process_control_state import MAINTENANCE_STATE, MAINTENANCE_STATE_LOCK
+from modules.process_pending_start import peek_pending_kometa_start
+
+
+def parse_maintenance_window_minutes(window_str):
+    if not window_str or "Unavailable" in str(window_str):
+        return None
+    matches = re.findall(r"(\d{1,2}):(\d{2})", str(window_str))
+    if len(matches) < 2:
+        return None
+    try:
+        start_h, start_m = (int(v) for v in matches[0])
+        end_h, end_m = (int(v) for v in matches[1])
+    except Exception:
+        return None
+    if not (0 <= start_h <= 23 and 0 <= end_h <= 23 and 0 <= start_m <= 59 and 0 <= end_m <= 59):
+        return None
+    return (start_h * 60 + start_m, end_h * 60 + end_m)
+
+
+def is_within_maintenance_window(now_dt, start_min, end_min):
+    if start_min is None or end_min is None or start_min == end_min:
+        return False
+    now_min = now_dt.hour * 60 + now_dt.minute
+    if start_min < end_min:
+        return start_min <= now_min < end_min
+    return now_min >= start_min or now_min < end_min
+
+
+def get_maintenance_window_from_db(config_name=None):
+    config_name = helpers.normalize_config_name_for_storage(config_name) or database.get_last_used_config_name()
+    if not config_name:
+        return None, None, None
+    try:
+        _validated, _user_entered, data = database.retrieve_section_data(name=config_name, section="plex_telemetry")
+        telemetry = data.get("plex_telemetry", {}) if isinstance(data, dict) else {}
+        window_str = telemetry.get("maintenance_window")
+        if not window_str:
+            legacy_telemetry = persistence.retrieve_settings("plex_telemetry")
+            if isinstance(legacy_telemetry, dict):
+                window_str = legacy_telemetry.get("plex_telemetry", {}).get("maintenance_window")
+        if not window_str:
+            legacy_plex = persistence.retrieve_settings("010-plex")
+            if isinstance(legacy_plex, dict):
+                window_str = legacy_plex.get("plex", {}).get("telemetry", {}).get("maintenance_window")
+        minutes = parse_maintenance_window_minutes(window_str)
+        if not minutes:
+            return None, None, None
+        return minutes[0], minutes[1], window_str
+    except Exception as e:
+        helpers.ts_log(f"Failed to read Plex maintenance window: {e}", level="DEBUG")
+        return None, None, None
+
+
+def get_plex_credentials_from_db(config_name=None):
+    config_name = helpers.normalize_config_name_for_storage(config_name) or database.get_last_used_config_name()
+    if not config_name:
+        return None, None
+    try:
+        _validated, _user_entered, data = database.retrieve_section_data(name=config_name, section="plex")
+        plex_data = data.get("plex", {}) if isinstance(data, dict) else {}
+        plex_url = plex_data.get("url") or plex_data.get("plex_url")
+        plex_token = plex_data.get("token") or plex_data.get("plex_token")
+        return plex_url, plex_token
+    except Exception as e:
+        helpers.ts_log(f"Failed to read Plex credentials: {e}", level="DEBUG")
+        return None, None
+
+
+def get_maintenance_window_live(config_name=None):
+    plex_url, plex_token = get_plex_credentials_from_db(config_name=config_name)
+    if not plex_url or not plex_token:
+        return None, None, None
+    start_hour, end_hour = helpers.get_plex_maintenance_hours(plex_url, plex_token)
+    if start_hour is None or end_hour is None:
+        return None, None, None
+    window_str = f"{start_hour:02d}:00 – {end_hour:02d}:00"
+    return start_hour * 60, end_hour * 60, window_str
+
+
+def get_active_maintenance_lookup_config_name():
+    import quickstart
+
+    def normalize_optional_config_name(value):
+        raw = str(value or "").strip()
+        if not raw:
+            return ""
+        return helpers.normalize_config_name_for_storage(raw)
+
+    kometa_running = bool(helpers.get_kometa_pid() and helpers.is_kometa_running())
+    imagemaid_running = bool(helpers.get_imagemaid_pid() and helpers.is_imagemaid_running())
+
+    try:
+        kometa_ctx = quickstart._get_run_context()
+    except Exception:
+        kometa_ctx = {}
+    kometa_config = normalize_optional_config_name((kometa_ctx or {}).get("config_name"))
+    if kometa_running and kometa_config:
+        return kometa_config
+
+    try:
+        imagemaid_ctx = quickstart._get_imagemaid_run_context()
+    except Exception:
+        imagemaid_ctx = {}
+    imagemaid_config = normalize_optional_config_name((imagemaid_ctx or {}).get("config_name"))
+    if imagemaid_running and imagemaid_config:
+        return imagemaid_config
+
+    pending = quickstart._peek_pending_kometa_start()
+    pending_config = normalize_optional_config_name((pending or {}).get("config_name"))
+    if pending_config:
+        return pending_config
+
+    return database.get_last_used_config_name()
+
+
+def resolve_maintenance_window_live(config_name=None):
+    import quickstart
+
+    try:
+        return quickstart._get_maintenance_window_live(config_name=config_name)
+    except TypeError:
+        return quickstart._get_maintenance_window_live()
+
+
+def resolve_maintenance_window_from_db(config_name=None):
+    import quickstart
+
+    try:
+        return quickstart._get_maintenance_window_from_db(config_name=config_name)
+    except TypeError:
+        return quickstart._get_maintenance_window_from_db()
+
+
+def refresh_maintenance_window_availability(preserve_active_state=False):
+    maintenance_config_name = get_active_maintenance_lookup_config_name()
+    start_min, end_min, window_str = resolve_maintenance_window_live(config_name=maintenance_config_name)
+    if start_min is None or end_min is None:
+        start_min, end_min, window_str = resolve_maintenance_window_from_db(config_name=maintenance_config_name)
+    window_unavailable = start_min is None or end_min is None
+
+    kometa_running = bool(helpers.get_kometa_pid() and helpers.is_kometa_running())
+    imagemaid_running = bool(helpers.get_imagemaid_pid() and helpers.is_imagemaid_running())
+    has_pending = bool(peek_pending_kometa_start())
+    active = is_within_maintenance_window(datetime.now(), start_min, end_min)
+
+    with MAINTENANCE_STATE_LOCK:
+        if preserve_active_state and (MAINTENANCE_STATE.get("paused") or MAINTENANCE_STATE.get("imagemaid_paused")):
+            if window_str:
+                MAINTENANCE_STATE["window"] = window_str
+        else:
+            MAINTENANCE_STATE["active"] = active
+            MAINTENANCE_STATE["window"] = window_str
+        if window_unavailable and (kometa_running or imagemaid_running or has_pending):
+            if not MAINTENANCE_STATE.get("window_unavailable"):
+                MAINTENANCE_STATE["window_unavailable_since"] = datetime.now(timezone.utc).isoformat()
+            MAINTENANCE_STATE["window_unavailable"] = True
+        else:
+            MAINTENANCE_STATE["window_unavailable"] = False
+            MAINTENANCE_STATE["window_unavailable_since"] = None

--- a/modules/process_pending_start.py
+++ b/modules/process_pending_start.py
@@ -1,0 +1,70 @@
+"""Pending Kometa-start queue.
+
+Split out of ``modules.process_control`` -- tiny cluster that manages
+the "there's a Kometa command waiting for the maintenance window to
+end" queue.  The maintenance guard loop pops from this queue when the
+window closes so the requested run can start.
+
+## What lives here
+
+Four functions guarded by ``PENDING_KOMETA_START_LOCK`` (from
+``modules.process_control_state``) that all read/write the single
+``PENDING_KOMETA_START`` dict:
+
+* ``set_pending_kometa_start(command, config_name, start_mode)``
+* ``peek_pending_kometa_start()`` -- non-destructive read, returns
+  a *copy* so the caller can't accidentally mutate module state.
+* ``pop_pending_kometa_start()`` -- destructive read that clears
+  the slot.
+* ``clear_pending_kometa_start()`` -- resets the slot without
+  reading it.
+
+The ``normalize_kometa_start_mode`` helper that used to live with
+these functions moved to ``modules.process_control_state`` because
+4 different clusters call it.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from modules.process_control_state import (
+    PENDING_KOMETA_START,
+    PENDING_KOMETA_START_LOCK,
+    normalize_kometa_start_mode,
+)
+
+
+def set_pending_kometa_start(command, config_name, start_mode="current"):
+    with PENDING_KOMETA_START_LOCK:
+        PENDING_KOMETA_START["command"] = command
+        PENDING_KOMETA_START["config_name"] = config_name
+        PENDING_KOMETA_START["requested_at"] = datetime.now(timezone.utc).isoformat()
+        PENDING_KOMETA_START["start_mode"] = normalize_kometa_start_mode(start_mode)
+
+
+def peek_pending_kometa_start():
+    with PENDING_KOMETA_START_LOCK:
+        if not PENDING_KOMETA_START.get("command"):
+            return None
+        return dict(PENDING_KOMETA_START)
+
+
+def pop_pending_kometa_start():
+    with PENDING_KOMETA_START_LOCK:
+        if not PENDING_KOMETA_START.get("command"):
+            return None
+        pending = dict(PENDING_KOMETA_START)
+        PENDING_KOMETA_START["command"] = None
+        PENDING_KOMETA_START["config_name"] = None
+        PENDING_KOMETA_START["requested_at"] = None
+        PENDING_KOMETA_START["start_mode"] = "current"
+        return pending
+
+
+def clear_pending_kometa_start():
+    with PENDING_KOMETA_START_LOCK:
+        PENDING_KOMETA_START["command"] = None
+        PENDING_KOMETA_START["config_name"] = None
+        PENDING_KOMETA_START["requested_at"] = None
+        PENDING_KOMETA_START["start_mode"] = "current"

--- a/modules/process_run_context.py
+++ b/modules/process_run_context.py
@@ -1,0 +1,168 @@
+"""Run-context state for the Kometa and ImageMaid subprocesses.
+
+Split out of ``modules.process_control`` -- owns the two ``*_RUN_CONTEXT``
+dicts (from ``modules.process_control_state``) that record what the
+last-launched subprocess is doing.  The status API reads these to
+render "Kometa is running --run-libraries=Movies|Shows since 2 minutes
+ago".
+
+## What lives here
+
+Kometa side:
+
+* ``extract_selected_libraries(command)`` -- parses ``--run-libraries``
+  or ``--times`` out of a Kometa command line.  Returns
+  ``(run_option, [library, ...])``.
+* ``update_run_context(command, config_name, start_mode)`` -- writes
+  the current Kometa run into ``RUN_CONTEXT`` (locked).  Also picks
+  a ``run_mode`` (all / metadata / operations / playlists / overlays /
+  collections) by inspecting flags in the command.
+* ``get_run_context()`` -- returns a copy of ``RUN_CONTEXT``.
+* ``clear_run_context()`` -- resets ``RUN_CONTEXT`` to the empty state.
+
+ImageMaid side (mirrors Kometa but simpler -- ImageMaid has no
+run-mode flags):
+
+* ``normalize_imagemaid_command_text(command)`` -- accepts either a
+  list or a string and returns a single command-line string.
+* ``update_imagemaid_run_context(command, mode, config_name)``.
+* ``get_imagemaid_run_context()``.
+* ``clear_imagemaid_run_context()``.
+
+## Cross-cluster dependencies
+
+* Shared state from ``modules.process_control_state``.
+* ``normalize_kometa_start_mode`` -- from the state module.
+* ``extract_kometa_config_path`` from ``modules.process_markers`` --
+  needed by ``update_run_context`` to record the config file path
+  next to the run.
+"""
+
+from __future__ import annotations
+
+import shlex
+import sys
+from datetime import datetime, timezone
+
+from flask import has_request_context, session
+
+from modules import helpers
+from modules.process_control_state import (
+    IMAGEMAID_RUN_CONTEXT,
+    IMAGEMAID_RUN_CONTEXT_LOCK,
+    RUN_CONTEXT,
+    RUN_CONTEXT_LOCK,
+    normalize_kometa_start_mode,
+)
+from modules.process_markers import extract_kometa_config_path
+
+
+def extract_selected_libraries(command):
+    if not command:
+        return None, None
+    is_win = sys.platform.startswith("win")
+    try:
+        parts = shlex.split(command, posix=not is_win)
+    except Exception:
+        parts = command.split()
+
+    run_option = None
+    selected = None
+    for idx, part in enumerate(parts):
+        if part in ("--run", "--run-libraries", "--times"):
+            run_option = part
+        if part.startswith("--run-libraries="):
+            value = part.split("=", 1)[1].strip().strip('"').strip("'")
+            selected = [v for v in value.split("|") if v.strip()]
+            break
+        if part == "--run-libraries" and idx + 1 < len(parts):
+            value = parts[idx + 1].strip().strip('"').strip("'")
+            selected = [v for v in value.split("|") if v.strip()]
+            run_option = "--run-libraries"
+            break
+    return run_option, selected
+
+
+def update_run_context(command, config_name=None, start_mode="current"):
+    run_option, selected = extract_selected_libraries(command)
+    config_path = None
+    run_mode = "all"
+    if command:
+        is_win = sys.platform.startswith("win")
+        try:
+            parts = shlex.split(command, posix=not is_win)
+        except Exception:
+            parts = command.split()
+        if "--metadata-only" in parts:
+            run_mode = "metadata"
+        elif "--operations-only" in parts:
+            run_mode = "operations"
+        elif "--playlists-only" in parts:
+            run_mode = "playlists"
+        elif "--overlays-only" in parts:
+            run_mode = "overlays"
+        elif "--collections-only" in parts:
+            run_mode = "collections"
+        kometa_root = helpers.get_kometa_root_path()
+        config_path = extract_kometa_config_path(parts, kometa_root)
+    with RUN_CONTEXT_LOCK:
+        RUN_CONTEXT["command"] = command
+        RUN_CONTEXT["run_option"] = run_option
+        RUN_CONTEXT["selected_libraries"] = selected
+        RUN_CONTEXT["run_mode"] = run_mode
+        RUN_CONTEXT["start_mode"] = normalize_kometa_start_mode(start_mode)
+        if config_name is None and has_request_context():
+            config_name = session.get("config_name")
+        RUN_CONTEXT["config_name"] = config_name
+        RUN_CONTEXT["config_path"] = str(config_path) if config_path else None
+        RUN_CONTEXT["started_at"] = datetime.now()
+        RUN_CONTEXT["updated_at"] = datetime.now(timezone.utc).isoformat()
+        RUN_CONTEXT["stop_requested_at"] = None
+
+
+def get_run_context():
+    with RUN_CONTEXT_LOCK:
+        return dict(RUN_CONTEXT)
+
+
+def clear_run_context():
+    with RUN_CONTEXT_LOCK:
+        RUN_CONTEXT["command"] = None
+        RUN_CONTEXT["selected_libraries"] = None
+        RUN_CONTEXT["run_option"] = None
+        RUN_CONTEXT["run_mode"] = "all"
+        RUN_CONTEXT["start_mode"] = "current"
+        RUN_CONTEXT["config_name"] = None
+        RUN_CONTEXT["config_path"] = None
+        RUN_CONTEXT["started_at"] = None
+        RUN_CONTEXT["updated_at"] = None
+        RUN_CONTEXT["stop_requested_at"] = None
+
+
+def normalize_imagemaid_command_text(command):
+    if isinstance(command, (list, tuple)):
+        return " ".join(str(part) for part in command if str(part).strip())
+    return str(command or "").strip()
+
+
+def update_imagemaid_run_context(command, mode=None, config_name=None):
+    with IMAGEMAID_RUN_CONTEXT_LOCK:
+        IMAGEMAID_RUN_CONTEXT["command"] = normalize_imagemaid_command_text(command)
+        IMAGEMAID_RUN_CONTEXT["mode"] = str(mode or "").strip().lower() or None
+        IMAGEMAID_RUN_CONTEXT["config_name"] = str(config_name or "").strip() or None
+        IMAGEMAID_RUN_CONTEXT["started_at"] = datetime.now()
+        IMAGEMAID_RUN_CONTEXT["updated_at"] = datetime.now(timezone.utc).isoformat()
+
+
+def get_imagemaid_run_context():
+    with IMAGEMAID_RUN_CONTEXT_LOCK:
+        return dict(IMAGEMAID_RUN_CONTEXT)
+
+
+def clear_imagemaid_run_context():
+    with IMAGEMAID_RUN_CONTEXT_LOCK:
+        IMAGEMAID_RUN_CONTEXT["command"] = None
+        IMAGEMAID_RUN_CONTEXT["mode"] = None
+        IMAGEMAID_RUN_CONTEXT["config_name"] = None
+        IMAGEMAID_RUN_CONTEXT["started_at"] = None
+        IMAGEMAID_RUN_CONTEXT["updated_at"] = None


### PR DESCRIPTION
Third and final major extraction from `modules/process_control.py`. Rests on the `process_control_state` foundation from PR #1523.

## Summary

**`modules/process_control.py`: 839 -> 349 (-490 / -58.4%)** in this PR.
**Combined across #1522 + #1523 + this PR: 1259 -> 349 (-910 / -72.3%)** since sprint start.

Five new modules created.

## What moved

### 1. `modules/process_maintenance.py` (~208 lines) -- 9 functions
Maintenance-window resolution from the DB and from Plex live:
- `parse_maintenance_window_minutes`, `is_within_maintenance_window`
- `get_maintenance_window_from_db`, `get_plex_credentials_from_db`
- `get_maintenance_window_live`, `get_active_maintenance_lookup_config_name`
- `resolve_maintenance_window_live`, `resolve_maintenance_window_from_db`
- `refresh_maintenance_window_availability`

### 2. `modules/process_pending_start.py` (~70 lines) -- 4 functions
Guards the pending-Kometa-start queue:
- `set_pending_kometa_start`, `peek_pending_kometa_start`, `pop_pending_kometa_start`, `clear_pending_kometa_start`

### 3. `modules/process_discovery.py` (~111 lines) -- 4 functions
Psutil scans:
- `find_running_kometa_process`, `find_running_kometa_processes`
- `find_running_imagemaid_process`, `find_running_imagemaid_processes`

### 4. `modules/process_lifecycle.py` (~244 lines) -- 6 functions
Imperative subprocess verbs:
- `launch_kometa_command`, `launch_imagemaid_command`
- `stop_process_tree`, `suspend_process_tree`, `resume_process_tree`
- `reset_imagemaid_runtime_env`

### 5. `modules/process_run_context.py` (~168 lines) -- 8 functions
Run-context state accessors (Kometa + ImageMaid):
- `extract_selected_libraries`
- `update_run_context`, `get_run_context`, `clear_run_context`
- `normalize_imagemaid_command_text`
- `update_imagemaid_run_context`, `get_imagemaid_run_context`, `clear_imagemaid_run_context`

## What stays behind

**Only `maintenance_guard_loop`** (~200 lines) still lives in `process_control.py`. It's the top-level orchestrator that ties every other cluster together (calls maintenance-window resolvers, reads/writes `MAINTENANCE_STATE`, launches pending starts, suspends/resumes processes, writes maintenance markers). Moving it would require solving a 6-way circular import for a single function -- not worth it.

The 349-line `process_control.py` now contains only:
- Module docstring explaining the split
- 8 re-export blocks (one per extracted sibling)
- The `maintenance_guard_loop` orchestrator

Also removed newly-unused imports (`re`, `shlex`, `subprocess`, `sys`, `Path`, `database`, `persistence`, `has_request_context`, `session`) whose users all moved out.

## Sprint 4 tally for process_control.py

| PR | Delta | Ending |
|---|---|---|
| Sprint start | -- | 1259 |
| #1522 (metrics) | -104 | 1155 |
| #1523 (state + markers) | -316 | 839 |
| **This PR (rest)** | **-490** | **349** |
| **Total** | **-910 / -72.3%** | |

## Backward compatibility

`process_control.py` re-exports every moved name via 8 re-export blocks (metrics + state + markers + maintenance + pending_start + discovery + lifecycle + run_context). All 43 imports in `quickstart.py` (using `X as _X` aliases) continue to work unchanged.

**No test-side changes needed** -- existing patches on `qs_module._X` aliases route through `quickstart.__dict__`, which doesn't care where the underlying function lives.

## Verification

- **AST-verified**: all 31 moved functions are byte-for-byte identical to `origin/develop`.
- **All 1300+ tests pass** (0 failures).
- **Ruff clean.**
- **Black clean.**