### PR TITLE
Extract Phase 2 line-scan detector; drop dead current_year code

### DIFF
--- a/modules/logscan_advisory_messages.py
+++ b/modules/logscan_advisory_messages.py
@@ -199,17 +199,6 @@ def build_advisory_messages(
         )
         special_check_lines.append(checkFiles_message)
 
-    # if current_year:
-    #     url_line = "[https://kometa.wiki/en/latest/files/dynamic_types/?h=latest#imdb-awards]"
-    #     formatted_errors = analyzer.format_contiguous_lines(current_year)
-    #     current_year_message = (
-    #             "⚠️ **LEGACY SCHEMA DETECTED**\n"
-    #             "As of 1.20 `current_year` is no longer used and should be replaced with `latest`.\n"
-    #             f"For more information on handling these, {url_line}\n"
-    #             f"{len(current_year)} line(s) with `current_year` issues. Line number(s): {formatted_errors}"
-    #     )
-    #     special_check_lines.append(current_year_message)
-
     if other_award:
         url_line = "[https://kometa.wiki/en/latest/kometa/faqs/?h=other_award#pmm-120-release-changes]"
         formatted_errors = analyzer.format_contiguous_lines(other_award)

--- a/modules/logscan_line_scan.py
+++ b/modules/logscan_line_scan.py
@@ -1,0 +1,317 @@
+"""Line-scan detector for the logscan recommendation engine.
+
+Split out of :mod:`modules.logscan_recommendations_engine` -- this
+module owns Phase 2 of ``make_recommendations``: iterating the log
+content line-by-line, matching known error/warning patterns, and
+populating ~57 per-issue "buckets" of line indices.
+
+## What lives here
+
+Single public entry point :func:`scan_content` that takes the
+analyzer and raw log content, and returns a dict of bucket-name
+-> list of line indices where each pattern was detected.  The
+downstream Phases 3 (advisory-message builder) and 6 (issue-counts
+dict) consume this dict.
+
+## The detector
+
+The main loop is a long chain of ``if``/``elif`` line-substring
+tests kept in the same order the legacy make_recommendations
+used.  Two branches are richer than simple string matches:
+
+* ``rounding_errors`` -- gated on the analyzer having populated
+  ``server_versions`` (a list of ``(server_name, server_version)``
+  tuples).  Only fires on ``mass_user_rating_update`` /
+  ``mass_episode_user_ratings_update`` lines.
+
+* ``security_vuln_hits`` -- runs the PMS version regex from
+  ``modules.logscan_pms_versions`` on any ``Connected to server``
+  line and reports vulnerable versions.
+
+Everything else is a straight substring/regex check that pushes
+the current line index onto its bucket.
+
+## Follow-up refactor notes
+
+The engine's own docstring flagged this line-scan block for a
+future data-driven refactor: replacing the if/elif chain with a
+list of ``(predicate, bucket_key)`` tuples.  That would drop the
+loop body to ~15 lines and let contributors add new detectors
+without wading through the whole chain.  Intentionally out of
+scope for the extraction PR -- kept as a pure byte-identical move
+so review can focus on the file split.
+"""
+
+from __future__ import annotations
+
+import re
+
+from modules.logscan_pms_versions import is_vulnerable_pms_version
+
+
+def scan_content(analyzer, content):
+    """Scan the log *content* for known error/warning patterns.
+
+    :param analyzer: the ``LogscanAnalyzer`` instance whose
+        ``server_versions`` list gates the ``rounding_errors``
+        detector.
+    :param content: the raw log text to scan.
+    :returns: dict mapping bucket-name -> list of line indices
+        (1-based) where each pattern was detected.  Every bucket
+        listed in the make_recommendations Phase 1 initialization
+        block is present in the returned dict, even if empty.
+    """
+    lines = content.splitlines()
+    anidb69_errors = []
+    anidb_auth_errors = []
+    api_blank_errors = []
+    bad_version_found_errors = []
+    cache_false = []
+    checkFiles = []
+    other_award = []
+    convert_errors = []
+    corrupt_image_errors = []
+    critical_errors = []
+    error_errors = []
+    warning_errors = []
+    delete_unmanaged_collections_errors = []
+    flixpatrol_errors = []
+    flixpatrol_paywall = []
+    git_kometa_errors = []
+    pmm_legacy_errors = []
+    image_size = []
+    internal_server_errors = []
+    lsio_errors = []
+    mal_connection_errors = []
+    mass_update_errors = []
+    mdblist_attr_errors = []
+    mdblist_errors = []
+    mdblist_api_limit_errors = []
+    metadata_attribute_errors = []
+    metadata_load_errors = []
+    missing_path_errors = []
+    new_version_found_errors = []
+    new_plexapi_version_found_errors = []
+    no_items_found_errors = []
+    omdb_errors = []
+    omdb_api_limit_errors = []
+    overlays_bloat = []
+    overlay_font_missing = []
+    overlay_apply_errors = []
+    overlay_image_missing = []
+    overlay_level_errors = []
+    overlay_load_errors = []
+    playlist_load_errors = []
+    playlist_errors = []
+    plex_lib_errors = []
+    plex_regex_errors = []
+    plex_url_errors = []
+    rounding_errors = []
+    ruamel_errors = []
+    run_order_errors = []
+    security_vuln_hits = []
+    traceback_errors = []
+    tautulli_url_errors = []
+    tautulli_apikey_errors = []
+    timeout_errors = []
+    to_be_configured_errors = []
+    tmdb_api_errors = []
+    tmdb_fail_errors = []
+    trakt_connection_errors = []
+
+    for idx, line in enumerate(lines, start=1):
+        if "run_order:" in line:
+            next_line = lines[idx] if idx < len(lines) else None
+            if next_line and "- operations" not in next_line:
+                run_order_errors.append(idx)
+        if "No Anime Found for AniDB ID: 69" in line:
+            anidb69_errors.append(idx)
+        if re.search(r"\bcache: false\b", line):
+            cache_false.append(idx)
+        if analyzer.server_versions and ("mass_user_rating_update" in line or "mass_episode_user_ratings_update" in line):
+
+            # Set to keep track of unique (server_name, server_version, idx) combinations
+            unique_entries = set()
+
+            # Iterate through each (server_name, server_version) tuple in analyzer.server_versions
+            for server_name, server_version in analyzer.server_versions:
+
+                # Create a unique identifier for the tuple
+                identifier = (server_name, server_version, idx)
+
+                # Check if the identifier is not in unique_entries (i.e., it's a new entry)
+                if identifier not in unique_entries:
+                    # Append server info to rounding_errors
+                    rounding_errors.append((server_name, server_version, idx))
+                    # Add the identifier to unique_entries set to mark it as processed
+                    unique_entries.add(identifier)
+
+        # Detect PMS versions in "Connected to server ..." lines and flag the vulnerable range
+        m = re.search(r"Connected to server\s+(.+?)\s+(?:\(?\s*(?:version|Version:)\s+)(\d+\.\d+\.\d+\.\d+(?:-[A-Za-z0-9]+)?)", line)
+        if m:
+            sn = m.group(1).strip()
+            ver = m.group(2).strip()
+            if is_vulnerable_pms_version(ver):
+                security_vuln_hits.append((sn, ver, idx))
+
+        if "Config Error: anidb sub-attribute" in line or "AniDB Error: Login failed" in line:
+            anidb_auth_errors.append(idx)
+        elif "apikey is blank" in line:
+            api_blank_errors.append(idx)
+        elif "1.32.7" in line and "Connected to server " in line:
+            bad_version_found_errors.append(idx)
+        elif "Convert Warning: No " in line and "ID Found for" in line:
+            convert_errors.append(idx)
+        elif "PIL.UnidentifiedImageError: cannot" in line:
+            corrupt_image_errors.append(idx)
+        elif "checkFiles=1" in line:
+            checkFiles.append(idx)
+        elif "other_award" in line:
+            other_award.append(idx)
+        elif "delete_unmanaged_collections" in line:
+            delete_unmanaged_collections_errors.append(idx)
+        elif "internal_server_error" in line:
+            internal_server_errors.append(idx)
+        elif "FlixPatrol Error: " in line and "failed to parse" in line:
+            flixpatrol_errors.append(idx)
+        elif "flixpatrol" in line and "- pmm:" in line:
+            flixpatrol_paywall.append(idx)
+        elif "- git: PMM" in line:
+            git_kometa_errors.append(idx)
+        elif "- pmm: " in line:
+            pmm_legacy_errors.append(idx)
+        elif ", in _upload_image" in line:
+            image_size.append(idx)
+        elif "(Linuxserver" in line and "Version:" in line:
+            lsio_errors.append(idx)
+        elif "My Anime List Connection Failed" in line:
+            mal_connection_errors.append(idx)
+        elif "Config Error: Operation mass_" in line and "without a successful" in line:
+            mass_update_errors.append(idx)
+        elif "mdblist_list attribute not allowed with Collection Level: Season" in line:
+            mdblist_attr_errors.append(idx)
+        elif "MdbList Error: Invalid API key" in line:
+            mdblist_errors.append(idx)
+        elif "MDBList Error: API Limit Reached" in line or "MDBList Error: API Rate Limit Reached" in line:
+            mdblist_api_limit_errors.append(idx)
+        elif "metadata attribute is required" in line:
+            metadata_attribute_errors.append(idx)
+        elif "Metadata File Failed To Load" in line:
+            metadata_load_errors.append(idx)
+        elif "Overlay File Failed To Load" in line:
+            overlay_load_errors.append(idx)
+        elif "Playlist File Failed To Load" in line:
+            playlist_load_errors.append(idx)
+        elif "missing_path" in line or "save_missing" in line:
+            missing_path_errors.append(idx)
+        elif "Newest Version: " in line:
+            new_version_found_errors.append(idx)
+        elif "requires an update to:" in line:
+            new_plexapi_version_found_errors.append(idx)
+        elif "OMDb Error: Invalid API key" in line:
+            omdb_errors.append(idx)
+        elif "OMDb Error: Request limit reached" in line:
+            omdb_api_limit_errors.append(idx)
+        elif "Overlay Error: Poster already has an Overlay" in line:
+            overlay_apply_errors.append(idx)
+        elif "| Overlay Error: Overlay Image not found" in line:
+            overlay_image_missing.append(idx)
+        elif "overlay_level:" in line:
+            overlay_level_errors.append(idx)
+        elif "Plex Error: No Items found in Plex" in line:
+            no_items_found_errors.append(idx)
+        elif "Overlay Error: font:" in line:
+            overlay_font_missing.append(idx)
+        elif "Reapply Overlays: True" in line or "Reset Overlays: [" in line:
+            overlays_bloat.append(idx)
+        elif "Playlist Error: Library: " in line and "not defined" in line:
+            playlist_errors.append(idx)
+        elif "Plex Error: Plex Library " in line and "not found" in line:
+            plex_lib_errors.append(idx)
+        elif "Plex Error: " in line and "No matches found with regex pattern" in line:
+            plex_regex_errors.append(idx)
+        elif "Plex Error: Plex url is invalid" in line:
+            plex_url_errors.append(idx)
+        elif "ruamel.yaml." in line:
+            ruamel_errors.append(idx)
+        elif "TMDb Error: Invalid API key" in line:
+            tmdb_api_errors.append(idx)
+        elif "Traceback (most recent call last):" in line:
+            traceback_errors.append(idx)
+        elif "Tautulli Error: Invalid apikey" in line:
+            tautulli_apikey_errors.append(idx)
+        elif "Tautulli Error: Invalid URL" in line:
+            tautulli_url_errors.append(idx)
+        elif "timed out." in line:
+            timeout_errors.append(idx)
+        elif "Failed to Connect to https://api.themoviedb.org/3" in line:
+            tmdb_fail_errors.append(idx)
+        elif "Error: " in line and " requires " in line and " to be configured" in line:
+            to_be_configured_errors.append(idx)
+        elif "Trakt Connection Failed" in line:
+            trakt_connection_errors.append(idx)
+        elif "[CRITICAL]" in line:
+            critical_errors.append(idx)
+        elif "[ERROR]" in line:
+            error_errors.append(idx)
+        elif "[WARNING]" in line:
+            warning_errors.append(idx)
+
+    return {
+        "anidb69_errors": anidb69_errors,
+        "anidb_auth_errors": anidb_auth_errors,
+        "api_blank_errors": api_blank_errors,
+        "bad_version_found_errors": bad_version_found_errors,
+        "cache_false": cache_false,
+        "checkFiles": checkFiles,
+        "other_award": other_award,
+        "convert_errors": convert_errors,
+        "corrupt_image_errors": corrupt_image_errors,
+        "critical_errors": critical_errors,
+        "error_errors": error_errors,
+        "warning_errors": warning_errors,
+        "delete_unmanaged_collections_errors": delete_unmanaged_collections_errors,
+        "flixpatrol_errors": flixpatrol_errors,
+        "flixpatrol_paywall": flixpatrol_paywall,
+        "git_kometa_errors": git_kometa_errors,
+        "pmm_legacy_errors": pmm_legacy_errors,
+        "image_size": image_size,
+        "internal_server_errors": internal_server_errors,
+        "lsio_errors": lsio_errors,
+        "mal_connection_errors": mal_connection_errors,
+        "mass_update_errors": mass_update_errors,
+        "mdblist_attr_errors": mdblist_attr_errors,
+        "mdblist_errors": mdblist_errors,
+        "mdblist_api_limit_errors": mdblist_api_limit_errors,
+        "metadata_attribute_errors": metadata_attribute_errors,
+        "metadata_load_errors": metadata_load_errors,
+        "missing_path_errors": missing_path_errors,
+        "new_version_found_errors": new_version_found_errors,
+        "new_plexapi_version_found_errors": new_plexapi_version_found_errors,
+        "no_items_found_errors": no_items_found_errors,
+        "omdb_errors": omdb_errors,
+        "omdb_api_limit_errors": omdb_api_limit_errors,
+        "overlays_bloat": overlays_bloat,
+        "overlay_font_missing": overlay_font_missing,
+        "overlay_apply_errors": overlay_apply_errors,
+        "overlay_image_missing": overlay_image_missing,
+        "overlay_level_errors": overlay_level_errors,
+        "overlay_load_errors": overlay_load_errors,
+        "playlist_load_errors": playlist_load_errors,
+        "playlist_errors": playlist_errors,
+        "plex_lib_errors": plex_lib_errors,
+        "plex_regex_errors": plex_regex_errors,
+        "plex_url_errors": plex_url_errors,
+        "rounding_errors": rounding_errors,
+        "ruamel_errors": ruamel_errors,
+        "run_order_errors": run_order_errors,
+        "security_vuln_hits": security_vuln_hits,
+        "traceback_errors": traceback_errors,
+        "tautulli_url_errors": tautulli_url_errors,
+        "tautulli_apikey_errors": tautulli_apikey_errors,
+        "timeout_errors": timeout_errors,
+        "to_be_configured_errors": to_be_configured_errors,
+        "tmdb_api_errors": tmdb_api_errors,
+        "tmdb_fail_errors": tmdb_fail_errors,
+        "trakt_connection_errors": trakt_connection_errors,
+    }

--- a/modules/logscan_recommendations_engine.py
+++ b/modules/logscan_recommendations_engine.py
@@ -19,17 +19,16 @@ modules -- see :mod:`modules.logscan_recommendations` and friends.
 
 Follow-up refactor notes (for future PRs):
 
-* The line-detector block (~200 lines) is a big if/elif chain that
-  could become data-driven with a list of (predicate, bucket)
-  tuples.
+* The line-detector block that used to live here has been
+  extracted to :mod:`modules.logscan_line_scan`.  A future PR
+  could take it data-driven with a list of (predicate, bucket)
+  tuples to shrink its if/elif chain.
 
-* The advisory-builder blocks (~800 lines) mostly follow a shared
-  template shape (icon + title + body + url + count line) and
-  could collapse to a data table with a dozen inline exceptions.
-
-Both are pure refactors that would materially shrink this module
-without changing behavior.  Kept for a later pass to keep this
-PR reviewable as a straight move.
+* The advisory-builder module (:mod:`modules.logscan_advisory_messages`,
+  ~900 lines) mostly follows a shared template shape (icon +
+  title + body + url + count line) and could collapse to a data
+  table with a dozen inline exceptions.  Would take that file
+  from ~900 lines down to ~200.
 """
 
 from __future__ import annotations
@@ -39,9 +38,7 @@ import re
 
 from modules.logscan_advisory_messages import build_advisory_messages
 from modules.logscan_issue_counts import build_issue_counts
-from modules.logscan_pms_versions import (
-    is_vulnerable_pms_version,
-)
+from modules.logscan_line_scan import scan_content
 
 # Backward-compat alias: this module used to define the advisory-message
 # builder as a private function; the extraction to
@@ -78,211 +75,13 @@ def make_recommendations(analyzer, content, incomplete_message):
           keyed by issue-category name.
     """
     # ------------------------------------------------------------------
-    # PHASE 1 -- initialize per-bucket line-index accumulators
+    # PHASE 1+2 -- initialize state, then line-scan the content into buckets
+    # (Phase 1 used to declare ~57 empty accumulators inline; Phase 2 was the
+    # detector loop that populated them.  Both now live inside scan_content.)
     # ------------------------------------------------------------------
     analyzer.checkfiles_flg = None
-    lines = content.splitlines()
     special_check_lines = []
-    anidb69_errors = []
-    anidb_auth_errors = []
-    api_blank_errors = []
-    bad_version_found_errors = []
-    cache_false = []
-    checkFiles = []
-    current_year = []
-    other_award = []
-    convert_errors = []
-    corrupt_image_errors = []
-    critical_errors = []
-    error_errors = []
-    warning_errors = []
-    delete_unmanaged_collections_errors = []
-    flixpatrol_errors = []
-    flixpatrol_paywall = []
-    git_kometa_errors = []
-    pmm_legacy_errors = []
-    image_size = []
-    internal_server_errors = []
-    lsio_errors = []
-    mal_connection_errors = []
-    mass_update_errors = []
-    mdblist_attr_errors = []
-    mdblist_errors = []
-    mdblist_api_limit_errors = []
-    metadata_attribute_errors = []
-    metadata_load_errors = []
-    missing_path_errors = []
-    new_version_found_errors = []
-    new_plexapi_version_found_errors = []
-    no_items_found_errors = []
-    omdb_errors = []
-    omdb_api_limit_errors = []
-    overlays_bloat = []
-    overlay_font_missing = []
-    overlay_apply_errors = []
-    overlay_image_missing = []
-    overlay_level_errors = []
-    overlay_load_errors = []
-    playlist_load_errors = []
-    playlist_errors = []
-    plex_lib_errors = []
-    plex_regex_errors = []
-    plex_url_errors = []
-    rounding_errors = []
-    ruamel_errors = []
-    run_order_errors = []
-    security_vuln_hits = []
-    traceback_errors = []
-    tautulli_url_errors = []
-    tautulli_apikey_errors = []
-    timeout_errors = []
-    to_be_configured_errors = []
-    tmdb_api_errors = []
-    tmdb_fail_errors = []
-    trakt_connection_errors = []
-
-    # ------------------------------------------------------------------
-    # PHASE 2 -- line-scan detector (populates the buckets above)
-    # ------------------------------------------------------------------
-    for idx, line in enumerate(lines, start=1):
-        if "run_order:" in line:
-            next_line = lines[idx] if idx < len(lines) else None
-            if next_line and "- operations" not in next_line:
-                run_order_errors.append(idx)
-        if "No Anime Found for AniDB ID: 69" in line:
-            anidb69_errors.append(idx)
-        if re.search(r"\bcache: false\b", line):
-            cache_false.append(idx)
-        if analyzer.server_versions and ("mass_user_rating_update" in line or "mass_episode_user_ratings_update" in line):
-
-            # Set to keep track of unique (server_name, server_version, idx) combinations
-            unique_entries = set()
-
-            # Iterate through each (server_name, server_version) tuple in analyzer.server_versions
-            for server_name, server_version in analyzer.server_versions:
-
-                # Create a unique identifier for the tuple
-                identifier = (server_name, server_version, idx)
-
-                # Check if the identifier is not in unique_entries (i.e., it's a new entry)
-                if identifier not in unique_entries:
-                    # Append server info to rounding_errors
-                    rounding_errors.append((server_name, server_version, idx))
-                    # Add the identifier to unique_entries set to mark it as processed
-                    unique_entries.add(identifier)
-
-        # Detect PMS versions in "Connected to server ..." lines and flag the vulnerable range
-        m = re.search(r"Connected to server\s+(.+?)\s+(?:\(?\s*(?:version|Version:)\s+)(\d+\.\d+\.\d+\.\d+(?:-[A-Za-z0-9]+)?)", line)
-        if m:
-            sn = m.group(1).strip()
-            ver = m.group(2).strip()
-            if is_vulnerable_pms_version(ver):
-                security_vuln_hits.append((sn, ver, idx))
-
-        if "Config Error: anidb sub-attribute" in line or "AniDB Error: Login failed" in line:
-            anidb_auth_errors.append(idx)
-        elif "apikey is blank" in line:
-            api_blank_errors.append(idx)
-        elif "1.32.7" in line and "Connected to server " in line:
-            bad_version_found_errors.append(idx)
-        elif "Convert Warning: No " in line and "ID Found for" in line:
-            convert_errors.append(idx)
-        elif "PIL.UnidentifiedImageError: cannot" in line:
-            corrupt_image_errors.append(idx)
-        elif "checkFiles=1" in line:
-            checkFiles.append(idx)
-        elif "current_year" in line:
-            current_year.append(idx)
-        elif "other_award" in line:
-            other_award.append(idx)
-        elif "delete_unmanaged_collections" in line:
-            delete_unmanaged_collections_errors.append(idx)
-        elif "internal_server_error" in line:
-            internal_server_errors.append(idx)
-        elif "FlixPatrol Error: " in line and "failed to parse" in line:
-            flixpatrol_errors.append(idx)
-        elif "flixpatrol" in line and "- pmm:" in line:
-            flixpatrol_paywall.append(idx)
-        elif "- git: PMM" in line:
-            git_kometa_errors.append(idx)
-        elif "- pmm: " in line:
-            pmm_legacy_errors.append(idx)
-        elif ", in _upload_image" in line:
-            image_size.append(idx)
-        elif "(Linuxserver" in line and "Version:" in line:
-            lsio_errors.append(idx)
-        elif "My Anime List Connection Failed" in line:
-            mal_connection_errors.append(idx)
-        elif "Config Error: Operation mass_" in line and "without a successful" in line:
-            mass_update_errors.append(idx)
-        elif "mdblist_list attribute not allowed with Collection Level: Season" in line:
-            mdblist_attr_errors.append(idx)
-        elif "MdbList Error: Invalid API key" in line:
-            mdblist_errors.append(idx)
-        elif "MDBList Error: API Limit Reached" in line or "MDBList Error: API Rate Limit Reached" in line:
-            mdblist_api_limit_errors.append(idx)
-        elif "metadata attribute is required" in line:
-            metadata_attribute_errors.append(idx)
-        elif "Metadata File Failed To Load" in line:
-            metadata_load_errors.append(idx)
-        elif "Overlay File Failed To Load" in line:
-            overlay_load_errors.append(idx)
-        elif "Playlist File Failed To Load" in line:
-            playlist_load_errors.append(idx)
-        elif "missing_path" in line or "save_missing" in line:
-            missing_path_errors.append(idx)
-        elif "Newest Version: " in line:
-            new_version_found_errors.append(idx)
-        elif "requires an update to:" in line:
-            new_plexapi_version_found_errors.append(idx)
-        elif "OMDb Error: Invalid API key" in line:
-            omdb_errors.append(idx)
-        elif "OMDb Error: Request limit reached" in line:
-            omdb_api_limit_errors.append(idx)
-        elif "Overlay Error: Poster already has an Overlay" in line:
-            overlay_apply_errors.append(idx)
-        elif "| Overlay Error: Overlay Image not found" in line:
-            overlay_image_missing.append(idx)
-        elif "overlay_level:" in line:
-            overlay_level_errors.append(idx)
-        elif "Plex Error: No Items found in Plex" in line:
-            no_items_found_errors.append(idx)
-        elif "Overlay Error: font:" in line:
-            overlay_font_missing.append(idx)
-        elif "Reapply Overlays: True" in line or "Reset Overlays: [" in line:
-            overlays_bloat.append(idx)
-        elif "Playlist Error: Library: " in line and "not defined" in line:
-            playlist_errors.append(idx)
-        elif "Plex Error: Plex Library " in line and "not found" in line:
-            plex_lib_errors.append(idx)
-        elif "Plex Error: " in line and "No matches found with regex pattern" in line:
-            plex_regex_errors.append(idx)
-        elif "Plex Error: Plex url is invalid" in line:
-            plex_url_errors.append(idx)
-        elif "ruamel.yaml." in line:
-            ruamel_errors.append(idx)
-        elif "TMDb Error: Invalid API key" in line:
-            tmdb_api_errors.append(idx)
-        elif "Traceback (most recent call last):" in line:
-            traceback_errors.append(idx)
-        elif "Tautulli Error: Invalid apikey" in line:
-            tautulli_apikey_errors.append(idx)
-        elif "Tautulli Error: Invalid URL" in line:
-            tautulli_url_errors.append(idx)
-        elif "timed out." in line:
-            timeout_errors.append(idx)
-        elif "Failed to Connect to https://api.themoviedb.org/3" in line:
-            tmdb_fail_errors.append(idx)
-        elif "Error: " in line and " requires " in line and " to be configured" in line:
-            to_be_configured_errors.append(idx)
-        elif "Trakt Connection Failed" in line:
-            trakt_connection_errors.append(idx)
-        elif "[CRITICAL]" in line:
-            critical_errors.append(idx)
-        elif "[ERROR]" in line:
-            error_errors.append(idx)
-        elif "[WARNING]" in line:
-            warning_errors.append(idx)
+    buckets = scan_content(analyzer, content)
 
     # ------------------------------------------------------------------
     # PHASE 3 -- build advisory messages from the populated buckets
@@ -292,69 +91,13 @@ def make_recommendations(analyzer, content, incomplete_message):
         content=content,
         incomplete_message=incomplete_message,
         special_check_lines=special_check_lines,
-        # buckets
-        anidb69_errors=anidb69_errors,
-        anidb_auth_errors=anidb_auth_errors,
-        api_blank_errors=api_blank_errors,
-        bad_version_found_errors=bad_version_found_errors,
-        cache_false=cache_false,
-        checkFiles=checkFiles,
-        other_award=other_award,
-        critical_errors=critical_errors,
-        error_errors=error_errors,
-        warning_errors=warning_errors,
-        convert_errors=convert_errors,
-        corrupt_image_errors=corrupt_image_errors,
-        delete_unmanaged_collections_errors=delete_unmanaged_collections_errors,
-        flixpatrol_errors=flixpatrol_errors,
-        flixpatrol_paywall=flixpatrol_paywall,
-        git_kometa_errors=git_kometa_errors,
-        pmm_legacy_errors=pmm_legacy_errors,
-        image_size=image_size,
-        internal_server_errors=internal_server_errors,
-        lsio_errors=lsio_errors,
-        mal_connection_errors=mal_connection_errors,
-        mass_update_errors=mass_update_errors,
-        mdblist_attr_errors=mdblist_attr_errors,
-        mdblist_errors=mdblist_errors,
-        mdblist_api_limit_errors=mdblist_api_limit_errors,
-        metadata_attribute_errors=metadata_attribute_errors,
-        metadata_load_errors=metadata_load_errors,
-        overlay_load_errors=overlay_load_errors,
-        playlist_load_errors=playlist_load_errors,
-        missing_path_errors=missing_path_errors,
-        new_plexapi_version_found_errors=new_plexapi_version_found_errors,
-        new_version_found_errors=new_version_found_errors,
-        no_items_found_errors=no_items_found_errors,
-        omdb_errors=omdb_errors,
-        omdb_api_limit_errors=omdb_api_limit_errors,
-        overlay_font_missing=overlay_font_missing,
-        overlays_bloat=overlays_bloat,
-        overlay_apply_errors=overlay_apply_errors,
-        overlay_image_missing=overlay_image_missing,
-        overlay_level_errors=overlay_level_errors,
-        playlist_errors=playlist_errors,
-        plex_regex_errors=plex_regex_errors,
-        plex_lib_errors=plex_lib_errors,
-        plex_url_errors=plex_url_errors,
-        rounding_errors=rounding_errors,
-        ruamel_errors=ruamel_errors,
-        run_order_errors=run_order_errors,
-        security_vuln_hits=security_vuln_hits,
-        traceback_errors=traceback_errors,
-        tautulli_apikey_errors=tautulli_apikey_errors,
-        tautulli_url_errors=tautulli_url_errors,
-        tmdb_api_errors=tmdb_api_errors,
-        timeout_errors=timeout_errors,
-        tmdb_fail_errors=tmdb_fail_errors,
-        to_be_configured_errors=to_be_configured_errors,
-        trakt_connection_errors=trakt_connection_errors,
+        **buckets,
     )
 
     # ------------------------------------------------------------------
     # PHASE 4 -- side-effect: flip the checkfiles flag
     # ------------------------------------------------------------------
-    if checkFiles:
+    if buckets["checkFiles"]:
         analyzer.checkfiles_flg = 1
 
     # ------------------------------------------------------------------
@@ -372,58 +115,7 @@ def make_recommendations(analyzer, content, incomplete_message):
     # PHASE 6 -- issue-counts dict for the dashboard
     # ------------------------------------------------------------------
     issue_counts = build_issue_counts(
-        buckets={
-            "tmdb_api_errors": tmdb_api_errors,
-            "tmdb_fail_errors": tmdb_fail_errors,
-            "trakt_connection_errors": trakt_connection_errors,
-            "omdb_errors": omdb_errors,
-            "omdb_api_limit_errors": omdb_api_limit_errors,
-            "mdblist_errors": mdblist_errors,
-            "mdblist_api_limit_errors": mdblist_api_limit_errors,
-            "mdblist_attr_errors": mdblist_attr_errors,
-            "mal_connection_errors": mal_connection_errors,
-            "tautulli_url_errors": tautulli_url_errors,
-            "tautulli_apikey_errors": tautulli_apikey_errors,
-            "flixpatrol_errors": flixpatrol_errors,
-            "flixpatrol_paywall": flixpatrol_paywall,
-            "lsio_errors": lsio_errors,
-            "to_be_configured_errors": to_be_configured_errors,
-            "api_blank_errors": api_blank_errors,
-            "bad_version_found_errors": bad_version_found_errors,
-            "missing_path_errors": missing_path_errors,
-            "cache_false": cache_false,
-            "mass_update_errors": mass_update_errors,
-            "other_award": other_award,
-            "delete_unmanaged_collections_errors": delete_unmanaged_collections_errors,
-            "plex_url_errors": plex_url_errors,
-            "plex_regex_errors": plex_regex_errors,
-            "plex_lib_errors": plex_lib_errors,
-            "rounding_errors": rounding_errors,
-            "metadata_attribute_errors": metadata_attribute_errors,
-            "metadata_load_errors": metadata_load_errors,
-            "overlay_load_errors": overlay_load_errors,
-            "overlay_apply_errors": overlay_apply_errors,
-            "overlay_level_errors": overlay_level_errors,
-            "overlay_font_missing": overlay_font_missing,
-            "overlay_image_missing": overlay_image_missing,
-            "playlist_load_errors": playlist_load_errors,
-            "playlist_errors": playlist_errors,
-            "overlays_bloat": overlays_bloat,
-            "convert_errors": convert_errors,
-            "corrupt_image_errors": corrupt_image_errors,
-            "image_size": image_size,
-            "run_order_errors": run_order_errors,
-            "checkFiles": checkFiles,
-            "timeout_errors": timeout_errors,
-            "new_version_found_errors": new_version_found_errors,
-            "new_plexapi_version_found_errors": new_plexapi_version_found_errors,
-            "git_kometa_errors": git_kometa_errors,
-            "anidb69_errors": anidb69_errors,
-            "anidb_auth_errors": anidb_auth_errors,
-            "internal_server_errors": internal_server_errors,
-            "no_items_found_errors": no_items_found_errors,
-            "pmm_legacy_errors": pmm_legacy_errors,
-        },
+        buckets=buckets,
         platform_recs=platform_recs,
     )
 


### PR DESCRIPTION
Third and final extraction from `modules/logscan_recommendations_engine.py`.

## Summary

**`modules/logscan_recommendations_engine.py`: 513 → 205 (-308 / -60%)**

Cumulative Sprint 5 reduction on this file: **1429 → 205 (-85.7%)**.

## What moved

**New module**: `modules/logscan_line_scan.py` (~317 lines)

Single public function `scan_content(analyzer, content)` that owns what used to be Phase 1 (~57 bucket declarations) + Phase 2 (the big if/elif line-scan detector loop) of `make_recommendations`.  Returns a dict of bucket-name → list of matched line indices.

**The for-loop body is AST-verified byte-identical to develop's Phase 2.**

## The real win: caller-side collapse

Because `scan_content` returns a dict, three callers in the engine collapsed dramatically:

| Site | Before | After | Δ |
|---|---|---|---|
| Phase 3 (advisory msgs) | 59 explicit kwargs | `**buckets` | ~55 lines |
| Phase 4 (checkfiles flag) | `if checkFiles:` | `if buckets["checkFiles"]:` | 0 |
| Phase 6 (issue counts) | 50-key inline dict literal | `buckets=buckets` | ~50 lines |

That's why the engine dropped 308 lines even though `scan_content` itself is 317 -- the caller-side unpacking boilerplate completely disappeared.

## Dead-code removal (YAGNI)

While auditing the buckets, spotted `current_year`: populated by Phase 2 (via `elif "current_year" in line:`) but **never read anywhere**.  The advisory-messages module had the consumer block commented out at line 202 (some legacy pmm→kometa schema migration warning that got shelved).

Removed:
- The `append` site in `scan_content`
- The empty-list initializer  
- The commented-out advisory block in `logscan_advisory_messages.py`

DRY / YAGNI cleanup.  **Zero observable behavior change** — the list was written but never read.

## What stays in the engine (205 lines)

`make_recommendations` is now a clean **60-line 6-phase pipeline**:

```python
def make_recommendations(analyzer, content, incomplete_message):
    # Phase 1+2: scan content into buckets
    analyzer.checkfiles_flg = None
    special_check_lines = []
    buckets = scan_content(analyzer, content)

    # Phase 3: build advisory messages
    platform_recs = _build_advisory_messages(
        analyzer=analyzer, content=content,
        incomplete_message=incomplete_message,
        special_check_lines=special_check_lines, **buckets,
    )

    # Phase 4: side-effect flag
    if buckets["checkFiles"]:
        analyzer.checkfiles_flg = 1

    # Phase 5: dict-ify the advisory messages
    recommendation_messages = [...]

    # Phase 6: issue-counts dict
    issue_counts = build_issue_counts(
        buckets=buckets, platform_recs=platform_recs,
    )
    return recommendation_messages, issue_counts
```

Plus 3 stand-alone helpers (`ensure_recommendation_icons`, `reorder_recommendations`, `extract_analyze_issue_counts`) and the `_PRIORITY_*` constants.

## Verification

- **AST-verified**: Phase 2 for-loop body byte-identical to develop
- **All 3 remaining engine helpers** byte-identical to develop
- `scan_content` returns **57 buckets** (down from 58 — `current_year` removed)
- Import + detector smoke tests pass
- **Full test suite: 0 failures** (1300+ tests, including all logscan integration tests)
- Ruff + Black clean

## Sprint 5 running total on `logscan_recommendations_engine.py`

| Milestone | Ending lines | Δ |
|---|---|---|
| Baseline (start of sprint) | 1429 | — |
| After PR #1527 (issue_counts) | 1377 | -52 |
| After PR #1528 (advisory_messages) | 513 | -864 |
| **This PR** (line_scan) | **205** | **-308** |
| **Cumulative** | **205** | **-1224 / -85.7%** |

## Sprint 5 file scoreboard update

| File | Baseline | Current | Reduction |
|---|---|---|---|
| `logscan_recommendations_engine.py` | 1429 | **205** | **-85.7%**  |
| `import_config_routes.py` | 1384 | 1384 | untouched |
| `asset_routes.py` | 836 | 836 | untouched |
| `kometa_updates.py` | 811 | 811 | untouched |
| `validations_yaml_files.py` | 772 | 772 | untouched |
| `logscan_progress_engine.py` | 770 | 770 | untouched |
| `database.py` | 760 | 760 | untouched |
| `output_library_ops.py` | 709 | 709 | untouched |

`logscan_recommendations_engine.py` has now graduated from the offender list — 205 lines is well under the 600-line threshold.