### PR TITLE
Split 900-kometa.js part 6: extract validation gate + migrate showYAML to state

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -14,7 +14,8 @@ import {
   pushSparkValue,
   buildSparklinePoints,
   buildSparklinePointsScaled,
-  copyTextToClipboard
+  copyTextToClipboard,
+  setMetaFlag
 } from './modules/kometa/_util.js'
 import {
   toggleTimesInputVisibility,
@@ -34,6 +35,10 @@ import {
   setActiveGridCard,
   loadHeaderGridSamples
 } from './modules/kometa/_headerGrid.js'
+import {
+  getFinalGateState,
+  updateValidationGate
+} from './modules/kometa/_validationGate.js'
 
 let KOMETA_UPDATING = false
 let KOMETA_VALIDATED = false
@@ -122,7 +127,6 @@ const runSparkMemSystem = document.getElementById('run-spark-mem-system')
 const runSparkMemKometa = document.getElementById('run-spark-mem-kometa')
 const yamlOutput = document.getElementById('final-yaml')
 const yamlLineCount = document.getElementById('yaml-line-count')
-let showYAML = false
 const stopModalEl = document.getElementById('stop-kometa-modal')
 const stopModal = (stopModalEl && typeof bootstrap !== 'undefined') ? new bootstrap.Modal(stopModalEl) : null
 const confirmStopBtn = document.getElementById('confirm-stop-kometa')
@@ -173,21 +177,6 @@ document.addEventListener('qs:maintenance-status', function (event) {
   syncKometaMaintenancePageBadge(event.detail || null)
 })
 
-function readMetaFlag (id, datasetKey, attrKey) {
-  const el = document.getElementById(id)
-  if (!el) return false
-  const raw = (el.dataset && el.dataset[datasetKey]) || el.getAttribute(`data-${attrKey}`) || ''
-  return String(raw).toLowerCase() === 'true'
-}
-
-function setMetaFlag (id, datasetKey, attrKey, value) {
-  const el = document.getElementById(id)
-  if (!el) return
-  const serialized = value ? 'True' : 'False'
-  if (el.dataset) el.dataset[datasetKey] = serialized
-  el.setAttribute(`data-${attrKey}`, serialized)
-}
-
 function updateConfigOutputHeaderBadges () {
   const yamlText = yamlOutput ? String(yamlOutput.value || '') : ''
   const lineCount = computeYamlLineCount(yamlText)
@@ -196,11 +185,11 @@ function updateConfigOutputHeaderBadges () {
     setHeaderRollupBadge('config-output-rollup-badge', 'unknown', 'No YAML')
     return
   }
-  setHeaderRollupBadge('config-output-rollup-badge', showYAML ? 'ok' : 'error', showYAML ? 'Validated' : 'Needs fixes')
+  setHeaderRollupBadge('config-output-rollup-badge', kometaState.showYAML ? 'ok' : 'error', kometaState.showYAML ? 'Validated' : 'Needs fixes')
 }
 
 function updateRunCommandHeaderBadge () {
-  if (!showYAML) {
+  if (!kometaState.showYAML) {
     setHeaderRollupBadge('run-command-rollup-badge', 'error', 'Fix validation')
     return
   }
@@ -255,105 +244,7 @@ function syncFinalAccordionRollups () {
   syncKometaBranchRollupBadge()
 }
 
-function getFinalGateState () {
-  const el = document.getElementById('final-gate-state')
-  if (!el) {
-    return {
-      stage: 'config',
-      autoValidate: false,
-      configValid: false
-    }
-  }
-  return {
-    stage: String(el.dataset.stage || 'config'),
-    todoCount: Number(el.dataset.todoCount || 0),
-    autoValidate: el.dataset.autoValidate === 'true',
-    configValid: el.dataset.configValid === 'true',
-    bulkFresh: el.dataset.bulkFresh === 'true'
-  }
-}
-
-function updateValidationGate () {
-  const validationMsgEl = document.getElementById('validation-messages')
-  const runControls = document.getElementById('run-controls-container')
-  const runNowEl = document.getElementById('run-now')
-  const runNowLabelEl = document.getElementById('run-now-label')
-  const warningIds = ['no-validation-warning', 'yaml-warnings', 'yaml-warning-msg', 'validation-error']
-  const downloadIds = ['download-btn', 'download-redacted-btn']
-  const yamlIds = ['yaml-content', 'final-yaml', 'download-btn', 'download-redacted-btn']
-
-  const toggleGroup = (ids, cls, add) => {
-    ids.forEach(id => {
-      const el = document.getElementById(id)
-      if (el) el.classList.toggle(cls, add)
-    })
-  }
-
-  const finalGate = getFinalGateState()
-  if (finalGate.stage === 'todo' || finalGate.stage === 'freshness') {
-    showYAML = false
-    if (validationMsgEl) validationMsgEl.classList.add('d-none')
-    toggleGroup(warningIds, 'd-none', true)
-    toggleGroup(downloadIds, 'd-none', true)
-    if (runControls) runControls.classList.add('d-none')
-    if (runNowEl) runNowEl.disabled = true
-    if (runNowLabelEl) runNowLabelEl.textContent = 'Run Now'
-    updateRunNowState()
-    syncFinalAccordionRollups()
-    return
-  }
-
-  const plexValid = readMetaFlag('plex_valid', 'plexValid', 'plex-valid')
-  const tmdbValid = readMetaFlag('tmdb_valid', 'tmdbValid', 'tmdb-valid')
-  const libsValid = readMetaFlag('libs_valid', 'libsValid', 'libs-valid')
-  const settValid = readMetaFlag('sett_valid', 'settValid', 'sett-valid')
-  const yamlValid = readMetaFlag('yaml_valid', 'yamlValid', 'yaml-valid')
-
-  showYAML = finalGate.configValid || (plexValid && tmdbValid && libsValid && settValid && yamlValid)
-
-  const validationMessages = []
-  const rowFor = (label, href) => {
-    return `
-      <div class="d-flex align-items-center justify-content-between flex-wrap gap-2">
-        <span>${label}</span>
-        <a href="${href}" class="ms-2 text-decoration-none">
-          Open page
-          <i class="bi bi-box-arrow-up-right"></i>
-        </a>
-      </div>
-    `
-  }
-  if (!plexValid) validationMessages.push(rowFor('Plex settings have not been validated successfully.', '/step/010-plex'))
-  if (!tmdbValid) validationMessages.push(rowFor('TMDb settings have not been validated successfully.', '/step/020-tmdb'))
-  if (!libsValid) validationMessages.push(rowFor('Libraries page settings have not been validated successfully.', '/step/025-libraries'))
-  if (!settValid) validationMessages.push(rowFor('Settings page values have likely been skipped.', '/step/150-settings'))
-
-  if (runNowEl) runNowEl.disabled = true
-  if (runNowLabelEl) runNowLabelEl.textContent = 'Run Now'
-  if (!showYAML) {
-    if (validationMessages.length && validationMsgEl) {
-      validationMsgEl.innerHTML = validationMessages.join('<br>')
-      validationMsgEl.classList.remove('d-none')
-    } else if (validationMsgEl) {
-      validationMsgEl.classList.add('d-none')
-    }
-    toggleGroup(warningIds, 'd-none', false)
-    toggleGroup(downloadIds, 'd-none', true)
-    if (runControls) runControls.classList.add('d-none') // Hide run section
-  } else {
-    if (validationMsgEl) validationMsgEl.classList.add('d-none')
-    toggleGroup(warningIds, 'd-none', true)
-    toggleGroup(yamlIds, 'd-none', false)
-    if (runControls) runControls.classList.remove('d-none') // Show run section
-    if (runNowEl) runNowEl.disabled = true
-    if (runNowLabelEl) runNowLabelEl.textContent = 'Run Now'
-  }
-
-  updateRunNowState()
-  syncFinalAccordionRollups()
-}
-
-updateValidationGate()
+updateValidationGate({ updateRunNowState, syncFinalAccordionRollups })
 
 if (tailSelect) {
   tailSize = tailSelect.value || tailSize
@@ -617,7 +508,7 @@ function setRunCommandPlaceholderState () {
     : 'Open Prepare Kometa to install, validate, or update the local Kometa setup before running.'
   let showButton = true
 
-  if (!showYAML) {
+  if (!kometaState.showYAML) {
     title = 'Fix validation before building the run command'
     message = 'Resolve the current validation issues first. The run command will appear after the config validates cleanly.'
     showButton = false
@@ -732,7 +623,7 @@ function updateRunNowState () {
     return
   }
 
-  if (!showYAML || KOMETA_VALIDATION_IN_PROGRESS || KOMETA_UPDATING || KOMETA_STATUS === 'running' || !KOMETA_VALIDATED) {
+  if (!kometaState.showYAML || KOMETA_VALIDATION_IN_PROGRESS || KOMETA_UPDATING || KOMETA_STATUS === 'running' || !KOMETA_VALIDATED) {
     runNow.disabled = true
     updateRunCommandHeaderBadge()
     syncIncompleteRunActions()
@@ -1023,7 +914,7 @@ function validateKometaRoot (options = {}) {
           const el = document.getElementById(id)
           return el ? el.dataset[key] : ''
         }
-        const allValid = showYAML && (finalGate.configValid || (
+        const allValid = kometaState.showYAML && (finalGate.configValid || (
           _dv('plex_valid', 'plexValid') === 'True' &&
           _dv('tmdb_valid', 'tmdbValid') === 'True' &&
           _dv('libs_valid', 'libsValid') === 'True' &&
@@ -3139,7 +3030,7 @@ let previousStatuses = {}
 
 if (validateAllBtn) {
   document.addEventListener('qs:bulk-validation-start', function () {
-    previouslyBlocked = !showYAML
+    previouslyBlocked = !kometaState.showYAML
     previousStatuses = {}
     document.querySelectorAll('[data-validation-key]').forEach(row => {
       const key = row.dataset.validationKey
@@ -3230,9 +3121,9 @@ if (validateAllBtn) {
       return
     }
 
-    updateValidationGate()
+    updateValidationGate({ updateRunNowState, syncFinalAccordionRollups })
     const anyNewlyValidated = Object.keys(results).some(key => results[key]?.status === 'validated' && !previousStatuses[key])
-    if (previouslyBlocked && showYAML) {
+    if (previouslyBlocked && kometaState.showYAML) {
       showToast('info', 'Validation complete. Refreshing YAML output...')
       setTimeout(() => window.location.reload(), 300)
       return

--- a/static/local-js/modules/kometa/_state.js
+++ b/static/local-js/modules/kometa/_state.js
@@ -76,5 +76,15 @@ export const kometaState = {
   // rolling log buffer we've already displayed.
   kometaUpdatePollInterval: null,
   kometaUpdateJobId: null,
-  kometaUpdateLogIndex: 0
+  kometaUpdateLogIndex: 0,
+
+  // ---- Validation gate ---------------------------------------------
+  // showYAML is the master "is the config known-good enough to show
+  // the YAML output + run controls" flag. Written by
+  // updateValidationGate (in _validationGate.js) after synthesizing
+  // five per-page validation flags + the final gate stage. Read by
+  // syncFinalAccordionRollups, the run controls, and the update job
+  // to gate their UI. Was a top-level `let showYAML` in 900-kometa.js
+  // pre-migration.
+  showYAML: false
 }

--- a/static/local-js/modules/kometa/_util.js
+++ b/static/local-js/modules/kometa/_util.js
@@ -347,3 +347,58 @@ export function copyTextToClipboard (text) {
     }
   })
 }
+
+// ---------------------------------------------------------------------
+// DOM dataset flag helpers
+// ---------------------------------------------------------------------
+//
+// Each wizard step page embeds its "has this been validated?" flag as
+// a data attribute on a hidden <meta>-ish element. Server-rendered
+// markup writes the initial value; JS reads it during gate evaluation
+// and re-writes it after successful in-page validation.
+//
+// The dual-source read (`el.dataset[datasetKey] || el.getAttribute(...)`)
+// exists because older templates set data-plex-valid via kebab-case
+// attribute directly, while newer templates go through dataset. The
+// pair of writes on set keeps both in sync so subsequent reads via
+// either path stay consistent.
+//
+// These are pure DOM I/O with no module-scoped state, so they belong
+// in _util.js rather than a state-holding module.
+
+/**
+ * Read a boolean flag stored on an element as both a data-attribute
+ * and (redundantly) as a dataset property.
+ *
+ * @param {string} id          The element's id.
+ * @param {string} datasetKey  Camel-case dataset key (e.g. 'plexValid').
+ * @param {string} attrKey     Kebab-case attribute stem (e.g. 'plex-valid';
+ *                             the function prepends 'data-').
+ * @returns {boolean}          True iff the value string is 'true'
+ *                             (case-insensitive). Missing element or
+ *                             empty value returns false.
+ */
+export function readMetaFlag (id, datasetKey, attrKey) {
+  const el = document.getElementById(id)
+  if (!el) return false
+  const raw = (el.dataset && el.dataset[datasetKey]) || el.getAttribute(`data-${attrKey}`) || ''
+  return String(raw).toLowerCase() === 'true'
+}
+
+/**
+ * Write a boolean flag to an element. Serializes as the Python-flavored
+ * 'True'/'False' string (matching what Flask/Jinja renders) so that
+ * subsequent server-side reads see identical values.
+ *
+ * @param {string}  id          The element's id.
+ * @param {string}  datasetKey  Camel-case dataset key.
+ * @param {string}  attrKey     Kebab-case attribute stem.
+ * @param {boolean} value       Truthy => 'True', falsy => 'False'.
+ */
+export function setMetaFlag (id, datasetKey, attrKey, value) {
+  const el = document.getElementById(id)
+  if (!el) return
+  const serialized = value ? 'True' : 'False'
+  if (el.dataset) el.dataset[datasetKey] = serialized
+  el.setAttribute(`data-${attrKey}`, serialized)
+}

--- a/static/local-js/modules/kometa/_validationGate.js
+++ b/static/local-js/modules/kometa/_validationGate.js
@@ -1,0 +1,199 @@
+// The "final validation gate" logic that decides whether the user can
+// see YAML output + run controls, or whether they need to keep fixing
+// upstream steps first.
+//
+// TWO EXPORTS, ONE INTERNAL STATE MUTATION:
+//
+//   getFinalGateState()      reads the hidden #final-gate-state element
+//                             (which the server populates with the
+//                             aggregate stage/todo/config-validity
+//                             status). Returns a small object; never
+//                             mutates anything.
+//
+//   updateValidationGate()   the main orchestration function. Called
+//                             on page load and whenever a validation
+//                             flag changes. Mutates kometaState.showYAML,
+//                             toggles a swarm of .d-none classes on
+//                             warning/download/YAML/run-controls
+//                             elements, populates the validation-messages
+//                             element with per-step links, and finally
+//                             delegates to two callback-style extension
+//                             points (updateRunNowState +
+//                             syncFinalAccordionRollups).
+//
+// EXTENSION POINTS:
+//
+//   updateValidationGate takes both callbacks as REQUIRED parameters.
+//   This is a temporary bridge pattern -- the "real" version once
+//   ALL of 900-kometa.js is split will be imports from the modules
+//   that own those functions. Until then, callers in 900-kometa.js
+//   pass the functions in explicitly.
+//
+//   Rationale: making the callbacks parameters (rather than importing
+//   them here) means _validationGate.js has ZERO imports from
+//   900-kometa.js, keeping the dependency graph acyclic. It also makes
+//   the module trivially testable -- vitest can pass vi.fn() spies.
+//
+// PROTOCOL FOR "GATE STAGE":
+//
+//   The server encodes the wizard's aggregate progress via
+//   #final-gate-state's data-* attributes:
+//     data-stage        'todo' | 'freshness' | 'config'
+//     data-todo-count   number
+//     data-auto-validate boolean
+//     data-config-valid  boolean
+//     data-bulk-fresh    boolean
+//
+//   When stage is 'todo' OR 'freshness', we hide everything downstream
+//   (YAML, run controls, downloads) -- the user has upstream work to
+//   do before this section is meaningful. When stage is 'config' (or
+//   anything else), we consult the per-page validity flags to decide
+//   whether YAML/run should be visible.
+
+import { kometaState } from './_state.js'
+import { readMetaFlag } from './_util.js'
+
+/**
+ * Read the current gate state from the server-populated
+ * #final-gate-state hidden element. Safe to call before DOMContentLoaded:
+ * returns a conservative default if the element is missing.
+ *
+ * @returns {{
+ *   stage: 'todo' | 'freshness' | 'config' | string,
+ *   todoCount?: number,
+ *   autoValidate: boolean,
+ *   configValid: boolean,
+ *   bulkFresh?: boolean
+ * }}
+ */
+export function getFinalGateState () {
+  const el = document.getElementById('final-gate-state')
+  if (!el) {
+    return {
+      stage: 'config',
+      autoValidate: false,
+      configValid: false
+    }
+  }
+  return {
+    stage: String(el.dataset.stage || 'config'),
+    todoCount: Number(el.dataset.todoCount || 0),
+    autoValidate: el.dataset.autoValidate === 'true',
+    configValid: el.dataset.configValid === 'true',
+    bulkFresh: el.dataset.bulkFresh === 'true'
+  }
+}
+
+// Small helper: toggle .d-none on a group of ids in one call. Missing
+// elements are silently skipped (matches the pre-extraction behavior).
+function toggleGroup (ids, cls, add) {
+  ids.forEach(id => {
+    const el = document.getElementById(id)
+    if (el) el.classList.toggle(cls, add)
+  })
+}
+
+// Single-source-of-truth for the per-validation link row template.
+// The `href` becomes an anchor to the corresponding wizard step;
+// clicking it lets the user jump back to fix the missing setting.
+function rowFor (label, href) {
+  return `
+      <div class="d-flex align-items-center justify-content-between flex-wrap gap-2">
+        <span>${label}</span>
+        <a href="${href}" class="ms-2 text-decoration-none">
+          Open page
+          <i class="bi bi-box-arrow-up-right"></i>
+        </a>
+      </div>
+    `
+}
+
+/**
+ * The main gate orchestration. Toggles the entire "final YAML +
+ * run controls" region visible or hidden based on:
+ *   - final-gate-state stage
+ *   - the five per-page validation flags
+ *
+ * MUTATES kometaState.showYAML as a side-effect. Callers should treat
+ * kometaState.showYAML as read-only after this returns.
+ *
+ * @param {{
+ *   updateRunNowState: () => void,
+ *   syncFinalAccordionRollups: () => void
+ * }} callbacks  Extension points, see module docstring. Both are
+ *               required; use no-op functions if the caller doesn't
+ *               care about a particular hook. Tests should pass
+ *               vi.fn() spies to verify orchestration order.
+ */
+export function updateValidationGate (callbacks) {
+  const { updateRunNowState, syncFinalAccordionRollups } = callbacks || {}
+
+  const validationMsgEl = document.getElementById('validation-messages')
+  const runControls = document.getElementById('run-controls-container')
+  const runNowEl = document.getElementById('run-now')
+  const runNowLabelEl = document.getElementById('run-now-label')
+  const warningIds = ['no-validation-warning', 'yaml-warnings', 'yaml-warning-msg', 'validation-error']
+  const downloadIds = ['download-btn', 'download-redacted-btn']
+  const yamlIds = ['yaml-content', 'final-yaml', 'download-btn', 'download-redacted-btn']
+
+  const finalGate = getFinalGateState()
+  if (finalGate.stage === 'todo' || finalGate.stage === 'freshness') {
+    // Upstream work pending. Hide EVERYTHING downstream and short-circuit.
+    kometaState.showYAML = false
+    if (validationMsgEl) validationMsgEl.classList.add('d-none')
+    toggleGroup(warningIds, 'd-none', true)
+    toggleGroup(downloadIds, 'd-none', true)
+    if (runControls) runControls.classList.add('d-none')
+    if (runNowEl) runNowEl.disabled = true
+    if (runNowLabelEl) runNowLabelEl.textContent = 'Run Now'
+    if (typeof updateRunNowState === 'function') updateRunNowState()
+    if (typeof syncFinalAccordionRollups === 'function') syncFinalAccordionRollups()
+    return
+  }
+
+  // stage === 'config' (or fallback). Consult per-page flags.
+  const plexValid = readMetaFlag('plex_valid', 'plexValid', 'plex-valid')
+  const tmdbValid = readMetaFlag('tmdb_valid', 'tmdbValid', 'tmdb-valid')
+  const libsValid = readMetaFlag('libs_valid', 'libsValid', 'libs-valid')
+  const settValid = readMetaFlag('sett_valid', 'settValid', 'sett-valid')
+  const yamlValid = readMetaFlag('yaml_valid', 'yamlValid', 'yaml-valid')
+
+  // Two paths to a "yes, show it" verdict:
+  //   1. Server-side config validation said 'yes' (finalGate.configValid)
+  //   2. ALL five client-side per-page flags say 'yes'
+  kometaState.showYAML = finalGate.configValid ||
+    (plexValid && tmdbValid && libsValid && settValid && yamlValid)
+
+  const validationMessages = []
+  if (!plexValid) validationMessages.push(rowFor('Plex settings have not been validated successfully.', '/step/010-plex'))
+  if (!tmdbValid) validationMessages.push(rowFor('TMDb settings have not been validated successfully.', '/step/020-tmdb'))
+  if (!libsValid) validationMessages.push(rowFor('Libraries page settings have not been validated successfully.', '/step/025-libraries'))
+  if (!settValid) validationMessages.push(rowFor('Settings page values have likely been skipped.', '/step/150-settings'))
+
+  if (runNowEl) runNowEl.disabled = true
+  if (runNowLabelEl) runNowLabelEl.textContent = 'Run Now'
+
+  if (!kometaState.showYAML) {
+    // Show validation messages if any, else just hide the panel
+    if (validationMessages.length && validationMsgEl) {
+      validationMsgEl.innerHTML = validationMessages.join('<br>')
+      validationMsgEl.classList.remove('d-none')
+    } else if (validationMsgEl) {
+      validationMsgEl.classList.add('d-none')
+    }
+    toggleGroup(warningIds, 'd-none', false)
+    toggleGroup(downloadIds, 'd-none', true)
+    if (runControls) runControls.classList.add('d-none')
+  } else {
+    if (validationMsgEl) validationMsgEl.classList.add('d-none')
+    toggleGroup(warningIds, 'd-none', true)
+    toggleGroup(yamlIds, 'd-none', false)
+    if (runControls) runControls.classList.remove('d-none')
+    // NOTE: runNowEl.disabled stays true here -- the actual "enable
+    // Run Now" call happens later in updateRunNowState after checking
+    // the runtime-state (Kometa installed?, not currently running?, etc.)
+  }
+
+  if (typeof updateRunNowState === 'function') updateRunNowState()
+  if (typeof syncFinalAccordionRollups === 'function') syncFinalAccordionRollups()
+}

--- a/tests/js/kometa/state.test.js
+++ b/tests/js/kometa/state.test.js
@@ -68,6 +68,15 @@ describe('kometaState initial values', () => {
     expect(typeof kometaState.kometaUpdateLogIndex).toBe('number')
   })
 
+  it('showYAML starts as false (gate defaults to hidden)', () => {
+    // The default matches the pre-migration `let showYAML = false`
+    // top-level in 900-kometa.js. This is important: on page load,
+    // before any validation runs, we must NOT show YAML output or
+    // run controls.
+    expect(kometaState.showYAML).toBe(false)
+    expect(typeof kometaState.showYAML).toBe('boolean')
+  })
+
   it('exports exactly the fields the runtime relies on (guards against typos)', () => {
     // Sorted alphabetically for a stable comparison
     expect(Object.keys(kometaState).sort()).toEqual([
@@ -77,7 +86,8 @@ describe('kometaState initial values', () => {
       'kometaStatusInterval',
       'kometaUpdateJobId',
       'kometaUpdateLogIndex',
-      'kometaUpdatePollInterval'
+      'kometaUpdatePollInterval',
+      'showYAML'
     ])
   })
 })

--- a/tests/js/kometa/validationGate.test.js
+++ b/tests/js/kometa/validationGate.test.js
@@ -1,0 +1,365 @@
+// Tests for static/local-js/modules/kometa/_validationGate.js
+//
+// Two exported functions:
+//   getFinalGateState   -- reads #final-gate-state data-* attrs
+//   updateValidationGate -- big orchestration: reads gate state +
+//                          per-page validation flags, mutates
+//                          kometaState.showYAML, toggles a swarm of
+//                          .d-none classes, calls the two extension
+//                          callbacks.
+//
+// COVERAGE STRATEGY:
+//
+//   For getFinalGateState:
+//     - missing element -> conservative default
+//     - populated element -> reads all fields correctly
+//     - defaults when data-* attrs are missing
+//     - boolean fields interpret 'true' string as true
+//
+//   For updateValidationGate we test each BRANCH of the gate:
+//     Path A: stage='todo'      -> everything hidden, showYAML=false
+//     Path B: stage='freshness' -> same as todo
+//     Path C: stage='config' + configValid=true -> everything shown
+//     Path D: stage='config' + all 5 flags true -> everything shown
+//     Path E: stage='config' + some flags missing -> validation msgs
+//     Path F: stage='config' + configValid + msg element missing (soft)
+//     Path G: callbacks are always invoked exactly once
+//     Path H: kometaState.showYAML is correctly toggled per branch
+//     Path I: run-now button label defaults to 'Run Now' in all branches
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { kometaState } from '../../../static/local-js/modules/kometa/_state.js'
+import {
+  getFinalGateState,
+  updateValidationGate
+} from '../../../static/local-js/modules/kometa/_validationGate.js'
+
+// ---------------------------------------------------------------------
+// Fixture DOM helpers
+// ---------------------------------------------------------------------
+
+/**
+ * Build a DOM matching the pieces updateValidationGate touches. All
+ * optional; omit for a bare-page test.
+ *
+ * gate options mirror the data-* attrs on #final-gate-state.
+ * flags optional per-page validation flags:
+ *   { plex, tmdb, libs, sett, yaml } -- boolean each
+ *
+ * Also installs the toggle-target elements the gate flips:
+ *   #validation-messages, #run-controls-container, #run-now,
+ *   #run-now-label, warning ids, download ids, yaml ids.
+ */
+function installGateDom ({
+  gate = {},
+  flags = {},
+  omit = []
+} = {}) {
+  const {
+    stage = 'config',
+    todoCount = 0,
+    autoValidate = false,
+    configValid = false,
+    bulkFresh = false
+  } = gate
+
+  const has = id => !omit.includes(id)
+
+  const parts = []
+  parts.push(`
+    <div id="final-gate-state"
+         data-stage="${stage}"
+         data-todo-count="${todoCount}"
+         data-auto-validate="${autoValidate}"
+         data-config-valid="${configValid}"
+         data-bulk-fresh="${bulkFresh}"></div>
+  `)
+
+  // Per-page validation flags: hidden data-carrying elements
+  const flagMap = [
+    ['plex_valid', 'plex-valid', flags.plex],
+    ['tmdb_valid', 'tmdb-valid', flags.tmdb],
+    ['libs_valid', 'libs-valid', flags.libs],
+    ['sett_valid', 'sett-valid', flags.sett],
+    ['yaml_valid', 'yaml-valid', flags.yaml]
+  ]
+  flagMap.forEach(([id, attr, val]) => {
+    if (has(id)) parts.push(`<div id="${id}" data-${attr}="${val ? 'True' : 'False'}"></div>`)
+  })
+
+  if (has('validation-messages')) parts.push('<div id="validation-messages" class="d-none"></div>')
+  if (has('run-controls-container')) parts.push('<div id="run-controls-container" class="d-none"></div>')
+  if (has('run-now')) parts.push('<button id="run-now" disabled></button>')
+  if (has('run-now-label')) parts.push('<span id="run-now-label">Different Label</span>')
+
+  const warningIds = ['no-validation-warning', 'yaml-warnings', 'yaml-warning-msg', 'validation-error']
+  warningIds.forEach(id => { if (has(id)) parts.push(`<div id="${id}" class="d-none"></div>`) })
+
+  const downloadIds = ['download-btn', 'download-redacted-btn']
+  downloadIds.forEach(id => { if (has(id)) parts.push(`<div id="${id}"></div>`) })
+
+  const yamlIds = ['yaml-content', 'final-yaml']
+  yamlIds.forEach(id => { if (has(id)) parts.push(`<div id="${id}" class="d-none"></div>`) })
+
+  document.body.innerHTML = parts.join('\n')
+}
+
+// Standard spy callbacks bundle -- shared shape across tests
+function makeCallbacks () {
+  return {
+    updateRunNowState: vi.fn(),
+    syncFinalAccordionRollups: vi.fn()
+  }
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  // Reset showYAML to its default so tests don't cross-contaminate
+  kometaState.showYAML = false
+  vi.restoreAllMocks()
+})
+
+// ---------------------------------------------------------------------
+// getFinalGateState
+// ---------------------------------------------------------------------
+
+describe('getFinalGateState', () => {
+  it('returns conservative default when element is missing', () => {
+    // Deliberately no DOM installed
+    const state = getFinalGateState()
+    expect(state).toEqual({
+      stage: 'config',
+      autoValidate: false,
+      configValid: false
+    })
+  })
+
+  it('reads all data-* fields when element is populated', () => {
+    installGateDom({
+      gate: {
+        stage: 'todo',
+        todoCount: 3,
+        autoValidate: true,
+        configValid: true,
+        bulkFresh: true
+      }
+    })
+    const state = getFinalGateState()
+    expect(state).toEqual({
+      stage: 'todo',
+      todoCount: 3,
+      autoValidate: true,
+      configValid: true,
+      bulkFresh: true
+    })
+  })
+
+  it('defaults stage to "config" when the attribute is missing', () => {
+    document.body.innerHTML = '<div id="final-gate-state"></div>'
+    expect(getFinalGateState().stage).toBe('config')
+  })
+
+  it('defaults todoCount to 0 when the attribute is missing', () => {
+    document.body.innerHTML = '<div id="final-gate-state"></div>'
+    expect(getFinalGateState().todoCount).toBe(0)
+  })
+
+  it('interprets non-"true" strings as false (autoValidate, configValid, bulkFresh)', () => {
+    document.body.innerHTML = `<div id="final-gate-state"
+      data-auto-validate="1" data-config-valid="yes" data-bulk-fresh=""></div>`
+    const state = getFinalGateState()
+    expect(state.autoValidate).toBe(false)
+    expect(state.configValid).toBe(false)
+    expect(state.bulkFresh).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------
+// updateValidationGate: TODO/freshness stage -> everything hidden
+// ---------------------------------------------------------------------
+
+describe('updateValidationGate stage=todo', () => {
+  it('hides YAML/run controls/downloads and sets showYAML=false', () => {
+    installGateDom({ gate: { stage: 'todo' } })
+    kometaState.showYAML = true // sanity: even if it was true before
+    const cb = makeCallbacks()
+    updateValidationGate(cb)
+    expect(kometaState.showYAML).toBe(false)
+    expect(document.getElementById('validation-messages').classList.contains('d-none')).toBe(true)
+    expect(document.getElementById('run-controls-container').classList.contains('d-none')).toBe(true)
+    expect(document.getElementById('download-btn').classList.contains('d-none')).toBe(true)
+    expect(document.getElementById('run-now').disabled).toBe(true)
+    expect(document.getElementById('run-now-label').textContent).toBe('Run Now')
+  })
+
+  it('invokes both callbacks exactly once', () => {
+    installGateDom({ gate: { stage: 'todo' } })
+    const cb = makeCallbacks()
+    updateValidationGate(cb)
+    expect(cb.updateRunNowState).toHaveBeenCalledTimes(1)
+    expect(cb.syncFinalAccordionRollups).toHaveBeenCalledTimes(1)
+  })
+
+  it('short-circuits: does not read per-page validation flags', () => {
+    // If it DID read them, an unset dataset would default to false.
+    // What we want to verify: showYAML doesn't depend on the flags in
+    // this branch. Set them all true; still expect showYAML=false.
+    installGateDom({
+      gate: { stage: 'todo', configValid: true },
+      flags: { plex: true, tmdb: true, libs: true, sett: true, yaml: true }
+    })
+    updateValidationGate(makeCallbacks())
+    expect(kometaState.showYAML).toBe(false)
+  })
+})
+
+describe('updateValidationGate stage=freshness', () => {
+  it('behaves identically to stage=todo', () => {
+    installGateDom({ gate: { stage: 'freshness' } })
+    const cb = makeCallbacks()
+    updateValidationGate(cb)
+    expect(kometaState.showYAML).toBe(false)
+    expect(cb.updateRunNowState).toHaveBeenCalledTimes(1)
+    expect(cb.syncFinalAccordionRollups).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ---------------------------------------------------------------------
+// updateValidationGate: config stage happy paths
+// ---------------------------------------------------------------------
+
+describe('updateValidationGate stage=config, all flags valid', () => {
+  it('sets showYAML=true, shows YAML + run controls, hides warnings', () => {
+    installGateDom({
+      gate: { stage: 'config', configValid: false },
+      flags: { plex: true, tmdb: true, libs: true, sett: true, yaml: true }
+    })
+    updateValidationGate(makeCallbacks())
+    expect(kometaState.showYAML).toBe(true)
+    expect(document.getElementById('validation-messages').classList.contains('d-none')).toBe(true)
+    expect(document.getElementById('no-validation-warning').classList.contains('d-none')).toBe(true)
+    expect(document.getElementById('yaml-content').classList.contains('d-none')).toBe(false)
+    expect(document.getElementById('final-yaml').classList.contains('d-none')).toBe(false)
+    expect(document.getElementById('run-controls-container').classList.contains('d-none')).toBe(false)
+  })
+
+  it('run-now stays disabled (runtime state checks happen later)', () => {
+    installGateDom({
+      gate: { stage: 'config' },
+      flags: { plex: true, tmdb: true, libs: true, sett: true, yaml: true }
+    })
+    updateValidationGate(makeCallbacks())
+    // The gate itself doesn't enable the button -- that's updateRunNowState's job
+    expect(document.getElementById('run-now').disabled).toBe(true)
+    expect(document.getElementById('run-now-label').textContent).toBe('Run Now')
+  })
+})
+
+describe('updateValidationGate stage=config, configValid=true (server override)', () => {
+  it('sets showYAML=true even when per-page flags are false', () => {
+    installGateDom({
+      gate: { stage: 'config', configValid: true },
+      flags: { plex: false, tmdb: false, libs: false, sett: false, yaml: false }
+    })
+    updateValidationGate(makeCallbacks())
+    expect(kometaState.showYAML).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// updateValidationGate: config stage sad paths (validation missing)
+// ---------------------------------------------------------------------
+
+describe('updateValidationGate stage=config, some flags missing', () => {
+  it('sets showYAML=false and renders validation message rows', () => {
+    installGateDom({
+      gate: { stage: 'config' },
+      flags: { plex: false, tmdb: true, libs: false, sett: true, yaml: true }
+    })
+    updateValidationGate(makeCallbacks())
+    expect(kometaState.showYAML).toBe(false)
+    const msg = document.getElementById('validation-messages')
+    expect(msg.classList.contains('d-none')).toBe(false)
+    expect(msg.innerHTML).toContain('Plex settings')
+    expect(msg.innerHTML).toContain('/step/010-plex')
+    expect(msg.innerHTML).toContain('Libraries page')
+    expect(msg.innerHTML).toContain('/step/025-libraries')
+    // Ones that are true should NOT appear
+    expect(msg.innerHTML).not.toContain('TMDb settings')
+    expect(msg.innerHTML).not.toContain('Settings page')
+  })
+
+  it('does not include yaml_valid in the messages (no user-facing text for it)', () => {
+    // The yaml_valid flag participates in showYAML AND-logic but has no
+    // corresponding "Open page" link -- the yaml is generated internally.
+    installGateDom({
+      gate: { stage: 'config' },
+      flags: { plex: true, tmdb: true, libs: true, sett: true, yaml: false }
+    })
+    updateValidationGate(makeCallbacks())
+    expect(kometaState.showYAML).toBe(false)
+    // With all page flags true but yaml false, no rows are pushed -->
+    // messages list is empty --> the branch that hides validation-messages
+    // when empty should fire.
+    const msg = document.getElementById('validation-messages')
+    expect(msg.classList.contains('d-none')).toBe(true)
+  })
+
+  it('warnings are shown, downloads/YAML are hidden', () => {
+    installGateDom({
+      gate: { stage: 'config' },
+      flags: { plex: false }
+    })
+    updateValidationGate(makeCallbacks())
+    expect(document.getElementById('no-validation-warning').classList.contains('d-none')).toBe(false)
+    expect(document.getElementById('download-btn').classList.contains('d-none')).toBe(true)
+    expect(document.getElementById('run-controls-container').classList.contains('d-none')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// updateValidationGate: robustness (missing DOM elements)
+// ---------------------------------------------------------------------
+
+describe('updateValidationGate robustness', () => {
+  it('does not throw when validation-messages is missing', () => {
+    installGateDom({
+      gate: { stage: 'config' },
+      flags: { plex: false },
+      omit: ['validation-messages']
+    })
+    expect(() => updateValidationGate(makeCallbacks())).not.toThrow()
+  })
+
+  it('does not throw when run-now / run-now-label are missing', () => {
+    installGateDom({
+      gate: { stage: 'todo' },
+      omit: ['run-now', 'run-now-label']
+    })
+    expect(() => updateValidationGate(makeCallbacks())).not.toThrow()
+  })
+
+  it('does not throw when any warning/download/yaml element is missing', () => {
+    installGateDom({
+      gate: { stage: 'config' },
+      flags: { plex: true, tmdb: true, libs: true, sett: true, yaml: true },
+      omit: ['no-validation-warning', 'yaml-warnings', 'download-btn', 'yaml-content']
+    })
+    expect(() => updateValidationGate(makeCallbacks())).not.toThrow()
+  })
+
+  it('handles callbacks being missing (undefined)', () => {
+    installGateDom({ gate: { stage: 'todo' } })
+    // Pass no callbacks arg at all
+    expect(() => updateValidationGate()).not.toThrow()
+    // Pass empty object
+    expect(() => updateValidationGate({})).not.toThrow()
+  })
+
+  it('handles callbacks that are not functions (silently skip)', () => {
+    installGateDom({ gate: { stage: 'todo' } })
+    expect(() =>
+      updateValidationGate({ updateRunNowState: 42, syncFinalAccordionRollups: 'hi' })
+    ).not.toThrow()
+  })
+})


### PR DESCRIPTION
## What

Sixth module out of the `900-kometa.js` god-file split (parts 1-4: #1554, #1556, #1557, #1560; part 5 in flight as #1561). `900-kometa.js`: 3661 → 3552 lines (**−109**). This PR also bundles the `showYAML` migration to `kometaState` because extracting the gate requires that anyway.

## What moved

Extracted to **`static/local-js/modules/kometa/_validationGate.js`**:

| Function | Role |
|---|---|
| `getFinalGateState` | reads `#final-gate-state` data-* attrs |
| `updateValidationGate` | gate orchestration: reads gate stage + per-page validation flags, mutates `kometaState.showYAML`, toggles `.d-none` on warning/download/YAML/run-controls elements, renders validation-message rows with per-step 'Open page' links |

Moved to **`static/local-js/modules/kometa/_util.js`**:

| Function | Why here |
|---|---|
| `readMetaFlag` | pure DOM I/O reads a boolean flag from an element's dataset + `data-*` attribute (dual-source for backwards compat with old templates) |
| `setMetaFlag` | writes to both places for consistency |

They're pure DOM I/O with no module-scoped state — fits the '_util.js is generic pure/DOM utility functions' invariant. Will likely be reused by future extractions that read per-page validation status.

Added to **`static/local-js/modules/kometa/_state.js`**:

| Field | Why |
|---|---|
| `showYAML: false` | promoted from `let showYAML` at top of 900-kometa.js. Written by `updateValidationGate` (now in the new module), read by 6 downstream sites (run controls, config-output badge, bulk validation). |

## Design: extension points as required callbacks

`updateValidationGate` calls back into two functions still owned by `900-kometa.js`:

- `updateRunNowState` — re-evaluates run-now enablement based on runtime state
- `syncFinalAccordionRollups` — redraws the accordion rollup badges

Both are passed as **required** properties of a callbacks object rather than:

- **Imported** (would create a circular dependency)
- **Looked up on globalThis** (would silently break once 900-kometa.js is gone)

Callbacks are `typeof === 'function'` checked before invocation, so `undefined` or non-function values are silently skipped — matches the tolerant style of the rest of the module. Once `updateRunNowState` + `syncFinalAccordionRollups` themselves migrate to their own modules, this hybrid pattern retires.

## `kometaState.showYAML` migration (11 sites)

- 1 declaration deleted from `900-kometa.js` (`let showYAML = false`)
- 2 writes moved (into the extracted `updateValidationGate`)
- 7 reads in `900-kometa.js` migrated to `kometaState.showYAML`
- 1 read moved WITH the extraction

Because `kometaState` is a shared object (not an exported `let`), all readers automatically see the latest value after `updateValidationGate` mutates it — same semantics as the pre-migration top-level `let`.

## Vitest coverage: 21 new tests

**`state.test.js`** (+1 test):
- `showYAML` starts as `false` (gate defaults to hidden)
- Shape guard test updated to include `showYAML` in the exhaustive keys list

**`validationGate.test.js`** (20 new tests):

- **`getFinalGateState`**: missing element → conservative default, populated element → reads all fields, missing-attr defaults (`stage='config'`, `todoCount=0`), non-`'true'` strings coerce to false (`autoValidate`, `configValid`, `bulkFresh`)
- **stage=`todo`**: hides all downstream elements, sets `showYAML=false`, invokes both callbacks exactly once, short-circuits per-page flag reading (even if all 5 flags are true, showYAML stays false)
- **stage=`freshness`**: identical to `todo`
- **stage=`config` happy paths**: all 5 flags valid → `showYAML=true` + YAML/run visible + warnings hidden; `configValid=true` (server override) → `showYAML=true` even when per-page flags are false; run-now stays disabled regardless (runtime gating happens later)
- **stage=`config` sad paths**: missing per-page flags → validation message rows rendered with correct 'Open page' links, correct step URLs (`/step/010-plex` etc.), `yaml_valid` does NOT get a user-facing row (participates in AND-logic only, no Open-page link exists for it)
- **robustness**: missing `validation-messages`, missing `run-now` / `run-now-label`, missing warning/download/yaml elements — all no-throw; callbacks `undefined` or non-function silently skipped

## Verification

- **778/778 Vitest pass** (was 757 after #1560 merged; +21 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- 4 additional `final/validation/gate` e2e tests: pass
- ESLint clean, Node syntax clean

## What's next

The badge stay-behinds from #1560 (`updateConfigOutputHeaderBadges`, `updateRunCommandHeaderBadge`, `updateLogscanHeaderBadge`, `syncFinalAccordionRollups`) can now **partially** migrate — `showYAML` is already on `kometaState`. Still need `KOMETA_*` flags + `lastLogscanPayload` migrated for the full move.

Or the next self-contained cluster:

- `_kometaRuntime.js` — install-mode + `validateKometaRoot`
- `_runCommand.js` — `buildCommand` + placeholder + mode badges
- `_kometaUpdate.js` — branch override + update job (~800 lines, biggest)
- `_runProgress.js` — `renderRunProgress` + sparkline
- `_logs.js` + `_logscan.js` — log stats, fetch, logscan analysis

Stacks cleanly on top of #1561 (they touch different code).