### PR TITLE
Step 7 Phase 2: Drop jQuery from 915-imagemaid.js

### DIFF
--- a/static/local-js/130-trakt.js
+++ b/static/local-js/130-trakt.js
@@ -1,201 +1,84 @@
-import { refreshValidationCallout } from './modules/validationPageBase.js'
-import {
-  STATUS_COLOR_SUCCESS,
-  STATUS_COLOR_ERROR,
-  isBlankTokenValue,
-  wireSecretToggle,
-  wireCredentialResetListeners,
-  showStatusMessage,
-  performValidationRequest
-} from './modules/oauthValidationHelpers.js'
+import { createOauthValidator } from './modules/createOauthValidator.js'
 
-// Trakt OAuth-PIN flow. Layered on top of oauthValidationHelpers.
-// All DOM event wiring uses addEventListener -- no inline oninput /
-// onclick attributes in the template, no window-exposed functions.
-// Module-local everything, the way it should be.
+// Trakt OAuth PIN flow. Migrated to the shared createOauthValidator
+// factory in #1334 Step 6 PR 2.
+//
+// Trakt-specific quirks preserved from the pre-factory implementation:
+//   - client_id length is 64 chars before the authorization URL is built
+//   - authorization URL format is Trakt's oob (out-of-band) redirect
+//   - validate endpoint returns 6 authorization fields to copy
+//   - Check Token endpoint may rotate the token set via data.authorization
+//   - After success, the PIN input and URL field are cleared, both
+//     PIN-flow buttons are disabled, and the Check Token button becomes
+//     enabled.
 
-const VALIDATED_FIELD_ID = 'trakt_validated'
+const TRAKT_CLIENT_ID_LENGTH = 64
 
-const validatedAtInput = document.getElementById('trakt_validated_at')
-const clientIdInput = document.getElementById('trakt_client_id')
-const clientSecretInput = document.getElementById('trakt_client_secret')
-const pinInput = document.getElementById('trakt_pin')
-const urlField = document.getElementById('trakt_url')
-const toggleButton = document.getElementById('toggleClientSecretVisibility')
-const openUrlButton = document.getElementById('trakt_open_url')
-const validateButton = document.getElementById('validate_trakt_pin')
-const checkTokenButton = document.getElementById('trakt_check_token')
-const isValidatedElement = document.getElementById('trakt_validated')
-
-wireSecretToggle(clientSecretInput, toggleButton)
-
-// Initial button enable/disable from persisted state.
-validateButton.disabled = isValidatedElement.value.toLowerCase() === 'true'
-if (checkTokenButton) {
-  const accessToken = document.getElementById('access_token')?.value || ''
-  checkTokenButton.disabled = isBlankTokenValue(accessToken)
-}
-
-wireCredentialResetListeners({
-  fieldIds: ['trakt_client_id', 'trakt_client_secret', 'trakt_pin'],
-  validatedField: isValidatedElement,
-  validatedAtField: validatedAtInput,
-  validateButton,
-  checkTokenButton,
-  validatedFieldId: VALIDATED_FIELD_ID
-})
-
-// Build the authorization URL when the client_id reaches the expected
-// 64-char length. Editing the credential also invalidates the saved
-// validated state (wireCredentialResetListeners already handles the
-// reset; this also clears the validatedAt and refreshes the callout
-// for symmetry with the legacy behavior).
-function updateTraktURL () {
-  const traktClientId = clientIdInput.value
-  let myURL = ''
-  if (traktClientId.length === 64) {
-    isValidatedElement.value = 'false'
-    if (validatedAtInput) validatedAtInput.value = ''
-    refreshValidationCallout(VALIDATED_FIELD_ID)
-    myURL = 'https://trakt.tv/oauth/authorize?response_type=code&client_id=' + traktClientId + '&redirect_uri=urn:ietf:wg:oauth:2.0:oob'
-  }
-  urlField.value = myURL
-  // The URL is built from credentials, so re-check the open-URL gate
-  // here directly. Listening on the hidden urlField for 'input' events
-  // wouldn't work -- programmatic .value assignment doesn't fire them.
-  openUrlButton.disabled = urlField.value === ''
-}
-
-// Wire updateTraktURL to the Client ID only. The legacy template wired
-// it to Client Secret too, but updateTraktURL doesn't read the secret,
-// so the second wiring was a no-op.
-clientIdInput.addEventListener('input', updateTraktURL)
-
-openUrlButton.addEventListener('click', function () {
-  const url = urlField.value
-  if (url) {
-    showSpinner('retrieve')
-    window.open(url, '_blank').focus()
-  }
-})
-
-pinInput.addEventListener('input', function () {
-  validateButton.disabled = pinInput.value === ''
-})
-
-// Initial gating after the page has rendered. Replaces the previous
-// `window.onload = ...` block.
-openUrlButton.disabled = true
-validateButton.disabled = true
-
-// Trakt-specific success bookkeeping: copy 6 authorization fields into
-// hidden form inputs, clear the PIN + URL, disable PIN-flow buttons,
-// enable the Check Token button.
-function applyTraktPinSuccess (data) {
-  isValidatedElement.value = 'true'
-  if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-  refreshValidationCallout(VALIDATED_FIELD_ID)
-  document.getElementById('access_token').value = data.trakt_authorization_access_token
-  document.getElementById('token_type').value = data.trakt_authorization_token_type
-  document.getElementById('expires_in').value = data.trakt_authorization_expires_in
-  document.getElementById('refresh_token').value = data.trakt_authorization_refresh_token
-  document.getElementById('scope').value = data.trakt_authorization_scope
-  document.getElementById('created_at').value = data.trakt_authorization_created_at
-  pinInput.value = ''
-  urlField.value = ''
-  openUrlButton.disabled = true
-  validateButton.disabled = true
-  if (checkTokenButton) checkTokenButton.disabled = false
-}
-
-// PIN flow: POST /validate_trakt with id/secret/pin -> access tokens.
-validateButton.addEventListener('click', function () {
-  const statusMessage = document.getElementById('statusMessage')
-  const traktClient = clientIdInput.value
-  const traktSecret = clientSecretInput.value
-  const traktPin = pinInput.value
-
-  if (!traktClient || !traktSecret || !traktPin) {
-    showStatusMessage(statusMessage, 'ID, secret, and PIN are all required.', STATUS_COLOR_ERROR)
-    return
-  }
-
-  hideSpinner('retrieve')
-  performValidationRequest({
-    endpoint: '/validate_trakt',
-    payload: { trakt_client_id: traktClient, trakt_client_secret: traktSecret, trakt_pin: traktPin },
-    spinnerKey: 'validate',
-    statusElement: statusMessage,
-    onSuccess: (data) => {
-      applyTraktPinSuccess(data)
-      showStatusMessage(statusMessage, 'Trakt credentials validated successfully!', STATUS_COLOR_SUCCESS)
-    },
-    onFailure: () => {
-      isValidatedElement.value = 'false'
-      if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout(VALIDATED_FIELD_ID)
-    },
-    onError: () => {
-      showStatusMessage(statusMessage, 'An error occurred while validating Trakt credentials.', STATUS_COLOR_ERROR)
-      if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout(VALIDATED_FIELD_ID)
+createOauthValidator({
+  serviceName: 'Trakt',
+  validatedFieldId: 'trakt_validated',
+  validatedAtFieldId: 'trakt_validated_at',
+  clientIdFieldId: 'trakt_client_id',
+  clientSecretFieldId: 'trakt_client_secret',
+  authorizeButtonId: 'trakt_open_url',
+  validateButtonId: 'validate_trakt_pin',
+  checkTokenButtonId: 'trakt_check_token',
+  urlFieldId: 'trakt_url',
+  expectedClientIdLength: TRAKT_CLIENT_ID_LENGTH,
+  buildAuthorizationURL: (clientId) =>
+    `https://trakt.tv/oauth/authorize?response_type=code&client_id=${clientId}&redirect_uri=urn:ietf:wg:oauth:2.0:oob`,
+  secondaryValueFieldId: 'trakt_pin',
+  validateEndpoint: '/validate_trakt',
+  validateSpinnerKey: 'validate',
+  buildValidatePayload: ({ clientId, clientSecret, secondaryValue }) => ({
+    trakt_client_id: clientId,
+    trakt_client_secret: clientSecret,
+    trakt_pin: secondaryValue
+  }),
+  messages: {
+    validateMissingFields: 'ID, secret, and PIN are all required.'
+  },
+  applyValidateSuccess: (data, ctx) => {
+    document.getElementById('access_token').value = data.trakt_authorization_access_token
+    document.getElementById('token_type').value = data.trakt_authorization_token_type
+    document.getElementById('expires_in').value = data.trakt_authorization_expires_in
+    document.getElementById('refresh_token').value = data.trakt_authorization_refresh_token
+    document.getElementById('scope').value = data.trakt_authorization_scope
+    document.getElementById('created_at').value = data.trakt_authorization_created_at
+    ctx.secondaryValueInput.value = ''
+    ctx.urlField.value = ''
+    ctx.authorizeButton.disabled = true
+    ctx.validateButton.disabled = true
+    if (ctx.checkTokenButton) ctx.checkTokenButton.disabled = false
+  },
+  checkTokenEndpoint: '/validate_trakt_token',
+  checkTokenSpinnerKey: 'check_trakt',
+  buildCheckTokenPayload: ({ accessToken, clientId, clientSecret, refreshToken }) => ({
+    access_token: accessToken,
+    client_id: clientId,
+    client_secret: clientSecret,
+    refresh_token: refreshToken,
+    debug: true
+  }),
+  checkTokenPreflight: ({ accessToken, clientId }) => {
+    // Trakt requires both accessToken AND clientId to be present
+    // before hitting the server (server would reject otherwise).
+    if (!accessToken.trim() || !clientId.trim()) {
+      return 'Missing access token or client ID.'
     }
-  })
-})
-
-// Check Token re-validation: POST /validate_trakt_token using the
-// already-saved access_token. On success, may rotate the token set
-// (server returns an `authorization` block when a refresh happened).
-if (checkTokenButton) {
-  checkTokenButton.addEventListener('click', function () {
-    const statusMessage = document.getElementById('statusMessage')
-    const accessToken = document.getElementById('access_token')?.value || ''
-    const clientId = clientIdInput?.value || ''
-
-    if (isBlankTokenValue(accessToken) || isBlankTokenValue(clientId)) {
-      showStatusMessage(statusMessage, 'Missing access token or client ID.', STATUS_COLOR_ERROR)
-      return
+    return null
+  },
+  applyCheckTokenSuccess: (data) => {
+    // Trakt-specific: response may rotate the token set. Copy the
+    // rotated fields when the server sent them.
+    if (data.authorization) {
+      const auth = data.authorization
+      if (auth.access_token) document.getElementById('access_token').value = auth.access_token
+      if (auth.token_type) document.getElementById('token_type').value = auth.token_type
+      if (auth.expires_in) document.getElementById('expires_in').value = auth.expires_in
+      if (auth.refresh_token) document.getElementById('refresh_token').value = auth.refresh_token
+      if (auth.scope) document.getElementById('scope').value = auth.scope
+      if (auth.created_at) document.getElementById('created_at').value = auth.created_at
     }
-
-    const clientSecret = clientSecretInput?.value || ''
-    const refreshToken = document.getElementById('refresh_token')?.value || ''
-
-    performValidationRequest({
-      endpoint: '/validate_trakt_token',
-      payload: {
-        access_token: accessToken,
-        client_id: clientId,
-        client_secret: clientSecret,
-        refresh_token: refreshToken,
-        debug: true
-      },
-      spinnerKey: 'check_trakt',
-      statusElement: statusMessage,
-      onSuccess: (data) => {
-        if (data.authorization) {
-          const auth = data.authorization
-          if (auth.access_token) document.getElementById('access_token').value = auth.access_token
-          if (auth.token_type) document.getElementById('token_type').value = auth.token_type
-          if (auth.expires_in) document.getElementById('expires_in').value = auth.expires_in
-          if (auth.refresh_token) document.getElementById('refresh_token').value = auth.refresh_token
-          if (auth.scope) document.getElementById('scope').value = auth.scope
-          if (auth.created_at) document.getElementById('created_at').value = auth.created_at
-        }
-        isValidatedElement.value = 'true'
-        if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-        refreshValidationCallout(VALIDATED_FIELD_ID)
-        showStatusMessage(statusMessage, 'Trakt token is valid.', STATUS_COLOR_SUCCESS)
-      },
-      onFailure: () => {
-        isValidatedElement.value = 'false'
-        if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout(VALIDATED_FIELD_ID)
-      },
-      onError: () => {
-        showStatusMessage(statusMessage, 'An error occurred while validating Trakt token.', STATUS_COLOR_ERROR)
-        if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout(VALIDATED_FIELD_ID)
-      }
-    })
-  })
-}
+  }
+})

--- a/static/local-js/140-mal.js
+++ b/static/local-js/140-mal.js
@@ -1,190 +1,60 @@
-import { refreshValidationCallout } from './modules/validationPageBase.js'
-import {
-  STATUS_COLOR_SUCCESS,
-  STATUS_COLOR_ERROR,
-  wireSecretToggle,
-  wireCredentialResetListeners,
-  showStatusMessage,
-  performValidationRequest
-} from './modules/oauthValidationHelpers.js'
+import { createOauthValidator } from './modules/createOauthValidator.js'
 
-// MyAnimeList OAuth flow. Layered on top of oauthValidationHelpers.
-// All DOM event wiring uses addEventListener -- no inline oninput /
-// onclick attributes in the template, no window-exposed functions.
+// MyAnimeList OAuth PKCE flow. Migrated to the shared createOauthValidator
+// factory in #1334 Step 6 PR 2.
 //
-// Shape mirrors Trakt (#130) but with three notable differences:
-//   - URL build is gated on client_id.length === 32 (Trakt is 64) and
-//     incorporates a code_verifier PKCE challenge.
-//   - The submission field is a localhost-redirect URL, not a PIN.
-//   - The Check Token endpoint only consumes access_token and does
-//     not rotate the token set on success.
+// MAL-specific quirks preserved from the pre-factory implementation:
+//   - client_id length is 32 chars before the authorization URL is built
+//   - authorization URL uses PKCE (code_challenge = code_verifier)
+//   - the "secondary value" is a localhost URL, not a PIN
+//   - validate endpoint returns 4 authorization fields to copy
+//   - Check Token endpoint doesn't rotate tokens; only marks valid
+//   - After success, both authorize + validate buttons are disabled
+//     and the Check Token button becomes enabled
 
-const VALIDATED_FIELD_ID = 'mal_validated'
+const MAL_CLIENT_ID_LENGTH = 32
 
-const validatedAtInput = document.getElementById('mal_validated_at')
-const clientIdInput = document.getElementById('mal_client_id')
-const clientSecretInput = document.getElementById('mal_client_secret')
-const codeVerifierInput = document.getElementById('mal_code_verifier')
-const urlField = document.getElementById('mal_url')
-const localhostUrlInput = document.getElementById('mal_localhost_url')
-const toggleButton = document.getElementById('toggleClientSecretVisibility')
-const authorizeButton = document.getElementById('mal_get_localhost_url')
-const validateButton = document.getElementById('validate_mal_url')
-const checkTokenButton = document.getElementById('mal_check_token')
-const isValidatedElement = document.getElementById('mal_validated')
-
-wireSecretToggle(clientSecretInput, toggleButton)
-
-// Initial button enable/disable from persisted state.
-const isValidated = isValidatedElement ? isValidatedElement.value.toLowerCase() : 'false'
-if (isValidated === 'true') validateButton.disabled = true
-if (checkTokenButton) {
-  const accessToken = document.getElementById('access_token')?.value || ''
-  checkTokenButton.disabled = !accessToken.trim()
-}
-
-wireCredentialResetListeners({
-  fieldIds: ['mal_client_id', 'mal_client_secret', 'mal_code_verifier', 'mal_localhost_url'],
-  validatedField: isValidatedElement,
-  validatedAtField: validatedAtInput,
-  validateButton,
-  checkTokenButton,
-  validatedFieldId: VALIDATED_FIELD_ID
-})
-
-// Build the authorization URL when the client_id reaches the expected
-// 32-char length. MAL needs the PKCE code_verifier to be present in
-// the URL as the code_challenge query param.
-function updateMALTargetURL () {
-  const malClientId = clientIdInput.value
-  const codeVerifier = codeVerifierInput.value
-  let myURL = ''
-  if (malClientId.length === 32) {
-    isValidatedElement.value = 'false'
-    if (validatedAtInput) validatedAtInput.value = ''
-    refreshValidationCallout(VALIDATED_FIELD_ID)
-    myURL = 'https://myanimelist.net/v1/oauth2/authorize?response_type=code&client_id=' + malClientId + '&code_challenge=' + codeVerifier
-  }
-  urlField.value = myURL
-  // Listening on the hidden urlField for 'input' events wouldn't work --
-  // programmatic .value assignment doesn't fire them. Re-check the
-  // Authorize button gate here directly.
-  authorizeButton.disabled = urlField.value === ''
-}
-
-// Wire updateMALTargetURL to the Client ID only. The legacy template
-// wired it to Client Secret too, but updateMALTargetURL doesn't read
-// the secret, so the second wiring was a no-op.
-clientIdInput.addEventListener('input', updateMALTargetURL)
-
-// The "Authorize" button opens the constructed authorization URL in
-// a new tab.
-authorizeButton.addEventListener('click', function () {
-  const url = urlField.value
-  if (url) {
-    showSpinner('retrieve')
-    window.open(url, '_blank').focus()
-  }
-})
-
-localhostUrlInput.addEventListener('input', function () {
-  validateButton.disabled = localhostUrlInput.value === ''
-})
-
-// Initial gating after the page has rendered. Replaces the previous
-// `window.onload = ...` block.
-validateButton.disabled = true
-authorizeButton.disabled = urlField.value === ''
-
-// MAL-specific success bookkeeping: copy 4 authorization fields into
-// hidden form inputs and disable both auth-flow buttons.
-function applyMALAuthSuccess (data) {
-  isValidatedElement.value = 'true'
-  if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-  refreshValidationCallout(VALIDATED_FIELD_ID)
-  document.getElementById('access_token').value = data.mal_authorization_access_token
-  document.getElementById('token_type').value = data.mal_authorization_token_type
-  document.getElementById('expires_in').value = data.mal_authorization_expires_in
-  document.getElementById('refresh_token').value = data.mal_authorization_refresh_token
-  authorizeButton.disabled = true
-  validateButton.disabled = true
-  if (checkTokenButton) checkTokenButton.disabled = false
-}
-
-// Auth completion: POST /validate_mal with id/secret/verifier/url ->
-// access tokens.
-validateButton.addEventListener('click', function () {
-  const statusMessage = document.getElementById('statusMessage')
-  const malClient = clientIdInput.value
-  const malSecret = clientSecretInput.value
-  const malVerifier = codeVerifierInput.value
-  const malLocalhostURL = localhostUrlInput.value
-
-  if (!malClient || !malSecret || !malVerifier || !malLocalhostURL) {
-    showStatusMessage(statusMessage, 'ID, secret, and localhost URL are all required.', STATUS_COLOR_ERROR)
-    return
-  }
-
-  hideSpinner('retrieve')
-  performValidationRequest({
-    endpoint: '/validate_mal',
-    payload: {
-      mal_client_id: malClient,
-      mal_client_secret: malSecret,
-      mal_code_verifier: malVerifier,
-      mal_localhost_url: malLocalhostURL
-    },
-    spinnerKey: 'validate',
-    statusElement: statusMessage,
-    onSuccess: (data) => {
-      applyMALAuthSuccess(data)
-      showStatusMessage(statusMessage, 'MyAnimeList credentials validated successfully!', STATUS_COLOR_SUCCESS)
-    },
-    onFailure: () => {
-      isValidatedElement.value = 'false'
-      if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout(VALIDATED_FIELD_ID)
-    },
-    onError: () => {
-      showStatusMessage(statusMessage, 'An error occurred while validating MAL credentials.', STATUS_COLOR_ERROR)
-      if (validatedAtInput) validatedAtInput.value = ''
-      refreshValidationCallout(VALIDATED_FIELD_ID)
-    }
+createOauthValidator({
+  serviceName: 'MyAnimeList',
+  validatedFieldId: 'mal_validated',
+  validatedAtFieldId: 'mal_validated_at',
+  clientIdFieldId: 'mal_client_id',
+  clientSecretFieldId: 'mal_client_secret',
+  authorizeButtonId: 'mal_get_localhost_url',
+  validateButtonId: 'validate_mal_url',
+  checkTokenButtonId: 'mal_check_token',
+  urlFieldId: 'mal_url',
+  expectedClientIdLength: MAL_CLIENT_ID_LENGTH,
+  extraCredentialFieldIds: ['mal_code_verifier'],
+  buildAuthorizationURL: (clientId, extras) =>
+    `https://myanimelist.net/v1/oauth2/authorize?response_type=code&client_id=${clientId}&code_challenge=${extras.mal_code_verifier}`,
+  secondaryValueFieldId: 'mal_localhost_url',
+  validateEndpoint: '/validate_mal',
+  validateSpinnerKey: 'validate',
+  buildValidatePayload: ({ clientId, clientSecret, secondaryValue, extras }) => ({
+    mal_client_id: clientId,
+    mal_client_secret: clientSecret,
+    mal_code_verifier: extras.mal_code_verifier,
+    mal_localhost_url: secondaryValue
+  }),
+  messages: {
+    validateMissingFields: 'ID, secret, and localhost URL are all required.'
+  },
+  applyValidateSuccess: (data, ctx) => {
+    document.getElementById('access_token').value = data.mal_authorization_access_token
+    document.getElementById('token_type').value = data.mal_authorization_token_type
+    document.getElementById('expires_in').value = data.mal_authorization_expires_in
+    document.getElementById('refresh_token').value = data.mal_authorization_refresh_token
+    ctx.authorizeButton.disabled = true
+    ctx.validateButton.disabled = true
+    if (ctx.checkTokenButton) ctx.checkTokenButton.disabled = false
+  },
+  checkTokenEndpoint: '/validate_mal_token',
+  checkTokenSpinnerKey: 'check_mal',
+  buildCheckTokenPayload: ({ accessToken }) => ({
+    access_token: accessToken,
+    debug: true
   })
+  // No applyCheckTokenSuccess -- MAL's check-token doesn't rotate tokens
+  // (unlike Trakt). Just marking validated is enough.
 })
-
-// Check Token: POST /validate_mal_token with the saved access token.
-if (checkTokenButton) {
-  checkTokenButton.addEventListener('click', function () {
-    const statusMessage = document.getElementById('statusMessage')
-    const accessToken = document.getElementById('access_token')?.value || ''
-
-    if (!accessToken.trim()) {
-      showStatusMessage(statusMessage, 'Missing access token.', STATUS_COLOR_ERROR)
-      return
-    }
-
-    performValidationRequest({
-      endpoint: '/validate_mal_token',
-      payload: { access_token: accessToken, debug: true },
-      spinnerKey: 'check_mal',
-      statusElement: statusMessage,
-      onSuccess: () => {
-        isValidatedElement.value = 'true'
-        if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
-        refreshValidationCallout(VALIDATED_FIELD_ID)
-        showStatusMessage(statusMessage, 'MyAnimeList token is valid.', STATUS_COLOR_SUCCESS)
-      },
-      onFailure: () => {
-        isValidatedElement.value = 'false'
-        if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout(VALIDATED_FIELD_ID)
-      },
-      onError: () => {
-        showStatusMessage(statusMessage, 'An error occurred while validating MyAnimeList token.', STATUS_COLOR_ERROR)
-        if (validatedAtInput) validatedAtInput.value = ''
-        refreshValidationCallout(VALIDATED_FIELD_ID)
-      }
-    })
-  })
-}

--- a/static/local-js/915-imagemaid.js
+++ b/static/local-js/915-imagemaid.js
@@ -22,7 +22,7 @@ let autosaveTimer = null
 let imagemaidAutosaveInFlight = false
 let imagemaidAutosavePending = false
 let imagemaidStartupDeadline = 0
-let lastImageMaidMode = String($('#imagemaid_mode').val() || 'report').trim().toLowerCase()
+let lastImageMaidMode = String(document.getElementById('imagemaid_mode').value || 'report').trim().toLowerCase()
 let restoreFolderModeConflict = false
 let imagemaidProbeInFlight = false
 let imagemaidUpdateCheckInFlight = false
@@ -59,89 +59,90 @@ if (stopModalEl && typeof bootstrap !== 'undefined') {
 }
 
 const els = {
-  installState: $('#imagemaid-install-state'),
-  installSummary: $('#imagemaid-install-summary'),
-  installLog: $('#imagemaid-install-log'),
-  installPath: $('#imagemaid-install-path'),
-  branchSelection: $('#imagemaid-branch-selection'),
-  effectiveBranch: $('#imagemaid-effective-branch'),
-  updatePhaseBadge: $('#imagemaid-update-phase-badge'),
-  localVersionStatus: $('#imagemaid-local-version-status'),
-  remoteVersionStatus: $('#imagemaid-remote-version-status'),
-  localBranchStatus: $('#imagemaid-local-branch-status'),
-  localShaStatus: $('#imagemaid-local-sha-status'),
-  remoteShaStatus: $('#imagemaid-remote-sha-status'),
-  branchSourceUrl: $('#imagemaid-branch-source-url'),
-  zipSourceUrl: $('#imagemaid-zip-source-url'),
-  branchOverrideWarning: $('#imagemaid-branch-override-warning'),
-  updateBox: $('#imagemaid-update-box'),
-  localVersionInline: $('#imagemaid-local-version-inline'),
-  localBranchInline: $('#imagemaid-local-branch-inline'),
-  localShaInline: $('#imagemaid-local-sha-inline'),
-  remoteVersionInline: $('#imagemaid-remote-version-inline'),
-  remoteShaInline: $('#imagemaid-remote-sha-inline'),
-  validationBadge: $('#imagemaid-validation-badge'),
-  validationStatus: $('#imagemaid-validation-status'),
-  maintenanceBadge: $('#imagemaid-maintenance-page-badge'),
-  runGate: $('#imagemaid-run-gate'),
-  runGateTitle: $('#imagemaid-run-gate-title'),
-  runGateText: $('#imagemaid-run-gate-text'),
-  runSurface: $('#imagemaid-run-surface'),
-  runState: $('#imagemaid-run-state'),
-  runStatusRow: $('#imagemaid-run-status-row'),
-  runStatusTimer: $('#imagemaid-run-status-timer'),
-  runStatusMetrics: $('#imagemaid-run-status-metrics'),
-  runStatusLog: $('#imagemaid-run-status-log'),
-  runStatusSparklines: $('#imagemaid-run-status-sparklines'),
-  runMaintenanceRow: $('#imagemaid-run-maintenance-row'),
-  runStatus: $('#imagemaid-run-status'),
-  runLog: $('#imagemaid-run-log'),
-  logAutoscroll: $('#imagemaid-log-autoscroll'),
-  logTailSize: $('#imagemaid-log-tail-size'),
-  tailLabel: $('#imagemaid-tail-label'),
-  downloadLog: $('#imagemaid-download-log'),
-  pauseLogPolling: $('#imagemaid-pause-log-polling'),
-  logFilter: $('#imagemaid-log-filter'),
-  logLevelButtons: $('.imagemaid-log-level-btn'),
-  logStatValues: $('[data-imagemaid-log-stat]'),
-  commandPreview: $('#imagemaid-command-preview'),
-  updateBtn: $('#update-imagemaid-btn'),
-  forceUpdateToggle: $('#force-update-imagemaid'),
-  validateBtn: $('#validate-imagemaid-btn'),
-  runBtn: $('#run-imagemaid-btn'),
-  stopBtn: $('#stop-imagemaid-btn'),
-  confirmMoveRunBtn: $('#confirm-imagemaid-move-run'),
-  mode: $('#imagemaid_mode'),
-  branch: $('#imagemaid_branch_override'),
-  modeHelp: $('#imagemaid-mode-help'),
-  modeHelpTitle: $('#imagemaid-mode-help-title'),
-  modeHelpText: $('#imagemaid-mode-help-text'),
-  modeHelpDetail: $('#imagemaid-mode-help-detail'),
-  moveConfirmDetail: $('#imagemaid-move-confirm-detail')
+  installState: document.getElementById('imagemaid-install-state'),
+  installSummary: document.getElementById('imagemaid-install-summary'),
+  installLog: document.getElementById('imagemaid-install-log'),
+  installPath: document.getElementById('imagemaid-install-path'),
+  branchSelection: document.getElementById('imagemaid-branch-selection'),
+  effectiveBranch: document.getElementById('imagemaid-effective-branch'),
+  updatePhaseBadge: document.getElementById('imagemaid-update-phase-badge'),
+  localVersionStatus: document.getElementById('imagemaid-local-version-status'),
+  remoteVersionStatus: document.getElementById('imagemaid-remote-version-status'),
+  localBranchStatus: document.getElementById('imagemaid-local-branch-status'),
+  localShaStatus: document.getElementById('imagemaid-local-sha-status'),
+  remoteShaStatus: document.getElementById('imagemaid-remote-sha-status'),
+  branchSourceUrl: document.getElementById('imagemaid-branch-source-url'),
+  zipSourceUrl: document.getElementById('imagemaid-zip-source-url'),
+  branchOverrideWarning: document.getElementById('imagemaid-branch-override-warning'),
+  updateBox: document.getElementById('imagemaid-update-box'),
+  localVersionInline: document.getElementById('imagemaid-local-version-inline'),
+  localBranchInline: document.getElementById('imagemaid-local-branch-inline'),
+  localShaInline: document.getElementById('imagemaid-local-sha-inline'),
+  remoteVersionInline: document.getElementById('imagemaid-remote-version-inline'),
+  remoteShaInline: document.getElementById('imagemaid-remote-sha-inline'),
+  validationBadge: document.getElementById('imagemaid-validation-badge'),
+  validationStatus: document.getElementById('imagemaid-validation-status'),
+  maintenanceBadge: document.getElementById('imagemaid-maintenance-page-badge'),
+  runGate: document.getElementById('imagemaid-run-gate'),
+  runGateTitle: document.getElementById('imagemaid-run-gate-title'),
+  runGateText: document.getElementById('imagemaid-run-gate-text'),
+  runSurface: document.getElementById('imagemaid-run-surface'),
+  runState: document.getElementById('imagemaid-run-state'),
+  runStatusRow: document.getElementById('imagemaid-run-status-row'),
+  runStatusTimer: document.getElementById('imagemaid-run-status-timer'),
+  runStatusMetrics: document.getElementById('imagemaid-run-status-metrics'),
+  runStatusLog: document.getElementById('imagemaid-run-status-log'),
+  runStatusSparklines: document.getElementById('imagemaid-run-status-sparklines'),
+  runMaintenanceRow: document.getElementById('imagemaid-run-maintenance-row'),
+  runStatus: document.getElementById('imagemaid-run-status'),
+  runLog: document.getElementById('imagemaid-run-log'),
+  logAutoscroll: document.getElementById('imagemaid-log-autoscroll'),
+  logTailSize: document.getElementById('imagemaid-log-tail-size'),
+  tailLabel: document.getElementById('imagemaid-tail-label'),
+  downloadLog: document.getElementById('imagemaid-download-log'),
+  pauseLogPolling: document.getElementById('imagemaid-pause-log-polling'),
+  logFilter: document.getElementById('imagemaid-log-filter'),
+  logLevelButtons: document.querySelectorAll('.imagemaid-log-level-btn'),
+  logStatValues: document.querySelectorAll('[data-imagemaid-log-stat]'),
+  commandPreview: document.getElementById('imagemaid-command-preview'),
+  updateBtn: document.getElementById('update-imagemaid-btn'),
+  forceUpdateToggle: document.getElementById('force-update-imagemaid'),
+  validateBtn: document.getElementById('validate-imagemaid-btn'),
+  runBtn: document.getElementById('run-imagemaid-btn'),
+  stopBtn: document.getElementById('stop-imagemaid-btn'),
+  confirmMoveRunBtn: document.getElementById('confirm-imagemaid-move-run'),
+  mode: document.getElementById('imagemaid_mode'),
+  branch: document.getElementById('imagemaid_branch_override'),
+  modeHelp: document.getElementById('imagemaid-mode-help'),
+  modeHelpTitle: document.getElementById('imagemaid-mode-help-title'),
+  modeHelpText: document.getElementById('imagemaid-mode-help-text'),
+  modeHelpDetail: document.getElementById('imagemaid-mode-help-detail'),
+  moveConfirmDetail: document.getElementById('imagemaid-move-confirm-detail')
 }
 
 const optionalRows = {
-  noVerifySsl: $('#imagemaid-no-verify-ssl-row'),
-  overlaysOnly: $('#imagemaid-overlays-only-row')
+  noVerifySsl: document.getElementById('imagemaid-no-verify-ssl-row'),
+  overlaysOnly: document.getElementById('imagemaid-overlays-only-row')
 }
-const $runSparkCpuSystem = $('#imagemaid-run-spark-cpu-system')
-const $runSparkCpuImageMaid = $('#imagemaid-run-spark-cpu-imagemaid')
-const $runSparkMemSystem = $('#imagemaid-run-spark-mem-system')
-const $runSparkMemImageMaid = $('#imagemaid-run-spark-mem-imagemaid')
+const runSparkCpuSystem = document.getElementById('imagemaid-run-spark-cpu-system')
+const runSparkCpuImageMaid = document.getElementById('imagemaid-run-spark-cpu-imagemaid')
+const runSparkMemSystem = document.getElementById('imagemaid-run-spark-mem-system')
+const runSparkMemImageMaid = document.getElementById('imagemaid-run-spark-mem-imagemaid')
 
 function syncMaintenanceBadge (data) {
-  if (!els.maintenanceBadge.length) return
+  if (!els.maintenanceBadge) return
   maintenanceActive = Boolean(data && data.maintenance_active)
   maintenanceWindowLabel = data && data.maintenance_window ? ` (${data.maintenance_window})` : ''
   const paused = Boolean(data && data.maintenance_paused)
   const active = maintenanceActive || paused
   const windowLabel = maintenanceWindowLabel
   if (active) {
-    els.maintenanceBadge.removeClass('d-none')
-    const textEl = els.maintenanceBadge.find('span').last()
-    if (textEl.length) textEl.text(`${paused ? 'Paused for' : 'Blocked by'} Plex maintenance${windowLabel}`)
+    els.maintenanceBadge.classList.remove('d-none')
+    const spans = els.maintenanceBadge.querySelectorAll('span')
+    const textEl = spans.length ? spans[spans.length - 1] : null
+    if (textEl) textEl.textContent = `${paused ? 'Paused for' : 'Blocked by'} Plex maintenance${windowLabel}`
   } else {
-    els.maintenanceBadge.addClass('d-none')
+    els.maintenanceBadge.classList.add('d-none')
   }
   syncRunGate()
 }
@@ -151,19 +152,19 @@ document.addEventListener('qs:maintenance-status', function (event) {
 })
 
 function syncOptionalCapabilityRows () {
-  optionalRows.noVerifySsl.toggleClass('d-none', !imagemaidSupportsNoVerifySsl)
-  optionalRows.overlaysOnly.toggleClass('d-none', !imagemaidSupportsOverlaysOnly)
+  if (optionalRows.noVerifySsl) optionalRows.noVerifySsl.classList.toggle('d-none', !imagemaidSupportsNoVerifySsl)
+  if (optionalRows.overlaysOnly) optionalRows.overlaysOnly.classList.toggle('d-none', !imagemaidSupportsOverlaysOnly)
 }
 
 function getRestoreDirPath () {
-  const plexPath = String($('#imagemaid_plex_path').val() || '').trim()
+  const plexPath = String(document.getElementById('imagemaid_plex_path').value || '').trim()
   if (!plexPath) return ''
   const normalized = plexPath.replace(/[\\/]+$/, '')
   return `${normalized}\\ImageMaid Restore`
 }
 
 function updateModeHelp () {
-  const mode = String(els.mode.val() || 'report').trim().toLowerCase()
+  const mode = String(els.mode.value || 'report').trim().toLowerCase()
   const restoreDir = getRestoreDirPath()
   const hasRestoreDirPath = Boolean(restoreDir)
   let tone = 'alert-secondary'
@@ -207,20 +208,21 @@ function updateModeHelp () {
       : 'Use nothing, restore, or clear while the existing ImageMaid Restore folder is present.'
   }
 
-  els.modeHelp.removeClass('alert-secondary alert-warning alert-danger').addClass(tone)
-  els.modeHelpTitle.text(title)
-  els.modeHelpText.text(text)
-  els.modeHelpDetail.text(detail)
-  if (els.moveConfirmDetail.length) {
+  els.modeHelp.classList.remove('alert-secondary', 'alert-warning', 'alert-danger')
+  els.modeHelp.classList.add(tone)
+  els.modeHelpTitle.textContent = title
+  els.modeHelpText.textContent = text
+  els.modeHelpDetail.textContent = detail
+  if (els.moveConfirmDetail) {
     const moveDetail = hasRestoreDirPath ? `Destination folder: ${restoreDir}` : 'Enter the Plex path first so Quickstart can show the restore folder.'
-    els.moveConfirmDetail.text(moveDetail)
+    els.moveConfirmDetail.textContent = moveDetail
   }
 }
 
-function setBadge ($el, tone, text) {
-  $el.removeClass('text-bg-secondary text-bg-success text-bg-warning text-bg-danger text-bg-primary')
-  $el.addClass(tone)
-  $el.text(text)
+function setBadge (el, tone, text) {
+  el.classList.remove('text-bg-secondary', 'text-bg-success', 'text-bg-warning', 'text-bg-danger', 'text-bg-primary')
+  el.classList.add(tone)
+  el.textContent = text
 }
 
 function shortSha (value) {
@@ -229,7 +231,7 @@ function shortSha (value) {
 }
 
 function syncBranchSummary () {
-  const override = String(els.branch.val() || '').trim().toLowerCase()
+  const override = String(els.branch.value || '').trim().toLowerCase()
   const selection = override || 'auto'
   let effective = 'develop'
   if (override === 'master' || override === 'develop') {
@@ -237,9 +239,9 @@ function syncBranchSummary () {
   } else if (imagemaidEffectiveBranch) {
     effective = imagemaidEffectiveBranch
   }
-  els.branchSelection.text(selection === 'auto' ? 'Auto' : selection)
-  els.effectiveBranch.text(effective)
-  els.branchOverrideWarning.toggleClass('d-none', selection === 'auto')
+  els.branchSelection.textContent = selection === 'auto' ? 'Auto' : selection
+  els.effectiveBranch.textContent = effective
+  els.branchOverrideWarning.classList.toggle('d-none', selection === 'auto')
 }
 
 function setUpdatePhase (tone, text) {
@@ -247,7 +249,7 @@ function setUpdatePhase (tone, text) {
 }
 
 function syncUpdateButtonLabel () {
-  const force = els.forceUpdateToggle.is(':checked')
+  const force = els.forceUpdateToggle.checked
   let html = '<i class="bi bi-arrow-clockwise me-1"></i> Check for ImageMaid Updates'
   if (force) {
     html = imagemaidInstalled
@@ -262,12 +264,12 @@ function syncUpdateButtonLabel () {
   } else if (imagemaidUpdateCheckCompleted && !imagemaidUpdateCheckSkipped) {
     html = '<i class="bi bi-check-circle me-1"></i> Up to date'
   }
-  els.updateBtn.html(html)
-  els.updateBtn.prop('disabled', imagemaidRunning && !force)
+  els.updateBtn.innerHTML = html
+  els.updateBtn.disabled = imagemaidRunning && !force
 }
 
 function syncPrepareSummary (body, options = {}) {
-  if (body && body.imagemaid_root_display) els.installPath.text(body.imagemaid_root_display)
+  if (body && body.imagemaid_root_display) els.installPath.textContent = body.imagemaid_root_display
   if (body && body.effective_branch) imagemaidEffectiveBranch = String(body.effective_branch || '').trim() || imagemaidEffectiveBranch
   imagemaidInstalled = Boolean(body && body.imagemaid_installed)
   imagemaidVenvReady = Boolean(body && body.venv_python_exists)
@@ -280,23 +282,23 @@ function syncPrepareSummary (body, options = {}) {
 
   const localVersion = String((body && body.local_version) || '').trim()
   const remoteVersion = String((body && body.remote_version) || '').trim()
-  els.localVersionStatus.text(localVersion || 'Unknown')
-  els.remoteVersionStatus.text(remoteVersion || (imagemaidUpdateCheckCompleted ? 'Unavailable' : 'Not checked'))
-  els.localBranchStatus.text((body && body.local_branch) || 'Unknown')
-  els.localShaStatus.text(shortSha(body && body.local_sha) || 'Unknown')
-  els.remoteShaStatus.text(shortSha(body && body.remote_sha) || (imagemaidUpdateCheckCompleted ? 'Unavailable' : 'Not checked'))
-  els.branchSourceUrl.text((body && body.branch_source_url) || '')
-  els.zipSourceUrl.text((body && body.zip_source_url) || '')
+  els.localVersionStatus.textContent = localVersion || 'Unknown'
+  els.remoteVersionStatus.textContent = remoteVersion || (imagemaidUpdateCheckCompleted ? 'Unavailable' : 'Not checked')
+  els.localBranchStatus.textContent = (body && body.local_branch) || 'Unknown'
+  els.localShaStatus.textContent = shortSha(body && body.local_sha) || 'Unknown'
+  els.remoteShaStatus.textContent = shortSha(body && body.remote_sha) || (imagemaidUpdateCheckCompleted ? 'Unavailable' : 'Not checked')
+  els.branchSourceUrl.textContent = (body && body.branch_source_url) || ''
+  els.zipSourceUrl.textContent = (body && body.zip_source_url) || ''
 
   const localBranch = (body && body.local_branch) || 'unknown'
   const localSha = shortSha(body && body.local_sha) || 'unknown'
   const remoteSha = shortSha(body && body.remote_sha) || 'unknown'
-  els.localVersionInline.text(localVersion || 'unknown')
-  els.localBranchInline.text(localBranch)
-  els.localShaInline.text(localSha)
-  els.remoteVersionInline.text(remoteVersion || 'unknown')
-  els.remoteShaInline.text(remoteSha)
-  els.updateBox.toggleClass('d-none', !imagemaidUpdateAvailable)
+  els.localVersionInline.textContent = localVersion || 'unknown'
+  els.localBranchInline.textContent = localBranch
+  els.localShaInline.textContent = localSha
+  els.remoteVersionInline.textContent = remoteVersion || 'unknown'
+  els.remoteShaInline.textContent = remoteSha
+  els.updateBox.classList.toggle('d-none', !imagemaidUpdateAvailable)
 
   if (options.phaseTone && options.phaseText) {
     setUpdatePhase(options.phaseTone, options.phaseText)
@@ -321,23 +323,24 @@ function syncPrepareSummary (body, options = {}) {
 }
 
 function boolValue (selector) {
-  return $(selector).is(':checked')
+  // selector is always an id-string like '#imagemaid_photo_transcoder'
+  return document.querySelector(selector)?.checked || false
 }
 
 function collectPayload () {
   const activeConfig = String(
     window.pageInfo?.config_name ||
-    $('#qs-active-config-input').val() ||
-    $('.qs-main-page-meta-value').first().text() ||
+    document.getElementById('qs-active-config-input').value ||
+    document.querySelector('.qs-main-page-meta-value')?.textContent ||
     ''
   ).trim()
   return {
     config_name: activeConfig,
-    branch_override: String($('#imagemaid_branch_override').val() || '').trim(),
-    plex_path: String($('#imagemaid_plex_path').val() || '').trim(),
-    mode: String($('#imagemaid_mode').val() || 'report').trim(),
-    timeout: String($('#imagemaid_timeout').val() || '').trim(),
-    sleep: String($('#imagemaid_sleep').val() || '').trim(),
+    branch_override: String(document.getElementById('imagemaid_branch_override').value || '').trim(),
+    plex_path: String(document.getElementById('imagemaid_plex_path').value || '').trim(),
+    mode: String(document.getElementById('imagemaid_mode').value || 'report').trim(),
+    timeout: String(document.getElementById('imagemaid_timeout').value || '').trim(),
+    sleep: String(document.getElementById('imagemaid_sleep').value || '').trim(),
     photo_transcoder: boolValue('#imagemaid_photo_transcoder'),
     empty_trash: boolValue('#imagemaid_empty_trash'),
     clean_bundles: boolValue('#imagemaid_clean_bundles'),
@@ -381,7 +384,7 @@ function escapeCommandValue (value) {
 function updatePreviewFromPayload () {
   const payload = collectPayload()
   if (!payload.plex_path) {
-    els.commandPreview.val('Preview unavailable until the Plex path is provided.')
+    els.commandPreview.value = 'Preview unavailable until the Plex path is provided.'
     return
   }
 
@@ -419,7 +422,7 @@ function updatePreviewFromPayload () {
   if (payload.timeout) parts.push('--timeout', payload.timeout)
   if (payload.sleep) parts.push('--sleep', payload.sleep)
 
-  els.commandPreview.val(parts.join(' '))
+  els.commandPreview.value = parts.join(' ')
 }
 
 function setInstallState (state, summary) {
@@ -434,58 +437,61 @@ function setInstallState (state, summary) {
   } else {
     setBadge(els.installState, 'text-bg-secondary', 'Not checked')
   }
-  if (summary) els.installSummary.text(summary)
+  if (summary) els.installSummary.textContent = summary
 }
 
 function syncRunGate () {
   if (imagemaidRunning || imagemaidStarting) {
-    els.runGate.addClass('d-none')
-    els.runSurface.removeClass('d-none')
+    els.runGate.classList.add('d-none')
+    els.runSurface.classList.remove('d-none')
     return
   }
 
   if (maintenanceActive) {
-    els.runGate.removeClass('d-none alert-secondary alert-danger').addClass('alert-warning')
-    els.runGateTitle.text('Blocked by Plex maintenance')
-    els.runGateText.text(`Plex maintenance is active${maintenanceWindowLabel}. Wait for the maintenance window to end before running ImageMaid.`)
-    els.runSurface.addClass('d-none')
+    els.runGate.classList.remove('d-none', 'alert-secondary', 'alert-danger')
+    els.runGate.classList.add('alert-warning')
+    els.runGateTitle.textContent = 'Blocked by Plex maintenance'
+    els.runGateText.textContent = `Plex maintenance is active${maintenanceWindowLabel}. Wait for the maintenance window to end before running ImageMaid.`
+    els.runSurface.classList.add('d-none')
     return
   }
 
   if (!imagemaidInstalled || !imagemaidVenvReady) {
-    els.runGate.removeClass('d-none alert-warning alert-danger').addClass('alert-secondary')
-    els.runGateTitle.text('Prepare ImageMaid first')
-    els.runGateText.text('Install or prepare ImageMaid before Quickstart can build the run command and show the run controls.')
-    els.runSurface.addClass('d-none')
+    els.runGate.classList.remove('d-none', 'alert-warning', 'alert-danger')
+    els.runGate.classList.add('alert-secondary')
+    els.runGateTitle.textContent = 'Prepare ImageMaid first'
+    els.runGateText.textContent = 'Install or prepare ImageMaid before Quickstart can build the run command and show the run controls.'
+    els.runSurface.classList.add('d-none')
     return
   }
 
   if (imagemaidDirty || !imagemaidValidated) {
-    els.runGate.removeClass('d-none alert-secondary alert-danger').addClass('alert-warning')
-    els.runGateTitle.text('Validate ImageMaid first')
-    els.runGateText.text('Configuration changed or has not been validated yet. Validate ImageMaid to unlock the command preview and run controls.')
-    els.runSurface.addClass('d-none')
+    els.runGate.classList.remove('d-none', 'alert-secondary', 'alert-danger')
+    els.runGate.classList.add('alert-warning')
+    els.runGateTitle.textContent = 'Validate ImageMaid first'
+    els.runGateText.textContent = 'Configuration changed or has not been validated yet. Validate ImageMaid to unlock the command preview and run controls.'
+    els.runSurface.classList.add('d-none')
     return
   }
 
-  els.runGate.addClass('d-none')
-  els.runSurface.removeClass('d-none')
+  els.runGate.classList.add('d-none')
+  els.runSurface.classList.remove('d-none')
 }
 
 function syncValidateButton (state) {
-  els.validateBtn.removeClass('btn-success btn-dark btn-warning btn-secondary')
+  els.validateBtn.classList.remove('btn-success', 'btn-dark', 'btn-warning', 'btn-secondary')
   if (state === 'ok') {
-    els.validateBtn.addClass('btn-dark')
-    els.validateBtn.prop('disabled', true)
-    els.validateBtn.html('<i class="bi bi-check2-circle me-1"></i> Validated')
+    els.validateBtn.classList.add('btn-dark')
+    els.validateBtn.disabled = true
+    els.validateBtn.innerHTML = '<i class="bi bi-check2-circle me-1"></i> Validated'
   } else if (state === 'running') {
-    els.validateBtn.addClass('btn-warning')
-    els.validateBtn.prop('disabled', true)
-    els.validateBtn.html('<i class="bi bi-arrow-repeat me-1"></i> Validating...')
+    els.validateBtn.classList.add('btn-warning')
+    els.validateBtn.disabled = true
+    els.validateBtn.innerHTML = '<i class="bi bi-arrow-repeat me-1"></i> Validating...'
   } else {
-    els.validateBtn.addClass('btn-success')
-    els.validateBtn.prop('disabled', false)
-    els.validateBtn.html('<i class="bi bi-check2-circle me-1"></i> Validate ImageMaid')
+    els.validateBtn.classList.add('btn-success')
+    els.validateBtn.disabled = false
+    els.validateBtn.innerHTML = '<i class="bi bi-check2-circle me-1"></i> Validate ImageMaid'
   }
 }
 
@@ -499,17 +505,17 @@ function setValidationState (state, message) {
   } else {
     setBadge(els.validationBadge, 'text-bg-secondary', 'Not validated')
   }
-  els.validationStatus.removeClass('text-muted text-success text-danger text-warning')
+  els.validationStatus.classList.remove('text-muted', 'text-success', 'text-danger', 'text-warning')
   if (state === 'ok') {
-    els.validationStatus.addClass('text-success')
+    els.validationStatus.classList.add('text-success')
   } else if (state === 'error') {
-    els.validationStatus.addClass('text-danger')
+    els.validationStatus.classList.add('text-danger')
   } else if (state === 'running') {
-    els.validationStatus.addClass('text-warning')
+    els.validationStatus.classList.add('text-warning')
   } else {
-    els.validationStatus.addClass('text-muted')
+    els.validationStatus.classList.add('text-muted')
   }
-  if (message) els.validationStatus.text(message)
+  if (message) els.validationStatus.textContent = message
   syncValidateButton(state)
   syncRunGate()
 }
@@ -543,12 +549,12 @@ function queueAutosave (payload = collectPayload(), signature = buildPayloadSign
             imagemaid_installed: imagemaidInstalled,
             venv_python_exists: imagemaidVenvReady,
             imagemaid_running: imagemaidRunning,
-            local_branch: els.localBranchStatus.text(),
-            local_sha: els.localShaStatus.text(),
+            local_branch: els.localBranchStatus.textContent,
+            local_sha: els.localShaStatus.textContent,
             effective_branch: imagemaidEffectiveBranch,
-            branch_source_url: els.branchSourceUrl.text(),
-            zip_source_url: els.zipSourceUrl.text(),
-            imagemaid_root_display: els.installPath.text()
+            branch_source_url: els.branchSourceUrl.textContent,
+            zip_source_url: els.zipSourceUrl.textContent,
+            imagemaid_root_display: els.installPath.textContent
           }, {
             updateAvailable: false,
             updateCheckCompleted: false,
@@ -631,20 +637,20 @@ function buildSparklinePointsScaled (series, maxValue) {
 }
 
 function renderRunSparklines () {
-  if (!els.runStatusSparklines.length) return
+  if (!els.runStatusSparklines) return
   const hasData = imagemaidSparkState.cpu.system.length || imagemaidSparkState.cpu.imagemaid.length ||
     imagemaidSparkState.mem.system.length || imagemaidSparkState.mem.imagemaid.length ||
     imagemaidSparkState.io.read.length || imagemaidSparkState.io.write.length
-  els.runStatusSparklines.toggleClass('d-none', !hasData)
-  $runSparkCpuSystem.attr('points', hasData ? buildSparklinePoints(imagemaidSparkState.cpu.system) : '')
-  $runSparkCpuImageMaid.attr('points', hasData ? buildSparklinePoints(imagemaidSparkState.cpu.imagemaid) : '')
-  $runSparkMemSystem.attr('points', hasData ? buildSparklinePoints(imagemaidSparkState.mem.system) : '')
-  $runSparkMemImageMaid.attr('points', hasData ? buildSparklinePoints(imagemaidSparkState.mem.imagemaid) : '')
-  const $runSparkIoRead = $('#imagemaid-run-spark-io-read')
-  const $runSparkIoWrite = $('#imagemaid-run-spark-io-write')
+  els.runStatusSparklines.classList.toggle('d-none', !hasData)
+  runSparkCpuSystem.setAttribute('points', hasData ? buildSparklinePoints(imagemaidSparkState.cpu.system) : '')
+  runSparkCpuImageMaid.setAttribute('points', hasData ? buildSparklinePoints(imagemaidSparkState.cpu.imagemaid) : '')
+  runSparkMemSystem.setAttribute('points', hasData ? buildSparklinePoints(imagemaidSparkState.mem.system) : '')
+  runSparkMemImageMaid.setAttribute('points', hasData ? buildSparklinePoints(imagemaidSparkState.mem.imagemaid) : '')
+  const runSparkIoRead = document.getElementById('imagemaid-run-spark-io-read')
+  const runSparkIoWrite = document.getElementById('imagemaid-run-spark-io-write')
   const ioMax = Math.max(0, ...imagemaidSparkState.io.read, ...imagemaidSparkState.io.write)
-  $runSparkIoRead.attr('points', hasData ? buildSparklinePointsScaled(imagemaidSparkState.io.read, ioMax) : '')
-  $runSparkIoWrite.attr('points', hasData ? buildSparklinePointsScaled(imagemaidSparkState.io.write, ioMax) : '')
+  runSparkIoRead.setAttribute('points', hasData ? buildSparklinePointsScaled(imagemaidSparkState.io.read, ioMax) : '')
+  runSparkIoWrite.setAttribute('points', hasData ? buildSparklinePointsScaled(imagemaidSparkState.io.write, ioMax) : '')
 }
 
 function resetRunSparklines () {
@@ -678,13 +684,13 @@ function updateRunSparklines (data) {
 }
 
 function syncRunStatusVisibility () {
-  if (!els.runStatusRow.length) return
-  const hasText = Boolean(els.runStatusTimer.text() || els.runStatusMetrics.text() || els.runStatusLog.text())
-  els.runStatusRow.toggleClass('d-none', !hasText)
+  if (!els.runStatusRow) return
+  const hasText = Boolean(els.runStatusTimer.textContent || els.runStatusMetrics.textContent || els.runStatusLog.textContent)
+  els.runStatusRow.classList.toggle('d-none', !hasText)
 }
 
 function updateRunStatusDetails (data) {
-  if (!els.runStatusRow.length) return
+  if (!els.runStatusRow) return
   const status = String((data && data.status) || '').trim().toLowerCase()
   if (status === 'running' || status === 'starting') {
     const startedAt = formatTimestampLocal(data.started_at)
@@ -716,21 +722,21 @@ function updateRunStatusDetails (data) {
     const diskText = hasDiskData
       ? ` | Disk: R ${formatDiskRate(data.disk_read_rate_mb_s)} • W ${formatDiskRate(data.disk_write_rate_mb_s)} • ${formatDiskMb(data.disk_read_mb)} read • ${formatDiskMb(data.disk_write_mb)} written`
       : ''
-    els.runStatusTimer.text(`${status === 'starting' ? 'Starting' : 'Running since'}: ${startedAt || 'n/a'}${elapsed ? ` • Elapsed: ${elapsed}` : ''}`)
-    els.runStatusMetrics.text(`ImageMaid: ${cpuText} CPU • ${memRss} (${memPct}) | System: ${sysCpu} CPU • ${sysUsed} / ${sysTotal} (${sysPct})${diskText}`)
+    els.runStatusTimer.textContent = `${status === 'starting' ? 'Starting' : 'Running since'}: ${startedAt || 'n/a'}${elapsed ? ` • Elapsed: ${elapsed}` : ''}`
+    els.runStatusMetrics.textContent = `ImageMaid: ${cpuText} CPU • ${memRss} (${memPct}) | System: ${sysCpu} CPU • ${sysUsed} / ${sysTotal} (${sysPct})${diskText}`
   } else if (status === 'done') {
-    els.runStatusTimer.text('ImageMaid run complete.')
-    els.runStatusMetrics.text('')
+    els.runStatusTimer.textContent = 'ImageMaid run complete.'
+    els.runStatusMetrics.textContent = ''
   } else {
-    els.runStatusTimer.text('')
-    els.runStatusMetrics.text('')
+    els.runStatusTimer.textContent = ''
+    els.runStatusMetrics.textContent = ''
   }
   updateRunSparklines(data)
   syncRunStatusVisibility()
 }
 
 function updateMaintenanceRow (data) {
-  if (!els.runMaintenanceRow.length) return
+  if (!els.runMaintenanceRow) return
   const windowLabel = data && data.maintenance_window ? ` (${data.maintenance_window})` : ''
   if (data && data.maintenance_paused) {
     let pauseLabel = 'Paused'
@@ -739,21 +745,24 @@ function updateMaintenanceRow (data) {
       const elapsedSeconds = Math.max(0, Math.floor((Date.now() - pausedSince.getTime()) / 1000))
       pauseLabel = formatRunSeconds(elapsedSeconds) || 'Paused'
     }
-    els.runMaintenanceRow.html(`
+    els.runMaintenanceRow.innerHTML = `
       <span class="me-2 fw-semibold">Maintenance</span>
       <span class="badge text-bg-warning text-dark">Paused${windowLabel}</span>
       <span class="badge text-bg-secondary">${pauseLabel}</span>
-    `).removeClass('d-none')
+    `
+    els.runMaintenanceRow.classList.remove('d-none')
     return
   }
   if (data && data.maintenance_active) {
-    els.runMaintenanceRow.html(`
+    els.runMaintenanceRow.innerHTML = `
       <span class="me-2 fw-semibold">Maintenance</span>
       <span class="badge text-bg-warning text-dark">Window Active${windowLabel}</span>
-    `).removeClass('d-none')
+    `
+    els.runMaintenanceRow.classList.remove('d-none')
     return
   }
-  els.runMaintenanceRow.addClass('d-none').empty()
+  els.runMaintenanceRow.classList.add('d-none')
+  els.runMaintenanceRow.replaceChildren()
 }
 
 function computeLogStats (text, matcher) {
@@ -776,28 +785,27 @@ function computeLogStats (text, matcher) {
 }
 
 function updateLogStatBadges (stats) {
-  els.logStatValues.each(function () {
-    const key = String($(this).data('imagemaid-log-stat') || '').trim()
-    $(this).text(String((stats && stats[key]) || 0))
+  els.logStatValues.forEach((el) => {
+    const key = String(el.dataset.imagemaidLogStat || '').trim()
+    el.textContent = String((stats && stats[key]) || 0)
   })
 }
 
 function syncLogLevelButtons () {
-  const activeFilter = String(els.logFilter.val() || '').trim()
-  els.logLevelButtons.each(function () {
-    const level = String($(this).data('level') || '').trim()
+  const activeFilter = String(els.logFilter.value || '').trim()
+  els.logLevelButtons.forEach((el) => {
+    const level = String(el.dataset.level || '').trim()
     const isActive = Boolean(level) && level === activeFilter
-    $(this)
-      .toggleClass('btn-primary', isActive)
-      .toggleClass('btn-outline-secondary', !isActive)
-      .attr('aria-pressed', isActive ? 'true' : 'false')
+    el.classList.toggle('btn-primary', isActive)
+    el.classList.toggle('btn-outline-secondary', !isActive)
+    el.setAttribute('aria-pressed', isActive ? 'true' : 'false')
   })
 }
 
 function applyLogFilter () {
   const payload = lastImageMaidLogPayload || {}
   const rawText = String(payload.text || lastImageMaidLogText || '')
-  const filterText = String(els.logFilter.val() || '').trim()
+  const filterText = String(els.logFilter.value || '').trim()
   let filteredText = rawText
   let textMatcher = null
   if (filterText) {
@@ -813,18 +821,18 @@ function applyLogFilter () {
   if (matcher) {
     filteredText = rawText.split(/\r?\n/).filter(line => matcher(line)).join('\n')
   }
-  els.runLog.text(filteredText || (rawText ? 'No lines matched the current filter.' : 'ImageMaid log is empty.'))
+  els.runLog.textContent = filteredText || (rawText ? 'No lines matched the current filter.' : 'ImageMaid log is empty.')
   updateLogStatBadges(computeLogStats(rawText, matcher))
   syncLogLevelButtons()
-  if (imagemaidLogAutoScroll && els.runLog.length) {
-    els.runLog.scrollTop(els.runLog[0].scrollHeight)
+  if (imagemaidLogAutoScroll && els.runLog) {
+    els.runLog.scrollTop = els.runLog.scrollHeight
   }
 }
 
 function updateLogRecency (payload) {
-  if (!els.runStatusLog.length) return
+  if (!els.runStatusLog) return
   if (!payload || typeof payload.log_age_seconds !== 'number') {
-    els.runStatusLog.text('')
+    els.runStatusLog.textContent = ''
     syncRunStatusVisibility()
     return
   }
@@ -832,7 +840,7 @@ function updateLogRecency (payload) {
   const totalLines = typeof payload.total_lines === 'number' && Number.isFinite(payload.total_lines)
     ? payload.total_lines.toLocaleString()
     : '0'
-  els.runStatusLog.text(`${lastImageMaidLogPath ? `${lastImageMaidLogPath.split(/[\\\\/]/).pop()} updated ` : 'Log updated '}${ageText} ago • ${totalLines} lines`)
+  els.runStatusLog.textContent = `${lastImageMaidLogPath ? `${lastImageMaidLogPath.split(/[\\\\/]/).pop()} updated ` : 'Log updated '}${ageText} ago • ${totalLines} lines`
   syncRunStatusVisibility()
 }
 
@@ -842,37 +850,37 @@ function setRunState (state, message) {
     imagemaidStarting = false
     imagemaidStartupDeadline = 0
     setBadge(els.runState, 'text-bg-success', 'Running')
-    els.runBtn.prop('disabled', true)
-    els.stopBtn.prop('disabled', false)
+    els.runBtn.disabled = true
+    els.stopBtn.disabled = false
   } else if (state === 'starting') {
     imagemaidRunning = false
     imagemaidStarting = true
     setBadge(els.runState, 'text-bg-primary', 'Starting')
-    els.runBtn.prop('disabled', true)
-    els.stopBtn.prop('disabled', false)
+    els.runBtn.disabled = true
+    els.stopBtn.disabled = false
   } else if (state === 'blocked') {
     imagemaidRunning = false
     imagemaidStarting = false
     imagemaidStartupDeadline = 0
     setBadge(els.runState, 'text-bg-warning', 'Blocked')
-    els.runBtn.prop('disabled', false)
-    els.stopBtn.prop('disabled', true)
+    els.runBtn.disabled = false
+    els.stopBtn.disabled = true
   } else if (state === 'error') {
     imagemaidRunning = false
     imagemaidStarting = false
     imagemaidStartupDeadline = 0
     setBadge(els.runState, 'text-bg-danger', 'Error')
-    els.runBtn.prop('disabled', false)
-    els.stopBtn.prop('disabled', true)
+    els.runBtn.disabled = false
+    els.stopBtn.disabled = true
   } else {
     imagemaidRunning = false
     imagemaidStarting = false
     imagemaidStartupDeadline = 0
     setBadge(els.runState, 'text-bg-secondary', 'Idle')
-    els.runBtn.prop('disabled', false)
-    els.stopBtn.prop('disabled', true)
+    els.runBtn.disabled = false
+    els.stopBtn.disabled = true
   }
-  if (message) els.runStatus.text(message)
+  if (message) els.runStatus.textContent = message
   if (!imagemaidRunning && !imagemaidStarting) {
     updateMaintenanceRow(lastImageMaidStatusPayload)
   }
@@ -881,8 +889,8 @@ function setRunState (state, message) {
 
 function appendInstallLog (lines) {
   if (!Array.isArray(lines) || !lines.length) return
-  els.installLog.text(lines.join('\n'))
-  els.installLog.scrollTop(els.installLog[0].scrollHeight)
+  els.installLog.textContent = lines.join('\n')
+  els.installLog.scrollTop = els.installLog.scrollHeight
 }
 
 function probeRoot () {
@@ -892,7 +900,7 @@ function probeRoot () {
   return fetch('/probe-imagemaid-root', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ path: rootPath, branch_override: String(els.branch.val() || '').trim() })
+    body: JSON.stringify({ path: rootPath, branch_override: String(els.branch.value || '').trim() })
   })
     .then(async (res) => ({ ok: res.ok, body: await res.json() }))
     .then(({ ok, body }) => {
@@ -929,7 +937,7 @@ function checkForImageMaidUpdate (forceRefresh = false) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       path: rootPath,
-      branch_override: String(els.branch.val() || '').trim(),
+      branch_override: String(els.branch.value || '').trim(),
       force: !!forceRefresh
     })
   })
@@ -977,11 +985,11 @@ function pollUpdateProgress () {
     .then(async (res) => ({ ok: res.ok, body: await res.json() }))
     .then(({ ok, body }) => {
       if (!ok || !body.success) return
-      const currentText = String(els.installLog.text() || '')
+      const currentText = String(els.installLog.textContent || '')
       const extra = Array.isArray(body.lines) ? body.lines : []
       if (extra.length) {
-        els.installLog.text([currentText, ...extra].filter(Boolean).join('\n'))
-        els.installLog.scrollTop(els.installLog[0].scrollHeight)
+        els.installLog.textContent = [currentText, ...extra].filter(Boolean).join('\n')
+        els.installLog.scrollTop = els.installLog.scrollHeight
       }
       updateLogIndex = Number(body.next_index || updateLogIndex)
       if (body.done) {
@@ -1010,12 +1018,12 @@ function pollUpdateProgress () {
 function startUpdate (force) {
   setInstallState('running', force ? 'Force updating ImageMaid...' : (imagemaidInstalled ? 'Preparing ImageMaid...' : 'Installing ImageMaid...'))
   setUpdatePhase('text-bg-primary', force ? 'Force update' : (imagemaidInstalled ? 'Preparing' : 'Installing'))
-  els.installLog.text('Starting ImageMaid update job...')
+  els.installLog.textContent = 'Starting ImageMaid update job...'
   fetch('/update-imagemaid', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
-      branch_override: String(els.branch.val() || '').trim(),
+      branch_override: String(els.branch.value || '').trim(),
       force: !!force,
       background: true
     })
@@ -1064,7 +1072,7 @@ function validateImageMaid () {
       imagemaidLastPayloadSignature = buildPayloadSignature()
       restoreFolderModeConflict = Boolean(body && body.reason === 'restore_dir_blocks_mode')
       if (body && body.command_preview) {
-        els.commandPreview.val(body.command_preview)
+        els.commandPreview.value = body.command_preview
       } else {
         updatePreviewFromPayload()
       }
@@ -1101,7 +1109,7 @@ function loadLog (force = false) {
         lastImageMaidLogPayload = null
         lastImageMaidLogText = ''
         lastImageMaidLogPath = ''
-        els.runLog.text((body && body.error) || 'No ImageMaid log found yet.')
+        els.runLog.textContent = (body && body.error) || 'No ImageMaid log found yet.'
         updateLogStatBadges({ filter: 0, cache: 0, debug: 0, info: 0, warn: 0, error: 0, crit: 0, trace: 0 })
         updateLogRecency(null)
         return
@@ -1110,13 +1118,13 @@ function loadLog (force = false) {
       lastImageMaidLogText = String(body.text || '')
       lastImageMaidLogPath = String(body.path || '')
       const requested = String(body.requested_lines || imagemaidTailSize)
-      els.tailLabel.text(requested.toLowerCase() === 'all' ? 'all' : requested)
+      els.tailLabel.textContent = requested.toLowerCase() === 'all' ? 'all' : requested
       updateLogRecency(body)
       applyLogFilter()
     })
     .catch(() => {
       lastImageMaidLogPayload = null
-      els.runLog.text('Failed to load the ImageMaid log.')
+      els.runLog.textContent = 'Failed to load the ImageMaid log.'
       updateLogRecency(null)
     })
     .finally(() => {
@@ -1137,7 +1145,7 @@ function updateStatus (force = false) {
       updateRunStatusDetails(body)
       updateMaintenanceRow(body)
       if (body && body.active_command && (String(body.status || '').trim().toLowerCase() === 'running' || String(body.status || '').trim().toLowerCase() === 'starting')) {
-        els.commandPreview.val(body.active_command)
+        els.commandPreview.value = body.active_command
       }
       if (typeof window.QS_handleImageMaidStatus === 'function') {
         window.QS_handleImageMaidStatus(body)
@@ -1203,7 +1211,7 @@ function submitRun () {
       if (status >= 400) {
         setRunState('error', body.error || 'ImageMaid failed to start.')
         if (body && body.error) {
-          els.runLog.text(body.error)
+          els.runLog.textContent = body.error
         }
         loadLog(true)
         showToast('error', body.error || 'ImageMaid failed to start.')
@@ -1267,13 +1275,13 @@ function onConfigChanged () {
   updateModeHelp()
   syncRunGate()
   queueAutosave(payload, nextSignature)
-  if (switchedToBlockedMode && String($('#imagemaid_plex_path').val() || '').trim()) {
+  if (switchedToBlockedMode && String(document.getElementById('imagemaid_plex_path').value || '').trim()) {
     validateImageMaid()
   }
 }
 
-els.updateBtn.on('click', () => {
-  const force = els.forceUpdateToggle.is(':checked')
+els.updateBtn.addEventListener('click', () => {
+  const force = els.forceUpdateToggle.checked
   if (force || !imagemaidInstalled || imagemaidUpdateAvailable) {
     startUpdate(force)
     return
@@ -1287,57 +1295,76 @@ els.updateBtn.on('click', () => {
     }
   })
 })
-els.forceUpdateToggle.on('change', syncUpdateButtonLabel)
-els.validateBtn.on('click', validateImageMaid)
-els.stopBtn.on('click', () => {
+els.forceUpdateToggle.addEventListener('change', syncUpdateButtonLabel)
+els.validateBtn.addEventListener('click', validateImageMaid)
+els.stopBtn.addEventListener('click', () => {
   if (stopConfirmModal) {
     stopConfirmModal.show()
     return
   }
   stopRunConfirmed()
 })
-els.runBtn.on('click', () => {
-  const mode = String(els.mode.val() || 'report').trim().toLowerCase()
+els.runBtn.addEventListener('click', () => {
+  const mode = String(els.mode.value || 'report').trim().toLowerCase()
   if (mode === 'move' && moveConfirmModal) {
     moveConfirmModal.show()
     return
   }
   submitRun()
 })
-els.confirmMoveRunBtn.on('click', () => {
+els.confirmMoveRunBtn.addEventListener('click', () => {
   if (moveConfirmModal) moveConfirmModal.hide()
   submitRun()
 })
-$('#confirm-stop-imagemaid').on('click', stopRunConfirmed)
+document.getElementById('confirm-stop-imagemaid').addEventListener('click', stopRunConfirmed)
 
-$('#imagemaid_mode, #imagemaid_plex_path, #imagemaid_timeout, #imagemaid_sleep, #imagemaid_branch_override').on('input change', onConfigChanged)
-$('#imagemaid_photo_transcoder, #imagemaid_empty_trash, #imagemaid_clean_bundles, #imagemaid_optimize_db, #imagemaid_local_db, #imagemaid_use_existing, #imagemaid_ignore_running, #imagemaid_trace, #imagemaid_log_requests, #imagemaid_no_verify_ssl, #imagemaid_overlays_only').on('change', onConfigChanged)
-els.logAutoscroll.on('change', function () {
-  imagemaidLogAutoScroll = $(this).is(':checked')
+function wireInputChange (selectors, handler) {
+  for (const selector of selectors) {
+    const el = document.querySelector(selector)
+    if (!el) continue
+    el.addEventListener('input', handler)
+    el.addEventListener('change', handler)
+  }
+}
+
+wireInputChange([
+  '#imagemaid_mode', '#imagemaid_plex_path', '#imagemaid_timeout',
+  '#imagemaid_sleep', '#imagemaid_branch_override'
+], onConfigChanged)
+wireInputChange([
+  '#imagemaid_photo_transcoder', '#imagemaid_empty_trash', '#imagemaid_clean_bundles',
+  '#imagemaid_optimize_db', '#imagemaid_local_db', '#imagemaid_use_existing',
+  '#imagemaid_ignore_running', '#imagemaid_trace', '#imagemaid_log_requests',
+  '#imagemaid_no_verify_ssl', '#imagemaid_overlays_only'
+], onConfigChanged)
+els.logAutoscroll.addEventListener('change', function () {
+  imagemaidLogAutoScroll = this.checked
 })
-els.logTailSize.on('change', function () {
-  const next = String($(this).val() || '2000').trim().toLowerCase()
+els.logTailSize.addEventListener('change', function () {
+  const next = String(this.value || '2000').trim().toLowerCase()
   imagemaidTailSize = next === 'all' ? 'all' : (['200', '2000', '20000'].includes(next) ? next : '2000')
-  els.tailLabel.text(imagemaidTailSize === 'all' ? 'all' : imagemaidTailSize)
+  els.tailLabel.textContent = imagemaidTailSize === 'all' ? 'all' : imagemaidTailSize
   loadLog(true)
 })
-els.logFilter.on('input', applyLogFilter)
-els.logLevelButtons.on('click', function () {
-  const nextLevel = String($(this).data('level') || '').trim()
-  const currentFilter = String(els.logFilter.val() || '').trim()
-  els.logFilter.val(currentFilter === nextLevel ? '' : nextLevel)
-  applyLogFilter()
+els.logFilter.addEventListener('input', applyLogFilter)
+els.logLevelButtons.forEach((btn) => {
+  btn.addEventListener('click', function () {
+    const nextLevel = String(this.dataset.level || '').trim()
+    const currentFilter = String(els.logFilter.value || '').trim()
+    els.logFilter.value = currentFilter === nextLevel ? '' : nextLevel
+    applyLogFilter()
+  })
 })
-els.pauseLogPolling.on('click', function () {
+els.pauseLogPolling.addEventListener('click', function () {
   imagemaidLogPollingPaused = !imagemaidLogPollingPaused
   if (imagemaidLogPollingPaused) {
-    $(this).html('<i class="bi bi-play-circle me-1"></i> Resume')
+    this.innerHTML = '<i class="bi bi-play-circle me-1"></i> Resume'
   } else {
-    $(this).html('<i class="bi bi-pause-circle me-1"></i> Pause')
+    this.innerHTML = '<i class="bi bi-pause-circle me-1"></i> Pause'
     loadLog(true)
   }
 })
-els.downloadLog.on('click', function () {
+els.downloadLog.addEventListener('click', function () {
   const text = String((lastImageMaidLogPayload && lastImageMaidLogPayload.text) || lastImageMaidLogText || '')
   const blob = new Blob([text], { type: 'text/plain;charset=utf-8' })
   const url = URL.createObjectURL(blob)
@@ -1360,10 +1387,10 @@ syncOptionalCapabilityRows()
 syncBranchSummary()
 syncUpdateButtonLabel()
 imagemaidLastPayloadSignature = buildPayloadSignature()
-els.tailLabel.text(imagemaidTailSize === 'all' ? 'all' : imagemaidTailSize)
-imagemaidLogAutoScroll = els.logAutoscroll.is(':checked')
+els.tailLabel.textContent = imagemaidTailSize === 'all' ? 'all' : imagemaidTailSize
+imagemaidLogAutoScroll = els.logAutoscroll.checked
 syncLogLevelButtons()
-setValidationState(imagemaidValidated ? 'ok' : 'idle', String(els.validationStatus.text() || '').trim())
+setValidationState(imagemaidValidated ? 'ok' : 'idle', String(els.validationStatus.textContent || '').trim())
 probeRoot()
 updateStatus(true)
 loadLog(true)

--- a/static/local-js/modules/createOauthValidator.js
+++ b/static/local-js/modules/createOauthValidator.js
@@ -1,0 +1,363 @@
+// OAuth-shaped wizard factory. Layered on top of oauthValidationHelpers.
+//
+// Trakt and MAL follow the same 5-phase flow:
+//   1. Toggle secret visibility on the client-secret input.
+//   2. Reset validated=false whenever any credential input changes.
+//   3. When the client_id reaches a wizard-specific length, build an
+//      authorization URL (opened in a new tab via the "authorize" button).
+//   4. Validate by POSTing the credentials + a secondary value (PIN or
+//      localhost URL) to the wizard's endpoint. On success, copy
+//      response fields into hidden form inputs.
+//   5. Optionally re-validate an already-saved access token via a
+//      separate check-token endpoint. May rotate the token set.
+//
+// Each of those phases is expressed via a small config block. The
+// factory wires the DOM listeners and delegates to oauthValidationHelpers
+// for the network + status-message primitives.
+//
+// The two callers today (130-trakt, 140-mal) shrink from ~200 lines
+// each to ~60 lines of pure config.
+
+import { refreshValidationCallout } from './validationPageBase.js'
+import {
+  STATUS_COLOR_SUCCESS,
+  STATUS_COLOR_ERROR,
+  isBlankTokenValue,
+  wireSecretToggle,
+  wireCredentialResetListeners,
+  showStatusMessage,
+  performValidationRequest
+} from './oauthValidationHelpers.js'
+
+const DEFAULT_STATUS_MESSAGE_ID = 'statusMessage'
+const DEFAULT_ACCESS_TOKEN_FIELD_ID = 'access_token'
+
+/**
+ * Register an OAuth-shaped wizard on the current page.
+ *
+ * @param {object} config - see JSDoc keys below.
+ *
+ * REQUIRED:
+ * @param {string} config.serviceName            Human-readable label used in status
+ *                                               messages (e.g. "Trakt", "MyAnimeList").
+ * @param {string} config.validatedFieldId       Hidden input tracking validated=true|false.
+ * @param {string} config.clientIdFieldId        Input id for the OAuth client_id.
+ * @param {string} config.clientSecretFieldId    Input id for the OAuth client_secret.
+ * @param {string} config.authorizeButtonId      Button that opens the authorization URL.
+ * @param {string} config.validateButtonId       Button that submits the validation flow.
+ * @param {string} config.urlFieldId             Hidden input holding the constructed URL.
+ * @param {number} config.expectedClientIdLength Trigger for building the auth URL.
+ * @param {(clientId: string, extras: object) => string} config.buildAuthorizationURL
+ *                                               Function producing the URL. `extras`
+ *                                               carries values from `extraCredentialFieldIds`
+ *                                               keyed by field id.
+ * @param {string[]} config.extraCredentialFieldIds
+ *                                               Additional credential input ids to
+ *                                               wire (reset-on-input + reset-validation
+ *                                               + optionally used inside URL builder
+ *                                               and payload builders).
+ * @param {string} config.secondaryValueFieldId  Input id whose non-empty value gates
+ *                                               validateButton (e.g. `trakt_pin`,
+ *                                               `mal_localhost_url`).
+ * @param {string} config.validateEndpoint       URL for the validation POST.
+ * @param {(payload: {clientId, clientSecret, extras, secondaryValue}) => object}
+ *                                               config.buildValidatePayload
+ * @param {string} config.validateSpinnerKey     Spinner key for the validate flow.
+ * @param {(data: object, ctx: OauthValidatorContext) => void}
+ *                                               config.applyValidateSuccess
+ *                                               Called with the response body after
+ *                                               a successful validation. The wizard
+ *                                               copies response fields into hidden
+ *                                               inputs here.
+ *
+ * OPTIONAL:
+ * @param {string} [config.validatedAtFieldId]   Hidden input tracking the ISO
+ *                                               timestamp of the last successful
+ *                                               validation.
+ * @param {string} [config.toggleButtonId='toggleClientSecretVisibility']
+ *                                               Button toggling client_secret visibility.
+ * @param {string} [config.checkTokenButtonId]   If present, wires the check-token flow.
+ * @param {string} [config.checkTokenEndpoint]   URL for the check-token POST.
+ * @param {(payload: {accessToken, clientId, clientSecret, refreshToken}) => object}
+ *                                               [config.buildCheckTokenPayload]
+ * @param {(payload: {accessToken, clientId, clientSecret, refreshToken}) => string|null}
+ *                                               [config.checkTokenPreflight]
+ *                                               Optional guard run before the check-token
+ *                                               request. Return a non-empty string to
+ *                                               abort with a status-message error; return
+ *                                               null/undefined/empty to proceed. Defaults
+ *                                               to blocking only on a blank access token.
+ * @param {string} [config.checkTokenSpinnerKey='check']
+ * @param {string} [config.accessTokenFieldId='access_token']
+ * @param {string} [config.refreshTokenFieldId='refresh_token']
+ * @param {(data: object, ctx: OauthValidatorContext) => void}
+ *                                               [config.applyCheckTokenSuccess]
+ *                                               Called with the response body on
+ *                                               successful check-token; default is
+ *                                               a no-op beyond marking validated.
+ * @param {string} [config.statusMessageId='statusMessage']
+ * @param {object} [config.messages]             Optional overrides for user-facing
+ *                                               copy. Keys: `validateSuccess`,
+ *                                               `validateError`, `validateMissingFields`,
+ *                                               `checkTokenSuccess`, `checkTokenError`,
+ *                                               `checkTokenMissingFields`.
+ */
+export function createOauthValidator (config) {
+  const {
+    serviceName,
+    validatedFieldId,
+    validatedAtFieldId,
+    clientIdFieldId,
+    clientSecretFieldId,
+    toggleButtonId = 'toggleClientSecretVisibility',
+    authorizeButtonId,
+    validateButtonId,
+    checkTokenButtonId,
+    urlFieldId,
+    expectedClientIdLength,
+    buildAuthorizationURL,
+    extraCredentialFieldIds = [],
+    secondaryValueFieldId,
+    validateEndpoint,
+    buildValidatePayload,
+    validateSpinnerKey,
+    applyValidateSuccess,
+    checkTokenEndpoint,
+    buildCheckTokenPayload,
+    checkTokenPreflight,
+    checkTokenSpinnerKey = 'check',
+    accessTokenFieldId = DEFAULT_ACCESS_TOKEN_FIELD_ID,
+    refreshTokenFieldId = 'refresh_token',
+    applyCheckTokenSuccess,
+    statusMessageId = DEFAULT_STATUS_MESSAGE_ID,
+    messages: messageOverrides = {}
+  } = config
+
+  requireConfig(config, [
+    'serviceName',
+    'validatedFieldId',
+    'clientIdFieldId',
+    'clientSecretFieldId',
+    'authorizeButtonId',
+    'validateButtonId',
+    'urlFieldId',
+    'expectedClientIdLength',
+    'buildAuthorizationURL',
+    'secondaryValueFieldId',
+    'validateEndpoint',
+    'buildValidatePayload',
+    'validateSpinnerKey',
+    'applyValidateSuccess'
+  ])
+
+  const messages = {
+    validateSuccess: `${serviceName} credentials validated successfully!`,
+    validateError: `An error occurred while validating ${serviceName} credentials.`,
+    validateMissingFields: 'ID, secret, and secondary value are all required.',
+    checkTokenSuccess: `${serviceName} token is valid.`,
+    checkTokenError: `An error occurred while validating ${serviceName} token.`,
+    checkTokenMissingFields: 'Missing access token.',
+    ...messageOverrides
+  }
+
+  const clientIdInput = document.getElementById(clientIdFieldId)
+  const clientSecretInput = document.getElementById(clientSecretFieldId)
+  const validatedField = document.getElementById(validatedFieldId)
+  const validatedAtInput = validatedAtFieldId ? document.getElementById(validatedAtFieldId) : null
+  const authorizeButton = document.getElementById(authorizeButtonId)
+  const validateButton = document.getElementById(validateButtonId)
+  const secondaryValueInput = document.getElementById(secondaryValueFieldId)
+  const urlField = document.getElementById(urlFieldId)
+  const toggleButton = document.getElementById(toggleButtonId)
+  const checkTokenButton = checkTokenButtonId ? document.getElementById(checkTokenButtonId) : null
+
+  // If the load-bearing elements aren't on the page, this wizard isn't
+  // fully rendered — bail. Matches createApiKeyValidator posture.
+  if (!clientIdInput || !clientSecretInput || !validatedField ||
+      !authorizeButton || !validateButton || !urlField || !secondaryValueInput) {
+    return
+  }
+
+  wireSecretToggle(clientSecretInput, toggleButton)
+
+  // Resolve extra credential inputs once. Missing entries are silently
+  // dropped from listener wiring + URL/payload extras.
+  const extraCredentialElements = extraCredentialFieldIds
+    .map(id => ({ id, el: document.getElementById(id) }))
+    .filter(entry => entry.el)
+
+  // Initial button gating from persisted state.
+  validateButton.disabled = validatedField.value.toLowerCase() === 'true'
+  if (checkTokenButton) {
+    const accessToken = document.getElementById(accessTokenFieldId)?.value || ''
+    checkTokenButton.disabled = isBlankTokenValue(accessToken)
+  }
+
+  wireCredentialResetListeners({
+    fieldIds: [clientIdFieldId, clientSecretFieldId, ...extraCredentialFieldIds, secondaryValueFieldId],
+    validatedField,
+    validatedAtField: validatedAtInput,
+    validateButton,
+    checkTokenButton,
+    validatedFieldId
+  })
+
+  // Build the authorization URL when client_id reaches the expected length.
+  function updateAuthorizationURL () {
+    const clientId = clientIdInput.value
+    let myURL = ''
+    if (clientId.length === expectedClientIdLength) {
+      validatedField.value = 'false'
+      if (validatedAtInput) validatedAtInput.value = ''
+      refreshValidationCallout(validatedFieldId)
+      const extras = collectExtras(extraCredentialElements)
+      myURL = buildAuthorizationURL(clientId, extras)
+    }
+    urlField.value = myURL
+    // Programmatic .value assignment doesn't fire 'input' events, so
+    // the authorize button gate is checked here directly.
+    authorizeButton.disabled = urlField.value === ''
+  }
+
+  clientIdInput.addEventListener('input', updateAuthorizationURL)
+
+  authorizeButton.addEventListener('click', function () {
+    const url = urlField.value
+    if (url) {
+      showSpinner('retrieve')
+      window.open(url, '_blank').focus()
+    }
+  })
+
+  secondaryValueInput.addEventListener('input', function () {
+    validateButton.disabled = secondaryValueInput.value === ''
+  })
+
+  // Initial gating after the page has rendered.
+  authorizeButton.disabled = urlField.value === ''
+  validateButton.disabled = validateButton.disabled || secondaryValueInput.value === ''
+
+  // Context passed to the success callbacks so they can mutate the DOM
+  // consistently without re-querying the same elements.
+  const ctx = {
+    clientIdInput,
+    clientSecretInput,
+    secondaryValueInput,
+    validatedField,
+    validatedAtInput,
+    urlField,
+    authorizeButton,
+    validateButton,
+    checkTokenButton,
+    extras: extraCredentialElements,
+    markValidated: () => {
+      validatedField.value = 'true'
+      if (validatedAtInput) validatedAtInput.value = new Date().toISOString()
+      refreshValidationCallout(validatedFieldId)
+    }
+  }
+
+  validateButton.addEventListener('click', function () {
+    const statusMessage = document.getElementById(statusMessageId)
+    const clientId = clientIdInput.value
+    const clientSecret = clientSecretInput.value
+    const secondaryValue = secondaryValueInput.value
+    const extras = collectExtras(extraCredentialElements)
+
+    if (!clientId || !clientSecret || !secondaryValue ||
+        extraCredentialElements.some(({ el }) => !el.value)) {
+      showStatusMessage(statusMessage, messages.validateMissingFields, STATUS_COLOR_ERROR)
+      return
+    }
+
+    hideSpinner('retrieve')
+    performValidationRequest({
+      endpoint: validateEndpoint,
+      payload: buildValidatePayload({ clientId, clientSecret, secondaryValue, extras }),
+      spinnerKey: validateSpinnerKey,
+      statusElement: statusMessage,
+      onSuccess: (data) => {
+        ctx.markValidated()
+        applyValidateSuccess(data, ctx)
+        showStatusMessage(statusMessage, messages.validateSuccess, STATUS_COLOR_SUCCESS)
+      },
+      onFailure: () => {
+        validatedField.value = 'false'
+        if (validatedAtInput) validatedAtInput.value = ''
+        refreshValidationCallout(validatedFieldId)
+      },
+      onError: () => {
+        showStatusMessage(statusMessage, messages.validateError, STATUS_COLOR_ERROR)
+        if (validatedAtInput) validatedAtInput.value = ''
+        refreshValidationCallout(validatedFieldId)
+      }
+    })
+  })
+
+  if (checkTokenButton && checkTokenEndpoint && buildCheckTokenPayload) {
+    checkTokenButton.addEventListener('click', function () {
+      const statusMessage = document.getElementById(statusMessageId)
+      const accessToken = document.getElementById(accessTokenFieldId)?.value || ''
+      const clientId = clientIdInput?.value || ''
+      const clientSecret = clientSecretInput?.value || ''
+      const refreshToken = refreshTokenFieldId
+        ? (document.getElementById(refreshTokenFieldId)?.value || '')
+        : ''
+
+      // Preflight guard. Wizards can plug in their own check (Trakt
+      // requires both accessToken AND clientId to be present); default
+      // is accessToken-only.
+      const guardFn = typeof checkTokenPreflight === 'function'
+        ? checkTokenPreflight
+        : ({ accessToken: at }) => (isBlankTokenValue(at) ? messages.checkTokenMissingFields : null)
+      const guardError = guardFn({ accessToken, clientId, clientSecret, refreshToken })
+      if (guardError) {
+        showStatusMessage(statusMessage, guardError, STATUS_COLOR_ERROR)
+        return
+      }
+
+      performValidationRequest({
+        endpoint: checkTokenEndpoint,
+        payload: buildCheckTokenPayload({ accessToken, clientId, clientSecret, refreshToken }),
+        spinnerKey: checkTokenSpinnerKey,
+        statusElement: statusMessage,
+        onSuccess: (data) => {
+          if (typeof applyCheckTokenSuccess === 'function') {
+            applyCheckTokenSuccess(data, ctx)
+          }
+          ctx.markValidated()
+          showStatusMessage(statusMessage, messages.checkTokenSuccess, STATUS_COLOR_SUCCESS)
+        },
+        onFailure: () => {
+          validatedField.value = 'false'
+          if (validatedAtInput) validatedAtInput.value = ''
+          refreshValidationCallout(validatedFieldId)
+        },
+        onError: () => {
+          showStatusMessage(statusMessage, messages.checkTokenError, STATUS_COLOR_ERROR)
+          if (validatedAtInput) validatedAtInput.value = ''
+          refreshValidationCallout(validatedFieldId)
+        }
+      })
+    })
+  }
+}
+
+function collectExtras (extraCredentialElements) {
+  const extras = {}
+  for (const { id, el } of extraCredentialElements) {
+    extras[id] = el.value
+  }
+  return extras
+}
+
+function requireConfig (config, keys) {
+  for (const key of keys) {
+    const value = config[key]
+    const missing = value === undefined || value === null ||
+      (typeof value === 'string' && value === '')
+    if (missing) {
+      throw new Error(`createOauthValidator: ${key} is required`)
+    }
+  }
+}

--- a/tests/js/modules/createOauthValidator.test.js
+++ b/tests/js/modules/createOauthValidator.test.js
@@ -1,0 +1,601 @@
+// Tests for static/local-js/modules/createOauthValidator.js
+// (#1334 Step 6 PR 2).
+//
+// The OAuth-shaped counterpart to createApiKeyValidator. Locks down
+// the behaviour before 130-trakt and 140-mal migrate onto it.
+//
+// SHIMS follow the same pattern as createApiKeyValidator.test.js:
+//   - showSpinner / hideSpinner stubbed as window globals
+//   - fetch stubbed via vi.stubGlobal
+//   - QSValidationCallouts optional per test
+//
+// FIXTURE:
+//   buildBaseHTML() renders a stripped-down Trakt-shaped page with the
+//   full standard element set. Tests override HTML fragments as needed
+//   for edge cases (missing checkTokenButton, extra credential inputs,
+//   etc.).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createOauthValidator } from '../../../static/local-js/modules/createOauthValidator.js'
+
+function buildBaseHTML ({
+  clientIdValue = '',
+  secretValue = '',
+  secondaryValue = '',
+  validated = 'false',
+  extraInputs = '',
+  includeCheckTokenButton = true
+} = {}) {
+  const checkTokenBtn = includeCheckTokenButton
+    ? '<button id="test_check_token" type="button">Check Token</button>'
+    : ''
+  return `
+    <form id="configForm">
+      <input id="test_client_id" type="text" value="${clientIdValue}">
+      <input id="test_client_secret" type="password" value="${secretValue}">
+      <input id="test_pin" type="text" value="${secondaryValue}">
+      <input id="test_url" type="hidden" value="">
+      <input id="test_validated" type="hidden" value="${validated}">
+      <input id="test_validated_at" type="hidden" value="">
+      <input id="access_token" type="hidden" value="">
+      <input id="refresh_token" type="hidden" value="">
+      <button id="toggleClientSecretVisibility" type="button">
+        <i class="bi"></i>
+      </button>
+      <button id="test_authorize" type="button">Authorize</button>
+      <button id="test_validate" type="button">Validate</button>
+      ${checkTokenBtn}
+      <div id="statusMessage" style="display:none"></div>
+      ${extraInputs}
+    </form>
+  `
+}
+
+function defaultConfig (overrides = {}) {
+  return {
+    serviceName: 'Test',
+    validatedFieldId: 'test_validated',
+    validatedAtFieldId: 'test_validated_at',
+    clientIdFieldId: 'test_client_id',
+    clientSecretFieldId: 'test_client_secret',
+    authorizeButtonId: 'test_authorize',
+    validateButtonId: 'test_validate',
+    checkTokenButtonId: 'test_check_token',
+    urlFieldId: 'test_url',
+    expectedClientIdLength: 8,
+    buildAuthorizationURL: (clientId) => `https://example.test/auth?client_id=${clientId}`,
+    secondaryValueFieldId: 'test_pin',
+    validateEndpoint: '/validate_test',
+    buildValidatePayload: ({ clientId, clientSecret, secondaryValue }) => ({
+      test_client_id: clientId,
+      test_client_secret: clientSecret,
+      test_pin: secondaryValue
+    }),
+    validateSpinnerKey: 'validate',
+    applyValidateSuccess: () => {},
+    checkTokenEndpoint: '/validate_test_token',
+    buildCheckTokenPayload: ({ accessToken }) => ({ access_token: accessToken, debug: true }),
+    ...overrides
+  }
+}
+
+function mockFetchOK (body) {
+  const fetchMock = vi.fn(() => Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve(body)
+  }))
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+function mockFetchReject (err = new Error('boom')) {
+  const fetchMock = vi.fn(() => Promise.reject(err))
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+async function flushPromises () {
+  // Two microtasks: one for fetch's then(res=>res.json()), one for the
+  // json()'s .then(...) callback that runs onSuccess/onFailure.
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+  window.showSpinner = vi.fn()
+  window.hideSpinner = vi.fn()
+  delete window.QSValidationCallouts
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  delete window.showSpinner
+  delete window.hideSpinner
+  delete window.QSValidationCallouts
+})
+
+describe('createOauthValidator config validation', () => {
+  it.each([
+    ['serviceName', { serviceName: undefined }],
+    ['validatedFieldId', { validatedFieldId: undefined }],
+    ['clientIdFieldId', { clientIdFieldId: undefined }],
+    ['clientSecretFieldId', { clientSecretFieldId: undefined }],
+    ['authorizeButtonId', { authorizeButtonId: undefined }],
+    ['validateButtonId', { validateButtonId: undefined }],
+    ['urlFieldId', { urlFieldId: undefined }],
+    ['expectedClientIdLength', { expectedClientIdLength: undefined }],
+    ['buildAuthorizationURL', { buildAuthorizationURL: undefined }],
+    ['secondaryValueFieldId', { secondaryValueFieldId: undefined }],
+    ['validateEndpoint', { validateEndpoint: undefined }],
+    ['buildValidatePayload', { buildValidatePayload: undefined }],
+    ['validateSpinnerKey', { validateSpinnerKey: undefined }],
+    ['applyValidateSuccess', { applyValidateSuccess: undefined }]
+  ])('throws when %s is missing', (fieldName, override) => {
+    document.body.innerHTML = buildBaseHTML()
+    expect(() => createOauthValidator(defaultConfig(override)))
+      .toThrow(new RegExp(`${fieldName} is required`))
+  })
+})
+
+describe('createOauthValidator wizard-not-rendered short-circuit', () => {
+  it('returns silently when clientId input is missing', () => {
+    document.body.innerHTML = '<form id="configForm"></form>'
+    expect(() => createOauthValidator(defaultConfig())).not.toThrow()
+  })
+
+  it('returns silently when validate button is missing', () => {
+    document.body.innerHTML = buildBaseHTML()
+    document.getElementById('test_validate').remove()
+    expect(() => createOauthValidator(defaultConfig())).not.toThrow()
+  })
+
+  it('returns silently when urlField is missing', () => {
+    document.body.innerHTML = buildBaseHTML()
+    document.getElementById('test_url').remove()
+    expect(() => createOauthValidator(defaultConfig())).not.toThrow()
+  })
+})
+
+describe('createOauthValidator initial button state', () => {
+  it('disables validate button when previously validated', () => {
+    document.body.innerHTML = buildBaseHTML({ validated: 'true' })
+    createOauthValidator(defaultConfig())
+    expect(document.getElementById('test_validate').disabled).toBe(true)
+  })
+
+  it('leaves validate button in "no secondary value" state when not previously validated', () => {
+    document.body.innerHTML = buildBaseHTML({ validated: 'false' })
+    createOauthValidator(defaultConfig())
+    // secondaryValue empty AND no persisted validation -> button disabled
+    expect(document.getElementById('test_validate').disabled).toBe(true)
+  })
+
+  it('starts authorize button disabled when urlField is empty', () => {
+    document.body.innerHTML = buildBaseHTML()
+    createOauthValidator(defaultConfig())
+    expect(document.getElementById('test_authorize').disabled).toBe(true)
+  })
+
+  it('disables check-token button when access_token is empty', () => {
+    document.body.innerHTML = buildBaseHTML()
+    createOauthValidator(defaultConfig())
+    expect(document.getElementById('test_check_token').disabled).toBe(true)
+  })
+
+  it('enables check-token button when access_token is populated', () => {
+    document.body.innerHTML = buildBaseHTML()
+    document.getElementById('access_token').value = 'existing-token'
+    createOauthValidator(defaultConfig())
+    expect(document.getElementById('test_check_token').disabled).toBe(false)
+  })
+})
+
+describe('createOauthValidator authorization URL builder', () => {
+  it('builds URL when clientId reaches expected length', () => {
+    document.body.innerHTML = buildBaseHTML()
+    createOauthValidator(defaultConfig({ expectedClientIdLength: 8 }))
+
+    const clientIdInput = document.getElementById('test_client_id')
+    clientIdInput.value = '12345678'
+    clientIdInput.dispatchEvent(new Event('input'))
+
+    expect(document.getElementById('test_url').value)
+      .toBe('https://example.test/auth?client_id=12345678')
+    expect(document.getElementById('test_authorize').disabled).toBe(false)
+  })
+
+  it('clears URL when clientId shrinks below expected length', () => {
+    document.body.innerHTML = buildBaseHTML()
+    createOauthValidator(defaultConfig({ expectedClientIdLength: 8 }))
+
+    const clientIdInput = document.getElementById('test_client_id')
+    clientIdInput.value = '12345678'
+    clientIdInput.dispatchEvent(new Event('input'))
+    clientIdInput.value = '1234567'
+    clientIdInput.dispatchEvent(new Event('input'))
+
+    expect(document.getElementById('test_url').value).toBe('')
+    expect(document.getElementById('test_authorize').disabled).toBe(true)
+  })
+
+  it('resets validated state when URL is built', () => {
+    document.body.innerHTML = buildBaseHTML({ validated: 'true' })
+    document.getElementById('test_validated_at').value = '2026-01-01T00:00:00Z'
+    createOauthValidator(defaultConfig({ expectedClientIdLength: 8 }))
+
+    const clientIdInput = document.getElementById('test_client_id')
+    clientIdInput.value = '12345678'
+    clientIdInput.dispatchEvent(new Event('input'))
+
+    expect(document.getElementById('test_validated').value).toBe('false')
+    expect(document.getElementById('test_validated_at').value).toBe('')
+  })
+
+  it('passes extra credential values into buildAuthorizationURL', () => {
+    document.body.innerHTML = buildBaseHTML({
+      extraInputs: '<input id="test_verifier" type="text" value="my-pkce-verifier">'
+    })
+    const buildURL = vi.fn((clientId, extras) =>
+      `https://example.test/auth?client_id=${clientId}&challenge=${extras.test_verifier}`)
+    createOauthValidator(defaultConfig({
+      expectedClientIdLength: 8,
+      buildAuthorizationURL: buildURL,
+      extraCredentialFieldIds: ['test_verifier']
+    }))
+
+    const clientIdInput = document.getElementById('test_client_id')
+    clientIdInput.value = '12345678'
+    clientIdInput.dispatchEvent(new Event('input'))
+
+    expect(buildURL).toHaveBeenCalledWith('12345678', { test_verifier: 'my-pkce-verifier' })
+    expect(document.getElementById('test_url').value)
+      .toBe('https://example.test/auth?client_id=12345678&challenge=my-pkce-verifier')
+  })
+})
+
+describe('createOauthValidator authorize button click', () => {
+  it('opens URL in new tab and shows retrieve spinner', () => {
+    document.body.innerHTML = buildBaseHTML()
+    const openSpy = vi.fn(() => ({ focus: vi.fn() }))
+    vi.stubGlobal('open', openSpy)
+    createOauthValidator(defaultConfig({ expectedClientIdLength: 8 }))
+
+    const clientIdInput = document.getElementById('test_client_id')
+    clientIdInput.value = '12345678'
+    clientIdInput.dispatchEvent(new Event('input'))
+
+    document.getElementById('test_authorize').click()
+
+    expect(openSpy).toHaveBeenCalledWith('https://example.test/auth?client_id=12345678', '_blank')
+    expect(window.showSpinner).toHaveBeenCalledWith('retrieve')
+  })
+
+  it('does nothing when URL is empty', () => {
+    document.body.innerHTML = buildBaseHTML()
+    const openSpy = vi.fn()
+    vi.stubGlobal('open', openSpy)
+    createOauthValidator(defaultConfig())
+
+    document.getElementById('test_authorize').click()
+    expect(openSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('createOauthValidator secondary value gating', () => {
+  it('enables validate button when secondary value is populated', () => {
+    document.body.innerHTML = buildBaseHTML()
+    createOauthValidator(defaultConfig())
+
+    const secondaryInput = document.getElementById('test_pin')
+    secondaryInput.value = 'ABC123'
+    secondaryInput.dispatchEvent(new Event('input'))
+
+    expect(document.getElementById('test_validate').disabled).toBe(false)
+  })
+
+  it('disables validate button when secondary value is cleared', () => {
+    document.body.innerHTML = buildBaseHTML({ secondaryValue: 'ABC123' })
+    createOauthValidator(defaultConfig())
+
+    const secondaryInput = document.getElementById('test_pin')
+    secondaryInput.value = ''
+    secondaryInput.dispatchEvent(new Event('input'))
+
+    expect(document.getElementById('test_validate').disabled).toBe(true)
+  })
+})
+
+describe('createOauthValidator validate flow', () => {
+  it('shows missing-fields message when any credential is empty', () => {
+    // Populate secondaryValue so the button is enabled, then clear the
+    // secret to trigger the missing-fields path when clicked.
+    document.body.innerHTML = buildBaseHTML({
+      clientIdValue: 'abc',
+      secretValue: 'x',
+      secondaryValue: 'ABC123'
+    })
+    createOauthValidator(defaultConfig())
+    // Now clear the secret post-init to leave it blank at click time.
+    document.getElementById('test_client_secret').value = ''
+
+    document.getElementById('test_validate').click()
+    expect(document.getElementById('statusMessage').textContent)
+      .toBe('ID, secret, and secondary value are all required.')
+  })
+
+  it('POSTs the payload from buildValidatePayload on click', async () => {
+    document.body.innerHTML = buildBaseHTML({
+      clientIdValue: 'my-client-id',
+      secretValue: 'my-secret',
+      secondaryValue: 'my-pin'
+    })
+    const fetchMock = mockFetchOK({ valid: true })
+    createOauthValidator(defaultConfig())
+
+    document.getElementById('test_validate').click()
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenCalledWith('/validate_test', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({
+        test_client_id: 'my-client-id',
+        test_client_secret: 'my-secret',
+        test_pin: 'my-pin'
+      })
+    }))
+  })
+
+  it('calls applyValidateSuccess and marks validated on ok response', async () => {
+    document.body.innerHTML = buildBaseHTML({
+      clientIdValue: 'my-client-id',
+      secretValue: 'my-secret',
+      secondaryValue: 'my-pin'
+    })
+    mockFetchOK({ valid: true, extra: 'stuff' })
+    const applySuccess = vi.fn()
+    createOauthValidator(defaultConfig({ applyValidateSuccess: applySuccess }))
+
+    document.getElementById('test_validate').click()
+    await flushPromises()
+
+    expect(applySuccess).toHaveBeenCalledWith(
+      expect.objectContaining({ valid: true, extra: 'stuff' }),
+      expect.objectContaining({ markValidated: expect.any(Function) })
+    )
+    expect(document.getElementById('test_validated').value).toBe('true')
+    expect(document.getElementById('test_validated_at').value).not.toBe('')
+    expect(document.getElementById('statusMessage').textContent)
+      .toContain('Test credentials validated successfully!')
+  })
+
+  it('sets validated=false on failure response', async () => {
+    document.body.innerHTML = buildBaseHTML({
+      clientIdValue: 'my-client-id',
+      secretValue: 'my-secret',
+      secondaryValue: 'my-pin',
+      validated: 'true'
+    })
+    document.getElementById('test_validated_at').value = '2026-01-01T00:00:00Z'
+    mockFetchOK({ valid: false })
+    createOauthValidator(defaultConfig())
+    // secondaryValueInput populated => re-enable button before click
+    document.getElementById('test_validate').disabled = false
+
+    document.getElementById('test_validate').click()
+    await flushPromises()
+
+    expect(document.getElementById('test_validated').value).toBe('false')
+    expect(document.getElementById('test_validated_at').value).toBe('')
+  })
+
+  it('shows error message on fetch rejection', async () => {
+    document.body.innerHTML = buildBaseHTML({
+      clientIdValue: 'my-client-id',
+      secretValue: 'my-secret',
+      secondaryValue: 'my-pin'
+    })
+    mockFetchReject()
+    createOauthValidator(defaultConfig())
+
+    document.getElementById('test_validate').click()
+    await flushPromises()
+
+    expect(document.getElementById('statusMessage').textContent)
+      .toBe('An error occurred while validating Test credentials.')
+  })
+})
+
+describe('createOauthValidator check-token flow', () => {
+  it('shows missing message when access_token is blank', () => {
+    document.body.innerHTML = buildBaseHTML()
+    createOauthValidator(defaultConfig())
+
+    document.getElementById('test_check_token').disabled = false
+    document.getElementById('test_check_token').click()
+    expect(document.getElementById('statusMessage').textContent).toBe('Missing access token.')
+  })
+
+  it('POSTs check-token payload and marks validated on success', async () => {
+    document.body.innerHTML = buildBaseHTML()
+    document.getElementById('access_token').value = 'my-access-token'
+    document.getElementById('refresh_token').value = 'my-refresh-token'
+    const fetchMock = mockFetchOK({ valid: true })
+    createOauthValidator(defaultConfig({
+      buildCheckTokenPayload: ({ accessToken, clientId, clientSecret, refreshToken }) => ({
+        access_token: accessToken,
+        client_id: clientId,
+        client_secret: clientSecret,
+        refresh_token: refreshToken,
+        debug: true
+      })
+    }))
+
+    document.getElementById('test_check_token').click()
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenCalledWith('/validate_test_token', expect.objectContaining({
+      body: JSON.stringify({
+        access_token: 'my-access-token',
+        client_id: '',
+        client_secret: '',
+        refresh_token: 'my-refresh-token',
+        debug: true
+      })
+    }))
+    expect(document.getElementById('test_validated').value).toBe('true')
+    expect(document.getElementById('statusMessage').textContent).toContain('Test token is valid.')
+  })
+
+  it('calls applyCheckTokenSuccess when provided', async () => {
+    document.body.innerHTML = buildBaseHTML()
+    document.getElementById('access_token').value = 'my-access-token'
+    mockFetchOK({ valid: true, authorization: { access_token: 'rotated' } })
+    const applyCheck = vi.fn()
+    createOauthValidator(defaultConfig({ applyCheckTokenSuccess: applyCheck }))
+
+    document.getElementById('test_check_token').click()
+    await flushPromises()
+
+    expect(applyCheck).toHaveBeenCalledWith(
+      expect.objectContaining({ authorization: { access_token: 'rotated' } }),
+      expect.objectContaining({ markValidated: expect.any(Function) })
+    )
+  })
+
+  it('does not wire check-token flow when checkTokenButtonId is omitted', () => {
+    document.body.innerHTML = buildBaseHTML({ includeCheckTokenButton: false })
+    expect(() => createOauthValidator(defaultConfig({
+      checkTokenButtonId: undefined,
+      checkTokenEndpoint: undefined,
+      buildCheckTokenPayload: undefined
+    }))).not.toThrow()
+  })
+
+  it('sets validated=false on check-token failure response', async () => {
+    document.body.innerHTML = buildBaseHTML({ validated: 'true' })
+    document.getElementById('access_token').value = 'my-access-token'
+    document.getElementById('test_validated_at').value = '2026-01-01T00:00:00Z'
+    mockFetchOK({ valid: false })
+    createOauthValidator(defaultConfig())
+
+    document.getElementById('test_check_token').disabled = false
+    document.getElementById('test_check_token').click()
+    await flushPromises()
+
+    expect(document.getElementById('test_validated').value).toBe('false')
+    expect(document.getElementById('test_validated_at').value).toBe('')
+  })
+
+  it('shows error message on check-token fetch rejection', async () => {
+    document.body.innerHTML = buildBaseHTML()
+    document.getElementById('access_token').value = 'my-access-token'
+    mockFetchReject()
+    createOauthValidator(defaultConfig())
+
+    document.getElementById('test_check_token').disabled = false
+    document.getElementById('test_check_token').click()
+    await flushPromises()
+
+    expect(document.getElementById('statusMessage').textContent)
+      .toBe('An error occurred while validating Test token.')
+  })
+
+  it('runs custom checkTokenPreflight guard when provided', () => {
+    document.body.innerHTML = buildBaseHTML()
+    document.getElementById('access_token').value = 'my-access-token'
+    const fetchMock = mockFetchOK({ valid: true })
+    createOauthValidator(defaultConfig({
+      checkTokenPreflight: ({ accessToken, clientId }) =>
+        (!accessToken.trim() || !clientId.trim())
+          ? 'Missing access token or client ID.'
+          : null
+    }))
+
+    // clientId is empty, so the preflight should abort with the custom message
+    document.getElementById('test_check_token').disabled = false
+    document.getElementById('test_check_token').click()
+
+    expect(document.getElementById('statusMessage').textContent)
+      .toBe('Missing access token or client ID.')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('proceeds when checkTokenPreflight returns null', async () => {
+    document.body.innerHTML = buildBaseHTML({ clientIdValue: 'x' })
+    document.getElementById('access_token').value = 'my-access-token'
+    const fetchMock = mockFetchOK({ valid: true })
+    createOauthValidator(defaultConfig({
+      checkTokenPreflight: () => null
+    }))
+
+    document.getElementById('test_check_token').disabled = false
+    document.getElementById('test_check_token').click()
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenCalled()
+  })
+})
+
+describe('createOauthValidator message overrides', () => {
+  it('uses custom messages from config', async () => {
+    document.body.innerHTML = buildBaseHTML({
+      clientIdValue: 'x', secretValue: 'y', secondaryValue: 'z'
+    })
+    mockFetchOK({ valid: true })
+    createOauthValidator(defaultConfig({
+      messages: {
+        validateSuccess: 'HOORAY!',
+        validateError: 'BOOM',
+        validateMissingFields: 'You forgot something.',
+        checkTokenSuccess: 'good token',
+        checkTokenError: 'bad token',
+        checkTokenMissingFields: 'no token yet'
+      }
+    }))
+
+    document.getElementById('test_validate').click()
+    await flushPromises()
+
+    expect(document.getElementById('statusMessage').textContent).toContain('HOORAY!')
+  })
+})
+
+describe('createOauthValidator credential reset listeners', () => {
+  it('resets validated state when clientId is edited', () => {
+    document.body.innerHTML = buildBaseHTML({ validated: 'true' })
+    document.getElementById('test_validated_at').value = '2026-01-01T00:00:00Z'
+    createOauthValidator(defaultConfig())
+
+    const clientIdInput = document.getElementById('test_client_id')
+    clientIdInput.value = 'a'
+    clientIdInput.dispatchEvent(new Event('input'))
+
+    expect(document.getElementById('test_validated').value).toBe('false')
+    expect(document.getElementById('test_validated_at').value).toBe('')
+  })
+
+  it('resets validated state when clientSecret is edited', () => {
+    document.body.innerHTML = buildBaseHTML({ validated: 'true' })
+    document.getElementById('test_validated_at').value = '2026-01-01T00:00:00Z'
+    createOauthValidator(defaultConfig())
+
+    const secretInput = document.getElementById('test_client_secret')
+    secretInput.value = 'new-secret'
+    secretInput.dispatchEvent(new Event('input'))
+
+    expect(document.getElementById('test_validated').value).toBe('false')
+  })
+
+  it('resets validated state when secondaryValue is edited', () => {
+    document.body.innerHTML = buildBaseHTML({ validated: 'true' })
+    createOauthValidator(defaultConfig())
+
+    const secondary = document.getElementById('test_pin')
+    secondary.value = 'newpin'
+    secondary.dispatchEvent(new Event('input'))
+
+    expect(document.getElementById('test_validated').value).toBe('false')
+  })
+})


### PR DESCRIPTION
## Summary

Roadmap issue #1335 Step 7 Phase 2 — converts `915-imagemaid.js` (1377 lines, ~250 jQuery touch points) to pure vanilla DOM. This is the smallest of the three big classic wizards so it sets the pattern before we tackle `905-analytics` (108 refs) and `900-kometa` (257 refs).

## Approach

Automated pass with a Python codemod (`/tmp/dejquery_imagemaid.py`, not committed) applied 208 mechanical conversions. The remaining ~40 sites needed hand-review for:
- Multi-class `addClass('a b c')` → split into individual `classList.add(a, b, c)` args
- Chained `.removeClass().addClass()` → split into two statements
- `.each() + $(this)` in event handlers → `forEach + this` context
- `.find('span').last()` chain → `querySelectorAll('span')[len-1]`
- `$('#a, #b, #c').on()` comma-separated selectors → new `wireInputChange(selectors, handler)` helper (DRY)
- `.empty()` → `replaceChildren()`
- `$el` and `$runSpark*` prefixed const names → prefix dropped (they're plain DOM now)

## Mechanical mappings applied

| jQuery | Vanilla |
|---|---|
| `$('#id')` | `document.getElementById('id')` |
| `$('.cls')` | `document.querySelectorAll('.cls')` |
| `$('[attr]')` | `document.querySelectorAll('[attr]')` |
| `.text(x)` / `.text()` | `.textContent = x` / `.textContent` |
| `.val(x)` / `.val()` | `.value = x` / `.value` |
| `.prop('disabled', x)` | `.disabled = x` |
| `.prop('checked', x)` | `.checked = x` |
| `.is(':checked')` | `.checked` |
| `.html(x)` | `.innerHTML = x` |
| `.addClass(x)` | `.classList.add(x)` |
| `.removeClass(x)` | `.classList.remove(x)` |
| `.toggleClass(x, b)` | `.classList.toggle(x, b)` |
| `.on(evt, fn)` | `.addEventListener(evt, fn)` |
| `.attr(k, v)` | `.setAttribute(k, v)` |
| `.scrollTop(x)` | `.scrollTop = x` |
| `$(this)` | `this` (native event-handler context) |
| `.data('foo-bar')` | `.dataset.fooBar` |
| `.each(fn)` | `forEach` |
| `.length` on single-element cache | plain truthy check |

## Bug fixes uncovered mid-refactor

Three latent issues where the post-conversion code still did `els.foo[0].scrollHeight` — that pattern returned `undefined` on plain DOM refs (as opposed to jQuery collections). Fixed to `els.foo.scrollHeight`. These would have manifested as broken autoscroll if any test had exercised the log-append paths.

## Verification

| Check | Result |
|---|---|
| `test_imagemaid_page_loads_as_module` |  pass |
| `test_imagemaid_module_does_not_leak_state_to_window` |  pass |
| `test_imagemaid_module_runs_without_console_errors` |  pass |
| Full Vitest suite | **370 pass**, 0 fail |
| ESLint | 0 errors |
| Pre-commit | 12/12 hooks green |
| Bare `$(` / `jQuery` in file | 0 (was 90) |

## Remaining jQuery in `static/local-js/`

* `900-kometa.js` (257 refs) — biggest classic wizard
* `905-analytics.js` (108 refs)
* `000-base.js` (bootstrap glue)
* `validationHandler.js` (legacy shim)

This PR reduces the total from ~460 refs across 5 files to ~370 across 4.