### PR TITLE
fix the markers linewrap and unknown

### DIFF
--- a/modules/process_markers.py
+++ b/modules/process_markers.py
@@ -85,6 +85,11 @@ def _get_version_info():
     return app.config.get("VERSION_CHECK") or {}
 
 
+def _resolve_version_fields(version_info=None):
+    data = version_info if version_info is not None else _get_version_info()
+    return data.get("local_version") or "unknown", data.get("branch") or "unknown"
+
+
 def _get_tool_log_dir(root):
     return Path(root) / "config" / "logs"
 
@@ -156,6 +161,25 @@ def _clear_marker_artifacts(*paths):
         _delete_text_file(path)
 
 
+def _logger_body(line):
+    if "|" not in line:
+        return str(line).strip()
+    return line.split("|", 1)[1].rsplit("|", 1)[0].strip()
+
+
+def _is_config_marker_continuation(line):
+    body = _logger_body(line)
+    if not body or body.startswith("#") or "[Quickstart]" in body:
+        return False
+    return "=" in body and ("[config.py:" in line.lower() or line.startswith(" "))
+
+
+def _has_config_marker(line):
+    stripped = str(line).lstrip()
+    body = _logger_body(line)
+    return any(stripped.startswith(prefix) or body.startswith(prefix) for prefix in QS_CONFIG_MARKER_PREFIXES)
+
+
 def _flush_pending_marker_file(log_path, pending_paths, marker_label):
     try:
         log_path = Path(log_path)
@@ -181,9 +205,10 @@ def _flush_pending_marker_file(log_path, pending_paths, marker_label):
         anchor_name = "eof"
 
         for idx, line in enumerate(file_lines):
-            stripped = line.lstrip()
-            if any(stripped.startswith(prefix) for prefix in QS_CONFIG_MARKER_PREFIXES):
+            if _has_config_marker(line):
                 anchor_index = idx + 1
+                while anchor_index < len(file_lines) and _is_config_marker_continuation(file_lines[anchor_index]):
+                    anchor_index += 1
                 anchor_name = "config_marker"
                 break
 
@@ -191,6 +216,9 @@ def _flush_pending_marker_file(log_path, pending_paths, marker_label):
             for idx, line in enumerate(file_lines):
                 if "[Quickstart]" in line:
                     anchor_index = idx + 1
+                    if _has_config_marker(line):
+                        while anchor_index < len(file_lines) and _is_config_marker_continuation(file_lines[anchor_index]):
+                            anchor_index += 1
                     anchor_name = "quickstart_line"
                     break
 
@@ -343,11 +371,9 @@ def flush_imagemaid_pending_markers(imagemaid_root, log_path=None, require_proce
     )
 
 
-def write_quickstart_run_marker(kometa_root, config_name=None, start_mode="current"):
+def write_quickstart_run_marker(kometa_root, config_name=None, start_mode="current", version_info=None):
     try:
-        version_info = _get_version_info()
-        qs_version = version_info.get("local_version") or "unknown"
-        qs_branch = version_info.get("branch") or "unknown"
+        qs_version, qs_branch = _resolve_version_fields(version_info)
         safe_config = (config_name or "default").strip() or "default"
         safe_start_mode = normalize_kometa_start_mode(start_mode)
         timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
@@ -463,8 +489,10 @@ def write_quickstart_imagemaid_maintenance_marker(imagemaid_root, event, mode=No
 
 
 def schedule_quickstart_run_marker(kometa_root, config_name=None, timeout_seconds=20, start_mode="current"):
+    version_info = dict(_get_version_info())
+
     def worker():
-        write_quickstart_run_marker(kometa_root, config_name, start_mode=start_mode)
+        write_quickstart_run_marker(kometa_root, config_name, start_mode=start_mode, version_info=version_info)
 
     threading.Thread(target=worker, daemon=True).start()
 

--- a/tests/test_process_markers.py
+++ b/tests/test_process_markers.py
@@ -18,6 +18,34 @@ def test_write_quickstart_run_marker_writes_pending_journal_without_touching_met
     assert "config=demo" in pending_text
 
 
+def test_schedule_quickstart_run_marker_preserves_version_outside_app_context(monkeypatch, tmp_path, qs_module):
+    import modules.process_markers as process_markers
+
+    captured = {}
+
+    class FakeThread:
+        def __init__(self, target, daemon=False):
+            captured["target"] = target
+            captured["daemon"] = daemon
+
+        def start(self):
+            captured["started"] = True
+
+    monkeypatch.setattr(process_markers.threading, "Thread", FakeThread)
+    qs_module.app.config["VERSION_CHECK"] = {"local_version": "0.10.4-build236", "branch": "develop"}
+
+    with qs_module.app.app_context():
+        process_markers.schedule_quickstart_run_marker(tmp_path, config_name="demo", start_mode="current")
+
+    assert captured["started"] is True
+    assert captured["daemon"] is True
+    captured["target"]()
+
+    pending_text = process_markers.get_kometa_pending_marker_path(tmp_path).read_text(encoding="utf-8")
+    assert "quickstart=0.10.4-build236" in pending_text
+    assert "branch=develop" in pending_text
+
+
 def test_write_quickstart_stop_marker_writes_pending_journal_without_touching_meta_log(monkeypatch, tmp_path):
     import modules.process_markers as process_markers
 
@@ -68,6 +96,42 @@ def test_flush_quickstart_pending_markers_falls_back_to_first_quickstart_line(mo
     continue_index = saved_text.index("[2026-05-05 01:01:00,000]")
     assert run_marker_index < replay_index < continue_index
     assert not pending_path.exists()
+
+
+def test_flush_quickstart_pending_markers_inserts_after_wrapped_config_marker(monkeypatch, tmp_path, qs_module):
+    log_dir = tmp_path / "config" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    meta_path = log_dir / "meta.log"
+    pending_path = log_dir / "meta.quickstart-pending.log"
+    run_marker_line = (
+        "[2026-07-07 16:48:11,436] [config.py:296]             [DEBUG]    | " "# [Quickstart] Run marker: started=2026-07-07T20:48:08.128590+00:00                                |"
+    )
+    marker_continuation_line = (
+        "[2026-07-07 16:48:11,436] [config.py:296]             [DEBUG]    | " "  config=docker_unraid_bullmoose20_prod quickstart=0.10.4-build236 branch=develop                  |"
+    )
+    warning_line = (
+        "[2026-07-07 16:48:12,093] [config.py:625]             [WARNING]  | " "Config Warning: settings sub-attribute auto_sort_hubs not found using None as default              |"
+    )
+    meta_path.write_text(
+        "\n".join([run_marker_line, marker_continuation_line, warning_line]) + "\n",
+        encoding="utf-8",
+    )
+    pending_path.write_text(
+        "[Quickstart] Maintenance marker: event=paused at=2026-07-07T20:49:15Z local_at=2026-07-07T16:49:15 window=02:00-19:00\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(qs_module.helpers, "is_kometa_running", lambda: False)
+    result = qs_module._flush_quickstart_pending_markers(tmp_path, require_process_stopped=True)
+
+    assert result["flushed"] is True
+    assert result["anchor"] == "config_marker"
+    saved_text = meta_path.read_text(encoding="utf-8")
+    run_marker_index = saved_text.index("# [Quickstart] Run marker:")
+    continuation_index = saved_text.index("config=docker_unraid_bullmoose20_prod")
+    replay_index = saved_text.index("# [Quickstart] Marker replay start")
+    warning_index = saved_text.index("Config Warning: settings sub-attribute auto_sort_hubs")
+    assert run_marker_index < continuation_index < replay_index < warning_index
 
 
 def test_stamp_quickstart_config_marker_replaces_legacy_prefix(tmp_path):


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

```markdown
## Summary

Fix Quickstart run marker replay handling for Kometa logs.

This addresses two related issues:

- Replay marker blocks could be inserted between the wrapped `# [Quickstart] Run marker:` line and its logger-wrapped continuation line containing `config=... quickstart=... branch=...`.
- Scheduled runtime run markers could emit `quickstart=unknown branch=unknown` because version data was read inside a background thread after Flask app context was no longer available.

## Changes

- Capture `VERSION_CHECK` before starting the scheduled run-marker background thread and pass it into the marker writer.
- Add marker-line helpers to recognize Quickstart config markers inside raw Kometa `config.py` debug log lines.
- Advance replay insertion past wrapped config-marker continuation lines before inserting pending replay markers.
- Add regression coverage for:
  - scheduled run markers preserving Quickstart version and branch outside app context
  - replay insertion after a wrapped config marker continuation line

## Verification

```powershell
venv\Scripts\python.exe -m pytest tests\test_process_markers.py
venv\Scripts\python.exe -m pytest tests\test_resume_hint.py -k pending_markers
```

Both passed.
```

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #1509

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
