### PR TITLE
Split 900-kometa.js part 4: extract pure header-badge helpers to _headerBadges.js

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -23,6 +23,15 @@ import {
   checkMaintenanceWarning
 } from './modules/kometa/_maintenanceWindow.js'
 import { kometaState } from './modules/kometa/_state.js'
+import {
+  setHeaderRollupBadge,
+  updateSectionStyleHeaderBadge,
+  updateModeHeaderBadge,
+  updateRunOptionHeaderBadge,
+  updateModeFlagsHeaderBadge,
+  updateLogFlagsHeaderBadge,
+  updateOtherFlagsHeaderBadge
+} from './modules/kometa/_headerBadges.js'
 
 let KOMETA_UPDATING = false
 let KOMETA_VALIDATED = false
@@ -181,32 +190,6 @@ function setMetaFlag (id, datasetKey, attrKey, value) {
   el.setAttribute(`data-${attrKey}`, serialized)
 }
 
-function setHeaderRollupBadge (id, state, label) {
-  const badge = document.getElementById(id)
-  if (!badge) return
-  badge.textContent = label
-  badge.classList.remove(
-    'qs-validation-rollup-badge--unknown',
-    'qs-validation-rollup-badge--ok',
-    'qs-validation-rollup-badge--warn',
-    'qs-validation-rollup-badge--error'
-  )
-  const normalized = ['unknown', 'ok', 'warn', 'error'].includes(state) ? state : 'unknown'
-  badge.classList.add(`qs-validation-rollup-badge--${normalized}`)
-}
-
-function prettifyFlag (value) {
-  const raw = String(value || '').trim()
-  if (!raw) return 'Default'
-  const noPrefix = raw.replace(/^--/, '')
-  return noPrefix.replace(/-/g, ' ')
-}
-
-function updateSectionStyleHeaderBadge (value) {
-  const label = formatHeaderStyleLabel(value)
-  setHeaderRollupBadge('header-style-rollup-badge', 'ok', label || 'Active')
-}
-
 function updateConfigOutputHeaderBadges () {
   const yamlText = yamlOutput ? String(yamlOutput.value || '') : ''
   const lineCount = computeYamlLineCount(yamlText)
@@ -216,71 +199,6 @@ function updateConfigOutputHeaderBadges () {
     return
   }
   setHeaderRollupBadge('config-output-rollup-badge', showYAML ? 'ok' : 'error', showYAML ? 'Validated' : 'Needs fixes')
-}
-
-function updateModeHeaderBadge () {
-  const cliToggle = document.getElementById('show-cli-toggle')
-  const showCli = Boolean(cliToggle && cliToggle.checked)
-  setHeaderRollupBadge('heading-mode-rollup-badge', showCli ? 'ok' : 'unknown', showCli ? 'CLI labels' : 'Friendly')
-}
-
-function updateRunOptionHeaderBadge () {
-  const mainOption = (document.querySelector('input[name="run-option"]:checked') || {}).value || ''
-  const libSelect = document.getElementById('library-multiselect')
-  const selectedLibs = libSelect ? Array.from(libSelect.selectedOptions || []).map(o => o.value) : []
-  if (mainOption === '--run-libraries') {
-    if (!selectedLibs.length) {
-      setHeaderRollupBadge('heading-runopt-rollup-badge', 'warn', 'Libraries needed')
-    } else {
-      setHeaderRollupBadge('heading-runopt-rollup-badge', 'ok', `${selectedLibs.length} libraries`)
-    }
-    return
-  }
-  if (mainOption === '--times') {
-    const timesInput = document.getElementById('times-input').value.trim()
-    if (!timesInput) {
-      setHeaderRollupBadge('heading-runopt-rollup-badge', 'warn', 'Times needed')
-      return
-    }
-    setHeaderRollupBadge('heading-runopt-rollup-badge', isValidTimesFormat(timesInput) ? 'ok' : 'error', isValidTimesFormat(timesInput) ? 'Times set' : 'Invalid times')
-    return
-  }
-  if (mainOption === '--run') {
-    setHeaderRollupBadge('heading-runopt-rollup-badge', 'ok', 'Run now')
-    return
-  }
-  setHeaderRollupBadge('heading-runopt-rollup-badge', 'unknown', 'Scheduled')
-}
-
-function updateModeFlagsHeaderBadge () {
-  const modeFlag = (document.querySelector('input[name="mode-flag"]:checked') || {}).value || ''
-  setHeaderRollupBadge('heading-modeflags-rollup-badge', modeFlag ? 'ok' : 'unknown', prettifyFlag(modeFlag))
-}
-
-function updateLogFlagsHeaderBadge () {
-  const logFlag = (document.querySelector('input[name="log-flag"]:checked') || {}).value || ''
-  setHeaderRollupBadge('heading-logflags-rollup-badge', logFlag ? 'ok' : 'unknown', prettifyFlag(logFlag))
-}
-
-function updateOtherFlagsHeaderBadge () {
-  const isChecked = (id) => {
-    const el = document.getElementById(id)
-    return Boolean(el && el.checked)
-  }
-  const coreCount = [
-    'delete-collections', 'delete-labels', 'read-only-config', 'low-priority',
-    'no-report', 'no-missing', 'no-countdown', 'ignore-ghost',
-    'ignore-schedules', 'no-verify-ssl', 'tests'
-  ].filter(opt => isChecked(`opt-${opt}`)).length
-  const extrasCount = (isChecked('opt-timeout') ? 1 : 0) +
-    (isChecked('opt-divider') ? 1 : 0) +
-    (isChecked('opt-width') ? 1 : 0)
-  const total = coreCount + extrasCount
-  if (!total) {
-    setHeaderRollupBadge('heading-otherflags-rollup-badge', 'unknown', 'Default')
-    return
-  }
-  setHeaderRollupBadge('heading-otherflags-rollup-badge', 'ok', `${total} enabled`)
 }
 
 function updateRunCommandHeaderBadge () {

--- a/static/local-js/modules/kometa/_headerBadges.js
+++ b/static/local-js/modules/kometa/_headerBadges.js
@@ -1,0 +1,208 @@
+// Section-header rollup badges for the Kometa page.
+//
+// The Kometa configuration page uses Bootstrap accordions. Each
+// accordion header displays a small "rollup" badge summarizing the
+// state of its section -- e.g. "Friendly", "3 libraries", "Times
+// needed", "Invalid times". This module owns the pure-DOM-reading
+// badge functions that read the current UI state and set the
+// appropriate badge text + color class.
+//
+// SCOPE OF THIS FILE (as of this PR):
+//
+//   Only the badge helpers that read exclusively from the DOM (no
+//   shared module-level state). Concretely:
+//
+//     setHeaderRollupBadge         -- generic setter used by all badges
+//     prettifyFlag                 -- helper for CLI flag -> label
+//     updateSectionStyleHeaderBadge
+//     updateModeHeaderBadge
+//     updateRunOptionHeaderBadge
+//     updateModeFlagsHeaderBadge
+//     updateLogFlagsHeaderBadge
+//     updateOtherFlagsHeaderBadge
+//
+//   Three sibling badge functions stay in 900-kometa.js FOR NOW:
+//
+//     updateConfigOutputHeaderBadges  -- needs the `showYAML` bool
+//     updateRunCommandHeaderBadge     -- needs 4 KOMETA_* flags,
+//                                        KOMETA_STATUS, showYAML,
+//                                        isRunCommandValid()
+//     updateLogscanHeaderBadge        -- needs lastLogscanPayload
+//
+//   And the orchestrator:
+//
+//     syncFinalAccordionRollups       -- calls both extracted and
+//                                        stay-behind functions
+//
+//   These will move here in follow-up PRs after the state they depend
+//   on migrates to _state.js (which is #1557's foundational work).
+//   Extracting the pure helpers first keeps the diff small and safe.
+//
+// COLOR CLASSES:
+//
+//   Every rollup badge lives in a single .qs-validation-rollup-badge
+//   element that gets exactly one modifier class:
+//
+//     --unknown  neutral / not-yet-evaluated
+//     --ok       everything looks good
+//     --warn     user attention needed but not broken
+//     --error    broken; must be fixed to proceed
+//
+//   setHeaderRollupBadge accepts any string; unknown values fall back
+//   to 'unknown' to keep the badge visually consistent.
+
+import { formatHeaderStyleLabel, isValidTimesFormat } from './_util.js'
+
+// ---------------------------------------------------------------------
+// Core primitives
+// ---------------------------------------------------------------------
+
+/**
+ * Update a single rollup badge in-place: sets its text and swaps
+ * exactly one color-modifier class.
+ *
+ * No-op if the target element is missing (badges can be legitimately
+ * absent when the enclosing accordion isn't rendered).
+ *
+ * @param {string} id       DOM id of the badge element
+ * @param {string} state    one of 'unknown' | 'ok' | 'warn' | 'error'
+ *                          (falls back to 'unknown' for any other value)
+ * @param {string} label    Text to display in the badge
+ */
+export function setHeaderRollupBadge (id, state, label) {
+  const badge = document.getElementById(id)
+  if (!badge) return
+  badge.textContent = label
+  badge.classList.remove(
+    'qs-validation-rollup-badge--unknown',
+    'qs-validation-rollup-badge--ok',
+    'qs-validation-rollup-badge--warn',
+    'qs-validation-rollup-badge--error'
+  )
+  const normalized = ['unknown', 'ok', 'warn', 'error'].includes(state) ? state : 'unknown'
+  badge.classList.add(`qs-validation-rollup-badge--${normalized}`)
+}
+
+/**
+ * Human-readable form of a CLI-style flag value.
+ *
+ *   ''             -> 'Default'
+ *   '--dry-run'    -> 'dry run'
+ *   'foo-bar'      -> 'foo bar'
+ *
+ * Used by the flag-radio-group badges (mode, log, other) where the
+ * <input value="--xxx"> is a CLI flag but we want to display it in
+ * a human-friendly form.
+ *
+ * @param {*} value  the flag value; coerced to string, trimmed
+ * @returns {string}
+ */
+export function prettifyFlag (value) {
+  const raw = String(value || '').trim()
+  if (!raw) return 'Default'
+  const noPrefix = raw.replace(/^--/, '')
+  return noPrefix.replace(/-/g, ' ')
+}
+
+// ---------------------------------------------------------------------
+// Individual section badges
+// ---------------------------------------------------------------------
+
+/**
+ * "Section style" is the header-look-and-feel picker. The badge
+ * mirrors the currently-selected style name.
+ */
+export function updateSectionStyleHeaderBadge (value) {
+  const label = formatHeaderStyleLabel(value)
+  setHeaderRollupBadge('header-style-rollup-badge', 'ok', label || 'Active')
+}
+
+/**
+ * "Mode" == the friendly-vs-CLI toggle. Two states: 'CLI labels' or
+ * 'Friendly'. Always 'ok' color because either choice is valid.
+ */
+export function updateModeHeaderBadge () {
+  const cliToggle = document.getElementById('show-cli-toggle')
+  const showCli = Boolean(cliToggle && cliToggle.checked)
+  setHeaderRollupBadge('heading-mode-rollup-badge', showCli ? 'ok' : 'unknown', showCli ? 'CLI labels' : 'Friendly')
+}
+
+/**
+ * "Run option" is the top-level radio group: --run, --run-libraries,
+ * --times, or scheduled default. Badge state depends on both the
+ * selection AND its dependent inputs (libraries or times).
+ */
+export function updateRunOptionHeaderBadge () {
+  const mainOption = (document.querySelector('input[name="run-option"]:checked') || {}).value || ''
+  const libSelect = document.getElementById('library-multiselect')
+  const selectedLibs = libSelect ? Array.from(libSelect.selectedOptions || []).map(o => o.value) : []
+  if (mainOption === '--run-libraries') {
+    if (!selectedLibs.length) {
+      setHeaderRollupBadge('heading-runopt-rollup-badge', 'warn', 'Libraries needed')
+    } else {
+      setHeaderRollupBadge('heading-runopt-rollup-badge', 'ok', `${selectedLibs.length} libraries`)
+    }
+    return
+  }
+  if (mainOption === '--times') {
+    const timesInput = document.getElementById('times-input').value.trim()
+    if (!timesInput) {
+      setHeaderRollupBadge('heading-runopt-rollup-badge', 'warn', 'Times needed')
+      return
+    }
+    setHeaderRollupBadge('heading-runopt-rollup-badge', isValidTimesFormat(timesInput) ? 'ok' : 'error', isValidTimesFormat(timesInput) ? 'Times set' : 'Invalid times')
+    return
+  }
+  if (mainOption === '--run') {
+    setHeaderRollupBadge('heading-runopt-rollup-badge', 'ok', 'Run now')
+    return
+  }
+  setHeaderRollupBadge('heading-runopt-rollup-badge', 'unknown', 'Scheduled')
+}
+
+/**
+ * "Mode flags" == the collections/overlays/operations/libraries-first
+ * radio group. Badge shows the human-friendly flag name.
+ */
+export function updateModeFlagsHeaderBadge () {
+  const modeFlag = (document.querySelector('input[name="mode-flag"]:checked') || {}).value || ''
+  setHeaderRollupBadge('heading-modeflags-rollup-badge', modeFlag ? 'ok' : 'unknown', prettifyFlag(modeFlag))
+}
+
+/**
+ * "Log flags" == the debug/trace radio group. Same shape as mode flags.
+ */
+export function updateLogFlagsHeaderBadge () {
+  const logFlag = (document.querySelector('input[name="log-flag"]:checked') || {}).value || ''
+  setHeaderRollupBadge('heading-logflags-rollup-badge', logFlag ? 'ok' : 'unknown', prettifyFlag(logFlag))
+}
+
+/**
+ * "Other flags" == the checkbox grid of boolean CLI flags plus the
+ * three "with-value" extras (timeout, divider, width). Badge shows
+ * a count of enabled flags.
+ *
+ * The core-flags list is hardcoded here because it maps 1:1 to the
+ * checkbox DOM ids in the template; keeping it inline is more
+ * readable than pushing it to a config file.
+ */
+export function updateOtherFlagsHeaderBadge () {
+  const isChecked = (id) => {
+    const el = document.getElementById(id)
+    return Boolean(el && el.checked)
+  }
+  const coreCount = [
+    'delete-collections', 'delete-labels', 'read-only-config', 'low-priority',
+    'no-report', 'no-missing', 'no-countdown', 'ignore-ghost',
+    'ignore-schedules', 'no-verify-ssl', 'tests'
+  ].filter(opt => isChecked(`opt-${opt}`)).length
+  const extrasCount = (isChecked('opt-timeout') ? 1 : 0) +
+    (isChecked('opt-divider') ? 1 : 0) +
+    (isChecked('opt-width') ? 1 : 0)
+  const total = coreCount + extrasCount
+  if (!total) {
+    setHeaderRollupBadge('heading-otherflags-rollup-badge', 'unknown', 'Default')
+    return
+  }
+  setHeaderRollupBadge('heading-otherflags-rollup-badge', 'ok', `${total} enabled`)
+}

--- a/tests/js/kometa/headerBadges.test.js
+++ b/tests/js/kometa/headerBadges.test.js
@@ -1,0 +1,442 @@
+// Tests for static/local-js/modules/kometa/_headerBadges.js
+//
+// Every function in this module reads exclusively from the DOM and
+// writes back into it. So the tests build a fresh fixture DOM in
+// beforeEach and inspect textContent + classList after each call.
+//
+// Coverage strategy per function:
+//
+//   setHeaderRollupBadge  -- happy path, missing element (no-op),
+//                            all 4 valid state values, invalid state
+//                            falling back to 'unknown', class swap
+//                            not accumulation
+//
+//   prettifyFlag          -- empty/null/undefined -> 'Default',
+//                            single flag stripping, hyphen-to-space,
+//                            edge cases (whitespace, non-string)
+//
+//   updateSectionStyleHeaderBadge  -- delegates to formatHeaderStyleLabel,
+//                            fallback to 'Active' when empty
+//
+//   updateModeHeaderBadge -- both checkbox states, missing element
+//
+//   updateRunOptionHeaderBadge -- 4 mode branches x their sub-states
+//
+//   updateModeFlagsHeaderBadge / updateLogFlagsHeaderBadge -- radio
+//                            selected vs none, various flag values
+//
+//   updateOtherFlagsHeaderBadge -- 0/some/all core flags, extras
+//                            (timeout/divider/width) counted separately
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  setHeaderRollupBadge,
+  prettifyFlag,
+  updateSectionStyleHeaderBadge,
+  updateModeHeaderBadge,
+  updateRunOptionHeaderBadge,
+  updateModeFlagsHeaderBadge,
+  updateLogFlagsHeaderBadge,
+  updateOtherFlagsHeaderBadge
+} from '../../../static/local-js/modules/kometa/_headerBadges.js'
+
+// ---------------------------------------------------------------------
+// Fixture DOM helpers
+// ---------------------------------------------------------------------
+//
+// installBadge(id) creates a minimal badge span so setHeaderRollupBadge
+// has something to mutate. Tests can pre-set the modifier class if
+// they want to prove the swap-not-accumulate behavior.
+
+function installBadge (id, initialClass = 'qs-validation-rollup-badge--unknown') {
+  const el = document.createElement('span')
+  el.id = id
+  el.className = `qs-validation-rollup-badge ${initialClass}`
+  el.textContent = ''
+  document.body.appendChild(el)
+  return el
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+// ---------------------------------------------------------------------
+// setHeaderRollupBadge
+// ---------------------------------------------------------------------
+
+describe('setHeaderRollupBadge', () => {
+  it('sets textContent and applies the ok modifier class', () => {
+    const el = installBadge('test-badge')
+    setHeaderRollupBadge('test-badge', 'ok', '3 libraries')
+    expect(el.textContent).toBe('3 libraries')
+    expect(el.classList.contains('qs-validation-rollup-badge--ok')).toBe(true)
+  })
+
+  it('is a no-op when the target element is missing', () => {
+    // Should not throw
+    expect(() => setHeaderRollupBadge('does-not-exist', 'ok', 'label')).not.toThrow()
+  })
+
+  it('accepts all four canonical state values', () => {
+    const states = ['unknown', 'ok', 'warn', 'error']
+    for (const state of states) {
+      const el = installBadge(`badge-${state}`)
+      setHeaderRollupBadge(`badge-${state}`, state, `label-${state}`)
+      expect(el.classList.contains(`qs-validation-rollup-badge--${state}`)).toBe(true)
+    }
+  })
+
+  it('falls back to unknown for any non-canonical state value', () => {
+    const el = installBadge('test-badge')
+    setHeaderRollupBadge('test-badge', 'purple-monkey-dishwasher', 'label')
+    expect(el.classList.contains('qs-validation-rollup-badge--unknown')).toBe(true)
+    // AND the other modifiers are not set
+    expect(el.classList.contains('qs-validation-rollup-badge--ok')).toBe(false)
+    expect(el.classList.contains('qs-validation-rollup-badge--warn')).toBe(false)
+    expect(el.classList.contains('qs-validation-rollup-badge--error')).toBe(false)
+  })
+
+  it('SWAPS the modifier class rather than accumulating', () => {
+    // A previous call set the badge to warn -- switching to ok must
+    // strip warn, not leave both classes present.
+    const el = installBadge('test-badge', 'qs-validation-rollup-badge--warn')
+    setHeaderRollupBadge('test-badge', 'ok', 'now green')
+    expect(el.classList.contains('qs-validation-rollup-badge--warn')).toBe(false)
+    expect(el.classList.contains('qs-validation-rollup-badge--ok')).toBe(true)
+  })
+
+  it('preserves the base .qs-validation-rollup-badge class', () => {
+    // The base class carries font/size/padding rules; the modifier
+    // only supplies color. Losing the base would collapse the badge.
+    const el = installBadge('test-badge')
+    setHeaderRollupBadge('test-badge', 'ok', 'label')
+    expect(el.classList.contains('qs-validation-rollup-badge')).toBe(true)
+  })
+
+  it('overwrites the text on repeated calls (not appends)', () => {
+    const el = installBadge('test-badge')
+    setHeaderRollupBadge('test-badge', 'ok', 'first')
+    setHeaderRollupBadge('test-badge', 'ok', 'second')
+    expect(el.textContent).toBe('second')
+  })
+})
+
+// ---------------------------------------------------------------------
+// prettifyFlag
+// ---------------------------------------------------------------------
+
+describe('prettifyFlag', () => {
+  it('returns "Default" for empty string', () => {
+    expect(prettifyFlag('')).toBe('Default')
+  })
+
+  it('returns "Default" for null', () => {
+    expect(prettifyFlag(null)).toBe('Default')
+  })
+
+  it('returns "Default" for undefined', () => {
+    expect(prettifyFlag(undefined)).toBe('Default')
+  })
+
+  it('returns "Default" for whitespace-only input', () => {
+    expect(prettifyFlag('   ')).toBe('Default')
+  })
+
+  it('strips leading -- prefix', () => {
+    expect(prettifyFlag('--collections')).toBe('collections')
+  })
+
+  it('converts single hyphen to space', () => {
+    expect(prettifyFlag('read-only-config')).toBe('read only config')
+  })
+
+  it('handles a CLI-style flag with hyphens', () => {
+    expect(prettifyFlag('--read-only-config')).toBe('read only config')
+  })
+
+  it('handles values without the -- prefix', () => {
+    // Even though these are radio-button values that typically DO
+    // have the prefix, the function should be resilient.
+    expect(prettifyFlag('overlays')).toBe('overlays')
+  })
+
+  it('coerces non-strings to strings', () => {
+    // Defensive: DOM values are always strings, but callers might
+    // pass numbers or booleans by accident.
+    expect(prettifyFlag(42)).toBe('42')
+  })
+})
+
+// ---------------------------------------------------------------------
+// updateSectionStyleHeaderBadge
+// ---------------------------------------------------------------------
+
+describe('updateSectionStyleHeaderBadge', () => {
+  it('renders the formatted label from formatHeaderStyleLabel', () => {
+    const el = installBadge('header-style-rollup-badge')
+    // formatHeaderStyleLabel('kometa') => 'Kometa' (see _util.js tests)
+    updateSectionStyleHeaderBadge('kometa')
+    expect(el.textContent).toBe('Kometa')
+    expect(el.classList.contains('qs-validation-rollup-badge--ok')).toBe(true)
+  })
+
+  it('renders the underlying util\'s empty-input fallback', () => {
+    // formatHeaderStyleLabel('') returns 'Single line' (not empty),
+    // so the || 'Active' fallback in the badge function is actually
+    // dead code today. Documenting the observed behavior anyway so
+    // if the util's fallback ever changes we notice here.
+    const el = installBadge('header-style-rollup-badge')
+    updateSectionStyleHeaderBadge('')
+    expect(el.textContent).toBe('Single line')
+  })
+})
+
+// ---------------------------------------------------------------------
+// updateModeHeaderBadge
+// ---------------------------------------------------------------------
+
+describe('updateModeHeaderBadge', () => {
+  it('shows "CLI labels" (ok) when the show-cli-toggle is checked', () => {
+    document.body.innerHTML = '<input type="checkbox" id="show-cli-toggle" checked />'
+    const badge = installBadge('heading-mode-rollup-badge')
+    updateModeHeaderBadge()
+    expect(badge.textContent).toBe('CLI labels')
+    expect(badge.classList.contains('qs-validation-rollup-badge--ok')).toBe(true)
+  })
+
+  it('shows "Friendly" (unknown) when the toggle is unchecked', () => {
+    document.body.innerHTML = '<input type="checkbox" id="show-cli-toggle" />'
+    const badge = installBadge('heading-mode-rollup-badge')
+    updateModeHeaderBadge()
+    expect(badge.textContent).toBe('Friendly')
+    expect(badge.classList.contains('qs-validation-rollup-badge--unknown')).toBe(true)
+  })
+
+  it('shows "Friendly" (unknown) when the toggle element is missing', () => {
+    const badge = installBadge('heading-mode-rollup-badge')
+    updateModeHeaderBadge()
+    expect(badge.textContent).toBe('Friendly')
+  })
+})
+
+// ---------------------------------------------------------------------
+// updateRunOptionHeaderBadge
+// ---------------------------------------------------------------------
+
+describe('updateRunOptionHeaderBadge', () => {
+  // Helper: build the DOM shape this function reads (a radio group +
+  // a library <select> + a times <input>).
+  function installRunOptionDom (checkedValue, libraryValues = [], timesValue = '') {
+    document.body.innerHTML = `
+      <input type="radio" name="run-option" value="--run" ${checkedValue === '--run' ? 'checked' : ''} />
+      <input type="radio" name="run-option" value="--run-libraries" ${checkedValue === '--run-libraries' ? 'checked' : ''} />
+      <input type="radio" name="run-option" value="--times" ${checkedValue === '--times' ? 'checked' : ''} />
+      <input type="radio" name="run-option" value="" ${checkedValue === '' ? 'checked' : ''} />
+      <select id="library-multiselect" multiple>
+        <option value="Movies">Movies</option>
+        <option value="TV Shows">TV Shows</option>
+        <option value="Anime">Anime</option>
+      </select>
+      <input type="text" id="times-input" value="${timesValue}" />
+    `
+    const select = document.getElementById('library-multiselect')
+    libraryValues.forEach(v => {
+      const opt = Array.from(select.options).find(o => o.value === v)
+      if (opt) opt.selected = true
+    })
+    installBadge('heading-runopt-rollup-badge')
+  }
+
+  it('--run: shows "Run now" (ok)', () => {
+    installRunOptionDom('--run')
+    updateRunOptionHeaderBadge()
+    const badge = document.getElementById('heading-runopt-rollup-badge')
+    expect(badge.textContent).toBe('Run now')
+    expect(badge.classList.contains('qs-validation-rollup-badge--ok')).toBe(true)
+  })
+
+  it('--run-libraries with no libraries selected: shows "Libraries needed" (warn)', () => {
+    installRunOptionDom('--run-libraries', [])
+    updateRunOptionHeaderBadge()
+    const badge = document.getElementById('heading-runopt-rollup-badge')
+    expect(badge.textContent).toBe('Libraries needed')
+    expect(badge.classList.contains('qs-validation-rollup-badge--warn')).toBe(true)
+  })
+
+  it('--run-libraries with 2 libraries: shows count (ok)', () => {
+    installRunOptionDom('--run-libraries', ['Movies', 'TV Shows'])
+    updateRunOptionHeaderBadge()
+    const badge = document.getElementById('heading-runopt-rollup-badge')
+    expect(badge.textContent).toBe('2 libraries')
+    expect(badge.classList.contains('qs-validation-rollup-badge--ok')).toBe(true)
+  })
+
+  it('--times with empty input: shows "Times needed" (warn)', () => {
+    installRunOptionDom('--times', [], '')
+    updateRunOptionHeaderBadge()
+    const badge = document.getElementById('heading-runopt-rollup-badge')
+    expect(badge.textContent).toBe('Times needed')
+    expect(badge.classList.contains('qs-validation-rollup-badge--warn')).toBe(true)
+  })
+
+  it('--times with valid input: shows "Times set" (ok)', () => {
+    installRunOptionDom('--times', [], '05:00|17:00')
+    updateRunOptionHeaderBadge()
+    const badge = document.getElementById('heading-runopt-rollup-badge')
+    expect(badge.textContent).toBe('Times set')
+    expect(badge.classList.contains('qs-validation-rollup-badge--ok')).toBe(true)
+  })
+
+  it('--times with garbage input: shows "Invalid times" (error)', () => {
+    installRunOptionDom('--times', [], 'not-a-time')
+    updateRunOptionHeaderBadge()
+    const badge = document.getElementById('heading-runopt-rollup-badge')
+    expect(badge.textContent).toBe('Invalid times')
+    expect(badge.classList.contains('qs-validation-rollup-badge--error')).toBe(true)
+  })
+
+  it('scheduled default (empty option): shows "Scheduled" (unknown)', () => {
+    installRunOptionDom('')
+    updateRunOptionHeaderBadge()
+    const badge = document.getElementById('heading-runopt-rollup-badge')
+    expect(badge.textContent).toBe('Scheduled')
+    expect(badge.classList.contains('qs-validation-rollup-badge--unknown')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// updateModeFlagsHeaderBadge  +  updateLogFlagsHeaderBadge
+// ---------------------------------------------------------------------
+//
+// These two functions have the same shape (radio group -> prettified
+// label) so we test them side-by-side to keep the tests DRY.
+
+describe('updateModeFlagsHeaderBadge', () => {
+  it('shows the prettified flag name (ok) when a radio is checked', () => {
+    document.body.innerHTML = `
+      <input type="radio" name="mode-flag" value="--collections" checked />
+      <input type="radio" name="mode-flag" value="--overlays" />
+    `
+    installBadge('heading-modeflags-rollup-badge')
+    updateModeFlagsHeaderBadge()
+    const badge = document.getElementById('heading-modeflags-rollup-badge')
+    expect(badge.textContent).toBe('collections')
+    expect(badge.classList.contains('qs-validation-rollup-badge--ok')).toBe(true)
+  })
+
+  it('shows "Default" (unknown) when no radio has value or none selected', () => {
+    document.body.innerHTML = `
+      <input type="radio" name="mode-flag" value="" checked />
+    `
+    installBadge('heading-modeflags-rollup-badge')
+    updateModeFlagsHeaderBadge()
+    const badge = document.getElementById('heading-modeflags-rollup-badge')
+    expect(badge.textContent).toBe('Default')
+    expect(badge.classList.contains('qs-validation-rollup-badge--unknown')).toBe(true)
+  })
+})
+
+describe('updateLogFlagsHeaderBadge', () => {
+  it('shows the prettified flag name (ok) when debug is selected', () => {
+    document.body.innerHTML = `
+      <input type="radio" name="log-flag" value="--debug" checked />
+    `
+    installBadge('heading-logflags-rollup-badge')
+    updateLogFlagsHeaderBadge()
+    const badge = document.getElementById('heading-logflags-rollup-badge')
+    expect(badge.textContent).toBe('debug')
+    expect(badge.classList.contains('qs-validation-rollup-badge--ok')).toBe(true)
+  })
+
+  it('shows "Default" (unknown) with no selection', () => {
+    installBadge('heading-logflags-rollup-badge')
+    updateLogFlagsHeaderBadge()
+    const badge = document.getElementById('heading-logflags-rollup-badge')
+    expect(badge.textContent).toBe('Default')
+  })
+})
+
+// ---------------------------------------------------------------------
+// updateOtherFlagsHeaderBadge
+// ---------------------------------------------------------------------
+
+describe('updateOtherFlagsHeaderBadge', () => {
+  // Helper: build the checkbox grid this function walks
+  function installOtherFlagsDom (opts = {}) {
+    const flags = [
+      'delete-collections', 'delete-labels', 'read-only-config', 'low-priority',
+      'no-report', 'no-missing', 'no-countdown', 'ignore-ghost',
+      'ignore-schedules', 'no-verify-ssl', 'tests',
+      'timeout', 'divider', 'width'
+    ]
+    const html = flags.map(f =>
+      `<input type="checkbox" id="opt-${f}" ${opts[f] ? 'checked' : ''} />`
+    ).join('')
+    document.body.innerHTML = html
+    installBadge('heading-otherflags-rollup-badge')
+  }
+
+  it('shows "Default" (unknown) when no flags are checked', () => {
+    installOtherFlagsDom({})
+    updateOtherFlagsHeaderBadge()
+    const badge = document.getElementById('heading-otherflags-rollup-badge')
+    expect(badge.textContent).toBe('Default')
+    expect(badge.classList.contains('qs-validation-rollup-badge--unknown')).toBe(true)
+  })
+
+  it('counts a single core flag correctly', () => {
+    installOtherFlagsDom({ 'delete-collections': true })
+    updateOtherFlagsHeaderBadge()
+    const badge = document.getElementById('heading-otherflags-rollup-badge')
+    expect(badge.textContent).toBe('1 enabled')
+    expect(badge.classList.contains('qs-validation-rollup-badge--ok')).toBe(true)
+  })
+
+  it('counts multiple core flags', () => {
+    installOtherFlagsDom({
+      'delete-collections': true,
+      'no-report': true,
+      'ignore-schedules': true
+    })
+    updateOtherFlagsHeaderBadge()
+    const badge = document.getElementById('heading-otherflags-rollup-badge')
+    expect(badge.textContent).toBe('3 enabled')
+  })
+
+  it('counts extras (timeout/divider/width) alongside core flags', () => {
+    installOtherFlagsDom({
+      'delete-collections': true,
+      timeout: true,
+      divider: true
+    })
+    updateOtherFlagsHeaderBadge()
+    const badge = document.getElementById('heading-otherflags-rollup-badge')
+    expect(badge.textContent).toBe('3 enabled')
+  })
+
+  it('counts all three extras when nothing else is set', () => {
+    installOtherFlagsDom({
+      timeout: true,
+      divider: true,
+      width: true
+    })
+    updateOtherFlagsHeaderBadge()
+    const badge = document.getElementById('heading-otherflags-rollup-badge')
+    expect(badge.textContent).toBe('3 enabled')
+  })
+
+  it('counts all 11 core flags + 3 extras when everything is on', () => {
+    // Full-house: verifies the two counting paths sum correctly
+    installOtherFlagsDom({
+      'delete-collections': true, 'delete-labels': true, 'read-only-config': true,
+      'low-priority': true, 'no-report': true, 'no-missing': true,
+      'no-countdown': true, 'ignore-ghost': true, 'ignore-schedules': true,
+      'no-verify-ssl': true, tests: true,
+      timeout: true, divider: true, width: true
+    })
+    updateOtherFlagsHeaderBadge()
+    const badge = document.getElementById('heading-otherflags-rollup-badge')
+    expect(badge.textContent).toBe('14 enabled')
+  })
+})


### PR DESCRIPTION
## What

Fourth module out of the 900-kometa.js god-file split (parts 1-3: #1554, #1556, #1557). `900-kometa.js`: 3747 → 3665 lines (**−82**).

## What moved

Extracted to `static/local-js/modules/kometa/_headerBadges.js`:

| Function | Role |
|---|---|
| `setHeaderRollupBadge` | core primitive — text + color class swap |
| `prettifyFlag` | CLI-flag → human-readable label |
| `updateSectionStyleHeaderBadge` | header-style picker badge |
| `updateModeHeaderBadge` | friendly/CLI toggle badge |
| `updateRunOptionHeaderBadge` | run-option radio group badge (4 branches) |
| `updateModeFlagsHeaderBadge` | mode-flag radio badge |
| `updateLogFlagsHeaderBadge` | log-flag radio badge |
| `updateOtherFlagsHeaderBadge` | checkbox-count badge |

**Every extracted function reads exclusively from the DOM and writes back into it. Zero module-scoped state dependencies.**

## What stayed behind (deliberately)

Three sibling badge functions and the orchestrator stay in `900-kometa.js` **for now** because they depend on shared state that hasn't migrated to `_state.js` yet:

| Function | Why it stayed |
|---|---|
| `updateConfigOutputHeaderBadges` | needs `showYAML` bool |
| `updateRunCommandHeaderBadge` | needs 4 `KOMETA_*` flags, `KOMETA_STATUS`, `showYAML`, `isRunCommandValid()` |
| `updateLogscanHeaderBadge` | needs `lastLogscanPayload` |
| `syncFinalAccordionRollups` | orchestrator (calls both extracted and stay-behind fns) |

These will move here in follow-up PRs after the state migrates to `_state.js` (which is #1557's foundational work). Keeping this split clean lets the reviewer verify the pure DOM-only extraction in isolation.

## Why `setHeaderRollupBadge` is exported even though stay-behind functions still use it

The stay-behind functions in `900-kometa.js` still call `setHeaderRollupBadge` from all their branches. Rather than duplicate the utility, `900-kometa.js` imports it back from `_headerBadges.js`. Same pattern used with `formatHeaderStyleLabel` + `isValidTimesFormat` from `_util.js` in previous extractions.

## Vitest coverage: 38 new tests

- **`setHeaderRollupBadge`**: happy path, missing element no-op, all 4 canonical states (`unknown`/`ok`/`warn`/`error`), invalid state fallback, modifier class **swap** (not accumulate), base class preservation, text overwrite (not append)
- **`prettifyFlag`**: empty/null/undefined/whitespace → `'Default'`, `--` prefix stripping, hyphen-to-space, non-string coercion
- **`updateSectionStyleHeaderBadge`**: happy path + a note documenting that the `|| 'Active'` fallback is dead code (the underlying `formatHeaderStyleLabel` never returns empty)
- **`updateModeHeaderBadge`**: checked / unchecked / missing element
- **`updateRunOptionHeaderBadge`**: all 4 branches (`--run`, `--run-libraries` with 0 or N libs, `--times` with empty/valid/invalid input, scheduled default)
- **`updateModeFlagsHeaderBadge`** / **`updateLogFlagsHeaderBadge`**: selected radio, empty-value → 'Default'
- **`updateOtherFlagsHeaderBadge`**: 0 flags, 1 core, N core, extras alongside core, all extras alone, full house (11 core + 3 extras = 14)

## Verification

- **742/742 Vitest pass** (was 704 after #1556 merged; +38 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- ESLint clean, Node syntax check clean

## What's next

Depending on merge order for #1557 (`_state.js`):

- **Path A** (if #1557 merges first): follow-up PR migrates the three stay-behind badge functions + `syncFinalAccordionRollups` to `_headerBadges.js`, importing `showYAML` and `KOMETA_*` flags from `kometaState`.
- **Path B** (in parallel with #1557): extract `_headerGrid.js` or `_validationGate.js` next — both are similarly self-contained and don't compete for state.

Remaining from the split roadmap:
- `_validationGate.js` — final gate + validation row rendering
- `_headerGrid.js` — font grid + sample loading
- `_kometaRuntime.js` — install-mode checks + `validateKometaRoot`
- `_runCommand.js` — `buildCommand` + placeholder state + mode badges
- `_kometaUpdate.js` — branch override + update job flow (~800 lines, biggest one)
- `_runProgress.js` — `renderRunProgress` + sparkline rendering
- `_logs.js` + `_logscan.js` — log stats, log fetch, logscan analysis