### PR TITLE
Split 900-kometa.js part 1: extract pure util helpers to modules/kometa/_util.js

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -1,4 +1,25 @@
 // Global flag so other handlers know an update is in progress
+import {
+  quoteIfNeeded,
+  formatElapsed,
+  computeYamlLineCount,
+  normalizeFontName,
+  formatHeaderStyleLabel,
+  linkifyText,
+  formatTimestampLocal,
+  clampPercent,
+  formatRunSeconds,
+  coerceRunSeconds,
+  isValidTimesFormat,
+  isTimeWithinRange,
+  applyLogFilter,
+  computeLogStats,
+  pushSparkValue,
+  buildSparklinePoints,
+  buildSparklinePointsScaled,
+  copyTextToClipboard
+} from './modules/kometa/_util.js'
+
 let KOMETA_UPDATING = false
 let KOMETA_VALIDATED = false
 let KOMETA_VALIDATION_IN_PROGRESS = false
@@ -35,6 +56,16 @@ let kometaUpdatePollInterval = null
 let kometaUpdateJobId = null
 let kometaUpdateLogIndex = 0
 
+// Sparkline state buffers. Rendering + reset + update functions that
+// operate on this still live in this file; the pure geometry helpers
+// (pushSparkValue, buildSparklinePoints, buildSparklinePointsScaled)
+// were extracted to _util.js.
+const runSparkState = {
+  cpu: { system: [], kometa: [] },
+  mem: { system: [], kometa: [] },
+  io: { read: [], write: [] }
+}
+
 const _qsEnvEl = document.getElementById('qs-env')
 const runningOn = (_qsEnvEl && _qsEnvEl.dataset.runningOn) ? _qsEnvEl.dataset.runningOn : ''
 const isWindows = typeof runningOn === 'string' && runningOn.includes('Windows')
@@ -43,15 +74,6 @@ const isWindows = typeof runningOn === 'string' && runningOn.includes('Windows')
 
 // function toDisplayPath (p) { return isWindows ? String(p).replace(/\//g, '\\') : String(p) }
 // function toPosix (p) { return String(p).replace(/\\/g, '/') }
-function quoteIfNeeded (s) { return /\s/.test(s) ? `"${s}"` : s }
-
-function formatElapsed (ms) {
-  const sec = Math.floor(ms / 1000)
-  const mm = String(Math.floor(sec / 60)).padStart(2, '0')
-  const ss = String(sec % 60).padStart(2, '0')
-  return `${mm}:${ss}`
-}
-
 const runLog = document.getElementById('run-output-log')
 const tailNotice = document.getElementById('run-output-notice')
 const tailSelect = document.getElementById('run-log-tail')
@@ -428,14 +450,6 @@ if (tailSelect) {
   })
 }
 
-function computeYamlLineCount (text) {
-  if (!text) return 0
-  const normalized = String(text).replace(/\r\n/g, '\n')
-  let count = normalized.split('\n').length
-  if (normalized.endsWith('\n')) count -= 1
-  return Math.max(0, count)
-}
-
 function updateYamlLineCount () {
   if (!yamlLineCount || !yamlOutput) return
   const lineCount = computeYamlLineCount(yamlOutput.value)
@@ -445,16 +459,6 @@ function updateYamlLineCount () {
 
 updateYamlLineCount()
 yamlOutput?.addEventListener('input', updateYamlLineCount)
-
-function normalizeFontName (value) {
-  return String(value || '').trim().replace(/_/g, ' ')
-}
-
-function formatHeaderStyleLabel (value) {
-  const text = normalizeFontName(value)
-  if (!text) return 'Single line'
-  return text.replace(/_/g, ' ').replace(/\b\w/g, letter => letter.toUpperCase())
-}
 
 function updateHeaderStyleLabel (value) {
   if (!headerStyleLabel) return
@@ -1414,31 +1418,6 @@ if (document.getElementById('run-command-output')) {
 
 initBootstrapTooltips(document, '[title]', { html: false, sanitize: true, placement: 'top', trigger: 'hover' })
 initBootstrapTooltips(document)
-
-function copyTextToClipboard (text) {
-  if (!text) return Promise.reject(new Error('Empty text'))
-  if (navigator.clipboard && navigator.clipboard.writeText) {
-    return navigator.clipboard.writeText(text)
-  }
-  return new Promise((resolve, reject) => {
-    const textarea = document.createElement('textarea')
-    textarea.value = text
-    textarea.setAttribute('readonly', '')
-    textarea.style.position = 'absolute'
-    textarea.style.left = '-9999px'
-    document.body.appendChild(textarea)
-    textarea.select()
-    try {
-      const success = document.execCommand('copy')
-      document.body.removeChild(textarea)
-      if (success) resolve()
-      else reject(new Error('Copy failed'))
-    } catch (err) {
-      document.body.removeChild(textarea)
-      reject(err)
-    }
-  })
-}
 
 function syncKometaUpdateAttention () {
   if (kometaActionsHeading && kometaActionsToggle) {
@@ -2733,51 +2712,6 @@ pauseLogBtn?.addEventListener('click', function() {
   }
 })
 
-function applyLogFilter (text, filter) {
-  if (!filter) return text
-
-  // Support literal matching by default; allow regex if user wraps with /
-  const trimmed = filter.trim()
-  let re
-  try {
-    if (trimmed.length > 2 && trimmed.startsWith('/') && trimmed.endsWith('/')) {
-      re = new RegExp(trimmed.slice(1, -1), 'i')
-    } else {
-      const escaped = trimmed.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-      re = new RegExp(escaped, 'i')
-    }
-  } catch {
-    return text
-  }
-
-  return text.split('\n').filter(line => re.test(line)).join('\n')
-}
-
-function computeLogStats (text) {
-  const stats = {
-    cache: 0,
-    debug: 0,
-    info: 0,
-    warning: 0,
-    error: 0,
-    critical: 0,
-    trace: 0
-  }
-  if (!text) return stats
-  const lines = text.split(/\r?\n/)
-  lines.forEach(line => {
-    if (!line) return
-    if (line.toLowerCase().includes('from cache')) stats.cache += 1
-    if (line.includes('[DEBUG]')) stats.debug += 1
-    if (line.includes('[INFO]')) stats.info += 1
-    if (line.includes('[WARNING]')) stats.warning += 1
-    if (line.includes('[ERROR]')) stats.error += 1
-    if (line.includes('[CRITICAL]')) stats.critical += 1
-    if (line.toLowerCase().includes('traceback')) stats.trace += 1
-  })
-  return stats
-}
-
 function updateStatRow (row, stats) {
   if (!row || !stats) return
   const keys = ['cache', 'debug', 'info', 'warning', 'error', 'critical', 'trace']
@@ -2797,144 +2731,10 @@ function renderLogStats () {
   updateStatRow(logStatsFiltered, filteredStats)
 }
 
-function formatRunSeconds (seconds) {
-  if (typeof seconds !== 'number' || !Number.isFinite(seconds)) return ''
-  const total = Math.max(0, Math.floor(seconds))
-  const hrs = Math.floor(total / 3600)
-  const mins = Math.floor((total % 3600) / 60)
-  const secs = total % 60
-  const parts = []
-  if (hrs) parts.push(`${hrs}h`)
-  if (mins || hrs) parts.push(`${mins}m`)
-  parts.push(`${secs}s`)
-  return parts.join(' ')
-}
-
-function coerceRunSeconds (value) {
-  if (typeof value === 'number' && Number.isFinite(value)) return value
-  if (typeof value !== 'string') return null
-  const trimmed = value.trim()
-  if (!trimmed) return null
-  if (/^\d+(\.\d+)?$/.test(trimmed)) return Number(trimmed)
-  const clockMatch = trimmed.match(/^(\d+):(\d{2}):(\d{2})$/)
-  if (clockMatch) {
-    const hrs = Number(clockMatch[1])
-    const mins = Number(clockMatch[2])
-    const secs = Number(clockMatch[3])
-    if ([hrs, mins, secs].every(num => Number.isFinite(num))) {
-      return (hrs * 3600) + (mins * 60) + secs
-    }
-  }
-  let total = 0
-  let matched = false
-  const hoursMatch = trimmed.match(/(\d+)\s*h\b/i)
-  if (hoursMatch) {
-    total += Number(hoursMatch[1]) * 3600
-    matched = true
-  }
-  const minsMatch = trimmed.match(/(\d+)\s*m\b/i)
-  if (minsMatch) {
-    total += Number(minsMatch[1]) * 60
-    matched = true
-  }
-  const secsMatch = trimmed.match(/(\d+)\s*s\b/i)
-  if (secsMatch) {
-    total += Number(secsMatch[1])
-    matched = true
-  }
-  if (matched && Number.isFinite(total)) return total
-  return null
-}
-
-function escapeHtml (value) {
-  return String(value || '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-}
-
-function linkifyText (value) {
-  if (!value) return ''
-  const escaped = escapeHtml(value)
-  const placeholders = []
-  let counter = 0
-  const withPlaceholders = escaped.replace(/\[(https?:\/\/[^\s\]]+)\]/g, (_match, url) => {
-    const token = `__URLTOKEN${counter}__`
-    placeholders.push({ token, url })
-    counter += 1
-    return token
-  })
-  let linked = withPlaceholders.replace(/(https?:\/\/[^\s<]+)/g, (url) => {
-    return `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`
-  })
-  placeholders.forEach(({ token, url }) => {
-    const anchor = `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`
-    linked = linked.replace(token, anchor)
-  })
-  return linked
-}
-
-function formatTimestampLocal (value) {
-  if (!value) return 'n/a'
-  const parsed = new Date(value)
-  if (Number.isNaN(parsed.getTime())) return String(value)
-  return parsed.toLocaleString()
-}
-
 function updateTailNotice () {
   if (!tailNotice) return
   const sizeLabel = tailSize === 'all' ? 'all lines' : `last ${tailSize} lines`
   tailNotice.textContent = `Showing ${sizeLabel} from meta.log`
-}
-
-const SPARKLINE_WIDTH = 180
-const SPARKLINE_HEIGHT = 48
-const SPARKLINE_PADDING = 2
-const SPARKLINE_MAX_POINTS = 40
-const runSparkState = {
-  cpu: { system: [], kometa: [] },
-  mem: { system: [], kometa: [] },
-  io: { read: [], write: [] }
-}
-
-function clampPercent (value) {
-  if (typeof value !== 'number' || !Number.isFinite(value)) return null
-  return Math.max(0, Math.min(100, value))
-}
-
-function pushSparkValue (series, value) {
-  if (value == null) {
-    if (!series.length) return false
-    series.push(series[series.length - 1])
-  } else {
-    series.push(value)
-  }
-  if (series.length > SPARKLINE_MAX_POINTS) series.shift()
-  return true
-}
-
-function buildSparklinePoints (series) {
-  if (!series.length) return ''
-  const width = SPARKLINE_WIDTH - SPARKLINE_PADDING * 2
-  const height = SPARKLINE_HEIGHT - SPARKLINE_PADDING * 2
-  const step = series.length > 1 ? width / (series.length - 1) : 0
-  return series.map((value, idx) => {
-    const x = SPARKLINE_PADDING + (idx * step)
-    const y = SPARKLINE_PADDING + (height - (height * (value / 100)))
-    return `${x.toFixed(1)},${y.toFixed(1)}`
-  }).join(' ')
-}
-
-function buildSparklinePointsScaled (series, maxValue) {
-  if (!series.length) return ''
-  const safeMax = typeof maxValue === 'number' && Number.isFinite(maxValue) && maxValue > 0 ? maxValue : 1
-  const normalized = series.map(value => {
-    if (typeof value !== 'number' || !Number.isFinite(value)) return 0
-    return Math.max(0, Math.min(100, (value / safeMax) * 100))
-  })
-  return buildSparklinePoints(normalized)
 }
 
 function renderRunSparklines () {
@@ -3943,13 +3743,6 @@ function checkKometaStatus () {
     })
 }
 
-function isValidTimesFormat (timesStr) {
-  if (!timesStr.trim()) return false
-  const times = timesStr.split('|')
-  const timeRegex = /^([01]\d|2[0-3]):[0-5]\d$/
-  return times.every(t => timeRegex.test(t.trim()))
-}
-
 function toggleTimesInputVisibility (mainOption) {
   const timesContainer = document.getElementById('times-input-container')
   if (mainOption === '--times') {
@@ -3966,15 +3759,6 @@ function getMaintenanceWindow () {
 
   const [start, end] = windowStr.split('–').map(t => t.trim())
   return { start, end } // Strings in "HH:MM" format
-}
-
-function isTimeWithinRange (time, rangeStart, rangeEnd) {
-  const toMinutes = t => {
-    const [h, m] = t.split(':').map(Number)
-    return h * 60 + m
-  }
-  const timeMin = toMinutes(time)
-  return timeMin >= toMinutes(rangeStart) && timeMin < toMinutes(rangeEnd)
 }
 
 function checkMaintenanceWarning (mainOption) {

--- a/static/local-js/modules/kometa/_util.js
+++ b/static/local-js/modules/kometa/_util.js
@@ -1,0 +1,349 @@
+// Pure utility helpers extracted from 900-kometa.js as Step 1 of the
+// classic-god-file split (see PR title / commit body for context).
+//
+// Everything in this file MUST be:
+//   1. Referentially transparent OR only touching document-level DOM
+//      APIs (no module-scoped state, no cached DOM refs)
+//   2. Independently unit-testable via Vitest
+//   3. Free of any imports from 900-kometa.js (this is a leaf module)
+//
+// If a helper needs KOMETA_STATUS, a cached DOM element, or a
+// polling handle, it does NOT belong here — it belongs in the future
+// _state.js or a feature-specific module. Keeping this file strictly
+// pure means every future extraction can freely import from it without
+// pulling in the whole god-file's transitive state.
+
+// ---------------------------------------------------------------------
+// String / formatting helpers
+// ---------------------------------------------------------------------
+
+export function quoteIfNeeded (s) {
+  return /\s/.test(s) ? `"${s}"` : s
+}
+
+export function formatElapsed (ms) {
+  const sec = Math.floor(ms / 1000)
+  const mm = String(Math.floor(sec / 60)).padStart(2, '0')
+  const ss = String(sec % 60).padStart(2, '0')
+  return `${mm}:${ss}`
+}
+
+export function computeYamlLineCount (text) {
+  if (!text) return 0
+  const normalized = String(text).replace(/\r\n/g, '\n')
+  let count = normalized.split('\n').length
+  if (normalized.endsWith('\n')) count -= 1
+  return Math.max(0, count)
+}
+
+export function normalizeFontName (value) {
+  return String(value || '').trim().replace(/_/g, ' ')
+}
+
+export function formatHeaderStyleLabel (value) {
+  const text = normalizeFontName(value)
+  if (!text) return 'Single line'
+  return text.replace(/_/g, ' ').replace(/\b\w/g, letter => letter.toUpperCase())
+}
+
+export function escapeHtml (value) {
+  return String(value || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+/**
+ * Turn plain text into HTML with any http(s) URLs converted to
+ * anchor tags. `[https://...]` bracket-wrapped URLs are also
+ * detected (the brackets are stripped from the display text).
+ *
+ * All non-URL text is escaped first, so this is safe to inject into
+ * innerHTML.
+ */
+export function linkifyText (value) {
+  if (!value) return ''
+  const escaped = escapeHtml(value)
+  const placeholders = []
+  let counter = 0
+  const withPlaceholders = escaped.replace(/\[(https?:\/\/[^\s\]]+)\]/g, (_match, url) => {
+    const token = `__URLTOKEN${counter}__`
+    placeholders.push({ token, url })
+    counter += 1
+    return token
+  })
+  let linked = withPlaceholders.replace(/(https?:\/\/[^\s<]+)/g, (url) => {
+    return `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`
+  })
+  placeholders.forEach(({ token, url }) => {
+    const anchor = `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`
+    linked = linked.replace(token, anchor)
+  })
+  return linked
+}
+
+export function formatTimestampLocal (value) {
+  if (!value) return 'n/a'
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return String(value)
+  return parsed.toLocaleString()
+}
+
+// ---------------------------------------------------------------------
+// Numeric / time helpers
+// ---------------------------------------------------------------------
+
+export function clampPercent (value) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  return Math.max(0, Math.min(100, value))
+}
+
+/**
+ * Format an integer number of seconds as e.g. "1h 5m 12s".
+ * Non-finite values return an empty string.
+ */
+export function formatRunSeconds (seconds) {
+  if (typeof seconds !== 'number' || !Number.isFinite(seconds)) return ''
+  const total = Math.max(0, Math.floor(seconds))
+  const hrs = Math.floor(total / 3600)
+  const mins = Math.floor((total % 3600) / 60)
+  const secs = total % 60
+  const parts = []
+  if (hrs) parts.push(`${hrs}h`)
+  if (mins || hrs) parts.push(`${mins}m`)
+  parts.push(`${secs}s`)
+  return parts.join(' ')
+}
+
+/**
+ * Best-effort parse of a seconds value that might come in as a
+ * number, a plain integer string, an HH:MM:SS clock string, or a
+ * mixed "Nh Nm Ns" form. Returns null if nothing sensible matches.
+ */
+export function coerceRunSeconds (value) {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  if (/^\d+(\.\d+)?$/.test(trimmed)) return Number(trimmed)
+  const clockMatch = trimmed.match(/^(\d+):(\d{2}):(\d{2})$/)
+  if (clockMatch) {
+    const hrs = Number(clockMatch[1])
+    const mins = Number(clockMatch[2])
+    const secs = Number(clockMatch[3])
+    if ([hrs, mins, secs].every(num => Number.isFinite(num))) {
+      return (hrs * 3600) + (mins * 60) + secs
+    }
+  }
+  let total = 0
+  let matched = false
+  const hoursMatch = trimmed.match(/(\d+)\s*h\b/i)
+  if (hoursMatch) {
+    total += Number(hoursMatch[1]) * 3600
+    matched = true
+  }
+  const minsMatch = trimmed.match(/(\d+)\s*m\b/i)
+  if (minsMatch) {
+    total += Number(minsMatch[1]) * 60
+    matched = true
+  }
+  const secsMatch = trimmed.match(/(\d+)\s*s\b/i)
+  if (secsMatch) {
+    total += Number(secsMatch[1])
+    matched = true
+  }
+  if (matched && Number.isFinite(total)) return total
+  return null
+}
+
+/**
+ * Return true when `timesStr` is a `|`-separated list of HH:MM
+ * clock strings (24h, zero-padded). Empty or whitespace-only strings
+ * return false.
+ */
+export function isValidTimesFormat (timesStr) {
+  if (!timesStr.trim()) return false
+  const times = timesStr.split('|')
+  const timeRegex = /^([01]\d|2[0-3]):[0-5]\d$/
+  return times.every(t => timeRegex.test(t.trim()))
+}
+
+/**
+ * True when `time` (HH:MM) is >= rangeStart and < rangeEnd.
+ * Half-open interval — matches the maintenance-window semantics
+ * the original inline function used.
+ */
+export function isTimeWithinRange (time, rangeStart, rangeEnd) {
+  const toMinutes = t => {
+    const [h, m] = t.split(':').map(Number)
+    return h * 60 + m
+  }
+  const timeMin = toMinutes(time)
+  return timeMin >= toMinutes(rangeStart) && timeMin < toMinutes(rangeEnd)
+}
+
+// ---------------------------------------------------------------------
+// Log helpers (pure text -> text / text -> counts)
+// ---------------------------------------------------------------------
+
+/**
+ * Filter a multi-line log string, returning only lines matching
+ * `filter`. If the filter is empty, the input is returned unchanged.
+ * A filter wrapped in `/.../` is treated as a case-insensitive
+ * regex; otherwise it's literal (with all regex metacharacters
+ * escaped). Invalid regex silently falls back to returning the
+ * unfiltered text.
+ */
+export function applyLogFilter (text, filter) {
+  if (!filter) return text
+  const trimmed = filter.trim()
+  let re
+  try {
+    if (trimmed.length > 2 && trimmed.startsWith('/') && trimmed.endsWith('/')) {
+      re = new RegExp(trimmed.slice(1, -1), 'i')
+    } else {
+      const escaped = trimmed.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      re = new RegExp(escaped, 'i')
+    }
+  } catch {
+    return text
+  }
+  return text.split('\n').filter(line => re.test(line)).join('\n')
+}
+
+/**
+ * Count log lines by level marker.
+ * Recognises Kometa's bracketed level tags: [DEBUG] [INFO] [WARNING]
+ * [ERROR] [CRITICAL]. `cache` counts lines containing "from cache"
+ * (case-insensitive) and `trace` counts lines containing "traceback".
+ */
+export function computeLogStats (text) {
+  const stats = {
+    cache: 0,
+    debug: 0,
+    info: 0,
+    warning: 0,
+    error: 0,
+    critical: 0,
+    trace: 0
+  }
+  if (!text) return stats
+  const lines = text.split(/\r?\n/)
+  lines.forEach(line => {
+    if (!line) return
+    if (line.toLowerCase().includes('from cache')) stats.cache += 1
+    if (line.includes('[DEBUG]')) stats.debug += 1
+    if (line.includes('[INFO]')) stats.info += 1
+    if (line.includes('[WARNING]')) stats.warning += 1
+    if (line.includes('[ERROR]')) stats.error += 1
+    if (line.includes('[CRITICAL]')) stats.critical += 1
+    if (line.toLowerCase().includes('traceback')) stats.trace += 1
+  })
+  return stats
+}
+
+// ---------------------------------------------------------------------
+// Sparkline geometry (pure)
+// ---------------------------------------------------------------------
+//
+// The stateful runSparkState buffer and the rendering functions that
+// wire these into the DOM (renderRunSparklines, updateRunSparklines,
+// resetRunSparklines) stay in the god file for now — they'll come out
+// in a later PR alongside their DOM cache-refs. What lives HERE is
+// purely the pixel-math + the shift-and-push buffer helper.
+
+export const SPARKLINE_WIDTH = 180
+export const SPARKLINE_HEIGHT = 48
+export const SPARKLINE_PADDING = 2
+export const SPARKLINE_MAX_POINTS = 40
+
+/**
+ * Push a sample onto a bounded series. `null`/`undefined` values
+ * repeat the previous sample (or are dropped if the series is empty).
+ * The series is trimmed to at most SPARKLINE_MAX_POINTS entries by
+ * shifting from the front.
+ *
+ * Returns true if a sample was appended, false otherwise (empty
+ * series + null value).
+ */
+export function pushSparkValue (series, value) {
+  if (value == null) {
+    if (!series.length) return false
+    series.push(series[series.length - 1])
+  } else {
+    series.push(value)
+  }
+  if (series.length > SPARKLINE_MAX_POINTS) series.shift()
+  return true
+}
+
+/**
+ * Convert a 0-100 series into an SVG polyline `points` attribute
+ * string within the sparkline's fixed viewport.
+ * Empty series -> empty string (safe to assign to points).
+ */
+export function buildSparklinePoints (series) {
+  if (!series.length) return ''
+  const width = SPARKLINE_WIDTH - SPARKLINE_PADDING * 2
+  const height = SPARKLINE_HEIGHT - SPARKLINE_PADDING * 2
+  const step = series.length > 1 ? width / (series.length - 1) : 0
+  return series.map((value, idx) => {
+    const x = SPARKLINE_PADDING + (idx * step)
+    const y = SPARKLINE_PADDING + (height - (height * (value / 100)))
+    return `${x.toFixed(1)},${y.toFixed(1)}`
+  }).join(' ')
+}
+
+/**
+ * Same as buildSparklinePoints but for a series with an arbitrary
+ * max (e.g. I/O throughput where percent doesn't apply). Values are
+ * normalized to 0-100 before delegating.
+ */
+export function buildSparklinePointsScaled (series, maxValue) {
+  if (!series.length) return ''
+  const safeMax = typeof maxValue === 'number' && Number.isFinite(maxValue) && maxValue > 0 ? maxValue : 1
+  const normalized = series.map(value => {
+    if (typeof value !== 'number' || !Number.isFinite(value)) return 0
+    return Math.max(0, Math.min(100, (value / safeMax) * 100))
+  })
+  return buildSparklinePoints(normalized)
+}
+
+// ---------------------------------------------------------------------
+// Clipboard (uses DOM but no module-scoped state)
+// ---------------------------------------------------------------------
+
+/**
+ * Copy the given text to the clipboard using navigator.clipboard when
+ * available, falling back to a hidden textarea + execCommand('copy')
+ * for older browsers / non-secure contexts.
+ *
+ * Returns a Promise that resolves on success and rejects with an
+ * Error on failure (empty input, permission denied, or copy failure).
+ */
+export function copyTextToClipboard (text) {
+  if (!text) return Promise.reject(new Error('Empty text'))
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    return navigator.clipboard.writeText(text)
+  }
+  return new Promise((resolve, reject) => {
+    const textarea = document.createElement('textarea')
+    textarea.value = text
+    textarea.setAttribute('readonly', '')
+    textarea.style.position = 'absolute'
+    textarea.style.left = '-9999px'
+    document.body.appendChild(textarea)
+    textarea.select()
+    try {
+      const success = document.execCommand('copy')
+      document.body.removeChild(textarea)
+      if (success) resolve()
+      else reject(new Error('Copy failed'))
+    } catch (err) {
+      document.body.removeChild(textarea)
+      reject(err)
+    }
+  })
+}

--- a/tests/js/kometa/util.test.js
+++ b/tests/js/kometa/util.test.js
@@ -1,0 +1,576 @@
+// Tests for static/local-js/modules/kometa/_util.js
+//
+// All functions in the module under test are pure or DOM-only (no
+// module-scoped state), so tests are dense and unit-shaped.
+//
+// Coverage strategy: exhaustive on the tricky ones (linkifyText's
+// escape-then-linkify order, coerceRunSeconds's four accepted forms,
+// applyLogFilter's literal-vs-regex dispatch, buildSparklinePoints'
+// pixel math) and representative on the trivial ones.
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  quoteIfNeeded,
+  formatElapsed,
+  computeYamlLineCount,
+  normalizeFontName,
+  formatHeaderStyleLabel,
+  escapeHtml,
+  linkifyText,
+  formatTimestampLocal,
+  clampPercent,
+  formatRunSeconds,
+  coerceRunSeconds,
+  isValidTimesFormat,
+  isTimeWithinRange,
+  applyLogFilter,
+  computeLogStats,
+  SPARKLINE_WIDTH,
+  SPARKLINE_HEIGHT,
+  SPARKLINE_PADDING,
+  SPARKLINE_MAX_POINTS,
+  pushSparkValue,
+  buildSparklinePoints,
+  buildSparklinePointsScaled,
+  copyTextToClipboard
+} from '../../../static/local-js/modules/kometa/_util.js'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ---------------------------------------------------------------------
+// String / formatting helpers
+// ---------------------------------------------------------------------
+
+describe('quoteIfNeeded', () => {
+  it('wraps whitespace-containing strings in double quotes', () => {
+    expect(quoteIfNeeded('has space')).toBe('"has space"')
+    expect(quoteIfNeeded('a\tb')).toBe('"a\tb"')
+    expect(quoteIfNeeded('a\nb')).toBe('"a\nb"')
+  })
+  it('returns whitespace-free strings unchanged', () => {
+    expect(quoteIfNeeded('nowhite')).toBe('nowhite')
+    expect(quoteIfNeeded('/some/path/to/kometa')).toBe('/some/path/to/kometa')
+  })
+  it('returns empty string unchanged (no whitespace present)', () => {
+    expect(quoteIfNeeded('')).toBe('')
+  })
+})
+
+describe('formatElapsed', () => {
+  it('formats sub-minute as MM:SS with zero-padded minutes', () => {
+    expect(formatElapsed(5000)).toBe('00:05')
+    expect(formatElapsed(59999)).toBe('00:59')
+  })
+  it('formats minute-plus correctly', () => {
+    expect(formatElapsed(60000)).toBe('01:00')
+    expect(formatElapsed(125000)).toBe('02:05')
+  })
+  it('handles multi-hour without overflow to hours (stays MM:SS)', () => {
+    expect(formatElapsed(3600000)).toBe('60:00')
+    expect(formatElapsed(3665000)).toBe('61:05')
+  })
+  it('handles 0ms', () => {
+    expect(formatElapsed(0)).toBe('00:00')
+  })
+})
+
+describe('computeYamlLineCount', () => {
+  it('returns 0 for empty or falsy input', () => {
+    expect(computeYamlLineCount('')).toBe(0)
+    expect(computeYamlLineCount(null)).toBe(0)
+    expect(computeYamlLineCount(undefined)).toBe(0)
+  })
+  it('counts a single non-terminated line as 1', () => {
+    expect(computeYamlLineCount('one line')).toBe(1)
+  })
+  it('counts newline-separated lines', () => {
+    expect(computeYamlLineCount('a\nb\nc')).toBe(3)
+  })
+  it('drops the trailing empty line when input ends with \\n', () => {
+    expect(computeYamlLineCount('a\nb\n')).toBe(2)
+  })
+  it('normalizes \\r\\n to \\n before counting', () => {
+    expect(computeYamlLineCount('a\r\nb\r\nc')).toBe(3)
+    expect(computeYamlLineCount('a\r\nb\r\n')).toBe(2)
+  })
+})
+
+describe('normalizeFontName', () => {
+  it('trims whitespace and replaces underscores with spaces', () => {
+    expect(normalizeFontName('  hello_world  ')).toBe('hello world')
+  })
+  it('handles null/undefined by returning empty string', () => {
+    expect(normalizeFontName(null)).toBe('')
+    expect(normalizeFontName(undefined)).toBe('')
+  })
+  it('leaves already-clean names alone', () => {
+    expect(normalizeFontName('roboto')).toBe('roboto')
+  })
+})
+
+describe('formatHeaderStyleLabel', () => {
+  it('returns "Single line" for empty input', () => {
+    expect(formatHeaderStyleLabel('')).toBe('Single line')
+    expect(formatHeaderStyleLabel(null)).toBe('Single line')
+  })
+  it('title-cases the normalized name', () => {
+    expect(formatHeaderStyleLabel('open_sans')).toBe('Open Sans')
+    expect(formatHeaderStyleLabel('roboto_condensed')).toBe('Roboto Condensed')
+  })
+})
+
+describe('escapeHtml', () => {
+  it('escapes the five standard HTML entities', () => {
+    expect(escapeHtml('<a href="x&y">it\'s</a>'))
+      .toBe('&lt;a href=&quot;x&amp;y&quot;&gt;it&#39;s&lt;/a&gt;')
+  })
+  it('returns empty string for falsy input', () => {
+    expect(escapeHtml(null)).toBe('')
+    expect(escapeHtml(undefined)).toBe('')
+    expect(escapeHtml('')).toBe('')
+  })
+  it('coerces non-string values to string first', () => {
+    expect(escapeHtml(42)).toBe('42')
+  })
+})
+
+describe('linkifyText', () => {
+  it('returns empty string for falsy input', () => {
+    expect(linkifyText('')).toBe('')
+    expect(linkifyText(null)).toBe('')
+  })
+  it('escapes text and linkifies http URLs', () => {
+    const out = linkifyText('see https://example.com/x for more')
+    expect(out).toContain('<a href="https://example.com/x"')
+    expect(out).toContain('target="_blank"')
+    expect(out).toContain('rel="noopener noreferrer"')
+  })
+  it('handles bracket-wrapped URLs (removes the brackets from anchor)', () => {
+    const out = linkifyText('go to [https://example.com] now')
+    expect(out).toContain('<a href="https://example.com"')
+    // The literal `[` and `]` do NOT appear around the anchor.
+    expect(out).not.toContain('[<a')
+    expect(out).not.toContain('a>]')
+  })
+  it('escapes untrusted markup BEFORE linkifying (no HTML injection)', () => {
+    const out = linkifyText('<script>alert(1)</script> https://x.example.com')
+    // Script tag must be escaped:
+    expect(out).toContain('&lt;script&gt;')
+    // The URL must still be linkified:
+    expect(out).toContain('<a href="https://x.example.com"')
+  })
+  it('handles multiple URLs in one input', () => {
+    const out = linkifyText('a https://x.com and https://y.com')
+    const anchorCount = (out.match(/<a href="/g) || []).length
+    expect(anchorCount).toBe(2)
+  })
+})
+
+describe('formatTimestampLocal', () => {
+  it('returns "n/a" for null/undefined/empty', () => {
+    expect(formatTimestampLocal(null)).toBe('n/a')
+    expect(formatTimestampLocal('')).toBe('n/a')
+  })
+  it('returns the original string when parsing fails', () => {
+    expect(formatTimestampLocal('not-a-date')).toBe('not-a-date')
+  })
+  it('formats a valid ISO timestamp using toLocaleString', () => {
+    const iso = '2026-06-30T12:34:56.000Z'
+    const expected = new Date(iso).toLocaleString()
+    expect(formatTimestampLocal(iso)).toBe(expected)
+  })
+})
+
+// ---------------------------------------------------------------------
+// Numeric / time helpers
+// ---------------------------------------------------------------------
+
+describe('clampPercent', () => {
+  it('clamps to [0, 100]', () => {
+    expect(clampPercent(-5)).toBe(0)
+    expect(clampPercent(0)).toBe(0)
+    expect(clampPercent(42.5)).toBe(42.5)
+    expect(clampPercent(100)).toBe(100)
+    expect(clampPercent(500)).toBe(100)
+  })
+  it('returns null for non-finite or non-number inputs', () => {
+    expect(clampPercent(null)).toBeNull()
+    expect(clampPercent(undefined)).toBeNull()
+    expect(clampPercent('42')).toBeNull()
+    expect(clampPercent(NaN)).toBeNull()
+    expect(clampPercent(Infinity)).toBeNull()
+  })
+})
+
+describe('formatRunSeconds', () => {
+  it('returns empty string for non-finite / non-number', () => {
+    expect(formatRunSeconds(null)).toBe('')
+    expect(formatRunSeconds(NaN)).toBe('')
+    expect(formatRunSeconds('12')).toBe('')
+    expect(formatRunSeconds(Infinity)).toBe('')
+  })
+  it('formats seconds-only', () => {
+    expect(formatRunSeconds(0)).toBe('0s')
+    expect(formatRunSeconds(45)).toBe('45s')
+    expect(formatRunSeconds(59)).toBe('59s')
+  })
+  it('formats minutes and seconds', () => {
+    expect(formatRunSeconds(60)).toBe('1m 0s')
+    expect(formatRunSeconds(125)).toBe('2m 5s')
+  })
+  it('formats hours/minutes/seconds', () => {
+    expect(formatRunSeconds(3661)).toBe('1h 1m 1s')
+    expect(formatRunSeconds(7200)).toBe('2h 0m 0s')
+  })
+  it('floors and clamps negatives to zero', () => {
+    expect(formatRunSeconds(-5)).toBe('0s')
+    expect(formatRunSeconds(1.9)).toBe('1s')
+  })
+})
+
+describe('coerceRunSeconds', () => {
+  it('passes through finite numbers', () => {
+    expect(coerceRunSeconds(42)).toBe(42)
+    expect(coerceRunSeconds(3.14)).toBe(3.14)
+  })
+  it('rejects non-finite numbers', () => {
+    expect(coerceRunSeconds(NaN)).toBeNull()
+    expect(coerceRunSeconds(Infinity)).toBeNull()
+  })
+  it('returns null for non-string non-number inputs', () => {
+    expect(coerceRunSeconds(null)).toBeNull()
+    expect(coerceRunSeconds(undefined)).toBeNull()
+    expect(coerceRunSeconds({})).toBeNull()
+  })
+  it('returns null for empty / whitespace strings', () => {
+    expect(coerceRunSeconds('')).toBeNull()
+    expect(coerceRunSeconds('   ')).toBeNull()
+  })
+  it('parses plain integer strings', () => {
+    expect(coerceRunSeconds('42')).toBe(42)
+    expect(coerceRunSeconds('3.14')).toBe(3.14)
+  })
+  it('parses HH:MM:SS clock strings', () => {
+    expect(coerceRunSeconds('01:02:03')).toBe(3723)
+    expect(coerceRunSeconds('0:00:45')).toBe(45)
+    expect(coerceRunSeconds('10:00:00')).toBe(36000)
+  })
+  it('parses "1h 2m 3s" mixed forms', () => {
+    expect(coerceRunSeconds('1h 2m 3s')).toBe(3723)
+    expect(coerceRunSeconds('5m')).toBe(300)
+    expect(coerceRunSeconds('45s')).toBe(45)
+    expect(coerceRunSeconds('2h')).toBe(7200)
+  })
+  it('is case-insensitive on the h/m/s suffixes', () => {
+    expect(coerceRunSeconds('1H 2M 3S')).toBe(3723)
+  })
+  it('returns null for strings with no recognizable form', () => {
+    expect(coerceRunSeconds('yesterday')).toBeNull()
+    expect(coerceRunSeconds('12:34')).toBeNull()  // MM:SS is NOT recognized
+  })
+})
+
+describe('isValidTimesFormat', () => {
+  it('accepts a single HH:MM (24h, zero-padded)', () => {
+    expect(isValidTimesFormat('05:00')).toBe(true)
+    expect(isValidTimesFormat('23:59')).toBe(true)
+  })
+  it('accepts pipe-delimited multi-time', () => {
+    expect(isValidTimesFormat('05:00|17:30')).toBe(true)
+    expect(isValidTimesFormat('05:00 | 17:30')).toBe(true)  // whitespace-trimmed
+  })
+  it('rejects times with hour out of range', () => {
+    expect(isValidTimesFormat('24:00')).toBe(false)
+    expect(isValidTimesFormat('99:00')).toBe(false)
+  })
+  it('rejects times with minute out of range', () => {
+    expect(isValidTimesFormat('12:60')).toBe(false)
+  })
+  it('rejects non-padded hours', () => {
+    expect(isValidTimesFormat('5:00')).toBe(false)
+  })
+  it('rejects empty or whitespace-only', () => {
+    expect(isValidTimesFormat('')).toBe(false)
+    expect(isValidTimesFormat('   ')).toBe(false)
+  })
+  it('rejects if any part is invalid', () => {
+    expect(isValidTimesFormat('05:00|garbage')).toBe(false)
+  })
+})
+
+describe('isTimeWithinRange', () => {
+  it('returns true when time is inside a normal range', () => {
+    expect(isTimeWithinRange('03:00', '02:00', '04:00')).toBe(true)
+  })
+  it('returns true at the start of the range (inclusive)', () => {
+    expect(isTimeWithinRange('02:00', '02:00', '04:00')).toBe(true)
+  })
+  it('returns false at the end of the range (exclusive)', () => {
+    expect(isTimeWithinRange('04:00', '02:00', '04:00')).toBe(false)
+  })
+  it('returns false when time is before the range', () => {
+    expect(isTimeWithinRange('01:59', '02:00', '04:00')).toBe(false)
+  })
+  it('returns false when time is after the range', () => {
+    expect(isTimeWithinRange('04:01', '02:00', '04:00')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------
+// Log helpers
+// ---------------------------------------------------------------------
+
+describe('applyLogFilter', () => {
+  it('returns text unchanged when filter is empty', () => {
+    expect(applyLogFilter('a\nb\nc', '')).toBe('a\nb\nc')
+    expect(applyLogFilter('a\nb\nc', null)).toBe('a\nb\nc')
+  })
+  it('applies a literal case-insensitive filter', () => {
+    expect(applyLogFilter('AAA\nbbb\nCcC', 'a')).toBe('AAA')
+  })
+  it('escapes regex metacharacters in literal filters', () => {
+    // Without escaping, `.` would match any character. With escaping,
+    // it should only match literal periods.
+    const log = 'foo.bar\nfoo_bar'
+    expect(applyLogFilter(log, 'foo.bar')).toBe('foo.bar')
+  })
+  it('treats /.../ as a case-insensitive regex', () => {
+    const log = 'AAA\nbbb\nCcC'
+    expect(applyLogFilter(log, '/a|b/')).toBe('AAA\nbbb')
+  })
+  it('falls back to original text on invalid regex', () => {
+    const log = 'AAA\nbbb'
+    expect(applyLogFilter(log, '/[/')).toBe('AAA\nbbb')
+  })
+  it('returns empty string when no lines match', () => {
+    expect(applyLogFilter('AAA\nbbb', 'zzz')).toBe('')
+  })
+})
+
+describe('computeLogStats', () => {
+  it('returns all zeros for empty/falsy input', () => {
+    const stats = computeLogStats('')
+    expect(stats).toEqual({
+      cache: 0, debug: 0, info: 0, warning: 0, error: 0, critical: 0, trace: 0
+    })
+  })
+  it('counts bracketed level tags', () => {
+    const log = '[DEBUG] a\n[INFO] b\n[INFO] c\n[WARNING] d\n[ERROR] e\n[CRITICAL] f'
+    const stats = computeLogStats(log)
+    expect(stats.debug).toBe(1)
+    expect(stats.info).toBe(2)
+    expect(stats.warning).toBe(1)
+    expect(stats.error).toBe(1)
+    expect(stats.critical).toBe(1)
+  })
+  it('counts "from cache" (case-insensitive) as cache hits', () => {
+    const log = 'loaded FROM CACHE\nSomething from cache\nnope'
+    expect(computeLogStats(log).cache).toBe(2)
+  })
+  it('counts "traceback" (case-insensitive) as trace lines', () => {
+    const log = 'Traceback (most recent call last):\ntraceback: nope\nfine'
+    expect(computeLogStats(log).trace).toBe(2)
+  })
+  it('handles CRLF line endings', () => {
+    const log = '[DEBUG] a\r\n[INFO] b\r\n'
+    const stats = computeLogStats(log)
+    expect(stats.debug).toBe(1)
+    expect(stats.info).toBe(1)
+  })
+  it('skips empty lines', () => {
+    const log = '\n\n[INFO] one\n\n'
+    expect(computeLogStats(log).info).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------
+// Sparkline helpers
+// ---------------------------------------------------------------------
+
+describe('SPARKLINE constants', () => {
+  it('exports the expected fixed values', () => {
+    expect(SPARKLINE_WIDTH).toBe(180)
+    expect(SPARKLINE_HEIGHT).toBe(48)
+    expect(SPARKLINE_PADDING).toBe(2)
+    expect(SPARKLINE_MAX_POINTS).toBe(40)
+  })
+})
+
+describe('pushSparkValue', () => {
+  it('appends a value to the series', () => {
+    const series = [10, 20]
+    pushSparkValue(series, 30)
+    expect(series).toEqual([10, 20, 30])
+  })
+  it('returns true when a value was appended', () => {
+    expect(pushSparkValue([10], 20)).toBe(true)
+  })
+  it('repeats the previous value when passed null/undefined', () => {
+    const series = [10, 20]
+    pushSparkValue(series, null)
+    expect(series).toEqual([10, 20, 20])
+    pushSparkValue(series, undefined)
+    expect(series).toEqual([10, 20, 20, 20])
+  })
+  it('does NOT push and returns false when series is empty AND value is null', () => {
+    const series = []
+    expect(pushSparkValue(series, null)).toBe(false)
+    expect(series).toEqual([])
+  })
+  it('trims to at most SPARKLINE_MAX_POINTS by shifting from front', () => {
+    const series = Array.from({ length: SPARKLINE_MAX_POINTS }, (_, i) => i)
+    pushSparkValue(series, 999)
+    expect(series).toHaveLength(SPARKLINE_MAX_POINTS)
+    expect(series[series.length - 1]).toBe(999)
+    expect(series[0]).toBe(1)  // 0 was shifted off
+  })
+})
+
+describe('buildSparklinePoints', () => {
+  it('returns empty string for empty series', () => {
+    expect(buildSparklinePoints([])).toBe('')
+  })
+  it('renders a single point in the middle of the y-axis for value 50', () => {
+    // With value=50 and step=0 (only one point), x = SPARKLINE_PADDING,
+    // y = SPARKLINE_PADDING + (H - H*0.5) where H = SPARKLINE_HEIGHT-2*PAD
+    const height = SPARKLINE_HEIGHT - SPARKLINE_PADDING * 2
+    const expectedY = SPARKLINE_PADDING + (height - (height * 0.5))
+    expect(buildSparklinePoints([50])).toBe(
+      `${SPARKLINE_PADDING.toFixed(1)},${expectedY.toFixed(1)}`
+    )
+  })
+  it('places value=0 at the bottom of the plot area', () => {
+    const height = SPARKLINE_HEIGHT - SPARKLINE_PADDING * 2
+    const expectedY = SPARKLINE_PADDING + height
+    expect(buildSparklinePoints([0])).toContain(`,${expectedY.toFixed(1)}`)
+  })
+  it('places value=100 at the top of the plot area', () => {
+    expect(buildSparklinePoints([100])).toContain(`,${SPARKLINE_PADDING.toFixed(1)}`)
+  })
+  it('spaces multi-point series evenly across the plot width', () => {
+    const out = buildSparklinePoints([100, 100, 100])
+    const points = out.split(' ')
+    expect(points).toHaveLength(3)
+    // With 3 points, step = (W - 2*PAD) / 2. First x = PAD, last x = W - PAD.
+    const firstX = parseFloat(points[0].split(',')[0])
+    const lastX = parseFloat(points[points.length - 1].split(',')[0])
+    expect(firstX).toBeCloseTo(SPARKLINE_PADDING, 1)
+    expect(lastX).toBeCloseTo(SPARKLINE_WIDTH - SPARKLINE_PADDING, 1)
+  })
+})
+
+describe('buildSparklinePointsScaled', () => {
+  it('returns empty string for empty series', () => {
+    expect(buildSparklinePointsScaled([], 100)).toBe('')
+  })
+  it('scales values proportionally to maxValue', () => {
+    // [50] with maxValue=100 should look identical to [50] in buildSparklinePoints
+    expect(buildSparklinePointsScaled([50], 100))
+      .toBe(buildSparklinePoints([50]))
+  })
+  it('normalizes to 0-100 range even for maxValue > 100', () => {
+    // [500] with maxValue=1000 should look like [50]
+    expect(buildSparklinePointsScaled([500], 1000))
+      .toBe(buildSparklinePoints([50]))
+  })
+  it('uses maxValue=1 as a safe fallback when maxValue is 0/negative/non-finite', () => {
+    // With safeMax=1, [0.5] should render as (0.5/1)*100 = 50%
+    expect(buildSparklinePointsScaled([0.5], 0))
+      .toBe(buildSparklinePoints([50]))
+    expect(buildSparklinePointsScaled([0.5], -100))
+      .toBe(buildSparklinePoints([50]))
+    expect(buildSparklinePointsScaled([0.5], NaN))
+      .toBe(buildSparklinePoints([50]))
+  })
+  it('clamps values outside [0, safeMax] into [0, 100] after normalization', () => {
+    // 200 with maxValue=100 -> 200%, clamped to 100
+    expect(buildSparklinePointsScaled([200], 100))
+      .toBe(buildSparklinePoints([100]))
+    // -10 with maxValue=100 -> -10%, clamped to 0
+    expect(buildSparklinePointsScaled([-10], 100))
+      .toBe(buildSparklinePoints([0]))
+  })
+  it('treats non-finite entries as 0', () => {
+    expect(buildSparklinePointsScaled([NaN], 100))
+      .toBe(buildSparklinePoints([0]))
+    expect(buildSparklinePointsScaled([Infinity], 100))
+      .toBe(buildSparklinePoints([0]))
+  })
+})
+
+// ---------------------------------------------------------------------
+// Clipboard
+// ---------------------------------------------------------------------
+
+describe('copyTextToClipboard', () => {
+  it('rejects with an Error for empty text', async () => {
+    await expect(copyTextToClipboard('')).rejects.toThrow('Empty text')
+    await expect(copyTextToClipboard(null)).rejects.toThrow('Empty text')
+    await expect(copyTextToClipboard(undefined)).rejects.toThrow('Empty text')
+  })
+
+  it('uses navigator.clipboard.writeText when available', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    // Install a fake clipboard for this test
+    const originalClipboard = navigator.clipboard
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText }
+    })
+    try {
+      await copyTextToClipboard('hello')
+      expect(writeText).toHaveBeenCalledWith('hello')
+    } finally {
+      // Restore
+      if (originalClipboard !== undefined) {
+        Object.defineProperty(navigator, 'clipboard', {
+          configurable: true,
+          value: originalClipboard
+        })
+      } else {
+        delete navigator.clipboard
+      }
+    }
+  })
+
+  it('falls back to hidden textarea + execCommand("copy") when clipboard API is missing', async () => {
+    const originalClipboard = navigator.clipboard
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: undefined
+    })
+    // execCommand is not a real thing in jsdom; install as a plain property.
+    const execFn = vi.fn().mockReturnValue(true)
+    document.execCommand = execFn
+    try {
+      await copyTextToClipboard('hi')
+      expect(execFn).toHaveBeenCalledWith('copy')
+    } finally {
+      delete document.execCommand
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: originalClipboard
+      })
+    }
+  })
+
+  it('rejects when the execCommand fallback returns false', async () => {
+    const originalClipboard = navigator.clipboard
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: undefined
+    })
+    document.execCommand = vi.fn().mockReturnValue(false)
+    try {
+      await expect(copyTextToClipboard('hi')).rejects.toThrow('Copy failed')
+    } finally {
+      delete document.execCommand
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: originalClipboard
+      })
+    }
+  })
+})


### PR DESCRIPTION
## What

Kicks off the multi-PR effort to decompose the `900-kometa.js` god-file (4004 → 3788 lines with this PR). The goal is to carve out cohesive modules under `static/local-js/modules/kometa/` so:

- jQuery stragglers can't hide in a 4000-line file (see #1549)
- Individual pieces become Vitest-testable in isolation
- The eventual Step 9 (Svelte islands) can pluck ready-to-port modules instead of untangling one blob
- Each future extraction is a small, reviewable diff instead of a scary big-bang refactor

## Why this ordering (leaf-first)

18 pure or DOM-only helpers with **zero module-scoped state dependencies** get extracted first. Because they're leaf functions, every future extraction (state, feature modules, etc.) can freely import from this file without pulling in any transitive kometa state. This eliminates a whole class of ''where does this actually live'' merge conflicts down the road.

## Extracted to `_util.js`

| Category | Functions |
|---|---|
| String/formatting | `quoteIfNeeded`, `formatElapsed`, `computeYamlLineCount`, `normalizeFontName`, `formatHeaderStyleLabel`, `escapeHtml`, `linkifyText`, `formatTimestampLocal` |
| Numeric/time | `clampPercent`, `formatRunSeconds`, `coerceRunSeconds`, `isValidTimesFormat`, `isTimeWithinRange` |
| Log helpers | `applyLogFilter`, `computeLogStats` |
| Sparkline geometry | `SPARKLINE_WIDTH/HEIGHT/PADDING/MAX_POINTS` constants, `pushSparkValue`, `buildSparklinePoints`, `buildSparklinePointsScaled` |
| Clipboard | `copyTextToClipboard` |

## Deliberately kept in `900-kometa.js` (for now)

- `runSparkState` buffer — mutable state used across the still-in-file `renderRunSparklines` / `updateRunSparklines` / `resetRunSparklines`. Will migrate with those functions in the sparkline extraction PR.
- All DOM cache-refs at the top of the file
- All 100+ other feature-specific functions

## Vitest coverage: 89 new tests

- **Exhaustive** on the tricky ones: `linkifyText`'s escape-then-linkify ordering (XSS-safe), `coerceRunSeconds`' 4 accepted forms (int / HH:MM:SS / `Nh Nm Ns` / plain number), `applyLogFilter`'s literal-vs-regex dispatch (with metacharacter escaping), `buildSparklinePoints`' pixel math (value=50 lands mid-plot, value=0 at bottom, value=100 at top), sparkline buffer trimming (shift-from-front at MAX_POINTS)
- **Representative** on the trivial ones (`quoteIfNeeded`, `formatElapsed`)
- **Clipboard fallback** path uses an `execCommand` shim since jsdom doesn't have a real one

## Verification

- **679/679 Vitest pass** (was 590; +89 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes (last session's jQuery-straggler regression test — the code path it covers is untouched by this PR)
- Pre-existing `test_validate_kometa_root_syncs_managed_assets_to_kometa` failure on develop is unrelated (venv/pip env issue, verified reproduces on unmodified develop)
- ESLint clean, pre-commit clean

## Extractions on deck (one per PR)

- `_state.js` — shared mutable `KOMETA_*` flags + polling handles
- `_headerBadges.js` — accordion rollup + header badge sync
- `_validationGate.js` — final gate + validation row rendering
- `_headerGrid.js` — font grid + sample loading
- `_kometaRuntime.js` — install-mode checks + `validateKometaRoot` etc.
- `_runCommand.js` — `buildCommand` + placeholder state + mode badges
- `_kometaUpdate.js` — branch override + update job flow (~800 lines, big one)
- `_runProgress.js` — `renderRunProgress` + sparkline rendering
- `_logs.js` + `_logscan.js` — log stats, log fetch, logscan analysis
- `_maintenanceWindow.js` — times validation + range check

After all of the above, `900-kometa.js` should shrink from ~4000 lines to ~500-800 lines of pure conductor / DOM wiring / event listener setup.