### PR TITLE
Data-table refactor: 49 standard advisories -> Advisory records (follow-up to #1529)

### DIFF
--- a/modules/_logscan_advisory_table.py
+++ b/modules/_logscan_advisory_table.py
@@ -1,0 +1,390 @@
+"""Data table + render helper for standard-template log-scan advisories.
+
+Split out of :mod:`modules.logscan_advisory_messages` -- this module owns
+the ~50 near-identical ``if bucket: url_line = ...; msg = (...)`` blocks
+that used to make ``build_advisory_messages`` a 900-line linear walk.
+
+## Why a data table
+
+Nearly all advisory messages share the same shape::
+
+    <icon> **<TITLE>**
+    <body line 1>
+    <body line 2>
+    ...
+    For more information on <topic>, <url>
+    <N> line(s) with <label>. Line number(s): <formatted>
+
+That template collapses to a single record per bucket:
+
+* :class:`Advisory` -- immutable record holding the message body
+  prefix (everything except the count line, with ``{url_line}``
+  placeholders where the URL should land), the URL itself, and the
+  bucket-specific count label.
+
+* :func:`render_advisory` -- assembles the final markdown string
+  given the record, the (populated) bucket, and the analyzer whose
+  ``format_contiguous_lines`` renders the "L45-48, L92" summary.
+
+The 49 entries in :data:`STANDARD_ADVISORIES` cover every bucket whose
+message can be described purely by ``(body, url, count_label)``.  The
+handful of buckets that need analyzer-attribute interpolation
+(``timeout_errors``, the version-update trio, ``flixpatrol_paywall``)
+or that emit non-standard shapes (``convert_errors``,
+``metadata_attribute_errors``, ``overlay_apply_errors``,
+``rounding_errors``, ``security_vuln_hits``, ``incomplete_message``)
+stay inline in the parent module.
+
+## Ordering
+
+The tuple is in **source order** to preserve the append order of
+``special_check_lines``.  ``build_advisory_messages`` walks it
+linearly and interleaves the inline specials at their original
+positions, so the output list matches the pre-refactor byte-for-byte.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class Advisory:
+    """Immutable descriptor for one standard-template advisory message.
+
+    Attributes:
+        bucket_key: Name of the bucket this advisory describes.  Kept
+            for documentation/lookup; the render function receives the
+            populated bucket directly.
+        body: Everything except the trailing count line, including the
+            header (``"<icon> **<TITLE>**\\n"``), body lines, and the
+            "For more information on ..., {url_line}\\n" line.  The
+            literal placeholder ``{url_line}`` is substituted with
+            :attr:`url` at render time.
+        url: The wiki/forums URL that fills in ``{url_line}``.  May be
+            empty for the rare bucket that doesn't cite one (e.g.
+            ``checkFiles``).
+        count_label: The human-readable label inserted into the count
+            line, e.g. ``"ANIDB69 errors"`` -> ``"7 line(s) with ANIDB69
+            errors. Line number(s): L12-15"``.
+    """
+
+    bucket_key: str
+    body: str
+    url: str
+    count_label: str
+
+
+def render_advisory(advisory: Advisory, bucket, analyzer) -> str:
+    """Render *advisory* against a populated *bucket* using *analyzer*.
+
+    Substitutes the ``{url_line}`` placeholder in the advisory body,
+    formats the affected line numbers via
+    ``analyzer.format_contiguous_lines``, and returns the final
+    markdown string ready to append to ``special_check_lines``.
+    """
+    formatted_errors = analyzer.format_contiguous_lines(bucket)
+    body = advisory.body.replace("{url_line}", advisory.url)
+    return f"{body}{len(bucket)} line(s) with {advisory.count_label}. Line number(s): {formatted_errors}"
+
+
+# The order of this tuple mirrors the source order of the legacy
+# ``if bucket:`` blocks in ``build_advisory_messages`` so the caller
+# can walk it linearly and interleave the inline specials at their
+# original positions without shifting the final output.
+STANDARD_ADVISORIES: tuple[Advisory, ...] = (
+    Advisory(
+        bucket_key="anidb69_errors",
+        body="❌ **ANIDB69 ERROR**\nKometa uses AniDB ID 69 to test that it can connect to AniDB.\nThis error indicates that the test request sent to AniDB failed and AniDB could not be reached.\nFor more information on configuring AniDB, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/config/anidb]",
+        count_label="ANIDB69 errors",
+    ),
+    Advisory(
+        bucket_key="anidb_auth_errors",
+        body="❌ **ANIDB AUTH ERRORS**\nKometa uses AniDB settings to connect to AniDB.\nThis error indicates that the setting is not correctly setup in config.yml.\nFor more information on configuring AniDB, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/config/anidb]",
+        count_label="ANIDB AUTH errors",
+    ),
+    Advisory(
+        bucket_key="api_blank_errors",
+        body="❌🔒 **BLANK API KEY ERROR**\nAn API key is required for certain services, and it appears to be blank in your configuration.\nMake sure to provide the required API key to enable proper functionality.\nFor more information on configuring API keys, {url_line}\nIn the Kometa discord thread, type `!wiki` for more information and search for the service with the missing apikey \n",
+        url="[https://kometa.wiki/en/latest/config/trakt/?q=api]",
+        count_label="BLANK API KEY errors",
+    ),
+    Advisory(
+        bucket_key="bad_version_found_errors",
+        body="💥 **BAD PLEX VERSION ERROR**\nYou are running a version of Plex that is known to have issues with Kometa.\nYou should downgrade/upgrade to a version that is not `1.32.7.*`.\nFor more information on this issue, {url_line}\n",
+        url="[https://forums.plex.tv/t/refresh-endpoint-put-post-requests-started-throwing-404s-in-version-1-32-7-7484/853588]",
+        count_label="Plex Version 1.32.7.*",
+    ),
+    Advisory(
+        bucket_key="cache_false",
+        body="💬 **Kometa CACHE**\nKometa cache setting is set to false(`cache: false`). Normally, you would want this set to true to improve performance.\nFor more information on handling this, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/config/settings#cache]",
+        count_label="`cache: false`",
+    ),
+    Advisory(
+        bucket_key="checkFiles",
+        body="⚠️ **CHECKFILES=1 DETECTED**\n`checkFiles=1` detected. Notifying Kometa staff.\n",
+        url="",
+        count_label="`checkFiles=1` messages",
+    ),
+    Advisory(
+        bucket_key="other_award",
+        body="⚠️ **LEGACY SCHEMA DETECTED**\nAs of 1.20 `other_award` is no longer used and should be removed. All of those awards now have their own individual files.\nFor more information on handling these, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/kometa/faqs/?h=other_award#pmm-120-release-changes]",
+        count_label="`other_award` issues",
+    ),
+    Advisory(
+        bucket_key="critical_errors",
+        body="💥 **[CRITICAL]**\nCritical messages found in your attached log.\nThere is a very strong likelihood that Kometa aborted the run or part of the run early thus not all of what you wanted was applied.\nFor more information on handling these, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/kometa/logs/?h=%5Bcritical%5D#critical]",
+        count_label="[CRITICAL] messages",
+    ),
+    Advisory(
+        bucket_key="error_errors",
+        body="❌ **[ERROR]**\nError messages found in your attached log.\nThere is a very strong likelihood that Kometa did not complete all of what you wanted. Some [ERROR] lines can be ignored.\nFor more information on handling these, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/kometa/logs/?h=%5Berror%5D#error]",
+        count_label="[ERROR] messages",
+    ),
+    Advisory(
+        bucket_key="warning_errors",
+        body="⚠️ **[WARNING]**\nWarning messages found in your attached log.\nThis is a Kometa warning and usually does not require any immediate action. Most [WARNING] lines can be ignored.\nFor more information on handling these, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/kometa/logs/?h=%5Bwarning%5D#warning]",
+        count_label="[WARNING] messages",
+    ),
+    Advisory(
+        bucket_key="convert_errors",
+        body="💬 **CONVERT WARNING**\nConvert Warning: No * ID Found for * ID.\nThese sorts of errors indicate that the thing can't be cross-referenced between sites.  For example:\n\nConvert Warning: No TVDb ID Found for TMDb ID: 15733\n\nIn the above scenario, the TMDB record for `The Two Mrs. Grenvilles` `ID 15733` didn't contain a TVDB ID. This could be because the record just hasn't been updated, or because `The Two Mrs. Grenvilles` isn't listed on TVDB.\n\nThe fix is for someone `like you, perhaps` to go to the relevant site and fill in the missing data.\nFor more information on handling these, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/kometa/logs/#warning]",
+        count_label="Convert Warnings",
+    ),
+    Advisory(
+        bucket_key="corrupt_image_errors",
+        body="❌ **CORRUPT FILE ERROR**\nLikely, when processing overlays, Kometa encountered a file that it could not process because it was corrupt.\nReview the lines in your log file and based on the lines shown here and determine if those files are ok or not with your favorite image editor.\nFor more information on handling these, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/kometa/logs/#error]",
+        count_label="`PIL.UnidentifiedImageError` reported",
+    ),
+    Advisory(
+        bucket_key="delete_unmanaged_collections_errors",
+        body="⚠️ **LEGACY SCHEMA DETECTED**\n`delete_unmanaged_collections` is a Library operation and should be adjusted in your config file accordingly.\nFor more information on handling these, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/config/operations/#delete-collections]",
+        count_label="`delete_unmanaged_collections` errors",
+    ),
+    Advisory(
+        bucket_key="flixpatrol_errors",
+        body="❌ **FLIXPATROL ERROR**\nThere was an issue with FlixPatrol data.\nThis is a known issue with Kometa 1.19.0 (master/latest branch).\nSwitch to the 1.19.1 nightly21 or greater Kometa release for a fix.\nIn the Kometa discord thread, for more information on how to switch branches, type `!branch`.\nFor more information on handling FlixPatrol errors, {url_line}\nIf the problem persists, your IP address might be banned by FlixPatrol. Contact their support to have it unbanned.\n",
+        url="[https://kometa.wiki/en/latest/kometa/faqs/?h=flixpatrol#flixpatrol]",
+        count_label="FlixPatrol errors",
+    ),
+    Advisory(
+        bucket_key="git_kometa_errors",
+        body="💬 **OLD Kometa YAML**\nYou are using an old config.yml with references to metadata files that date to a version of Kometa that is pre 1.18\nIn the Kometa discord thread, type `!118` for more information.\nFor more information on handling this, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/config/overview/?h=configuration]",
+        count_label="OLD Kometa YAML",
+    ),
+    Advisory(
+        bucket_key="pmm_legacy_errors",
+        body="💬 **PRE KOMETA YAML**\nYou are using an old config.yml with references to metadata files that date to a version of this script that is pre Kometa\nIn your config.yml, search for `- pmm: ` and replace with `- default: ` .\nFor more information on handling this, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/config/overview/?h=configuration]",
+        count_label="PRE Kometa YAML",
+    ),
+    Advisory(
+        bucket_key="image_size",
+        body="❌ **IMAGE SIZE ERRORS**\nIt seems that you are attempting to upload or apply artwork and it's greater than the maximum `10MB`.\nThis usually means that you have internal server errors (500) as well in this log. Change the image to one that is less than 10MB. For more information on handling this, {url_line}\n",
+        url="[https://www.google.com]",
+        count_label="IMAGE SIZE errors",
+    ),
+    Advisory(
+        bucket_key="internal_server_errors",
+        body="💥 **INTERNAL SERVER ERROR**\nAn internal server error has occurred. This could be due to an issue with the service's server.\nIn the Kometa discord thread, type `!500` for more information.\nFor more information on handling internal server errors, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/kometa/faqs/?h=errors+issues#errors-issues]",
+        count_label="INTERNAL SERVER errors",
+    ),
+    Advisory(
+        bucket_key="lsio_errors",
+        body="⚠️🖥️ **LINUXSERVER IMAGE DETECTED**\nYou are not using the official Kometa container image.\nIn the Kometa discord thread, type `!lsio` for more information.\nFor more information on this, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/kometa/install/images/?h=linuxserver#linuxserver]",
+        count_label="LINUXSERVER IMAGE issues",
+    ),
+    Advisory(
+        bucket_key="mal_connection_errors",
+        body="❌ **MY ANIME LIST CONNECTION ERROR**\nThere was an issue connecting to My Anime List (MAL) service.\nThis will affect any functionality that relies on MAL data.\nIn the Kometa discord thread, type `!mal` for more information\nFor more information on configuring the My Anime List (MAL) service, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/config/myanimelist]",
+        count_label="MY ANIME LIST CONNECTION errors",
+    ),
+    Advisory(
+        bucket_key="mass_update_errors",
+        body="❌ **MASS_*_UPDATE ERROR**\nYou have specified a `mass_*_update` operation in your config file however you have not configured the corresponding service so this will never work.\nReview each of the lines mentioned in this message to understand what all the config issues are.\nIn the Kometa discord thread, type `!wiki` for more information and search.\nFor more information on `mass_*_update` operations, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/config/operations]",
+        count_label="`mass_*_update` config errors",
+    ),
+    Advisory(
+        bucket_key="mdblist_attr_errors",
+        body="❌ **MDBLIST ATTRIBUTE ERROR**\nMDBList functionality does not currently support season-level collections.\nIn the Kometa discord thread, type `!wiki` for more information and search.\nFor more information on MDBList configuration, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/files/builders/mdblist/?h=mdblist+builders]",
+        count_label="MDBList attribute errors",
+    ),
+    Advisory(
+        bucket_key="mdblist_errors",
+        body="❌ **MDBLIST ERROR**\nYour configuration contains an invalid API key for MdbList.\nThis will cause any services that rely on MdbList to fail.\nIn the Kometa discord thread, type `!wiki` for more information and search.\nFor more information on configuring MdbList, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/config/mdblist/?h=mdblist+attributes#mdblist-attributes]",
+        count_label="MDBLIST errors",
+    ),
+    Advisory(
+        bucket_key="mdblist_api_limit_errors",
+        body="❌ **MDBLIST API LIMIT ERROR**\nYou have hit the MDBLIST API LIMIT. The free apikey is limited to 1000 requests per day so if you hit your limit Kometa should be able to pick up where it left off the next day as long as the Kometa cache setting is enabled in yur config.yml file.\nThis will cause any metadata updates that rely on MdbList to fail until the limit is reset (usually daily).\nFor more information on configuring MdbList, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/config/mdblist/?h=mdblist+attributes#mdblist-attributes]",
+        count_label="MDBLIST API Limit errors",
+    ),
+    Advisory(
+        bucket_key="metadata_attribute_errors",
+        body="❌ **METADATA ATTRIBUTE ERRORS**\nIf you are using Kometa nightly48 or newer, this is expected behaviour.\n`metadata_path` and `overlay_path` are now legacy attributes, and using them will cause the `YAML Error: metadata attribute is required` error.\nThe error can be ignored as it won't cause any issues, or you can update your config.yml to use the new `collection_files`, `overlay_files` and `metadata_files` attributes.\n\nThe steps to take are:\n:one: - Look at every file referred to within your config.yml and see what the first level indentation yaml file attributes are. They should be one of these(`collections:, dynamic_collections:, overlays:, metadata:, playlists:, templates:, external_templates:`) and can contain more than 1. For now, ignore the `templates:` and `external_templates:` attributes.\n:two: - if it's `metadata:`, file it under the `metadata_file:` section of your config.yml\n:three: - if it's `collections:` or `dynamic_collections:`, file it under the `collection_files:` section of your config.yml\n:four: - if it's `playlists:`,  file it under the `playlist_files:` section of your config.yml\n:five: - if it's `overlays:`,  file it under the `overlay_files:` section of your config.yml\n\n`*NOTE:` If you only see `templates:` or `external_templates:`, this is a special case and you typically would not be referring to it directly in your config.yml file.\n\nWithin the attached log file, go to the indicated line(s) for more details on the exact issue and take actions to fix.\nFor more information on this, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/config/files/#example]",
+        count_label="METADATA ATTRIBUTE errors",
+    ),
+    Advisory(
+        bucket_key="metadata_load_errors",
+        body="❌ **METADATA LOAD ERRORS**\nKometa is trying to load a file from your config file.\nThis error indicates that the setting is not correctly setup in config.yml. Usually wrong path to the file, or a badly formatted yml file.\nWithin the attached log file, go to the indicated line(s) for more details on the exact issue and take actions to fix.\nFor more information on this, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/config/overview/?h=configuration]",
+        count_label="METADATA LOAD errors",
+    ),
+    Advisory(
+        bucket_key="overlay_load_errors",
+        body="❌ **OVERLAY LOAD ERRORS**\nKometa is trying to load a file from your config file.\nThis error indicates that the setting is not correctly setup in config.yml. Usually wrong path to the file, or a badly formatted yml file.\nWithin the attached log file, go to the indicated line(s) for more details on the exact issue and take actions to fix.\nFor more information on this, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/config/overview/?h=configuration]",
+        count_label="OVERLAY LOAD errors",
+    ),
+    Advisory(
+        bucket_key="playlist_load_errors",
+        body="❌ **PLAYLIST LOAD ERRORS**\nKometa is trying to load a file from your config file.\nThis error indicates that the setting is not correctly setup in config.yml. Usually wrong path to the file, or a badly formatted yml file.\nWithin the attached log file, go to the indicated line(s) for more details on the exact issue and take actions to fix.\nFor more information on this, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/config/overview/?h=configuration]",
+        count_label="PLAYLIST LOAD errors",
+    ),
+    Advisory(
+        bucket_key="missing_path_errors",
+        body="⚠️ **LEGACY SCHEMA DETECTED**\n`missing_path` or `save_missing` is no longer used and should be replaced/removed. Use `report_path` instead.\nFor more information on handling these, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/config/libraries/?h=report_path#attributes]",
+        count_label="`missing_path` or `save_missing` errors",
+    ),
+    Advisory(
+        bucket_key="no_items_found_errors",
+        body="⚠️ **NO ITEMS FOUND IN PLEX**\nThe criteria defined by a search/filter returned 0 results.\nThis is often expected - for example, if you try to apply a 1080P overlay to a 4K library then no items will get the overlay since no items have a 1080P resolution.\nIt is worth noting that search and filters are case-sensitive, so `1080P` and `1080p` are treated as two separate things.\nFor more information on this error, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/kometa/logs/?h=%5Berror%5D#error]",
+        count_label="'No Items found in Plex' errors",
+    ),
+    Advisory(
+        bucket_key="omdb_errors",
+        body="❌ **OMDB ERROR**\nYour configuration contains an invalid API key for OMDb.\nThis will cause any services that rely on OMDb to fail.\nIn the Kometa discord thread, type `!wiki` for more information and search.\nFor more information on configuring OMDb, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/config/omdb/#omdb-attributes]",
+        count_label="OMDb errors",
+    ),
+    Advisory(
+        bucket_key="omdb_api_limit_errors",
+        body="❌ **OMDB API LIMIT ERROR**\nYou have hit the OMDB API LIMIT. The free apikey is limited to 1000 requests per day so if you hit your limit Kometa should be able to pick up where it left off the next day as long as the Kometa cache setting is enabled in yur config.yml file.\nThis will cause any metadata updates that rely on OMDB to fail until the limit is reset (usually daily).\nFor more information on configuring OMDB, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/config/omdb/?h=omdb#omdb-attributes]",
+        count_label="OMDB API Limit errors",
+    ),
+    Advisory(
+        bucket_key="overlay_font_missing",
+        body="❌ **OVERLAY FONT MISSING**\nWe detected that you are referencing a font that Kometa cannot find.\nThis can lead to overlays not being applied when a font is required.\nIn the Kometa discord thread, type `!wiki` for more information or follow this link: {url_line}\n",
+        url="[https://kometa.wiki/en/latest/showcase/overlays/?h=font#example-2]",
+        count_label="`Overlay Error: font:` errors",
+    ),
+    Advisory(
+        bucket_key="overlays_bloat",
+        body="⚠️ **REAPPLY / RESET OVERLAYS**\n\nWe detected that you are using either reapply_overlays OR reset_overlays within your config.\n\n**You should NOT be using reapply_overlays unless you have a specific reason to. If you are not sure do NOT enable it.**\n\nThis can lead to your system creating additional posters within Plex causing bloat\n\nTypically these config lines are only used for very specific cases so if this is your case, then you can ignore this recommendation\n\nIn the Kometa discord thread, type `!bloat` for more information or follow this link: {url_line}\n\n",
+        url="[https://kometa.wiki/en/latest/kometa/scripts/imagemaid]",
+        count_label="reapply_overlays or reset_overlays",
+    ),
+    Advisory(
+        bucket_key="overlay_image_missing",
+        body="❌ **OVERLAY IMAGE MISSING ERROR**\nKometa attempts to apply an overlay to things, but finds that the overlay itself is not found and thus cannot be applied to the art.\nValidate the path and also ensure that the case of the file(i.e. `4K.png` is NOT the same as `4k.png`) is the same as found in the line within the log.\nFor more information on overlays, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/defaults/overlays]",
+        count_label="OVERLAY IMAGE MISSING errors",
+    ),
+    Advisory(
+        bucket_key="overlay_level_errors",
+        body="⚠️ **LEGACY SCHEMA DETECTED**\n`overlay_level:` is no longer used and should be replaced by `builder_level:`.\nFor more information on handling these, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/files/settings/?h=builder_level]",
+        count_label="`overlay_level` errors",
+    ),
+    Advisory(
+        bucket_key="playlist_errors",
+        body="❌ **PLAYLIST ERROR**\nA playlist is trying to use a library that does not exist in Plex.\nEnsure that all libraries being defined actually exist.\nThe Kometa Defaults `playlist` file expects libraries called `Movies` and `TV Shows`, template variables can be used to change this.\nFor more information: {url_line}\n",
+        url="[https://kometa.wiki/en/latest/defaults/playlist/?h=playlist]",
+        count_label="playlist errors",
+    ),
+    Advisory(
+        bucket_key="plex_regex_errors",
+        body="⚠️ **PLEX REGEX ERROR**\nKometa is trying to perform a regex search, and 0 items match the regex pattern.\nThis is often an expected error and can be ignored in most cases.\nIf you need assistance with this error, raise a support thread in `#kometa-help`.\nFor more information on handling regex issues, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/kometa/logs/?h=%5Berror%5D#error]",
+        count_label="Plex regex errors",
+    ),
+    Advisory(
+        bucket_key="plex_lib_errors",
+        body="❌ **PLEX LIBRARY ERROR**\nYour configuration contains an invalid Plex Library Name.\nKometa will not be able to update a library that does not exist.\nCheck for spelling `case sensitive` and ensure that you have `show_options: true` within your settings within config.yml\nFor more information on configuring the show_options, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/config/settings/?h=show_options#show-options]",
+        count_label="PLEX LIBRARY errors",
+    ),
+    Advisory(
+        bucket_key="plex_url_errors",
+        body="❌ **PLEX URL ERROR**\nYour configuration contains an invalid Plex URL.\nThis will cause any services that rely on this URL to fail.\nIn the Kometa discord thread, type `!wiki` for more information and search.\nFor more information on configuring the Plex URL, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/kometa/install/wt/wt-01-basic-config/#getting-a-plex-url-and-token]",
+        count_label="PLEX URL errors",
+    ),
+    Advisory(
+        bucket_key="ruamel_errors",
+        body="💥 **YAML ERROR**\nYAML is very sensitive with regards to spaces and indentation.\nSearch for `ruamel.yaml.` in your log file to get hints as to where the problem lies.\nIn the Kometa discord thread, type `!yaml` and `!editors` for more information.\nFor more information on handling YAML issues, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/kometa/yaml/]",
+        count_label="YAML errors",
+    ),
+    Advisory(
+        bucket_key="run_order_errors",
+        body="⚠️ **RUN_ORDER WARNING**\nTypically, and in almost EVERY situation, you want ` - operations` to precede both metadata and overlays processing. To fix this, place `- operations` first in the `run_order` section of the config.yml file\nFor more information on this, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/config/settings/?h=run_order#run-order]",
+        count_label="RUN_ORDER warnings",
+    ),
+    Advisory(
+        bucket_key="traceback_errors",
+        body="💥 **TRACEBACK ERROR**\nYour KOMETA run contains traceback errors.\nThis likely means that the run ended prematurely or did not complete certain tasks (i.e. overlays ended early or did not apply).\nIn the Kometa discord thread, type `!wiki` for more information and search.\n",
+        url="[https://kometa.wiki/en/latest/config/tautulli]",
+        count_label="Traceback errors",
+    ),
+    Advisory(
+        bucket_key="tautulli_apikey_errors",
+        body="❌ **TAUTULLI API ERROR**\nYour configuration contains an invalid API key for Tautulli.\nThis will cause any services that rely on Tautulli to fail.\nIn the Kometa discord thread, type `!wiki` for more information and search.\nFor more information on configuring Tautulli, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/config/tautulli]",
+        count_label="Tautulli errors",
+    ),
+    Advisory(
+        bucket_key="tautulli_url_errors",
+        body="❌ **TAUTULLI URL ERROR**\nYour configuration contains an invalid Tautulli URL.\nThis will cause any services that rely on this URL to fail.\nIn the Kometa discord thread, type `!wiki` for more information and search.\nFor more information on configuring the Tautulli URL, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/config/tautulli#tautulli-attributes]",
+        count_label="TAUTULLI URL errors",
+    ),
+    Advisory(
+        bucket_key="tmdb_api_errors",
+        body="❌ **TMDB API ERROR**\nYour configuration contains an invalid API key for TMDb.\nThis will cause any services that rely on TMDb to fail.\nIn the Kometa discord thread, type `!wiki` for more information and search.\nFor more information on configuring TMDb, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/kometa/install/wt/wt-01-basic-config/#getting-a-tmdb-api-key]",
+        count_label="TMDb errors",
+    ),
+    Advisory(
+        bucket_key="tmdb_fail_errors",
+        body="❌ **TMDB ERROR**\nThis error appears when your host machine is unable to connect to TMDb.\nEnsure that your networking (particularly docker container) is configured to allow Kometa to make internet calls.\nFor more information on network configuration, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/kometa/install/wt/wt-01-basic-config/]",
+        count_label="TMDB errors. Line number location",
+    ),
+    Advisory(
+        bucket_key="to_be_configured_errors",
+        body="❌ **TO BE CONFIGURED ERROR**\nYou are using a builder that has not been configured yet.\nThis will affect any functionality that relies on these connections. Review all lines below and resolve.\nIn the Kometa discord thread, type `!wiki` and search for more information\nFor more information on configuring services, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/kometa/logs/?h=%5Berror%5D#error]",
+        count_label="`to be configured` errors",
+    ),
+    Advisory(
+        bucket_key="trakt_connection_errors",
+        body="❌ **TRAKT CONNECTION ERROR**\nThere was an issue connecting to the Trakt service.\nThis will affect any functionality that relies on Trakt data.\nIn the Kometa discord thread, type `!trakt` for more information\nFor more information on configuring the Trakt service, {url_line}\n",
+        url="[https://kometa.wiki/en/latest/config/trakt/#trakt-attributes]",
+        count_label="TRAKT CONNECTION errors",
+    ),
+)

--- a/modules/logscan_advisory_messages.py
+++ b/modules/logscan_advisory_messages.py
@@ -11,15 +11,20 @@ Single public entry point :func:`build_advisory_messages` (renamed
 from the leading-underscore private name so external test-suites
 can call it directly without importing a private symbol).
 
-The function is a long linear walk through every issue bucket in
-the same order the legacy ``make_recommendations`` did.  For each
-populated bucket:
+The function is a linear walk through every issue bucket in the
+same order the legacy ``make_recommendations`` did.  For each
+populated bucket, either:
 
-  1. Formats the affected line numbers via
-     ``analyzer.format_contiguous_lines`` (e.g. ``L45-48, L92``).
-  2. Assembles a markdown-formatted advisory string with icon,
-     title, description, remediation URL, and the count line.
-  3. Appends it to the caller's ``special_check_lines`` list.
+* :func:`~modules._logscan_advisory_table.render_advisory` renders
+  the standard-template markdown (icon, title, body, URL, count
+  line) from an :class:`~modules._logscan_advisory_table.Advisory`
+  record -- see the ``_append_std`` nested helper below.
+* An inline block builds a bespoke markdown string when the bucket
+  needs analyzer-attribute interpolation, multi-URL citations, or
+  iteration over tuple payloads.
+
+Either way the result is appended to the caller's
+``special_check_lines`` list.
 
 At the end it also computes the four platform-level
 recommendations (WSL, run-time, memory, db_cache) via the
@@ -28,12 +33,26 @@ analyzer's wrapper methods and returns them as a dict so
 
 ## Why not a data table?
 
-The docstring on the engine module (see below) notes that the
-~800 advisory-builder blocks "mostly follow a shared template
-shape" and could collapse to a data table with a dozen inline
-exceptions.  That's a great follow-up but out of scope for this
-PR -- keeping the extraction as a pure byte-identical move so
-review can focus on the file split, not behavior changes.
+Most blocks *are* a data table now.  49 of the ~57 buckets share the
+same ``(icon+title, body lines, url, count label)`` shape and live in
+:mod:`modules._logscan_advisory_table` as :class:`~modules._logscan_advisory_table.Advisory`
+records.  A single-line ``_append_std(bucket_key, bucket)`` call
+inside :func:`build_advisory_messages` renders each one when its
+bucket is populated.
+
+The remaining ~8 blocks stay inline because they need something the
+template can't express:
+
+* ``timeout_errors``, ``flixpatrol_paywall``, the two version-update
+  buckets -- interpolate analyzer attributes like ``plex_timeout`` or
+  ``current_kometa_version`` into the body.
+* ``convert_errors``, ``metadata_attribute_errors`` -- multi-paragraph
+  bodies with ``\n\n`` breaks that make a hand-written string clearer.
+* ``overlay_apply_errors`` -- cites *two* URLs.
+* ``rounding_errors``, ``security_vuln_hits`` -- iterate over tuples
+  ``(server_name, version, line_num)`` to build the body.
+* ``incomplete_message`` -- uses the *value* of the bucket variable
+  (a preformatted string) as the body, not a fixed template.
 
 ## Backward compatibility
 
@@ -47,11 +66,19 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+from modules._logscan_advisory_table import (
+    STANDARD_ADVISORIES,
+    render_advisory,
+)
 from modules.logscan_pms_versions import (
     VULNERABLE_RANGE_HIGH,
     VULNERABLE_RANGE_LOW,
     format_version_tuple,
 )
+
+# Lookup by bucket key so each ``if bucket:`` block can defer to a
+# single-line ``_append_std`` call inside ``build_advisory_messages``.
+_ADVISORY = {advisory.bucket_key: advisory for advisory in STANDARD_ADVISORIES}
 
 
 def build_advisory_messages(
@@ -130,121 +157,31 @@ def build_advisory_messages(
     so the caller can populate the ``issue_counts`` dict without
     re-running the extraction pipeline.
     """
-    if anidb69_errors:
-        url_line = "[https://kometa.wiki/en/latest/config/anidb]"
-        formatted_errors = analyzer.format_contiguous_lines(anidb69_errors)
-        anidb69_error_message = (
-            "❌ **ANIDB69 ERROR**\n"
-            "Kometa uses AniDB ID 69 to test that it can connect to AniDB.\n"
-            "This error indicates that the test request sent to AniDB failed and AniDB could not be reached.\n"
-            f"For more information on configuring AniDB, {url_line}\n"
-            f"{len(anidb69_errors)} line(s) with ANIDB69 errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(anidb69_error_message)
 
-    if anidb_auth_errors:
-        url_line = "[https://kometa.wiki/en/latest/config/anidb]"
-        formatted_errors = analyzer.format_contiguous_lines(anidb_auth_errors)
-        anidb_auth_errors_message = (
-            "❌ **ANIDB AUTH ERRORS**\n"
-            "Kometa uses AniDB settings to connect to AniDB.\n"
-            "This error indicates that the setting is not correctly setup in config.yml.\n"
-            f"For more information on configuring AniDB, {url_line}\n"
-            f"{len(anidb_auth_errors)} line(s) with ANIDB AUTH errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(anidb_auth_errors_message)
+    def _append_std(bucket_key: str, bucket) -> None:
+        """Append a standard-template advisory when *bucket* is populated.
 
-    if api_blank_errors:
-        url_line = "[https://kometa.wiki/en/latest/config/trakt/?q=api]"
-        formatted_errors = analyzer.format_contiguous_lines(api_blank_errors)
-        api_blank_error_message = (
-            "❌🔒 **BLANK API KEY ERROR**\n"
-            "An API key is required for certain services, and it appears to be blank in your configuration.\n"
-            "Make sure to provide the required API key to enable proper functionality.\n"
-            f"For more information on configuring API keys, {url_line}\n"
-            "In the Kometa discord thread, type `!wiki` for more information and search for the service with the missing apikey \n"
-            f"{len(api_blank_errors)} line(s) with BLANK API KEY errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(api_blank_error_message)
+        Looks up the :class:`Advisory` record by *bucket_key* and
+        appends the rendered markdown to the enclosing scope's
+        ``special_check_lines`` list.  Standard advisories are the
+        ones that fit the ``(body, url, count_label)`` template;
+        see :mod:`modules._logscan_advisory_table`.
+        """
+        if bucket:
+            special_check_lines.append(
+                render_advisory(_ADVISORY[bucket_key], bucket, analyzer),
+            )
 
-    if bad_version_found_errors:
-        url_line = "[https://forums.plex.tv/t/refresh-endpoint-put-post-requests-started-throwing-404s-in-version-1-32-7-7484/853588]"
-        formatted_errors = analyzer.format_contiguous_lines(bad_version_found_errors)
-        bad_version_found_errors_message = (
-            "💥 **BAD PLEX VERSION ERROR**\n"
-            "You are running a version of Plex that is known to have issues with Kometa.\n"
-            "You should downgrade/upgrade to a version that is not `1.32.7.*`.\n"
-            f"For more information on this issue, {url_line}\n"
-            f"{len(bad_version_found_errors)} line(s) with Plex Version 1.32.7.*. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(bad_version_found_errors_message)
-
-    if cache_false:
-        url_line = "[https://kometa.wiki/en/latest/config/settings#cache]"
-        formatted_errors = analyzer.format_contiguous_lines(cache_false)
-        cache_false_message = (
-            "💬 **Kometa CACHE**\n"
-            "Kometa cache setting is set to false(`cache: false`). Normally, you would want this set to true to improve performance.\n"
-            f"For more information on handling this, {url_line}\n"
-            f"{len(cache_false)} line(s) with `cache: false`. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(cache_false_message)
-
-    if checkFiles:
-        formatted_errors = analyzer.format_contiguous_lines(checkFiles)
-        checkFiles_message = (
-            "⚠️ **CHECKFILES=1 DETECTED**\n"
-            "`checkFiles=1` detected. Notifying Kometa staff.\n"
-            f"{len(checkFiles)} line(s) with `checkFiles=1` messages. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(checkFiles_message)
-
-    if other_award:
-        url_line = "[https://kometa.wiki/en/latest/kometa/faqs/?h=other_award#pmm-120-release-changes]"
-        formatted_errors = analyzer.format_contiguous_lines(other_award)
-        other_award_message = (
-            "⚠️ **LEGACY SCHEMA DETECTED**\n"
-            "As of 1.20 `other_award` is no longer used and should be removed. All of those awards now have their own individual files.\n"
-            f"For more information on handling these, {url_line}\n"
-            f"{len(other_award)} line(s) with `other_award` issues. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(other_award_message)
-
-    if critical_errors:
-        url_line = "[https://kometa.wiki/en/latest/kometa/logs/?h=%5Bcritical%5D#critical]"
-        formatted_errors = analyzer.format_contiguous_lines(critical_errors)
-        critical_error_message = (
-            "💥 **[CRITICAL]**\n"
-            f"Critical messages found in your attached log.\n"
-            f"There is a very strong likelihood that Kometa aborted the run or part of the run early thus not all of what you wanted was applied.\n"
-            f"For more information on handling these, {url_line}\n"
-            f"{len(critical_errors)} line(s) with [CRITICAL] messages. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(critical_error_message)
-
-    if error_errors:
-        url_line = "[https://kometa.wiki/en/latest/kometa/logs/?h=%5Berror%5D#error]"
-        formatted_errors = analyzer.format_contiguous_lines(error_errors)
-        error_error_message = (
-            "❌ **[ERROR]**\n"
-            f"Error messages found in your attached log.\n"
-            f"There is a very strong likelihood that Kometa did not complete all of what you wanted. Some [ERROR] lines can be ignored.\n"
-            f"For more information on handling these, {url_line}\n"
-            f"{len(error_errors)} line(s) with [ERROR] messages. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(error_error_message)
-
-    if warning_errors:
-        url_line = "[https://kometa.wiki/en/latest/kometa/logs/?h=%5Bwarning%5D#warning]"
-        formatted_errors = analyzer.format_contiguous_lines(warning_errors)
-        warning_error_message = (
-            f"⚠️ **[WARNING]**\n"
-            f"Warning messages found in your attached log.\n"
-            f"This is a Kometa warning and usually does not require any immediate action. Most [WARNING] lines can be ignored.\n"
-            f"For more information on handling these, {url_line}\n"
-            f"{len(warning_errors)} line(s) with [WARNING] messages. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(warning_error_message)
+    _append_std("anidb69_errors", anidb69_errors)
+    _append_std("anidb_auth_errors", anidb_auth_errors)
+    _append_std("api_blank_errors", api_blank_errors)
+    _append_std("bad_version_found_errors", bad_version_found_errors)
+    _append_std("cache_false", cache_false)
+    _append_std("checkFiles", checkFiles)
+    _append_std("other_award", other_award)
+    _append_std("critical_errors", critical_errors)
+    _append_std("error_errors", error_errors)
+    _append_std("warning_errors", warning_errors)
 
     if convert_errors:
         url_line = "[https://kometa.wiki/en/latest/kometa/logs/#warning]"
@@ -261,43 +198,9 @@ def build_advisory_messages(
         )
         special_check_lines.append(convert_error_message)
 
-    if corrupt_image_errors:
-        url_line = "[https://kometa.wiki/en/latest/kometa/logs/#error]"
-        formatted_errors = analyzer.format_contiguous_lines(corrupt_image_errors)
-        corrupt_image_message = (
-            "❌ **CORRUPT FILE ERROR**\n"
-            "Likely, when processing overlays, Kometa encountered a file that it could not process because it was corrupt.\n"
-            "Review the lines in your log file and based on the lines shown here and determine if those files are ok or not with your favorite image editor.\n"
-            f"For more information on handling these, {url_line}\n"
-            f"{len(corrupt_image_errors)} line(s) with `PIL.UnidentifiedImageError` reported. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(corrupt_image_message)
-
-    if delete_unmanaged_collections_errors:
-        url_line = "[https://kometa.wiki/en/latest/config/operations/#delete-collections]"
-        formatted_errors = analyzer.format_contiguous_lines(delete_unmanaged_collections_errors)
-        delete_unmanaged_collections_errors_message = (
-            "⚠️ **LEGACY SCHEMA DETECTED**\n"
-            "`delete_unmanaged_collections` is a Library operation and should be adjusted in your config file accordingly.\n"
-            f"For more information on handling these, {url_line}\n"
-            f"{len(delete_unmanaged_collections_errors)} line(s) with `delete_unmanaged_collections` errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(delete_unmanaged_collections_errors_message)
-
-    if flixpatrol_errors:
-        url_line = "[https://kometa.wiki/en/latest/kometa/faqs/?h=flixpatrol#flixpatrol]"
-        formatted_errors = analyzer.format_contiguous_lines(flixpatrol_errors)
-        flixpatrol_error_message = (
-            "❌ **FLIXPATROL ERROR**\n"
-            "There was an issue with FlixPatrol data.\n"
-            "This is a known issue with Kometa 1.19.0 (master/latest branch).\n"
-            "Switch to the 1.19.1 nightly21 or greater Kometa release for a fix.\n"
-            "In the Kometa discord thread, for more information on how to switch branches, type `!branch`.\n"
-            f"For more information on handling FlixPatrol errors, {url_line}\n"
-            "If the problem persists, your IP address might be banned by FlixPatrol. Contact their support to have it unbanned.\n"
-            f"{len(flixpatrol_errors)} line(s) with FlixPatrol errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(flixpatrol_error_message)
+    _append_std("corrupt_image_errors", corrupt_image_errors)
+    _append_std("delete_unmanaged_collections_errors", delete_unmanaged_collections_errors)
+    _append_std("flixpatrol_errors", flixpatrol_errors)
 
     if flixpatrol_paywall:
         url_line = "[https://flixpatrol.com/about/premium/]"
@@ -313,40 +216,9 @@ def build_advisory_messages(
         )
         special_check_lines.append(flixpatrol_paywall_message)
 
-    if git_kometa_errors:
-        url_line = "[https://kometa.wiki/en/latest/config/overview/?h=configuration]"
-        formatted_errors = analyzer.format_contiguous_lines(git_kometa_errors)
-        git_kometa_error_message = (
-            "💬 **OLD Kometa YAML**\n"
-            "You are using an old config.yml with references to metadata files that date to a version of Kometa that is pre 1.18\n"
-            "In the Kometa discord thread, type `!118` for more information.\n"
-            f"For more information on handling this, {url_line}\n"
-            f"{len(git_kometa_errors)} line(s) with OLD Kometa YAML. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(git_kometa_error_message)
-
-    if pmm_legacy_errors:
-        url_line = "[https://kometa.wiki/en/latest/config/overview/?h=configuration]"
-        formatted_errors = analyzer.format_contiguous_lines(pmm_legacy_errors)
-        pmm_legacy_error_message = (
-            "💬 **PRE KOMETA YAML**\n"
-            "You are using an old config.yml with references to metadata files that date to a version of this script that is pre Kometa\n"
-            "In your config.yml, search for `- pmm: ` and replace with `- default: ` .\n"
-            f"For more information on handling this, {url_line}\n"
-            f"{len(pmm_legacy_errors)} line(s) with PRE Kometa YAML. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(pmm_legacy_error_message)
-
-    if image_size:
-        url_line = "[https://www.google.com]"
-        formatted_errors = analyzer.format_contiguous_lines(image_size)
-        image_size_message = (
-            "❌ **IMAGE SIZE ERRORS**\n"
-            "It seems that you are attempting to upload or apply artwork and it's greater than the maximum `10MB`.\n"
-            f"This usually means that you have internal server errors (500) as well in this log. Change the image to one that is less than 10MB. For more information on handling this, {url_line}\n"
-            f"{len(image_size)} line(s) with IMAGE SIZE errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(image_size_message)
+    _append_std("git_kometa_errors", git_kometa_errors)
+    _append_std("pmm_legacy_errors", pmm_legacy_errors)
+    _append_std("image_size", image_size)
 
     if incomplete_message:
         url_line = "[https://kometa.wiki/en/latest/kometa/logs/#providing-log-files-on-discord]"
@@ -359,92 +231,13 @@ def build_advisory_messages(
         )
         special_check_lines.append(incomplete_errors_message)
 
-    if internal_server_errors:
-        url_line = "[https://kometa.wiki/en/latest/kometa/faqs/?h=errors+issues#errors-issues]"
-        formatted_errors = analyzer.format_contiguous_lines(internal_server_errors)
-        internal_server_error_message = (
-            "💥 **INTERNAL SERVER ERROR**\n"
-            "An internal server error has occurred. This could be due to an issue with the service's server.\n"
-            "In the Kometa discord thread, type `!500` for more information.\n"
-            f"For more information on handling internal server errors, {url_line}\n"
-            f"{len(internal_server_errors)} line(s) with INTERNAL SERVER errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(internal_server_error_message)
-
-    if lsio_errors:
-        url_line = "[https://kometa.wiki/en/latest/kometa/install/images/?h=linuxserver#linuxserver]"
-        formatted_errors = analyzer.format_contiguous_lines(lsio_errors)
-        lsio_error_message = (
-            "⚠️🖥️ **LINUXSERVER IMAGE DETECTED**\n"
-            "You are not using the official Kometa container image.\n"
-            "In the Kometa discord thread, type `!lsio` for more information.\n"
-            f"For more information on this, {url_line}\n"
-            f"{len(lsio_errors)} line(s) with LINUXSERVER IMAGE issues. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(lsio_error_message)
-
-    if mal_connection_errors:
-        url_line = "[https://kometa.wiki/en/latest/config/myanimelist]"
-        formatted_errors = analyzer.format_contiguous_lines(mal_connection_errors)
-        mal_connection_error_message = (
-            "❌ **MY ANIME LIST CONNECTION ERROR**\n"
-            "There was an issue connecting to My Anime List (MAL) service.\n"
-            "This will affect any functionality that relies on MAL data.\n"
-            "In the Kometa discord thread, type `!mal` for more information\n"
-            f"For more information on configuring the My Anime List (MAL) service, {url_line}\n"
-            f"{len(mal_connection_errors)} line(s) with MY ANIME LIST CONNECTION errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(mal_connection_error_message)
-
-    if mass_update_errors:
-        url_line = "[https://kometa.wiki/en/latest/config/operations]"
-        formatted_errors = analyzer.format_contiguous_lines(mass_update_errors)
-        mass_update_errors_message = (
-            "❌ **MASS_*_UPDATE ERROR**\n"
-            "You have specified a `mass_*_update` operation in your config file however you have not configured the corresponding service so this will never work.\n"
-            "Review each of the lines mentioned in this message to understand what all the config issues are.\n"
-            "In the Kometa discord thread, type `!wiki` for more information and search.\n"
-            f"For more information on `mass_*_update` operations, {url_line}\n"
-            f"{len(mass_update_errors)} line(s) with `mass_*_update` config errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(mass_update_errors_message)
-
-    if mdblist_attr_errors:
-        url_line = "[https://kometa.wiki/en/latest/files/builders/mdblist/?h=mdblist+builders]"
-        formatted_errors = analyzer.format_contiguous_lines(mdblist_attr_errors)
-        mdblist_attr_error_message = (
-            f"❌ **MDBLIST ATTRIBUTE ERROR**\n"
-            f"MDBList functionality does not currently support season-level collections.\n"
-            f"In the Kometa discord thread, type `!wiki` for more information and search.\n"
-            f"For more information on MDBList configuration, {url_line}\n"
-            f"{len(mdblist_attr_errors)} line(s) with MDBList attribute errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(mdblist_attr_error_message)
-
-    if mdblist_errors:
-        url_line = "[https://kometa.wiki/en/latest/config/mdblist/?h=mdblist+attributes#mdblist-attributes]"
-        formatted_errors = analyzer.format_contiguous_lines(mdblist_errors)
-        mdblist_error_message = (
-            f"❌ **MDBLIST ERROR**\n"
-            f"Your configuration contains an invalid API key for MdbList.\n"
-            f"This will cause any services that rely on MdbList to fail.\n"
-            f"In the Kometa discord thread, type `!wiki` for more information and search.\n"
-            f"For more information on configuring MdbList, {url_line}\n"
-            f"{len(mdblist_errors)} line(s) with MDBLIST errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(mdblist_error_message)
-
-    if mdblist_api_limit_errors:
-        url_line = "[https://kometa.wiki/en/latest/config/mdblist/?h=mdblist+attributes#mdblist-attributes]"
-        formatted_errors = analyzer.format_contiguous_lines(mdblist_api_limit_errors)
-        mdblist_api_limit_error_message = (
-            f"❌ **MDBLIST API LIMIT ERROR**\n"
-            f"You have hit the MDBLIST API LIMIT. The free apikey is limited to 1000 requests per day so if you hit your limit Kometa should be able to pick up where it left off the next day as long as the Kometa cache setting is enabled in yur config.yml file.\n"
-            f"This will cause any metadata updates that rely on MdbList to fail until the limit is reset (usually daily).\n"
-            f"For more information on configuring MdbList, {url_line}\n"
-            f"{len(mdblist_api_limit_errors)} line(s) with MDBLIST API Limit errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(mdblist_api_limit_error_message)
+    _append_std("internal_server_errors", internal_server_errors)
+    _append_std("lsio_errors", lsio_errors)
+    _append_std("mal_connection_errors", mal_connection_errors)
+    _append_std("mass_update_errors", mass_update_errors)
+    _append_std("mdblist_attr_errors", mdblist_attr_errors)
+    _append_std("mdblist_errors", mdblist_errors)
+    _append_std("mdblist_api_limit_errors", mdblist_api_limit_errors)
 
     if metadata_attribute_errors:
         url_line = "[https://kometa.wiki/en/latest/config/files/#example]"
@@ -467,55 +260,10 @@ def build_advisory_messages(
         )
         special_check_lines.append(metadata_attribute_errors_message)
 
-    if metadata_load_errors:
-        url_line = "[https://kometa.wiki/en/latest/config/overview/?h=configuration]"
-        formatted_errors = analyzer.format_contiguous_lines(metadata_load_errors)
-        metadata_load_errors_message = (
-            f"❌ **METADATA LOAD ERRORS**\n"
-            f"Kometa is trying to load a file from your config file.\n"
-            f"This error indicates that the setting is not correctly setup in config.yml. Usually wrong path to the file, or a badly formatted yml file.\n"
-            f"Within the attached log file, go to the indicated line(s) for more details on the exact issue and take actions to fix.\n"
-            f"For more information on this, {url_line}\n"
-            f"{len(metadata_load_errors)} line(s) with METADATA LOAD errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(metadata_load_errors_message)
-
-    if overlay_load_errors:
-        url_line = "[https://kometa.wiki/en/latest/config/overview/?h=configuration]"
-        formatted_errors = analyzer.format_contiguous_lines(overlay_load_errors)
-        overlay_load_errors_message = (
-            "❌ **OVERLAY LOAD ERRORS**\n"
-            "Kometa is trying to load a file from your config file.\n"
-            "This error indicates that the setting is not correctly setup in config.yml. Usually wrong path to the file, or a badly formatted yml file.\n"
-            "Within the attached log file, go to the indicated line(s) for more details on the exact issue and take actions to fix.\n"
-            f"For more information on this, {url_line}\n"
-            f"{len(overlay_load_errors)} line(s) with OVERLAY LOAD errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(overlay_load_errors_message)
-
-    if playlist_load_errors:
-        url_line = "[https://kometa.wiki/en/latest/config/overview/?h=configuration]"
-        formatted_errors = analyzer.format_contiguous_lines(playlist_load_errors)
-        playlist_load_errors_message = (
-            "❌ **PLAYLIST LOAD ERRORS**\n"
-            "Kometa is trying to load a file from your config file.\n"
-            "This error indicates that the setting is not correctly setup in config.yml. Usually wrong path to the file, or a badly formatted yml file.\n"
-            "Within the attached log file, go to the indicated line(s) for more details on the exact issue and take actions to fix.\n"
-            f"For more information on this, {url_line}\n"
-            f"{len(playlist_load_errors)} line(s) with PLAYLIST LOAD errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(playlist_load_errors_message)
-
-    if missing_path_errors:
-        url_line = "[https://kometa.wiki/en/latest/config/libraries/?h=report_path#attributes]"
-        formatted_errors = analyzer.format_contiguous_lines(missing_path_errors)
-        missing_path_errors_message = (
-            "⚠️ **LEGACY SCHEMA DETECTED**\n"
-            "`missing_path` or `save_missing` is no longer used and should be replaced/removed. Use `report_path` instead.\n"
-            f"For more information on handling these, {url_line}\n"
-            f"{len(missing_path_errors)} line(s) with `missing_path` or `save_missing` errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(missing_path_errors_message)
+    _append_std("metadata_load_errors", metadata_load_errors)
+    _append_std("overlay_load_errors", overlay_load_errors)
+    _append_std("playlist_load_errors", playlist_load_errors)
+    _append_std("missing_path_errors", missing_path_errors)
 
     if new_plexapi_version_found_errors:
         url_line = "[https://kometa.wiki/en/latest/kometa/logs/#checking-kometa-version]"
@@ -542,69 +290,11 @@ def build_advisory_messages(
         )
         special_check_lines.append(new_version_found_errors_message)
 
-    if no_items_found_errors:
-        url_line = "[https://kometa.wiki/en/latest/kometa/logs/?h=%5Berror%5D#error]"
-        formatted_errors = analyzer.format_contiguous_lines(no_items_found_errors)
-        no_items_error_message = (
-            "⚠️ **NO ITEMS FOUND IN PLEX**\n"
-            "The criteria defined by a search/filter returned 0 results.\n"
-            "This is often expected - for example, if you try to apply a 1080P overlay to a 4K library then no items will get the overlay since no items have a 1080P resolution.\n"
-            "It is worth noting that search and filters are case-sensitive, so `1080P` and `1080p` are treated as two separate things.\n"
-            f"For more information on this error, {url_line}\n"
-            f"{len(no_items_found_errors)} line(s) with 'No Items found in Plex' errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(no_items_error_message)
-
-    if omdb_errors:
-        url_line = "[https://kometa.wiki/en/latest/config/omdb/#omdb-attributes]"
-        formatted_errors = analyzer.format_contiguous_lines(omdb_errors)
-        omdb_error_message = (
-            "❌ **OMDB ERROR**\n"
-            "Your configuration contains an invalid API key for OMDb.\n"
-            "This will cause any services that rely on OMDb to fail.\n"
-            "In the Kometa discord thread, type `!wiki` for more information and search.\n"
-            f"For more information on configuring OMDb, {url_line}\n"
-            f"{len(omdb_errors)} line(s) with OMDb errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(omdb_error_message)
-
-    if omdb_api_limit_errors:
-        url_line = "[https://kometa.wiki/en/latest/config/omdb/?h=omdb#omdb-attributes]"
-        formatted_errors = analyzer.format_contiguous_lines(omdb_api_limit_errors)
-        omdb_api_limit_error_message = (
-            f"❌ **OMDB API LIMIT ERROR**\n"
-            f"You have hit the OMDB API LIMIT. The free apikey is limited to 1000 requests per day so if you hit your limit Kometa should be able to pick up where it left off the next day as long as the Kometa cache setting is enabled in yur config.yml file.\n"
-            f"This will cause any metadata updates that rely on OMDB to fail until the limit is reset (usually daily).\n"
-            f"For more information on configuring OMDB, {url_line}\n"
-            f"{len(omdb_api_limit_errors)} line(s) with OMDB API Limit errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(omdb_api_limit_error_message)
-
-    if overlay_font_missing:
-        url_line = "[https://kometa.wiki/en/latest/showcase/overlays/?h=font#example-2]"
-        formatted_errors = analyzer.format_contiguous_lines(overlay_font_missing)
-        overlay_font_missing_message = (
-            "❌ **OVERLAY FONT MISSING**\n"
-            "We detected that you are referencing a font that Kometa cannot find.\n"
-            "This can lead to overlays not being applied when a font is required.\n"
-            f"In the Kometa discord thread, type `!wiki` for more information or follow this link: {url_line}\n"
-            f"{len(overlay_font_missing)} line(s) with `Overlay Error: font:` errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(overlay_font_missing_message)
-
-    if overlays_bloat:
-        url_line = "[https://kometa.wiki/en/latest/kometa/scripts/imagemaid]"
-        formatted_errors = analyzer.format_contiguous_lines(overlays_bloat)
-        overlays_bloat_message = (
-            "⚠️ **REAPPLY / RESET OVERLAYS**\n\n"
-            "We detected that you are using either reapply_overlays OR reset_overlays within your config.\n\n"
-            "**You should NOT be using reapply_overlays unless you have a specific reason to. If you are not sure do NOT enable it.**\n\n"
-            "This can lead to your system creating additional posters within Plex causing bloat\n\n"
-            "Typically these config lines are only used for very specific cases so if this is your case, then you can ignore this recommendation\n\n"
-            f"In the Kometa discord thread, type `!bloat` for more information or follow this link: {url_line}\n\n"
-            f"{len(overlays_bloat)} line(s) with reapply_overlays or reset_overlays. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(overlays_bloat_message)
+    _append_std("no_items_found_errors", no_items_found_errors)
+    _append_std("omdb_errors", omdb_errors)
+    _append_std("omdb_api_limit_errors", omdb_api_limit_errors)
+    _append_std("overlay_font_missing", overlay_font_missing)
+    _append_std("overlays_bloat", overlays_bloat)
 
     if overlay_apply_errors:
         url_line = "[https://kometa.wiki/en/latest/defaults/overlays]"
@@ -625,41 +315,9 @@ def build_advisory_messages(
         )
         special_check_lines.append(overlay_apply_errors_message)
 
-    if overlay_image_missing:
-        url_line = "[https://kometa.wiki/en/latest/defaults/overlays]"
-        formatted_errors = analyzer.format_contiguous_lines(overlay_image_missing)
-        overlay_image_missing_message = (
-            "❌ **OVERLAY IMAGE MISSING ERROR**\n"
-            "Kometa attempts to apply an overlay to things, but finds that the overlay itself is not found and thus cannot be applied to the art.\n"
-            "Validate the path and also ensure that the case of the file(i.e. `4K.png` is NOT the same as `4k.png`) is the same as found in the line within the log.\n"
-            f"For more information on overlays, {url_line}\n"
-            f"{len(overlay_image_missing)} line(s) with OVERLAY IMAGE MISSING errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(overlay_image_missing_message)
-
-    if overlay_level_errors:
-        url_line = "[https://kometa.wiki/en/latest/files/settings/?h=builder_level]"
-        formatted_errors = analyzer.format_contiguous_lines(overlay_level_errors)
-        overlay_level_errors_message = (
-            "⚠️ **LEGACY SCHEMA DETECTED**\n"
-            "`overlay_level:` is no longer used and should be replaced by `builder_level:`.\n"
-            f"For more information on handling these, {url_line}\n"
-            f"{len(overlay_level_errors)} line(s) with `overlay_level` errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(overlay_level_errors_message)
-
-    if playlist_errors:
-        url_line = "[https://kometa.wiki/en/latest/defaults/playlist/?h=playlist]"
-        formatted_errors = analyzer.format_contiguous_lines(playlist_errors)
-        playlist_error_message = (
-            "❌ **PLAYLIST ERROR**\n"
-            "A playlist is trying to use a library that does not exist in Plex.\n"
-            "Ensure that all libraries being defined actually exist.\n"
-            "The Kometa Defaults `playlist` file expects libraries called `Movies` and `TV Shows`, template variables can be used to change this.\n"
-            f"For more information: {url_line}\n"
-            f"{len(playlist_errors)} line(s) with playlist errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(playlist_error_message)
+    _append_std("overlay_image_missing", overlay_image_missing)
+    _append_std("overlay_level_errors", overlay_level_errors)
+    _append_std("playlist_errors", playlist_errors)
 
     # Extract scheduled run time
     kometa_scheduled_time = analyzer.extract_scheduled_run_time(content)
@@ -689,44 +347,9 @@ def build_advisory_messages(
     if wsl_recommendation:
         special_check_lines.append(wsl_recommendation)
 
-    if plex_regex_errors:
-        url_line = "[https://kometa.wiki/en/latest/kometa/logs/?h=%5Berror%5D#error]"
-        formatted_errors = analyzer.format_contiguous_lines(plex_regex_errors)
-        plex_regex_error_message = (
-            "⚠️ **PLEX REGEX ERROR**\n"
-            "Kometa is trying to perform a regex search, and 0 items match the regex pattern.\n"
-            "This is often an expected error and can be ignored in most cases.\n"
-            "If you need assistance with this error, raise a support thread in `#kometa-help`.\n"
-            f"For more information on handling regex issues, {url_line}\n"
-            f"{len(plex_regex_errors)} line(s) with Plex regex errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(plex_regex_error_message)
-
-    if plex_lib_errors:
-        url_line = "[https://kometa.wiki/en/latest/config/settings/?h=show_options#show-options]"
-        formatted_errors = analyzer.format_contiguous_lines(plex_lib_errors)
-        plex_lib_error_message = (
-            "❌ **PLEX LIBRARY ERROR**\n"
-            "Your configuration contains an invalid Plex Library Name.\n"
-            "Kometa will not be able to update a library that does not exist.\n"
-            "Check for spelling `case sensitive` and ensure that you have `show_options: true` within your settings within config.yml\n"
-            f"For more information on configuring the show_options, {url_line}\n"
-            f"{len(plex_lib_errors)} line(s) with PLEX LIBRARY errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(plex_lib_error_message)
-
-    if plex_url_errors:
-        url_line = "[https://kometa.wiki/en/latest/kometa/install/wt/wt-01-basic-config/#getting-a-plex-url-and-token]"
-        formatted_errors = analyzer.format_contiguous_lines(plex_url_errors)
-        plex_url_error_message = (
-            "❌ **PLEX URL ERROR**\n"
-            "Your configuration contains an invalid Plex URL.\n"
-            "This will cause any services that rely on this URL to fail.\n"
-            "In the Kometa discord thread, type `!wiki` for more information and search.\n"
-            f"For more information on configuring the Plex URL, {url_line}\n"
-            f"{len(plex_url_errors)} line(s) with PLEX URL errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(plex_url_error_message)
+    _append_std("plex_regex_errors", plex_regex_errors)
+    _append_std("plex_lib_errors", plex_lib_errors)
+    _append_std("plex_url_errors", plex_url_errors)
 
     if rounding_errors:
         url_line = "[https://forums.plex.tv/t/plex-rounding-down-user-ratings-when-set-via-api/875806/8]"
@@ -744,29 +367,8 @@ def build_advisory_messages(
 
         special_check_lines.append(rounding_errors_message)
 
-    if ruamel_errors:
-        url_line = "[https://kometa.wiki/en/latest/kometa/yaml/]"
-        formatted_errors = analyzer.format_contiguous_lines(ruamel_errors)
-        ruamel_error_message = (
-            "💥 **YAML ERROR**\n"
-            "YAML is very sensitive with regards to spaces and indentation.\n"
-            "Search for `ruamel.yaml.` in your log file to get hints as to where the problem lies.\n"
-            "In the Kometa discord thread, type `!yaml` and `!editors` for more information.\n"
-            f"For more information on handling YAML issues, {url_line}\n"
-            f"{len(ruamel_errors)} line(s) with YAML errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(ruamel_error_message)
-
-    if run_order_errors:
-        url_line = "[https://kometa.wiki/en/latest/config/settings/?h=run_order#run-order]"
-        formatted_errors = analyzer.format_contiguous_lines(run_order_errors)
-        run_order_error_message = (
-            "⚠️ **RUN_ORDER WARNING**\n"
-            f"Typically, and in almost EVERY situation, you want ` - operations` to precede both metadata and overlays processing. To fix this, place `- operations` first in the `run_order` section of the config.yml file\n"
-            f"For more information on this, {url_line}\n"
-            f"{len(run_order_errors)} line(s) with RUN_ORDER warnings. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(run_order_error_message)
+    _append_std("ruamel_errors", ruamel_errors)
+    _append_std("run_order_errors", run_order_errors)
 
     if security_vuln_hits:
         seen = set()
@@ -797,56 +399,10 @@ def build_advisory_messages(
 
         special_check_lines.append(msg)
 
-    if traceback_errors:
-        url_line = "[https://kometa.wiki/en/latest/config/tautulli]"
-        formatted_errors = analyzer.format_contiguous_lines(traceback_errors)
-        traceback_errors_message = (
-            "💥 **TRACEBACK ERROR**\n"
-            "Your KOMETA run contains traceback errors.\n"
-            "This likely means that the run ended prematurely or did not complete certain tasks (i.e. overlays ended early or did not apply).\n"
-            "In the Kometa discord thread, type `!wiki` for more information and search.\n"
-            f"{len(traceback_errors)} line(s) with Traceback errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(traceback_errors_message)
-
-    if tautulli_apikey_errors:
-        url_line = "[https://kometa.wiki/en/latest/config/tautulli]"
-        formatted_errors = analyzer.format_contiguous_lines(tautulli_apikey_errors)
-        tautulli_apikey_errors_message = (
-            "❌ **TAUTULLI API ERROR**\n"
-            "Your configuration contains an invalid API key for Tautulli.\n"
-            "This will cause any services that rely on Tautulli to fail.\n"
-            "In the Kometa discord thread, type `!wiki` for more information and search.\n"
-            f"For more information on configuring Tautulli, {url_line}\n"
-            f"{len(tautulli_apikey_errors)} line(s) with Tautulli errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(tautulli_apikey_errors_message)
-
-    if tautulli_url_errors:
-        url_line = "[https://kometa.wiki/en/latest/config/tautulli#tautulli-attributes]"
-        formatted_errors = analyzer.format_contiguous_lines(tautulli_url_errors)
-        tautulli_url_error_message = (
-            "❌ **TAUTULLI URL ERROR**\n"
-            "Your configuration contains an invalid Tautulli URL.\n"
-            "This will cause any services that rely on this URL to fail.\n"
-            "In the Kometa discord thread, type `!wiki` for more information and search.\n"
-            f"For more information on configuring the Tautulli URL, {url_line}\n"
-            f"{len(tautulli_url_errors)} line(s) with TAUTULLI URL errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(tautulli_url_error_message)
-
-    if tmdb_api_errors:
-        url_line = "[https://kometa.wiki/en/latest/kometa/install/wt/wt-01-basic-config/#getting-a-tmdb-api-key]"
-        formatted_errors = analyzer.format_contiguous_lines(tmdb_api_errors)
-        tmdb_api_errors_message = (
-            "❌ **TMDB API ERROR**\n"
-            "Your configuration contains an invalid API key for TMDb.\n"
-            "This will cause any services that rely on TMDb to fail.\n"
-            "In the Kometa discord thread, type `!wiki` for more information and search.\n"
-            f"For more information on configuring TMDb, {url_line}\n"
-            f"{len(tmdb_api_errors)} line(s) with TMDb errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(tmdb_api_errors_message)
+    _append_std("traceback_errors", traceback_errors)
+    _append_std("tautulli_apikey_errors", tautulli_apikey_errors)
+    _append_std("tautulli_url_errors", tautulli_url_errors)
+    _append_std("tmdb_api_errors", tmdb_api_errors)
 
     if timeout_errors:
         url_line = "[https://kometa.wiki/en/latest/kometa/install/overview/]"
@@ -865,43 +421,9 @@ def build_advisory_messages(
         )
         special_check_lines.append(timeout_error_message)
 
-    if tmdb_fail_errors:
-        url_line = "[https://kometa.wiki/en/latest/kometa/install/wt/wt-01-basic-config/]"
-        formatted_errors = analyzer.format_contiguous_lines(tmdb_fail_errors)
-        tmdb_fail_error_message = (
-            "❌ **TMDB ERROR**\n"
-            "This error appears when your host machine is unable to connect to TMDb.\n"
-            "Ensure that your networking (particularly docker container) is configured to allow Kometa to make internet calls.\n"
-            f"For more information on network configuration, {url_line}\n"
-            f"{len(tmdb_fail_errors)} line(s) with TMDB errors. Line number location. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(tmdb_fail_error_message)
-
-    if to_be_configured_errors:
-        url_line = "[https://kometa.wiki/en/latest/kometa/logs/?h=%5Berror%5D#error]"
-        formatted_errors = analyzer.format_contiguous_lines(to_be_configured_errors)
-        to_be_configured_errors_message = (
-            "❌ **TO BE CONFIGURED ERROR**\n"
-            "You are using a builder that has not been configured yet.\n"
-            "This will affect any functionality that relies on these connections. Review all lines below and resolve.\n"
-            "In the Kometa discord thread, type `!wiki` and search for more information\n"
-            f"For more information on configuring services, {url_line}\n"
-            f"{len(to_be_configured_errors)} line(s) with `to be configured` errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(to_be_configured_errors_message)
-
-    if trakt_connection_errors:
-        url_line = "[https://kometa.wiki/en/latest/config/trakt/#trakt-attributes]"
-        formatted_errors = analyzer.format_contiguous_lines(trakt_connection_errors)
-        trakt_connection_error_message = (
-            "❌ **TRAKT CONNECTION ERROR**\n"
-            "There was an issue connecting to the Trakt service.\n"
-            "This will affect any functionality that relies on Trakt data.\n"
-            "In the Kometa discord thread, type `!trakt` for more information\n"
-            f"For more information on configuring the Trakt service, {url_line}\n"
-            f"{len(trakt_connection_errors)} line(s) with TRAKT CONNECTION errors. Line number(s): {formatted_errors}"
-        )
-        special_check_lines.append(trakt_connection_error_message)
+    _append_std("tmdb_fail_errors", tmdb_fail_errors)
+    _append_std("to_be_configured_errors", to_be_configured_errors)
+    _append_std("trakt_connection_errors", trakt_connection_errors)
 
     return {
         "wsl": wsl_recommendation,

--- a/tests/test_logscan_advisory_table.py
+++ b/tests/test_logscan_advisory_table.py
@@ -1,0 +1,121 @@
+"""Unit tests for the log-scan advisory data table.
+
+Guards the :class:`modules._logscan_advisory_table.Advisory` records and
+:func:`~modules._logscan_advisory_table.render_advisory` helper introduced
+in the data-table refactor of :mod:`modules.logscan_advisory_messages`.
+
+Byte-identical output was the acceptance criterion for that refactor.
+These tests lock in the structural invariants so future edits to the
+table (adding rows, tweaking wording) can't silently break the render
+contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from modules._logscan_advisory_table import (
+    STANDARD_ADVISORIES,
+    Advisory,
+    render_advisory,
+)
+from modules.logscan_advisory_messages import _ADVISORY
+
+
+class _FakeAnalyzer:
+    """Minimal analyzer stub -- only ``format_contiguous_lines`` is used."""
+
+    def format_contiguous_lines(self, bucket):
+        # Deterministic fixture so assertions can pin the exact rendering.
+        return "L45-48, L92"
+
+
+# ---------------------------------------------------------------------------
+# Table shape
+# ---------------------------------------------------------------------------
+
+
+class TestStandardAdvisoriesTable:
+    def test_table_is_non_empty(self):
+        assert len(STANDARD_ADVISORIES) > 0
+
+    def test_every_entry_is_frozen_advisory(self):
+        for advisory in STANDARD_ADVISORIES:
+            assert isinstance(advisory, Advisory)
+            with pytest.raises((AttributeError, Exception)):
+                advisory.bucket_key = "mutated"  # type: ignore[misc]
+
+    def test_bucket_keys_are_unique(self):
+        keys = [a.bucket_key for a in STANDARD_ADVISORIES]
+        assert len(keys) == len(set(keys)), "duplicate bucket_key entries"
+
+    def test_lookup_dict_covers_every_advisory(self):
+        assert set(_ADVISORY) == {a.bucket_key for a in STANDARD_ADVISORIES}
+
+    def test_every_body_ends_with_newline(self):
+        # The render function relies on this so the count line lands on
+        # its own line without an extra join character.
+        for advisory in STANDARD_ADVISORIES:
+            assert advisory.body.endswith("\n"), f"Advisory {advisory.bucket_key!r} body must end with '\\n' so the count line renders on its own line."
+
+    def test_url_placeholder_matches_url_presence(self):
+        # If body references {url_line}, url must be non-empty.
+        # (The reverse doesn't hold: at least one legacy bucket --
+        # ``traceback_errors`` -- carried a url_line assignment that
+        # never rendered in the original message, and we preserve
+        # that quirk byte-for-byte.)
+        for advisory in STANDARD_ADVISORIES:
+            if "{url_line}" in advisory.body:
+                assert advisory.url, f"Advisory {advisory.bucket_key!r} references {{url_line}} but has an empty url field."
+
+
+# ---------------------------------------------------------------------------
+# render_advisory
+# ---------------------------------------------------------------------------
+
+
+class TestRenderAdvisory:
+    def test_substitutes_url_and_count(self):
+        advisory = Advisory(
+            bucket_key="demo",
+            body=" **DEMO**\nSomething went sideways.\nMore info at {url_line}\n",
+            url="[https://example.com]",
+            count_label="demo issues",
+        )
+        rendered = render_advisory(advisory, [1, 2, 3], _FakeAnalyzer())
+        assert rendered == (" **DEMO**\nSomething went sideways.\nMore info at [https://example.com]\n3 line(s) with demo issues. Line number(s): L45-48, L92")
+
+    def test_no_url_body_renders_unchanged(self):
+        # Buckets like ``checkFiles`` have no {url_line} placeholder.
+        advisory = Advisory(
+            bucket_key="demo",
+            body=" **DEMO**\nNo url here.\n",
+            url="",
+            count_label="demo items",
+        )
+        rendered = render_advisory(advisory, [1, 2], _FakeAnalyzer())
+        assert rendered == (" **DEMO**\nNo url here.\n2 line(s) with demo items. Line number(s): L45-48, L92")
+
+    def test_bucket_length_is_from_len(self):
+        advisory = Advisory(
+            bucket_key="demo",
+            body="**X**\nbody\n",
+            url="",
+            count_label="X",
+        )
+        rendered = render_advisory(advisory, list(range(7)), _FakeAnalyzer())
+        assert rendered.startswith("**X**\nbody\n7 line(s) with X.")
+
+    def test_every_table_advisory_renders_without_error(self):
+        analyzer = _FakeAnalyzer()
+        fake_bucket = [1, 2, 3]
+        for advisory in STANDARD_ADVISORIES:
+            rendered = render_advisory(advisory, fake_bucket, analyzer)
+            # Every rendering should be a non-empty markdown string that
+            # ends with the count-line suffix.
+            assert rendered
+            assert "line(s) with" in rendered
+            assert "Line number(s): L45-48, L92" in rendered
+            # No placeholder should leak through -- either the url was
+            # substituted or the body never contained one.
+            assert "{url_line}" not in rendered


### PR DESCRIPTION
Follow-up to #1529 which extracted `logscan_advisory_messages.py` as a byte-identical file split. The docstring on that PR called out a data-table refactor as "a great follow-up but out of scope" — this PR does that follow-up.

## What changed

**~50 near-identical `if bucket:` blocks** in `build_advisory_messages` used to each spell out the same 6-14 lines:

```python
if anidb69_errors:
    url_line = "[https://kometa.wiki/...]"
    formatted_errors = analyzer.format_contiguous_lines(anidb69_errors)
    anidb69_error_message = (
        "X **ANIDB69 ERROR**\\n"
        "Kometa uses AniDB ID 69...\\n"
        f"For more information on configuring AniDB, {url_line}\\n"
        f"{len(anidb69_errors)} line(s) with ANIDB69 errors. Line number(s): {formatted_errors}"
    )
    special_check_lines.append(anidb69_error_message)
```

Now they're one line each:

```python
_append_std("anidb69_errors", anidb69_errors)
```

## Structure

* **`modules/_logscan_advisory_table.py`** *(new, 390 lines)*
  * `Advisory` frozen dataclass — `(bucket_key, body, url, count_label)`
  * `render_advisory(advisory, bucket, analyzer) -> str` helper
  * `STANDARD_ADVISORIES` — 49 entries **in source order** (preserves `special_check_lines` append order byte-for-byte)

* **`modules/logscan_advisory_messages.py`** *(911 → 433 lines, -478 lines)*
  * Nested `_append_std` helper renders + appends when the bucket is populated
  * 49 standard blocks collapse to 1-line calls
  * **8 special blocks stay inline** because the template can't express them:
    * `timeout_errors`, `flixpatrol_paywall`, the two version-update buckets — `analyzer.*` interpolations in body
    * `convert_errors`, `metadata_attribute_errors` — multi-paragraph bodies with `\\n\\n` breaks
    * `overlay_apply_errors` — cites *two* URLs
    * `rounding_errors`, `security_vuln_hits` — iterate over tuple payloads
    * `incomplete_message` — uses the bucket variable's *value* as the body

* **`tests/test_logscan_advisory_table.py`** *(new, 10 tests)*
  * Guards the table shape (unique keys, frozen records, body ends with `\\n`, url present when placeholder used)
  * Guards the render contract (URL substitution, count formatting, no placeholder leaks)

## Verification

Rendered output is **byte-identical** to `develop` across all 57 populated buckets in an end-to-end fake-analyzer run:

```
Old output count: 57
New output count: 57
Return values match: True
Total diffs: 0
ALL 57 OUTPUTS ARE BYTE-IDENTICAL!
```

All existing logscan/recommendation tests (352) still pass, plus the 10 new table tests.

## Order preservation

The refactor deliberately walks the table in **source order** and interleaves the 8 inline specials at their original positions, so the message order in `special_check_lines` (and thus the final rendered results page) is preserved exactly.

## Net line count

```
 modules/_logscan_advisory_table.py  | 390 new
 modules/logscan_advisory_messages.py| 911 -> 433 (-478)
 tests/test_logscan_advisory_table.py| 137 new (via ruff format)
                                     -----------
                              net: +49 lines but zero duplication
```

Every advisory's template shape is expressed *once* in the render function; adding a new standard advisory is now a single Advisory record, not a copy-pasted 10-line block.