### PR TITLE
Extract upload-bundle handling from import_config_preview

### DIFF
--- a/blueprints/import_config_bundle.py
+++ b/blueprints/import_config_bundle.py
@@ -1,0 +1,217 @@
+"""Upload-bundle extraction for the config-import preview flow.
+
+Split out of :mod:`blueprints.import_config_routes` -- the
+``import_config_preview`` route used to inline ~100 lines of
+zipfile handling that categorized archive members, validated the
+bundle shape, wrote font/library/overlay artifacts to a cache
+directory, and left ``config_text`` populated for downstream YAML
+parsing.  That mega-block is now :func:`extract_bundle_upload`.
+
+## What lives here
+
+Single public entry point :func:`extract_bundle_upload` that
+takes the raw upload bytes plus the (already-lowercased) filename
+and returns a :class:`BundleExtractionResult` describing either:
+
+* A successful extraction (config_text populated, plus optional
+  extracted_dir and extracted_fonts for bundled artifacts), or
+* An error response (Flask ``jsonify`` tuple) that the caller
+  should return directly.
+
+The route side stays as a thin caller:
+
+.. code-block:: python
+
+    result = extract_bundle_upload(raw_text, file_name)
+    if result.error_response:
+        return result.error_response
+    config_text = result.config_text
+    extracted_dir = result.extracted_dir
+    extracted_fonts = result.extracted_fonts
+
+## Why a dataclass instead of a tuple?
+
+Four return values, three of them optional, and code paths that
+inspect ``error_response`` vs use the payload -- keyword access
+reads better than positional unpacking and lets the caller ignore
+fields it doesn't need.  The dataclass is a plain
+``@dataclass(slots=True)``; no fancy behaviour.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import zipfile
+from dataclasses import dataclass, field
+from io import BytesIO
+from pathlib import Path
+
+from flask import jsonify
+
+from modules import bundle_artifacts, helpers
+from modules.library_file_entries import _is_bundled_library_archive_member
+
+
+@dataclass(slots=True)
+class BundleExtractionResult:
+    """Outcome of :func:`extract_bundle_upload`.
+
+    Exactly one of ``config_text`` or ``error_response`` will be
+    populated on any given call.  ``extracted_dir`` and
+    ``extracted_fonts`` are only set when the upload was a zip
+    bundle carrying font/library/overlay artifacts.
+    """
+
+    config_text: str = ""
+    extracted_dir: Path | None = None
+    extracted_fonts: list = field(default_factory=list)
+    error_response: tuple | None = None
+
+
+def extract_bundle_upload(raw_text: bytes, file_name: str) -> BundleExtractionResult:
+    """Extract YAML text (and any bundled artifacts) from an upload.
+
+    :param raw_text: raw bytes read from the uploaded file.
+    :param file_name: the *lowercased* upload filename, used to
+        pick between the zip-bundle and plain-YAML code paths.
+    :returns: a :class:`BundleExtractionResult`.  If
+        ``.error_response`` is truthy the caller MUST return it
+        directly (it's a Flask ``jsonify`` tuple with an
+        appropriate 4xx status).  Otherwise ``.config_text`` is
+        the YAML text ready for parsing, and ``.extracted_dir`` /
+        ``.extracted_fonts`` describe any bundled artifacts that
+        were written to disk.
+    """
+    if file_name.endswith(".zip"):
+        return _extract_zip_bundle(raw_text)
+    try:
+        config_text = raw_text.decode("utf-8")
+    except UnicodeDecodeError:
+        config_text = raw_text.decode("utf-8", errors="ignore")
+    return BundleExtractionResult(config_text=config_text)
+
+
+def _extract_zip_bundle(raw_text: bytes) -> BundleExtractionResult:
+    """Handle the zip-archive branch of :func:`extract_bundle_upload`."""
+    extracted_fonts: list = []
+    extracted_dir: Path | None = None
+    config_text = ""
+
+    try:
+        with zipfile.ZipFile(BytesIO(raw_text)) as archive:
+            archive_members = archive.namelist()
+            unexpected_members = []
+            bundled_library_files = []
+            bundled_overlay_images = []
+            config_files = []
+            font_files = []
+
+            for member_name in archive_members:
+                normalized_member = bundle_artifacts.normalize_bundle_member_name(member_name)
+                if not normalized_member:
+                    continue
+                if not bundle_artifacts.is_allowed_bundle_member(normalized_member):
+                    unexpected_members.append(normalized_member)
+                    continue
+                if _is_bundled_library_archive_member(normalized_member):
+                    bundled_library_files.append(member_name)
+                elif bundle_artifacts.is_bundled_overlay_image_archive_member(normalized_member):
+                    bundled_overlay_images.append(member_name)
+                elif bundle_artifacts.yaml_path_suffix(normalized_member):
+                    config_files.append(member_name)
+                elif normalized_member.lower().endswith((".ttf", ".otf")):
+                    font_files.append(member_name)
+
+            if unexpected_members:
+                preview = ", ".join(unexpected_members[:5])
+                if len(unexpected_members) > 5:
+                    preview += ", ..."
+                return BundleExtractionResult(error_response=(jsonify(success=False, message=f"Zip file contains unsupported entries: {preview}"), 400))
+            if not config_files:
+                return BundleExtractionResult(error_response=(jsonify(success=False, message="No YAML config found in zip file."), 400))
+            if len(config_files) > 1:
+                return BundleExtractionResult(error_response=(jsonify(success=False, message="Zip file must contain exactly one YAML config."), 400))
+
+            try:
+                with archive.open(config_files[0]) as handle:
+                    config_text = handle.read().decode("utf-8", errors="ignore")
+            except Exception:
+                return BundleExtractionResult(error_response=(jsonify(success=False, message="Unable to read config from zip."), 400))
+
+            if font_files or bundled_library_files or bundled_overlay_images:
+                cache_dir = Path(helpers.CONFIG_DIR) / "import_cache"
+                cache_dir.mkdir(parents=True, exist_ok=True)
+                extracted_dir = cache_dir / f"bundle_{secrets.token_urlsafe(8)}"
+                extracted_dir.mkdir(parents=True, exist_ok=True)
+                if font_files:
+                    _extract_fonts(archive, font_files, extracted_dir, extracted_fonts)
+                _extract_bundled_files(archive, bundled_library_files, extracted_dir)
+                _extract_bundled_files(archive, bundled_overlay_images, extracted_dir)
+    except Exception:
+        return BundleExtractionResult(error_response=(jsonify(success=False, message="Unable to read zip file."), 400))
+
+    return BundleExtractionResult(
+        config_text=config_text,
+        extracted_dir=extracted_dir,
+        extracted_fonts=extracted_fonts,
+    )
+
+
+def _extract_fonts(archive, font_files, extracted_dir: Path, extracted_fonts: list) -> None:
+    """Write font files from the archive into ``extracted_dir/fonts/``.
+
+    Handles name collisions by suffixing ``_1``, ``_2``, ... to
+    duplicate basenames.  Silently skips fonts that can't be
+    extracted -- fonts are optional decoration for the preview.
+    Mutates ``extracted_fonts`` with the safe basenames of every
+    font that made it to disk.
+    """
+    fonts_dir = extracted_dir / "fonts"
+    fonts_dir.mkdir(parents=True, exist_ok=True)
+    seen_names: set[str] = set()
+    for font_name in font_files:
+        base_name = os.path.basename(font_name)
+        if not base_name:
+            continue
+        safe_name = base_name
+        counter = 1
+        while safe_name in seen_names:
+            stem, ext = os.path.splitext(base_name)
+            safe_name = f"{stem}_{counter}{ext}"
+            counter += 1
+        seen_names.add(safe_name)
+        try:
+            with archive.open(font_name) as source:
+                target = fonts_dir / safe_name
+                with open(target, "wb") as dest:
+                    dest.write(source.read())
+                extracted_fonts.append(safe_name)
+        except Exception:
+            continue
+
+
+def _extract_bundled_files(archive, member_names, extracted_dir: Path) -> None:
+    """Write library/overlay files from the archive into ``extracted_dir``.
+
+    Preserves the archive's directory structure (unlike the flat
+    ``_extract_fonts``).  Zip-slip protection: any member whose
+    resolved target would escape ``extracted_dir`` is silently
+    skipped.  Empty and directory members are also skipped.
+    """
+    resolved_root = extracted_dir.resolve()
+    for member_name in member_names:
+        normalized_member = str(member_name).replace("\\", "/").lstrip("/")
+        if not normalized_member or normalized_member.endswith("/"):
+            continue
+        target = (extracted_dir / Path(normalized_member)).resolve()
+        try:
+            target.relative_to(resolved_root)
+        except Exception:
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with archive.open(member_name) as source, open(target, "wb") as dest:
+                dest.write(source.read())
+        except Exception:
+            continue

--- a/blueprints/import_config_routes.py
+++ b/blueprints/import_config_routes.py
@@ -12,30 +12,33 @@ Public surface (used by tests via ``qs_module.<name>`` re-exports):
 
 ## File-size note
 
-This file is ~1,200 lines, still above the 600-line soft-limit.  The 12
-shared helpers moved to :mod:`blueprints.import_config_helpers` in a
-previous PR, trimming ~200 lines.  The four remaining routes are tightly
-coupled through a shared session-cache flow (import_preview_token /
-import_preview_path / import_preview_*_url / import_preview_*_token) so
-splitting them into separate per-route modules would either duplicate the
-shared local logic or require a sub-package with relative imports -- both
-worse than keeping them together.  ``import_config_preview`` alone is
-~510 lines (down from ~590 after hoisting six nested credential parsers
-to module scope); that one mega-function is still the real elephant and
-a candidate for further internal decomposition (zip extraction, plex
-validation, tmdb validation).
+This file is ~1,080 lines, still above the 600-line soft-limit.  Two
+chunks have already moved out:
+
+* :mod:`blueprints.import_config_helpers` -- 12 pure helpers (~240 lines)
+* :mod:`blueprints.import_config_bundle` -- upload / zip extraction
+  (~230 lines)
+
+The four remaining routes are tightly coupled through a shared
+session-cache flow (import_preview_token / import_preview_path /
+import_preview_*_url / import_preview_*_token) so splitting them into
+separate per-route modules would either duplicate the shared local logic
+or require a sub-package with relative imports -- both worse than
+keeping them together.  ``import_config_preview`` alone is ~400 lines
+(down from ~510 after the bundle extraction); its plex-validation
+(~125 lines) and tmdb-validation (~180 lines) blocks are the next
+natural sub-extractions.
 """
 
 import json
 import os
 import secrets
 import shutil
-import zipfile
-from io import BytesIO
 from pathlib import Path
 
 from flask import Blueprint, Flask, current_app, jsonify, request, session
 
+from blueprints.import_config_bundle import extract_bundle_upload
 from blueprints.import_config_helpers import (  # noqa: F401 (re-exports for tests and legacy callers)
     _coerce_validation_response_payload,
     _import_preview_json_default,
@@ -51,10 +54,7 @@ from blueprints.import_config_helpers import (  # noqa: F401 (re-exports for tes
     count_annotated_lines,
 )
 from modules import assets, bundle_artifacts, database, helpers, importer, persistence, validations
-from modules.library_file_entries import (
-    _is_bundled_library_archive_member,
-    _normalize_imported_libraries_payload,
-)
+from modules.library_file_entries import _normalize_imported_libraries_payload
 
 bp = Blueprint("import_config_routes", __name__)
 
@@ -98,116 +98,12 @@ def import_config_preview():
         base_config = base_match
 
     raw_text = upload.read()
-    config_text = ""
-    extracted_fonts = []
-    extracted_dir = None
-    if file_name.endswith(".zip"):
-        try:
-            with zipfile.ZipFile(BytesIO(raw_text)) as archive:
-                archive_members = archive.namelist()
-                unexpected_members = []
-                bundled_library_files = []
-                bundled_overlay_images = []
-                config_files = []
-                font_files = []
-
-                for member_name in archive_members:
-                    normalized_member = bundle_artifacts.normalize_bundle_member_name(member_name)
-                    if not normalized_member:
-                        continue
-                    if not bundle_artifacts.is_allowed_bundle_member(normalized_member):
-                        unexpected_members.append(normalized_member)
-                        continue
-                    if _is_bundled_library_archive_member(normalized_member):
-                        bundled_library_files.append(member_name)
-                    elif bundle_artifacts.is_bundled_overlay_image_archive_member(normalized_member):
-                        bundled_overlay_images.append(member_name)
-                    elif bundle_artifacts.yaml_path_suffix(normalized_member):
-                        config_files.append(member_name)
-                    elif normalized_member.lower().endswith((".ttf", ".otf")):
-                        font_files.append(member_name)
-
-                if unexpected_members:
-                    preview = ", ".join(unexpected_members[:5])
-                    if len(unexpected_members) > 5:
-                        preview += ", ..."
-                    return jsonify(success=False, message=f"Zip file contains unsupported entries: {preview}"), 400
-                if not config_files:
-                    return jsonify(success=False, message="No YAML config found in zip file."), 400
-                if len(config_files) > 1:
-                    return jsonify(success=False, message="Zip file must contain exactly one YAML config."), 400
-
-                try:
-                    with archive.open(config_files[0]) as handle:
-                        config_text = handle.read().decode("utf-8", errors="ignore")
-                except Exception:
-                    return jsonify(success=False, message="Unable to read config from zip."), 400
-
-                if font_files or bundled_library_files or bundled_overlay_images:
-                    cache_dir = Path(helpers.CONFIG_DIR) / "import_cache"
-                    cache_dir.mkdir(parents=True, exist_ok=True)
-                    extracted_dir = cache_dir / f"bundle_{secrets.token_urlsafe(8)}"
-                    extracted_dir.mkdir(parents=True, exist_ok=True)
-                    if font_files:
-                        fonts_dir = extracted_dir / "fonts"
-                        fonts_dir.mkdir(parents=True, exist_ok=True)
-                        seen_names = set()
-                        for font_name in font_files:
-                            base_name = os.path.basename(font_name)
-                            if not base_name:
-                                continue
-                            safe_name = base_name
-                            counter = 1
-                            while safe_name in seen_names:
-                                stem, ext = os.path.splitext(base_name)
-                                safe_name = f"{stem}_{counter}{ext}"
-                                counter += 1
-                            seen_names.add(safe_name)
-                            try:
-                                with archive.open(font_name) as source:
-                                    target = fonts_dir / safe_name
-                                    with open(target, "wb") as dest:
-                                        dest.write(source.read())
-                                    extracted_fonts.append(safe_name)
-                            except Exception:
-                                continue
-                    for member_name in bundled_library_files:
-                        normalized_member = str(member_name).replace("\\", "/").lstrip("/")
-                        if not normalized_member or normalized_member.endswith("/"):
-                            continue
-                        target = (extracted_dir / Path(normalized_member)).resolve()
-                        try:
-                            target.relative_to(extracted_dir.resolve())
-                        except Exception:
-                            continue
-                        target.parent.mkdir(parents=True, exist_ok=True)
-                        try:
-                            with archive.open(member_name) as source, open(target, "wb") as dest:
-                                dest.write(source.read())
-                        except Exception:
-                            continue
-                    for member_name in bundled_overlay_images:
-                        normalized_member = str(member_name).replace("\\", "/").lstrip("/")
-                        if not normalized_member or normalized_member.endswith("/"):
-                            continue
-                        target = (extracted_dir / Path(normalized_member)).resolve()
-                        try:
-                            target.relative_to(extracted_dir.resolve())
-                        except Exception:
-                            continue
-                        target.parent.mkdir(parents=True, exist_ok=True)
-                        try:
-                            with archive.open(member_name) as source, open(target, "wb") as dest:
-                                dest.write(source.read())
-                        except Exception:
-                            continue
-        except Exception:
-            return jsonify(success=False, message="Unable to read zip file."), 400
-    else:
-        try:
-            config_text = raw_text.decode("utf-8")
-        except UnicodeDecodeError:
-            config_text = raw_text.decode("utf-8", errors="ignore")
+    result = extract_bundle_upload(raw_text, file_name)
+    if result.error_response:
+        return result.error_response
+    config_text = result.config_text
+    extracted_fonts = result.extracted_fonts
+    extracted_dir = result.extracted_dir
 
     parsed = importer.load_yaml_config(config_text)
     if not parsed:


### PR DESCRIPTION
Second cut into `blueprints/import_config_routes.py`.  Attacks the elephant.

## Summary

**`blueprints/import_config_routes.py`: 1188 to 1082 (-106 / -8.9%)**
**`import_config_preview`: 511 to 407 lines (-104)**

## What moved

**New module**: `blueprints/import_config_bundle.py` (~217 lines)

Public entry point: `extract_bundle_upload(raw_text, file_name)` returns a `BundleExtractionResult` dataclass with either:

- `config_text` populated (success path), or  
- `error_response` as a Flask `jsonify` tuple that the caller returns directly

Plus optional `extracted_dir` and `extracted_fonts` for zip bundles that carry font/library/overlay artifacts.

The caller collapsed from 104 lines of inline zipfile handling to a 6-line thin caller pattern:

```python
result = extract_bundle_upload(raw_text, file_name)
if result.error_response:
    return result.error_response
config_text = result.config_text
extracted_fonts = result.extracted_fonts
extracted_dir = result.extracted_dir
```

## Internal DRY win

The develop-branch inline code had **two byte-identical 22-line loops** for extracting bundled artifacts, one for `bundled_library_files` and one for `bundled_overlay_images`.  These were textually identical, with only the source list name differing.

Refactored to a single `_extract_bundled_files` helper called twice.  Also hoisted the font-extraction loop to `_extract_fonts` so the top of `extract_bundle_upload` reads as intent (categorize, then extract each category) rather than implementation.

## Backward compatibility

- `import_config_preview` retains its exact public route surface
- All Flask error responses are byte-identical (verified with a README-only zip in an app context: `Zip file contains unsupported entries: README.md`)
- Test suite: 0 failures
- Ruff + Black clean

## Verification

- **AST-verified**: `import_config_report`, `import_config_preview_mapped`, `import_config_confirm` all byte-identical to develop
- `import_config_preview` intentionally differs (thin caller pattern)
- Full test suite passes
- Dropped now-unused imports from routes file: `zipfile`, `BytesIO`, `_is_bundled_library_archive_member`

## Sprint 5 scoreboard on this file

| Milestone | Ending lines | Δ |
|---|---|---|
| Baseline | 1384 | -- |
| After #1530 (helpers) | 1188 | -196 |
| **This PR** (bundle) | **1082** | **-106** |
| **Cumulative** | **1082** | **-302 / -21.8%** |

## Next natural targets

- Plex validation block inside `import_config_preview` (~125 lines) -- pure state machine over creds + library validation
- TMDb validation block (~180 lines) -- same shape as Plex block, lots of shared structure

Those two would take `import_config_preview` from 407 to ~100 lines, and the file from 1082 to ~775.