### PR TITLE
Split 900-kometa.js part 8: extract run-command builder + active-command state

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -1,6 +1,5 @@
 // Global flag so other handlers know an update is in progress
 import {
-  quoteIfNeeded,
   formatElapsed,
   computeYamlLineCount,
   linkifyText,
@@ -8,7 +7,6 @@ import {
   clampPercent,
   formatRunSeconds,
   coerceRunSeconds,
-  isValidTimesFormat,
   applyLogFilter,
   computeLogStats,
   pushSparkValue,
@@ -18,7 +16,6 @@ import {
   setMetaFlag
 } from './modules/kometa/_util.js'
 import {
-  toggleTimesInputVisibility,
   checkMaintenanceWarning
 } from './modules/kometa/_maintenanceWindow.js'
 import { kometaState } from './modules/kometa/_state.js'
@@ -48,6 +45,20 @@ import {
   kometaCanProbeRuntime,
   kometaCanReadLogs
 } from './modules/kometa/_runtime.js'
+import {
+  buildCommand as _buildCommand,
+  isRunCommandValid,
+  applyActiveRunCommandState,
+  clearActiveRunCommandState
+} from './modules/kometa/_runCommand.js'
+
+// Thin wrapper: buildCommand needs updateRunNowState and
+// syncFinalAccordionRollups callbacks, but both are still owned by
+// this file. Wrapping here keeps every call site simple
+// (`buildCommand()` with no args), matching the pre-extraction API.
+function buildCommand () {
+  return _buildCommand({ updateRunNowState, syncFinalAccordionRollups })
+}
 
 let KOMETA_UPDATING = false
 let KOMETA_VALIDATED = false
@@ -75,8 +86,6 @@ let finalLogscanAnalyzeTriggered = false
 let lastRunProgressPayload = null
 let logscanAnalyzeInFlight = false
 let runProgressInFlight = false
-let activeRunCommandOverride = null
-let activeRunCommandMode = null
 let latestKometaStatusPayload = null
 const KOMETA_BRANCH_OVERRIDE_STORAGE_KEY = 'qs-kometa-branch-override'
 
@@ -90,14 +99,6 @@ const runSparkState = {
   io: { read: [], write: [] }
 }
 
-const _qsEnvEl = document.getElementById('qs-env')
-const runningOn = (_qsEnvEl && _qsEnvEl.dataset.runningOn) ? _qsEnvEl.dataset.runningOn : ''
-const isWindows = typeof runningOn === 'string' && runningOn.includes('Windows')
-// const isFrozen = typeof runningOn === 'string' && runningOn.startsWith('Frozen')
-// const isDocker = runningOn === 'Docker'
-
-// function toDisplayPath (p) { return isWindows ? String(p).replace(/\//g, '\\') : String(p) }
-// function toPosix (p) { return String(p).replace(/\\/g, '/') }
 const runLog = document.getElementById('run-output-log')
 const tailNotice = document.getElementById('run-output-notice')
 const tailSelect = document.getElementById('run-log-tail')
@@ -496,11 +497,6 @@ if (showCliToggle) {
   })
 }
 
-function isRunCommandValid () {
-  const cmd = document.getElementById('run-command-output').textContent.trim()
-  return Boolean(cmd) && !cmd.startsWith('??')
-}
-
 function setRunCommandPlaceholderState () {
   const panel = document.getElementById('run-command-panel-message')
   const panelTitle = document.getElementById('run-command-panel-title')
@@ -561,58 +557,6 @@ function clearRunCommandPlaceholderState () {
   document.getElementById('copy-command').classList.remove('d-none')
 }
 
-function getRunCommandModeLabel (mode) {
-  const normalized = String(mode || 'current').trim().toLowerCase()
-  if (normalized === 'recovery') return 'Recovery Command'
-  if (normalized === 'logged') return 'Last Logged Command'
-  return 'Command'
-}
-
-function getRunCommandModeBadgeLabel (mode) {
-  const normalized = String(mode || 'current').trim().toLowerCase()
-  if (normalized === 'recovery') return 'Recovery Active'
-  if (normalized === 'logged') return 'Logged Active'
-  return 'Current Active'
-}
-
-function getRunCommandModeBadgeClass (mode) {
-  const normalized = String(mode || 'current').trim().toLowerCase()
-  if (normalized === 'recovery') return 'text-bg-warning'
-  if (normalized === 'logged') return 'text-bg-secondary'
-  return 'text-bg-primary'
-}
-
-function applyActiveRunCommandState (command, mode) {
-  const normalizedMode = String(mode || 'current').trim().toLowerCase() || 'current'
-  activeRunCommandOverride = command || null
-  activeRunCommandMode = normalizedMode
-
-  if (command) {
-    document.getElementById('run-command-output').textContent = command
-  }
-
-  document.getElementById('run-command-label').textContent = getRunCommandModeLabel(normalizedMode)
-  const activeBadge = document.getElementById('run-command-active-badge')
-  if (activeBadge) {
-    activeBadge.classList.remove('d-none', 'text-bg-warning', 'text-bg-secondary', 'text-bg-primary')
-    activeBadge.classList.add(getRunCommandModeBadgeClass(normalizedMode))
-    activeBadge.textContent = getRunCommandModeBadgeLabel(normalizedMode)
-  }
-}
-
-function clearActiveRunCommandState () {
-  activeRunCommandOverride = null
-  activeRunCommandMode = null
-  const label = document.getElementById('run-command-label')
-  if (label) label.textContent = 'Command'
-  const activeBadge = document.getElementById('run-command-active-badge')
-  if (activeBadge) {
-    activeBadge.classList.add('d-none')
-    activeBadge.classList.remove('text-bg-warning', 'text-bg-secondary', 'text-bg-primary')
-    activeBadge.textContent = 'Recovery Active'
-  }
-}
-
 function resolveFreshnessGateAfterBulkValidation () {
   const gateEl = document.getElementById('final-gate-state')
   if (gateEl) {
@@ -649,135 +593,6 @@ function updateRunNowState () {
   runNow.disabled = false
   updateRunCommandHeaderBadge()
   syncIncompleteRunActions()
-}
-
-function buildCommand () {
-  const runCmdOutput = document.getElementById('run-command-output')
-  if (!runCmdOutput) return
-  const configFilename = runCmdOutput.dataset.configFilename || ''
-
-  // Always use normalized forward slashes internally
-  const pythonBinNorm = (runCmdOutput.dataset.venvPython || 'python3').replace(/\\/g, '/')
-  const kometaRootNorm = (runCmdOutput.dataset.kometaRoot || '').replace(/\\/g, '/')
-
-  const fullKometaPy = `${kometaRootNorm}/kometa.py`
-  const fullConfigPath = `${kometaRootNorm}/config/${configFilename}`
-
-  // use the global isWindows we computed from backend values
-  const finalPythonBin = isWindows ? pythonBinNorm.replace(/\//g, '\\') : pythonBinNorm
-  const finalKometaPy = isWindows ? fullKometaPy.replace(/\//g, '\\') : fullKometaPy
-  const finalConfigPath = isWindows ? fullConfigPath.replace(/\//g, '\\') : fullConfigPath
-
-  // Quote paths that may contain spaces
-  let cli = `${quoteIfNeeded(finalPythonBin)} ${quoteIfNeeded(finalKometaPy)}`
-
-  const mainOption = (document.querySelector('input[name="run-option"]:checked') || {}).value || ''
-  const libSelectEl = document.getElementById('library-multiselect')
-  const selectedLibs = libSelectEl ? Array.from(libSelectEl.selectedOptions || []).map(o => o.value) : []
-
-  if (mainOption) cli += ` ${mainOption}`
-
-  if (mainOption === '--times') {
-    const timesInput = document.getElementById('times-input').value.trim()
-    const isValid = isValidTimesFormat(timesInput)
-    toggleTimesInputVisibility('--times')
-    if (!isValid) {
-      document.getElementById('times-error').classList.remove('d-none')
-      runCmdOutput.textContent = '⚠️ Invalid time format. Use pipe-separated 24h times like 06:00|15:00.'
-      updateRunNowState()
-      syncFinalAccordionRollups()
-      return false
-    } else {
-      document.getElementById('times-error').classList.add('d-none')
-      checkMaintenanceWarning(mainOption)
-      cli += ` "${timesInput}"`
-    }
-  } else {
-    toggleTimesInputVisibility(mainOption)
-  }
-
-  if (mainOption === '--run-libraries') {
-    if (!selectedLibs.length) {
-      runCmdOutput.textContent = '⚠️ Please select at least one library when using --run-libraries.'
-      updateRunNowState()
-      syncFinalAccordionRollups()
-      return false
-    }
-    cli += ` "${selectedLibs.join('|')}"`
-  }
-
-  const modeFlag = (document.querySelector('input[name="mode-flag"]:checked') || {}).value
-  if (modeFlag) cli += ` ${modeFlag}`
-
-  const logFlag = (document.querySelector('input[name="log-flag"]:checked') || {}).value
-  if (logFlag) cli += ` ${logFlag}`
-
-  const checkboxFlags = [
-    'delete-collections', 'delete-labels', 'read-only-config', 'low-priority',
-    'no-report', 'no-missing', 'no-countdown', 'ignore-ghost',
-    'ignore-schedules', 'no-verify-ssl', 'tests'
-  ]
-  checkboxFlags.forEach(opt => {
-    const checkbox = document.getElementById(`opt-${opt}`)
-    if (checkbox && checkbox.checked) cli += ` --${opt}`
-  })
-
-  // Always append --config with platform-adjusted path
-  cli += ` --config ${quoteIfNeeded(finalConfigPath)}`
-
-  const timeoutChecked = document.getElementById('opt-timeout').checked
-  const timeoutValue = document.getElementById('opt-timeout-val').value.trim()
-  if (timeoutChecked) {
-    const timeoutNum = parseInt(timeoutValue, 10)
-    if (!/^\d+$/.test(timeoutValue) || timeoutNum <= 0) {
-      document.getElementById('timeout-error').classList.remove('d-none')
-      runCmdOutput.textContent = '⚠️ Invalid timeout. Please enter a positive whole number.'
-      updateRunNowState()
-      syncFinalAccordionRollups()
-      return false
-    } else {
-      document.getElementById('timeout-error').classList.add('d-none')
-      cli += ` --timeout ${timeoutNum}`
-    }
-  }
-
-  const widthChecked = document.getElementById('opt-width').checked
-  const widthValue = document.getElementById('opt-width-val').value.trim()
-  if (widthChecked) {
-    const widthNum = parseInt(widthValue, 10)
-    if (!/^\d+$/.test(widthValue) || widthNum < 90 || widthNum > 300) {
-      document.getElementById('width-error').classList.remove('d-none')
-      runCmdOutput.textContent = '⚠️ Width must be a number between 90 and 300.'
-      updateRunNowState()
-      syncFinalAccordionRollups()
-      return false
-    } else {
-      document.getElementById('width-error').classList.add('d-none')
-      cli += ` --width ${widthNum}`
-    }
-  }
-
-  if (document.getElementById('opt-divider').checked) {
-    const dividerValue = document.getElementById('opt-divider-val').value.trim()
-    if (!dividerValue || dividerValue.length !== 1) {
-      document.getElementById('divider-error').classList.remove('d-none')
-      runCmdOutput.textContent = '⚠️ Divider must be a single character.'
-      updateRunNowState()
-      syncFinalAccordionRollups()
-      return false
-    } else {
-      document.getElementById('divider-error').classList.add('d-none')
-      cli += ` --divider "${dividerValue}"`
-    }
-  }
-
-  runCmdOutput.dataset.builtCommand = cli
-  if (!activeRunCommandOverride) {
-    runCmdOutput.textContent = cli
-  }
-  updateRunNowState()
-  syncFinalAccordionRollups()
-  return true
 }
 
 document.querySelectorAll('input[name="run-option"]').forEach(el => el.addEventListener('change', function () {
@@ -3315,8 +3130,8 @@ function checkKometaStatus () {
 
       if (data.pending_start && data.status !== 'running') {
         applyActiveRunCommandState(
-          data.pending_command || activeRunCommandOverride || getRecoveryRunCommand(),
-          data.pending_start_mode || activeRunCommandMode || 'recovery'
+          data.pending_command || kometaState.activeRunCommandOverride || getRecoveryRunCommand(),
+          data.pending_start_mode || kometaState.activeRunCommandMode || 'recovery'
         )
         const windowLabel = data.maintenance_window ? ` (${data.maintenance_window})` : ''
         const nowLabel = (typeof window.QS_formatTimestamp === 'function') ? window.QS_formatTimestamp() : new Date().toLocaleString()
@@ -3346,8 +3161,8 @@ function checkKometaStatus () {
       // Handle Kometa process states
       if (data.status === 'running') {
         applyActiveRunCommandState(
-          data.active_command || activeRunCommandOverride || getCurrentRunCommand(),
-          data.start_mode || activeRunCommandMode || 'current'
+          data.active_command || kometaState.activeRunCommandOverride || getCurrentRunCommand(),
+          data.start_mode || kometaState.activeRunCommandMode || 'current'
         )
         KOMETA_PENDING_START = false
         finalLogscanAnalyzeTriggered = false

--- a/static/local-js/modules/kometa/_runCommand.js
+++ b/static/local-js/modules/kometa/_runCommand.js
@@ -1,0 +1,362 @@
+// Kometa run-command builder and active-command state management.
+//
+// The "run command" is the exact CLI Quickstart shows in the UI --
+// the one users can copy-paste to launch Kometa manually, or that
+// Quickstart itself invokes on "Run Now". It's assembled from:
+//
+//   - the venv python + kometa.py paths (from #run-command-output dataset)
+//   - the currently-selected run option (radio: default, --times,
+//     --run-libraries, --collections-only, etc.)
+//   - mode / log flag radios
+//   - a bunch of independent option checkboxes (--delete-collections,
+//     --read-only-config, ...)
+//   - optional numeric fields (--timeout, --width, --divider) each
+//     with their own validation rules
+//   - the config filename (appended as --config)
+//
+// This module owns:
+//
+//   buildCommand                     -- the big assembler (~120 lines).
+//                                        Returns true/false/undefined
+//                                        depending on validation state.
+//   isRunCommandValid                -- true iff the run-command-output
+//                                        element has non-empty, non-'??'
+//                                        text content
+//
+//   getRunCommandModeLabel           -- label above the command panel
+//   getRunCommandModeBadgeLabel      -- text of the mode indicator badge
+//   getRunCommandModeBadgeClass      -- Bootstrap text-bg-* class for
+//                                        the mode indicator badge
+//
+//   applyActiveRunCommandState       -- freeze the command panel at a
+//                                        specific command + mode (writes
+//                                        kometaState.activeRunCommand*)
+//   clearActiveRunCommandState       -- reset to live-build mode (clears
+//                                        kometaState.activeRunCommand*)
+//
+// Design notes:
+//
+//   1. buildCommand takes callbacks (updateRunNowState,
+//      syncFinalAccordionRollups) as required properties of an
+//      options bag. Same hybrid pattern as _validationGate.js --
+//      once those functions themselves migrate to their own modules,
+//      the callbacks retire in favor of direct imports.
+//
+//   2. isWindowsPlatform is computed lazily via a private helper
+//      each call rather than cached at module load. Trivial cost,
+//      makes tests trivially controllable.
+//
+//   3. Validation error paths in buildCommand write to
+//      runCmdOutput.textContent AND to specific error <div>s
+//      (times-error, timeout-error, width-error, divider-error).
+//      This dual-signal was pre-existing behavior: the top-line
+//      command panel shows a friendly warning, and the field-level
+//      error div shows the exact rule that was violated.
+
+import { kometaState } from './_state.js'
+import { quoteIfNeeded, isValidTimesFormat } from './_util.js'
+import { toggleTimesInputVisibility, checkMaintenanceWarning } from './_maintenanceWindow.js'
+
+// ---------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------
+
+/**
+ * Lazily reads the `#qs-env` element's `data-running-on` attribute and
+ * returns true iff the runtime is Windows. Called on every buildCommand
+ * invocation -- getElementById is trivially fast and this way tests
+ * can flip the env without a module reload.
+ *
+ * @returns {boolean}
+ */
+function isWindowsPlatform () {
+  const envEl = document.getElementById('qs-env')
+  const runningOn = (envEl && envEl.dataset.runningOn) || ''
+  return typeof runningOn === 'string' && runningOn.includes('Windows')
+}
+
+// A "normalize the mode string" helper used by both the label
+// look-ups and the state setters. Small enough to duplicate at each
+// site would be OK, but centralizing makes it obvious the same
+// normalization rule applies everywhere.
+function normalizeMode (mode) {
+  return String(mode || 'current').trim().toLowerCase() || 'current'
+}
+
+// ---------------------------------------------------------------------
+// Command validity + labels
+// ---------------------------------------------------------------------
+
+/**
+ * True iff the run-command panel currently shows a real command
+ * (non-empty, not a "??" placeholder for missing paths).
+ *
+ * @returns {boolean}
+ */
+export function isRunCommandValid () {
+  const el = document.getElementById('run-command-output')
+  if (!el) return false
+  const cmd = (el.textContent || '').trim()
+  return Boolean(cmd) && !cmd.startsWith('??')
+}
+
+/**
+ * The user-facing label above the run-command panel. Matches the
+ * "which command are we showing?" mode indicator.
+ *
+ * @param {string} mode
+ * @returns {'Command' | 'Recovery Command' | 'Last Logged Command'}
+ */
+export function getRunCommandModeLabel (mode) {
+  const normalized = normalizeMode(mode)
+  if (normalized === 'recovery') return 'Recovery Command'
+  if (normalized === 'logged') return 'Last Logged Command'
+  return 'Command'
+}
+
+/**
+ * The text of the mode indicator badge next to the run-command label.
+ *
+ * @param {string} mode
+ * @returns {'Current Active' | 'Recovery Active' | 'Logged Active'}
+ */
+export function getRunCommandModeBadgeLabel (mode) {
+  const normalized = normalizeMode(mode)
+  if (normalized === 'recovery') return 'Recovery Active'
+  if (normalized === 'logged') return 'Logged Active'
+  return 'Current Active'
+}
+
+/**
+ * The Bootstrap `text-bg-*` class to paint the mode indicator badge.
+ *
+ * @param {string} mode
+ * @returns {'text-bg-warning' | 'text-bg-secondary' | 'text-bg-primary'}
+ */
+export function getRunCommandModeBadgeClass (mode) {
+  const normalized = normalizeMode(mode)
+  if (normalized === 'recovery') return 'text-bg-warning'
+  if (normalized === 'logged') return 'text-bg-secondary'
+  return 'text-bg-primary'
+}
+
+// ---------------------------------------------------------------------
+// Active override state
+// ---------------------------------------------------------------------
+
+/**
+ * Freeze the run-command panel on a specific command + mode.
+ * Writes to kometaState.activeRunCommand{Override,Mode} so buildCommand
+ * knows not to overwrite the panel on its next call.
+ *
+ * @param {string|null} command  The command string to display. Falsy
+ *                                clears the override.
+ * @param {string} mode          'current' | 'recovery' | 'logged'
+ */
+export function applyActiveRunCommandState (command, mode) {
+  const normalizedMode = normalizeMode(mode)
+  kometaState.activeRunCommandOverride = command || null
+  kometaState.activeRunCommandMode = normalizedMode
+
+  if (command) {
+    const outEl = document.getElementById('run-command-output')
+    if (outEl) outEl.textContent = command
+  }
+
+  const labelEl = document.getElementById('run-command-label')
+  if (labelEl) labelEl.textContent = getRunCommandModeLabel(normalizedMode)
+
+  const activeBadge = document.getElementById('run-command-active-badge')
+  if (activeBadge) {
+    activeBadge.classList.remove('d-none', 'text-bg-warning', 'text-bg-secondary', 'text-bg-primary')
+    activeBadge.classList.add(getRunCommandModeBadgeClass(normalizedMode))
+    activeBadge.textContent = getRunCommandModeBadgeLabel(normalizedMode)
+  }
+}
+
+/**
+ * Reset to live-build mode. Clears the override state and restores the
+ * default "Command" label + hides the mode-indicator badge.
+ */
+export function clearActiveRunCommandState () {
+  kometaState.activeRunCommandOverride = null
+  kometaState.activeRunCommandMode = null
+
+  const label = document.getElementById('run-command-label')
+  if (label) label.textContent = 'Command'
+
+  const activeBadge = document.getElementById('run-command-active-badge')
+  if (activeBadge) {
+    activeBadge.classList.add('d-none')
+    activeBadge.classList.remove('text-bg-warning', 'text-bg-secondary', 'text-bg-primary')
+    activeBadge.textContent = 'Recovery Active'
+  }
+}
+
+// ---------------------------------------------------------------------
+// buildCommand
+// ---------------------------------------------------------------------
+
+// Central list of "no-value option" checkboxes. Their id is
+// `opt-<name>` and if checked they append `--<name>` to the CLI.
+// Kept here as a top-level const so tests can import it if we ever
+// want to assert the set.
+const CHECKBOX_FLAGS = [
+  'delete-collections', 'delete-labels', 'read-only-config', 'low-priority',
+  'no-report', 'no-missing', 'no-countdown', 'ignore-ghost',
+  'ignore-schedules', 'no-verify-ssl', 'tests'
+]
+
+/**
+ * Assemble the current run command from the wizard's radios,
+ * checkboxes, and text inputs. Writes the result to two places:
+ *
+ *   run-command-output.dataset.builtCommand -- always, as ground truth
+ *   run-command-output.textContent          -- only if there's no
+ *                                              active override
+ *
+ * Returns:
+ *   true         -- command built successfully
+ *   false        -- validation failed for a specific field
+ *                    (times / --run-libraries / timeout / width /
+ *                     divider)
+ *   undefined    -- no run-command-output in the DOM (short-circuit)
+ *
+ * @param {{
+ *   updateRunNowState: () => void,
+ *   syncFinalAccordionRollups: () => void
+ * }} callbacks  Both hooks are required (see module docstring).
+ *
+ * @returns {boolean | undefined}
+ */
+export function buildCommand (callbacks) {
+  const { updateRunNowState, syncFinalAccordionRollups } = callbacks || {}
+  const notify = () => {
+    if (typeof updateRunNowState === 'function') updateRunNowState()
+    if (typeof syncFinalAccordionRollups === 'function') syncFinalAccordionRollups()
+  }
+
+  const runCmdOutput = document.getElementById('run-command-output')
+  if (!runCmdOutput) return
+  const configFilename = runCmdOutput.dataset.configFilename || ''
+
+  // Always normalize to forward slashes for internal path assembly,
+  // then swap to backslashes at the end only if we're on Windows.
+  const pythonBinNorm = (runCmdOutput.dataset.venvPython || 'python3').replace(/\\/g, '/')
+  const kometaRootNorm = (runCmdOutput.dataset.kometaRoot || '').replace(/\\/g, '/')
+
+  const fullKometaPy = `${kometaRootNorm}/kometa.py`
+  const fullConfigPath = `${kometaRootNorm}/config/${configFilename}`
+
+  const isWin = isWindowsPlatform()
+  const finalPythonBin = isWin ? pythonBinNorm.replace(/\//g, '\\') : pythonBinNorm
+  const finalKometaPy = isWin ? fullKometaPy.replace(/\//g, '\\') : fullKometaPy
+  const finalConfigPath = isWin ? fullConfigPath.replace(/\//g, '\\') : fullConfigPath
+
+  let cli = `${quoteIfNeeded(finalPythonBin)} ${quoteIfNeeded(finalKometaPy)}`
+
+  // ---- Primary run option (one radio in run-option group) ---------
+  const mainOption = (document.querySelector('input[name="run-option"]:checked') || {}).value || ''
+  const libSelectEl = document.getElementById('library-multiselect')
+  const selectedLibs = libSelectEl ? Array.from(libSelectEl.selectedOptions || []).map(o => o.value) : []
+
+  if (mainOption) cli += ` ${mainOption}`
+
+  // ---- --times: validate + append quoted value --------------------
+  if (mainOption === '--times') {
+    const timesInput = document.getElementById('times-input').value.trim()
+    const isValid = isValidTimesFormat(timesInput)
+    toggleTimesInputVisibility('--times')
+    if (!isValid) {
+      document.getElementById('times-error').classList.remove('d-none')
+      runCmdOutput.textContent = '⚠️ Invalid time format. Use pipe-separated 24h times like 06:00|15:00.'
+      notify()
+      return false
+    }
+    document.getElementById('times-error').classList.add('d-none')
+    checkMaintenanceWarning(mainOption)
+    cli += ` "${timesInput}"`
+  } else {
+    toggleTimesInputVisibility(mainOption)
+  }
+
+  // ---- --run-libraries: require at least one library selected -----
+  if (mainOption === '--run-libraries') {
+    if (!selectedLibs.length) {
+      runCmdOutput.textContent = '⚠️ Please select at least one library when using --run-libraries.'
+      notify()
+      return false
+    }
+    cli += ` "${selectedLibs.join('|')}"`
+  }
+
+  // ---- Mode + log flag radios (optional, mutually exclusive) ------
+  const modeFlag = (document.querySelector('input[name="mode-flag"]:checked') || {}).value
+  if (modeFlag) cli += ` ${modeFlag}`
+
+  const logFlag = (document.querySelector('input[name="log-flag"]:checked') || {}).value
+  if (logFlag) cli += ` ${logFlag}`
+
+  // ---- Standalone flag checkboxes ---------------------------------
+  CHECKBOX_FLAGS.forEach(opt => {
+    const checkbox = document.getElementById(`opt-${opt}`)
+    if (checkbox && checkbox.checked) cli += ` --${opt}`
+  })
+
+  // Always append --config with the platform-adjusted path
+  cli += ` --config ${quoteIfNeeded(finalConfigPath)}`
+
+  // ---- --timeout: positive integer only ---------------------------
+  const timeoutCheckbox = document.getElementById('opt-timeout')
+  const timeoutChecked = !!(timeoutCheckbox && timeoutCheckbox.checked)
+  const timeoutValue = (document.getElementById('opt-timeout-val') || {}).value?.trim?.() || ''
+  if (timeoutChecked) {
+    const timeoutNum = parseInt(timeoutValue, 10)
+    if (!/^\d+$/.test(timeoutValue) || timeoutNum <= 0) {
+      document.getElementById('timeout-error').classList.remove('d-none')
+      runCmdOutput.textContent = '⚠️ Invalid timeout. Please enter a positive whole number.'
+      notify()
+      return false
+    }
+    document.getElementById('timeout-error').classList.add('d-none')
+    cli += ` --timeout ${timeoutNum}`
+  }
+
+  // ---- --width: integer in [90, 300] ------------------------------
+  const widthCheckbox = document.getElementById('opt-width')
+  const widthChecked = !!(widthCheckbox && widthCheckbox.checked)
+  const widthValue = (document.getElementById('opt-width-val') || {}).value?.trim?.() || ''
+  if (widthChecked) {
+    const widthNum = parseInt(widthValue, 10)
+    if (!/^\d+$/.test(widthValue) || widthNum < 90 || widthNum > 300) {
+      document.getElementById('width-error').classList.remove('d-none')
+      runCmdOutput.textContent = '⚠️ Width must be a number between 90 and 300.'
+      notify()
+      return false
+    }
+    document.getElementById('width-error').classList.add('d-none')
+    cli += ` --width ${widthNum}`
+  }
+
+  // ---- --divider: exactly one character ---------------------------
+  const dividerCheckbox = document.getElementById('opt-divider')
+  if (dividerCheckbox && dividerCheckbox.checked) {
+    const dividerValue = (document.getElementById('opt-divider-val') || {}).value?.trim?.() || ''
+    if (!dividerValue || dividerValue.length !== 1) {
+      document.getElementById('divider-error').classList.remove('d-none')
+      runCmdOutput.textContent = '⚠️ Divider must be a single character.'
+      notify()
+      return false
+    }
+    document.getElementById('divider-error').classList.add('d-none')
+    cli += ` --divider "${dividerValue}"`
+  }
+
+  // ---- Success path -----------------------------------------------
+  runCmdOutput.dataset.builtCommand = cli
+  if (!kometaState.activeRunCommandOverride) {
+    runCmdOutput.textContent = cli
+  }
+  notify()
+  return true
+}

--- a/static/local-js/modules/kometa/_state.js
+++ b/static/local-js/modules/kometa/_state.js
@@ -86,5 +86,23 @@ export const kometaState = {
   // syncFinalAccordionRollups, the run controls, and the update job
   // to gate their UI. Was a top-level `let showYAML` in 900-kometa.js
   // pre-migration.
-  showYAML: false
+  showYAML: false,
+
+  // ---- Run command override ---------------------------------------
+  // When set, the run-command output panel shows this specific
+  // command (instead of the one buildCommand would freshly produce).
+  // Used for two paths:
+  //   - "recovery": show the command that Kometa was invoked with
+  //     when a run was interrupted and needs to be resumed
+  //   - "logged": show the command from the last completed log
+  //
+  // activeRunCommandOverride  = string or null (the frozen command)
+  // activeRunCommandMode      = 'current' | 'recovery' | 'logged'
+  //
+  // Written by applyActiveRunCommandState / clearActiveRunCommandState
+  // in _runCommand.js. Read by buildCommand (to decide whether to
+  // overwrite the output panel) and by the run-command polling loop
+  // (to include mode in the start-run payload).
+  activeRunCommandOverride: null,
+  activeRunCommandMode: null
 }

--- a/tests/js/kometa/runCommand.test.js
+++ b/tests/js/kometa/runCommand.test.js
@@ -1,0 +1,564 @@
+// Tests for static/local-js/modules/kometa/_runCommand.js
+//
+// The module exports seven functions. Coverage strategy:
+//
+//   isRunCommandValid            trivial DOM read, 4 tests
+//   getRunCommandModeLabel       pure fn, 3 tests
+//   getRunCommandModeBadgeLabel  pure fn, 3 tests
+//   getRunCommandModeBadgeClass  pure fn, 3 tests
+//   applyActiveRunCommandState   writes state + DOM, 5 tests
+//   clearActiveRunCommandState   inverse, 3 tests
+//   buildCommand                 big one, 25+ tests covering every
+//                                validation branch
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { kometaState } from '../../../static/local-js/modules/kometa/_state.js'
+import {
+  buildCommand,
+  isRunCommandValid,
+  getRunCommandModeLabel,
+  getRunCommandModeBadgeLabel,
+  getRunCommandModeBadgeClass,
+  applyActiveRunCommandState,
+  clearActiveRunCommandState
+} from '../../../static/local-js/modules/kometa/_runCommand.js'
+
+// ---------------------------------------------------------------------
+// Fixture DOM helpers
+// ---------------------------------------------------------------------
+
+/**
+ * Build the minimal DOM that buildCommand consults. Every option
+ * is disabled/unchecked by default; individual tests flip the ones
+ * they need.
+ *
+ * @param {{
+ *   platform?: 'Linux' | 'Windows' | 'Docker',
+ *   configFilename?: string,
+ *   venvPython?: string,
+ *   kometaRoot?: string,
+ *   runOption?: string,
+ *   modeFlag?: string,
+ *   logFlag?: string
+ * }} [opts]
+ */
+function installRunCommandDom (opts = {}) {
+  const {
+    platform = 'Linux',
+    configFilename = 'config.yml',
+    venvPython = '/venv/bin/python',
+    kometaRoot = '/opt/kometa',
+    runOption = '',
+    modeFlag = '',
+    logFlag = ''
+  } = opts
+
+  document.body.innerHTML = `
+    <div id="qs-env" data-running-on="${platform}"></div>
+    <div id="run-command-output"
+         data-config-filename="${configFilename}"
+         data-venv-python="${venvPython}"
+         data-kometa-root="${kometaRoot}"></div>
+    <div id="run-command-label"></div>
+    <div id="run-command-active-badge" class="d-none"></div>
+
+    <input type="radio" name="run-option" value="" ${runOption === '' ? 'checked' : ''}>
+    <input type="radio" name="run-option" value="--collections-only" ${runOption === '--collections-only' ? 'checked' : ''}>
+    <input type="radio" name="run-option" value="--times" ${runOption === '--times' ? 'checked' : ''}>
+    <input type="radio" name="run-option" value="--run-libraries" ${runOption === '--run-libraries' ? 'checked' : ''}>
+
+    <input id="times-input" value="">
+    <div id="times-error" class="d-none"></div>
+
+    <select id="library-multiselect" multiple>
+      <option value="Movies">Movies</option>
+      <option value="TV Shows">TV Shows</option>
+    </select>
+
+    <input type="radio" name="mode-flag" value="" ${modeFlag === '' ? 'checked' : ''}>
+    <input type="radio" name="mode-flag" value="--dry-run" ${modeFlag === '--dry-run' ? 'checked' : ''}>
+
+    <input type="radio" name="log-flag" value="" ${logFlag === '' ? 'checked' : ''}>
+    <input type="radio" name="log-flag" value="--debug" ${logFlag === '--debug' ? 'checked' : ''}>
+
+    <input type="checkbox" id="opt-delete-collections">
+    <input type="checkbox" id="opt-delete-labels">
+    <input type="checkbox" id="opt-read-only-config">
+    <input type="checkbox" id="opt-low-priority">
+    <input type="checkbox" id="opt-no-report">
+    <input type="checkbox" id="opt-no-missing">
+    <input type="checkbox" id="opt-no-countdown">
+    <input type="checkbox" id="opt-ignore-ghost">
+    <input type="checkbox" id="opt-ignore-schedules">
+    <input type="checkbox" id="opt-no-verify-ssl">
+    <input type="checkbox" id="opt-tests">
+
+    <input type="checkbox" id="opt-timeout">
+    <input id="opt-timeout-val" value="">
+    <div id="timeout-error" class="d-none"></div>
+
+    <input type="checkbox" id="opt-width">
+    <input id="opt-width-val" value="">
+    <div id="width-error" class="d-none"></div>
+
+    <input type="checkbox" id="opt-divider">
+    <input id="opt-divider-val" value="">
+    <div id="divider-error" class="d-none"></div>
+
+    <!-- Maintenance-window helpers (unused for most tests but must
+         exist for toggleTimesInputVisibility + checkMaintenanceWarning
+         to work as no-ops when the run-option is --times) -->
+    <div id="times-input-container" class="d-none"></div>
+    <div id="times-warning" class="d-none"></div>
+    <div id="maintenance-warning" class="d-none"></div>
+    <div id="plex-maintenance-window" data-window=""></div>
+  `
+}
+
+function makeCallbacks () {
+  return {
+    updateRunNowState: vi.fn(),
+    syncFinalAccordionRollups: vi.fn()
+  }
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  kometaState.activeRunCommandOverride = null
+  kometaState.activeRunCommandMode = null
+  vi.restoreAllMocks()
+})
+
+// ---------------------------------------------------------------------
+// isRunCommandValid
+// ---------------------------------------------------------------------
+
+describe('isRunCommandValid', () => {
+  it('is true when the run-command-output has real content', () => {
+    document.body.innerHTML = '<div id="run-command-output">python kometa.py --config config.yml</div>'
+    expect(isRunCommandValid()).toBe(true)
+  })
+
+  it("is false when the content starts with '??' placeholder", () => {
+    document.body.innerHTML = '<div id="run-command-output">?? no kometa root ??</div>'
+    expect(isRunCommandValid()).toBe(false)
+  })
+
+  it('is false when the content is empty/whitespace', () => {
+    document.body.innerHTML = '<div id="run-command-output">   </div>'
+    expect(isRunCommandValid()).toBe(false)
+  })
+
+  it('is false when the element is missing', () => {
+    document.body.innerHTML = ''
+    expect(isRunCommandValid()).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------
+// Mode label functions (pure)
+// ---------------------------------------------------------------------
+
+describe('getRunCommandModeLabel', () => {
+  it("returns 'Recovery Command' for mode='recovery'", () => {
+    expect(getRunCommandModeLabel('recovery')).toBe('Recovery Command')
+  })
+
+  it("returns 'Last Logged Command' for mode='logged'", () => {
+    expect(getRunCommandModeLabel('logged')).toBe('Last Logged Command')
+  })
+
+  it("returns 'Command' for anything else (current, null, empty, garbage)", () => {
+    expect(getRunCommandModeLabel('current')).toBe('Command')
+    expect(getRunCommandModeLabel(null)).toBe('Command')
+    expect(getRunCommandModeLabel('')).toBe('Command')
+    expect(getRunCommandModeLabel('nope')).toBe('Command')
+  })
+})
+
+describe('getRunCommandModeBadgeLabel', () => {
+  it('returns per-mode active labels', () => {
+    expect(getRunCommandModeBadgeLabel('recovery')).toBe('Recovery Active')
+    expect(getRunCommandModeBadgeLabel('logged')).toBe('Logged Active')
+    expect(getRunCommandModeBadgeLabel('current')).toBe('Current Active')
+  })
+
+  it('normalizes case + whitespace on the input', () => {
+    expect(getRunCommandModeBadgeLabel('  RECOVERY ')).toBe('Recovery Active')
+  })
+
+  it("defaults to 'Current Active' for null / undefined / unknown", () => {
+    expect(getRunCommandModeBadgeLabel(null)).toBe('Current Active')
+    expect(getRunCommandModeBadgeLabel(undefined)).toBe('Current Active')
+    expect(getRunCommandModeBadgeLabel('nope')).toBe('Current Active')
+  })
+})
+
+describe('getRunCommandModeBadgeClass', () => {
+  it('returns per-mode Bootstrap classes', () => {
+    expect(getRunCommandModeBadgeClass('recovery')).toBe('text-bg-warning')
+    expect(getRunCommandModeBadgeClass('logged')).toBe('text-bg-secondary')
+    expect(getRunCommandModeBadgeClass('current')).toBe('text-bg-primary')
+  })
+
+  it("defaults to 'text-bg-primary' for unknown values", () => {
+    expect(getRunCommandModeBadgeClass('nope')).toBe('text-bg-primary')
+  })
+
+  it('normalizes case + whitespace on the input', () => {
+    expect(getRunCommandModeBadgeClass('LOGGED')).toBe('text-bg-secondary')
+  })
+})
+
+// ---------------------------------------------------------------------
+// applyActiveRunCommandState / clearActiveRunCommandState
+// ---------------------------------------------------------------------
+
+describe('applyActiveRunCommandState', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="run-command-output"></div>
+      <div id="run-command-label"></div>
+      <div id="run-command-active-badge" class="d-none"></div>
+    `
+  })
+
+  it("writes the command to kometaState + textContent (mode='recovery')", () => {
+    applyActiveRunCommandState('python kometa.py --recovery', 'recovery')
+    expect(kometaState.activeRunCommandOverride).toBe('python kometa.py --recovery')
+    expect(kometaState.activeRunCommandMode).toBe('recovery')
+    expect(document.getElementById('run-command-output').textContent).toBe('python kometa.py --recovery')
+  })
+
+  it("updates the label to 'Recovery Command' for mode='recovery'", () => {
+    applyActiveRunCommandState('cmd', 'recovery')
+    expect(document.getElementById('run-command-label').textContent).toBe('Recovery Command')
+  })
+
+  it("updates the badge with the correct class + text (mode='logged')", () => {
+    applyActiveRunCommandState('cmd', 'logged')
+    const badge = document.getElementById('run-command-active-badge')
+    expect(badge.classList.contains('d-none')).toBe(false)
+    expect(badge.classList.contains('text-bg-secondary')).toBe(true)
+    expect(badge.textContent).toBe('Logged Active')
+  })
+
+  it('does NOT overwrite textContent when the command arg is falsy', () => {
+    const outEl = document.getElementById('run-command-output')
+    outEl.textContent = 'existing content'
+    applyActiveRunCommandState(null, 'current')
+    expect(outEl.textContent).toBe('existing content')
+    // but state should still be cleared/updated
+    expect(kometaState.activeRunCommandOverride).toBeNull()
+    expect(kometaState.activeRunCommandMode).toBe('current')
+  })
+
+  it('normalizes the mode input (case + whitespace)', () => {
+    applyActiveRunCommandState('cmd', '  RECOVERY  ')
+    expect(kometaState.activeRunCommandMode).toBe('recovery')
+  })
+})
+
+describe('clearActiveRunCommandState', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="run-command-label">Recovery Command</div>
+      <div id="run-command-active-badge" class="text-bg-warning">Recovery Active</div>
+    `
+    kometaState.activeRunCommandOverride = 'stale command'
+    kometaState.activeRunCommandMode = 'recovery'
+  })
+
+  it('clears the state fields to null', () => {
+    clearActiveRunCommandState()
+    expect(kometaState.activeRunCommandOverride).toBeNull()
+    expect(kometaState.activeRunCommandMode).toBeNull()
+  })
+
+  it("resets the label to 'Command'", () => {
+    clearActiveRunCommandState()
+    expect(document.getElementById('run-command-label').textContent).toBe('Command')
+  })
+
+  it('hides the badge and strips per-mode classes', () => {
+    clearActiveRunCommandState()
+    const badge = document.getElementById('run-command-active-badge')
+    expect(badge.classList.contains('d-none')).toBe(true)
+    expect(badge.classList.contains('text-bg-warning')).toBe(false)
+    expect(badge.classList.contains('text-bg-secondary')).toBe(false)
+    expect(badge.classList.contains('text-bg-primary')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------
+// buildCommand
+// ---------------------------------------------------------------------
+
+describe('buildCommand basic path (no flags)', () => {
+  it('assembles python + kometa.py + --config with quoting', () => {
+    installRunCommandDom()
+    const cb = makeCallbacks()
+    const result = buildCommand(cb)
+    expect(result).toBe(true)
+    const out = document.getElementById('run-command-output')
+    expect(out.dataset.builtCommand).toBe('/venv/bin/python /opt/kometa/kometa.py --config /opt/kometa/config/config.yml')
+    expect(out.textContent).toBe(out.dataset.builtCommand)
+  })
+
+  it('invokes both callbacks exactly once on the success path', () => {
+    installRunCommandDom()
+    const cb = makeCallbacks()
+    buildCommand(cb)
+    expect(cb.updateRunNowState).toHaveBeenCalledTimes(1)
+    expect(cb.syncFinalAccordionRollups).toHaveBeenCalledTimes(1)
+  })
+
+  it('short-circuits (returns undefined) when run-command-output is missing', () => {
+    document.body.innerHTML = '<div id="qs-env"></div>' // no run-command-output
+    const cb = makeCallbacks()
+    const result = buildCommand(cb)
+    expect(result).toBeUndefined()
+    // Callbacks should NOT have been called
+    expect(cb.updateRunNowState).not.toHaveBeenCalled()
+  })
+
+  it('quotes paths containing spaces', () => {
+    installRunCommandDom({
+      venvPython: '/opt/my venv/bin/python',
+      kometaRoot: '/opt/my kometa'
+    })
+    buildCommand(makeCallbacks())
+    const out = document.getElementById('run-command-output').dataset.builtCommand
+    expect(out).toContain('"/opt/my venv/bin/python"')
+    expect(out).toContain('"/opt/my kometa/kometa.py"')
+    expect(out).toContain('"/opt/my kometa/config/config.yml"')
+  })
+
+  it('converts forward slashes to backslashes on Windows', () => {
+    installRunCommandDom({
+      platform: 'Windows',
+      venvPython: 'C:/venv/Scripts/python.exe',
+      kometaRoot: 'C:/Kometa'
+    })
+    buildCommand(makeCallbacks())
+    const out = document.getElementById('run-command-output').dataset.builtCommand
+    expect(out).toContain('C:\\venv\\Scripts\\python.exe')
+    expect(out).toContain('C:\\Kometa\\kometa.py')
+    expect(out).toContain('C:\\Kometa\\config\\config.yml')
+    // No forward slashes in the assembled path
+    expect(out).not.toContain('C:/venv')
+  })
+
+  it('does NOT overwrite textContent when kometaState.activeRunCommandOverride is set', () => {
+    installRunCommandDom()
+    const out = document.getElementById('run-command-output')
+    out.textContent = 'FROZEN COMMAND'
+    kometaState.activeRunCommandOverride = 'FROZEN COMMAND'
+    buildCommand(makeCallbacks())
+    expect(out.textContent).toBe('FROZEN COMMAND')
+    // But dataset.builtCommand should still be updated
+    expect(out.dataset.builtCommand).toBe('/venv/bin/python /opt/kometa/kometa.py --config /opt/kometa/config/config.yml')
+  })
+
+  it('uses default python3 when venv-python attr is missing', () => {
+    installRunCommandDom({ venvPython: '' })
+    buildCommand(makeCallbacks())
+    const out = document.getElementById('run-command-output').dataset.builtCommand
+    expect(out.startsWith('python3 ')).toBe(true)
+  })
+})
+
+describe('buildCommand mainOption --times', () => {
+  it('appends quoted times string when valid', () => {
+    installRunCommandDom({ runOption: '--times' })
+    document.getElementById('times-input').value = '06:00|15:00'
+    buildCommand(makeCallbacks())
+    const out = document.getElementById('run-command-output').dataset.builtCommand
+    expect(out).toContain('--times "06:00|15:00"')
+  })
+
+  it("returns false and shows 'Invalid time format' on bad input", () => {
+    installRunCommandDom({ runOption: '--times' })
+    document.getElementById('times-input').value = 'not a time'
+    const cb = makeCallbacks()
+    const result = buildCommand(cb)
+    expect(result).toBe(false)
+    expect(document.getElementById('times-error').classList.contains('d-none')).toBe(false)
+    expect(document.getElementById('run-command-output').textContent).toContain('Invalid time format')
+    // Callbacks should still fire on the failure path (so run-now
+    // gets disabled and the accordion rollup updates)
+    expect(cb.updateRunNowState).toHaveBeenCalledTimes(1)
+    expect(cb.syncFinalAccordionRollups).toHaveBeenCalledTimes(1)
+  })
+
+  it('hides the times-error div when the value becomes valid', () => {
+    installRunCommandDom({ runOption: '--times' })
+    document.getElementById('times-input').value = '06:00'
+    document.getElementById('times-error').classList.remove('d-none') // stale
+    buildCommand(makeCallbacks())
+    expect(document.getElementById('times-error').classList.contains('d-none')).toBe(true)
+  })
+})
+
+describe('buildCommand mainOption --run-libraries', () => {
+  it('appends quoted pipe-joined selection', () => {
+    installRunCommandDom({ runOption: '--run-libraries' })
+    const sel = document.getElementById('library-multiselect')
+    Array.from(sel.options).forEach(o => { o.selected = true })
+    buildCommand(makeCallbacks())
+    const out = document.getElementById('run-command-output').dataset.builtCommand
+    expect(out).toContain('--run-libraries "Movies|TV Shows"')
+  })
+
+  it('returns false with a warning when no libraries are selected', () => {
+    installRunCommandDom({ runOption: '--run-libraries' })
+    // Nothing selected
+    const result = buildCommand(makeCallbacks())
+    expect(result).toBe(false)
+    expect(document.getElementById('run-command-output').textContent).toContain('Please select at least one library')
+  })
+})
+
+describe('buildCommand mode/log flags', () => {
+  it('appends the selected mode flag', () => {
+    installRunCommandDom({ modeFlag: '--dry-run' })
+    buildCommand(makeCallbacks())
+    expect(document.getElementById('run-command-output').dataset.builtCommand).toContain('--dry-run')
+  })
+
+  it('appends the selected log flag', () => {
+    installRunCommandDom({ logFlag: '--debug' })
+    buildCommand(makeCallbacks())
+    expect(document.getElementById('run-command-output').dataset.builtCommand).toContain('--debug')
+  })
+})
+
+describe('buildCommand no-value checkboxes', () => {
+  it('appends each checked flag', () => {
+    installRunCommandDom()
+    document.getElementById('opt-delete-collections').checked = true
+    document.getElementById('opt-read-only-config').checked = true
+    document.getElementById('opt-no-verify-ssl').checked = true
+    buildCommand(makeCallbacks())
+    const out = document.getElementById('run-command-output').dataset.builtCommand
+    expect(out).toContain('--delete-collections')
+    expect(out).toContain('--read-only-config')
+    expect(out).toContain('--no-verify-ssl')
+    // Not checked -> not in command
+    expect(out).not.toContain('--delete-labels')
+    expect(out).not.toContain('--tests')
+  })
+
+  it('is silent when a checkbox element is missing (no throw)', () => {
+    installRunCommandDom()
+    document.getElementById('opt-tests').remove()
+    expect(() => buildCommand(makeCallbacks())).not.toThrow()
+  })
+})
+
+describe('buildCommand --timeout validation', () => {
+  it('appends --timeout N when checked with a valid positive integer', () => {
+    installRunCommandDom()
+    document.getElementById('opt-timeout').checked = true
+    document.getElementById('opt-timeout-val').value = '60'
+    buildCommand(makeCallbacks())
+    expect(document.getElementById('run-command-output').dataset.builtCommand).toContain('--timeout 60')
+  })
+
+  it('rejects a non-integer timeout', () => {
+    installRunCommandDom()
+    document.getElementById('opt-timeout').checked = true
+    document.getElementById('opt-timeout-val').value = 'abc'
+    expect(buildCommand(makeCallbacks())).toBe(false)
+    expect(document.getElementById('timeout-error').classList.contains('d-none')).toBe(false)
+  })
+
+  it('rejects a zero or negative timeout', () => {
+    installRunCommandDom()
+    document.getElementById('opt-timeout').checked = true
+    document.getElementById('opt-timeout-val').value = '0'
+    expect(buildCommand(makeCallbacks())).toBe(false)
+  })
+
+  it('is a no-op when the timeout checkbox is unchecked', () => {
+    installRunCommandDom()
+    document.getElementById('opt-timeout').checked = false
+    document.getElementById('opt-timeout-val').value = 'garbage but should be ignored'
+    expect(buildCommand(makeCallbacks())).toBe(true)
+    expect(document.getElementById('run-command-output').dataset.builtCommand).not.toContain('--timeout')
+  })
+})
+
+describe('buildCommand --width validation', () => {
+  it('appends --width N in [90, 300]', () => {
+    installRunCommandDom()
+    document.getElementById('opt-width').checked = true
+    document.getElementById('opt-width-val').value = '120'
+    buildCommand(makeCallbacks())
+    expect(document.getElementById('run-command-output').dataset.builtCommand).toContain('--width 120')
+  })
+
+  it('rejects widths under 90', () => {
+    installRunCommandDom()
+    document.getElementById('opt-width').checked = true
+    document.getElementById('opt-width-val').value = '80'
+    expect(buildCommand(makeCallbacks())).toBe(false)
+  })
+
+  it('rejects widths over 300', () => {
+    installRunCommandDom()
+    document.getElementById('opt-width').checked = true
+    document.getElementById('opt-width-val').value = '400'
+    expect(buildCommand(makeCallbacks())).toBe(false)
+  })
+
+  it('accepts boundary values 90 and 300', () => {
+    installRunCommandDom()
+    document.getElementById('opt-width').checked = true
+    document.getElementById('opt-width-val').value = '90'
+    expect(buildCommand(makeCallbacks())).toBe(true)
+
+    installRunCommandDom()
+    document.getElementById('opt-width').checked = true
+    document.getElementById('opt-width-val').value = '300'
+    expect(buildCommand(makeCallbacks())).toBe(true)
+  })
+})
+
+describe('buildCommand --divider validation', () => {
+  it('appends --divider "X" for a single-character value', () => {
+    installRunCommandDom()
+    document.getElementById('opt-divider').checked = true
+    document.getElementById('opt-divider-val').value = '='
+    buildCommand(makeCallbacks())
+    expect(document.getElementById('run-command-output').dataset.builtCommand).toContain('--divider "="')
+  })
+
+  it('rejects multi-character dividers', () => {
+    installRunCommandDom()
+    document.getElementById('opt-divider').checked = true
+    document.getElementById('opt-divider-val').value = '=='
+    expect(buildCommand(makeCallbacks())).toBe(false)
+  })
+
+  it('rejects empty divider even when checkbox is checked', () => {
+    installRunCommandDom()
+    document.getElementById('opt-divider').checked = true
+    document.getElementById('opt-divider-val').value = ''
+    expect(buildCommand(makeCallbacks())).toBe(false)
+  })
+})
+
+describe('buildCommand robustness (missing callbacks)', () => {
+  it('does not throw when callbacks are undefined', () => {
+    installRunCommandDom()
+    expect(() => buildCommand()).not.toThrow()
+  })
+
+  it('does not throw when callbacks are non-functions', () => {
+    installRunCommandDom()
+    expect(() =>
+      buildCommand({ updateRunNowState: 42, syncFinalAccordionRollups: 'hi' })
+    ).not.toThrow()
+  })
+})

--- a/tests/js/kometa/state.test.js
+++ b/tests/js/kometa/state.test.js
@@ -77,9 +77,25 @@ describe('kometaState initial values', () => {
     expect(typeof kometaState.showYAML).toBe('boolean')
   })
 
+  it('activeRunCommandOverride starts as null', () => {
+    // Null (not '' or undefined) so buildCommand's
+    // `if (!kometaState.activeRunCommandOverride)` short-circuit
+    // works uniformly on first load.
+    expect(kometaState.activeRunCommandOverride).toBeNull()
+  })
+
+  it('activeRunCommandMode starts as null', () => {
+    // Callers fall back to 'current' or 'recovery' explicitly when
+    // no mode is set, so null (rather than 'current') keeps the
+    // "never been set" state distinguishable from "set to current".
+    expect(kometaState.activeRunCommandMode).toBeNull()
+  })
+
   it('exports exactly the fields the runtime relies on (guards against typos)', () => {
     // Sorted alphabetically for a stable comparison
     expect(Object.keys(kometaState).sort()).toEqual([
+      'activeRunCommandMode',
+      'activeRunCommandOverride',
       'kometaInterval',
       'kometaPollingStarted',
       'kometaProgressInterval',


### PR DESCRIPTION
## What

Eighth module out of the `900-kometa.js` god-file split (parts 1-7: #1554, #1556, #1557, #1560, #1561, #1562, #1563). `900-kometa.js`: 3406 → 3221 lines (**−185**). Bundles the `activeRunCommand*` state migration since extracting the setters requires it anyway.

## What moved

Extracted to `static/local-js/modules/kometa/_runCommand.js`:

| Function | Role |
|---|---|
| `buildCommand` | the big command assembler (~130 lines) — now takes `updateRunNowState` + `syncFinalAccordionRollups` callbacks |
| `isRunCommandValid` | true iff `run-command-output` has non-empty, non-`'??'` content |
| `getRunCommandModeLabel` | `'Command'` \| `'Recovery Command'` \| `'Last Logged Command'` |
| `getRunCommandModeBadgeLabel` | `'Current Active'` \| `'Recovery Active'` \| `'Logged Active'` |
| `getRunCommandModeBadgeClass` | `'text-bg-primary'` \| `'text-bg-warning'` \| `'text-bg-secondary'` |
| `applyActiveRunCommandState` | freeze the panel on a specific command + mode; writes `kometaState.activeRunCommand*` |
| `clearActiveRunCommandState` | reset to live-build mode |

Added to `static/local-js/modules/kometa/_state.js`:

| Field | Purpose |
|---|---|
| `activeRunCommandOverride: null` | when set, `buildCommand` does NOT overwrite `run-command-output.textContent` |
| `activeRunCommandMode: null` | `'current'` \| `'recovery'` \| `'logged'` |

Both were top-level `let` in `900-kometa.js`. Migrating to `kometaState` was necessary because the setters (`apply/clearActiveRunCommandState`) need to write them, and `buildCommand` needs to read them — all three moved to `_runCommand.js`, so the state had to go too.

## Design notes

1. **`buildCommand` is wrapped** in `900-kometa.js` as:

   ```js
   function buildCommand () {
     return _buildCommand({ updateRunNowState, syncFinalAccordionRollups })
   }
   ```

   Keeps every existing call site simple (`buildCommand()` with no args) while the extracted function requires the callbacks explicitly. Same pattern as `_validationGate.js`. Once `updateRunNowState` + `syncFinalAccordionRollups` themselves migrate (a future PR), the wrapper retires.

2. **`isWindowsPlatform` is a private lazy helper** inside `_runCommand.js` that reads `#qs-env[data-running-on]` on each `buildCommand` call. Avoids stale-cache pitfalls if the platform value ever changes (unlikely in prod, common in tests).

3. **`CHECKBOX_FLAGS` is a top-level const** — single source of truth for the 'no-value flag' list.

4. **Validation error paths preserve dual-signal** — both `run-command-output.textContent` (top-line warning) AND the specific error `<div>` (`#times-error` etc.) get updated. Pre-existing behavior, kept verbatim.

## Cleanup: dead code removed from `900-kometa.js`

Once `buildCommand` moved out, these became unused:
- Imports: `quoteIfNeeded`, `isValidTimesFormat`, `toggleTimesInputVisibility`
- Top-level: `_qsEnvEl`, `runningOn`, `isWindows` (all lazy-computed inside `_runCommand.js` now)
- 2 commented-out helpers (`toDisplayPath`, `toPosix`) + 2 commented-out flags (`isFrozen`, `isDocker`) — all dead code

## Vitest coverage: 52 new tests

**`state.test.js`** (+2 tests):
- `activeRunCommand{Override,Mode}` both start as `null`
- Shape guard updated to 10 fields

**`runCommand.test.js`** (50 new tests):
- **`isRunCommandValid`** (4): real content / `'??'` placeholder / empty / missing element
- **Mode label helpers** (9): per-mode returns, case+whitespace normalization, unknown/null defaults
- **`applyActiveRunCommandState`** (5): state write, label update, badge class+text, falsy command preserves textContent, mode normalization
- **`clearActiveRunCommandState`** (3): nulls state, resets label, hides badge + strips per-mode classes
- **`buildCommand` basic** (7): assembly + quoting + missing-element short-circuit + spaces in paths + Windows backslash conversion + override preserves textContent + default `python3`
- **`buildCommand --times`** (3): valid appends quoted, invalid returns false + error UI, valid clears stale error
- **`buildCommand --run-libraries`** (2): multi-select, empty selection error
- **`buildCommand` mode/log flags** (2): each appends when selected
- **`buildCommand` checkbox flags** (2): selective append, missing element no-throw
- **`buildCommand --timeout`** (4): valid integer, non-integer rejects, zero rejects, unchecked = no append
- **`buildCommand --width`** (4): valid, under-90 rejects, over-300 rejects, boundaries 90 and 300
- **`buildCommand --divider`** (3): single-char, multi-char rejects, empty rejects
- **`buildCommand` robustness** (2): undefined / non-function callbacks don't throw

## Verification

- **890/890 Vitest pass** (was 838; +52 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- 6 additional 'run' e2e tests: pass
- ESLint clean, Node syntax clean

## What's next

- `_kometaRuntime.js` — `validateKometaRoot` + `probeKometaRoot` (needs `KOMETA_*` mutable state migration first)
- `_kometaUpdate.js` — branch override + update job flow (~800 lines, biggest single target)
- `_logs.js` / `_logscan.js` — log stats, fetch, logscan analysis