### PR TITLE
run marker fix part2

### DIFF
--- a/modules/process_markers.py
+++ b/modules/process_markers.py
@@ -64,7 +64,6 @@ working unchanged.
 from __future__ import annotations
 
 import threading
-import time
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -133,15 +132,11 @@ def _read_marker_lines(path):
         return []
 
 
-def _write_marker_with_pending_fallback(direct_writer, pending_writer, root, line, warning_message):
-    direct_ok = direct_writer(root, line)
-    pending_ok = pending_writer(root, line) if not direct_ok else False
-    if not direct_ok:
-        if pending_ok:
-            helpers.ts_log(warning_message, level="WARNING")
-        else:
-            helpers.ts_log(f"{warning_message.rstrip('.')} and could not be written to the pending journal.", level="WARNING")
-    return bool(direct_ok or pending_ok)
+def _append_marker_to_pending_journal(pending_writer, root, line, marker_label):
+    pending_ok = pending_writer(root, line)
+    if not pending_ok:
+        helpers.ts_log(f"Failed to append {marker_label} marker to the pending journal.", level="WARNING")
+    return bool(pending_ok)
 
 
 def _collect_unique_pending_marker_lines(*paths):
@@ -270,13 +265,11 @@ def is_logscan_maintenance_sidecar(path):
 
 
 def _write_quickstart_marker_line(kometa_root, line, marker_kind="marker"):
-    message = f"Quickstart {marker_kind} marker could not be appended to meta.log; preserved in pending journal instead."
-    return _write_marker_with_pending_fallback(
-        append_quickstart_meta_log_line,
+    return _append_marker_to_pending_journal(
         append_kometa_pending_marker_line,
         kometa_root,
         line,
-        message,
+        f"Quickstart {marker_kind}",
     )
 
 
@@ -328,22 +321,11 @@ def append_imagemaid_pending_marker_line(imagemaid_root, line):
 
 
 def _write_imagemaid_marker_line(imagemaid_root, line, log_path=None, marker_kind="marker"):
-    def direct_writer(root, value):
-        return append_quickstart_imagemaid_log_line(root, value, log_path=log_path)
-
-    pending_target = "the live ImageMaid log"
-    if log_path:
-        try:
-            pending_target = Path(log_path).name
-        except Exception:
-            pending_target = "the live ImageMaid log"
-    message = f"ImageMaid {marker_kind} marker could not be appended to {pending_target}; preserved in pending journal instead."
-    return _write_marker_with_pending_fallback(
-        direct_writer,
+    return _append_marker_to_pending_journal(
         append_imagemaid_pending_marker_line,
         imagemaid_root,
         line,
-        message,
+        f"ImageMaid {marker_kind}",
     )
 
 
@@ -481,33 +463,7 @@ def write_quickstart_imagemaid_maintenance_marker(imagemaid_root, event, mode=No
 
 
 def schedule_quickstart_run_marker(kometa_root, config_name=None, timeout_seconds=20, start_mode="current"):
-    log_path = _get_tool_log_dir(kometa_root) / "meta.log"
-    state = {"mtime": None, "size": None}
-    if log_path.exists():
-        try:
-            stat = log_path.stat()
-            state["mtime"] = stat.st_mtime
-            state["size"] = stat.st_size
-        except OSError:
-            pass
-
     def worker():
-        deadline = time.time() + timeout_seconds
-        while time.time() < deadline:
-            try:
-                if log_path.exists():
-                    stat = log_path.stat()
-                    if state["mtime"] is None:
-                        if stat.st_size > 0:
-                            write_quickstart_run_marker(kometa_root, config_name, start_mode=start_mode)
-                            return
-                    else:
-                        if stat.st_mtime != state["mtime"] and stat.st_size > 0:
-                            write_quickstart_run_marker(kometa_root, config_name, start_mode=start_mode)
-                            return
-            except OSError:
-                pass
-            time.sleep(0.5)
         write_quickstart_run_marker(kometa_root, config_name, start_mode=start_mode)
 
     threading.Thread(target=worker, daemon=True).start()

--- a/tests/test_process_markers.py
+++ b/tests/test_process_markers.py
@@ -1,8 +1,12 @@
-def test_write_quickstart_run_marker_falls_back_to_pending_journal(monkeypatch, tmp_path, qs_module):
+def test_write_quickstart_run_marker_writes_pending_journal_without_touching_meta_log(monkeypatch, tmp_path, qs_module):
     import modules.process_markers as process_markers
 
     with qs_module.app.app_context():
-        monkeypatch.setattr(process_markers, "append_quickstart_meta_log_line", lambda *_args, **_kwargs: False)
+        monkeypatch.setattr(
+            process_markers,
+            "append_quickstart_meta_log_line",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("meta.log should not be written during runtime")),
+        )
 
         ok = process_markers.write_quickstart_run_marker(tmp_path, config_name="demo", start_mode="current")
 
@@ -14,10 +18,14 @@ def test_write_quickstart_run_marker_falls_back_to_pending_journal(monkeypatch, 
     assert "config=demo" in pending_text
 
 
-def test_write_quickstart_stop_marker_falls_back_to_pending_journal(monkeypatch, tmp_path):
+def test_write_quickstart_stop_marker_writes_pending_journal_without_touching_meta_log(monkeypatch, tmp_path):
     import modules.process_markers as process_markers
 
-    monkeypatch.setattr(process_markers, "append_quickstart_meta_log_line", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(
+        process_markers,
+        "append_quickstart_meta_log_line",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("meta.log should not be written during runtime")),
+    )
 
     ok = process_markers.write_quickstart_stop_marker(tmp_path, config_name="demo", reason="user_stop")
 

--- a/tests/test_resume_hint.py
+++ b/tests/test_resume_hint.py
@@ -399,11 +399,15 @@ def test_read_logscan_text_appends_live_kometa_maintenance_sidecar(tmp_path, qs_
     assert content.count("Maintenance marker") == 1
 
 
-def test_write_quickstart_maintenance_marker_falls_back_to_pending_journal(monkeypatch, tmp_path, qs_module):
+def test_write_quickstart_maintenance_marker_writes_pending_journal_without_touching_meta_log(monkeypatch, tmp_path, qs_module):
     import modules.process_markers as process_markers
 
     kometa_root = tmp_path
-    monkeypatch.setattr(process_markers, "append_quickstart_meta_log_line", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(
+        process_markers,
+        "append_quickstart_meta_log_line",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("meta.log should not be written during runtime")),
+    )
 
     ok = qs_module._write_quickstart_maintenance_marker(kometa_root, "paused", window="02:00-05:00")
 

--- a/tests/test_start_stop.py
+++ b/tests/test_start_stop.py
@@ -393,7 +393,7 @@ def test_start_imagemaid_blocked_during_maintenance(client, tmp_path, monkeypatc
     assert data["maintenance_window"] == "01:00-02:00"
     assert "Plex maintenance window" in data["error"]
 
-    content = (log_dir / "imagemaid.log").read_text(encoding="utf-8")
+    content = (log_dir / "imagemaid.quickstart-pending.log").read_text(encoding="utf-8")
     assert "[Quickstart] Maintenance marker: event=blocked_start" in content
     assert "config=" in content
     assert "tool=imagemaid" in content
@@ -731,7 +731,7 @@ def test_stop_kometa_writes_stop_marker(tmp_path, client, monkeypatch, qs_module
 
     resp = client.post("/stop-kometa")
     assert resp.status_code == 200
-    content = (log_dir / "meta.log").read_text(encoding="utf-8")
+    content = (log_dir / "meta.quickstart-pending.log").read_text(encoding="utf-8")
     assert "[Quickstart] Run event: event=stopped" in content
     assert "tool=kometa" in content
     assert "config=bullmoose20_prod9" in content
@@ -1182,13 +1182,14 @@ def test_stop_imagemaid_writes_stop_marker(tmp_path, client, monkeypatch, qs_mod
 
     resp = client.post("/stop-imagemaid")
     assert resp.status_code == 200
-    content = log_path.read_text(encoding="utf-8")
+    pending_path = imagemaid_root / "config" / "logs" / "imagemaid.quickstart-pending.log"
+    content = pending_path.read_text(encoding="utf-8")
     assert "[Quickstart] Run event: event=stopped" in content
     assert "tool=imagemaid" in content
     assert "mode=restore" in content
 
 
-def test_write_quickstart_imagemaid_run_marker_writes_runtime_log(tmp_path, qs_module):
+def test_write_quickstart_imagemaid_run_marker_writes_pending_journal(tmp_path, qs_module):
     imagemaid_root = tmp_path / "imagemaid"
     log_path = imagemaid_root / "config" / "logs" / "imagemaid.log"
     log_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1199,7 +1200,8 @@ def test_write_quickstart_imagemaid_run_marker_writes_runtime_log(tmp_path, qs_m
     ok = qs_module._write_quickstart_imagemaid_run_marker(imagemaid_root, mode="restore", config_name="demo", log_path=log_path)
     assert ok is True
 
-    content = log_path.read_text(encoding="utf-8")
+    pending_path = imagemaid_root / "config" / "logs" / "imagemaid.quickstart-pending.log"
+    content = pending_path.read_text(encoding="utf-8")
     assert "[Quickstart] Run marker:" in content
     assert "config=demo" in content
     assert "tool=imagemaid" in content


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

## Summary

This PR switches Quickstart runtime markers to a journal-first model.

Instead of trying to write run/maintenance/stop markers directly into Kometa or ImageMaid runtime logs while those processes are active, Quickstart now writes all runtime markers to the pending journal during the run and only replays them into the canonical log after the process has stopped.

## Problem

Direct runtime writes to `meta.log` and `imagemaid.log` were not reliable while Kometa/ImageMaid were running.

Observed behavior showed:
- the config marker was present and echoed by Kometa
- actual runtime markers were inconsistent or missing
- maintenance pause/resume logic fired, but markers did not reliably appear in the live log
- fallback timing was confusing because some markers only appeared later via replay

That made marker persistence nondeterministic and difficult to reason about.

## What changed

### Runtime markers are now journal-first

During an active run, Quickstart no longer writes runtime markers directly to:
- `meta.log`
- `imagemaid.log`

Instead, runtime markers are written only to:
- `meta.quickstart-pending.log`
- `imagemaid.quickstart-pending.log`

This applies to:
- run markers
- maintenance markers
- stop/run-event markers

### Config marker remains immediate

The config/YAML marker behavior is unchanged in principle:
- the stamped config marker is still written directly into the config file
- this remains the only marker written immediately during runtime setup

### Replay still happens after stop

The existing replay/flush path remains responsible for merging pending markers into the canonical log after the process is no longer running.

That means:
- pending journal is now the source of truth during runtime
- `meta.log` / `imagemaid.log` become the persisted historical source after replay

### Run-marker scheduling simplified

Because runtime marker writes no longer depend on live log writability, `schedule_quickstart_run_marker()` no longer needs to wait for a writable `meta.log` state before writing the runtime marker to the pending journal.

## Why this is better

This model removes the ambiguity of:
- “did the direct write succeed?”
- “did it fail and fallback?”
- “was the replay delayed?”
- “did the marker get partially persisted?”

It gives Quickstart a cleaner contract:
1. write runtime markers to the pending journal during the run
2. replay them into the canonical log only after the process is stopped

That is much easier to reason about and better matches the real behavior of locked/live runtime logs.

## Files changed

Core implementation:
- `modules/process_markers.py`

Tests updated for the new contract:
- `tests/test_process_markers.py`
- `tests/test_resume_hint.py`
- `tests/test_start_stop.py`

## Test updates

Tests now assert that:
- runtime marker APIs succeed without touching live `meta.log`
- Kometa stop markers land in `meta.quickstart-pending.log`
- ImageMaid run/stop/maintenance markers land in `imagemaid.quickstart-pending.log`
- replay/flush behavior still works after the process stops

## Verification

Ran:

```powershell
venv\Scripts\python.exe -m pytest tests/test_process_markers.py tests/test_resume_hint.py tests/test_start_stop.py -q
venv\Scripts\python.exe -m pytest tests/test_logscan_endpoints.py tests/test_logscan_library_stats.py -q
```

Passed.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #1509 

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [x] Docker
- [ ] Other
