### PR TITLE
Split 900-kometa.js part 5: extract header-style grid + fix 2 latent bugs

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -3,8 +3,6 @@ import {
   quoteIfNeeded,
   formatElapsed,
   computeYamlLineCount,
-  normalizeFontName,
-  formatHeaderStyleLabel,
   linkifyText,
   formatTimestampLocal,
   clampPercent,
@@ -25,13 +23,17 @@ import {
 import { kometaState } from './modules/kometa/_state.js'
 import {
   setHeaderRollupBadge,
-  updateSectionStyleHeaderBadge,
   updateModeHeaderBadge,
   updateRunOptionHeaderBadge,
   updateModeFlagsHeaderBadge,
   updateLogFlagsHeaderBadge,
   updateOtherFlagsHeaderBadge
 } from './modules/kometa/_headerBadges.js'
+import {
+  updateHeaderStyleLabel,
+  setActiveGridCard,
+  loadHeaderGridSamples
+} from './modules/kometa/_headerGrid.js'
 
 let KOMETA_UPDATING = false
 let KOMETA_VALIDATED = false
@@ -129,10 +131,6 @@ const headerGrid = document.getElementById('header-style-grid')
 const headerGridCollapse = document.getElementById('header-style-grid-collapse')
 const headerStyleWait = document.getElementById('header-style-wait')
 const finalContentWrapper = document.getElementById('final-content-wrapper')
-const headerGridStatus = document.getElementById('header-style-grid-status')
-const headerGridProgress = document.getElementById('header-style-grid-progress')
-const headerGridProgressBar = headerGridProgress ? headerGridProgress.querySelector('.progress-bar') : null
-const headerStyleLabel = document.getElementById('header-style-label')
 const kometaActionsHeading = document.getElementById('kometa-actions-heading')
 const kometaActionsCollapse = document.getElementById('kometa-actions-collapse')
 const kometaActionsToggle = document.getElementById('kometa-actions-toggle')
@@ -377,12 +375,6 @@ function updateYamlLineCount () {
 updateYamlLineCount()
 yamlOutput?.addEventListener('input', updateYamlLineCount)
 
-function updateHeaderStyleLabel (value) {
-  if (!headerStyleLabel) return
-  headerStyleLabel.textContent = formatHeaderStyleLabel(value)
-  updateSectionStyleHeaderBadge(value)
-}
-
 function initBootstrapTooltips (scope, selector, options) {
   if (typeof bootstrap === 'undefined' || !bootstrap.Tooltip) return
   const root = scope || document
@@ -418,109 +410,6 @@ function disposeBootstrapTooltips (scope, selector) {
     const existing = bootstrap.Tooltip.getInstance(el)
     if (existing) existing.dispose()
   })
-}
-
-function setActiveGridCard (fontName) {
-  if (!headerGrid) return
-  const activeFont = normalizeFontName(fontName)
-  headerGrid.querySelectorAll('.header-style-card').forEach(card => {
-    card.classList.toggle('active', card.dataset.font === activeFont)
-  })
-}
-
-function updateGridStatus (message) {
-  if (headerGridStatus) headerGridStatus.textContent = message || ''
-}
-
-function updateGridProgress (loaded, total) {
-  if (!headerGridProgress || !headerGridProgressBar) return
-  if (!total) {
-    headerGridProgress.classList.add('d-none')
-    headerGridProgressBar.style.width = '0%'
-    return
-  }
-  const pct = Math.min(100, Math.round((loaded / total) * 100))
-  headerGridProgress.classList.remove('d-none')
-  headerGridProgressBar.style.width = `${pct}%`
-}
-
-async function loadHeaderGridSamples () {
-  if (!headerGrid) return
-  const fonts = JSON.parse(headerGrid.dataset.fonts || '[]')
-  if (!fonts.length) {
-    headerGrid.replaceChildren()
-    const empty = document.createElement('div')
-    empty.className = 'text-muted small'
-    empty.textContent = 'No fonts available.'
-    headerGrid.appendChild(empty)
-    updateGridStatus('')
-    updateGridProgress(0, 0)
-    return
-  }
-
-  updateGridStatus(`Loading ${fonts.length} font previews...`)
-  updateGridProgress(0, fonts.length)
-
-  headerGrid.replaceChildren()
-  fonts.forEach(font => {
-    const card = document.createElement('button')
-    card.type = 'button'
-    card.className = 'header-style-card'
-    card.dataset.font = font
-    const title = document.createElement('div')
-    title.className = 'header-style-card-title'
-    title.textContent = font.replace(/_/g, ' ')
-    const preview = document.createElement('pre')
-    preview.className = 'header-style-card-preview'
-    preview.textContent = 'Loading...'
-    card.insertAdjacentHTML('beforeend', title, preview)
-    card.addEventListener('click', () => {
-      if (headerSelect) {
-        headerSelect.value = font
-        headerSelect.dispatchEvent(new Event('change'))
-      }
-      updateHeaderStyleLabel(font)
-      setActiveGridCard(font)
-    })
-    headerGrid.appendChild(card)
-  })
-
-  setActiveGridCard(headerSelect ? headerSelect.value : '')
-
-  const chunkSize = 12
-  let loadedCount = 0
-  for (let i = 0; i < fonts.length; i += chunkSize) {
-    const chunk = fonts.slice(i, i + chunkSize)
-    try {
-      const res = await fetch('/header-style-previews', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ fonts: chunk })
-      })
-      const data = await res.json()
-      if (!res.ok || !data.success) {
-        throw new Error(data.message || 'Preview unavailable.')
-      }
-      const previews = data.previews || []
-      previews.forEach(entry => {
-        const card = headerGrid.querySelector(`.header-style-card[data-font="${entry.font}"]`)
-        const pre = card ? card.querySelector('.header-style-card-preview') : null
-        if (pre) pre.textContent = entry.preview || ''
-      })
-    } catch {
-      chunk.forEach(font => {
-        const card = headerGrid.querySelector(`.header-style-card[data-font="${font}"]`)
-        const pre = card ? card.querySelector('.header-style-card-preview') : null
-        if (pre) pre.textContent = 'Preview unavailable.'
-      })
-    }
-    loadedCount += chunk.length
-    updateGridStatus(`Loaded ${Math.min(loadedCount, fonts.length)} of ${fonts.length} previews`)
-    updateGridProgress(Math.min(loadedCount, fonts.length), fonts.length)
-  }
-  updateGridStatus(`Loaded ${fonts.length} previews`)
-  updateGridProgress(fonts.length, fonts.length)
-  setTimeout(() => updateGridProgress(0, 0), 800)
 }
 
 if (headerGridCollapse && headerGrid) {

--- a/static/local-js/modules/kometa/_headerGrid.js
+++ b/static/local-js/modules/kometa/_headerGrid.js
@@ -1,0 +1,245 @@
+// Header-style font grid + sample loading.
+//
+// The Kometa config page has a "Header style" section where the user
+// picks the ASCII-art font used in generated section headers. The
+// section header opens up a Bootstrap collapse containing a GRID of
+// cards -- one per available font -- each showing a live preview
+// rendered by the backend.
+//
+// This module owns:
+//
+//   updateHeaderStyleLabel   -- keep the small text label in sync
+//                               with the currently-selected font
+//   setActiveGridCard        -- toggle the .active class on the
+//                               correct card
+//   loadHeaderGridSamples    -- lazy-load preview text for every
+//                               font, in chunks, updating a status
+//                               line + progress bar as it goes
+//
+// The two private helpers `updateGridStatus` and `updateGridProgress`
+// are also here but not exported -- they're only used by
+// loadHeaderGridSamples.
+//
+// DESIGN NOTES:
+//
+//   1. DOM refs are resolved LAZILY inside each function (not cached
+//      at module init) so that:
+//        - Import order doesn't matter (the module can be imported
+//          before DOMContentLoaded)
+//        - Tests can install a fresh DOM in each beforeEach without
+//          re-importing the module
+//        - The extra getElementById cost is negligible (nanoseconds)
+//
+//   2. The chunked fetch call in loadHeaderGridSamples is designed
+//      for pagination + progressive UI: 12 fonts per POST to
+//      /header-style-previews. This is a deliberate tradeoff --
+//      one giant fetch would be simpler but leave the user staring
+//      at "Loading..." placeholders longer.
+//
+//   3. loadHeaderGridSamples takes an optional `fetchImpl` param
+//      that defaults to global `fetch`. Solely for testability --
+//      lets vitest inject a mock without stubbing globals.
+//
+// BUG FIX INCLUDED (see PR):
+//
+//   The pre-extraction code had:
+//     card.insertAdjacentHTML('beforeend', title, preview)
+//
+//   That's a mistake -- insertAdjacentHTML takes a STRING, not DOM
+//   elements. `title` (a <div>) got string-coerced to
+//   '[object HTMLDivElement]', which appeared literally in every
+//   card. And `preview` was silently ignored (extra args are dropped).
+//
+//   The fix is to use card.append(title, preview) which correctly
+//   appends DOM nodes.
+
+import { formatHeaderStyleLabel } from './_util.js'
+import { updateSectionStyleHeaderBadge } from './_headerBadges.js'
+
+// ---------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------
+
+function getStatusEl () {
+  return document.getElementById('header-style-grid-status')
+}
+
+function getProgressEl () {
+  return document.getElementById('header-style-grid-progress')
+}
+
+function getProgressBarEl () {
+  const wrapper = getProgressEl()
+  return wrapper ? wrapper.querySelector('.progress-bar') : null
+}
+
+function updateGridStatus (message) {
+  const el = getStatusEl()
+  if (el) el.textContent = message || ''
+}
+
+function updateGridProgress (loaded, total) {
+  const wrapper = getProgressEl()
+  const bar = getProgressBarEl()
+  if (!wrapper || !bar) return
+  if (!total) {
+    wrapper.classList.add('d-none')
+    bar.style.width = '0%'
+    return
+  }
+  const pct = Math.min(100, Math.round((loaded / total) * 100))
+  wrapper.classList.remove('d-none')
+  bar.style.width = `${pct}%`
+}
+
+// ---------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------
+
+/**
+ * Sync the small `<span id="header-style-label">` and the accordion
+ * header badge with the currently-selected font.
+ *
+ * @param {string} value  Font name (e.g. 'ansi_shadow'). Empty/undefined
+ *                        falls back to whatever formatHeaderStyleLabel
+ *                        returns for empty input ('Single line' today).
+ */
+export function updateHeaderStyleLabel (value) {
+  const el = document.getElementById('header-style-label')
+  if (!el) return
+  el.textContent = formatHeaderStyleLabel(value)
+  updateSectionStyleHeaderBadge(value)
+}
+
+/**
+ * Highlight exactly one card in the grid, matched by its data-font
+ * attribute. Removes the active class from all other cards.
+ *
+ * No-op if the grid isn't in the DOM (Bootstrap collapse hasn't been
+ * expanded yet, or we're on a page that doesn't render the grid).
+ *
+ * @param {string} fontName  The font to mark active. Compared as a
+ *                           raw string against each card's data-font
+ *                           attribute (no normalization) -- both
+ *                           sides originate from the same backend
+ *                           enumeration, so they already match
+ *                           character-for-character.
+ *
+ *                           Note: pre-fix, this function passed the
+ *                           input through normalizeFontName which
+ *                           replaces underscores with spaces. That
+ *                           meant a font like 'ansi_shadow' compared
+ *                           to card.dataset.font='ansi_shadow' as
+ *                           'ansi shadow' !== 'ansi_shadow' -- so
+ *                           any underscored font never activated.
+ *                           The bundled fonts happen to be underscore-
+ *                           free (big, doom, standard, ...) so the
+ *                           bug was invisible with default config.
+ */
+export function setActiveGridCard (fontName) {
+  const grid = document.getElementById('header-style-grid')
+  if (!grid) return
+  const target = String(fontName || '').trim()
+  grid.querySelectorAll('.header-style-card').forEach(card => {
+    card.classList.toggle('active', card.dataset.font === target)
+  })
+}
+
+/**
+ * Lazy-load font previews for every font declared in
+ * `#header-style-grid[data-fonts]`. Renders one clickable card per
+ * font, then fills in previews from the backend in batches of 12.
+ *
+ * Called once when the accordion collapse first expands (see the
+ * `show.bs.collapse` listener in 900-kometa.js). Should NOT be
+ * called on every open -- the caller is expected to gate on a
+ * `gridLoaded` flag.
+ *
+ * @param {typeof fetch} [fetchImpl]  Injectable fetch for testing.
+ *                                    Defaults to global fetch.
+ * @returns {Promise<void>}
+ */
+export async function loadHeaderGridSamples (fetchImpl = fetch) {
+  const grid = document.getElementById('header-style-grid')
+  if (!grid) return
+  const fonts = JSON.parse(grid.dataset.fonts || '[]')
+  if (!fonts.length) {
+    grid.replaceChildren()
+    const empty = document.createElement('div')
+    empty.className = 'text-muted small'
+    empty.textContent = 'No fonts available.'
+    grid.appendChild(empty)
+    updateGridStatus('')
+    updateGridProgress(0, 0)
+    return
+  }
+
+  updateGridStatus(`Loading ${fonts.length} font previews...`)
+  updateGridProgress(0, fonts.length)
+
+  const headerSelect = document.getElementById('header-style')
+
+  grid.replaceChildren()
+  fonts.forEach(font => {
+    const card = document.createElement('button')
+    card.type = 'button'
+    card.className = 'header-style-card'
+    card.dataset.font = font
+    const title = document.createElement('div')
+    title.className = 'header-style-card-title'
+    title.textContent = font.replace(/_/g, ' ')
+    const preview = document.createElement('pre')
+    preview.className = 'header-style-card-preview'
+    preview.textContent = 'Loading...'
+    // FIX: was card.insertAdjacentHTML('beforeend', title, preview),
+    // which coerces `title` to '[object HTMLDivElement]' (rendered
+    // as literal text) and silently drops `preview`. See docstring.
+    card.append(title, preview)
+    card.addEventListener('click', () => {
+      if (headerSelect) {
+        headerSelect.value = font
+        headerSelect.dispatchEvent(new Event('change'))
+      }
+      updateHeaderStyleLabel(font)
+      setActiveGridCard(font)
+    })
+    grid.appendChild(card)
+  })
+
+  setActiveGridCard(headerSelect ? headerSelect.value : '')
+
+  const chunkSize = 12
+  let loadedCount = 0
+  for (let i = 0; i < fonts.length; i += chunkSize) {
+    const chunk = fonts.slice(i, i + chunkSize)
+    try {
+      const res = await fetchImpl('/header-style-previews', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ fonts: chunk })
+      })
+      const data = await res.json()
+      if (!res.ok || !data.success) {
+        throw new Error(data.message || 'Preview unavailable.')
+      }
+      const previews = data.previews || []
+      previews.forEach(entry => {
+        const card = grid.querySelector(`.header-style-card[data-font="${entry.font}"]`)
+        const pre = card ? card.querySelector('.header-style-card-preview') : null
+        if (pre) pre.textContent = entry.preview || ''
+      })
+    } catch {
+      chunk.forEach(font => {
+        const card = grid.querySelector(`.header-style-card[data-font="${font}"]`)
+        const pre = card ? card.querySelector('.header-style-card-preview') : null
+        if (pre) pre.textContent = 'Preview unavailable.'
+      })
+    }
+    loadedCount += chunk.length
+    updateGridStatus(`Loaded ${Math.min(loadedCount, fonts.length)} of ${fonts.length} previews`)
+    updateGridProgress(Math.min(loadedCount, fonts.length), fonts.length)
+  }
+  updateGridStatus(`Loaded ${fonts.length} previews`)
+  updateGridProgress(fonts.length, fonts.length)
+  setTimeout(() => updateGridProgress(0, 0), 800)
+}

--- a/tests/js/kometa/headerGrid.test.js
+++ b/tests/js/kometa/headerGrid.test.js
@@ -1,0 +1,345 @@
+// Tests for static/local-js/modules/kometa/_headerGrid.js
+//
+// The module has three exported functions and two private helpers.
+// Tests build a fresh fixture DOM in beforeEach and inspect the
+// resulting DOM state after each call.
+//
+// Coverage strategy:
+//
+//   updateHeaderStyleLabel   -- happy path, missing label element,
+//                               delegates to updateSectionStyleHeaderBadge
+//                               (which we verify via the badge DOM)
+//
+//   setActiveGridCard        -- toggles .active on exactly one card,
+//                               empty grid no-op, unknown font clears
+//                               all actives, normalizes the input
+//
+//   loadHeaderGridSamples    -- empty fonts list (renders "No fonts"),
+//                               happy path with a mocked fetch that
+//                               returns previews in chunks, fetch
+//                               failure fallback ("Preview unavailable"),
+//                               the BUG-FIX assertion (card contains
+//                               the title as a DOM node, not the
+//                               literal "[object HTMLDivElement]"),
+//                               clicking a card updates the select
+//                               and the label
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  updateHeaderStyleLabel,
+  setActiveGridCard,
+  loadHeaderGridSamples
+} from '../../../static/local-js/modules/kometa/_headerGrid.js'
+
+// ---------------------------------------------------------------------
+// Fixture DOM helpers
+// ---------------------------------------------------------------------
+//
+// The full grid page shape:
+//   #header-style-label       -- small text label above the accordion
+//   #header-style-grid        -- container for the cards; carries
+//                                data-fonts JSON array
+//   #header-style-grid-status -- status text ("Loading N of M")
+//   #header-style-grid-progress + child .progress-bar -- progress UI
+//   #header-style               -- the underlying <select> element
+//   #header-style-rollup-badge  -- the accordion header badge that
+//                                  updateSectionStyleHeaderBadge writes
+//                                  to (from _headerBadges.js)
+
+function installGridDom ({ fonts = [], selected = '' } = {}) {
+  document.body.innerHTML = `
+    <span id="header-style-label"></span>
+    <span id="header-style-rollup-badge" class="qs-validation-rollup-badge qs-validation-rollup-badge--unknown"></span>
+    <select id="header-style">
+      ${fonts.map(f => `<option value="${f}" ${f === selected ? 'selected' : ''}>${f}</option>`).join('')}
+    </select>
+    <div id="header-style-grid" data-fonts='${JSON.stringify(fonts)}'></div>
+    <div id="header-style-grid-status"></div>
+    <div id="header-style-grid-progress" class="d-none">
+      <div class="progress-bar" style="width: 0%"></div>
+    </div>
+  `
+}
+
+// Build a card manually (mimics what loadHeaderGridSamples produces,
+// without the async fetch). Useful for testing setActiveGridCard in
+// isolation.
+function installCard (fontName, activeInitially = false) {
+  const grid = document.getElementById('header-style-grid')
+  const card = document.createElement('button')
+  card.type = 'button'
+  card.className = 'header-style-card'
+  if (activeInitially) card.classList.add('active')
+  card.dataset.font = fontName
+  grid.appendChild(card)
+  return card
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  vi.restoreAllMocks()
+})
+
+// ---------------------------------------------------------------------
+// updateHeaderStyleLabel
+// ---------------------------------------------------------------------
+
+describe('updateHeaderStyleLabel', () => {
+  beforeEach(() => {
+    installGridDom()
+  })
+
+  it('sets the label element text via formatHeaderStyleLabel', () => {
+    updateHeaderStyleLabel('ansi_shadow')
+    const label = document.getElementById('header-style-label')
+    // formatHeaderStyleLabel replaces _ with space and title-cases
+    expect(label.textContent).toBe('Ansi Shadow')
+  })
+
+  it('is a no-op when the label element is missing', () => {
+    document.getElementById('header-style-label').remove()
+    expect(() => updateHeaderStyleLabel('anything')).not.toThrow()
+  })
+
+  it('also updates the section-style rollup badge (via headerBadges)', () => {
+    updateHeaderStyleLabel('big')
+    const badge = document.getElementById('header-style-rollup-badge')
+    expect(badge.textContent).toBe('Big')
+    expect(badge.classList.contains('qs-validation-rollup-badge--ok')).toBe(true)
+  })
+
+  it('handles empty input (uses the util\'s fallback: "Single line")', () => {
+    updateHeaderStyleLabel('')
+    const label = document.getElementById('header-style-label')
+    expect(label.textContent).toBe('Single line')
+  })
+})
+
+// ---------------------------------------------------------------------
+// setActiveGridCard
+// ---------------------------------------------------------------------
+
+describe('setActiveGridCard', () => {
+  beforeEach(() => {
+    installGridDom()
+  })
+
+  it('marks the matching card active and no others', () => {
+    installCard('ansi_shadow')
+    installCard('big')
+    installCard('block')
+    setActiveGridCard('big')
+    const cards = document.querySelectorAll('.header-style-card')
+    expect(cards[0].classList.contains('active')).toBe(false)
+    expect(cards[1].classList.contains('active')).toBe(true)
+    expect(cards[2].classList.contains('active')).toBe(false)
+  })
+
+  it('BUG FIX: matches underscored font names against raw data-font (no normalization)', () => {
+    // Pre-fix, this function passed the input through normalizeFontName
+    // which converts underscores to spaces. So 'ansi_shadow' compared
+    // against card.dataset.font='ansi_shadow' as 'ansi shadow' !==
+    // 'ansi_shadow' -- underscored font names never activated.
+    installCard('ansi_shadow')
+    installCard('big')
+    setActiveGridCard('ansi_shadow')
+    const cards = document.querySelectorAll('.header-style-card')
+    expect(cards[0].classList.contains('active')).toBe(true)
+    expect(cards[1].classList.contains('active')).toBe(false)
+  })
+
+  it('trims whitespace around the input', () => {
+    installCard('big')
+    setActiveGridCard('  big  ')
+    expect(document.querySelector('.header-style-card').classList.contains('active')).toBe(true)
+  })
+
+  it('clears active from a previously-active card when switching', () => {
+    installCard('a', true) // pre-active
+    installCard('b')
+    setActiveGridCard('b')
+    const cards = document.querySelectorAll('.header-style-card')
+    expect(cards[0].classList.contains('active')).toBe(false)
+    expect(cards[1].classList.contains('active')).toBe(true)
+  })
+
+  it('clears active from all cards when the font matches none', () => {
+    installCard('a', true)
+    installCard('b', true)
+    setActiveGridCard('nonexistent')
+    const cards = document.querySelectorAll('.header-style-card')
+    expect(cards[0].classList.contains('active')).toBe(false)
+    expect(cards[1].classList.contains('active')).toBe(false)
+  })
+
+  it('is a no-op when the grid element is missing', () => {
+    document.getElementById('header-style-grid').remove()
+    expect(() => setActiveGridCard('anything')).not.toThrow()
+  })
+
+  it('handles an empty grid (no cards installed)', () => {
+    // Grid exists but has no card children
+    expect(() => setActiveGridCard('anything')).not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------
+// loadHeaderGridSamples
+// ---------------------------------------------------------------------
+
+describe('loadHeaderGridSamples', () => {
+  // Helper: build a fetch stub that returns the given preview map
+  function makeFetchStub (previewsByFont) {
+    return vi.fn(async (url, init) => {
+      const body = JSON.parse(init.body)
+      const previews = body.fonts.map(f => ({
+        font: f,
+        preview: previewsByFont[f] || `-- preview of ${f} --`
+      }))
+      return {
+        ok: true,
+        json: async () => ({ success: true, previews })
+      }
+    })
+  }
+
+  it('renders "No fonts available." when data-fonts is empty', async () => {
+    installGridDom({ fonts: [] })
+    const fetchStub = vi.fn()
+    await loadHeaderGridSamples(fetchStub)
+    const grid = document.getElementById('header-style-grid')
+    expect(grid.querySelector('.text-muted').textContent).toBe('No fonts available.')
+    // fetch should NOT have been called for an empty list
+    expect(fetchStub).not.toHaveBeenCalled()
+  })
+
+  it('renders one card per font with a normalized title', async () => {
+    installGridDom({ fonts: ['ansi_shadow', 'big'] })
+    await loadHeaderGridSamples(makeFetchStub({}))
+    const cards = document.querySelectorAll('.header-style-card')
+    expect(cards).toHaveLength(2)
+    const titles = Array.from(document.querySelectorAll('.header-style-card-title'))
+    expect(titles[0].textContent).toBe('ansi shadow') // _ -> space
+    expect(titles[1].textContent).toBe('big')
+  })
+
+  // === THE BUG FIX ASSERTION ===
+  it('BUG FIX: card contains the title as a proper DOM node, not "[object HTMLDivElement]" text', async () => {
+    // Pre-fix behavior:
+    //   card.insertAdjacentHTML('beforeend', title, preview)
+    // string-coerced `title` (a <div>) into the literal string
+    // "[object HTMLDivElement]" and dropped `preview` entirely.
+    //
+    // Correct behavior:
+    //   card.append(title, preview) appends the DOM nodes directly.
+    installGridDom({ fonts: ['ansi_shadow'] })
+    await loadHeaderGridSamples(makeFetchStub({ ansi_shadow: 'PREVIEW' }))
+    const card = document.querySelector('.header-style-card')
+    // 1. There's a real .header-style-card-title child element
+    const title = card.querySelector('.header-style-card-title')
+    expect(title).not.toBeNull()
+    expect(title.tagName).toBe('DIV')
+    expect(title.textContent).toBe('ansi shadow')
+    // 2. There's a real .header-style-card-preview child element
+    const pre = card.querySelector('.header-style-card-preview')
+    expect(pre).not.toBeNull()
+    expect(pre.tagName).toBe('PRE')
+    // 3. The card's textContent does NOT contain the buggy literal
+    expect(card.textContent).not.toContain('[object HTMLDivElement]')
+    expect(card.textContent).not.toContain('[object HTMLPreElement]')
+  })
+
+  it('populates preview text after the fetch resolves', async () => {
+    installGridDom({ fonts: ['ansi_shadow'] })
+    await loadHeaderGridSamples(makeFetchStub({ ansi_shadow: 'BIG PREVIEW' }))
+    const pre = document.querySelector('.header-style-card-preview')
+    expect(pre.textContent).toBe('BIG PREVIEW')
+  })
+
+  it('chunks fetches in batches of 12', async () => {
+    // 15 fonts should produce two POSTs (12 + 3)
+    const fonts = Array.from({ length: 15 }, (_, i) => `font${i}`)
+    installGridDom({ fonts })
+    const fetchStub = makeFetchStub({})
+    await loadHeaderGridSamples(fetchStub)
+    expect(fetchStub).toHaveBeenCalledTimes(2)
+    const firstCall = JSON.parse(fetchStub.mock.calls[0][1].body)
+    const secondCall = JSON.parse(fetchStub.mock.calls[1][1].body)
+    expect(firstCall.fonts).toHaveLength(12)
+    expect(secondCall.fonts).toHaveLength(3)
+  })
+
+  it('falls back to "Preview unavailable." when the fetch throws', async () => {
+    installGridDom({ fonts: ['a', 'b'] })
+    const failingFetch = vi.fn(async () => { throw new Error('network down') })
+    await loadHeaderGridSamples(failingFetch)
+    const previews = Array.from(document.querySelectorAll('.header-style-card-preview'))
+    expect(previews.every(p => p.textContent === 'Preview unavailable.')).toBe(true)
+  })
+
+  it('falls back on !res.ok', async () => {
+    installGridDom({ fonts: ['a'] })
+    const failingFetch = vi.fn(async () => ({
+      ok: false,
+      json: async () => ({ success: false, message: 'server broke' })
+    }))
+    await loadHeaderGridSamples(failingFetch)
+    const pre = document.querySelector('.header-style-card-preview')
+    expect(pre.textContent).toBe('Preview unavailable.')
+  })
+
+  it('falls back on !data.success even when res.ok', async () => {
+    installGridDom({ fonts: ['a'] })
+    const failingFetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ success: false })
+    }))
+    await loadHeaderGridSamples(failingFetch)
+    const pre = document.querySelector('.header-style-card-preview')
+    expect(pre.textContent).toBe('Preview unavailable.')
+  })
+
+  it('clicking a card updates the select value + fires change + updates label', async () => {
+    installGridDom({ fonts: ['ansi_shadow', 'big'], selected: 'ansi_shadow' })
+    await loadHeaderGridSamples(makeFetchStub({}))
+    const select = document.getElementById('header-style')
+    const changeSpy = vi.fn()
+    select.addEventListener('change', changeSpy)
+
+    const bigCard = document.querySelector('[data-font="big"]')
+    bigCard.click()
+
+    expect(select.value).toBe('big')
+    expect(changeSpy).toHaveBeenCalledTimes(1)
+    // Label reflects the new selection
+    expect(document.getElementById('header-style-label').textContent).toBe('Big')
+    // AND the clicked card is now the active one
+    expect(bigCard.classList.contains('active')).toBe(true)
+    expect(document.querySelector('[data-font="ansi_shadow"]').classList.contains('active')).toBe(false)
+  })
+
+  it('is a no-op when the grid element is missing entirely', async () => {
+    // No installGridDom() call
+    const fetchStub = vi.fn()
+    await loadHeaderGridSamples(fetchStub)
+    expect(fetchStub).not.toHaveBeenCalled()
+  })
+
+  it('sets the initial active card based on the select value', async () => {
+    installGridDom({ fonts: ['a', 'b', 'c'], selected: 'b' })
+    await loadHeaderGridSamples(makeFetchStub({}))
+    const cards = document.querySelectorAll('.header-style-card')
+    expect(cards[0].classList.contains('active')).toBe(false)
+    expect(cards[1].classList.contains('active')).toBe(true)
+    expect(cards[2].classList.contains('active')).toBe(false)
+  })
+
+  it('updates the status line to show progress', async () => {
+    // Deliberately use 3 fonts so we can inspect intermediate + final
+    installGridDom({ fonts: ['a', 'b', 'c'] })
+    await loadHeaderGridSamples(makeFetchStub({}))
+    const status = document.getElementById('header-style-grid-status')
+    // Final message
+    expect(status.textContent).toBe('Loaded 3 previews')
+  })
+})


### PR DESCRIPTION
## What

Fifth module out of the 900-kometa.js god-file split (parts 1-4: #1554, #1556, #1557, #1560). `900-kometa.js`: 3661 → 3550 lines (**−111**). **Bonus:** adds tests + fixes for two pre-existing bugs the extraction uncovered.

## What moved

Extracted to `static/local-js/modules/kometa/_headerGrid.js`:

| Function | Role |
|---|---|
| `updateHeaderStyleLabel` | keeps label + rollup badge in sync with selected font |
| `setActiveGridCard` | toggles `.active` on exactly one card |
| `loadHeaderGridSamples` | lazy-loads previews for every font in chunks of 12 with progress UI |

Private helpers not exported: `updateGridStatus`, `updateGridProgress`.

##  Latent bugs found and fixed

### BUG 1: card contents rendered as literal `[object HTMLDivElement]`

Pre-fix, `loadHeaderGridSamples` had:

```js
card.insertAdjacentHTML('beforeend', title, preview)
```

`insertAdjacentHTML` takes a **string** as its 2nd arg. Passing DOM elements string-coerces `title` (a `<div>`) to the literal string `'[object HTMLDivElement]'`, which appeared inside every card. And `preview` (a `<pre>`) was silently dropped — extra args to `insertAdjacentHTML` are ignored, no error.

**Fix:** use `card.append(title, preview)` which correctly appends the DOM nodes.

### BUG 2: `setActiveGridCard` silently fails for underscored font names

Pre-fix, `setActiveGridCard` normalized the input via `normalizeFontName` (which replaces underscores with spaces) but compared against the raw `card.dataset.font`. So a font like `'ansi_shadow'` compared as `'ansi shadow' !== 'ansi_shadow'` — the active class never applied.

The bug was **invisible for the 10 bundled fonts** (`big`, `doom`, `ghost`, `slant`, `standard`, ...) which happen to be underscore-free. Users on pyfiglet's global font list (many of which have underscores) would have hit it.

**Fix:** drop the normalization. Both sides of the comparison originate from the same backend font enumeration, so they already match character-for-character.

Both bugs would have been caught by **any** test coverage. Adding tests IS the fix — they force the correct DOM contract.

## Design notes

1. **DOM refs resolved lazily** inside each function (not cached at module init) so import order doesn't matter and tests can install fresh DOM in `beforeEach`.
2. **`loadHeaderGridSamples` takes an optional `fetchImpl` param** defaulting to global `fetch`. Purely for testability — lets vitest inject a mock without stubbing globals.
3. Cleaned up 3 now-unused DOM refs from `900-kometa.js` (`headerGridStatus`, `headerGridProgress`, `headerGridProgressBar`, `headerStyleLabel`) and 2 now-unused util imports (`normalizeFontName`, `formatHeaderStyleLabel`).

## Vitest coverage: 23 new tests

- **`updateHeaderStyleLabel`**: happy path, missing label element, delegates to `updateSectionStyleHeaderBadge` (verified via badge DOM), empty input uses util's fallback
- **`setActiveGridCard`**: matches active card, **BUG 2 fix assertion** (underscored name activates correctly), whitespace trimming, active class swap (previous active cleared), unknown font clears all actives, missing/empty grid no-op
- **`loadHeaderGridSamples`**: empty fonts → `'No fonts available.'`, renders one card per font, **BUG 1 fix assertion** (card contains proper DOM nodes, not literal `'[object HTMLDivElement]'`), preview text populated after fetch, chunks in batches of 12 (verified via `vi.fn` call count), `'Preview unavailable.'` fallback on fetch throw / `!res.ok` / `!data.success`, click updates select + fires change + updates label, missing grid no-op, initial active card from select value, final status message

## Verification

- **780/780 Vitest pass** (was 757 after #1560 merged; +23 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- ESLint clean, Node syntax check clean

## What's next

Now that `_state.js` is merged, the deferred badge stay-behinds from #1560 can migrate here in a follow-up PR (`updateConfigOutputHeaderBadges`, `updateRunCommandHeaderBadge`, `updateLogscanHeaderBadge`, `syncFinalAccordionRollups`). Or the next self-contained cluster:

- `_validationGate.js` — final gate + validation row rendering
- `_kometaRuntime.js` — install-mode + `validateKometaRoot`
- `_runCommand.js` — `buildCommand` + placeholder + mode badges
- `_kometaUpdate.js` — branch override + update job (~800 lines, biggest)
- `_runProgress.js` — `renderRunProgress` + sparkline rendering
- `_logs.js` + `_logscan.js` — log stats, fetch, logscan analysis