### PR TITLE
Split 900-kometa.js part 10: extract remaining rollup badge functions

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -20,12 +20,10 @@ import {
 } from './modules/kometa/_maintenanceWindow.js'
 import { kometaState } from './modules/kometa/_state.js'
 import {
-  setHeaderRollupBadge,
-  updateModeHeaderBadge,
-  updateRunOptionHeaderBadge,
-  updateModeFlagsHeaderBadge,
-  updateLogFlagsHeaderBadge,
-  updateOtherFlagsHeaderBadge
+  updateConfigOutputHeaderBadges,
+  updateRunCommandHeaderBadge,
+  updateLogscanHeaderBadge,
+  syncFinalAccordionRollups as _syncFinalAccordionRollups
 } from './modules/kometa/_headerBadges.js'
 import {
   updateHeaderStyleLabel,
@@ -60,6 +58,14 @@ function buildCommand () {
   return _buildCommand({ updateRunNowState, syncFinalAccordionRollups })
 }
 
+// Thin wrapper: the extracted syncFinalAccordionRollups still needs
+// to call syncKometaBranchRollupBadge, which lives here (it depends
+// on branch-override helpers not yet migrated to _kometaUpdate.js).
+// Wrapping here keeps every call site simple.
+function syncFinalAccordionRollups () {
+  _syncFinalAccordionRollups({ syncKometaBranchRollupBadge })
+}
+
 // Kometa runtime status flags migrated to modules/kometa/_state.js
 // (kometaState.kometaInstalled, kometaValidated, kometaStatus, etc.).
 // See _state.js docstring for the state-machine notes.
@@ -70,7 +76,6 @@ let logFilter = ''
 let lastLogText = ''
 let lastLogStatsTotal = null
 let logStatsPollCounter = 0
-let lastLogscanPayload = null
 let logscanPollCounter = 0
 let finalLogscanAnalyzeTriggered = false
 let lastRunProgressPayload = null
@@ -176,73 +181,6 @@ function syncKometaMaintenancePageBadge (data) {
 document.addEventListener('qs:maintenance-status', function (event) {
   syncKometaMaintenancePageBadge(event.detail || null)
 })
-
-function updateConfigOutputHeaderBadges () {
-  const yamlText = yamlOutput ? String(yamlOutput.value || '') : ''
-  const lineCount = computeYamlLineCount(yamlText)
-  setHeaderRollupBadge('config-output-lines-badge', lineCount > 0 ? 'ok' : 'unknown', `${lineCount} lines`)
-  if (!yamlText.trim()) {
-    setHeaderRollupBadge('config-output-rollup-badge', 'unknown', 'No YAML')
-    return
-  }
-  setHeaderRollupBadge('config-output-rollup-badge', kometaState.showYAML ? 'ok' : 'error', kometaState.showYAML ? 'Validated' : 'Needs fixes')
-}
-
-function updateRunCommandHeaderBadge () {
-  if (!kometaState.showYAML) {
-    setHeaderRollupBadge('run-command-rollup-badge', 'error', 'Fix validation')
-    return
-  }
-  if (kometaState.kometaValidationInProgress) {
-    setHeaderRollupBadge('run-command-rollup-badge', 'unknown', 'Checking Kometa')
-    return
-  }
-  if (kometaState.kometaUpdating) {
-    setHeaderRollupBadge('run-command-rollup-badge', 'unknown', 'Updating Kometa')
-    return
-  }
-  if (!kometaState.kometaValidated) {
-    setHeaderRollupBadge('run-command-rollup-badge', 'warn', 'Validate Kometa')
-    return
-  }
-  if (kometaState.kometaStatus === 'running') {
-    setHeaderRollupBadge('run-command-rollup-badge', 'warn', 'Run in progress')
-    return
-  }
-  setHeaderRollupBadge('run-command-rollup-badge', isRunCommandValid() ? 'ok' : 'warn', isRunCommandValid() ? 'Ready' : 'Incomplete')
-}
-
-function updateLogscanHeaderBadge (data) {
-  const source = data || lastLogscanPayload
-  if (!source) {
-    setHeaderRollupBadge('logscan-rollup-badge', 'unknown', 'Pending')
-    return
-  }
-  if (source.error) {
-    setHeaderRollupBadge('logscan-rollup-badge', 'error', 'Unavailable')
-    return
-  }
-  const recCount = Array.isArray(source.recommendations) ? source.recommendations.length : 0
-  const missingCount = Array.isArray(source.missing_people) ? source.missing_people.length : 0
-  const issueCount = recCount + missingCount
-  if (!issueCount) {
-    setHeaderRollupBadge('logscan-rollup-badge', 'ok', 'No issues')
-    return
-  }
-  setHeaderRollupBadge('logscan-rollup-badge', 'warn', `${issueCount} items`)
-}
-
-function syncFinalAccordionRollups () {
-  updateModeHeaderBadge()
-  updateRunOptionHeaderBadge()
-  updateModeFlagsHeaderBadge()
-  updateLogFlagsHeaderBadge()
-  updateOtherFlagsHeaderBadge()
-  updateConfigOutputHeaderBadges()
-  updateRunCommandHeaderBadge()
-  updateLogscanHeaderBadge()
-  syncKometaBranchRollupBadge()
-}
 
 updateValidationGate({ updateRunNowState, syncFinalAccordionRollups })
 
@@ -2480,7 +2418,7 @@ function renderLogscan (data) {
 function fetchLogscanAnalysis (force = false) {
   if (!logscanPanel) return
   logscanPollCounter += 1
-  const shouldFetch = force || (logscanPollCounter % 5 === 0) || !lastLogscanPayload
+  const shouldFetch = force || (logscanPollCounter % 5 === 0) || !kometaState.lastLogscanPayload
   if (!shouldFetch || logscanAnalyzeInFlight) return
 
   logscanAnalyzeInFlight = true
@@ -2488,7 +2426,7 @@ function fetchLogscanAnalysis (force = false) {
   fetch('/logscan/analyze')
     .then(res => res.json())
     .then(data => {
-      lastLogscanPayload = data
+      kometaState.lastLogscanPayload = data
       renderLogscan(data)
     })
     .catch(err => {

--- a/static/local-js/modules/kometa/_headerBadges.js
+++ b/static/local-js/modules/kometa/_headerBadges.js
@@ -3,14 +3,13 @@
 // The Kometa configuration page uses Bootstrap accordions. Each
 // accordion header displays a small "rollup" badge summarizing the
 // state of its section -- e.g. "Friendly", "3 libraries", "Times
-// needed", "Invalid times". This module owns the pure-DOM-reading
-// badge functions that read the current UI state and set the
-// appropriate badge text + color class.
+// needed", "Invalid times". This module owns the badge functions that
+// read the current UI + kometaState and set the appropriate badge
+// text + color class.
 //
-// SCOPE OF THIS FILE (as of this PR):
+// EXPORTS (grouped by dependency):
 //
-//   Only the badge helpers that read exclusively from the DOM (no
-//   shared module-level state). Concretely:
+//   Pure DOM-reading helpers (no kometaState reads):
 //
 //     setHeaderRollupBadge         -- generic setter used by all badges
 //     prettifyFlag                 -- helper for CLI flag -> label
@@ -21,22 +20,23 @@
 //     updateLogFlagsHeaderBadge
 //     updateOtherFlagsHeaderBadge
 //
-//   Three sibling badge functions stay in 900-kometa.js FOR NOW:
+//   State-consulting helpers (read kometaState + maybe DOM):
 //
-//     updateConfigOutputHeaderBadges  -- needs the `showYAML` bool
-//     updateRunCommandHeaderBadge     -- needs 4 KOMETA_* flags,
-//                                        KOMETA_STATUS, showYAML,
-//                                        isRunCommandValid()
-//     updateLogscanHeaderBadge        -- needs lastLogscanPayload
+//     updateConfigOutputHeaderBadges  -- reads showYAML
+//     updateRunCommandHeaderBadge     -- reads showYAML + kometaValidated
+//                                        + kometaValidationInProgress
+//                                        + kometaUpdating + kometaStatus
+//                                        + isRunCommandValid()
+//     updateLogscanHeaderBadge        -- reads lastLogscanPayload
 //
-//   And the orchestrator:
+//   Orchestrator:
 //
-//     syncFinalAccordionRollups       -- calls both extracted and
-//                                        stay-behind functions
-//
-//   These will move here in follow-up PRs after the state they depend
-//   on migrates to _state.js (which is #1557's foundational work).
-//   Extracting the pure helpers first keeps the diff small and safe.
+//     syncFinalAccordionRollups({ syncKometaBranchRollupBadge })
+//                                     -- one call to refresh every
+//                                        badge on the page. Takes a
+//                                        callbacks bag for functions
+//                                        that still live in
+//                                        900-kometa.js.
 //
 // COLOR CLASSES:
 //
@@ -51,7 +51,9 @@
 //   setHeaderRollupBadge accepts any string; unknown values fall back
 //   to 'unknown' to keep the badge visually consistent.
 
-import { formatHeaderStyleLabel, isValidTimesFormat } from './_util.js'
+import { formatHeaderStyleLabel, isValidTimesFormat, computeYamlLineCount } from './_util.js'
+import { kometaState } from './_state.js'
+import { isRunCommandValid } from './_runCommand.js'
 
 // ---------------------------------------------------------------------
 // Core primitives
@@ -205,4 +207,136 @@ export function updateOtherFlagsHeaderBadge () {
     return
   }
   setHeaderRollupBadge('heading-otherflags-rollup-badge', 'ok', `${total} enabled`)
+}
+
+// ---------------------------------------------------------------------
+// State-consulting badges (read kometaState)
+// ---------------------------------------------------------------------
+
+/**
+ * Config-output section rollup: shows YAML line count + a Validated /
+ * Needs-fixes badge driven by kometaState.showYAML.
+ *
+ * DOM contract:
+ *   - #final-yaml           <textarea> holding the generated YAML.
+ *                            If absent or empty, the rollup badge
+ *                            reports 'No YAML'.
+ *   - #config-output-lines-badge   count-of-lines badge
+ *   - #config-output-rollup-badge  overall pass/fail badge
+ */
+export function updateConfigOutputHeaderBadges () {
+  const yamlOutput = document.getElementById('final-yaml')
+  const yamlText = yamlOutput ? String(yamlOutput.value || '') : ''
+  const lineCount = computeYamlLineCount(yamlText)
+  setHeaderRollupBadge('config-output-lines-badge', lineCount > 0 ? 'ok' : 'unknown', `${lineCount} lines`)
+  if (!yamlText.trim()) {
+    setHeaderRollupBadge('config-output-rollup-badge', 'unknown', 'No YAML')
+    return
+  }
+  setHeaderRollupBadge(
+    'config-output-rollup-badge',
+    kometaState.showYAML ? 'ok' : 'error',
+    kometaState.showYAML ? 'Validated' : 'Needs fixes'
+  )
+}
+
+/**
+ * Run-command section rollup: a five-way state machine keyed on
+ * validation + install + running-status flags. Prioritized top-down:
+ *
+ *   showYAML false                    -- config not passing yet:
+ *                                        'Fix validation' (error)
+ *   kometaValidationInProgress        -- 'Checking Kometa' (unknown)
+ *   kometaUpdating                    -- 'Updating Kometa' (unknown)
+ *   !kometaValidated                  -- 'Validate Kometa' (warn)
+ *   kometaStatus === 'running'        -- 'Run in progress' (warn)
+ *   otherwise                         -- isRunCommandValid() ?
+ *                                          'Ready' (ok) :
+ *                                          'Incomplete' (warn)
+ */
+export function updateRunCommandHeaderBadge () {
+  if (!kometaState.showYAML) {
+    setHeaderRollupBadge('run-command-rollup-badge', 'error', 'Fix validation')
+    return
+  }
+  if (kometaState.kometaValidationInProgress) {
+    setHeaderRollupBadge('run-command-rollup-badge', 'unknown', 'Checking Kometa')
+    return
+  }
+  if (kometaState.kometaUpdating) {
+    setHeaderRollupBadge('run-command-rollup-badge', 'unknown', 'Updating Kometa')
+    return
+  }
+  if (!kometaState.kometaValidated) {
+    setHeaderRollupBadge('run-command-rollup-badge', 'warn', 'Validate Kometa')
+    return
+  }
+  if (kometaState.kometaStatus === 'running') {
+    setHeaderRollupBadge('run-command-rollup-badge', 'warn', 'Run in progress')
+    return
+  }
+  const valid = isRunCommandValid()
+  setHeaderRollupBadge(
+    'run-command-rollup-badge',
+    valid ? 'ok' : 'warn',
+    valid ? 'Ready' : 'Incomplete'
+  )
+}
+
+/**
+ * Logscan section rollup: driven by the most recent /logscan payload.
+ * Callers can pass a fresh payload directly (e.g. right after fetch);
+ * omitting the arg uses the cached one in kometaState.lastLogscanPayload.
+ *
+ * @param {object} [data]  Optional payload to render from. Falls back
+ *                         to kometaState.lastLogscanPayload.
+ */
+export function updateLogscanHeaderBadge (data) {
+  const source = data || kometaState.lastLogscanPayload
+  if (!source) {
+    setHeaderRollupBadge('logscan-rollup-badge', 'unknown', 'Pending')
+    return
+  }
+  if (source.error) {
+    setHeaderRollupBadge('logscan-rollup-badge', 'error', 'Unavailable')
+    return
+  }
+  const recCount = Array.isArray(source.recommendations) ? source.recommendations.length : 0
+  const missingCount = Array.isArray(source.missing_people) ? source.missing_people.length : 0
+  const issueCount = recCount + missingCount
+  if (!issueCount) {
+    setHeaderRollupBadge('logscan-rollup-badge', 'ok', 'No issues')
+    return
+  }
+  setHeaderRollupBadge('logscan-rollup-badge', 'warn', `${issueCount} items`)
+}
+
+// ---------------------------------------------------------------------
+// Orchestrator
+// ---------------------------------------------------------------------
+
+/**
+ * Refresh every section-header rollup badge on the page. One call
+ * to bring the whole accordion into sync with current state.
+ *
+ * The `syncKometaBranchRollupBadge` function still lives in
+ * 900-kometa.js (it depends on branch-override helpers that haven't
+ * been extracted yet), so we take it as a callback. When those
+ * helpers migrate to _kometaUpdate.js, this callback retires in favor
+ * of a direct import.
+ *
+ * @param {{ syncKometaBranchRollupBadge: () => void }} [callbacks]
+ */
+export function syncFinalAccordionRollups (callbacks) {
+  updateModeHeaderBadge()
+  updateRunOptionHeaderBadge()
+  updateModeFlagsHeaderBadge()
+  updateLogFlagsHeaderBadge()
+  updateOtherFlagsHeaderBadge()
+  updateConfigOutputHeaderBadges()
+  updateRunCommandHeaderBadge()
+  updateLogscanHeaderBadge()
+  if (callbacks && typeof callbacks.syncKometaBranchRollupBadge === 'function') {
+    callbacks.syncKometaBranchRollupBadge()
+  }
 }

--- a/static/local-js/modules/kometa/_state.js
+++ b/static/local-js/modules/kometa/_state.js
@@ -151,5 +151,22 @@ export const kometaState = {
   kometaUpdateCheckSkipped: false,
   kometaUpdateCheckCompleted: false,
   kometaStatus: null,
-  kometaPendingStart: false
+  kometaPendingStart: false,
+
+  // ---- Logscan cache -----------------------------------------------
+  // The most recent /logscan payload fetched from the server, kept
+  // around so header-badge refreshes and other polling passes can
+  // work off a snapshot instead of blocking on a new HTTP round-trip.
+  //
+  //   null                       -- never fetched successfully yet
+  //   { error: '...' }           -- fetch failed; renderers show
+  //                                 'Unavailable' state
+  //   { recommendations: [...],  -- fetch succeeded; count arrays
+  //     missing_people: [...],     drive the 'N items' badge
+  //     ... }
+  //
+  // Written by the polling loop in 900-kometa.js after every
+  // successful fetchLogscan(). Read by updateLogscanHeaderBadge (in
+  // _headerBadges.js) when it's called without an explicit data arg.
+  lastLogscanPayload: null
 }

--- a/tests/js/kometa/headerBadges.test.js
+++ b/tests/js/kometa/headerBadges.test.js
@@ -28,7 +28,7 @@
 //   updateOtherFlagsHeaderBadge -- 0/some/all core flags, extras
 //                            (timeout/divider/width) counted separately
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   setHeaderRollupBadge,
   prettifyFlag,
@@ -37,8 +37,13 @@ import {
   updateRunOptionHeaderBadge,
   updateModeFlagsHeaderBadge,
   updateLogFlagsHeaderBadge,
-  updateOtherFlagsHeaderBadge
+  updateOtherFlagsHeaderBadge,
+  updateConfigOutputHeaderBadges,
+  updateRunCommandHeaderBadge,
+  updateLogscanHeaderBadge,
+  syncFinalAccordionRollups
 } from '../../../static/local-js/modules/kometa/_headerBadges.js'
+import { kometaState } from '../../../static/local-js/modules/kometa/_state.js'
 
 // ---------------------------------------------------------------------
 // Fixture DOM helpers
@@ -438,5 +443,254 @@ describe('updateOtherFlagsHeaderBadge', () => {
     updateOtherFlagsHeaderBadge()
     const badge = document.getElementById('heading-otherflags-rollup-badge')
     expect(badge.textContent).toBe('14 enabled')
+  })
+})
+
+// ---------------------------------------------------------------------
+// State-consulting: updateConfigOutputHeaderBadges
+// ---------------------------------------------------------------------
+
+describe('updateConfigOutputHeaderBadges', () => {
+  beforeEach(() => {
+    kometaState.showYAML = false
+  })
+
+  it('shows "No YAML" when the textarea is missing', () => {
+    installBadge('config-output-lines-badge')
+    installBadge('config-output-rollup-badge')
+    updateConfigOutputHeaderBadges()
+    expect(document.getElementById('config-output-rollup-badge').textContent).toBe('No YAML')
+    expect(document.getElementById('config-output-rollup-badge').classList.contains('qs-validation-rollup-badge--unknown')).toBe(true)
+  })
+
+  it('shows "No YAML" when the textarea has only whitespace', () => {
+    const t = document.createElement('textarea')
+    t.id = 'final-yaml'
+    t.value = '   \n  \t  '
+    document.body.appendChild(t)
+    installBadge('config-output-lines-badge')
+    installBadge('config-output-rollup-badge')
+    updateConfigOutputHeaderBadges()
+    expect(document.getElementById('config-output-rollup-badge').textContent).toBe('No YAML')
+  })
+
+  it('shows line count + "Validated" (ok) when showYAML is true', () => {
+    const t = document.createElement('textarea')
+    t.id = 'final-yaml'
+    t.value = 'libraries:\n  Movies:\n    metadata_path: []'
+    document.body.appendChild(t)
+    installBadge('config-output-lines-badge')
+    installBadge('config-output-rollup-badge')
+    kometaState.showYAML = true
+    updateConfigOutputHeaderBadges()
+    expect(document.getElementById('config-output-lines-badge').textContent).toBe('3 lines')
+    expect(document.getElementById('config-output-rollup-badge').textContent).toBe('Validated')
+    expect(document.getElementById('config-output-rollup-badge').classList.contains('qs-validation-rollup-badge--ok')).toBe(true)
+  })
+
+  it('shows "Needs fixes" (error) when YAML present but showYAML is false', () => {
+    const t = document.createElement('textarea')
+    t.id = 'final-yaml'
+    t.value = 'broken:\n  yaml'
+    document.body.appendChild(t)
+    installBadge('config-output-lines-badge')
+    installBadge('config-output-rollup-badge')
+    kometaState.showYAML = false
+    updateConfigOutputHeaderBadges()
+    expect(document.getElementById('config-output-rollup-badge').textContent).toBe('Needs fixes')
+    expect(document.getElementById('config-output-rollup-badge').classList.contains('qs-validation-rollup-badge--error')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// State-consulting: updateRunCommandHeaderBadge (five-way state machine)
+// ---------------------------------------------------------------------
+
+describe('updateRunCommandHeaderBadge', () => {
+  // Reset the whole state slice this function reads. beforeEach
+  // matters here because tests intentionally flip one flag at a time.
+  beforeEach(() => {
+    kometaState.showYAML = false
+    kometaState.kometaValidated = false
+    kometaState.kometaValidationInProgress = false
+    kometaState.kometaUpdating = false
+    kometaState.kometaStatus = null
+    installBadge('run-command-rollup-badge')
+  })
+
+  it('shows "Fix validation" (error) when showYAML is false [highest priority]', () => {
+    // All other flags could be favorable; showYAML=false still wins.
+    kometaState.kometaValidated = true
+    kometaState.kometaStatus = 'idle'
+    updateRunCommandHeaderBadge()
+    const b = document.getElementById('run-command-rollup-badge')
+    expect(b.textContent).toBe('Fix validation')
+    expect(b.classList.contains('qs-validation-rollup-badge--error')).toBe(true)
+  })
+
+  it('shows "Checking Kometa" (unknown) when validationInProgress is true', () => {
+    kometaState.showYAML = true
+    kometaState.kometaValidationInProgress = true
+    updateRunCommandHeaderBadge()
+    expect(document.getElementById('run-command-rollup-badge').textContent).toBe('Checking Kometa')
+  })
+
+  it('shows "Updating Kometa" (unknown) when kometaUpdating is true', () => {
+    kometaState.showYAML = true
+    kometaState.kometaUpdating = true
+    updateRunCommandHeaderBadge()
+    expect(document.getElementById('run-command-rollup-badge').textContent).toBe('Updating Kometa')
+  })
+
+  it('shows "Validate Kometa" (warn) when validated is false [and no in-progress]', () => {
+    kometaState.showYAML = true
+    kometaState.kometaValidated = false
+    updateRunCommandHeaderBadge()
+    const b = document.getElementById('run-command-rollup-badge')
+    expect(b.textContent).toBe('Validate Kometa')
+    expect(b.classList.contains('qs-validation-rollup-badge--warn')).toBe(true)
+  })
+
+  it("shows \"Run in progress\" (warn) when kometaStatus is 'running'", () => {
+    kometaState.showYAML = true
+    kometaState.kometaValidated = true
+    kometaState.kometaStatus = 'running'
+    updateRunCommandHeaderBadge()
+    expect(document.getElementById('run-command-rollup-badge').textContent).toBe('Run in progress')
+  })
+
+  it('shows "Ready" (ok) when everything passes and run command is valid', () => {
+    kometaState.showYAML = true
+    kometaState.kometaValidated = true
+    // Install a valid run-command-output so isRunCommandValid() returns true
+    const out = document.createElement('div')
+    out.id = 'run-command-output'
+    out.textContent = 'python kometa.py --config config.yml'
+    document.body.appendChild(out)
+    updateRunCommandHeaderBadge()
+    const b = document.getElementById('run-command-rollup-badge')
+    expect(b.textContent).toBe('Ready')
+    expect(b.classList.contains('qs-validation-rollup-badge--ok')).toBe(true)
+  })
+
+  it('shows "Incomplete" (warn) when everything passes but run command is placeholder', () => {
+    kometaState.showYAML = true
+    kometaState.kometaValidated = true
+    const out = document.createElement('div')
+    out.id = 'run-command-output'
+    out.textContent = '?? no root ??'
+    document.body.appendChild(out)
+    updateRunCommandHeaderBadge()
+    expect(document.getElementById('run-command-rollup-badge').textContent).toBe('Incomplete')
+  })
+})
+
+// ---------------------------------------------------------------------
+// State-consulting: updateLogscanHeaderBadge
+// ---------------------------------------------------------------------
+
+describe('updateLogscanHeaderBadge', () => {
+  beforeEach(() => {
+    kometaState.lastLogscanPayload = null
+    installBadge('logscan-rollup-badge')
+  })
+
+  it('shows "Pending" (unknown) when no data available', () => {
+    updateLogscanHeaderBadge()
+    const b = document.getElementById('logscan-rollup-badge')
+    expect(b.textContent).toBe('Pending')
+    expect(b.classList.contains('qs-validation-rollup-badge--unknown')).toBe(true)
+  })
+
+  it('reads from kometaState.lastLogscanPayload when no arg is passed', () => {
+    kometaState.lastLogscanPayload = { recommendations: [1, 2], missing_people: [] }
+    updateLogscanHeaderBadge()
+    expect(document.getElementById('logscan-rollup-badge').textContent).toBe('2 items')
+  })
+
+  it('passed data arg WINS over kometaState.lastLogscanPayload', () => {
+    kometaState.lastLogscanPayload = { recommendations: [1, 2, 3] }
+    updateLogscanHeaderBadge({ recommendations: [], missing_people: [] })
+    expect(document.getElementById('logscan-rollup-badge').textContent).toBe('No issues')
+  })
+
+  it('shows "Unavailable" (error) when payload has an error field', () => {
+    updateLogscanHeaderBadge({ error: 'boom' })
+    const b = document.getElementById('logscan-rollup-badge')
+    expect(b.textContent).toBe('Unavailable')
+    expect(b.classList.contains('qs-validation-rollup-badge--error')).toBe(true)
+  })
+
+  it('shows "No issues" (ok) for empty recs+missing arrays', () => {
+    updateLogscanHeaderBadge({ recommendations: [], missing_people: [] })
+    const b = document.getElementById('logscan-rollup-badge')
+    expect(b.textContent).toBe('No issues')
+    expect(b.classList.contains('qs-validation-rollup-badge--ok')).toBe(true)
+  })
+
+  it('sums recommendations + missing_people counts', () => {
+    updateLogscanHeaderBadge({ recommendations: [1, 2, 3], missing_people: [4, 5] })
+    expect(document.getElementById('logscan-rollup-badge').textContent).toBe('5 items')
+  })
+
+  it('handles missing/non-array recommendations gracefully', () => {
+    updateLogscanHeaderBadge({ missing_people: [1] })
+    expect(document.getElementById('logscan-rollup-badge').textContent).toBe('1 items')
+  })
+})
+
+// ---------------------------------------------------------------------
+// Orchestrator: syncFinalAccordionRollups
+// ---------------------------------------------------------------------
+
+describe('syncFinalAccordionRollups', () => {
+  beforeEach(() => {
+    // Install all badges the orchestrator touches
+    installBadge('heading-style-rollup-badge')
+    installBadge('heading-mode-rollup-badge')
+    installBadge('heading-runopt-rollup-badge')
+    installBadge('heading-modeflags-rollup-badge')
+    installBadge('heading-logflags-rollup-badge')
+    installBadge('heading-otherflags-rollup-badge')
+    installBadge('config-output-lines-badge')
+    installBadge('config-output-rollup-badge')
+    installBadge('run-command-rollup-badge')
+    installBadge('logscan-rollup-badge')
+  })
+
+  it('invokes syncKometaBranchRollupBadge callback exactly once', () => {
+    const cb = vi.fn()
+    syncFinalAccordionRollups({ syncKometaBranchRollupBadge: cb })
+    expect(cb).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not throw when callbacks arg is undefined', () => {
+    expect(() => syncFinalAccordionRollups()).not.toThrow()
+  })
+
+  it('does not throw when syncKometaBranchRollupBadge is not a function', () => {
+    expect(() => syncFinalAccordionRollups({ syncKometaBranchRollupBadge: 42 })).not.toThrow()
+  })
+
+  it('refreshes every rollup badge on the page (touches all 10 ids)', () => {
+    // Pre-mark every badge with a sentinel string. After the call,
+    // every badge must have been rewritten (i.e. not equal to the
+    // sentinel).
+    const ids = [
+      'heading-mode-rollup-badge',
+      'heading-runopt-rollup-badge',
+      'heading-modeflags-rollup-badge',
+      'heading-logflags-rollup-badge',
+      'heading-otherflags-rollup-badge',
+      'config-output-lines-badge',
+      'config-output-rollup-badge',
+      'run-command-rollup-badge',
+      'logscan-rollup-badge'
+    ]
+    for (const id of ids) document.getElementById(id).textContent = 'SENTINEL'
+    syncFinalAccordionRollups({ syncKometaBranchRollupBadge: () => {} })
+    for (const id of ids) {
+      expect(document.getElementById(id).textContent).not.toBe('SENTINEL')
+    }
   })
 })

--- a/tests/js/kometa/state.test.js
+++ b/tests/js/kometa/state.test.js
@@ -115,6 +115,14 @@ describe('kometaState initial values', () => {
     expect(kometaState.kometaStatus).toBeNull()
   })
 
+  it('lastLogscanPayload starts as null', () => {
+    // The logscan header badge distinguishes "no data yet" (Pending)
+    // from "data with 0 issues" (No issues) -- both are legit states.
+    // Null (rather than {}) keeps that distinction sharp on first
+    // page load, before the first /logscan poll returns.
+    expect(kometaState.lastLogscanPayload).toBeNull()
+  })
+
   it('exports exactly the fields the runtime relies on (guards against typos)', () => {
     // Sorted alphabetically for a stable comparison
     expect(Object.keys(kometaState).sort()).toEqual([
@@ -137,6 +145,7 @@ describe('kometaState initial values', () => {
       'kometaUpdating',
       'kometaValidated',
       'kometaValidationInProgress',
+      'lastLogscanPayload',
       'showYAML'
     ])
   })


### PR DESCRIPTION
## What

Completes the header-badge extraction started in #1560. Now that `kometaState` holds all the flags these functions read (from #1562, #1564, #1565), the three state-consulting badges + the orchestrator can move out of `900-kometa.js`.

`900-kometa.js`: 3211 → 3149 lines (**−62**).

## What moved

Extracted to `static/local-js/modules/kometa/_headerBadges.js` (already existed from #1560; grew from 208 → 342 lines):

| Function | Role |
|---|---|
| `updateConfigOutputHeaderBadges` | YAML line count + Validated/Needs-fixes badge, driven by `kometaState.showYAML` |
| `updateRunCommandHeaderBadge` | five-way state machine on `showYAML` + validation flags + `kometaStatus` + `isRunCommandValid()` |
| `updateLogscanHeaderBadge` | reads `kometaState.lastLogscanPayload` unless data arg overrides |
| `syncFinalAccordionRollups` | orchestrator; refreshes every rollup badge on the page |

Added to `kometaState` (in `modules/kometa/_state.js`):

| Field | Purpose |
|---|---|
| `lastLogscanPayload: null` | cached `/logscan` response, written by the polling loop, read by `updateLogscanHeaderBadge` |

## Design notes

1. **`syncFinalAccordionRollups` takes a callbacks bag** for `syncKometaBranchRollupBadge`, which still lives in `900-kometa.js` (depends on branch-override helpers targeted for `_kometaUpdate.js` in a future PR). Same 'wait for the callee to migrate' pattern as #1562's `_validationGate.js` extraction.

   A thin wrapper in `900-kometa.js` binds the callback:

   ```js
   function syncFinalAccordionRollups () {
     _syncFinalAccordionRollups({ syncKometaBranchRollupBadge })
   }
   ```

   Every call site keeps its no-args signature.

2. **`updateConfigOutputHeaderBadges` now looks up its own `#final-yaml`** via `document.getElementById` rather than importing the module-level `yamlOutput` const. Cheap, keeps `_headerBadges.js` independent of `900-kometa.js` DOM caches.

3. **`isRunCommandValid` is imported from `_runCommand.js`** — no circular dep, since `_runCommand.js` does not import from `_headerBadges.js`.

## Cleanup: 6 unused imports removed from `900-kometa.js`

Once `syncFinalAccordionRollups` moved, these 5 pure badges + the generic setter became callers-of-nothing from `900-kometa.js`:
- `setHeaderRollupBadge`
- `updateModeHeaderBadge`
- `updateRunOptionHeaderBadge`
- `updateModeFlagsHeaderBadge`
- `updateLogFlagsHeaderBadge`
- `updateOtherFlagsHeaderBadge`

The 3 state-consulting badges stay imported because they still get called directly from `900-kometa.js` callback sites (mainly the logscan fetch and the validation gate follow-ups).

## Vitest coverage: 23 new tests

**`state.test.js`**: +1 test (`lastLogscanPayload` starts as null)

**`headerBadges.test.js`**: 22 new tests
- **`updateConfigOutputHeaderBadges`** (4): missing textarea, whitespace-only, `showYAML=true` validates, `showYAML=false` shows Needs fixes
- **`updateRunCommandHeaderBadge`** (7): full state-machine coverage — `showYAML=false` wins, `validationInProgress`, `kometaUpdating`, `!kometaValidated`, `kometaStatus='running'`, Ready path, Incomplete path
- **`updateLogscanHeaderBadge`** (7): Pending default, reads from `kometaState`, data arg wins over cached, error field, no-issues, sums recs+missing, handles missing recommendations gracefully
- **`syncFinalAccordionRollups`** (4): callback invoked once, undefined callbacks don't throw, non-function callbacks don't throw, all 9 badges get rewritten in one pass

## Verification

- **915/915 Vitest pass** (was 892 after #1565; +23 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- **36 broader e2e tests** (kometa/run/valid/install/badge/accord): pass
- ESLint clean, Node syntax clean

## What's next

- **`_kometaRuntime.js`** — `validateKometaRoot` + `probeKometaRoot` (mutates `kometaInstalled`/`Validated`/etc.)
- **`_kometaUpdate.js`** — branch override + update job flow (~800 lines, biggest remaining target)
- **`_logs.js` / `_logscan.js`** — log-tail polling + logscan fetch/analysis

`_headerBadges.js` is now at 342 lines, still well under the 600-line threshold. If it needs to grow again (unlikely), the current 'pure DOM' vs 'state-consulting' vs 'orchestrator' grouping is the natural seam.