### PR TITLE
Split 900-kometa.js part 3: extract polling handles to _state.js (foundational)

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -22,6 +22,7 @@ import {
   toggleTimesInputVisibility,
   checkMaintenanceWarning
 } from './modules/kometa/_maintenanceWindow.js'
+import { kometaState } from './modules/kometa/_state.js'
 
 let KOMETA_UPDATING = false
 let KOMETA_VALIDATED = false
@@ -31,11 +32,9 @@ let KOMETA_UPDATE_CHECK_SKIPPED = false
 let KOMETA_UPDATE_CHECK_COMPLETED = false
 let KOMETA_INSTALLED = false
 let KOMETA_LOCAL_CHECK_COMPLETED = false
-// Polling handles (hoist to top so all handlers see them safely)
-let kometaInterval = null
-let kometaStatusInterval = null
-let kometaProgressInterval = null
-let kometaPollingStarted = false
+// Kometa run + update polling handles live in modules/kometa/_state.js
+// so they can be shared with extracted modules without ES-module
+// binding-reassignment pain. See _state.js docstring.
 let autoScrollEnabled = true
 let tailSize = '2000'
 let KOMETA_STATUS = null
@@ -55,9 +54,6 @@ let activeRunCommandOverride = null
 let activeRunCommandMode = null
 let latestKometaStatusPayload = null
 const KOMETA_BRANCH_OVERRIDE_STORAGE_KEY = 'qs-kometa-branch-override'
-let kometaUpdatePollInterval = null
-let kometaUpdateJobId = null
-let kometaUpdateLogIndex = 0
 
 // Sparkline state buffers. Rendering + reset + update functions that
 // operate on this still live in this file; the pure geometry helpers
@@ -1700,15 +1696,15 @@ function runKometaStatusPass (forceRefresh = false) {
 }
 
 function stopKometaUpdatePolling () {
-  if (kometaUpdatePollInterval) {
-    clearInterval(kometaUpdatePollInterval)
-    kometaUpdatePollInterval = null
+  if (kometaState.kometaUpdatePollInterval) {
+    clearInterval(kometaState.kometaUpdatePollInterval)
+    kometaState.kometaUpdatePollInterval = null
   }
 }
 
 function pollKometaUpdateProgress () {
-  if (!kometaUpdateJobId) return Promise.resolve(null)
-  return fetch(`/background-jobs/${encodeURIComponent(kometaUpdateJobId)}?since=${encodeURIComponent(String(kometaUpdateLogIndex))}`)
+  if (!kometaState.kometaUpdateJobId) return Promise.resolve(null)
+  return fetch(`/background-jobs/${encodeURIComponent(kometaState.kometaUpdateJobId)}?since=${encodeURIComponent(String(kometaState.kometaUpdateLogIndex))}`)
     .then(async res => {
       const data = await res.json()
       if (!res.ok || !data.success || !data.job) throw new Error(data.error || 'Failed to fetch Kometa update progress.')
@@ -1720,7 +1716,7 @@ function pollKometaUpdateProgress () {
       if (job.phase === 'error') setKometaUpdatePhaseBadge('failed')
       const lines = Array.isArray(data.lines) ? data.lines : []
       lines.forEach(line => appendKometaStatusLine(line))
-      if (typeof data.next_index === 'number') kometaUpdateLogIndex = data.next_index
+      if (typeof data.next_index === 'number') kometaState.kometaUpdateLogIndex = data.next_index
       if (data.done) {
         stopKometaUpdatePolling()
       }
@@ -1943,8 +1939,8 @@ function startKometaCommand (command, opts = {}) {
           }
         }
         document.getElementById('stop-now').classList.add('d-none')
-        if (kometaStatusInterval) clearInterval(kometaStatusInterval)
-        kometaStatusInterval = setInterval(checkKometaStatus, 5000)
+        if (kometaState.kometaStatusInterval) clearInterval(kometaState.kometaStatusInterval)
+        kometaState.kometaStatusInterval = setInterval(checkKometaStatus, 5000)
         syncIncompleteRunActions()
         return
       }
@@ -1952,7 +1948,7 @@ function startKometaCommand (command, opts = {}) {
       applyActiveRunCommandState(command, startMode)
 
       setTimeout(() => {
-        kometaPollingStarted = false
+        kometaState.kometaPollingStarted = false
         startPollingIfNeeded()
       }, 5500)
     })
@@ -2011,16 +2007,16 @@ function showRunCommandSectionAfterValidated () {
   updateRunNowState()
 }
 function startPollingIfNeeded () {
-  if (kometaPollingStarted) return
-  kometaPollingStarted = true
-  if (kometaInterval) clearInterval(kometaInterval)
-  if (kometaStatusInterval) clearInterval(kometaStatusInterval)
-  if (kometaProgressInterval) clearInterval(kometaProgressInterval)
+  if (kometaState.kometaPollingStarted) return
+  kometaState.kometaPollingStarted = true
+  if (kometaState.kometaInterval) clearInterval(kometaState.kometaInterval)
+  if (kometaState.kometaStatusInterval) clearInterval(kometaState.kometaStatusInterval)
+  if (kometaState.kometaProgressInterval) clearInterval(kometaState.kometaProgressInterval)
   fetchKometaLog()
   fetchRunProgress()
-  kometaInterval = setInterval(fetchKometaLog, 3000)
-  kometaStatusInterval = setInterval(checkKometaStatus, 5000)
-  kometaProgressInterval = setInterval(fetchRunProgress, 5000)
+  kometaState.kometaInterval = setInterval(fetchKometaLog, 3000)
+  kometaState.kometaStatusInterval = setInterval(checkKometaStatus, 5000)
+  kometaState.kometaProgressInterval = setInterval(fetchRunProgress, 5000)
 }
 
 function resumeKometaLiveView () {
@@ -2029,7 +2025,7 @@ function resumeKometaLiveView () {
     .catch(() => null)
     .finally(() => {
       if (KOMETA_STATUS === 'running' || KOMETA_PENDING_START) {
-        kometaPollingStarted = false
+        kometaState.kometaPollingStarted = false
         startPollingIfNeeded()
         fetchRunProgress(true)
         fetchKometaLog()
@@ -2038,9 +2034,9 @@ function resumeKometaLiveView () {
 }
 
 function stopProgressPolling () {
-  if (kometaProgressInterval) {
-    clearInterval(kometaProgressInterval)
-    kometaProgressInterval = null
+  if (kometaState.kometaProgressInterval) {
+    clearInterval(kometaState.kometaProgressInterval)
+    kometaState.kometaProgressInterval = null
   }
 }
 
@@ -2500,8 +2496,8 @@ function callUpdateKometa () {
   const cleanupUI = () => {
     clearInterval(heartbeatId)
     stopKometaUpdatePolling()
-    kometaUpdateJobId = null
-    kometaUpdateLogIndex = 0
+    kometaState.kometaUpdateJobId = null
+    kometaState.kometaUpdateLogIndex = 0
     KOMETA_UPDATING = false
     runBox.classList.remove('opacity-50', 'position-relative')
     runNow.disabled = prevRunNowDisabled
@@ -2541,8 +2537,8 @@ function callUpdateKometa () {
     .then(data => {
       if (!data) return
       if (data.success && data.job_id) {
-        kometaUpdateJobId = data.job_id
-        kometaUpdateLogIndex = 0
+        kometaState.kometaUpdateJobId = data.job_id
+        kometaState.kometaUpdateLogIndex = 0
         stopKometaUpdatePolling()
         const finalize = (progress) => {
           if (!progress || !progress.done) return false
@@ -2577,7 +2573,7 @@ function callUpdateKometa () {
         return pollKometaUpdateProgress()
           .then(progress => {
             if (finalize(progress)) return
-            kometaUpdatePollInterval = setInterval(() => {
+            kometaState.kometaUpdatePollInterval = setInterval(() => {
               pollKometaUpdateProgress()
                 .then(finalize)
                 .catch(err => {
@@ -3537,8 +3533,8 @@ function performStopKometa () {
           showToast('success', msg)
         }
       }
-      clearInterval(kometaInterval)
-      clearInterval(kometaStatusInterval)
+      clearInterval(kometaState.kometaInterval)
+      clearInterval(kometaState.kometaStatusInterval)
       stopProgressPolling()
       if (lastRunProgressPayload) {
         const stoppedPayload = JSON.parse(JSON.stringify(lastRunProgressPayload))
@@ -3670,8 +3666,8 @@ function checkKometaStatus () {
           document.getElementById('run-output-log').insertAdjacentHTML('beforeend', `\n${message}`)
         }
         syncIncompleteRunActions()
-        if (kometaStatusInterval) clearInterval(kometaStatusInterval)
-        kometaStatusInterval = setInterval(checkKometaStatus, 5000)
+        if (kometaState.kometaStatusInterval) clearInterval(kometaState.kometaStatusInterval)
+        kometaState.kometaStatusInterval = setInterval(checkKometaStatus, 5000)
         return
       }
 
@@ -3707,8 +3703,8 @@ function checkKometaStatus () {
       }
 
       // If we reach here, it's either "done" or "not started"
-      if (typeof kometaInterval !== 'undefined' && kometaInterval) clearInterval(kometaInterval)
-      if (typeof kometaStatusInterval !== 'undefined' && kometaStatusInterval) clearInterval(kometaStatusInterval)
+      if (typeof kometaState.kometaInterval !== 'undefined' && kometaState.kometaInterval) clearInterval(kometaState.kometaInterval)
+      if (typeof kometaState.kometaStatusInterval !== 'undefined' && kometaState.kometaStatusInterval) clearInterval(kometaState.kometaStatusInterval)
       stopProgressPolling()
       clearRunProgress(true)
       clearActiveRunCommandState()

--- a/static/local-js/modules/kometa/_state.js
+++ b/static/local-js/modules/kometa/_state.js
@@ -1,0 +1,80 @@
+// Shared mutable state for the Kometa page.
+//
+// Why an exported object (rather than exported `let`s)?
+//
+//   ES module bindings are LIVE but READ-ONLY from the importer's
+//   side. That means:
+//
+//     // _state.js
+//     export let kometaInterval = null
+//     // 900-kometa.js
+//     import { kometaInterval } from './_state.js'
+//     kometaInterval = setInterval(...)   // TypeError!
+//
+//   Exporting an object avoids the assignment-to-import problem
+//   because we're mutating a property of the object, not reassigning
+//   the binding itself:
+//
+//     // _state.js
+//     export const kometaState = { kometaInterval: null }
+//     // 900-kometa.js
+//     import { kometaState } from './_state.js'
+//     kometaState.kometaInterval = setInterval(...)  // works
+//
+//   The same `kometaState` object is shared across every module that
+//   imports it, so mutations are visible everywhere. That's exactly
+//   the semantics the pre-extraction code relied on (top-level
+//   `let`s in a single script tag).
+//
+//   Naming note: we call the export `kometaState` (not just `state`)
+//   to avoid shadowing three pre-existing local `state` variables
+//   in 900-kometa.js -- a `setHeaderRollupBadge(id, state, label)`
+//   parameter, a destructured `const { state } = getKometaRollupStatus()`,
+//   and a `const state = window.QSBulkValidation.getSummaryState(...)`.
+//   None of those are semantically related to shared page state, so
+//   qualifying the import name is the least invasive fix.
+//
+// SCOPE OF THIS FILE (as of this PR):
+//
+//   Only the polling-handle group. These are 7 mutable variables
+//   that behave as a natural cluster -- they're all timer handles or
+//   job coordinators used by the Kometa run + update flows. Extracting
+//   them first has three benefits:
+//
+//     1. Small, reviewable diff (~40 call sites) proves the pattern
+//        works end-to-end without needing to touch hot paths
+//     2. Establishes the file so future extractions (which will need
+//        their own mutable state) have a place to add fields
+//     3. Doesn't force any downstream module extraction to happen
+//        together with the state move
+//
+//   Later extractions may add fields here as they need them. When
+//   ADDING a field, prefer:
+//     - camelCase names (matches the existing legacy names once
+//       the SCREAMING_SNAKE_CASE ones migrate)
+//     - a comment noting which module(s) are the primary reader(s)
+//     - grouping visually with related fields
+
+export const kometaState = {
+  // ---- Kometa run polling handles -----------------------------------
+  // These three intervals are the heart of the "Kometa is running"
+  // page: fetchKometaLog, checkKometaStatus, fetchRunProgress. They're
+  // set up together in startKometaPolling and torn down together in
+  // stopKometaPolling.
+  kometaInterval: null,
+  kometaStatusInterval: null,
+  kometaProgressInterval: null,
+  // Sentinel to prevent double-start of the polling group. Also reset
+  // when the run finishes so the next run can re-enter the polling
+  // setup path.
+  kometaPollingStarted: false,
+
+  // ---- Kometa update job coordination -------------------------------
+  // These three drive the background-job polling for the git pull /
+  // pip install / restart flow. The jobId comes back from the POST
+  // that kicks off the job; logIndex tracks how far into the job's
+  // rolling log buffer we've already displayed.
+  kometaUpdatePollInterval: null,
+  kometaUpdateJobId: null,
+  kometaUpdateLogIndex: 0
+}

--- a/tests/js/kometa/state.test.js
+++ b/tests/js/kometa/state.test.js
@@ -1,0 +1,139 @@
+// Tests for static/local-js/modules/kometa/_state.js
+//
+// The module has zero behavior of its own -- it just exports a
+// mutable object. That means the tests exist to prove three things
+// that WILL matter as future PRs extract more feature modules that
+// read/write this state:
+//
+//   1. Initial values are correct on first import (defensive: a stray
+//      typo like `kometaPollingStarted: 'false'` would silently break
+//      the polling guards downstream)
+//   2. Property mutation works end-to-end (which is the whole point
+//      of the object-vs-`let` design decision documented in _state.js)
+//   3. The same object identity is shared across importers (proves
+//      the "shared mutable state" contract that lets extracted modules
+//      coordinate with 900-kometa.js without extra plumbing)
+//
+// Because ES module instances are cached per specifier, importing
+// `_state.js` from two different `import` statements returns the
+// exact same object reference. That's easy to verify.
+
+import { describe, expect, it, beforeEach } from 'vitest'
+import { kometaState } from '../../../static/local-js/modules/kometa/_state.js'
+
+// Snapshot the initial defaults so any test that mutates kometaState
+// can restore it. Without this, test order would matter.
+const INITIAL_STATE = { ...kometaState }
+
+beforeEach(() => {
+  // Reset every field to its declared initial value. Using Object.assign
+  // rather than reassigning `kometaState` because reassignment wouldn't
+  // affect the shared reference held by any other importer.
+  Object.assign(kometaState, INITIAL_STATE)
+})
+
+describe('kometaState initial values', () => {
+  it('kometaInterval starts as null (no polling handle)', () => {
+    expect(kometaState.kometaInterval).toBeNull()
+  })
+
+  it('kometaStatusInterval starts as null', () => {
+    expect(kometaState.kometaStatusInterval).toBeNull()
+  })
+
+  it('kometaProgressInterval starts as null', () => {
+    expect(kometaState.kometaProgressInterval).toBeNull()
+  })
+
+  it('kometaPollingStarted starts as false (not the string "false")', () => {
+    // Explicit strict check: a typo like `false` -> `'false'` would
+    // silently break the `if (kometaState.kometaPollingStarted) return`
+    // guard in startKometaPolling because the string 'false' is truthy.
+    expect(kometaState.kometaPollingStarted).toBe(false)
+    expect(typeof kometaState.kometaPollingStarted).toBe('boolean')
+  })
+
+  it('kometaUpdatePollInterval starts as null', () => {
+    expect(kometaState.kometaUpdatePollInterval).toBeNull()
+  })
+
+  it('kometaUpdateJobId starts as null', () => {
+    expect(kometaState.kometaUpdateJobId).toBeNull()
+  })
+
+  it('kometaUpdateLogIndex starts as 0 (not null, not "0")', () => {
+    // The log index is used as a numeric offset in the log-tail fetch;
+    // if it were null we'd send "null" over the wire.
+    expect(kometaState.kometaUpdateLogIndex).toBe(0)
+    expect(typeof kometaState.kometaUpdateLogIndex).toBe('number')
+  })
+
+  it('exports exactly the fields the runtime relies on (guards against typos)', () => {
+    // Sorted alphabetically for a stable comparison
+    expect(Object.keys(kometaState).sort()).toEqual([
+      'kometaInterval',
+      'kometaPollingStarted',
+      'kometaProgressInterval',
+      'kometaStatusInterval',
+      'kometaUpdateJobId',
+      'kometaUpdateLogIndex',
+      'kometaUpdatePollInterval'
+    ])
+  })
+})
+
+describe('kometaState mutation semantics', () => {
+  it('allows reassigning fields to non-null values', () => {
+    // Simulates startKometaPolling storing a setInterval handle
+    const fakeHandle = { fake: 'interval handle' }
+    kometaState.kometaInterval = fakeHandle
+    expect(kometaState.kometaInterval).toBe(fakeHandle)
+  })
+
+  it('allows resetting fields to null (stopKometaPolling flow)', () => {
+    kometaState.kometaProgressInterval = { fake: 'handle' }
+    kometaState.kometaProgressInterval = null
+    expect(kometaState.kometaProgressInterval).toBeNull()
+  })
+
+  it('allows numeric increment of kometaUpdateLogIndex', () => {
+    // Mirrors: if (typeof data.next_index === 'number')
+    //           kometaState.kometaUpdateLogIndex = data.next_index
+    kometaState.kometaUpdateLogIndex = 42
+    expect(kometaState.kometaUpdateLogIndex).toBe(42)
+    kometaState.kometaUpdateLogIndex = 128
+    expect(kometaState.kometaUpdateLogIndex).toBe(128)
+  })
+
+  it('allows storing an arbitrary string jobId', () => {
+    kometaState.kometaUpdateJobId = 'abc-123-def-456'
+    expect(kometaState.kometaUpdateJobId).toBe('abc-123-def-456')
+  })
+
+  it('allows toggling kometaPollingStarted (guard flag)', () => {
+    expect(kometaState.kometaPollingStarted).toBe(false)
+    kometaState.kometaPollingStarted = true
+    expect(kometaState.kometaPollingStarted).toBe(true)
+    kometaState.kometaPollingStarted = false
+    expect(kometaState.kometaPollingStarted).toBe(false)
+  })
+})
+
+describe('kometaState shared identity across importers', () => {
+  it('re-importing returns the same object reference (module caching)', async () => {
+    // ES module instance caching means the second import returns the
+    // exact same object -- not a copy, not a new instance.
+    const second = await import('../../../static/local-js/modules/kometa/_state.js')
+    expect(second.kometaState).toBe(kometaState)
+  })
+
+  it('mutations made through one import are visible through another', async () => {
+    const second = await import('../../../static/local-js/modules/kometa/_state.js')
+    kometaState.kometaUpdateJobId = 'shared-through-imports'
+    expect(second.kometaState.kometaUpdateJobId).toBe('shared-through-imports')
+    // And symmetrically -- writing through the second import is seen
+    // through the first
+    second.kometaState.kometaUpdateLogIndex = 9999
+    expect(kometaState.kometaUpdateLogIndex).toBe(9999)
+  })
+})


### PR DESCRIPTION
## What

Third module out of the 900-kometa.js god-file split (see #1554 / #1556 for parts 1-2). This is the **foundational** extraction that unlocks all future feature-module splits which need access to shared mutable page state.

`900-kometa.js`: 3788 → 3782 lines (−6). The line count isn't the point — establishing the shared-state pattern is.

## The ES-module let-export problem

Every previous approach at splitting this file had to reckon with:

```js
// _polling.js
export let kometaInterval = null

// 900-kometa.js
import { kometaInterval } from './_polling.js'
kometaInterval = setInterval(...)   // TypeError: Assignment to constant
```

ES module bindings are LIVE but READ-ONLY from the importer's side. The exporter can mutate its own `let`, but importers see the binding as read-only. This is the reason 30+ mutable top-level `let`s all still live in `900-kometa.js` despite it being a maintenance nightmare.

## The fix: exported mutable object

```js
// _state.js
export const kometaState = { kometaInterval: null, /* ... */ }

// 900-kometa.js
import { kometaState } from './_state.js'
kometaState.kometaInterval = setInterval(...)   // works
```

We're mutating a **property**, not reassigning the binding, so ES module semantics stay happy. All importers share the same object reference (module instance caching guarantees this), so mutations are visible everywhere. That's exactly the semantics the top-level `let`s gave us before extraction.

## Scope of THIS PR

Only the 7 polling-handle variables. They're a tight semantic cluster — the three run intervals + polling-started guard, plus the three update-job coordinators — and moving them all together produces a small, reviewable diff (~40 call sites). Future PRs will add fields to `kometaState` as they extract feature modules that need them.

Extracted to `static/local-js/modules/kometa/_state.js`:

| Field | Role |
|---|---|
| `kometaState.kometaInterval` | `fetchKometaLog` interval |
| `kometaState.kometaStatusInterval` | `checkKometaStatus` interval |
| `kometaState.kometaProgressInterval` | `fetchRunProgress` interval |
| `kometaState.kometaPollingStarted` | start-guard flag |
| `kometaState.kometaUpdatePollInterval` | update job progress poller |
| `kometaState.kometaUpdateJobId` | background-job id |
| `kometaState.kometaUpdateLogIndex` | rolling log offset |

## Naming: why `kometaState` not just `state`

Three pre-existing local uses of the name `state` in `900-kometa.js` (a `setHeaderRollupBadge` parameter, a destructured `const { state, label }`, and a `const state = window.QSBulkValidation.getSummaryState(...)`) trigger eslint `no-shadow` errors if the import is named `state`. Qualifying with `kometaState` is the least invasive fix.

## Verification

- **694/694 Vitest pass** (was 679 with #1554 leaves; +15 new for `_state.js`)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- ESLint clean
- Node syntax check clean

## Test coverage: 15 new (`tests/js/kometa/state.test.js`)

Three describe blocks matching what future extractors will care about:

1. **Initial values**: strict type + value checks so a typo like `false` → `'false'` (truthy string!) fails loudly. Includes a full `Object.keys()` shape check to catch accidental renames.
2. **Mutation semantics**: proves all three access patterns actually used in runtime — reassign, reset-to-null, numeric increment, string assignment, boolean toggle.
3. **Shared identity**: re-imports the module and verifies `second.kometaState === kometaState`, then proves cross-import mutation visibility symmetrically. This is the contract future extracted modules depend on.

## What's next

Now that the state pattern is proven, feature-module extractions become much less risky. From #1554's roadmap:

- `_headerBadges.js` — accordion rollup + header badge sync
- `_validationGate.js` — final gate + validation row rendering
- `_headerGrid.js` — font grid + sample loading
- `_kometaRuntime.js` — install-mode checks + `validateKometaRoot`
- `_runCommand.js` — `buildCommand` + placeholder state + mode badges
- `_kometaUpdate.js` — branch override + update job flow (~800 lines, biggest one)
- `_runProgress.js` — `renderRunProgress` + sparkline rendering
- `_logs.js` + `_logscan.js` — log stats, log fetch, logscan analysis