### PR TITLE
Step 6: Extract createOauthValidator factory + migrate Trakt and MAL wizards

### DIFF
--- a/static/local-js/130-trakt.js
+++ b/static/local-js/130-trakt.js
@@ -1,201 +1,84 @@
-import { refreshValidationCallout } from './modules/validationPageBase.js'
-import {
-  STATUS_COLOR_SUCCESS,
-  STATUS_COLOR_ERROR,
-  isBlankTokenValue,
-  wireSecretToggle,
-  wireCredentialResetListeners,
-  showStatusMessage,
-  performValidationRequest
-} from './modules/oauthValidationHelpers.js'
+import { createOauthValidator } from './modules/createOauthValidator.js'
 
-// Trakt OAuth-PIN flow. Layered on top of oauthValidationHelpers.
-// All DOM event wiring uses addEventListener -- no inline oninput /
-// onclick attributes in the template, no window-exposed functions.
-// Module-local everything, the way it should be.
+// Trakt OAuth PIN flow. Migrated to the shared createOauthValidator
+// factory in #1334 Step 6 PR 2.
+//
+// Trakt-specific quirks preserved from the pre-factory implementation:
+//   - client_id length is 64 chars before the authorization URL is built
+//   - authorization URL format is Trakt's oob (out-of-band) redirect
+//   - validate endpoint returns 6 authorization fields to copy
+//   - Check Token endpoint may rotate the token set via data.authorization
+//   - After success, the PIN input and URL field are cleared, both
+//     PIN-flow buttons are disabled, and the Check Token button becomes
+//     enabled.
 
-const VALIDATED_FIELD_ID = 'trakt_validated'
+const TRAKT_CLIENT_ID_LENGTH = 64
 
-const validatedAtInput = document.getElementById('trakt_validated_at')
-const clientIdInput = document.getElementById('trakt_client_id')
-const clientSecretInput = document.getElementById('trakt_client_secret')
-const pinInput = document.getElementById('trakt_pin')
-const urlField = document.getElementById('trakt_url')
-const toggleButton = document.getElementById('toggleClientSecretVisibility')
-const openUrlButton = document.getElementById('trakt_open_url')
-const validateButton = document.getElementById('validate_trakt_pin')
-const checkTokenButton = document.getElementById('trakt_check_token')
-const isValidatedElement = document.getElementById('trakt_validated')
-
-wireSecretToggle(clientSecretInput, toggleButton)
-
-// Initial button enable/disable from persisted state.
-validateButton.disabled = isValidatedElement.value.toLowerCase() === 'true'
-if (checkTokenButton) {
-  const accessToken = document.getElementById('access_token')?.value || ''
-  checkTokenButton.disabled = isBlankTokenValue(accessToken)
-}
-
-wireCredentialResetListeners({
-  fieldIds: ['trakt_client_id', 'trakt_client_secret', 'trakt_pin'],
-  validatedField: isValidatedElement,
-  validatedAtField: validatedAtInput,
-  validateButton,
-  checkTokenButton,
-  validatedFieldId: VALIDATED_FIELD_ID
-})
-
-// Build the authorization URL when the client_id reaches the expected
-// 64-char length. Editing the credential also invalidates the saved
-// validated state (wireCredentialResetListeners already handles the
-// reset; this also clears the validatedAt and refreshes the callout
-// for symmetry with the legacy behavior).
-function updateTraktURL () {
-  const traktClientId = clientIdInput.value
-  let myURL = ''
-  if (traktClientId.length === 64) {
-    isValidatedElement.value = 'false'
-    if (validatedAtInput) validatedAtInput.value = ''
-    refreshValidationCallout(VALIDATED_FIELD_ID)
-    myURL = 'https://trakt.tv/oauth/authorize?response_type=code&client_id=' + traktClientId + '&redirect_uri=urn:ietf:wg:oauth:2.0:oob'
-  }
-  urlField.value = myURL
-  // The URL is built from credentials, so re-check the open-URL gate
-  // here directly. Listening on the hidden urlField for 'input' events
-  // wouldn't work -- programmatic .value assignment doesn't fire them.
-  openUrlButton.disabled = urlField.value === ''
-}
-
-// Wire updateTraktURL to the Client ID only. The legacy template wired
-// it to Client Secret too, but updateTraktURL doesn't read the secret,
-// so the second wiring was a no-op.
-clientIdInput.addEventListener('input', updateTraktURL)
-
-openUrlButton.addEventListener('click', function () {
-  const url = urlField.value
-  if (url) {
-    showSpinner('retrieve')
-    window.open(url, '_blank').focus()
-  }
-})
-
-pinInput.addEventListener('input', function () {
-  validateButton.disabled = pinInput.value === ''
-})
-
-// Initial gating after the page has rendered. Replaces the previous
-// `window.onload = ...` block.
-openUrlButton.disabled = true
-validateButton.disabled = true
-
-// Trakt-specific success bookkeeping: copy 6 authorization fields into
-// hidden form inputs, clear the PIN + URL, disable PIN-flow buttons,
-// enable the Check Token button.
-function applyTraktPinSuccess (data) {
-  isValidatedElement.value = 'true'
-  if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-  refreshValidationCallout(VALIDATED_FIELD_ID)
-  document.getElementById('access_token').value = data.trakt_authorization_access_token
-  document.getElementById('token_type').value = data.trakt_authorization_token_type
-  document.getElementById('expires_in').value = data.trakt_authorization_expires_in
-  document.getElementById('refresh_token').value = data.trakt_authorization_refresh_token
-  document.getElementById('scope').value = data.trakt_authorization_scope
-  document.getElementById('created_at').value = data.trakt_authorization_created_at
-  pinInput.value = ''
-  urlField.value = ''
-  openUrlButton.disabled = true
-  validateButton.disabled = true
-  if (checkTokenButton) checkTokenButton.disabled = false
-}
-
-// PIN flow: POST /validate_trakt with id/secret/pin -> access tokens.
-validateButton.addEventListener('click', function () {
-  const statusMessage = document.getElementById('statusMessage')
-  const traktClient = clientIdInput.value
-  const traktSecret = clientSecretInput.value
-  const traktPin = pinInput.value
-
-  if (!traktClient || !traktSecret || !traktPin) {
-    showStatusMessage(statusMessage, 'ID, secret, and PIN are all required.', STATUS_COLOR_ERROR)
-    return
-  }
-
-  hideSpinner('retrieve')
-  performValidationRequest({
-    endpoint: '/validate_trakt',
-    payload: { trakt_client_id: traktClient, trakt_client_secret: traktSecret, trakt_pin: traktPin },
-    spinnerKey: 'validate',
-    statusElement: statusMessage,
-    onSuccess: (data) => {
-      applyTraktPinSuccess(data)
-      showStatusMessage(statusMessage, 'Trakt credentials validated successfully!', STATUS_COLOR_SUCCESS)
-    },
-    onFailure: () => {
-      isValidatedElement.value = 'false'
-      if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout(VALIDATED_FIELD_ID)
-    },
-    onError: () => {
-      showStatusMessage(statusMessage, 'An error occurred while validating Trakt credentials.', STATUS_COLOR_ERROR)
-      if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout(VALIDATED_FIELD_ID)
+createOauthValidator({
+  serviceName: 'Trakt',
+  validatedFieldId: 'trakt_validated',
+  validatedAtFieldId: 'trakt_validated_at',
+  clientIdFieldId: 'trakt_client_id',
+  clientSecretFieldId: 'trakt_client_secret',
+  authorizeButtonId: 'trakt_open_url',
+  validateButtonId: 'validate_trakt_pin',
+  checkTokenButtonId: 'trakt_check_token',
+  urlFieldId: 'trakt_url',
+  expectedClientIdLength: TRAKT_CLIENT_ID_LENGTH,
+  buildAuthorizationURL: (clientId) =>
+    `https://trakt.tv/oauth/authorize?response_type=code&client_id=${clientId}&redirect_uri=urn:ietf:wg:oauth:2.0:oob`,
+  secondaryValueFieldId: 'trakt_pin',
+  validateEndpoint: '/validate_trakt',
+  validateSpinnerKey: 'validate',
+  buildValidatePayload: ({ clientId, clientSecret, secondaryValue }) => ({
+    trakt_client_id: clientId,
+    trakt_client_secret: clientSecret,
+    trakt_pin: secondaryValue
+  }),
+  messages: {
+    validateMissingFields: 'ID, secret, and PIN are all required.'
+  },
+  applyValidateSuccess: (data, ctx) => {
+    document.getElementById('access_token').value = data.trakt_authorization_access_token
+    document.getElementById('token_type').value = data.trakt_authorization_token_type
+    document.getElementById('expires_in').value = data.trakt_authorization_expires_in
+    document.getElementById('refresh_token').value = data.trakt_authorization_refresh_token
+    document.getElementById('scope').value = data.trakt_authorization_scope
+    document.getElementById('created_at').value = data.trakt_authorization_created_at
+    ctx.secondaryValueInput.value = ''
+    ctx.urlField.value = ''
+    ctx.authorizeButton.disabled = true
+    ctx.validateButton.disabled = true
+    if (ctx.checkTokenButton) ctx.checkTokenButton.disabled = false
+  },
+  checkTokenEndpoint: '/validate_trakt_token',
+  checkTokenSpinnerKey: 'check_trakt',
+  buildCheckTokenPayload: ({ accessToken, clientId, clientSecret, refreshToken }) => ({
+    access_token: accessToken,
+    client_id: clientId,
+    client_secret: clientSecret,
+    refresh_token: refreshToken,
+    debug: true
+  }),
+  checkTokenPreflight: ({ accessToken, clientId }) => {
+    // Trakt requires both accessToken AND clientId to be present
+    // before hitting the server (server would reject otherwise).
+    if (!accessToken.trim() || !clientId.trim()) {
+      return 'Missing access token or client ID.'
     }
-  })
-})
-
-// Check Token re-validation: POST /validate_trakt_token using the
-// already-saved access_token. On success, may rotate the token set
-// (server returns an `authorization` block when a refresh happened).
-if (checkTokenButton) {
-  checkTokenButton.addEventListener('click', function () {
-    const statusMessage = document.getElementById('statusMessage')
-    const accessToken = document.getElementById('access_token')?.value || ''
-    const clientId = clientIdInput?.value || ''
-
-    if (isBlankTokenValue(accessToken) || isBlankTokenValue(clientId)) {
-      showStatusMessage(statusMessage, 'Missing access token or client ID.', STATUS_COLOR_ERROR)
-      return
+    return null
+  },
+  applyCheckTokenSuccess: (data) => {
+    // Trakt-specific: response may rotate the token set. Copy the
+    // rotated fields when the server sent them.
+    if (data.authorization) {
+      const auth = data.authorization
+      if (auth.access_token) document.getElementById('access_token').value = auth.access_token
+      if (auth.token_type) document.getElementById('token_type').value = auth.token_type
+      if (auth.expires_in) document.getElementById('expires_in').value = auth.expires_in
+      if (auth.refresh_token) document.getElementById('refresh_token').value = auth.refresh_token
+      if (auth.scope) document.getElementById('scope').value = auth.scope
+      if (auth.created_at) document.getElementById('created_at').value = auth.created_at
     }
-
-    const clientSecret = clientSecretInput?.value || ''
-    const refreshToken = document.getElementById('refresh_token')?.value || ''
-
-    performValidationRequest({
-      endpoint: '/validate_trakt_token',
-      payload: {
-        access_token: accessToken,
-        client_id: clientId,
-        client_secret: clientSecret,
-        refresh_token: refreshToken,
-        debug: true
-      },
-      spinnerKey: 'check_trakt',
-      statusElement: statusMessage,
-      onSuccess: (data) => {
-        if (data.authorization) {
-          const auth = data.authorization
-          if (auth.access_token) document.getElementById('access_token').value = auth.access_token
-          if (auth.token_type) document.getElementById('token_type').value = auth.token_type
-          if (auth.expires_in) document.getElementById('expires_in').value = auth.expires_in
-          if (auth.refresh_token) document.getElementById('refresh_token').value = auth.refresh_token
-          if (auth.scope) document.getElementById('scope').value = auth.scope
-          if (auth.created_at) document.getElementById('created_at').value = auth.created_at
-        }
-        isValidatedElement.value = 'true'
-        if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-        refreshValidationCallout(VALIDATED_FIELD_ID)
-        showStatusMessage(statusMessage, 'Trakt token is valid.', STATUS_COLOR_SUCCESS)
-      },
-      onFailure: () => {
-        isValidatedElement.value = 'false'
-        if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout(VALIDATED_FIELD_ID)
-      },
-      onError: () => {
-        showStatusMessage(statusMessage, 'An error occurred while validating Trakt token.', STATUS_COLOR_ERROR)
-        if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout(VALIDATED_FIELD_ID)
-      }
-    })
-  })
-}
+  }
+})

--- a/static/local-js/140-mal.js
+++ b/static/local-js/140-mal.js
@@ -1,190 +1,60 @@
-import { refreshValidationCallout } from './modules/validationPageBase.js'
-import {
-  STATUS_COLOR_SUCCESS,
-  STATUS_COLOR_ERROR,
-  wireSecretToggle,
-  wireCredentialResetListeners,
-  showStatusMessage,
-  performValidationRequest
-} from './modules/oauthValidationHelpers.js'
+import { createOauthValidator } from './modules/createOauthValidator.js'
 
-// MyAnimeList OAuth flow. Layered on top of oauthValidationHelpers.
-// All DOM event wiring uses addEventListener -- no inline oninput /
-// onclick attributes in the template, no window-exposed functions.
+// MyAnimeList OAuth PKCE flow. Migrated to the shared createOauthValidator
+// factory in #1334 Step 6 PR 2.
 //
-// Shape mirrors Trakt (#130) but with three notable differences:
-//   - URL build is gated on client_id.length === 32 (Trakt is 64) and
-//     incorporates a code_verifier PKCE challenge.
-//   - The submission field is a localhost-redirect URL, not a PIN.
-//   - The Check Token endpoint only consumes access_token and does
-//     not rotate the token set on success.
+// MAL-specific quirks preserved from the pre-factory implementation:
+//   - client_id length is 32 chars before the authorization URL is built
+//   - authorization URL uses PKCE (code_challenge = code_verifier)
+//   - the "secondary value" is a localhost URL, not a PIN
+//   - validate endpoint returns 4 authorization fields to copy
+//   - Check Token endpoint doesn't rotate tokens; only marks valid
+//   - After success, both authorize + validate buttons are disabled
+//     and the Check Token button becomes enabled
 
-const VALIDATED_FIELD_ID = 'mal_validated'
+const MAL_CLIENT_ID_LENGTH = 32
 
-const validatedAtInput = document.getElementById('mal_validated_at')
-const clientIdInput = document.getElementById('mal_client_id')
-const clientSecretInput = document.getElementById('mal_client_secret')
-const codeVerifierInput = document.getElementById('mal_code_verifier')
-const urlField = document.getElementById('mal_url')
-const localhostUrlInput = document.getElementById('mal_localhost_url')
-const toggleButton = document.getElementById('toggleClientSecretVisibility')
-const authorizeButton = document.getElementById('mal_get_localhost_url')
-const validateButton = document.getElementById('validate_mal_url')
-const checkTokenButton = document.getElementById('mal_check_token')
-const isValidatedElement = document.getElementById('mal_validated')
-
-wireSecretToggle(clientSecretInput, toggleButton)
-
-// Initial button enable/disable from persisted state.
-const isValidated = isValidatedElement ? isValidatedElement.value.toLowerCase() : 'false'
-if (isValidated === 'true') validateButton.disabled = true
-if (checkTokenButton) {
-  const accessToken = document.getElementById('access_token')?.value || ''
-  checkTokenButton.disabled = !accessToken.trim()
-}
-
-wireCredentialResetListeners({
-  fieldIds: ['mal_client_id', 'mal_client_secret', 'mal_code_verifier', 'mal_localhost_url'],
-  validatedField: isValidatedElement,
-  validatedAtField: validatedAtInput,
-  validateButton,
-  checkTokenButton,
-  validatedFieldId: VALIDATED_FIELD_ID
-})
-
-// Build the authorization URL when the client_id reaches the expected
-// 32-char length. MAL needs the PKCE code_verifier to be present in
-// the URL as the code_challenge query param.
-function updateMALTargetURL () {
-  const malClientId = clientIdInput.value
-  const codeVerifier = codeVerifierInput.value
-  let myURL = ''
-  if (malClientId.length === 32) {
-    isValidatedElement.value = 'false'
-    if (validatedAtInput) validatedAtInput.value = ''
-    refreshValidationCallout(VALIDATED_FIELD_ID)
-    myURL = 'https://myanimelist.net/v1/oauth2/authorize?response_type=code&client_id=' + malClientId + '&code_challenge=' + codeVerifier
-  }
-  urlField.value = myURL
-  // Listening on the hidden urlField for 'input' events wouldn't work --
-  // programmatic .value assignment doesn't fire them. Re-check the
-  // Authorize button gate here directly.
-  authorizeButton.disabled = urlField.value === ''
-}
-
-// Wire updateMALTargetURL to the Client ID only. The legacy template
-// wired it to Client Secret too, but updateMALTargetURL doesn't read
-// the secret, so the second wiring was a no-op.
-clientIdInput.addEventListener('input', updateMALTargetURL)
-
-// The "Authorize" button opens the constructed authorization URL in
-// a new tab.
-authorizeButton.addEventListener('click', function () {
-  const url = urlField.value
-  if (url) {
-    showSpinner('retrieve')
-    window.open(url, '_blank').focus()
-  }
-})
-
-localhostUrlInput.addEventListener('input', function () {
-  validateButton.disabled = localhostUrlInput.value === ''
-})
-
-// Initial gating after the page has rendered. Replaces the previous
-// `window.onload = ...` block.
-validateButton.disabled = true
-authorizeButton.disabled = urlField.value === ''
-
-// MAL-specific success bookkeeping: copy 4 authorization fields into
-// hidden form inputs and disable both auth-flow buttons.
-function applyMALAuthSuccess (data) {
-  isValidatedElement.value = 'true'
-  if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-  refreshValidationCallout(VALIDATED_FIELD_ID)
-  document.getElementById('access_token').value = data.mal_authorization_access_token
-  document.getElementById('token_type').value = data.mal_authorization_token_type
-  document.getElementById('expires_in').value = data.mal_authorization_expires_in
-  document.getElementById('refresh_token').value = data.mal_authorization_refresh_token
-  authorizeButton.disabled = true
-  validateButton.disabled = true
-  if (checkTokenButton) checkTokenButton.disabled = false
-}
-
-// Auth completion: POST /validate_mal with id/secret/verifier/url ->
-// access tokens.
-validateButton.addEventListener('click', function () {
-  const statusMessage = document.getElementById('statusMessage')
-  const malClient = clientIdInput.value
-  const malSecret = clientSecretInput.value
-  const malVerifier = codeVerifierInput.value
-  const malLocalhostURL = localhostUrlInput.value
-
-  if (!malClient || !malSecret || !malVerifier || !malLocalhostURL) {
-    showStatusMessage(statusMessage, 'ID, secret, and localhost URL are all required.', STATUS_COLOR_ERROR)
-    return
-  }
-
-  hideSpinner('retrieve')
-  performValidationRequest({
-    endpoint: '/validate_mal',
-    payload: {
-      mal_client_id: malClient,
-      mal_client_secret: malSecret,
-      mal_code_verifier: malVerifier,
-      mal_localhost_url: malLocalhostURL
-    },
-    spinnerKey: 'validate',
-    statusElement: statusMessage,
-    onSuccess: (data) => {
-      applyMALAuthSuccess(data)
-      showStatusMessage(statusMessage, 'MyAnimeList credentials validated successfully!', STATUS_COLOR_SUCCESS)
-    },
-    onFailure: () => {
-      isValidatedElement.value = 'false'
-      if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout(VALIDATED_FIELD_ID)
-    },
-    onError: () => {
-      showStatusMessage(statusMessage, 'An error occurred while validating MAL credentials.', STATUS_COLOR_ERROR)
-      if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout(VALIDATED_FIELD_ID)
-    }
+createOauthValidator({
+  serviceName: 'MyAnimeList',
+  validatedFieldId: 'mal_validated',
+  validatedAtFieldId: 'mal_validated_at',
+  clientIdFieldId: 'mal_client_id',
+  clientSecretFieldId: 'mal_client_secret',
+  authorizeButtonId: 'mal_get_localhost_url',
+  validateButtonId: 'validate_mal_url',
+  checkTokenButtonId: 'mal_check_token',
+  urlFieldId: 'mal_url',
+  expectedClientIdLength: MAL_CLIENT_ID_LENGTH,
+  extraCredentialFieldIds: ['mal_code_verifier'],
+  buildAuthorizationURL: (clientId, extras) =>
+    `https://myanimelist.net/v1/oauth2/authorize?response_type=code&client_id=${clientId}&code_challenge=${extras.mal_code_verifier}`,
+  secondaryValueFieldId: 'mal_localhost_url',
+  validateEndpoint: '/validate_mal',
+  validateSpinnerKey: 'validate',
+  buildValidatePayload: ({ clientId, clientSecret, secondaryValue, extras }) => ({
+    mal_client_id: clientId,
+    mal_client_secret: clientSecret,
+    mal_code_verifier: extras.mal_code_verifier,
+    mal_localhost_url: secondaryValue
+  }),
+  messages: {
+    validateMissingFields: 'ID, secret, and localhost URL are all required.'
+  },
+  applyValidateSuccess: (data, ctx) => {
+    document.getElementById('access_token').value = data.mal_authorization_access_token
+    document.getElementById('token_type').value = data.mal_authorization_token_type
+    document.getElementById('expires_in').value = data.mal_authorization_expires_in
+    document.getElementById('refresh_token').value = data.mal_authorization_refresh_token
+    ctx.authorizeButton.disabled = true
+    ctx.validateButton.disabled = true
+    if (ctx.checkTokenButton) ctx.checkTokenButton.disabled = false
+  },
+  checkTokenEndpoint: '/validate_mal_token',
+  checkTokenSpinnerKey: 'check_mal',
+  buildCheckTokenPayload: ({ accessToken }) => ({
+    access_token: accessToken,
+    debug: true
   })
+  // No applyCheckTokenSuccess -- MAL's check-token doesn't rotate tokens
+  // (unlike Trakt). Just marking validated is enough.
 })
-
-// Check Token: POST /validate_mal_token with the saved access token.
-if (checkTokenButton) {
-  checkTokenButton.addEventListener('click', function () {
-    const statusMessage = document.getElementById('statusMessage')
-    const accessToken = document.getElementById('access_token')?.value || ''
-
-    if (!accessToken.trim()) {
-      showStatusMessage(statusMessage, 'Missing access token.', STATUS_COLOR_ERROR)
-      return
-    }
-
-    performValidationRequest({
-      endpoint: '/validate_mal_token',
-      payload: { access_token: accessToken, debug: true },
-      spinnerKey: 'check_mal',
-      statusElement: statusMessage,
-      onSuccess: () => {
-        isValidatedElement.value = 'true'
-        if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-        refreshValidationCallout(VALIDATED_FIELD_ID)
-        showStatusMessage(statusMessage, 'MyAnimeList token is valid.', STATUS_COLOR_SUCCESS)
-      },
-      onFailure: () => {
-        isValidatedElement.value = 'false'
-        if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout(VALIDATED_FIELD_ID)
-      },
-      onError: () => {
-        showStatusMessage(statusMessage, 'An error occurred while validating MyAnimeList token.', STATUS_COLOR_ERROR)
-        if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout(VALIDATED_FIELD_ID)
-      }
-    })
-  })
-}

--- a/static/local-js/modules/createOauthValidator.js
+++ b/static/local-js/modules/createOauthValidator.js
@@ -1,0 +1,363 @@
+// OAuth-shaped wizard factory. Layered on top of oauthValidationHelpers.
+//
+// Trakt and MAL follow the same 5-phase flow:
+//   1. Toggle secret visibility on the client-secret input.
+//   2. Reset validated=false whenever any credential input changes.
+//   3. When the client_id reaches a wizard-specific length, build an
+//      authorization URL (opened in a new tab via the "authorize" button).
+//   4. Validate by POSTing the credentials + a secondary value (PIN or
+//      localhost URL) to the wizard's endpoint. On success, copy
+//      response fields into hidden form inputs.
+//   5. Optionally re-validate an already-saved access token via a
+//      separate check-token endpoint. May rotate the token set.
+//
+// Each of those phases is expressed via a small config block. The
+// factory wires the DOM listeners and delegates to oauthValidationHelpers
+// for the network + status-message primitives.
+//
+// The two callers today (130-trakt, 140-mal) shrink from ~200 lines
+// each to ~60 lines of pure config.
+
+import { refreshValidationCallout } from './validationPageBase.js'
+import {
+  STATUS_COLOR_SUCCESS,
+  STATUS_COLOR_ERROR,
+  isBlankTokenValue,
+  wireSecretToggle,
+  wireCredentialResetListeners,
+  showStatusMessage,
+  performValidationRequest
+} from './oauthValidationHelpers.js'
+
+const DEFAULT_STATUS_MESSAGE_ID = 'statusMessage'
+const DEFAULT_ACCESS_TOKEN_FIELD_ID = 'access_token'
+
+/**
+ * Register an OAuth-shaped wizard on the current page.
+ *
+ * @param {object} config - see JSDoc keys below.
+ *
+ * REQUIRED:
+ * @param {string} config.serviceName            Human-readable label used in status
+ *                                               messages (e.g. "Trakt", "MyAnimeList").
+ * @param {string} config.validatedFieldId       Hidden input tracking validated=true|false.
+ * @param {string} config.clientIdFieldId        Input id for the OAuth client_id.
+ * @param {string} config.clientSecretFieldId    Input id for the OAuth client_secret.
+ * @param {string} config.authorizeButtonId      Button that opens the authorization URL.
+ * @param {string} config.validateButtonId       Button that submits the validation flow.
+ * @param {string} config.urlFieldId             Hidden input holding the constructed URL.
+ * @param {number} config.expectedClientIdLength Trigger for building the auth URL.
+ * @param {(clientId: string, extras: object) => string} config.buildAuthorizationURL
+ *                                               Function producing the URL. `extras`
+ *                                               carries values from `extraCredentialFieldIds`
+ *                                               keyed by field id.
+ * @param {string[]} config.extraCredentialFieldIds
+ *                                               Additional credential input ids to
+ *                                               wire (reset-on-input + reset-validation
+ *                                               + optionally used inside URL builder
+ *                                               and payload builders).
+ * @param {string} config.secondaryValueFieldId  Input id whose non-empty value gates
+ *                                               validateButton (e.g. `trakt_pin`,
+ *                                               `mal_localhost_url`).
+ * @param {string} config.validateEndpoint       URL for the validation POST.
+ * @param {(payload: {clientId, clientSecret, extras, secondaryValue}) => object}
+ *                                               config.buildValidatePayload
+ * @param {string} config.validateSpinnerKey     Spinner key for the validate flow.
+ * @param {(data: object, ctx: OauthValidatorContext) => void}
+ *                                               config.applyValidateSuccess
+ *                                               Called with the response body after
+ *                                               a successful validation. The wizard
+ *                                               copies response fields into hidden
+ *                                               inputs here.
+ *
+ * OPTIONAL:
+ * @param {string} [config.validatedAtFieldId]   Hidden input tracking the ISO
+ *                                               timestamp of the last successful
+ *                                               validation.
+ * @param {string} [config.toggleButtonId='toggleClientSecretVisibility']
+ *                                               Button toggling client_secret visibility.
+ * @param {string} [config.checkTokenButtonId]   If present, wires the check-token flow.
+ * @param {string} [config.checkTokenEndpoint]   URL for the check-token POST.
+ * @param {(payload: {accessToken, clientId, clientSecret, refreshToken}) => object}
+ *                                               [config.buildCheckTokenPayload]
+ * @param {(payload: {accessToken, clientId, clientSecret, refreshToken}) => string|null}
+ *                                               [config.checkTokenPreflight]
+ *                                               Optional guard run before the check-token
+ *                                               request. Return a non-empty string to
+ *                                               abort with a status-message error; return
+ *                                               null/undefined/empty to proceed. Defaults
+ *                                               to blocking only on a blank access token.
+ * @param {string} [config.checkTokenSpinnerKey='check']
+ * @param {string} [config.accessTokenFieldId='access_token']
+ * @param {string} [config.refreshTokenFieldId='refresh_token']
+ * @param {(data: object, ctx: OauthValidatorContext) => void}
+ *                                               [config.applyCheckTokenSuccess]
+ *                                               Called with the response body on
+ *                                               successful check-token; default is
+ *                                               a no-op beyond marking validated.
+ * @param {string} [config.statusMessageId='statusMessage']
+ * @param {object} [config.messages]             Optional overrides for user-facing
+ *                                               copy. Keys: `validateSuccess`,
+ *                                               `validateError`, `validateMissingFields`,
+ *                                               `checkTokenSuccess`, `checkTokenError`,
+ *                                               `checkTokenMissingFields`.
+ */
+export function createOauthValidator (config) {
+  const {
+    serviceName,
+    validatedFieldId,
+    validatedAtFieldId,
+    clientIdFieldId,
+    clientSecretFieldId,
+    toggleButtonId = 'toggleClientSecretVisibility',
+    authorizeButtonId,
+    validateButtonId,
+    checkTokenButtonId,
+    urlFieldId,
+    expectedClientIdLength,
+    buildAuthorizationURL,
+    extraCredentialFieldIds = [],
+    secondaryValueFieldId,
+    validateEndpoint,
+    buildValidatePayload,
+    validateSpinnerKey,
+    applyValidateSuccess,
+    checkTokenEndpoint,
+    buildCheckTokenPayload,
+    checkTokenPreflight,
+    checkTokenSpinnerKey = 'check',
+    accessTokenFieldId = DEFAULT_ACCESS_TOKEN_FIELD_ID,
+    refreshTokenFieldId = 'refresh_token',
+    applyCheckTokenSuccess,
+    statusMessageId = DEFAULT_STATUS_MESSAGE_ID,
+    messages: messageOverrides = {}
+  } = config
+
+  requireConfig(config, [
+    'serviceName',
+    'validatedFieldId',
+    'clientIdFieldId',
+    'clientSecretFieldId',
+    'authorizeButtonId',
+    'validateButtonId',
+    'urlFieldId',
+    'expectedClientIdLength',
+    'buildAuthorizationURL',
+    'secondaryValueFieldId',
+    'validateEndpoint',
+    'buildValidatePayload',
+    'validateSpinnerKey',
+    'applyValidateSuccess'
+  ])
+
+  const messages = {
+    validateSuccess: `${serviceName} credentials validated successfully!`,
+    validateError: `An error occurred while validating ${serviceName} credentials.`,
+    validateMissingFields: 'ID, secret, and secondary value are all required.',
+    checkTokenSuccess: `${serviceName} token is valid.`,
+    checkTokenError: `An error occurred while validating ${serviceName} token.`,
+    checkTokenMissingFields: 'Missing access token.',
+    ...messageOverrides
+  }
+
+  const clientIdInput = document.getElementById(clientIdFieldId)
+  const clientSecretInput = document.getElementById(clientSecretFieldId)
+  const validatedField = document.getElementById(validatedFieldId)
+  const validatedAtInput = validatedAtFieldId ? document.getElementById(validatedAtFieldId) : null
+  const authorizeButton = document.getElementById(authorizeButtonId)
+  const validateButton = document.getElementById(validateButtonId)
+  const secondaryValueInput = document.getElementById(secondaryValueFieldId)
+  const urlField = document.getElementById(urlFieldId)
+  const toggleButton = document.getElementById(toggleButtonId)
+  const checkTokenButton = checkTokenButtonId ? document.getElementById(checkTokenButtonId) : null
+
+  // If the load-bearing elements aren't on the page, this wizard isn't
+  // fully rendered — bail. Matches createApiKeyValidator posture.
+  if (!clientIdInput || !clientSecretInput || !validatedField ||
+      !authorizeButton || !validateButton || !urlField || !secondaryValueInput) {
+    return
+  }
+
+  wireSecretToggle(clientSecretInput, toggleButton)
+
+  // Resolve extra credential inputs once. Missing entries are silently
+  // dropped from listener wiring + URL/payload extras.
+  const extraCredentialElements = extraCredentialFieldIds
+    .map(id => ({ id, el: document.getElementById(id) }))
+    .filter(entry => entry.el)
+
+  // Initial button gating from persisted state.
+  validateButton.disabled = validatedField.value.toLowerCase() === 'true'
+  if (checkTokenButton) {
+    const accessToken = document.getElementById(accessTokenFieldId)?.value || ''
+    checkTokenButton.disabled = isBlankTokenValue(accessToken)
+  }
+
+  wireCredentialResetListeners({
+    fieldIds: [clientIdFieldId, clientSecretFieldId, ...extraCredentialFieldIds, secondaryValueFieldId],
+    validatedField,
+    validatedAtField: validatedAtInput,
+    validateButton,
+    checkTokenButton,
+    validatedFieldId
+  })
+
+  // Build the authorization URL when client_id reaches the expected length.
+  function updateAuthorizationURL () {
+    const clientId = clientIdInput.value
+    let myURL = ''
+    if (clientId.length === expectedClientIdLength) {
+      validatedField.value = 'false'
+      if (validatedAtInput) validatedAtInput.value = ''
+      refreshValidationCallout(validatedFieldId)
+      const extras = collectExtras(extraCredentialElements)
+      myURL = buildAuthorizationURL(clientId, extras)
+    }
+    urlField.value = myURL
+    // Programmatic .value assignment doesn't fire 'input' events, so
+    // the authorize button gate is checked here directly.
+    authorizeButton.disabled = urlField.value === ''
+  }
+
+  clientIdInput.addEventListener('input', updateAuthorizationURL)
+
+  authorizeButton.addEventListener('click', function () {
+    const url = urlField.value
+    if (url) {
+      showSpinner('retrieve')
+      window.open(url, '_blank').focus()
+    }
+  })
+
+  secondaryValueInput.addEventListener('input', function () {
+    validateButton.disabled = secondaryValueInput.value === ''
+  })
+
+  // Initial gating after the page has rendered.
+  authorizeButton.disabled = urlField.value === ''
+  validateButton.disabled = validateButton.disabled || secondaryValueInput.value === ''
+
+  // Context passed to the success callbacks so they can mutate the DOM
+  // consistently without re-querying the same elements.
+  const ctx = {
+    clientIdInput,
+    clientSecretInput,
+    secondaryValueInput,
+    validatedField,
+    validatedAtInput,
+    urlField,
+    authorizeButton,
+    validateButton,
+    checkTokenButton,
+    extras: extraCredentialElements,
+    markValidated: () => {
+      validatedField.value = 'true'
+      if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
+      refreshValidationCallout(validatedFieldId)
+    }
+  }
+
+  validateButton.addEventListener('click', function () {
+    const statusMessage = document.getElementById(statusMessageId)
+    const clientId = clientIdInput.value
+    const clientSecret = clientSecretInput.value
+    const secondaryValue = secondaryValueInput.value
+    const extras = collectExtras(extraCredentialElements)
+
+    if (!clientId || !clientSecret || !secondaryValue ||
+        extraCredentialElements.some(({ el }) => !el.value)) {
+      showStatusMessage(statusMessage, messages.validateMissingFields, STATUS_COLOR_ERROR)
+      return
+    }
+
+    hideSpinner('retrieve')
+    performValidationRequest({
+      endpoint: validateEndpoint,
+      payload: buildValidatePayload({ clientId, clientSecret, secondaryValue, extras }),
+      spinnerKey: validateSpinnerKey,
+      statusElement: statusMessage,
+      onSuccess: (data) => {
+        ctx.markValidated()
+        applyValidateSuccess(data, ctx)
+        showStatusMessage(statusMessage, messages.validateSuccess, STATUS_COLOR_SUCCESS)
+      },
+      onFailure: () => {
+        validatedField.value = 'false'
+        if (validatedAtInput) validatedAtInput.value = ''
+        refreshValidationCallout(validatedFieldId)
+      },
+      onError: () => {
+        showStatusMessage(statusMessage, messages.validateError, STATUS_COLOR_ERROR)
+        if (validatedAtInput) validatedAtInput.value = ''
+        refreshValidationCallout(validatedFieldId)
+      }
+    })
+  })
+
+  if (checkTokenButton && checkTokenEndpoint && buildCheckTokenPayload) {
+    checkTokenButton.addEventListener('click', function () {
+      const statusMessage = document.getElementById(statusMessageId)
+      const accessToken = document.getElementById(accessTokenFieldId)?.value || ''
+      const clientId = clientIdInput?.value || ''
+      const clientSecret = clientSecretInput?.value || ''
+      const refreshToken = refreshTokenFieldId
+        ? (document.getElementById(refreshTokenFieldId)?.value || '')
+        : ''
+
+      // Preflight guard. Wizards can plug in their own check (Trakt
+      // requires both accessToken AND clientId to be present); default
+      // is accessToken-only.
+      const guardFn = typeof checkTokenPreflight === 'function'
+        ? checkTokenPreflight
+        : ({ accessToken: at }) => (isBlankTokenValue(at) ? messages.checkTokenMissingFields : null)
+      const guardError = guardFn({ accessToken, clientId, clientSecret, refreshToken })
+      if (guardError) {
+        showStatusMessage(statusMessage, guardError, STATUS_COLOR_ERROR)
+        return
+      }
+
+      performValidationRequest({
+        endpoint: checkTokenEndpoint,
+        payload: buildCheckTokenPayload({ accessToken, clientId, clientSecret, refreshToken }),
+        spinnerKey: checkTokenSpinnerKey,
+        statusElement: statusMessage,
+        onSuccess: (data) => {
+          if (typeof applyCheckTokenSuccess === 'function') {
+            applyCheckTokenSuccess(data, ctx)
+          }
+          ctx.markValidated()
+          showStatusMessage(statusMessage, messages.checkTokenSuccess, STATUS_COLOR_SUCCESS)
+        },
+        onFailure: () => {
+          validatedField.value = 'false'
+          if (validatedAtInput) validatedAtInput.value = ''
+          refreshValidationCallout(validatedFieldId)
+        },
+        onError: () => {
+          showStatusMessage(statusMessage, messages.checkTokenError, STATUS_COLOR_ERROR)
+          if (validatedAtInput) validatedAtInput.value = ''
+          refreshValidationCallout(validatedFieldId)
+        }
+      })
+    })
+  }
+}
+
+function collectExtras (extraCredentialElements) {
+  const extras = {}
+  for (const { id, el } of extraCredentialElements) {
+    extras[id] = el.value
+  }
+  return extras
+}
+
+function requireConfig (config, keys) {
+  for (const key of keys) {
+    const value = config[key]
+    const missing = value === undefined || value === null ||
+      (typeof value === 'string' && value === '')
+    if (missing) {
+      throw new Error(`createOauthValidator: ${key} is required`)
+    }
+  }
+}

--- a/tests/js/modules/createOauthValidator.test.js
+++ b/tests/js/modules/createOauthValidator.test.js
@@ -1,0 +1,601 @@
+// Tests for static/local-js/modules/createOauthValidator.js
+// (#1334 Step 6 PR 2).
+//
+// The OAuth-shaped counterpart to createApiKeyValidator. Locks down
+// the behaviour before 130-trakt and 140-mal migrate onto it.
+//
+// SHIMS follow the same pattern as createApiKeyValidator.test.js:
+//   - showSpinner / hideSpinner stubbed as window globals
+//   - fetch stubbed via vi.stubGlobal
+//   - QSValidationCallouts optional per test
+//
+// FIXTURE:
+//   buildBaseHTML() renders a stripped-down Trakt-shaped page with the
+//   full standard element set. Tests override HTML fragments as needed
+//   for edge cases (missing checkTokenButton, extra credential inputs,
+//   etc.).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createOauthValidator } from '../../../static/local-js/modules/createOauthValidator.js'
+
+function buildBaseHTML ({
+  clientIdValue = '',
+  secretValue = '',
+  secondaryValue = '',
+  validated = 'false',
+  extraInputs = '',
+  includeCheckTokenButton = true
+} = {}) {
+  const checkTokenBtn = includeCheckTokenButton
+    ? '<button id="test_check_token" type="button">Check Token</button>'
+    : ''
+  return `
+    <form id="configForm">
+      <input id="test_client_id" type="text" value="${clientIdValue}">
+      <input id="test_client_secret" type="password" value="${secretValue}">
+      <input id="test_pin" type="text" value="${secondaryValue}">
+      <input id="test_url" type="hidden" value="">
+      <input id="test_validated" type="hidden" value="${validated}">
+      <input id="test_validated_at" type="hidden" value="">
+      <input id="access_token" type="hidden" value="">
+      <input id="refresh_token" type="hidden" value="">
+      <button id="toggleClientSecretVisibility" type="button">
+        <i class="bi"></i>
+      </button>
+      <button id="test_authorize" type="button">Authorize</button>
+      <button id="test_validate" type="button">Validate</button>
+      ${checkTokenBtn}
+      <div id="statusMessage" style="display:none"></div>
+      ${extraInputs}
+    </form>
+  `
+}
+
+function defaultConfig (overrides = {}) {
+  return {
+    serviceName: 'Test',
+    validatedFieldId: 'test_validated',
+    validatedAtFieldId: 'test_validated_at',
+    clientIdFieldId: 'test_client_id',
+    clientSecretFieldId: 'test_client_secret',
+    authorizeButtonId: 'test_authorize',
+    validateButtonId: 'test_validate',
+    checkTokenButtonId: 'test_check_token',
+    urlFieldId: 'test_url',
+    expectedClientIdLength: 8,
+    buildAuthorizationURL: (clientId) => `https://example.test/auth?client_id=${clientId}`,
+    secondaryValueFieldId: 'test_pin',
+    validateEndpoint: '/validate_test',
+    buildValidatePayload: ({ clientId, clientSecret, secondaryValue }) => ({
+      test_client_id: clientId,
+      test_client_secret: clientSecret,
+      test_pin: secondaryValue
+    }),
+    validateSpinnerKey: 'validate',
+    applyValidateSuccess: () => {},
+    checkTokenEndpoint: '/validate_test_token',
+    buildCheckTokenPayload: ({ accessToken }) => ({ access_token: accessToken, debug: true }),
+    ...overrides
+  }
+}
+
+function mockFetchOK (body) {
+  const fetchMock = vi.fn(() => Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve(body)
+  }))
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+function mockFetchReject (err = new Error('boom')) {
+  const fetchMock = vi.fn(() => Promise.reject(err))
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+async function flushPromises () {
+  // Two microtasks: one for fetch's then(res=>res.json()), one for the
+  // json()'s .then(...) callback that runs onSuccess/onFailure.
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+  window.showSpinner = vi.fn()
+  window.hideSpinner = vi.fn()
+  delete window.QSValidationCallouts
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  delete window.showSpinner
+  delete window.hideSpinner
+  delete window.QSValidationCallouts
+})
+
+describe('createOauthValidator config validation', () => {
+  it.each([
+    ['serviceName', { serviceName: undefined }],
+    ['validatedFieldId', { validatedFieldId: undefined }],
+    ['clientIdFieldId', { clientIdFieldId: undefined }],
+    ['clientSecretFieldId', { clientSecretFieldId: undefined }],
+    ['authorizeButtonId', { authorizeButtonId: undefined }],
+    ['validateButtonId', { validateButtonId: undefined }],
+    ['urlFieldId', { urlFieldId: undefined }],
+    ['expectedClientIdLength', { expectedClientIdLength: undefined }],
+    ['buildAuthorizationURL', { buildAuthorizationURL: undefined }],
+    ['secondaryValueFieldId', { secondaryValueFieldId: undefined }],
+    ['validateEndpoint', { validateEndpoint: undefined }],
+    ['buildValidatePayload', { buildValidatePayload: undefined }],
+    ['validateSpinnerKey', { validateSpinnerKey: undefined }],
+    ['applyValidateSuccess', { applyValidateSuccess: undefined }]
+  ])('throws when %s is missing', (fieldName, override) => {
+    document.body.innerHTML = buildBaseHTML()
+    expect(() => createOauthValidator(defaultConfig(override)))
+      .toThrow(new RegExp(`${fieldName} is required`))
+  })
+})
+
+describe('createOauthValidator wizard-not-rendered short-circuit', () => {
+  it('returns silently when clientId input is missing', () => {
+    document.body.innerHTML = '<form id="configForm"></form>'
+    expect(() => createOauthValidator(defaultConfig())).not.toThrow()
+  })
+
+  it('returns silently when validate button is missing', () => {
+    document.body.innerHTML = buildBaseHTML()
+    document.getElementById('test_validate').remove()
+    expect(() => createOauthValidator(defaultConfig())).not.toThrow()
+  })
+
+  it('returns silently when urlField is missing', () => {
+    document.body.innerHTML = buildBaseHTML()
+    document.getElementById('test_url').remove()
+    expect(() => createOauthValidator(defaultConfig())).not.toThrow()
+  })
+})
+
+describe('createOauthValidator initial button state', () => {
+  it('disables validate button when previously validated', () => {
+    document.body.innerHTML = buildBaseHTML({ validated: 'true' })
+    createOauthValidator(defaultConfig())
+    expect(document.getElementById('test_validate').disabled).toBe(true)
+  })
+
+  it('leaves validate button in "no secondary value" state when not previously validated', () => {
+    document.body.innerHTML = buildBaseHTML({ validated: 'false' })
+    createOauthValidator(defaultConfig())
+    // secondaryValue empty AND no persisted validation -> button disabled
+    expect(document.getElementById('test_validate').disabled).toBe(true)
+  })
+
+  it('starts authorize button disabled when urlField is empty', () => {
+    document.body.innerHTML = buildBaseHTML()
+    createOauthValidator(defaultConfig())
+    expect(document.getElementById('test_authorize').disabled).toBe(true)
+  })
+
+  it('disables check-token button when access_token is empty', () => {
+    document.body.innerHTML = buildBaseHTML()
+    createOauthValidator(defaultConfig())
+    expect(document.getElementById('test_check_token').disabled).toBe(true)
+  })
+
+  it('enables check-token button when access_token is populated', () => {
+    document.body.innerHTML = buildBaseHTML()
+    document.getElementById('access_token').value = 'existing-token'
+    createOauthValidator(defaultConfig())
+    expect(document.getElementById('test_check_token').disabled).toBe(false)
+  })
+})
+
+describe('createOauthValidator authorization URL builder', () => {
+  it('builds URL when clientId reaches expected length', () => {
+    document.body.innerHTML = buildBaseHTML()
+    createOauthValidator(defaultConfig({ expectedClientIdLength: 8 }))
+
+    const clientIdInput = document.getElementById('test_client_id')
+    clientIdInput.value = '12345678'
+    clientIdInput.dispatchEvent(new Event('input'))
+
+    expect(document.getElementById('test_url').value)
+      .toBe('https://example.test/auth?client_id=12345678')
+    expect(document.getElementById('test_authorize').disabled).toBe(false)
+  })
+
+  it('clears URL when clientId shrinks below expected length', () => {
+    document.body.innerHTML = buildBaseHTML()
+    createOauthValidator(defaultConfig({ expectedClientIdLength: 8 }))
+
+    const clientIdInput = document.getElementById('test_client_id')
+    clientIdInput.value = '12345678'
+    clientIdInput.dispatchEvent(new Event('input'))
+    clientIdInput.value = '1234567'
+    clientIdInput.dispatchEvent(new Event('input'))
+
+    expect(document.getElementById('test_url').value).toBe('')
+    expect(document.getElementById('test_authorize').disabled).toBe(true)
+  })
+
+  it('resets validated state when URL is built', () => {
+    document.body.innerHTML = buildBaseHTML({ validated: 'true' })
+    document.getElementById('test_validated_at').value = '2026-01-01T00:00:00Z'
+    createOauthValidator(defaultConfig({ expectedClientIdLength: 8 }))
+
+    const clientIdInput = document.getElementById('test_client_id')
+    clientIdInput.value = '12345678'
+    clientIdInput.dispatchEvent(new Event('input'))
+
+    expect(document.getElementById('test_validated').value).toBe('false')
+    expect(document.getElementById('test_validated_at').value).toBe('')
+  })
+
+  it('passes extra credential values into buildAuthorizationURL', () => {
+    document.body.innerHTML = buildBaseHTML({
+      extraInputs: '<input id="test_verifier" type="text" value="my-pkce-verifier">'
+    })
+    const buildURL = vi.fn((clientId, extras) =>
+      `https://example.test/auth?client_id=${clientId}&challenge=${extras.test_verifier}`)
+    createOauthValidator(defaultConfig({
+      expectedClientIdLength: 8,
+      buildAuthorizationURL: buildURL,
+      extraCredentialFieldIds: ['test_verifier']
+    }))
+
+    const clientIdInput = document.getElementById('test_client_id')
+    clientIdInput.value = '12345678'
+    clientIdInput.dispatchEvent(new Event('input'))
+
+    expect(buildURL).toHaveBeenCalledWith('12345678', { test_verifier: 'my-pkce-verifier' })
+    expect(document.getElementById('test_url').value)
+      .toBe('https://example.test/auth?client_id=12345678&challenge=my-pkce-verifier')
+  })
+})
+
+describe('createOauthValidator authorize button click', () => {
+  it('opens URL in new tab and shows retrieve spinner', () => {
+    document.body.innerHTML = buildBaseHTML()
+    const openSpy = vi.fn(() => ({ focus: vi.fn() }))
+    vi.stubGlobal('open', openSpy)
+    createOauthValidator(defaultConfig({ expectedClientIdLength: 8 }))
+
+    const clientIdInput = document.getElementById('test_client_id')
+    clientIdInput.value = '12345678'
+    clientIdInput.dispatchEvent(new Event('input'))
+
+    document.getElementById('test_authorize').click()
+
+    expect(openSpy).toHaveBeenCalledWith('https://example.test/auth?client_id=12345678', '_blank')
+    expect(window.showSpinner).toHaveBeenCalledWith('retrieve')
+  })
+
+  it('does nothing when URL is empty', () => {
+    document.body.innerHTML = buildBaseHTML()
+    const openSpy = vi.fn()
+    vi.stubGlobal('open', openSpy)
+    createOauthValidator(defaultConfig())
+
+    document.getElementById('test_authorize').click()
+    expect(openSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('createOauthValidator secondary value gating', () => {
+  it('enables validate button when secondary value is populated', () => {
+    document.body.innerHTML = buildBaseHTML()
+    createOauthValidator(defaultConfig())
+
+    const secondaryInput = document.getElementById('test_pin')
+    secondaryInput.value = 'ABC123'
+    secondaryInput.dispatchEvent(new Event('input'))
+
+    expect(document.getElementById('test_validate').disabled).toBe(false)
+  })
+
+  it('disables validate button when secondary value is cleared', () => {
+    document.body.innerHTML = buildBaseHTML({ secondaryValue: 'ABC123' })
+    createOauthValidator(defaultConfig())
+
+    const secondaryInput = document.getElementById('test_pin')
+    secondaryInput.value = ''
+    secondaryInput.dispatchEvent(new Event('input'))
+
+    expect(document.getElementById('test_validate').disabled).toBe(true)
+  })
+})
+
+describe('createOauthValidator validate flow', () => {
+  it('shows missing-fields message when any credential is empty', () => {
+    // Populate secondaryValue so the button is enabled, then clear the
+    // secret to trigger the missing-fields path when clicked.
+    document.body.innerHTML = buildBaseHTML({
+      clientIdValue: 'abc',
+      secretValue: 'x',
+      secondaryValue: 'ABC123'
+    })
+    createOauthValidator(defaultConfig())
+    // Now clear the secret post-init to leave it blank at click time.
+    document.getElementById('test_client_secret').value = ''
+
+    document.getElementById('test_validate').click()
+    expect(document.getElementById('statusMessage').textContent)
+      .toBe('ID, secret, and secondary value are all required.')
+  })
+
+  it('POSTs the payload from buildValidatePayload on click', async () => {
+    document.body.innerHTML = buildBaseHTML({
+      clientIdValue: 'my-client-id',
+      secretValue: 'my-secret',
+      secondaryValue: 'my-pin'
+    })
+    const fetchMock = mockFetchOK({ valid: true })
+    createOauthValidator(defaultConfig())
+
+    document.getElementById('test_validate').click()
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenCalledWith('/validate_test', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({
+        test_client_id: 'my-client-id',
+        test_client_secret: 'my-secret',
+        test_pin: 'my-pin'
+      })
+    }))
+  })
+
+  it('calls applyValidateSuccess and marks validated on ok response', async () => {
+    document.body.innerHTML = buildBaseHTML({
+      clientIdValue: 'my-client-id',
+      secretValue: 'my-secret',
+      secondaryValue: 'my-pin'
+    })
+    mockFetchOK({ valid: true, extra: 'stuff' })
+    const applySuccess = vi.fn()
+    createOauthValidator(defaultConfig({ applyValidateSuccess: applySuccess }))
+
+    document.getElementById('test_validate').click()
+    await flushPromises()
+
+    expect(applySuccess).toHaveBeenCalledWith(
+      expect.objectContaining({ valid: true, extra: 'stuff' }),
+      expect.objectContaining({ markValidated: expect.any(Function) })
+    )
+    expect(document.getElementById('test_validated').value).toBe('true')
+    expect(document.getElementById('test_validated_at').value).not.toBe('')
+    expect(document.getElementById('statusMessage').textContent)
+      .toContain('Test credentials validated successfully!')
+  })
+
+  it('sets validated=false on failure response', async () => {
+    document.body.innerHTML = buildBaseHTML({
+      clientIdValue: 'my-client-id',
+      secretValue: 'my-secret',
+      secondaryValue: 'my-pin',
+      validated: 'true'
+    })
+    document.getElementById('test_validated_at').value = '2026-01-01T00:00:00Z'
+    mockFetchOK({ valid: false })
+    createOauthValidator(defaultConfig())
+    // secondaryValueInput populated => re-enable button before click
+    document.getElementById('test_validate').disabled = false
+
+    document.getElementById('test_validate').click()
+    await flushPromises()
+
+    expect(document.getElementById('test_validated').value).toBe('false')
+    expect(document.getElementById('test_validated_at').value).toBe('')
+  })
+
+  it('shows error message on fetch rejection', async () => {
+    document.body.innerHTML = buildBaseHTML({
+      clientIdValue: 'my-client-id',
+      secretValue: 'my-secret',
+      secondaryValue: 'my-pin'
+    })
+    mockFetchReject()
+    createOauthValidator(defaultConfig())
+
+    document.getElementById('test_validate').click()
+    await flushPromises()
+
+    expect(document.getElementById('statusMessage').textContent)
+      .toBe('An error occurred while validating Test credentials.')
+  })
+})
+
+describe('createOauthValidator check-token flow', () => {
+  it('shows missing message when access_token is blank', () => {
+    document.body.innerHTML = buildBaseHTML()
+    createOauthValidator(defaultConfig())
+
+    document.getElementById('test_check_token').disabled = false
+    document.getElementById('test_check_token').click()
+    expect(document.getElementById('statusMessage').textContent).toBe('Missing access token.')
+  })
+
+  it('POSTs check-token payload and marks validated on success', async () => {
+    document.body.innerHTML = buildBaseHTML()
+    document.getElementById('access_token').value = 'my-access-token'
+    document.getElementById('refresh_token').value = 'my-refresh-token'
+    const fetchMock = mockFetchOK({ valid: true })
+    createOauthValidator(defaultConfig({
+      buildCheckTokenPayload: ({ accessToken, clientId, clientSecret, refreshToken }) => ({
+        access_token: accessToken,
+        client_id: clientId,
+        client_secret: clientSecret,
+        refresh_token: refreshToken,
+        debug: true
+      })
+    }))
+
+    document.getElementById('test_check_token').click()
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenCalledWith('/validate_test_token', expect.objectContaining({
+      body: JSON.stringify({
+        access_token: 'my-access-token',
+        client_id: '',
+        client_secret: '',
+        refresh_token: 'my-refresh-token',
+        debug: true
+      })
+    }))
+    expect(document.getElementById('test_validated').value).toBe('true')
+    expect(document.getElementById('statusMessage').textContent).toContain('Test token is valid.')
+  })
+
+  it('calls applyCheckTokenSuccess when provided', async () => {
+    document.body.innerHTML = buildBaseHTML()
+    document.getElementById('access_token').value = 'my-access-token'
+    mockFetchOK({ valid: true, authorization: { access_token: 'rotated' } })
+    const applyCheck = vi.fn()
+    createOauthValidator(defaultConfig({ applyCheckTokenSuccess: applyCheck }))
+
+    document.getElementById('test_check_token').click()
+    await flushPromises()
+
+    expect(applyCheck).toHaveBeenCalledWith(
+      expect.objectContaining({ authorization: { access_token: 'rotated' } }),
+      expect.objectContaining({ markValidated: expect.any(Function) })
+    )
+  })
+
+  it('does not wire check-token flow when checkTokenButtonId is omitted', () => {
+    document.body.innerHTML = buildBaseHTML({ includeCheckTokenButton: false })
+    expect(() => createOauthValidator(defaultConfig({
+      checkTokenButtonId: undefined,
+      checkTokenEndpoint: undefined,
+      buildCheckTokenPayload: undefined
+    }))).not.toThrow()
+  })
+
+  it('sets validated=false on check-token failure response', async () => {
+    document.body.innerHTML = buildBaseHTML({ validated: 'true' })
+    document.getElementById('access_token').value = 'my-access-token'
+    document.getElementById('test_validated_at').value = '2026-01-01T00:00:00Z'
+    mockFetchOK({ valid: false })
+    createOauthValidator(defaultConfig())
+
+    document.getElementById('test_check_token').disabled = false
+    document.getElementById('test_check_token').click()
+    await flushPromises()
+
+    expect(document.getElementById('test_validated').value).toBe('false')
+    expect(document.getElementById('test_validated_at').value).toBe('')
+  })
+
+  it('shows error message on check-token fetch rejection', async () => {
+    document.body.innerHTML = buildBaseHTML()
+    document.getElementById('access_token').value = 'my-access-token'
+    mockFetchReject()
+    createOauthValidator(defaultConfig())
+
+    document.getElementById('test_check_token').disabled = false
+    document.getElementById('test_check_token').click()
+    await flushPromises()
+
+    expect(document.getElementById('statusMessage').textContent)
+      .toBe('An error occurred while validating Test token.')
+  })
+
+  it('runs custom checkTokenPreflight guard when provided', () => {
+    document.body.innerHTML = buildBaseHTML()
+    document.getElementById('access_token').value = 'my-access-token'
+    const fetchMock = mockFetchOK({ valid: true })
+    createOauthValidator(defaultConfig({
+      checkTokenPreflight: ({ accessToken, clientId }) =>
+        (!accessToken.trim() || !clientId.trim())
+          ? 'Missing access token or client ID.'
+          : null
+    }))
+
+    // clientId is empty, so the preflight should abort with the custom message
+    document.getElementById('test_check_token').disabled = false
+    document.getElementById('test_check_token').click()
+
+    expect(document.getElementById('statusMessage').textContent)
+      .toBe('Missing access token or client ID.')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('proceeds when checkTokenPreflight returns null', async () => {
+    document.body.innerHTML = buildBaseHTML({ clientIdValue: 'x' })
+    document.getElementById('access_token').value = 'my-access-token'
+    const fetchMock = mockFetchOK({ valid: true })
+    createOauthValidator(defaultConfig({
+      checkTokenPreflight: () => null
+    }))
+
+    document.getElementById('test_check_token').disabled = false
+    document.getElementById('test_check_token').click()
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenCalled()
+  })
+})
+
+describe('createOauthValidator message overrides', () => {
+  it('uses custom messages from config', async () => {
+    document.body.innerHTML = buildBaseHTML({
+      clientIdValue: 'x', secretValue: 'y', secondaryValue: 'z'
+    })
+    mockFetchOK({ valid: true })
+    createOauthValidator(defaultConfig({
+      messages: {
+        validateSuccess: 'HOORAY!',
+        validateError: 'BOOM',
+        validateMissingFields: 'You forgot something.',
+        checkTokenSuccess: 'good token',
+        checkTokenError: 'bad token',
+        checkTokenMissingFields: 'no token yet'
+      }
+    }))
+
+    document.getElementById('test_validate').click()
+    await flushPromises()
+
+    expect(document.getElementById('statusMessage').textContent).toContain('HOORAY!')
+  })
+})
+
+describe('createOauthValidator credential reset listeners', () => {
+  it('resets validated state when clientId is edited', () => {
+    document.body.innerHTML = buildBaseHTML({ validated: 'true' })
+    document.getElementById('test_validated_at').value = '2026-01-01T00:00:00Z'
+    createOauthValidator(defaultConfig())
+
+    const clientIdInput = document.getElementById('test_client_id')
+    clientIdInput.value = 'a'
+    clientIdInput.dispatchEvent(new Event('input'))
+
+    expect(document.getElementById('test_validated').value).toBe('false')
+    expect(document.getElementById('test_validated_at').value).toBe('')
+  })
+
+  it('resets validated state when clientSecret is edited', () => {
+    document.body.innerHTML = buildBaseHTML({ validated: 'true' })
+    document.getElementById('test_validated_at').value = '2026-01-01T00:00:00Z'
+    createOauthValidator(defaultConfig())
+
+    const secretInput = document.getElementById('test_client_secret')
+    secretInput.value = 'new-secret'
+    secretInput.dispatchEvent(new Event('input'))
+
+    expect(document.getElementById('test_validated').value).toBe('false')
+  })
+
+  it('resets validated state when secondaryValue is edited', () => {
+    document.body.innerHTML = buildBaseHTML({ validated: 'true' })
+    createOauthValidator(defaultConfig())
+
+    const secondary = document.getElementById('test_pin')
+    secondary.value = 'newpin'
+    secondary.dispatchEvent(new Event('input'))
+
+    expect(document.getElementById('test_validated').value).toBe('false')
+  })
+})


### PR DESCRIPTION
## Summary

Roadmap issue #1335 Step 6 — extends the shared validation-widget work by adding a factory for the **OAuth wizard pattern**, mirroring the existing `createApiKeyValidator` used by 12 wizards.

The two callers today (`130-trakt.js`, `140-mal.js`) shrink from ~200 lines each to 60-84 lines of pure config. Zero behavior changes.

## The abstraction

Both Trakt and MAL implement the same 5-phase OAuth flow:
1. Toggle client-secret visibility
2. Reset validated=false on any credential input change
3. Build an authorization URL when client_id reaches a wizard-specific length
4. POST credentials + a secondary value (PIN / localhost URL) to validate
5. Optionally re-validate an already-saved access token

The differences are shape (payload keys, URL format, expected client_id length) and content (success message text, which fields to copy from the response, whether tokens rotate).

## Design

`createOauthValidator(config)` takes 6 required hooks + 6 optional:

| Hook | Trakt | MAL |
|---|---|---|
| `buildAuthorizationURL` | oob redirect URL | PKCE code_challenge URL |
| `buildValidatePayload` | `{trakt_client_id, trakt_client_secret, trakt_pin}` | `{mal_client_id, mal_client_secret, mal_code_verifier, mal_localhost_url}` |
| `applyValidateSuccess` | Copy 6 auth fields, clear PIN, clear URL | Copy 4 auth fields |
| `buildCheckTokenPayload` | `{access_token, client_id, client_secret, refresh_token, debug}` | `{access_token, debug}` |
| `applyCheckTokenSuccess` | May rotate 6 token fields via `data.authorization` | (omitted; no rotation) |
| `checkTokenPreflight` | Blocks on missing client_id | (default; access_token only) |

The `ctx` object passed to `applyValidateSuccess` exposes the resolved DOM elements + a `markValidated()` helper so callers don't re-query.

## Files

* **NEW** `static/local-js/modules/createOauthValidator.js` (363 lines)
* **NEW** `tests/js/modules/createOauthValidator.test.js` (47 Vitest tests)
* `static/local-js/130-trakt.js`: **201 → 84 lines** (**-58%**)
* `static/local-js/140-mal.js`: **190 → 60 lines** (**-68%**)

## Verification

| Check | Result |
|---|---|
| Vitest total | **370 pass** (was 323; +47 new) |
| Trakt e2e (Playwright) | **5/5 pass** |
| MAL e2e (Playwright) | **4/4 pass** |
| ESLint | 0 errors |
| Pre-commit | 12/12 hooks green |

## Test coverage of the new factory

47 tests covering:
- Config validation (14 required-field throws)
- DOM short-circuit when wizard isn't rendered (3 cases)
- Initial button state from persisted validated + access_token (5 cases)
- Authorization URL builder (4 cases inc. clientId shrink + extra credentials)
- Authorize button click behavior (2 cases)
- Secondary value gating (2 cases)
- Validate flow: missing fields, POST payload, apply success, mark validated, failure response, error message (5 cases)
- Check-token flow: missing token, POST payload, apply success, no-op when button omitted, failure response, error message, preflight guard (7 cases)
- Message overrides (1 case)
- Credential reset listeners (3 cases)

## What's next

This is Step 6 PR 2 (the extension covering OAuth wizards after `createApiKeyValidator` covered API-key wizards). After this lands, Step 6 is effectively complete — the remaining wizards (`090-webhooks`, `150-settings`, `100-anidb`, `027-playlist_files`) don't match either factory pattern by design.