### PR TITLE
Extract shared cache-load + preview-mapped report builders

### DIFF
--- a/blueprints/import_config_cache.py
+++ b/blueprints/import_config_cache.py
@@ -1,0 +1,68 @@
+"""Import-preview session cache load helpers.
+
+The four routes in :mod:`blueprints.import_config_routes` share a
+common pattern for looking up the disk-backed preview cache written
+by ``/import-config/preview``:
+
+1. Validate the request token against the session token.
+2. Read the cache path from the session.
+3. Load the JSON blob at that path.
+
+Three of the four routes had this pattern duplicated inline
+(``import_config_report``, ``import_config_preview_mapped``,
+``import_config_confirm``).  This module owns the shared load.
+
+Each function returns ``(cached_dict, cache_path, None)`` on success or
+``(None, None, error_response_tuple)`` on failure so the caller can:
+
+.. code-block:: python
+
+    cached, cache_path, err = load_preview_cache(token)
+    if err:
+        return err
+    ...
+
+``cache_path`` is returned so the two routes that need to write back
+or remove the cache file (``preview_mapped`` and ``confirm``) don't
+have to re-read the session key themselves.
+"""
+
+from __future__ import annotations
+
+import json
+
+from flask import jsonify, session
+
+
+def load_preview_cache(token: str | None) -> tuple[dict | None, str | None, tuple | None]:
+    """Validate the import-preview token and load the cached blob.
+
+    :param token: the token from the incoming request.
+    :returns: ``(cached_dict, cache_path, None)`` on success or
+              ``(None, None, (jsonify_response, status_code))`` on
+              failure.  ``cache_path`` is returned so callers that
+              need to write-back the modified cache (preview_mapped)
+              or remove it (confirm) don't have to re-read the
+              session key.
+
+    Three distinct failure modes, each with a byte-identical error
+    message to the original inline code:
+
+    * Missing / mismatched token -> "Import token is invalid."
+    * Missing session cache path -> "Import preview not found."
+    * File read or JSON parse fails -> "Import preview is unavailable."
+    """
+    if not token or token != session.get("import_preview_token"):
+        return None, None, (jsonify(success=False, message="Import token is invalid."), 400)
+
+    cache_path = session.get("import_preview_path")
+    if not cache_path:
+        return None, None, (jsonify(success=False, message="Import preview not found."), 400)
+
+    try:
+        with open(cache_path, "r", encoding="utf-8") as handle:
+            cached = json.load(handle)
+    except Exception:
+        return None, None, (jsonify(success=False, message="Import preview is unavailable."), 400)
+
+    return cached, cache_path, None

--- a/blueprints/import_config_report_builder.py
+++ b/blueprints/import_config_report_builder.py
@@ -1,0 +1,104 @@
+"""Preview-mapped report line builders.
+
+The ``/import-config/preview-mapped`` route produces a text report
+showing which parts of the imported config will land in the DB and
+which will be skipped.  Two chunks of report-building logic used to
+live inline in that route:
+
+1. :func:`build_alias_report_lines` -- for libraries that were
+   renamed via a mapping (e.g. imported "Anime Movies" mapped to
+   Plex "Movies"), generate additional report lines showing the
+   original name so the user can see "your Anime Movies config
+   will go to Movies".
+
+2. :func:`compute_line_counts` -- count imported / not_imported /
+   comment / blank / diff lines from the raw + annotated YAML.
+"""
+
+from __future__ import annotations
+
+from blueprints.import_config_helpers import count_annotated_lines
+
+
+def build_alias_report_lines(
+    *,
+    report_lines: list,
+    alias_map: dict,
+    libraries_payload,
+) -> list:
+    """Generate aliased duplicate report lines for renamed libraries.
+
+    For each entry in ``alias_map`` (imported-name -> plex-target-name),
+    find every report line under ``libraries.<target>`` and emit an
+    aliased copy under ``libraries.<original>`` so the user can see
+    exactly what will happen to the config they uploaded.
+
+    :param report_lines: existing report lines (not mutated).
+    :param alias_map: dict of imported library name -> Plex target.
+    :param libraries_payload: the ``config_data.get("libraries")``
+        value; the alias lines are only generated if this is a dict.
+    :returns: a list of NEW alias lines to append (never modifies
+              the input); empty if there's nothing to alias.
+    """
+    if not alias_map or not isinstance(libraries_payload, dict):
+        return []
+
+    alias_lines: list = []
+    seen = set(report_lines)
+    for original_name, mapped_name in alias_map.items():
+        if not original_name:
+            continue
+        mapped_name = str(mapped_name).strip()
+        if not mapped_name or mapped_name == "__ignore__":
+            continue
+        if mapped_name == original_name:
+            continue
+        prefix = f"libraries.{mapped_name}"
+        for line in report_lines:
+            if not isinstance(line, str) or ":" not in line:
+                continue
+            status, rest = line.split(":", 1)
+            status = status.strip()
+            path = rest.strip()
+            suffix = ""
+            if " :: " in path:
+                path, reason = path.split(" :: ", 1)
+                path = path.strip()
+                suffix = f" :: {reason}"
+            elif status != "imported" and " - " in path:
+                path, reason = path.split(" - ", 1)
+                path = path.strip()
+                suffix = f" - {reason}"
+            if path == prefix or path.startswith(prefix + "."):
+                alias_path = f"libraries.{original_name}{path[len(prefix) :]}"
+                alias_line = f"{status}: {alias_path}{suffix}"
+                if alias_line not in seen:
+                    alias_lines.append(alias_line)
+                    seen.add(alias_line)
+    return alias_lines
+
+
+def compute_line_counts(*, config_text: str, annotated_report: str, comments_count: int) -> dict:
+    """Compute imported / not_imported / comment / blank / total / diff counts.
+
+    :param config_text: the raw YAML text of the imported config.
+    :param annotated_report: the annotated version with report markers.
+    :param comments_count: pre-computed comment line count (from cache).
+    :returns: dict with keys imported_lines, not_imported_lines,
+              comments, blank, total, diff.
+    """
+    text_str = str(config_text)
+    blank_count = sum(1 for line in text_str.splitlines() if not line.strip())
+    total_lines = len(text_str.splitlines())
+    annotated_counts = count_annotated_lines(str(annotated_report))
+    imported_lines = annotated_counts.get("imported", 0)
+    not_imported_lines = annotated_counts.get("not_imported", 0)
+    diff_count = total_lines - (imported_lines + not_imported_lines + blank_count + comments_count)
+    return {
+        "imported_lines": imported_lines,
+        "not_imported_lines": not_imported_lines,
+        "comments": comments_count,
+        "blank": blank_count,
+        "total": total_lines,
+        "diff": diff_count,
+    }

--- a/blueprints/import_config_routes.py
+++ b/blueprints/import_config_routes.py
@@ -12,21 +12,25 @@ Public surface (used by tests via ``qs_module.<name>`` re-exports):
 
 ## File-size note
 
-This file is ~810 lines, still above the 600-line soft-limit.  Four
-chunks have already moved out:
+This file is ~730 lines, still above the 600-line soft-limit.  Six
+chunks have moved out:
 
-* :mod:`blueprints.import_config_helpers` -- 12 pure helpers (~240 lines)
+* :mod:`blueprints.import_config_helpers` -- 12 pure helpers (~245 lines)
 * :mod:`blueprints.import_config_bundle` -- upload / zip extraction
-  and the ``cleanup_bundle_dir`` helper (~245 lines)
+  and the ``cleanup_bundle_dir`` helper (~240 lines)
 * :mod:`blueprints.import_config_validators` -- Plex + TMDb credential
   validation state machines for BOTH the preview and confirm flows,
-  plus the library-mapping validator (~555 lines)
+  plus the ``validate_library_mapping`` (confirm, error-on-fail) and
+  ``apply_library_mapping_for_preview`` (accumulate-and-report)
+  variants (~650 lines)
+* :mod:`blueprints.import_config_cache` -- shared token + cache-load
+  logic used by three routes (~70 lines)
+* :mod:`blueprints.import_config_report_builder` -- the alias-line
+  generator and line-counts calculator (~105 lines)
 
-Both ``import_config_preview`` (~220 lines) and ``import_config_confirm``
-(~250 lines) are now firmly out of elephant territory.  The four
-routes remain in one file because they're tightly coupled through a
-shared session-cache flow (import_preview_token / import_preview_path
-/ import_preview_*_url / import_preview_*_token).
+All four routes are now under 250 lines each.  The four remain in
+one file because they're tightly coupled through the shared
+session-cache flow.
 """
 
 import json
@@ -38,6 +42,7 @@ from pathlib import Path
 from flask import Blueprint, current_app, jsonify, request, session
 
 from blueprints.import_config_bundle import extract_bundle_upload
+from blueprints.import_config_cache import load_preview_cache
 from blueprints.import_config_helpers import (  # noqa: F401 (re-exports for tests and legacy callers)
     _coerce_validation_response_payload,
     _import_preview_json_default,
@@ -52,7 +57,12 @@ from blueprints.import_config_helpers import (  # noqa: F401 (re-exports for tes
     _parse_tmdb_credentials_from_form,
     count_annotated_lines,
 )
+from blueprints.import_config_report_builder import (
+    build_alias_report_lines,
+    compute_line_counts,
+)
 from blueprints.import_config_validators import (
+    apply_library_mapping_for_preview,
     validate_confirm_plex_credentials,
     validate_confirm_tmdb_credentials,
     validate_library_mapping,
@@ -294,18 +304,9 @@ def import_config_preview():
 @bp.route("/import-config/report", methods=["GET"])
 def import_config_report():
     token = request.args.get("token")
-    if not token or token != session.get("import_preview_token"):
-        return jsonify(success=False, message="Import token is invalid."), 400
-
-    cache_path = session.get("import_preview_path")
-    if not cache_path:
-        return jsonify(success=False, message="Import preview not found."), 400
-
-    try:
-        with open(cache_path, "r", encoding="utf-8") as handle:
-            cached = json.load(handle)
-    except Exception:
-        return jsonify(success=False, message="Import preview is unavailable."), 400
+    cached, _cache_path, err = load_preview_cache(token)
+    if err:
+        return err
 
     config_name = cached.get("config_name") or "import"
     report_lines = cached.get("report_lines") or []
@@ -364,15 +365,9 @@ def import_config_preview_mapped():
     if library_mapping and not isinstance(library_mapping, dict):
         return jsonify(success=False, message="Invalid library mapping."), 400
 
-    cache_path = session.get("import_preview_path")
-    if not cache_path:
-        return jsonify(success=False, message="Import preview not found."), 400
-
-    try:
-        with open(cache_path, "r", encoding="utf-8") as handle:
-            cached = json.load(handle)
-    except Exception:
-        return jsonify(success=False, message="Import preview is unavailable."), 400
+    cached, cache_path, err = load_preview_cache(token)
+    if err:
+        return err
 
     config_data = cached.get("config_data") or {}
     if not isinstance(config_data, dict):
@@ -401,45 +396,19 @@ def import_config_preview_mapped():
     alias_map = {}
     mapping_stats = {"mapped": 0, "ignored": 0, "missing": 0, "invalid": 0, "duplicate": 0}
     if isinstance(config_data.get("libraries"), dict):
-        mapped_libraries = {}
-        used_targets = set()
-        for lib_name, lib_cfg in config_data.get("libraries", {}).items():
-            name = str(lib_name)
-            if name in plex_lookup:
-                target = plex_lookup[name]
-            else:
-                mapped = library_mapping.get(name)
-                if mapped is None or str(mapped).strip() == "":
-                    mapping_skip_reasons[name] = "Library mapping not provided."
-                    mapping_stats["missing"] += 1
-                    continue
-                mapped = str(mapped).strip()
-                if mapped == "__ignore__":
-                    mapping_skip_reasons[name] = "Mapping set to ignore library."
-                    mapping_stats["ignored"] += 1
-                    continue
-                if mapped not in plex_lookup:
-                    mapping_skip_reasons[name] = "Mapped library not found in Plex."
-                    mapping_stats["invalid"] += 1
-                    continue
-                target = plex_lookup[mapped]
-
-            if target != name:
-                alias_map[name] = target
-
-            if target in used_targets:
-                mapping_skip_reasons[name] = "Mapped library already assigned to another entry."
-                if name not in plex_names:
-                    mapping_stats["duplicate"] += 1
-                continue
-            used_targets.add(target)
-            mapped_libraries[target] = lib_cfg
-            if name not in plex_names:
-                mapping_stats["mapped"] += 1
+        mapping_result = apply_library_mapping_for_preview(
+            libraries_payload=config_data.get("libraries", {}),
+            library_mapping=library_mapping,
+            movie_names=movie_names,
+            show_names=show_names,
+        )
+        mapping_skip_reasons = mapping_result.skip_reasons
+        alias_map = mapping_result.alias_map
+        mapping_stats = mapping_result.stats
 
         config_copy = json.loads(json.dumps(config_data))
-        if mapped_libraries:
-            config_copy["libraries"] = mapped_libraries
+        if mapping_result.mapped_libraries:
+            config_copy["libraries"] = mapping_result.mapped_libraries
         else:
             config_copy.pop("libraries", None)
     else:
@@ -460,58 +429,22 @@ def import_config_preview_mapped():
                 report_lines.append(line)
                 seen.add(line)
     if alias_map and isinstance(config_data.get("libraries"), dict):
-        alias_lines = []
-        seen = set(report_lines)
-        for original_name, mapped_name in alias_map.items():
-            if not original_name:
-                continue
-            mapped_name = str(mapped_name).strip()
-            if not mapped_name or mapped_name == "__ignore__":
-                continue
-            if mapped_name == original_name:
-                continue
-            prefix = f"libraries.{mapped_name}"
-            for line in report_lines:
-                if not isinstance(line, str) or ":" not in line:
-                    continue
-                status, rest = line.split(":", 1)
-                status = status.strip()
-                path = rest.strip()
-                suffix = ""
-                if " :: " in path:
-                    path, reason = path.split(" :: ", 1)
-                    path = path.strip()
-                    suffix = f" :: {reason}"
-                elif status != "imported" and " - " in path:
-                    path, reason = path.split(" - ", 1)
-                    path = path.strip()
-                    suffix = f" - {reason}"
-                if path == prefix or path.startswith(prefix + "."):
-                    alias_path = f"libraries.{original_name}{path[len(prefix):]}"
-                    alias_line = f"{status}: {alias_path}{suffix}"
-                    if alias_line not in seen:
-                        alias_lines.append(alias_line)
-                        seen.add(alias_line)
+        alias_lines = build_alias_report_lines(
+            report_lines=report_lines,
+            alias_map=alias_map,
+            libraries_payload=config_data.get("libraries"),
+        )
         if alias_lines:
             report_lines.extend(alias_lines)
     annotated_report = importer.annotate_yaml_with_report(config_text, report_lines, binary=True)
     comments_count = cached.get("comments_count")
     if not isinstance(comments_count, int):
         comments_count = sum(1 for line in str(config_text).splitlines() if line.lstrip().startswith("#"))
-    blank_count = sum(1 for line in str(config_text).splitlines() if not line.strip())
-    total_lines = len(str(config_text).splitlines())
-    annotated_counts = count_annotated_lines(str(annotated_report))
-    imported_lines = annotated_counts.get("imported", 0)
-    not_imported_lines = annotated_counts.get("not_imported", 0)
-    diff_count = total_lines - (imported_lines + not_imported_lines + blank_count + comments_count)
-    line_counts = {
-        "imported_lines": imported_lines,
-        "not_imported_lines": not_imported_lines,
-        "comments": comments_count,
-        "blank": blank_count,
-        "total": total_lines,
-        "diff": diff_count,
-    }
+    line_counts = compute_line_counts(
+        config_text=config_text,
+        annotated_report=annotated_report,
+        comments_count=comments_count,
+    )
 
     cached["payload"] = payload
     cached["report_lines"] = report_lines
@@ -571,15 +504,9 @@ def import_config_confirm():
 
     merge_mode = _boolish(raw_merge_mode)
 
-    cache_path = session.get("import_preview_path")
-    if not cache_path:
-        return jsonify(success=False, message="Import preview not found."), 400
-
-    try:
-        with open(cache_path, "r", encoding="utf-8") as handle:
-            cached = json.load(handle)
-    except Exception:
-        return jsonify(success=False, message="Import preview is unavailable."), 400
+    cached, cache_path, err = load_preview_cache(token)
+    if err:
+        return err
 
     config_name = cached.get("config_name")
     payload = cached.get("payload") or {}

--- a/blueprints/import_config_routes.py
+++ b/blueprints/import_config_routes.py
@@ -12,24 +12,21 @@ Public surface (used by tests via ``qs_module.<name>`` re-exports):
 
 ## File-size note
 
-This file is ~875 lines, still above the 600-line soft-limit.  Three
+This file is ~810 lines, still above the 600-line soft-limit.  Four
 chunks have already moved out:
 
 * :mod:`blueprints.import_config_helpers` -- 12 pure helpers (~240 lines)
 * :mod:`blueprints.import_config_bundle` -- upload / zip extraction
   and the ``cleanup_bundle_dir`` helper (~245 lines)
 * :mod:`blueprints.import_config_validators` -- Plex + TMDb credential
-  validation state machines (~340 lines)
+  validation state machines for BOTH the preview and confirm flows,
+  plus the library-mapping validator (~555 lines)
 
-``import_config_preview`` alone is now ~85 lines (down from ~510) --
-firmly out of elephant territory.
-
-The four remaining routes are tightly coupled through a shared
-session-cache flow (import_preview_token / import_preview_path /
-import_preview_*_url / import_preview_*_token) so splitting them into
-separate per-route modules would either duplicate the shared local logic
-or require a sub-package with relative imports -- both worse than
-keeping them together.
+Both ``import_config_preview`` (~220 lines) and ``import_config_confirm``
+(~250 lines) are now firmly out of elephant territory.  The four
+routes remain in one file because they're tightly coupled through a
+shared session-cache flow (import_preview_token / import_preview_path
+/ import_preview_*_url / import_preview_*_token).
 """
 
 import json
@@ -38,7 +35,7 @@ import secrets
 import shutil
 from pathlib import Path
 
-from flask import Blueprint, Flask, current_app, jsonify, request, session
+from flask import Blueprint, current_app, jsonify, request, session
 
 from blueprints.import_config_bundle import extract_bundle_upload
 from blueprints.import_config_helpers import (  # noqa: F401 (re-exports for tests and legacy callers)
@@ -56,6 +53,9 @@ from blueprints.import_config_helpers import (  # noqa: F401 (re-exports for tes
     count_annotated_lines,
 )
 from blueprints.import_config_validators import (
+    validate_confirm_plex_credentials,
+    validate_confirm_tmdb_credentials,
+    validate_library_mapping,
     validate_plex_credentials,
     validate_tmdb_credentials,
 )
@@ -656,137 +656,35 @@ def import_config_confirm():
                 # Skip Plex validation when base config provides library cache.
                 pass
             else:
-                plex_url = session.get("import_preview_plex_url") or ""
-                plex_token = session.get("import_preview_plex_token") or ""
-                if not plex_url or not plex_token:
-                    return (
-                        jsonify(
-                            success=False,
-                            message="Plex credentials are required to confirm the import. Re-run Preview Import.",
-                        ),
-                        400,
-                    )
-
-                plex_response = validations.validate_plex_server({"plex_url": plex_url, "plex_token": plex_token})
-                plex_result = plex_response.get_json() if isinstance(plex_response, Flask.response_class) else plex_response
-                if not plex_result or not plex_result.get("validated"):
-                    error_message = plex_result.get("error") if isinstance(plex_result, dict) else None
-                    return (
-                        jsonify(
-                            success=False,
-                            message=error_message or "Plex validation failed. Re-run Preview Import.",
-                        ),
-                        400,
-                    )
-                movie_names = _parse_csv_or_list_to_set(plex_result.get("movie_libraries", []))
-                show_names = _parse_csv_or_list_to_set(plex_result.get("show_libraries", []))
-                if not movie_names and not show_names:
-                    return (
-                        jsonify(
-                            success=False,
-                            message="No movie or show libraries found in Plex.",
-                        ),
-                        400,
-                    )
+                plex_outcome = validate_confirm_plex_credentials()
+                if plex_outcome.error_response:
+                    return plex_outcome.error_response
+                movie_names = plex_outcome.movie_names
+                show_names = plex_outcome.show_names
         else:
             plex_data = persistence.retrieve_settings("010-plex").get("plex", {})
             movie_names = _parse_csv_or_list_to_set(plex_data.get("tmp_movie_libraries", ""))
             show_names = _parse_csv_or_list_to_set(plex_data.get("tmp_show_libraries", ""))
 
         if needs_tmdb:
-            tmdb_apikey = session.get("import_preview_tmdb_apikey") or ""
-            if not tmdb_apikey:
-                return (
-                    jsonify(
-                        success=False,
-                        message="TMDb API key is required to confirm the import. Re-run Preview Import.",
-                    ),
-                    400,
-                )
-            tmdb_response = validations.validate_tmdb_server({"tmdb_apikey": tmdb_apikey})
-            tmdb_result = tmdb_response.get_json() if isinstance(tmdb_response, Flask.response_class) else tmdb_response
-            if not tmdb_result or not tmdb_result.get("valid"):
-                error_message = tmdb_result.get("message") if isinstance(tmdb_result, dict) else None
-                return (
-                    jsonify(
-                        success=False,
-                        message=error_message or "TMDb validation failed. Re-run Preview Import.",
-                    ),
-                    400,
-                )
+            tmdb_error = validate_confirm_tmdb_credentials()
+            if tmdb_error:
+                return tmdb_error
 
         plex_lookup = {name: name for name in movie_names}
         plex_lookup.update({name: name for name in show_names})
         plex_names = set(plex_lookup.values())
 
         if isinstance(libraries_payload, dict):
-            if needs_plex and not plex_names:
-                return (
-                    jsonify(
-                        success=False,
-                        message="Plex libraries are unavailable. Validate Plex and preview the import again.",
-                    ),
-                    400,
-                )
-
-            missing = []
-            invalid_targets = []
-            duplicates = []
-            used_targets = set()
-            mapped_libraries = {}
-
-            for lib_name, lib_cfg in libraries_payload.items():
-                name = str(lib_name)
-                if name in plex_lookup:
-                    target = plex_lookup[name]
-                else:
-                    mapped = library_mapping.get(name)
-                    if mapped is None:
-                        missing.append(name)
-                        continue
-                    mapped = str(mapped).strip()
-                    if not mapped:
-                        missing.append(name)
-                        continue
-                    if mapped == "__ignore__":
-                        continue
-                    if mapped not in plex_lookup:
-                        invalid_targets.append(mapped)
-                        continue
-                    target = plex_lookup[mapped]
-
-                if target in used_targets:
-                    duplicates.append(target)
-                    continue
-                used_targets.add(target)
-                mapped_libraries[target] = lib_cfg
-
-            if missing:
-                return (
-                    jsonify(
-                        success=False,
-                        message=f"Library mapping required for: {', '.join(missing)}",
-                    ),
-                    400,
-                )
-            if invalid_targets:
-                unique_targets = sorted(set(invalid_targets))
-                return (
-                    jsonify(
-                        success=False,
-                        message=f"Invalid Plex libraries selected: {', '.join(unique_targets)}",
-                    ),
-                    400,
-                )
-            if duplicates:
-                unique_targets = sorted(set(duplicates))
-                return (
-                    jsonify(
-                        success=False,
-                        message=f"Multiple imports mapped to the same Plex library: {', '.join(unique_targets)}",
-                    ),
-                    400,
-                )
+            mapped_libraries, mapping_error = validate_library_mapping(
+                libraries_payload=libraries_payload,
+                library_mapping=library_mapping,
+                movie_names=movie_names,
+                show_names=show_names,
+                needs_plex=needs_plex,
+            )
+            if mapping_error:
+                return mapping_error
 
             if mapped_libraries:
                 config_data["libraries"] = mapped_libraries

--- a/blueprints/import_config_validators.py
+++ b/blueprints/import_config_validators.py
@@ -553,3 +553,96 @@ def validate_library_mapping(
         )
 
     return mapped_libraries, None
+
+
+# ---------------------------------------------------------------------------
+# Preview-mapped library mapping (accumulating variant).
+#
+# import_config_preview_mapped needs to run the same library-mapping logic
+# as import_config_confirm, but with different failure semantics: instead
+# of erroring on missing / invalid / duplicate entries, it accumulates
+# skip reasons + stats so the preview UI can show a "here's what will
+# happen" report.  The failure modes and their string messages are
+# byte-identical to the develop code they replace.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class PreviewMappingResult:
+    """Outcome of :func:`apply_library_mapping_for_preview`.
+
+    Unlike :class:`PlexValidationOutcome` there's no ``error_response``
+    -- preview-mapped never errors out on library mapping issues, it
+    just records them and lets the caller build a report.
+    """
+
+    mapped_libraries: dict = field(default_factory=dict)
+    alias_map: dict = field(default_factory=dict)
+    skip_reasons: dict = field(default_factory=dict)
+    stats: dict = field(default_factory=lambda: {"mapped": 0, "ignored": 0, "missing": 0, "invalid": 0, "duplicate": 0})
+
+
+def apply_library_mapping_for_preview(
+    *,
+    libraries_payload: dict,
+    library_mapping: dict,
+    movie_names,
+    show_names,
+) -> PreviewMappingResult:
+    """Apply library mapping to a preview-mapped payload, accumulating stats.
+
+    Same core loop as :func:`validate_library_mapping` (confirm flow)
+    but records outcomes rather than returning an error tuple.  Callers
+    use the returned ``skip_reasons`` and ``alias_map`` to build the
+    preview report shown to the user before they hit "Import".
+
+    :param libraries_payload: dict of imported library name -> config.
+    :param library_mapping: dict of imported name -> Plex target name.
+    :param movie_names: known Plex movie library names.
+    :param show_names: known Plex show library names.
+    :returns: :class:`PreviewMappingResult` with mapped_libraries,
+              alias_map (source -> target rename), skip_reasons (per
+              library name), and stats counters.
+    """
+    plex_lookup = {name: name for name in movie_names}
+    plex_lookup.update({name: name for name in show_names})
+    plex_names = set(plex_lookup.values())
+
+    result = PreviewMappingResult()
+    used_targets: set = set()
+
+    for lib_name, lib_cfg in libraries_payload.items():
+        name = str(lib_name)
+        if name in plex_lookup:
+            target = plex_lookup[name]
+        else:
+            mapped = library_mapping.get(name)
+            if mapped is None or str(mapped).strip() == "":
+                result.skip_reasons[name] = "Library mapping not provided."
+                result.stats["missing"] += 1
+                continue
+            mapped = str(mapped).strip()
+            if mapped == "__ignore__":
+                result.skip_reasons[name] = "Mapping set to ignore library."
+                result.stats["ignored"] += 1
+                continue
+            if mapped not in plex_lookup:
+                result.skip_reasons[name] = "Mapped library not found in Plex."
+                result.stats["invalid"] += 1
+                continue
+            target = plex_lookup[mapped]
+
+        if target != name:
+            result.alias_map[name] = target
+
+        if target in used_targets:
+            result.skip_reasons[name] = "Mapped library already assigned to another entry."
+            if name not in plex_names:
+                result.stats["duplicate"] += 1
+            continue
+        used_targets.add(target)
+        result.mapped_libraries[target] = lib_cfg
+        if name not in plex_names:
+            result.stats["mapped"] += 1
+
+    return result

--- a/blueprints/import_config_validators.py
+++ b/blueprints/import_config_validators.py
@@ -337,3 +337,219 @@ def validate_tmdb_credentials(
             parsed["tmdb"] = tmdb_block
         tmdb_block["apikey"] = used_tmdb_key
     return None
+
+
+# ---------------------------------------------------------------------------
+# Confirm-flow validators.
+#
+# The /import-config/confirm route re-validates the session-stored Plex
+# and TMDb credentials before writing the imported config to the database.
+# These functions are the confirm-side analog of validate_plex_credentials
+# / validate_tmdb_credentials but simpler: creds always come from the
+# session (populated by the preview flow), and there's no bundle-cleanup
+# to do because at confirm time the bundle directory has already been
+# moved out of the scratch cache dir.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class ConfirmPlexOutcome:
+    """Outcome of :func:`validate_confirm_plex_credentials`.
+
+    On success ``movie_names`` and ``show_names`` are populated with
+    what Plex reported.  On failure ``error_response`` is populated
+    and the caller should return it directly.
+    """
+
+    error_response: tuple | None = None
+    movie_names: set = field(default_factory=set)
+    show_names: set = field(default_factory=set)
+
+
+def validate_confirm_plex_credentials() -> ConfirmPlexOutcome:
+    """Validate the session-stored Plex credentials during /confirm.
+
+    Reads ``import_preview_plex_url`` and ``import_preview_plex_token``
+    from the Flask session, re-runs the Plex validation call, and
+    returns the reported movie/show library names.  Emits distinct
+    error messages that direct the user to "Re-run Preview Import"
+    (unlike the preview validator which asks the user to enter creds).
+    """
+    plex_url = session.get("import_preview_plex_url") or ""
+    plex_token = session.get("import_preview_plex_token") or ""
+    if not plex_url or not plex_token:
+        return ConfirmPlexOutcome(
+            error_response=(
+                jsonify(
+                    success=False,
+                    message="Plex credentials are required to confirm the import. Re-run Preview Import.",
+                ),
+                400,
+            )
+        )
+    plex_response = validations.validate_plex_server({"plex_url": plex_url, "plex_token": plex_token})
+    plex_result = _coerce_validation_response_payload(plex_response)
+    if not plex_result or not plex_result.get("validated"):
+        error_message = plex_result.get("error") if isinstance(plex_result, dict) else None
+        return ConfirmPlexOutcome(
+            error_response=(
+                jsonify(
+                    success=False,
+                    message=error_message or "Plex validation failed. Re-run Preview Import.",
+                ),
+                400,
+            )
+        )
+    movie_names = _parse_csv_or_list_to_set(plex_result.get("movie_libraries", []))
+    show_names = _parse_csv_or_list_to_set(plex_result.get("show_libraries", []))
+    if not movie_names and not show_names:
+        return ConfirmPlexOutcome(
+            error_response=(
+                jsonify(
+                    success=False,
+                    message="No movie or show libraries found in Plex.",
+                ),
+                400,
+            )
+        )
+    return ConfirmPlexOutcome(movie_names=movie_names, show_names=show_names)
+
+
+def validate_confirm_tmdb_credentials() -> tuple | None:
+    """Validate the session-stored TMDb API key during /confirm.
+
+    Reads ``import_preview_tmdb_apikey`` from the Flask session and
+    re-runs the TMDb validation call.  Returns the error response
+    tuple on failure or None on success.
+    """
+    tmdb_apikey = session.get("import_preview_tmdb_apikey") or ""
+    if not tmdb_apikey:
+        return (
+            jsonify(
+                success=False,
+                message="TMDb API key is required to confirm the import. Re-run Preview Import.",
+            ),
+            400,
+        )
+    tmdb_response = validations.validate_tmdb_server({"tmdb_apikey": tmdb_apikey})
+    tmdb_result = _coerce_validation_response_payload(tmdb_response)
+    if not tmdb_result or not tmdb_result.get("valid"):
+        error_message = tmdb_result.get("message") if isinstance(tmdb_result, dict) else None
+        return (
+            jsonify(
+                success=False,
+                message=error_message or "TMDb validation failed. Re-run Preview Import.",
+            ),
+            400,
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Library mapping validation (confirm flow only).
+# ---------------------------------------------------------------------------
+
+
+def validate_library_mapping(
+    *,
+    libraries_payload: dict,
+    library_mapping: dict,
+    movie_names,
+    show_names,
+    needs_plex: bool,
+) -> tuple[dict | None, tuple | None]:
+    """Validate + apply a library-mapping dict to a libraries payload.
+
+    Called from /import-config/confirm after Plex credentials have been
+    re-validated.  For each library in ``libraries_payload`` either:
+
+    * The library name matches an existing Plex library -- passes through.
+    * The library name has an entry in ``library_mapping`` -- gets
+      renamed to the mapping target (or dropped if the target is the
+      ``__ignore__`` sentinel).
+    * The library name has no mapping -- reported as "missing".
+    * The library name maps to something not in Plex -- reported as
+      "invalid targets".
+    * Two libraries map to the same target -- reported as "duplicates".
+
+    On success, MUTATES ``libraries_payload``'s enclosing dict via
+    the caller's ``config_data`` -- but here we just return the
+    filtered ``mapped_libraries`` dict (or None on error, with the
+    error_response tuple that the caller returns directly).
+
+    :returns: (mapped_libraries_dict, None) on success, or
+              (None, error_response_tuple) on failure.
+    """
+    plex_lookup = {name: name for name in movie_names}
+    plex_lookup.update({name: name for name in show_names})
+    plex_names = set(plex_lookup.values())
+
+    if needs_plex and not plex_names:
+        return None, (
+            jsonify(
+                success=False,
+                message="Plex libraries are unavailable. Validate Plex and preview the import again.",
+            ),
+            400,
+        )
+
+    missing: list = []
+    invalid_targets: list = []
+    duplicates: list = []
+    used_targets: set = set()
+    mapped_libraries: dict = {}
+
+    for lib_name, lib_cfg in libraries_payload.items():
+        name = str(lib_name)
+        if name in plex_lookup:
+            target = plex_lookup[name]
+        else:
+            mapped = library_mapping.get(name)
+            if mapped is None:
+                missing.append(name)
+                continue
+            mapped = str(mapped).strip()
+            if not mapped:
+                missing.append(name)
+                continue
+            if mapped == "__ignore__":
+                continue
+            if mapped not in plex_lookup:
+                invalid_targets.append(mapped)
+                continue
+            target = plex_lookup[mapped]
+
+        if target in used_targets:
+            duplicates.append(target)
+            continue
+        used_targets.add(target)
+        mapped_libraries[target] = lib_cfg
+
+    if missing:
+        return None, (
+            jsonify(
+                success=False,
+                message=f"Library mapping required for: {', '.join(missing)}",
+            ),
+            400,
+        )
+    if invalid_targets:
+        unique_targets = sorted(set(invalid_targets))
+        return None, (
+            jsonify(
+                success=False,
+                message=f"Invalid Plex libraries selected: {', '.join(unique_targets)}",
+            ),
+            400,
+        )
+    if duplicates:
+        unique_targets = sorted(set(duplicates))
+        return None, (
+            jsonify(
+                success=False,
+                message=f"Multiple imports mapped to the same Plex library: {', '.join(unique_targets)}",
+            ),
+            400,
+        )
+
+    return mapped_libraries, None


### PR DESCRIPTION
Fifth cut into `blueprints/import_config_routes.py`.  Attacks three inline blocks in `import_config_preview_mapped` and DRY-collapses the cache-load pattern shared across three routes.

**NOTE**: Stacked on top of #1533.  GitHub will show that PR's diff as part of this one until it merges; the actual delta for THIS PR is the top commit (`Extract shared cache-load + preview-mapped report builders`).

## Summary

**`blueprints/import_config_routes.py`: 805 to 728 (-77 / -9.6%)**
**`import_config_preview_mapped`: 194 to 125 lines (-69)**
**Cross-route DRY win**: cache-load pattern deduplicated 3 -> 1.

## What moved

### New module: `blueprints/import_config_cache.py` (~70 lines)

`load_preview_cache(token)` returns `(cached, cache_path, err)` -- encapsulates the token-check + session-path + JSON-load pattern that was duplicated across `import_config_report`, `import_config_preview_mapped`, and `import_config_confirm`.

### New module: `blueprints/import_config_report_builder.py` (~105 lines)

Two public entry points extracted from `import_config_preview_mapped`:

- `build_alias_report_lines(...)` -- generates aliased duplicate report lines for renamed libraries (e.g. imported `Anime Movies` mapped to Plex `Movies` also emits `libraries.Anime Movies.*` lines so the user sees what will happen to the config they uploaded).  Returns new lines, never mutates input.
- `compute_line_counts(...)` -- counts imported / not_imported / comment / blank / total / diff lines from the raw + annotated YAML.

### Extended: `blueprints/import_config_validators.py` (+90 lines)

`apply_library_mapping_for_preview(...)` returns a `PreviewMappingResult`.  Same core loop as `validate_library_mapping` (confirm flow) but **accumulates** failure modes into `skip_reasons` + `stats` instead of erroring out.  The preview flow shows a "here's what will happen" report before the user hits Import, so it can't error on partial mappings.

## Caller collapse

`import_config_preview_mapped` compressed from 194 to 125 lines:

| Block | Before | After | Δ |
|---|---|---|---|
| Cache-load | 14 lines | 3 lines | -11 |
| Library mapping loop | 40 lines | 15 lines | -25 |
| Alias-lines nested loops | 29 lines | 6 lines | -23 |
| Line-counts | 16 lines | 5 lines | -11 |

Bonus: `import_config_report` + `import_config_confirm` each shed the same 14-line cache-load block for a 3-line call.

## Verification

- **AST-verified**: `import_config_preview` byte-identical to develop (only route not touched by this PR)
- **5 error-path smoke tests** for `load_preview_cache`: no-token, bad-token, no-path, missing-file, success -- all match develop payloads
- **4 unit tests** for the new mapping + report builders
- **Full test suite: 0 failures**
- Ruff + Black clean

## Sprint 5 scoreboard on this file

| PR | Ending lines | Δ |
|---|---|---|
| Baseline | 1384 | -- |
| #1530 (helpers) | 1188 | -196 |
| #1531 (bundle) | 1082 | -106 |
| #1532 (validators) | 907 | -175 |
| #1533 (confirm) | 805 | -102 |
| **This PR** (cache + preview-mapped) | **728** | **-77** |
| **Cumulative** | **728** | **-656 / -47.4%** |

## What's left

All four routes now under 250 lines:

| Route | Lines |
|---|---|
| `import_config_confirm` | 246 |
| `import_config_preview` | 222 |
| `import_config_preview_mapped` | 125 |
| `import_config_report` | 52 |

File still at 728 -- above the 600 soft-limit, but every remaining line has a clear owner.