### PR TITLE
Split 900-kometa.js part 2: extract maintenance-window helpers

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -11,7 +11,6 @@ import {
   formatRunSeconds,
   coerceRunSeconds,
   isValidTimesFormat,
-  isTimeWithinRange,
   applyLogFilter,
   computeLogStats,
   pushSparkValue,
@@ -19,6 +18,10 @@ import {
   buildSparklinePointsScaled,
   copyTextToClipboard
 } from './modules/kometa/_util.js'
+import {
+  toggleTimesInputVisibility,
+  checkMaintenanceWarning
+} from './modules/kometa/_maintenanceWindow.js'
 
 let KOMETA_UPDATING = false
 let KOMETA_VALIDATED = false
@@ -3741,48 +3744,4 @@ function checkKometaStatus () {
       const outLog = document.getElementById('run-output-log')
       if (outLog) outLog.insertAdjacentHTML('beforeend', '\n️  Failed to check Kometa status.')
     })
-}
-
-function toggleTimesInputVisibility (mainOption) {
-  const timesContainer = document.getElementById('times-input-container')
-  if (mainOption === '--times') {
-    timesContainer.classList.remove('d-none')
-  } else {
-    timesContainer.classList.add('d-none')
-    document.getElementById('times-error').classList.add('d-none')
-  }
-}
-
-function getMaintenanceWindow () {
-  const windowStr = document.getElementById('plex-maintenance-window').dataset.window // e.g., "03:00–05:00"
-  if (!windowStr || !windowStr.includes('–')) return null
-
-  const [start, end] = windowStr.split('–').map(t => t.trim())
-  return { start, end } // Strings in "HH:MM" format
-}
-
-function checkMaintenanceWarning (mainOption) {
-  const warningBox = document.getElementById('times-warning')
-  const maintenance = getMaintenanceWindow()
-  warningBox.classList.add('d-none')
-
-  if (!maintenance) return
-
-  if (mainOption === '') {
-    const defaultTime = '05:00'
-    if (isTimeWithinRange(defaultTime, maintenance.start, maintenance.end)) {
-      warningBox.classList.remove('d-none')
-    }
-  }
-
-  if (mainOption === '--times') {
-    const timesInput = document.getElementById('times-input').value.trim()
-    if (isValidTimesFormat(timesInput)) {
-      const times = timesInput.split('|').map(t => t.trim())
-      const overlaps = times.some(t => isTimeWithinRange(t, maintenance.start, maintenance.end))
-      if (overlaps) {
-        warningBox.classList.remove('d-none')
-      }
-    }
-  }
 }

--- a/static/local-js/modules/kometa/_maintenanceWindow.js
+++ b/static/local-js/modules/kometa/_maintenanceWindow.js
@@ -1,0 +1,91 @@
+// Maintenance-window helpers extracted from 900-kometa.js as part of
+// the god-file split (see modules/kometa/_util.js for context).
+//
+// These functions coordinate the "Times / maintenance window" UI on
+// the Kometa run page:
+//   - toggleTimesInputVisibility: show/hide the times input row when
+//     the user picks --times as their run mode
+//   - getMaintenanceWindow: read the Plex maintenance window that the
+//     backend wrote to a data-* attribute on the page
+//   - checkMaintenanceWarning: show a warning if the user's chosen
+//     schedule overlaps with the Plex maintenance window (Kometa can't
+//     talk to Plex during maintenance, so we surface that)
+//
+// They all touch the DOM but share NO module-scoped state with the
+// rest of 900-kometa.js. The `times-input` / `times-error` element
+// IDs are also referenced from other functions in 900-kometa.js
+// (updateRunOptionHeaderBadge, buildCommand) but those callers touch
+// the DOM directly, not through helpers here.
+
+import { isTimeWithinRange, isValidTimesFormat } from './_util.js'
+
+/**
+ * Show or hide the "times" input container based on the currently
+ * selected main run option. When the user picks a mode other than
+ * `--times`, we also proactively hide any lingering times validation
+ * error so the UI doesn't look wrong after a mode switch.
+ */
+export function toggleTimesInputVisibility (mainOption) {
+  const timesContainer = document.getElementById('times-input-container')
+  if (mainOption === '--times') {
+    timesContainer.classList.remove('d-none')
+  } else {
+    timesContainer.classList.add('d-none')
+    document.getElementById('times-error').classList.add('d-none')
+  }
+}
+
+/**
+ * Return the currently-configured Plex maintenance window, as
+ * `{ start, end }` HH:MM strings. Reads from the
+ * `#plex-maintenance-window` element's `data-window` attribute,
+ * which the backend populates with a string like "03:00–05:00"
+ * (note the EN-DASH separator, not a hyphen).
+ *
+ * Returns null when the element is present but has no configured
+ * window, or when the payload is malformed.
+ */
+export function getMaintenanceWindow () {
+  const windowStr = document.getElementById('plex-maintenance-window').dataset.window
+  if (!windowStr || !windowStr.includes('–')) return null
+  const [start, end] = windowStr.split('–').map(t => t.trim())
+  return { start, end }
+}
+
+/**
+ * Show or hide the "your schedule overlaps Plex maintenance"
+ * warning box. Handles both the implicit-schedule case (main option
+ * empty -> Kometa's built-in 05:00 default) and the user's own
+ * pipe-separated `--times` list.
+ *
+ * No-op when there's no configured maintenance window, or when the
+ * user's --times input is invalid (they'll get a different, more
+ * useful validation error from elsewhere in that case).
+ */
+export function checkMaintenanceWarning (mainOption) {
+  const warningBox = document.getElementById('times-warning')
+  const maintenance = getMaintenanceWindow()
+  warningBox.classList.add('d-none')
+
+  if (!maintenance) return
+
+  if (mainOption === '') {
+    // Kometa's implicit default schedule fires at 05:00.
+    const defaultTime = '05:00'
+    if (isTimeWithinRange(defaultTime, maintenance.start, maintenance.end)) {
+      warningBox.classList.remove('d-none')
+    }
+    return
+  }
+
+  if (mainOption === '--times') {
+    const timesInput = document.getElementById('times-input').value.trim()
+    if (isValidTimesFormat(timesInput)) {
+      const times = timesInput.split('|').map(t => t.trim())
+      const overlaps = times.some(t => isTimeWithinRange(t, maintenance.start, maintenance.end))
+      if (overlaps) {
+        warningBox.classList.remove('d-none')
+      }
+    }
+  }
+}

--- a/tests/js/kometa/maintenanceWindow.test.js
+++ b/tests/js/kometa/maintenanceWindow.test.js
@@ -1,0 +1,271 @@
+// Tests for static/local-js/modules/kometa/_maintenanceWindow.js
+//
+// These functions all touch the DOM but share no module-scoped state
+// with the rest of 900-kometa.js. Every test builds a fresh fixture
+// DOM in beforeEach and inspects the .d-none class transitions after
+// calling the module's functions. That mirrors the actual runtime
+// behavior: Bootstrap uses .d-none for show/hide.
+//
+// Coverage strategy:
+//   - toggleTimesInputVisibility: verify both branches AND the side
+//     effect of hiding the error box when the mode changes away from
+//     --times
+//   - getMaintenanceWindow: exhaustive on the parse-or-null contract
+//     (well-formed, missing attribute, missing separator, non-ASCII
+//     en-dash boundary)
+//   - checkMaintenanceWarning: 3 x 3 matrix covering (implicit
+//     default / --times valid / --times invalid) x (window unset /
+//     overlaps / doesn't overlap)
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  toggleTimesInputVisibility,
+  getMaintenanceWindow,
+  checkMaintenanceWarning
+} from '../../../static/local-js/modules/kometa/_maintenanceWindow.js'
+
+// ---------------------------------------------------------------------
+// Fixture DOM
+// ---------------------------------------------------------------------
+//
+// Mirrors the shape of the real templates: a container div with the
+// times input inside, a hidden validation-error row, a maintenance
+// data-carrier div, and a warning box. All start hidden (d-none)
+// except the container, which the real template shows only when the
+// user has selected --times.
+
+function installFixtureDom ({ maintenanceWindow = '' } = {}) {
+  document.body.innerHTML = `
+    <div id="times-input-container" class="d-none">
+      <input id="times-input" type="text" value="" />
+      <div id="times-error" class="d-none">Invalid time format</div>
+    </div>
+    <div id="plex-maintenance-window" data-window="${maintenanceWindow}"></div>
+    <div id="times-warning" class="d-none">Overlaps with Plex maintenance</div>
+  `
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+// ---------------------------------------------------------------------
+// toggleTimesInputVisibility
+// ---------------------------------------------------------------------
+
+describe('toggleTimesInputVisibility', () => {
+  beforeEach(() => {
+    installFixtureDom()
+  })
+
+  it('reveals the times container when mainOption is --times', () => {
+    const container = document.getElementById('times-input-container')
+    expect(container.classList.contains('d-none')).toBe(true) // sanity
+    toggleTimesInputVisibility('--times')
+    expect(container.classList.contains('d-none')).toBe(false)
+  })
+
+  it('hides the times container for any other mainOption', () => {
+    const container = document.getElementById('times-input-container')
+    container.classList.remove('d-none') // pretend it was visible
+    toggleTimesInputVisibility('--run')
+    expect(container.classList.contains('d-none')).toBe(true)
+  })
+
+  it('hides the times container when mainOption is empty', () => {
+    const container = document.getElementById('times-input-container')
+    container.classList.remove('d-none')
+    toggleTimesInputVisibility('')
+    expect(container.classList.contains('d-none')).toBe(true)
+  })
+
+  it('also hides the times-error box when switching away from --times', () => {
+    // Simulate an in-progress error state: container visible, error visible
+    const container = document.getElementById('times-input-container')
+    const error = document.getElementById('times-error')
+    container.classList.remove('d-none')
+    error.classList.remove('d-none')
+
+    toggleTimesInputVisibility('--run')
+
+    expect(container.classList.contains('d-none')).toBe(true)
+    expect(error.classList.contains('d-none')).toBe(true)
+  })
+
+  it('does NOT touch times-error when switching TO --times (only when switching away)', () => {
+    // If the user is coming back to --times and there was a lingering
+    // error, we want to preserve it so they still see it. The function
+    // deliberately only hides the error in the else branch.
+    const error = document.getElementById('times-error')
+    error.classList.remove('d-none')
+
+    toggleTimesInputVisibility('--times')
+
+    expect(error.classList.contains('d-none')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------
+// getMaintenanceWindow
+// ---------------------------------------------------------------------
+
+describe('getMaintenanceWindow', () => {
+  it('returns { start, end } for a well-formed window', () => {
+    installFixtureDom({ maintenanceWindow: '03:00–05:00' })
+    expect(getMaintenanceWindow()).toEqual({ start: '03:00', end: '05:00' })
+  })
+
+  it('trims whitespace around the times', () => {
+    installFixtureDom({ maintenanceWindow: '  03:00 – 05:00  ' })
+    expect(getMaintenanceWindow()).toEqual({ start: '03:00', end: '05:00' })
+  })
+
+  it('returns null when the data-window attribute is empty', () => {
+    installFixtureDom({ maintenanceWindow: '' })
+    expect(getMaintenanceWindow()).toBeNull()
+  })
+
+  it('returns null when the payload lacks the en-dash separator', () => {
+    // A hyphen (`-`) is NOT the same as the en-dash (`–`). The backend
+    // deliberately uses the en-dash to make the separator visually
+    // distinct in the maintenance summary UI.
+    installFixtureDom({ maintenanceWindow: '03:00-05:00' })
+    expect(getMaintenanceWindow()).toBeNull()
+  })
+
+  it('returns null when the payload has garbage', () => {
+    installFixtureDom({ maintenanceWindow: 'not-a-window' })
+    expect(getMaintenanceWindow()).toBeNull()
+  })
+
+  it('handles a payload that is just the en-dash (empty start/end)', () => {
+    installFixtureDom({ maintenanceWindow: '–' })
+    // Splitting '–' by '–' produces ['', ''] which are trimmed to '' each.
+    // The contract is "the string included a separator", so this is a
+    // known-degenerate but non-null case. Both fields are empty strings.
+    expect(getMaintenanceWindow()).toEqual({ start: '', end: '' })
+  })
+})
+
+// ---------------------------------------------------------------------
+// checkMaintenanceWarning
+// ---------------------------------------------------------------------
+
+describe('checkMaintenanceWarning', () => {
+  function warningIsVisible () {
+    return !document.getElementById('times-warning').classList.contains('d-none')
+  }
+
+  describe('when there is no configured maintenance window', () => {
+    beforeEach(() => {
+      installFixtureDom({ maintenanceWindow: '' })
+    })
+
+    it('hides the warning for the implicit-default mode', () => {
+      // Pre-set warning to visible to prove the function actively hides
+      document.getElementById('times-warning').classList.remove('d-none')
+      checkMaintenanceWarning('')
+      expect(warningIsVisible()).toBe(false)
+    })
+
+    it('hides the warning for --times mode', () => {
+      document.getElementById('times-warning').classList.remove('d-none')
+      document.getElementById('times-input').value = '05:00|17:00'
+      checkMaintenanceWarning('--times')
+      expect(warningIsVisible()).toBe(false)
+    })
+  })
+
+  describe('with mainOption="" (Kometa\'s implicit 05:00 default)', () => {
+    it('shows the warning when 05:00 falls inside the maintenance window', () => {
+      installFixtureDom({ maintenanceWindow: '04:00–06:00' })
+      checkMaintenanceWarning('')
+      expect(warningIsVisible()).toBe(true)
+    })
+
+    it('hides the warning when 05:00 is outside the maintenance window', () => {
+      installFixtureDom({ maintenanceWindow: '01:00–02:00' })
+      checkMaintenanceWarning('')
+      expect(warningIsVisible()).toBe(false)
+    })
+
+    it('hides the warning when 05:00 is exactly AT the window end (exclusive)', () => {
+      // Range check is [start, end) - end is exclusive
+      installFixtureDom({ maintenanceWindow: '03:00–05:00' })
+      checkMaintenanceWarning('')
+      expect(warningIsVisible()).toBe(false)
+    })
+
+    it('shows the warning when 05:00 is exactly AT the window start (inclusive)', () => {
+      installFixtureDom({ maintenanceWindow: '05:00–07:00' })
+      checkMaintenanceWarning('')
+      expect(warningIsVisible()).toBe(true)
+    })
+  })
+
+  describe('with mainOption="--times" (user-supplied schedule)', () => {
+    it('shows the warning when any user time falls inside the window', () => {
+      installFixtureDom({ maintenanceWindow: '04:00–06:00' })
+      document.getElementById('times-input').value = '05:00|17:00'
+      checkMaintenanceWarning('--times')
+      expect(warningIsVisible()).toBe(true)
+    })
+
+    it('hides the warning when all user times are outside the window', () => {
+      installFixtureDom({ maintenanceWindow: '04:00–06:00' })
+      document.getElementById('times-input').value = '10:00|17:00'
+      checkMaintenanceWarning('--times')
+      expect(warningIsVisible()).toBe(false)
+    })
+
+    it('hides the warning when the user\'s --times input is empty', () => {
+      installFixtureDom({ maintenanceWindow: '04:00–06:00' })
+      document.getElementById('times-input').value = ''
+      // Warning starts hidden by installFixtureDom
+      checkMaintenanceWarning('--times')
+      expect(warningIsVisible()).toBe(false)
+    })
+
+    it('hides the warning when the user\'s --times input is invalid', () => {
+      installFixtureDom({ maintenanceWindow: '04:00–06:00' })
+      document.getElementById('times-input').value = 'garbage|nope'
+      checkMaintenanceWarning('--times')
+      expect(warningIsVisible()).toBe(false)
+    })
+
+    it('trims whitespace around individual times before checking', () => {
+      installFixtureDom({ maintenanceWindow: '04:00–06:00' })
+      document.getElementById('times-input').value = ' 05:00 | 17:00 '
+      checkMaintenanceWarning('--times')
+      expect(warningIsVisible()).toBe(true)
+    })
+  })
+
+  describe('with unrecognized mainOption values', () => {
+    it('always hides the warning (no --times, no default)', () => {
+      installFixtureDom({ maintenanceWindow: '04:00–06:00' })
+      // Pre-set warning visible so we can prove it's hidden
+      document.getElementById('times-warning').classList.remove('d-none')
+      checkMaintenanceWarning('--run')
+      expect(warningIsVisible()).toBe(false)
+    })
+
+    it('hides for --collections mode', () => {
+      installFixtureDom({ maintenanceWindow: '04:00–06:00' })
+      document.getElementById('times-warning').classList.remove('d-none')
+      checkMaintenanceWarning('--collections')
+      expect(warningIsVisible()).toBe(false)
+    })
+  })
+
+  it('always starts by hiding the warning (idempotent on repeated calls)', () => {
+    installFixtureDom({ maintenanceWindow: '04:00–06:00' })
+    // First call: overlap -> shows
+    checkMaintenanceWarning('')
+    expect(warningIsVisible()).toBe(true)
+    // Change conditions so the second call should hide it
+    document.getElementById('plex-maintenance-window').dataset.window = '01:00–02:00'
+    checkMaintenanceWarning('')
+    expect(warningIsVisible()).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

Second module out of the 900-kometa.js god-file split (see #1554 for the plan). 900-kometa.js: 3788 → 3747 lines (−41).

Extracted to `static/local-js/modules/kometa/_maintenanceWindow.js`:

- `toggleTimesInputVisibility(mainOption)`
- `getMaintenanceWindow()`
- `checkMaintenanceWarning(mainOption)`

## Why these three together

- They coordinate a single UI region (the times-input row + the 'your schedule overlaps Plex maintenance' warning)
- `checkMaintenanceWarning` is the ONLY caller of `getMaintenanceWindow`
- All three touch the DOM but share **zero** module-scoped state with the rest of `900-kometa.js` (unlike, say, the sparkline buffer which will be trickier)
- Cleanly imports the two util helpers they need (`isTimeWithinRange`, `isValidTimesFormat`) from the peer `_util.js` module — proves the leaf-module foundation from #1554 is doing its job

## Bonus cleanup

The extraction let me drop `isTimeWithinRange` from 900-kometa.js's import list — it was only ever used inside `checkMaintenanceWarning`, so it now travels with its only caller. Same story for `getMaintenanceWindow` (only called by `checkMaintenanceWarning`, not re-exported).

## Vitest coverage: 25 new tests

- **`toggleTimesInputVisibility`**: both branches + the important side effect that switching AWAY from `--times` hides the error box, but switching TO `--times` preserves any lingering error
- **`getMaintenanceWindow`**: parse-or-null contract with well-formed payload, empty payload, hyphen-vs-en-dash separator gotcha (the backend deliberately uses `–`, not `-`), trimming, and the degenerate 'just the separator' case
- **`checkMaintenanceWarning`**: full matrix of (implicit default / `--times` valid / `--times` invalid / `--times` empty / unknown mode) × (window unset / overlaps / doesn't overlap), plus edge cases (05:00 at inclusive start boundary, 05:00 at exclusive end boundary, idempotency on repeated calls)

## Verification

- **704/704 Vitest pass** (was 679; +25 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- ESLint clean, pre-commit clean

## What's still on deck

From #1554's roadmap:

- `_state.js` — shared mutable `KOMETA_*` flags + polling handles (foundational, unlocks the rest)
- `_headerBadges.js` — accordion rollup + header badge sync
- `_validationGate.js` — final gate + validation row rendering
- `_headerGrid.js` — font grid + sample loading
- `_kometaRuntime.js` — install-mode checks + `validateKometaRoot`
- `_runCommand.js` — `buildCommand` + placeholder state + mode badges
- `_kometaUpdate.js` — branch override + update job flow (~800 lines, big one)
- `_runProgress.js` — `renderRunProgress` + sparkline rendering
- `_logs.js` + `_logscan.js` — log stats, log fetch, logscan analysis