### PR TITLE
Split 900-kometa.js part 7: extract runtime configuration readers to _runtime.js

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -39,6 +39,15 @@ import {
   getFinalGateState,
   updateValidationGate
 } from './modules/kometa/_validationGate.js'
+import {
+  getConfiguredKometaInstallMode,
+  getConfiguredKometaRootPosix,
+  getConfiguredKometaRootDisplay,
+  kometaCanLaunch,
+  kometaCanCheckUpdateStatus,
+  kometaCanProbeRuntime,
+  kometaCanReadLogs
+} from './modules/kometa/_runtime.js'
 
 let KOMETA_UPDATING = false
 let KOMETA_VALIDATED = false
@@ -794,50 +803,6 @@ checkboxFlags.forEach(opt => {
   const checkbox = document.getElementById(`opt-${opt}`)
   if (checkbox) checkbox.addEventListener('change', buildCommand)
 })
-
-function getConfiguredKometaInstallMode () {
-  const out = document.getElementById('run-command-output')
-  const raw = (out.dataset.kometaInstallMode || 'managed').toString().trim().toLowerCase()
-  if (raw === 'existing' || raw === 'external') return raw
-  return 'managed'
-}
-
-function getConfiguredKometaRootPosix () {
-  const out = document.getElementById('run-command-output')
-  const selected = (out.dataset.kometaRootSelected || '').toString().trim()
-  const fallback = (out.dataset.kometaRootDefault || '').toString().trim()
-  const configDir = (out.dataset.kometaConfigDir || '').toString().trim()
-  if (getConfiguredKometaInstallMode() === 'external') return configDir
-  return selected || fallback
-}
-
-function getConfiguredKometaRootDisplay () {
-  const out = document.getElementById('run-command-output')
-  const selected = (out.dataset.kometaRootSelectedDisplay || '').toString().trim()
-  const fallback = (out.dataset.kometaRootDefaultDisplay || getConfiguredKometaRootPosix())
-  const configDir = (out.dataset.kometaConfigDirDisplay || '').toString().trim()
-  if (getConfiguredKometaInstallMode() === 'external') return configDir || getConfiguredKometaRootPosix()
-  return selected || fallback
-}
-
-function kometaCanLaunch () {
-  const el = document.getElementById('run-command-output')
-  return ((el && el.dataset.kometaCanLaunch) || '').toString().toLowerCase() === 'true'
-}
-
-function kometaCanCheckUpdateStatus () {
-  return getConfiguredKometaInstallMode() !== 'external' && kometaCanProbeRuntime()
-}
-
-function kometaCanProbeRuntime () {
-  const el = document.getElementById('run-command-output')
-  return ((el && el.dataset.kometaCanProbeRuntime) || '').toString().toLowerCase() === 'true'
-}
-
-function kometaCanReadLogs () {
-  const el = document.getElementById('run-command-output')
-  return ((el && el.dataset.kometaCanReadLogs) || '').toString().toLowerCase() === 'true'
-}
 
 function validateKometaRoot (options = {}) {
   if (!kometaCanProbeRuntime()) {

--- a/static/local-js/modules/kometa/_runtime.js
+++ b/static/local-js/modules/kometa/_runtime.js
@@ -1,0 +1,169 @@
+// Kometa runtime configuration readers.
+//
+// The Kometa-run/update page has a hidden `#run-command-output` element
+// whose data-* attributes carry the server's authoritative view of:
+//
+//   - How Kometa is installed (managed / existing / external)
+//   - Where the Kometa root is (as both a POSIX path for the backend
+//     and a user-facing display path)
+//   - What runtime capabilities exist for the current config
+//     (can we launch it? can we validate it? can we read its logs?)
+//
+// This module owns the seven small readers that consult those
+// dataset fields. They're the "first line" of every runtime-related
+// operation -- validateKometaRoot, buildCommand, syncKometaRollupBadge,
+// probeKometaRoot, and the update flow all start by asking these
+// helpers "what mode are we in?" and "where does Kometa live?".
+//
+// DESIGN NOTES:
+//
+//   1. Each reader is a PURE DOM read -- no mutation, no side effects,
+//      no module-scoped state. Callers get a fresh snapshot every
+//      time. This matches the pre-extraction behavior (the dataset
+//      is treated as the single source of truth and re-read on every
+//      access).
+//
+//   2. All seven read the SAME element (#run-command-output). Rather
+//      than exporting a single "get everything" helper (which would
+//      be a temptation to cache), we kept the API split by concern
+//      so callers can express intent clearly:
+//
+//         if (kometaCanProbeRuntime()) { validateKometaRoot(...) }
+//         if (kometaCanReadLogs())     { fetchLogTail(...) }
+//
+//      is more readable than
+//
+//         const runtime = getKometaRuntime()
+//         if (runtime.canProbe) { ... }
+//         if (runtime.canReadLogs) { ... }
+//
+//      and it lets each helper own its own dataset key mapping.
+//
+//   3. Every helper returns a SAFE default when the element or
+//      attribute is missing (empty string, false, or 'managed'). This
+//      matches how ES module load order interacts with the DOM: if
+//      code imports this module before DOMContentLoaded, calls
+//      wouldn't throw -- they'd just report the conservative "nothing
+//      is available" state until the DOM catches up.
+
+/**
+ * Get the install mode configured on the current wizard page.
+ *
+ * @returns {'managed' | 'existing' | 'external'}
+ *   'managed'  = Quickstart manages the Kometa install (git clone into
+ *                a folder Quickstart owns)
+ *   'existing' = user has an existing Kometa install on disk that
+ *                Quickstart will sync config to and launch
+ *   'external' = Kometa runs outside of Quickstart's reach entirely
+ *                (Docker container, remote machine, ...); Quickstart
+ *                only writes config here. No launch, no probe, no logs.
+ *
+ * Default (missing element or unknown value) is 'managed' to match
+ * the historic pre-extraction fallback.
+ */
+export function getConfiguredKometaInstallMode () {
+  const out = document.getElementById('run-command-output')
+  const raw = ((out && out.dataset.kometaInstallMode) || 'managed').toString().trim().toLowerCase()
+  if (raw === 'existing' || raw === 'external') return raw
+  return 'managed'
+}
+
+/**
+ * Get the Kometa root path as a POSIX string, suitable for sending
+ * to the backend / embedding in JSON payloads.
+ *
+ * The three data-* attributes we consult:
+ *   kometaRootSelected   -- user-chosen root (highest priority)
+ *   kometaRootDefault    -- fallback when nothing is chosen
+ *   kometaConfigDir      -- returned instead when mode is 'external'
+ *                            (config dir is the only thing Quickstart
+ *                            has visibility into in that mode)
+ *
+ * @returns {string} POSIX path, or empty string if nothing is set.
+ */
+export function getConfiguredKometaRootPosix () {
+  const out = document.getElementById('run-command-output')
+  if (!out) return ''
+  const selected = (out.dataset.kometaRootSelected || '').toString().trim()
+  const fallback = (out.dataset.kometaRootDefault || '').toString().trim()
+  const configDir = (out.dataset.kometaConfigDir || '').toString().trim()
+  if (getConfiguredKometaInstallMode() === 'external') return configDir
+  return selected || fallback
+}
+
+/**
+ * Get the Kometa root path as a user-facing display string.
+ *
+ * Same priority order as getConfiguredKometaRootPosix, but reading
+ * the *Display variants of each dataset key. Falls back to the
+ * POSIX version if no display-specific value was provided.
+ *
+ * @returns {string}
+ */
+export function getConfiguredKometaRootDisplay () {
+  const out = document.getElementById('run-command-output')
+  if (!out) return getConfiguredKometaRootPosix()
+  const selected = (out.dataset.kometaRootSelectedDisplay || '').toString().trim()
+  const fallback = (out.dataset.kometaRootDefaultDisplay || getConfiguredKometaRootPosix())
+  const configDir = (out.dataset.kometaConfigDirDisplay || '').toString().trim()
+  if (getConfiguredKometaInstallMode() === 'external') return configDir || getConfiguredKometaRootPosix()
+  return selected || fallback
+}
+
+// ---------------------------------------------------------------------
+// Runtime capability flags
+// ---------------------------------------------------------------------
+//
+// Server-computed booleans that gate which runtime operations are
+// even attempted for the current config. Each one keys off a separate
+// data-* attribute so the server can independently disable, e.g.,
+// launch (for read-only remote Kometa) or logs (for a non-mounted
+// external volume).
+
+/**
+ * True iff Quickstart can invoke Kometa to run (as opposed to only
+ * being able to write config files). Gates the "Run Now" button.
+ *
+ * @returns {boolean}
+ */
+export function kometaCanLaunch () {
+  const el = document.getElementById('run-command-output')
+  return ((el && el.dataset.kometaCanLaunch) || '').toString().toLowerCase() === 'true'
+}
+
+/**
+ * True iff Quickstart can probe the Kometa install to determine
+ * what version is installed and whether an update is available.
+ * Gates the "check for updates" background flow.
+ *
+ * External Kometa mode disables this because Quickstart has no
+ * filesystem access to the install directory.
+ *
+ * @returns {boolean}
+ */
+export function kometaCanCheckUpdateStatus () {
+  return getConfiguredKometaInstallMode() !== 'external' && kometaCanProbeRuntime()
+}
+
+/**
+ * True iff Quickstart can run validateKometaRoot / probeKometaRoot
+ * against the current install (i.e., we have filesystem access to
+ * the root). Gates all runtime-validation flows.
+ *
+ * @returns {boolean}
+ */
+export function kometaCanProbeRuntime () {
+  const el = document.getElementById('run-command-output')
+  return ((el && el.dataset.kometaCanProbeRuntime) || '').toString().toLowerCase() === 'true'
+}
+
+/**
+ * True iff Quickstart can tail the Kometa log file. Gates the
+ * live-log polling on the Run screen.
+ *
+ * @returns {boolean}
+ */
+export function kometaCanReadLogs () {
+  const el = document.getElementById('run-command-output')
+  return ((el && el.dataset.kometaCanReadLogs) || '').toString().toLowerCase() === 'true'
+}

--- a/tests/js/kometa/runtime.test.js
+++ b/tests/js/kometa/runtime.test.js
@@ -1,0 +1,331 @@
+// Tests for static/local-js/modules/kometa/_runtime.js
+//
+// The module has seven pure DOM readers. All read from the hidden
+// #run-command-output element's dataset. Tests build a fresh element
+// in beforeEach with the desired data-* attributes and inspect the
+// return value.
+//
+// Coverage strategy:
+//
+//   getConfiguredKometaInstallMode
+//     - default 'managed' when element missing or attr missing
+//     - reads 'managed' | 'existing' | 'external'
+//     - falls back to 'managed' for unknown values
+//     - lowercases + trims the raw attribute value
+//
+//   getConfiguredKometaRootPosix
+//     - reads selected first, falls back to default
+//     - returns configDir instead when mode is 'external'
+//     - empty string when nothing is set
+//     - empty string when element is missing
+//
+//   getConfiguredKometaRootDisplay
+//     - reads *Display variants first, falls back to *Default variants
+//     - falls back to POSIX version when nothing display-specific
+//     - returns configDirDisplay when mode is 'external'
+//
+//   kometaCanLaunch / kometaCanProbeRuntime / kometaCanReadLogs
+//     - true for 'true' (case-insensitive), false otherwise
+//     - false when element or attr missing
+//
+//   kometaCanCheckUpdateStatus
+//     - false when mode is 'external'
+//     - depends on kometaCanProbeRuntime otherwise
+
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  getConfiguredKometaInstallMode,
+  getConfiguredKometaRootPosix,
+  getConfiguredKometaRootDisplay,
+  kometaCanLaunch,
+  kometaCanCheckUpdateStatus,
+  kometaCanProbeRuntime,
+  kometaCanReadLogs
+} from '../../../static/local-js/modules/kometa/_runtime.js'
+
+// ---------------------------------------------------------------------
+// Fixture DOM helpers
+// ---------------------------------------------------------------------
+
+/**
+ * Install a #run-command-output element with the given dataset. Pass
+ * `null` for `dataset` to install NO element (missing-element case).
+ * Pass `{}` for an empty element.
+ */
+function installRuntimeDom (dataset) {
+  if (dataset === null) {
+    document.body.innerHTML = ''
+    return
+  }
+  const el = document.createElement('div')
+  el.id = 'run-command-output'
+  Object.entries(dataset).forEach(([key, value]) => {
+    el.dataset[key] = value
+  })
+  document.body.innerHTML = ''
+  document.body.appendChild(el)
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+// ---------------------------------------------------------------------
+// getConfiguredKometaInstallMode
+// ---------------------------------------------------------------------
+
+describe('getConfiguredKometaInstallMode', () => {
+  it("defaults to 'managed' when the element is missing", () => {
+    installRuntimeDom(null)
+    expect(getConfiguredKometaInstallMode()).toBe('managed')
+  })
+
+  it("defaults to 'managed' when the attribute is missing", () => {
+    installRuntimeDom({})
+    expect(getConfiguredKometaInstallMode()).toBe('managed')
+  })
+
+  it("returns 'managed' when explicitly set", () => {
+    installRuntimeDom({ kometaInstallMode: 'managed' })
+    expect(getConfiguredKometaInstallMode()).toBe('managed')
+  })
+
+  it("returns 'existing' when set", () => {
+    installRuntimeDom({ kometaInstallMode: 'existing' })
+    expect(getConfiguredKometaInstallMode()).toBe('existing')
+  })
+
+  it("returns 'external' when set", () => {
+    installRuntimeDom({ kometaInstallMode: 'external' })
+    expect(getConfiguredKometaInstallMode()).toBe('external')
+  })
+
+  it('lowercases the attribute value', () => {
+    installRuntimeDom({ kometaInstallMode: 'EXTERNAL' })
+    expect(getConfiguredKometaInstallMode()).toBe('external')
+  })
+
+  it('trims whitespace around the attribute value', () => {
+    installRuntimeDom({ kometaInstallMode: '  existing  ' })
+    expect(getConfiguredKometaInstallMode()).toBe('existing')
+  })
+
+  it("falls back to 'managed' for unknown values", () => {
+    installRuntimeDom({ kometaInstallMode: 'docker' })
+    expect(getConfiguredKometaInstallMode()).toBe('managed')
+  })
+})
+
+// ---------------------------------------------------------------------
+// getConfiguredKometaRootPosix
+// ---------------------------------------------------------------------
+
+describe('getConfiguredKometaRootPosix', () => {
+  it('returns empty string when element is missing', () => {
+    installRuntimeDom(null)
+    expect(getConfiguredKometaRootPosix()).toBe('')
+  })
+
+  it('returns empty string when no attrs are set', () => {
+    installRuntimeDom({})
+    expect(getConfiguredKometaRootPosix()).toBe('')
+  })
+
+  it('returns kometaRootSelected when set', () => {
+    installRuntimeDom({
+      kometaRootSelected: '/opt/kometa-user',
+      kometaRootDefault: '/opt/kometa-default'
+    })
+    expect(getConfiguredKometaRootPosix()).toBe('/opt/kometa-user')
+  })
+
+  it('falls back to kometaRootDefault when selected is empty', () => {
+    installRuntimeDom({ kometaRootDefault: '/opt/kometa-default' })
+    expect(getConfiguredKometaRootPosix()).toBe('/opt/kometa-default')
+  })
+
+  it("returns configDir when mode is 'external' (ignores selected/default)", () => {
+    installRuntimeDom({
+      kometaInstallMode: 'external',
+      kometaRootSelected: '/ignored/selected',
+      kometaRootDefault: '/ignored/default',
+      kometaConfigDir: '/mnt/config'
+    })
+    expect(getConfiguredKometaRootPosix()).toBe('/mnt/config')
+  })
+
+  it("returns empty when mode='external' but configDir is missing", () => {
+    installRuntimeDom({ kometaInstallMode: 'external' })
+    expect(getConfiguredKometaRootPosix()).toBe('')
+  })
+
+  it('trims whitespace on the selected value', () => {
+    installRuntimeDom({ kometaRootSelected: '   /opt/kometa   ' })
+    expect(getConfiguredKometaRootPosix()).toBe('/opt/kometa')
+  })
+})
+
+// ---------------------------------------------------------------------
+// getConfiguredKometaRootDisplay
+// ---------------------------------------------------------------------
+
+describe('getConfiguredKometaRootDisplay', () => {
+  it('returns kometaRootSelectedDisplay when set', () => {
+    installRuntimeDom({
+      kometaRootSelectedDisplay: 'C:\\Users\\me\\Kometa',
+      kometaRootSelected: '/mnt/c/Users/me/Kometa'
+    })
+    expect(getConfiguredKometaRootDisplay()).toBe('C:\\Users\\me\\Kometa')
+  })
+
+  it('falls back to kometaRootDefaultDisplay when *Selected* variants missing', () => {
+    installRuntimeDom({
+      kometaRootDefaultDisplay: 'D:\\Default'
+    })
+    expect(getConfiguredKometaRootDisplay()).toBe('D:\\Default')
+  })
+
+  it('falls back to POSIX root when no Display variants exist', () => {
+    installRuntimeDom({ kometaRootDefault: '/opt/kometa' })
+    expect(getConfiguredKometaRootDisplay()).toBe('/opt/kometa')
+  })
+
+  it("returns configDirDisplay when mode is 'external'", () => {
+    installRuntimeDom({
+      kometaInstallMode: 'external',
+      kometaConfigDirDisplay: 'C:\\Configs',
+      kometaConfigDir: '/mnt/c/Configs'
+    })
+    expect(getConfiguredKometaRootDisplay()).toBe('C:\\Configs')
+  })
+
+  it("falls back to POSIX configDir when mode='external' and no Display", () => {
+    installRuntimeDom({
+      kometaInstallMode: 'external',
+      kometaConfigDir: '/mnt/c/Configs'
+    })
+    expect(getConfiguredKometaRootDisplay()).toBe('/mnt/c/Configs')
+  })
+
+  it('returns empty when element missing', () => {
+    installRuntimeDom(null)
+    expect(getConfiguredKometaRootDisplay()).toBe('')
+  })
+})
+
+// ---------------------------------------------------------------------
+// kometaCanLaunch
+// ---------------------------------------------------------------------
+
+describe('kometaCanLaunch', () => {
+  it('returns true for exact "true"', () => {
+    installRuntimeDom({ kometaCanLaunch: 'true' })
+    expect(kometaCanLaunch()).toBe(true)
+  })
+
+  it('is case-insensitive on the value', () => {
+    installRuntimeDom({ kometaCanLaunch: 'TRUE' })
+    expect(kometaCanLaunch()).toBe(true)
+  })
+
+  it('returns false for "false"', () => {
+    installRuntimeDom({ kometaCanLaunch: 'false' })
+    expect(kometaCanLaunch()).toBe(false)
+  })
+
+  it('returns false when attribute is missing', () => {
+    installRuntimeDom({})
+    expect(kometaCanLaunch()).toBe(false)
+  })
+
+  it('returns false when element is missing', () => {
+    installRuntimeDom(null)
+    expect(kometaCanLaunch()).toBe(false)
+  })
+
+  it('returns false for random truthy-looking values', () => {
+    installRuntimeDom({ kometaCanLaunch: '1' })
+    expect(kometaCanLaunch()).toBe(false)
+    installRuntimeDom({ kometaCanLaunch: 'yes' })
+    expect(kometaCanLaunch()).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------
+// kometaCanProbeRuntime
+// ---------------------------------------------------------------------
+
+describe('kometaCanProbeRuntime', () => {
+  it('reads kometaCanProbeRuntime dataset key', () => {
+    installRuntimeDom({ kometaCanProbeRuntime: 'true' })
+    expect(kometaCanProbeRuntime()).toBe(true)
+  })
+
+  it('returns false for empty string', () => {
+    installRuntimeDom({ kometaCanProbeRuntime: '' })
+    expect(kometaCanProbeRuntime()).toBe(false)
+  })
+
+  it('does NOT confuse with kometaCanLaunch', () => {
+    installRuntimeDom({ kometaCanLaunch: 'true' })
+    expect(kometaCanProbeRuntime()).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------
+// kometaCanReadLogs
+// ---------------------------------------------------------------------
+
+describe('kometaCanReadLogs', () => {
+  it('reads kometaCanReadLogs dataset key', () => {
+    installRuntimeDom({ kometaCanReadLogs: 'true' })
+    expect(kometaCanReadLogs()).toBe(true)
+  })
+
+  it('does NOT confuse with kometaCanProbeRuntime', () => {
+    installRuntimeDom({ kometaCanProbeRuntime: 'true' })
+    expect(kometaCanReadLogs()).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------
+// kometaCanCheckUpdateStatus (composite)
+// ---------------------------------------------------------------------
+
+describe('kometaCanCheckUpdateStatus', () => {
+  it("is false when mode is 'external' regardless of probe capability", () => {
+    installRuntimeDom({
+      kometaInstallMode: 'external',
+      kometaCanProbeRuntime: 'true'
+    })
+    expect(kometaCanCheckUpdateStatus()).toBe(false)
+  })
+
+  it("is false when mode is 'managed' but probe capability is false", () => {
+    installRuntimeDom({ kometaInstallMode: 'managed' })
+    expect(kometaCanCheckUpdateStatus()).toBe(false)
+  })
+
+  it("is true when mode is 'managed' AND probe capability is true", () => {
+    installRuntimeDom({
+      kometaInstallMode: 'managed',
+      kometaCanProbeRuntime: 'true'
+    })
+    expect(kometaCanCheckUpdateStatus()).toBe(true)
+  })
+
+  it("is true when mode is 'existing' AND probe capability is true", () => {
+    installRuntimeDom({
+      kometaInstallMode: 'existing',
+      kometaCanProbeRuntime: 'true'
+    })
+    expect(kometaCanCheckUpdateStatus()).toBe(true)
+  })
+
+  it('is false when element is entirely missing', () => {
+    installRuntimeDom(null)
+    // getConfiguredKometaInstallMode -> 'managed' (default),
+    // kometaCanProbeRuntime -> false. So composite = false.
+    expect(kometaCanCheckUpdateStatus()).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

Seventh module out of the `900-kometa.js` god-file split (parts 1-6: #1554, #1556, #1557, #1560, #1561, #1562). `900-kometa.js`: 3441 → 3406 lines (**−35**). Small foundational extraction that **unblocks the next two bigger targets** (`_runCommand.js` and `_kometaUpdate.js`) by giving them a clean API for reading Kometa runtime configuration.

## What moved

Extracted to `static/local-js/modules/kometa/_runtime.js`:

| Function | Role |
|---|---|
| `getConfiguredKometaInstallMode` | `'managed'` \| `'existing'` \| `'external'` |
| `getConfiguredKometaRootPosix` | POSIX path (or configDir when external) |
| `getConfiguredKometaRootDisplay` | user-facing string version |
| `kometaCanLaunch` | gate for 'Run Now' button |
| `kometaCanCheckUpdateStatus` | gate for update-check flow |
| `kometaCanProbeRuntime` | gate for `validateKometaRoot` etc. |
| `kometaCanReadLogs` | gate for live log tail |

All seven consult the same element (`#run-command-output`) via different `data-*` attributes. They're the 'first line' of every runtime-related operation and get called **~37 times** across the file.

## Design notes

1. **Pure DOM readers** — no mutation, no side effects, no module-scoped state. Callers get a fresh snapshot every time. Matches the pre-extraction behavior of treating the dataset as the single source of truth.

2. **API split by concern rather than aggregated.** Resisted the temptation to export a single `getKometaRuntime()` → `{mode, rootPosix, canLaunch, ...}` because:
   - Each helper owns its own dataset key mapping and can be independently tested
   - Call sites read more clearly: `if (kometaCanProbeRuntime()) { ... }` vs `if (runtime.canProbe) { ... }`
   - An aggregate would be a temptation to **cache**, which would break the 'fresh read every time' invariant

3. **Every helper returns a safe default** when the element or attribute is missing:
   - `getConfiguredKometaInstallMode` → `'managed'`
   - `getConfiguredKometaRootPosix` → `''`
   - `getConfiguredKometaRootDisplay` → POSIX fallback (which itself → `''` when nothing set)
   - `kometaCan*` → `false`

   This makes it safe to import this module before `DOMContentLoaded` — calls report the conservative 'nothing available' state until the DOM catches up.

## Vitest coverage: 37 new tests

- **`getConfiguredKometaInstallMode`**: 8 tests (default `'managed'`, all 3 valid values, case-insensitive, whitespace-trim, unknown → managed)
- **`getConfiguredKometaRootPosix`**: 7 tests (missing element, empty attrs, selected priority, fallback to default, external mode returns `configDir` instead, external + missing configDir → empty, whitespace trim)
- **`getConfiguredKometaRootDisplay`**: 6 tests (`selectedDisplay` priority, `defaultDisplay` fallback, POSIX fallback, external + `configDirDisplay`, external + POSIX-only `configDir`, missing element)
- **`kometaCanLaunch`**: 6 tests (true/false/missing/case-insensitive, rejects non-`'true'` truthy values `'1'`/`'yes'`)
- **`kometaCanProbeRuntime`**: 3 tests (basic, empty string, key isolation from Launch)
- **`kometaCanReadLogs`**: 2 tests (basic, key isolation from Probe)
- **`kometaCanCheckUpdateStatus`**: 5 tests (composite of mode + probe, external mode always false, missing element handled)

## Verification

- **838/838 Vitest pass** (was 801 after #1562 merged; +37 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- ESLint clean, Node syntax clean

## What's next

With runtime readers cleanly separated, the next larger extractions become tractable:

- `_runCommand.js` — `buildCommand` + placeholder + mode badges; heavy user of `getConfiguredKometa*` readers
- `_kometaRuntime.js` — `validateKometaRoot` + `probeKometaRoot` (needs `KOMETA_*` mutable state migrated first)
- `_kometaUpdate.js` — branch override + update job (~800 lines, biggest)

Or the still-pending badge stay-behinds from #1560 (`KOMETA_*` flags need to migrate to `kometaState` first).