### PR TITLE
Extract confirm-flow validators + library-mapping validator

### DIFF
--- a/blueprints/import_config_routes.py
+++ b/blueprints/import_config_routes.py
@@ -12,24 +12,21 @@ Public surface (used by tests via ``qs_module.<name>`` re-exports):
 
 ## File-size note
 
-This file is ~875 lines, still above the 600-line soft-limit.  Three
+This file is ~810 lines, still above the 600-line soft-limit.  Four
 chunks have already moved out:
 
 * :mod:`blueprints.import_config_helpers` -- 12 pure helpers (~240 lines)
 * :mod:`blueprints.import_config_bundle` -- upload / zip extraction
   and the ``cleanup_bundle_dir`` helper (~245 lines)
 * :mod:`blueprints.import_config_validators` -- Plex + TMDb credential
-  validation state machines (~340 lines)
+  validation state machines for BOTH the preview and confirm flows,
+  plus the library-mapping validator (~555 lines)
 
-``import_config_preview`` alone is now ~85 lines (down from ~510) --
-firmly out of elephant territory.
-
-The four remaining routes are tightly coupled through a shared
-session-cache flow (import_preview_token / import_preview_path /
-import_preview_*_url / import_preview_*_token) so splitting them into
-separate per-route modules would either duplicate the shared local logic
-or require a sub-package with relative imports -- both worse than
-keeping them together.
+Both ``import_config_preview`` (~220 lines) and ``import_config_confirm``
+(~250 lines) are now firmly out of elephant territory.  The four
+routes remain in one file because they're tightly coupled through a
+shared session-cache flow (import_preview_token / import_preview_path
+/ import_preview_*_url / import_preview_*_token).
 """
 
 import json
@@ -38,7 +35,7 @@ import secrets
 import shutil
 from pathlib import Path
 
-from flask import Blueprint, Flask, current_app, jsonify, request, session
+from flask import Blueprint, current_app, jsonify, request, session
 
 from blueprints.import_config_bundle import extract_bundle_upload
 from blueprints.import_config_helpers import (  # noqa: F401 (re-exports for tests and legacy callers)
@@ -56,6 +53,9 @@ from blueprints.import_config_helpers import (  # noqa: F401 (re-exports for tes
     count_annotated_lines,
 )
 from blueprints.import_config_validators import (
+    validate_confirm_plex_credentials,
+    validate_confirm_tmdb_credentials,
+    validate_library_mapping,
     validate_plex_credentials,
     validate_tmdb_credentials,
 )
@@ -656,137 +656,35 @@ def import_config_confirm():
                 # Skip Plex validation when base config provides library cache.
                 pass
             else:
-                plex_url = session.get("import_preview_plex_url") or ""
-                plex_token = session.get("import_preview_plex_token") or ""
-                if not plex_url or not plex_token:
-                    return (
-                        jsonify(
-                            success=False,
-                            message="Plex credentials are required to confirm the import. Re-run Preview Import.",
-                        ),
-                        400,
-                    )
-
-                plex_response = validations.validate_plex_server({"plex_url": plex_url, "plex_token": plex_token})
-                plex_result = plex_response.get_json() if isinstance(plex_response, Flask.response_class) else plex_response
-                if not plex_result or not plex_result.get("validated"):
-                    error_message = plex_result.get("error") if isinstance(plex_result, dict) else None
-                    return (
-                        jsonify(
-                            success=False,
-                            message=error_message or "Plex validation failed. Re-run Preview Import.",
-                        ),
-                        400,
-                    )
-                movie_names = _parse_csv_or_list_to_set(plex_result.get("movie_libraries", []))
-                show_names = _parse_csv_or_list_to_set(plex_result.get("show_libraries", []))
-                if not movie_names and not show_names:
-                    return (
-                        jsonify(
-                            success=False,
-                            message="No movie or show libraries found in Plex.",
-                        ),
-                        400,
-                    )
+                plex_outcome = validate_confirm_plex_credentials()
+                if plex_outcome.error_response:
+                    return plex_outcome.error_response
+                movie_names = plex_outcome.movie_names
+                show_names = plex_outcome.show_names
         else:
             plex_data = persistence.retrieve_settings("010-plex").get("plex", {})
             movie_names = _parse_csv_or_list_to_set(plex_data.get("tmp_movie_libraries", ""))
             show_names = _parse_csv_or_list_to_set(plex_data.get("tmp_show_libraries", ""))
 
         if needs_tmdb:
-            tmdb_apikey = session.get("import_preview_tmdb_apikey") or ""
-            if not tmdb_apikey:
-                return (
-                    jsonify(
-                        success=False,
-                        message="TMDb API key is required to confirm the import. Re-run Preview Import.",
-                    ),
-                    400,
-                )
-            tmdb_response = validations.validate_tmdb_server({"tmdb_apikey": tmdb_apikey})
-            tmdb_result = tmdb_response.get_json() if isinstance(tmdb_response, Flask.response_class) else tmdb_response
-            if not tmdb_result or not tmdb_result.get("valid"):
-                error_message = tmdb_result.get("message") if isinstance(tmdb_result, dict) else None
-                return (
-                    jsonify(
-                        success=False,
-                        message=error_message or "TMDb validation failed. Re-run Preview Import.",
-                    ),
-                    400,
-                )
+            tmdb_error = validate_confirm_tmdb_credentials()
+            if tmdb_error:
+                return tmdb_error
 
         plex_lookup = {name: name for name in movie_names}
         plex_lookup.update({name: name for name in show_names})
         plex_names = set(plex_lookup.values())
 
         if isinstance(libraries_payload, dict):
-            if needs_plex and not plex_names:
-                return (
-                    jsonify(
-                        success=False,
-                        message="Plex libraries are unavailable. Validate Plex and preview the import again.",
-                    ),
-                    400,
-                )
-
-            missing = []
-            invalid_targets = []
-            duplicates = []
-            used_targets = set()
-            mapped_libraries = {}
-
-            for lib_name, lib_cfg in libraries_payload.items():
-                name = str(lib_name)
-                if name in plex_lookup:
-                    target = plex_lookup[name]
-                else:
-                    mapped = library_mapping.get(name)
-                    if mapped is None:
-                        missing.append(name)
-                        continue
-                    mapped = str(mapped).strip()
-                    if not mapped:
-                        missing.append(name)
-                        continue
-                    if mapped == "__ignore__":
-                        continue
-                    if mapped not in plex_lookup:
-                        invalid_targets.append(mapped)
-                        continue
-                    target = plex_lookup[mapped]
-
-                if target in used_targets:
-                    duplicates.append(target)
-                    continue
-                used_targets.add(target)
-                mapped_libraries[target] = lib_cfg
-
-            if missing:
-                return (
-                    jsonify(
-                        success=False,
-                        message=f"Library mapping required for: {', '.join(missing)}",
-                    ),
-                    400,
-                )
-            if invalid_targets:
-                unique_targets = sorted(set(invalid_targets))
-                return (
-                    jsonify(
-                        success=False,
-                        message=f"Invalid Plex libraries selected: {', '.join(unique_targets)}",
-                    ),
-                    400,
-                )
-            if duplicates:
-                unique_targets = sorted(set(duplicates))
-                return (
-                    jsonify(
-                        success=False,
-                        message=f"Multiple imports mapped to the same Plex library: {', '.join(unique_targets)}",
-                    ),
-                    400,
-                )
+            mapped_libraries, mapping_error = validate_library_mapping(
+                libraries_payload=libraries_payload,
+                library_mapping=library_mapping,
+                movie_names=movie_names,
+                show_names=show_names,
+                needs_plex=needs_plex,
+            )
+            if mapping_error:
+                return mapping_error
 
             if mapped_libraries:
                 config_data["libraries"] = mapped_libraries

--- a/blueprints/import_config_validators.py
+++ b/blueprints/import_config_validators.py
@@ -337,3 +337,219 @@ def validate_tmdb_credentials(
             parsed["tmdb"] = tmdb_block
         tmdb_block["apikey"] = used_tmdb_key
     return None
+
+
+# ---------------------------------------------------------------------------
+# Confirm-flow validators.
+#
+# The /import-config/confirm route re-validates the session-stored Plex
+# and TMDb credentials before writing the imported config to the database.
+# These functions are the confirm-side analog of validate_plex_credentials
+# / validate_tmdb_credentials but simpler: creds always come from the
+# session (populated by the preview flow), and there's no bundle-cleanup
+# to do because at confirm time the bundle directory has already been
+# moved out of the scratch cache dir.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class ConfirmPlexOutcome:
+    """Outcome of :func:`validate_confirm_plex_credentials`.
+
+    On success ``movie_names`` and ``show_names`` are populated with
+    what Plex reported.  On failure ``error_response`` is populated
+    and the caller should return it directly.
+    """
+
+    error_response: tuple | None = None
+    movie_names: set = field(default_factory=set)
+    show_names: set = field(default_factory=set)
+
+
+def validate_confirm_plex_credentials() -> ConfirmPlexOutcome:
+    """Validate the session-stored Plex credentials during /confirm.
+
+    Reads ``import_preview_plex_url`` and ``import_preview_plex_token``
+    from the Flask session, re-runs the Plex validation call, and
+    returns the reported movie/show library names.  Emits distinct
+    error messages that direct the user to "Re-run Preview Import"
+    (unlike the preview validator which asks the user to enter creds).
+    """
+    plex_url = session.get("import_preview_plex_url") or ""
+    plex_token = session.get("import_preview_plex_token") or ""
+    if not plex_url or not plex_token:
+        return ConfirmPlexOutcome(
+            error_response=(
+                jsonify(
+                    success=False,
+                    message="Plex credentials are required to confirm the import. Re-run Preview Import.",
+                ),
+                400,
+            )
+        )
+    plex_response = validations.validate_plex_server({"plex_url": plex_url, "plex_token": plex_token})
+    plex_result = _coerce_validation_response_payload(plex_response)
+    if not plex_result or not plex_result.get("validated"):
+        error_message = plex_result.get("error") if isinstance(plex_result, dict) else None
+        return ConfirmPlexOutcome(
+            error_response=(
+                jsonify(
+                    success=False,
+                    message=error_message or "Plex validation failed. Re-run Preview Import.",
+                ),
+                400,
+            )
+        )
+    movie_names = _parse_csv_or_list_to_set(plex_result.get("movie_libraries", []))
+    show_names = _parse_csv_or_list_to_set(plex_result.get("show_libraries", []))
+    if not movie_names and not show_names:
+        return ConfirmPlexOutcome(
+            error_response=(
+                jsonify(
+                    success=False,
+                    message="No movie or show libraries found in Plex.",
+                ),
+                400,
+            )
+        )
+    return ConfirmPlexOutcome(movie_names=movie_names, show_names=show_names)
+
+
+def validate_confirm_tmdb_credentials() -> tuple | None:
+    """Validate the session-stored TMDb API key during /confirm.
+
+    Reads ``import_preview_tmdb_apikey`` from the Flask session and
+    re-runs the TMDb validation call.  Returns the error response
+    tuple on failure or None on success.
+    """
+    tmdb_apikey = session.get("import_preview_tmdb_apikey") or ""
+    if not tmdb_apikey:
+        return (
+            jsonify(
+                success=False,
+                message="TMDb API key is required to confirm the import. Re-run Preview Import.",
+            ),
+            400,
+        )
+    tmdb_response = validations.validate_tmdb_server({"tmdb_apikey": tmdb_apikey})
+    tmdb_result = _coerce_validation_response_payload(tmdb_response)
+    if not tmdb_result or not tmdb_result.get("valid"):
+        error_message = tmdb_result.get("message") if isinstance(tmdb_result, dict) else None
+        return (
+            jsonify(
+                success=False,
+                message=error_message or "TMDb validation failed. Re-run Preview Import.",
+            ),
+            400,
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Library mapping validation (confirm flow only).
+# ---------------------------------------------------------------------------
+
+
+def validate_library_mapping(
+    *,
+    libraries_payload: dict,
+    library_mapping: dict,
+    movie_names,
+    show_names,
+    needs_plex: bool,
+) -> tuple[dict | None, tuple | None]:
+    """Validate + apply a library-mapping dict to a libraries payload.
+
+    Called from /import-config/confirm after Plex credentials have been
+    re-validated.  For each library in ``libraries_payload`` either:
+
+    * The library name matches an existing Plex library -- passes through.
+    * The library name has an entry in ``library_mapping`` -- gets
+      renamed to the mapping target (or dropped if the target is the
+      ``__ignore__`` sentinel).
+    * The library name has no mapping -- reported as "missing".
+    * The library name maps to something not in Plex -- reported as
+      "invalid targets".
+    * Two libraries map to the same target -- reported as "duplicates".
+
+    On success, MUTATES ``libraries_payload``'s enclosing dict via
+    the caller's ``config_data`` -- but here we just return the
+    filtered ``mapped_libraries`` dict (or None on error, with the
+    error_response tuple that the caller returns directly).
+
+    :returns: (mapped_libraries_dict, None) on success, or
+              (None, error_response_tuple) on failure.
+    """
+    plex_lookup = {name: name for name in movie_names}
+    plex_lookup.update({name: name for name in show_names})
+    plex_names = set(plex_lookup.values())
+
+    if needs_plex and not plex_names:
+        return None, (
+            jsonify(
+                success=False,
+                message="Plex libraries are unavailable. Validate Plex and preview the import again.",
+            ),
+            400,
+        )
+
+    missing: list = []
+    invalid_targets: list = []
+    duplicates: list = []
+    used_targets: set = set()
+    mapped_libraries: dict = {}
+
+    for lib_name, lib_cfg in libraries_payload.items():
+        name = str(lib_name)
+        if name in plex_lookup:
+            target = plex_lookup[name]
+        else:
+            mapped = library_mapping.get(name)
+            if mapped is None:
+                missing.append(name)
+                continue
+            mapped = str(mapped).strip()
+            if not mapped:
+                missing.append(name)
+                continue
+            if mapped == "__ignore__":
+                continue
+            if mapped not in plex_lookup:
+                invalid_targets.append(mapped)
+                continue
+            target = plex_lookup[mapped]
+
+        if target in used_targets:
+            duplicates.append(target)
+            continue
+        used_targets.add(target)
+        mapped_libraries[target] = lib_cfg
+
+    if missing:
+        return None, (
+            jsonify(
+                success=False,
+                message=f"Library mapping required for: {', '.join(missing)}",
+            ),
+            400,
+        )
+    if invalid_targets:
+        unique_targets = sorted(set(invalid_targets))
+        return None, (
+            jsonify(
+                success=False,
+                message=f"Invalid Plex libraries selected: {', '.join(unique_targets)}",
+            ),
+            400,
+        )
+    if duplicates:
+        unique_targets = sorted(set(duplicates))
+        return None, (
+            jsonify(
+                success=False,
+                message=f"Multiple imports mapped to the same Plex library: {', '.join(unique_targets)}",
+            ),
+            400,
+        )
+
+    return mapped_libraries, None


### PR DESCRIPTION
Fourth cut into `blueprints/import_config_routes.py`.  Attacks three inline blocks in `import_config_confirm`.

## Summary

**`blueprints/import_config_routes.py`: 908 to 805 (-103 / -11.3%)**
**`import_config_confirm`: 354 to 253 lines (-101)**

## What moved

Extended `blueprints/import_config_validators.py` with three confirm-flow entry points (~215 new lines):

### `validate_confirm_plex_credentials()` returns `ConfirmPlexOutcome`

- Session-only Plex cred read + revalidation
- Simpler than the preview validator (no 3-source resolution)
- Error messages direct user to "Re-run Preview Import" (vs preview's "Enter valid credentials")

### `validate_confirm_tmdb_credentials()` returns `tuple | None`

- Same shape for TMDb API key

### `validate_library_mapping(...)` returns `(mapped_libraries, error_response)`

- Self-contained validator for the library-name to Plex-library mapping dict
- Handles four failure modes with distinct 400 responses:
  1. `needs_plex` but empty Plex libraries -> `Plex libraries are unavailable`
  2. Library in payload with no mapping -> `Library mapping required for: X`
  3. Mapping to a name not in Plex -> `Invalid Plex libraries selected: X`
  4. Two libraries mapping to the same target -> `Multiple imports mapped to the same Plex library`
- Handles the `__ignore__` sentinel for skipped libraries

## Caller collapse

The three inline blocks in `import_config_confirm` collapsed like this:

| Block | Before | After | Δ |
|---|---|---|---|
| Plex validation | 36 lines | 5 lines | -31 |
| TMDb validation | 20 lines | 3 lines | -17 |
| Library mapping | 62 lines | 12 lines | -50 |

Also dropped now-unused import `Flask` from the routes module (it was only used to test `isinstance(., Flask.response_class)`, which is now inside `_coerce_validation_response_payload`).

## Verification

- **AST-verified**: `import_config_report`, `import_config_preview_mapped` byte-identical to develop
- **7 error-path smoke tests** in Flask app context: all match develop payloads
- **Full test suite: 0 failures**
- Ruff + Black clean

## Sprint 5 scoreboard on this file

| PR | Ending lines | Δ |
|---|---|---|
| Baseline | 1384 | -- |
| #1530 (helpers) | 1188 | -196 |
| #1531 (bundle) | 1082 | -106 |
| #1532 (validators) | 907 | -175 |
| **This PR** (confirm) | **805** | **-102** |
| **Cumulative** | **805** | **-579 / -41.8%** |

## What's left

Both elephant routes are now defanged:

| Route | Before Sprint 5 | Now | Δ |
|---|---|---|---|
| `import_config_preview` | 511 | 222 | -289 |
| `import_config_confirm` | 354 | 253 | -101 |
| `import_config_preview_mapped` | 194 | 194 | 0 |
| `import_config_report` | 62 | 62 | 0 |

No route is over 300 lines anymore.  File is 805 -- still above the 600-line soft-limit, but further reduction would either need to (a) extract the session/cache management pattern shared across all four routes into an `import_preview_session.py` module, or (b) tackle `import_config_preview_mapped`'s untouched validation logic. Both feasible but lower-value than what we've done.