### PR TITLE
Fix: jQuery straggler .removeAttr() in 900-kometa.js breaks Final validation page

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -1879,7 +1879,7 @@ function syncIncompleteRunActions () {
   runRecovery.classList.toggle('d-none', !alertVisible)
   runRecovery.disabled = !recoveryRunnable
   if (recoveryRunnable) {
-    runRecovery.removeAttr('title')
+    runRecovery.removeAttribute('title')
   } else if (!alertVisible) {
     runRecovery.setAttribute('title', 'Recovery actions are only available when an incomplete-run recovery command is visible.')
   } else if (KOMETA_VALIDATION_IN_PROGRESS) {

--- a/tests/e2e/test_wizard_e2e.py
+++ b/tests/e2e/test_wizard_e2e.py
@@ -2064,3 +2064,78 @@ def test_overlayhandler_module_loads_via_import(page, live_server):
     assert state["hasBoards"], "OverlayHandler.initializeOverlayBoards must be a function"
     assert state["hasJumpBtns"], "OverlayHandler.initializeJumpButtons must be a function"
     assert state["hasToggleSync"], "window.setupParentChildToggleSync must be a function"
+
+
+# Regression test for the jQuery straggler `runRecovery.removeAttr('title')`
+# fixed in fix/900-kometa-removeattr-regression.
+#
+# Original bug: syncIncompleteRunActions() called runRecovery.removeAttr('title')
+# — a jQuery method. On the vanilla DOM node returned by
+# document.getElementById(), that throws TypeError, breaking the whole
+# updateValidationGate() chain.
+#
+# The bug fires only when recoveryRunnable === true, which requires
+# (a) #run-recovery-command exists, (b) #incomplete-run-alert visible,
+# (c) #recovery-command-output has non-empty text, (d) no in-progress flags.
+# In the natural /step/900-kometa render these elements only appear when
+# an incomplete resume hint exists — the existing generic console-error
+# smoke test misses this code path entirely.
+#
+# We use `page.add_init_script` to install those elements BEFORE the
+# module bootstraps, then assert no TypeError fired.
+
+
+@pytest.mark.e2e
+def test_900_kometa_sync_incomplete_run_actions_no_jquery(page, live_server):
+    errors: list[str] = []
+    page.on("pageerror", lambda exc: errors.append(str(exc)))
+    page.on(
+        "console",
+        lambda msg: errors.append(f"{msg.type}: {msg.text}") if msg.type == "error" else None,
+    )
+
+    # Inject the incomplete-run DOM at DOMContentLoaded, before 900-kometa.js
+    # runs its bootstrap chain (updateValidationGate -> updateRunNowState ->
+    # syncIncompleteRunActions). This puts us into the recoveryRunnable=true
+    # branch that hits the removeAttribute() call.
+    page.add_init_script("""
+        document.addEventListener('DOMContentLoaded', function () {
+            if (!document.getElementById('incomplete-run-alert')) {
+                const alert = document.createElement('div')
+                alert.id = 'incomplete-run-alert'
+                alert.className = 'alert alert-warning'
+                document.body.appendChild(alert)
+            }
+            if (!document.getElementById('recovery-command-output')) {
+                const cmd = document.createElement('code')
+                cmd.id = 'recovery-command-output'
+                cmd.textContent = 'kometa --run something'
+                document.body.appendChild(cmd)
+            }
+            if (!document.getElementById('run-recovery-command')) {
+                const btn = document.createElement('button')
+                btn.id = 'run-recovery-command'
+                btn.setAttribute('title', 'stale placeholder title')
+                document.body.appendChild(btn)
+            }
+        }, { once: true })
+    """)
+
+    page.goto(f"{live_server}/step/900-kometa", wait_until="domcontentloaded")
+    # Let the module fully bootstrap.
+    page.wait_for_timeout(500)
+
+    # 1) No TypeError from a jQuery-shaped call.
+    remove_attr_errors = [e for e in errors if "removeAttr" in e or "is not a function" in e]
+    assert not remove_attr_errors, f"900-kometa.js hit a jQuery-shaped method on a vanilla DOM element: " f"{remove_attr_errors}"
+
+    # 2) The button's stale placeholder title should be gone — proof that
+    #    removeAttribute() ran successfully in the recoveryRunnable=true
+    #    branch. (If the call had thrown, the title would still be there.)
+    button_title = page.evaluate("""() => {
+        const btn = document.getElementById('run-recovery-command')
+        return btn ? btn.getAttribute('title') : '__missing__'
+    }""")
+    assert button_title != "stale placeholder title", (
+        f"syncIncompleteRunActions didn't update the title (got: " f"'{button_title}'). Suggests the function threw before reaching " f"the title-setting branch."
+    )


### PR DESCRIPTION
## The bug

User reported the Final validation page (`/step/900-kometa`) throwing on load:

```
900-kometa.js:1882 Uncaught TypeError: runRecovery.removeAttr is not a function
    at syncIncompleteRunActions (900-kometa.js:1882:17)
    at updateRunNowState (900-kometa.js:928:5)
    at updateValidationGate (900-kometa.js:415:3)
    at 900-kometa.js:419:1
```

This breaks the entire `updateValidationGate` bootstrap chain.

## Root cause

Line 1882 called `runRecovery.removeAttr('title')` — a **jQuery method**. Since we removed jQuery in PR #1545, that method no longer exists. `runRecovery` is a vanilla DOM node from `document.getElementById()`, so it needs `.removeAttribute('title')`.

This is a straggler the Phase 2 de-jQuery sweep of `900-kometa.js` (PR #1541) missed. It's inside the `recoveryRunnable` branch, which only fires when the user has an incomplete-run resume hint — the natural render path in local dev and existing e2e tests doesn't hit that state, so it slipped through the generic console-error smoke test at `test_kometa_module_runs_without_console_errors`.

## Fix

One-character change: `.removeAttr` → `.removeAttribute`.

I also swept the entire `static/local-js/` tree for any other `.removeAttr(` calls (zero left) and audited the other jQuery-shape methods (`.on()`, `.toggleClass()`, etc.) — all remaining calls are on the custom `elementGroup` wrapper, which has its own compatible API. No other stragglers.

## Regression test

Added `tests/e2e/test_wizard_e2e.py::test_900_kometa_sync_incomplete_run_actions_no_jquery`.

The tricky part: forcing the `recoveryRunnable=true` branch requires `#incomplete-run-alert`, `#recovery-command-output`, and `#run-recovery-command` to all exist at module bootstrap. In the natural render those only appear when there's an actual incomplete resume hint. Solution: use Playwright's `page.add_init_script` to install those elements at `DOMContentLoaded`, **before** `900-kometa.js` bootstraps its `updateValidationGate` chain.

The test asserts:
1. No `removeAttr is not a function` TypeError fires
2. The stale placeholder `title` attribute is actually removed (proving `removeAttribute()` ran successfully in the intended branch)

Verified the test correctly:
- **FAILS** with the old jQuery-shape code (I temporarily reverted the fix and confirmed the error)
- **PASSES** with the fix in place

## Verification

- Playwright e2e test: passes with fix, fails without fix
- pre-commit hooks: all green (eslint, ruff, black)
- No other `.removeAttr` calls anywhere in `static/local-js/`