### PR TITLE
Split 900-kometa.js part 11: extract run-status sparklines

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -4,14 +4,10 @@ import {
   computeYamlLineCount,
   linkifyText,
   formatTimestampLocal,
-  clampPercent,
   formatRunSeconds,
   coerceRunSeconds,
   applyLogFilter,
   computeLogStats,
-  pushSparkValue,
-  buildSparklinePoints,
-  buildSparklinePointsScaled,
   copyTextToClipboard,
   setMetaFlag
 } from './modules/kometa/_util.js'
@@ -49,6 +45,9 @@ import {
   applyActiveRunCommandState,
   clearActiveRunCommandState
 } from './modules/kometa/_runCommand.js'
+import {
+  updateRunSparklines
+} from './modules/kometa/_sparklines.js'
 
 // Thin wrapper: buildCommand needs updateRunNowState and
 // syncFinalAccordionRollups callbacks, but both are still owned by
@@ -84,16 +83,6 @@ let runProgressInFlight = false
 let latestKometaStatusPayload = null
 const KOMETA_BRANCH_OVERRIDE_STORAGE_KEY = 'qs-kometa-branch-override'
 
-// Sparkline state buffers. Rendering + reset + update functions that
-// operate on this still live in this file; the pure geometry helpers
-// (pushSparkValue, buildSparklinePoints, buildSparklinePointsScaled)
-// were extracted to _util.js.
-const runSparkState = {
-  cpu: { system: [], kometa: [] },
-  mem: { system: [], kometa: [] },
-  io: { read: [], write: [] }
-}
-
 const runLog = document.getElementById('run-output-log')
 const tailNotice = document.getElementById('run-output-notice')
 const tailSelect = document.getElementById('run-log-tail')
@@ -125,11 +114,6 @@ const runStatusRow = document.getElementById('run-status-row')
 const runStatusTimer = document.getElementById('run-status-timer')
 const runStatusMetrics = document.getElementById('run-status-metrics')
 const runStatusLog = document.getElementById('run-status-log')
-const runStatusSparklines = document.getElementById('run-status-sparklines')
-const runSparkCpuSystem = document.getElementById('run-spark-cpu-system')
-const runSparkCpuKometa = document.getElementById('run-spark-cpu-kometa')
-const runSparkMemSystem = document.getElementById('run-spark-mem-system')
-const runSparkMemKometa = document.getElementById('run-spark-mem-kometa')
 const yamlOutput = document.getElementById('final-yaml')
 const yamlLineCount = document.getElementById('yaml-line-count')
 const stopModalEl = document.getElementById('stop-kometa-modal')
@@ -2140,68 +2124,6 @@ function updateTailNotice () {
   if (!tailNotice) return
   const sizeLabel = tailSize === 'all' ? 'all lines' : `last ${tailSize} lines`
   tailNotice.textContent = `Showing ${sizeLabel} from meta.log`
-}
-
-function renderRunSparklines () {
-  if (!runStatusSparklines) return
-  const hasData = runSparkState.cpu.system.length || runSparkState.cpu.kometa.length ||
-    runSparkState.mem.system.length || runSparkState.mem.kometa.length ||
-    runSparkState.io.read.length || runSparkState.io.write.length
-  runStatusSparklines.classList.toggle('d-none', !hasData)
-  if (!hasData) {
-    if (runSparkCpuSystem) runSparkCpuSystem.setAttribute('points', '')
-    if (runSparkCpuKometa) runSparkCpuKometa.setAttribute('points', '')
-    if (runSparkMemSystem) runSparkMemSystem.setAttribute('points', '')
-    if (runSparkMemKometa) runSparkMemKometa.setAttribute('points', '')
-    const runSparkIoRead = document.getElementById('run-spark-io-read')
-    const runSparkIoWrite = document.getElementById('run-spark-io-write')
-    if (runSparkIoRead) runSparkIoRead.setAttribute('points', '')
-    if (runSparkIoWrite) runSparkIoWrite.setAttribute('points', '')
-    return
-  }
-  if (runSparkCpuSystem) runSparkCpuSystem.setAttribute('points', buildSparklinePoints(runSparkState.cpu.system))
-  if (runSparkCpuKometa) runSparkCpuKometa.setAttribute('points', buildSparklinePoints(runSparkState.cpu.kometa))
-  if (runSparkMemSystem) runSparkMemSystem.setAttribute('points', buildSparklinePoints(runSparkState.mem.system))
-  if (runSparkMemKometa) runSparkMemKometa.setAttribute('points', buildSparklinePoints(runSparkState.mem.kometa))
-  const runSparkIoRead = document.getElementById('run-spark-io-read')
-  const runSparkIoWrite = document.getElementById('run-spark-io-write')
-  const ioMax = Math.max(0, ...runSparkState.io.read, ...runSparkState.io.write)
-  if (runSparkIoRead) runSparkIoRead.setAttribute('points', buildSparklinePointsScaled(runSparkState.io.read, ioMax))
-  if (runSparkIoWrite) runSparkIoWrite.setAttribute('points', buildSparklinePointsScaled(runSparkState.io.write, ioMax))
-}
-
-function resetRunSparklines () {
-  runSparkState.cpu.system = []
-  runSparkState.cpu.kometa = []
-  runSparkState.mem.system = []
-  runSparkState.mem.kometa = []
-  runSparkState.io.read = []
-  runSparkState.io.write = []
-  renderRunSparklines()
-}
-
-function updateRunSparklines (data) {
-  if (!data || data.status !== 'running') {
-    resetRunSparklines()
-    return
-  }
-  const cpuSystem = clampPercent(data.system_cpu_percent)
-  const cpuKometa = clampPercent(data.cpu_percent)
-  const memSystem = clampPercent(data.system_memory_percent)
-  const memKometa = clampPercent(data.memory_percent)
-  const ioRead = (typeof data.disk_read_rate_mb_s === 'number' && Number.isFinite(data.disk_read_rate_mb_s))
-    ? Math.max(0, data.disk_read_rate_mb_s)
-    : null
-  const ioWrite = (typeof data.disk_write_rate_mb_s === 'number' && Number.isFinite(data.disk_write_rate_mb_s))
-    ? Math.max(0, data.disk_write_rate_mb_s)
-    : null
-  pushSparkValue(runSparkState.cpu.system, cpuSystem)
-  pushSparkValue(runSparkState.cpu.kometa, cpuKometa)
-  pushSparkValue(runSparkState.mem.system, memSystem)
-  pushSparkValue(runSparkState.mem.kometa, memKometa)
-  pushSparkValue(runSparkState.io.read, ioRead)
-  pushSparkValue(runSparkState.io.write, ioWrite)
-  renderRunSparklines()
 }
 
 function syncRunStatusVisibility () {

--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -20,12 +20,10 @@ import {
 } from './modules/kometa/_maintenanceWindow.js'
 import { kometaState } from './modules/kometa/_state.js'
 import {
-  setHeaderRollupBadge,
-  updateModeHeaderBadge,
-  updateRunOptionHeaderBadge,
-  updateModeFlagsHeaderBadge,
-  updateLogFlagsHeaderBadge,
-  updateOtherFlagsHeaderBadge
+  updateConfigOutputHeaderBadges,
+  updateRunCommandHeaderBadge,
+  updateLogscanHeaderBadge,
+  syncFinalAccordionRollups as _syncFinalAccordionRollups
 } from './modules/kometa/_headerBadges.js'
 import {
   updateHeaderStyleLabel,
@@ -60,6 +58,14 @@ function buildCommand () {
   return _buildCommand({ updateRunNowState, syncFinalAccordionRollups })
 }
 
+// Thin wrapper: the extracted syncFinalAccordionRollups still needs
+// to call syncKometaBranchRollupBadge, which lives here (it depends
+// on branch-override helpers not yet migrated to _kometaUpdate.js).
+// Wrapping here keeps every call site simple.
+function syncFinalAccordionRollups () {
+  _syncFinalAccordionRollups({ syncKometaBranchRollupBadge })
+}
+
 // Kometa runtime status flags migrated to modules/kometa/_state.js
 // (kometaState.kometaInstalled, kometaValidated, kometaStatus, etc.).
 // See _state.js docstring for the state-machine notes.
@@ -70,7 +76,6 @@ let logFilter = ''
 let lastLogText = ''
 let lastLogStatsTotal = null
 let logStatsPollCounter = 0
-let lastLogscanPayload = null
 let logscanPollCounter = 0
 let finalLogscanAnalyzeTriggered = false
 let lastRunProgressPayload = null
@@ -176,73 +181,6 @@ function syncKometaMaintenancePageBadge (data) {
 document.addEventListener('qs:maintenance-status', function (event) {
   syncKometaMaintenancePageBadge(event.detail || null)
 })
-
-function updateConfigOutputHeaderBadges () {
-  const yamlText = yamlOutput ? String(yamlOutput.value || '') : ''
-  const lineCount = computeYamlLineCount(yamlText)
-  setHeaderRollupBadge('config-output-lines-badge', lineCount > 0 ? 'ok' : 'unknown', `${lineCount} lines`)
-  if (!yamlText.trim()) {
-    setHeaderRollupBadge('config-output-rollup-badge', 'unknown', 'No YAML')
-    return
-  }
-  setHeaderRollupBadge('config-output-rollup-badge', kometaState.showYAML ? 'ok' : 'error', kometaState.showYAML ? 'Validated' : 'Needs fixes')
-}
-
-function updateRunCommandHeaderBadge () {
-  if (!kometaState.showYAML) {
-    setHeaderRollupBadge('run-command-rollup-badge', 'error', 'Fix validation')
-    return
-  }
-  if (kometaState.kometaValidationInProgress) {
-    setHeaderRollupBadge('run-command-rollup-badge', 'unknown', 'Checking Kometa')
-    return
-  }
-  if (kometaState.kometaUpdating) {
-    setHeaderRollupBadge('run-command-rollup-badge', 'unknown', 'Updating Kometa')
-    return
-  }
-  if (!kometaState.kometaValidated) {
-    setHeaderRollupBadge('run-command-rollup-badge', 'warn', 'Validate Kometa')
-    return
-  }
-  if (kometaState.kometaStatus === 'running') {
-    setHeaderRollupBadge('run-command-rollup-badge', 'warn', 'Run in progress')
-    return
-  }
-  setHeaderRollupBadge('run-command-rollup-badge', isRunCommandValid() ? 'ok' : 'warn', isRunCommandValid() ? 'Ready' : 'Incomplete')
-}
-
-function updateLogscanHeaderBadge (data) {
-  const source = data || lastLogscanPayload
-  if (!source) {
-    setHeaderRollupBadge('logscan-rollup-badge', 'unknown', 'Pending')
-    return
-  }
-  if (source.error) {
-    setHeaderRollupBadge('logscan-rollup-badge', 'error', 'Unavailable')
-    return
-  }
-  const recCount = Array.isArray(source.recommendations) ? source.recommendations.length : 0
-  const missingCount = Array.isArray(source.missing_people) ? source.missing_people.length : 0
-  const issueCount = recCount + missingCount
-  if (!issueCount) {
-    setHeaderRollupBadge('logscan-rollup-badge', 'ok', 'No issues')
-    return
-  }
-  setHeaderRollupBadge('logscan-rollup-badge', 'warn', `${issueCount} items`)
-}
-
-function syncFinalAccordionRollups () {
-  updateModeHeaderBadge()
-  updateRunOptionHeaderBadge()
-  updateModeFlagsHeaderBadge()
-  updateLogFlagsHeaderBadge()
-  updateOtherFlagsHeaderBadge()
-  updateConfigOutputHeaderBadges()
-  updateRunCommandHeaderBadge()
-  updateLogscanHeaderBadge()
-  syncKometaBranchRollupBadge()
-}
 
 updateValidationGate({ updateRunNowState, syncFinalAccordionRollups })
 
@@ -2480,7 +2418,7 @@ function renderLogscan (data) {
 function fetchLogscanAnalysis (force = false) {
   if (!logscanPanel) return
   logscanPollCounter += 1
-  const shouldFetch = force || (logscanPollCounter % 5 === 0) || !lastLogscanPayload
+  const shouldFetch = force || (logscanPollCounter % 5 === 0) || !kometaState.lastLogscanPayload
   if (!shouldFetch || logscanAnalyzeInFlight) return
 
   logscanAnalyzeInFlight = true
@@ -2488,7 +2426,7 @@ function fetchLogscanAnalysis (force = false) {
   fetch('/logscan/analyze')
     .then(res => res.json())
     .then(data => {
-      lastLogscanPayload = data
+      kometaState.lastLogscanPayload = data
       renderLogscan(data)
     })
     .catch(err => {

--- a/static/local-js/modules/kometa/_headerBadges.js
+++ b/static/local-js/modules/kometa/_headerBadges.js
@@ -3,14 +3,13 @@
 // The Kometa configuration page uses Bootstrap accordions. Each
 // accordion header displays a small "rollup" badge summarizing the
 // state of its section -- e.g. "Friendly", "3 libraries", "Times
-// needed", "Invalid times". This module owns the pure-DOM-reading
-// badge functions that read the current UI state and set the
-// appropriate badge text + color class.
+// needed", "Invalid times". This module owns the badge functions that
+// read the current UI + kometaState and set the appropriate badge
+// text + color class.
 //
-// SCOPE OF THIS FILE (as of this PR):
+// EXPORTS (grouped by dependency):
 //
-//   Only the badge helpers that read exclusively from the DOM (no
-//   shared module-level state). Concretely:
+//   Pure DOM-reading helpers (no kometaState reads):
 //
 //     setHeaderRollupBadge         -- generic setter used by all badges
 //     prettifyFlag                 -- helper for CLI flag -> label
@@ -21,22 +20,23 @@
 //     updateLogFlagsHeaderBadge
 //     updateOtherFlagsHeaderBadge
 //
-//   Three sibling badge functions stay in 900-kometa.js FOR NOW:
+//   State-consulting helpers (read kometaState + maybe DOM):
 //
-//     updateConfigOutputHeaderBadges  -- needs the `showYAML` bool
-//     updateRunCommandHeaderBadge     -- needs 4 KOMETA_* flags,
-//                                        KOMETA_STATUS, showYAML,
-//                                        isRunCommandValid()
-//     updateLogscanHeaderBadge        -- needs lastLogscanPayload
+//     updateConfigOutputHeaderBadges  -- reads showYAML
+//     updateRunCommandHeaderBadge     -- reads showYAML + kometaValidated
+//                                        + kometaValidationInProgress
+//                                        + kometaUpdating + kometaStatus
+//                                        + isRunCommandValid()
+//     updateLogscanHeaderBadge        -- reads lastLogscanPayload
 //
-//   And the orchestrator:
+//   Orchestrator:
 //
-//     syncFinalAccordionRollups       -- calls both extracted and
-//                                        stay-behind functions
-//
-//   These will move here in follow-up PRs after the state they depend
-//   on migrates to _state.js (which is #1557's foundational work).
-//   Extracting the pure helpers first keeps the diff small and safe.
+//     syncFinalAccordionRollups({ syncKometaBranchRollupBadge })
+//                                     -- one call to refresh every
+//                                        badge on the page. Takes a
+//                                        callbacks bag for functions
+//                                        that still live in
+//                                        900-kometa.js.
 //
 // COLOR CLASSES:
 //
@@ -51,7 +51,9 @@
 //   setHeaderRollupBadge accepts any string; unknown values fall back
 //   to 'unknown' to keep the badge visually consistent.
 
-import { formatHeaderStyleLabel, isValidTimesFormat } from './_util.js'
+import { formatHeaderStyleLabel, isValidTimesFormat, computeYamlLineCount } from './_util.js'
+import { kometaState } from './_state.js'
+import { isRunCommandValid } from './_runCommand.js'
 
 // ---------------------------------------------------------------------
 // Core primitives
@@ -205,4 +207,136 @@ export function updateOtherFlagsHeaderBadge () {
     return
   }
   setHeaderRollupBadge('heading-otherflags-rollup-badge', 'ok', `${total} enabled`)
+}
+
+// ---------------------------------------------------------------------
+// State-consulting badges (read kometaState)
+// ---------------------------------------------------------------------
+
+/**
+ * Config-output section rollup: shows YAML line count + a Validated /
+ * Needs-fixes badge driven by kometaState.showYAML.
+ *
+ * DOM contract:
+ *   - #final-yaml           <textarea> holding the generated YAML.
+ *                            If absent or empty, the rollup badge
+ *                            reports 'No YAML'.
+ *   - #config-output-lines-badge   count-of-lines badge
+ *   - #config-output-rollup-badge  overall pass/fail badge
+ */
+export function updateConfigOutputHeaderBadges () {
+  const yamlOutput = document.getElementById('final-yaml')
+  const yamlText = yamlOutput ? String(yamlOutput.value || '') : ''
+  const lineCount = computeYamlLineCount(yamlText)
+  setHeaderRollupBadge('config-output-lines-badge', lineCount > 0 ? 'ok' : 'unknown', `${lineCount} lines`)
+  if (!yamlText.trim()) {
+    setHeaderRollupBadge('config-output-rollup-badge', 'unknown', 'No YAML')
+    return
+  }
+  setHeaderRollupBadge(
+    'config-output-rollup-badge',
+    kometaState.showYAML ? 'ok' : 'error',
+    kometaState.showYAML ? 'Validated' : 'Needs fixes'
+  )
+}
+
+/**
+ * Run-command section rollup: a five-way state machine keyed on
+ * validation + install + running-status flags. Prioritized top-down:
+ *
+ *   showYAML false                    -- config not passing yet:
+ *                                        'Fix validation' (error)
+ *   kometaValidationInProgress        -- 'Checking Kometa' (unknown)
+ *   kometaUpdating                    -- 'Updating Kometa' (unknown)
+ *   !kometaValidated                  -- 'Validate Kometa' (warn)
+ *   kometaStatus === 'running'        -- 'Run in progress' (warn)
+ *   otherwise                         -- isRunCommandValid() ?
+ *                                          'Ready' (ok) :
+ *                                          'Incomplete' (warn)
+ */
+export function updateRunCommandHeaderBadge () {
+  if (!kometaState.showYAML) {
+    setHeaderRollupBadge('run-command-rollup-badge', 'error', 'Fix validation')
+    return
+  }
+  if (kometaState.kometaValidationInProgress) {
+    setHeaderRollupBadge('run-command-rollup-badge', 'unknown', 'Checking Kometa')
+    return
+  }
+  if (kometaState.kometaUpdating) {
+    setHeaderRollupBadge('run-command-rollup-badge', 'unknown', 'Updating Kometa')
+    return
+  }
+  if (!kometaState.kometaValidated) {
+    setHeaderRollupBadge('run-command-rollup-badge', 'warn', 'Validate Kometa')
+    return
+  }
+  if (kometaState.kometaStatus === 'running') {
+    setHeaderRollupBadge('run-command-rollup-badge', 'warn', 'Run in progress')
+    return
+  }
+  const valid = isRunCommandValid()
+  setHeaderRollupBadge(
+    'run-command-rollup-badge',
+    valid ? 'ok' : 'warn',
+    valid ? 'Ready' : 'Incomplete'
+  )
+}
+
+/**
+ * Logscan section rollup: driven by the most recent /logscan payload.
+ * Callers can pass a fresh payload directly (e.g. right after fetch);
+ * omitting the arg uses the cached one in kometaState.lastLogscanPayload.
+ *
+ * @param {object} [data]  Optional payload to render from. Falls back
+ *                         to kometaState.lastLogscanPayload.
+ */
+export function updateLogscanHeaderBadge (data) {
+  const source = data || kometaState.lastLogscanPayload
+  if (!source) {
+    setHeaderRollupBadge('logscan-rollup-badge', 'unknown', 'Pending')
+    return
+  }
+  if (source.error) {
+    setHeaderRollupBadge('logscan-rollup-badge', 'error', 'Unavailable')
+    return
+  }
+  const recCount = Array.isArray(source.recommendations) ? source.recommendations.length : 0
+  const missingCount = Array.isArray(source.missing_people) ? source.missing_people.length : 0
+  const issueCount = recCount + missingCount
+  if (!issueCount) {
+    setHeaderRollupBadge('logscan-rollup-badge', 'ok', 'No issues')
+    return
+  }
+  setHeaderRollupBadge('logscan-rollup-badge', 'warn', `${issueCount} items`)
+}
+
+// ---------------------------------------------------------------------
+// Orchestrator
+// ---------------------------------------------------------------------
+
+/**
+ * Refresh every section-header rollup badge on the page. One call
+ * to bring the whole accordion into sync with current state.
+ *
+ * The `syncKometaBranchRollupBadge` function still lives in
+ * 900-kometa.js (it depends on branch-override helpers that haven't
+ * been extracted yet), so we take it as a callback. When those
+ * helpers migrate to _kometaUpdate.js, this callback retires in favor
+ * of a direct import.
+ *
+ * @param {{ syncKometaBranchRollupBadge: () => void }} [callbacks]
+ */
+export function syncFinalAccordionRollups (callbacks) {
+  updateModeHeaderBadge()
+  updateRunOptionHeaderBadge()
+  updateModeFlagsHeaderBadge()
+  updateLogFlagsHeaderBadge()
+  updateOtherFlagsHeaderBadge()
+  updateConfigOutputHeaderBadges()
+  updateRunCommandHeaderBadge()
+  updateLogscanHeaderBadge()
+  if (callbacks && typeof callbacks.syncKometaBranchRollupBadge === 'function') {
+    callbacks.syncKometaBranchRollupBadge()
+  }
 }

--- a/static/local-js/modules/kometa/_sparklines.js
+++ b/static/local-js/modules/kometa/_sparklines.js
@@ -1,0 +1,195 @@
+// Run-status sparklines: the tiny inline SVG line-charts that appear
+// above the run-status panel while Kometa is running. Six series in
+// total, arranged as three pairs:
+//
+//   CPU:  system %      | kometa %
+//   MEM:  system %      | kometa %
+//   IO:   read MB/s     | write MB/s
+//
+// The CPU + MEM series are percentages 0-100 and rendered on a shared
+// 0-100 scale. The IO series are raw MB/s and get normalized against
+// the max of BOTH read+write for the current window, so the two lines
+// stay visually comparable regardless of absolute magnitude.
+//
+// DATA FLOW:
+//
+//   fetchRunProgress (900-kometa.js) -> updateRunStatus (900-kometa.js)
+//       -> updateRunSparklines(data)  [this module]
+//           -> pushSparkValue (from _util.js) into the ring buffers
+//           -> renderRunSparklines()
+//               -> writeAttribute('points', ...) on 6 <polyline>s
+//
+//   When status flips to !running, updateRunSparklines calls
+//   resetRunSparklines which clears the buffers + re-renders (which
+//   hides the panel by adding .d-none).
+//
+// MODULE STATE:
+//
+//   sparkBuffers  private object holding the 6 ring buffers. Not
+//                 exported -- callers should mutate it only through
+//                 updateRunSparklines / resetRunSparklines.
+//
+//   getSparkBuffers  read-only accessor for tests to snapshot buffer
+//                    state without needing kometaState-level plumbing
+//                    (this module doesn't need cross-module sharing;
+//                    the buffers are truly private).
+//
+// The three CPU/MEM/IO DOM elements are looked up lazily on each
+// render so the module doesn't hard-depend on DOM readiness at import
+// time. Cheap. Keeps the module trivially unit-testable.
+
+import { buildSparklinePoints, buildSparklinePointsScaled, clampPercent, pushSparkValue } from './_util.js'
+
+// Ring buffers for each series. Populated by pushSparkValue (which
+// bounds them at N samples -- see _util.js for N). The nested shape
+// exactly mirrors the pre-extraction top-level `runSparkState` const
+// so any test/debug snippet can still recognize it.
+const sparkBuffers = {
+  cpu: { system: [], kometa: [] },
+  mem: { system: [], kometa: [] },
+  io: { read: [], write: [] }
+}
+
+/**
+ * Test-only accessor. Returns the LIVE buffer object so callers can
+ * inspect current samples without going through render (which would
+ * require a DOM). Do NOT rely on this from production code -- prefer
+ * exposing an API that tests + prod both use.
+ *
+ * @returns {typeof sparkBuffers}
+ */
+export function getSparkBuffers () {
+  return sparkBuffers
+}
+
+/**
+ * Whether any of the six buffers has at least one sample.
+ * @returns {boolean}
+ */
+function hasAnyData () {
+  return (
+    sparkBuffers.cpu.system.length > 0 ||
+    sparkBuffers.cpu.kometa.length > 0 ||
+    sparkBuffers.mem.system.length > 0 ||
+    sparkBuffers.mem.kometa.length > 0 ||
+    sparkBuffers.io.read.length > 0 ||
+    sparkBuffers.io.write.length > 0
+  )
+}
+
+/**
+ * Repaint all six sparklines. Toggles the .d-none class on the
+ * enclosing container so an empty state hides the whole widget.
+ *
+ * No-op if #run-status-sparklines container is missing (page hasn't
+ * rendered yet).
+ */
+export function renderRunSparklines () {
+  const container = document.getElementById('run-status-sparklines')
+  if (!container) return
+
+  // Lazily resolve each polyline. Two paths below (empty vs data)
+  // both need the CPU + MEM elements; IO elements only when we're
+  // painting data.
+  const cpuSystem = document.getElementById('run-spark-cpu-system')
+  const cpuKometa = document.getElementById('run-spark-cpu-kometa')
+  const memSystem = document.getElementById('run-spark-mem-system')
+  const memKometa = document.getElementById('run-spark-mem-kometa')
+  const ioRead = document.getElementById('run-spark-io-read')
+  const ioWrite = document.getElementById('run-spark-io-write')
+
+  const dataPresent = hasAnyData()
+  container.classList.toggle('d-none', !dataPresent)
+
+  if (!dataPresent) {
+    // Clear every polyline so a subsequent "has data" render doesn't
+    // briefly show stale lines during the layout flush.
+    if (cpuSystem) cpuSystem.setAttribute('points', '')
+    if (cpuKometa) cpuKometa.setAttribute('points', '')
+    if (memSystem) memSystem.setAttribute('points', '')
+    if (memKometa) memKometa.setAttribute('points', '')
+    if (ioRead) ioRead.setAttribute('points', '')
+    if (ioWrite) ioWrite.setAttribute('points', '')
+    return
+  }
+
+  // CPU + MEM lines share the fixed 0-100 scale (buildSparklinePoints).
+  if (cpuSystem) cpuSystem.setAttribute('points', buildSparklinePoints(sparkBuffers.cpu.system))
+  if (cpuKometa) cpuKometa.setAttribute('points', buildSparklinePoints(sparkBuffers.cpu.kometa))
+  if (memSystem) memSystem.setAttribute('points', buildSparklinePoints(sparkBuffers.mem.system))
+  if (memKometa) memKometa.setAttribute('points', buildSparklinePoints(sparkBuffers.mem.kometa))
+
+  // IO lines share a dynamically-computed scale based on the max of
+  // BOTH read + write across the current window. Ensures the two
+  // lines stay visually comparable when magnitudes differ (e.g.
+  // 50 MB/s read + 3 MB/s write should NOT flatten the write line
+  // to zero).
+  const ioMax = Math.max(0, ...sparkBuffers.io.read, ...sparkBuffers.io.write)
+  if (ioRead) ioRead.setAttribute('points', buildSparklinePointsScaled(sparkBuffers.io.read, ioMax))
+  if (ioWrite) ioWrite.setAttribute('points', buildSparklinePointsScaled(sparkBuffers.io.write, ioMax))
+}
+
+/**
+ * Empty every ring buffer and repaint. Called when a run stops.
+ */
+export function resetRunSparklines () {
+  sparkBuffers.cpu.system = []
+  sparkBuffers.cpu.kometa = []
+  sparkBuffers.mem.system = []
+  sparkBuffers.mem.kometa = []
+  sparkBuffers.io.read = []
+  sparkBuffers.io.write = []
+  renderRunSparklines()
+}
+
+/**
+ * Ingest one polling payload from the run-progress endpoint. If the
+ * payload indicates the run is stopped, we reset instead. Otherwise
+ * pushes six samples (four percentages + two rates) and renders.
+ *
+ * The IO rates are pushed as `null` when the server omits them
+ * (typical during warm-up before the first delta is computed) -- the
+ * ring-buffer code in pushSparkValue handles null as "gap".
+ *
+ * @param {{
+ *   status?: string,
+ *   system_cpu_percent?: number,
+ *   cpu_percent?: number,
+ *   system_memory_percent?: number,
+ *   memory_percent?: number,
+ *   disk_read_rate_mb_s?: number,
+ *   disk_write_rate_mb_s?: number
+ * } | null | undefined} data
+ */
+export function updateRunSparklines (data) {
+  if (!data || data.status !== 'running') {
+    resetRunSparklines()
+    return
+  }
+
+  const cpuSystem = clampPercent(data.system_cpu_percent)
+  const cpuKometa = clampPercent(data.cpu_percent)
+  const memSystem = clampPercent(data.system_memory_percent)
+  const memKometa = clampPercent(data.memory_percent)
+
+  // Rates: server may omit them during the first tick after start,
+  // when there's no previous sample to compute a delta from. Push
+  // null rather than 0 -- pushSparkValue handles null by repeating
+  // the previous sample (or dropping the push entirely if the buffer
+  // is still empty). Either way, no spurious "dip to zero" appears.
+  const ioRead = (typeof data.disk_read_rate_mb_s === 'number' && Number.isFinite(data.disk_read_rate_mb_s))
+    ? Math.max(0, data.disk_read_rate_mb_s)
+    : null
+  const ioWrite = (typeof data.disk_write_rate_mb_s === 'number' && Number.isFinite(data.disk_write_rate_mb_s))
+    ? Math.max(0, data.disk_write_rate_mb_s)
+    : null
+
+  pushSparkValue(sparkBuffers.cpu.system, cpuSystem)
+  pushSparkValue(sparkBuffers.cpu.kometa, cpuKometa)
+  pushSparkValue(sparkBuffers.mem.system, memSystem)
+  pushSparkValue(sparkBuffers.mem.kometa, memKometa)
+  pushSparkValue(sparkBuffers.io.read, ioRead)
+  pushSparkValue(sparkBuffers.io.write, ioWrite)
+
+  renderRunSparklines()
+}

--- a/static/local-js/modules/kometa/_state.js
+++ b/static/local-js/modules/kometa/_state.js
@@ -151,5 +151,22 @@ export const kometaState = {
   kometaUpdateCheckSkipped: false,
   kometaUpdateCheckCompleted: false,
   kometaStatus: null,
-  kometaPendingStart: false
+  kometaPendingStart: false,
+
+  // ---- Logscan cache -----------------------------------------------
+  // The most recent /logscan payload fetched from the server, kept
+  // around so header-badge refreshes and other polling passes can
+  // work off a snapshot instead of blocking on a new HTTP round-trip.
+  //
+  //   null                       -- never fetched successfully yet
+  //   { error: '...' }           -- fetch failed; renderers show
+  //                                 'Unavailable' state
+  //   { recommendations: [...],  -- fetch succeeded; count arrays
+  //     missing_people: [...],     drive the 'N items' badge
+  //     ... }
+  //
+  // Written by the polling loop in 900-kometa.js after every
+  // successful fetchLogscan(). Read by updateLogscanHeaderBadge (in
+  // _headerBadges.js) when it's called without an explicit data arg.
+  lastLogscanPayload: null
 }

--- a/tests/js/kometa/headerBadges.test.js
+++ b/tests/js/kometa/headerBadges.test.js
@@ -28,7 +28,7 @@
 //   updateOtherFlagsHeaderBadge -- 0/some/all core flags, extras
 //                            (timeout/divider/width) counted separately
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   setHeaderRollupBadge,
   prettifyFlag,
@@ -37,8 +37,13 @@ import {
   updateRunOptionHeaderBadge,
   updateModeFlagsHeaderBadge,
   updateLogFlagsHeaderBadge,
-  updateOtherFlagsHeaderBadge
+  updateOtherFlagsHeaderBadge,
+  updateConfigOutputHeaderBadges,
+  updateRunCommandHeaderBadge,
+  updateLogscanHeaderBadge,
+  syncFinalAccordionRollups
 } from '../../../static/local-js/modules/kometa/_headerBadges.js'
+import { kometaState } from '../../../static/local-js/modules/kometa/_state.js'
 
 // ---------------------------------------------------------------------
 // Fixture DOM helpers
@@ -438,5 +443,254 @@ describe('updateOtherFlagsHeaderBadge', () => {
     updateOtherFlagsHeaderBadge()
     const badge = document.getElementById('heading-otherflags-rollup-badge')
     expect(badge.textContent).toBe('14 enabled')
+  })
+})
+
+// ---------------------------------------------------------------------
+// State-consulting: updateConfigOutputHeaderBadges
+// ---------------------------------------------------------------------
+
+describe('updateConfigOutputHeaderBadges', () => {
+  beforeEach(() => {
+    kometaState.showYAML = false
+  })
+
+  it('shows "No YAML" when the textarea is missing', () => {
+    installBadge('config-output-lines-badge')
+    installBadge('config-output-rollup-badge')
+    updateConfigOutputHeaderBadges()
+    expect(document.getElementById('config-output-rollup-badge').textContent).toBe('No YAML')
+    expect(document.getElementById('config-output-rollup-badge').classList.contains('qs-validation-rollup-badge--unknown')).toBe(true)
+  })
+
+  it('shows "No YAML" when the textarea has only whitespace', () => {
+    const t = document.createElement('textarea')
+    t.id = 'final-yaml'
+    t.value = '   \n  \t  '
+    document.body.appendChild(t)
+    installBadge('config-output-lines-badge')
+    installBadge('config-output-rollup-badge')
+    updateConfigOutputHeaderBadges()
+    expect(document.getElementById('config-output-rollup-badge').textContent).toBe('No YAML')
+  })
+
+  it('shows line count + "Validated" (ok) when showYAML is true', () => {
+    const t = document.createElement('textarea')
+    t.id = 'final-yaml'
+    t.value = 'libraries:\n  Movies:\n    metadata_path: []'
+    document.body.appendChild(t)
+    installBadge('config-output-lines-badge')
+    installBadge('config-output-rollup-badge')
+    kometaState.showYAML = true
+    updateConfigOutputHeaderBadges()
+    expect(document.getElementById('config-output-lines-badge').textContent).toBe('3 lines')
+    expect(document.getElementById('config-output-rollup-badge').textContent).toBe('Validated')
+    expect(document.getElementById('config-output-rollup-badge').classList.contains('qs-validation-rollup-badge--ok')).toBe(true)
+  })
+
+  it('shows "Needs fixes" (error) when YAML present but showYAML is false', () => {
+    const t = document.createElement('textarea')
+    t.id = 'final-yaml'
+    t.value = 'broken:\n  yaml'
+    document.body.appendChild(t)
+    installBadge('config-output-lines-badge')
+    installBadge('config-output-rollup-badge')
+    kometaState.showYAML = false
+    updateConfigOutputHeaderBadges()
+    expect(document.getElementById('config-output-rollup-badge').textContent).toBe('Needs fixes')
+    expect(document.getElementById('config-output-rollup-badge').classList.contains('qs-validation-rollup-badge--error')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// State-consulting: updateRunCommandHeaderBadge (five-way state machine)
+// ---------------------------------------------------------------------
+
+describe('updateRunCommandHeaderBadge', () => {
+  // Reset the whole state slice this function reads. beforeEach
+  // matters here because tests intentionally flip one flag at a time.
+  beforeEach(() => {
+    kometaState.showYAML = false
+    kometaState.kometaValidated = false
+    kometaState.kometaValidationInProgress = false
+    kometaState.kometaUpdating = false
+    kometaState.kometaStatus = null
+    installBadge('run-command-rollup-badge')
+  })
+
+  it('shows "Fix validation" (error) when showYAML is false [highest priority]', () => {
+    // All other flags could be favorable; showYAML=false still wins.
+    kometaState.kometaValidated = true
+    kometaState.kometaStatus = 'idle'
+    updateRunCommandHeaderBadge()
+    const b = document.getElementById('run-command-rollup-badge')
+    expect(b.textContent).toBe('Fix validation')
+    expect(b.classList.contains('qs-validation-rollup-badge--error')).toBe(true)
+  })
+
+  it('shows "Checking Kometa" (unknown) when validationInProgress is true', () => {
+    kometaState.showYAML = true
+    kometaState.kometaValidationInProgress = true
+    updateRunCommandHeaderBadge()
+    expect(document.getElementById('run-command-rollup-badge').textContent).toBe('Checking Kometa')
+  })
+
+  it('shows "Updating Kometa" (unknown) when kometaUpdating is true', () => {
+    kometaState.showYAML = true
+    kometaState.kometaUpdating = true
+    updateRunCommandHeaderBadge()
+    expect(document.getElementById('run-command-rollup-badge').textContent).toBe('Updating Kometa')
+  })
+
+  it('shows "Validate Kometa" (warn) when validated is false [and no in-progress]', () => {
+    kometaState.showYAML = true
+    kometaState.kometaValidated = false
+    updateRunCommandHeaderBadge()
+    const b = document.getElementById('run-command-rollup-badge')
+    expect(b.textContent).toBe('Validate Kometa')
+    expect(b.classList.contains('qs-validation-rollup-badge--warn')).toBe(true)
+  })
+
+  it("shows \"Run in progress\" (warn) when kometaStatus is 'running'", () => {
+    kometaState.showYAML = true
+    kometaState.kometaValidated = true
+    kometaState.kometaStatus = 'running'
+    updateRunCommandHeaderBadge()
+    expect(document.getElementById('run-command-rollup-badge').textContent).toBe('Run in progress')
+  })
+
+  it('shows "Ready" (ok) when everything passes and run command is valid', () => {
+    kometaState.showYAML = true
+    kometaState.kometaValidated = true
+    // Install a valid run-command-output so isRunCommandValid() returns true
+    const out = document.createElement('div')
+    out.id = 'run-command-output'
+    out.textContent = 'python kometa.py --config config.yml'
+    document.body.appendChild(out)
+    updateRunCommandHeaderBadge()
+    const b = document.getElementById('run-command-rollup-badge')
+    expect(b.textContent).toBe('Ready')
+    expect(b.classList.contains('qs-validation-rollup-badge--ok')).toBe(true)
+  })
+
+  it('shows "Incomplete" (warn) when everything passes but run command is placeholder', () => {
+    kometaState.showYAML = true
+    kometaState.kometaValidated = true
+    const out = document.createElement('div')
+    out.id = 'run-command-output'
+    out.textContent = '?? no root ??'
+    document.body.appendChild(out)
+    updateRunCommandHeaderBadge()
+    expect(document.getElementById('run-command-rollup-badge').textContent).toBe('Incomplete')
+  })
+})
+
+// ---------------------------------------------------------------------
+// State-consulting: updateLogscanHeaderBadge
+// ---------------------------------------------------------------------
+
+describe('updateLogscanHeaderBadge', () => {
+  beforeEach(() => {
+    kometaState.lastLogscanPayload = null
+    installBadge('logscan-rollup-badge')
+  })
+
+  it('shows "Pending" (unknown) when no data available', () => {
+    updateLogscanHeaderBadge()
+    const b = document.getElementById('logscan-rollup-badge')
+    expect(b.textContent).toBe('Pending')
+    expect(b.classList.contains('qs-validation-rollup-badge--unknown')).toBe(true)
+  })
+
+  it('reads from kometaState.lastLogscanPayload when no arg is passed', () => {
+    kometaState.lastLogscanPayload = { recommendations: [1, 2], missing_people: [] }
+    updateLogscanHeaderBadge()
+    expect(document.getElementById('logscan-rollup-badge').textContent).toBe('2 items')
+  })
+
+  it('passed data arg WINS over kometaState.lastLogscanPayload', () => {
+    kometaState.lastLogscanPayload = { recommendations: [1, 2, 3] }
+    updateLogscanHeaderBadge({ recommendations: [], missing_people: [] })
+    expect(document.getElementById('logscan-rollup-badge').textContent).toBe('No issues')
+  })
+
+  it('shows "Unavailable" (error) when payload has an error field', () => {
+    updateLogscanHeaderBadge({ error: 'boom' })
+    const b = document.getElementById('logscan-rollup-badge')
+    expect(b.textContent).toBe('Unavailable')
+    expect(b.classList.contains('qs-validation-rollup-badge--error')).toBe(true)
+  })
+
+  it('shows "No issues" (ok) for empty recs+missing arrays', () => {
+    updateLogscanHeaderBadge({ recommendations: [], missing_people: [] })
+    const b = document.getElementById('logscan-rollup-badge')
+    expect(b.textContent).toBe('No issues')
+    expect(b.classList.contains('qs-validation-rollup-badge--ok')).toBe(true)
+  })
+
+  it('sums recommendations + missing_people counts', () => {
+    updateLogscanHeaderBadge({ recommendations: [1, 2, 3], missing_people: [4, 5] })
+    expect(document.getElementById('logscan-rollup-badge').textContent).toBe('5 items')
+  })
+
+  it('handles missing/non-array recommendations gracefully', () => {
+    updateLogscanHeaderBadge({ missing_people: [1] })
+    expect(document.getElementById('logscan-rollup-badge').textContent).toBe('1 items')
+  })
+})
+
+// ---------------------------------------------------------------------
+// Orchestrator: syncFinalAccordionRollups
+// ---------------------------------------------------------------------
+
+describe('syncFinalAccordionRollups', () => {
+  beforeEach(() => {
+    // Install all badges the orchestrator touches
+    installBadge('heading-style-rollup-badge')
+    installBadge('heading-mode-rollup-badge')
+    installBadge('heading-runopt-rollup-badge')
+    installBadge('heading-modeflags-rollup-badge')
+    installBadge('heading-logflags-rollup-badge')
+    installBadge('heading-otherflags-rollup-badge')
+    installBadge('config-output-lines-badge')
+    installBadge('config-output-rollup-badge')
+    installBadge('run-command-rollup-badge')
+    installBadge('logscan-rollup-badge')
+  })
+
+  it('invokes syncKometaBranchRollupBadge callback exactly once', () => {
+    const cb = vi.fn()
+    syncFinalAccordionRollups({ syncKometaBranchRollupBadge: cb })
+    expect(cb).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not throw when callbacks arg is undefined', () => {
+    expect(() => syncFinalAccordionRollups()).not.toThrow()
+  })
+
+  it('does not throw when syncKometaBranchRollupBadge is not a function', () => {
+    expect(() => syncFinalAccordionRollups({ syncKometaBranchRollupBadge: 42 })).not.toThrow()
+  })
+
+  it('refreshes every rollup badge on the page (touches all 10 ids)', () => {
+    // Pre-mark every badge with a sentinel string. After the call,
+    // every badge must have been rewritten (i.e. not equal to the
+    // sentinel).
+    const ids = [
+      'heading-mode-rollup-badge',
+      'heading-runopt-rollup-badge',
+      'heading-modeflags-rollup-badge',
+      'heading-logflags-rollup-badge',
+      'heading-otherflags-rollup-badge',
+      'config-output-lines-badge',
+      'config-output-rollup-badge',
+      'run-command-rollup-badge',
+      'logscan-rollup-badge'
+    ]
+    for (const id of ids) document.getElementById(id).textContent = 'SENTINEL'
+    syncFinalAccordionRollups({ syncKometaBranchRollupBadge: () => {} })
+    for (const id of ids) {
+      expect(document.getElementById(id).textContent).not.toBe('SENTINEL')
+    }
   })
 })

--- a/tests/js/kometa/sparklines.test.js
+++ b/tests/js/kometa/sparklines.test.js
@@ -1,0 +1,272 @@
+// Tests for static/local-js/modules/kometa/_sparklines.js
+//
+// Coverage strategy per exported function:
+//
+//   renderRunSparklines
+//     - no container in DOM -> silent no-op
+//     - empty buffers -> hides container (.d-none) and clears each
+//       polyline's `points` attribute
+//     - populated buffers -> shows container and writes points
+//       attribute on each polyline
+//     - IO polylines get the scaled-points geometry (based on max
+//       of read+write)
+//
+//   resetRunSparklines
+//     - empties all six buffers
+//     - triggers a re-render (adds .d-none)
+//
+//   updateRunSparklines
+//     - null/undefined data -> resets (delegates to resetRunSparklines)
+//     - data.status !== 'running' -> resets
+//     - data.status === 'running' -> pushes six samples + renders
+//     - missing/non-numeric disk rates get pushed as null (gap marker)
+//     - negative rates get clamped to 0
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  renderRunSparklines,
+  resetRunSparklines,
+  updateRunSparklines,
+  getSparkBuffers
+} from '../../../static/local-js/modules/kometa/_sparklines.js'
+
+// ---------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------
+
+function installSparklineDom () {
+  document.body.innerHTML = `
+    <div id="run-status-sparklines" class="d-none">
+      <svg><polyline id="run-spark-cpu-system"/></svg>
+      <svg><polyline id="run-spark-cpu-kometa"/></svg>
+      <svg><polyline id="run-spark-mem-system"/></svg>
+      <svg><polyline id="run-spark-mem-kometa"/></svg>
+      <svg><polyline id="run-spark-io-read"/></svg>
+      <svg><polyline id="run-spark-io-write"/></svg>
+    </div>
+  `
+}
+
+// Reset the internal buffers BEFORE every test so state doesn't
+// leak across the module-level ring buffers. resetRunSparklines
+// happens to be exactly that reset (plus a render), so it's the
+// simplest way to fixture. If it ever breaks, tests catch each
+// other's state -- which is the right failure mode.
+beforeEach(() => {
+  installSparklineDom()
+  resetRunSparklines()
+})
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+// ---------------------------------------------------------------------
+// renderRunSparklines
+// ---------------------------------------------------------------------
+
+describe('renderRunSparklines', () => {
+  it('is a no-op when the container is missing from the DOM', () => {
+    document.body.innerHTML = ''
+    expect(() => renderRunSparklines()).not.toThrow()
+  })
+
+  it('hides the container and clears polylines when all buffers empty', () => {
+    // Force the container to visible so we can prove render toggles it back
+    const container = document.getElementById('run-status-sparklines')
+    container.classList.remove('d-none')
+    // Give the polylines stale point data
+    document.getElementById('run-spark-cpu-system').setAttribute('points', 'STALE')
+    document.getElementById('run-spark-io-write').setAttribute('points', 'STALE')
+
+    renderRunSparklines()
+
+    expect(container.classList.contains('d-none')).toBe(true)
+    expect(document.getElementById('run-spark-cpu-system').getAttribute('points')).toBe('')
+    expect(document.getElementById('run-spark-io-write').getAttribute('points')).toBe('')
+  })
+
+  it('shows the container and writes points when at least one buffer has data', () => {
+    updateRunSparklines({ status: 'running', system_cpu_percent: 42 })
+    const container = document.getElementById('run-status-sparklines')
+    expect(container.classList.contains('d-none')).toBe(false)
+    // system CPU line got a value; kometa CPU line got a null (from
+    // missing key) so its polyline shape depends on the util --
+    // just prove SOMETHING got written.
+    const cpuSysPoints = document.getElementById('run-spark-cpu-system').getAttribute('points')
+    expect(cpuSysPoints).toBeTruthy()
+    expect(cpuSysPoints.length).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------
+// resetRunSparklines
+// ---------------------------------------------------------------------
+
+describe('resetRunSparklines', () => {
+  it('empties all six buffer arrays', () => {
+    // Prime with a value
+    updateRunSparklines({
+      status: 'running',
+      system_cpu_percent: 50,
+      cpu_percent: 40,
+      system_memory_percent: 60,
+      memory_percent: 55,
+      disk_read_rate_mb_s: 10,
+      disk_write_rate_mb_s: 5
+    })
+
+    // Sanity: each buffer has 1 sample
+    const before = getSparkBuffers()
+    expect(before.cpu.system.length).toBe(1)
+    expect(before.io.write.length).toBe(1)
+
+    resetRunSparklines()
+
+    const after = getSparkBuffers()
+    expect(after.cpu.system).toEqual([])
+    expect(after.cpu.kometa).toEqual([])
+    expect(after.mem.system).toEqual([])
+    expect(after.mem.kometa).toEqual([])
+    expect(after.io.read).toEqual([])
+    expect(after.io.write).toEqual([])
+  })
+
+  it('re-renders (adds .d-none to the container)', () => {
+    // First populate + render to visible
+    updateRunSparklines({ status: 'running', cpu_percent: 10 })
+    const container = document.getElementById('run-status-sparklines')
+    expect(container.classList.contains('d-none')).toBe(false)
+
+    resetRunSparklines()
+    expect(container.classList.contains('d-none')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// updateRunSparklines
+// ---------------------------------------------------------------------
+
+describe('updateRunSparklines', () => {
+  it('resets when data is null/undefined', () => {
+    // Prime state first so we can prove the reset actually happens
+    updateRunSparklines({ status: 'running', cpu_percent: 99 })
+    expect(getSparkBuffers().cpu.kometa.length).toBe(1)
+
+    updateRunSparklines(null)
+    expect(getSparkBuffers().cpu.kometa).toEqual([])
+
+    updateRunSparklines({ status: 'running', cpu_percent: 99 })
+    updateRunSparklines(undefined)
+    expect(getSparkBuffers().cpu.kometa).toEqual([])
+  })
+
+  it("resets when data.status is not 'running'", () => {
+    updateRunSparklines({ status: 'running', cpu_percent: 42 })
+    expect(getSparkBuffers().cpu.kometa.length).toBe(1)
+
+    updateRunSparklines({ status: 'idle', cpu_percent: 42 })
+    expect(getSparkBuffers().cpu.kometa).toEqual([])
+  })
+
+  it('pushes all six samples when status is running', () => {
+    updateRunSparklines({
+      status: 'running',
+      system_cpu_percent: 25,
+      cpu_percent: 30,
+      system_memory_percent: 40,
+      memory_percent: 45,
+      disk_read_rate_mb_s: 10,
+      disk_write_rate_mb_s: 5
+    })
+
+    const b = getSparkBuffers()
+    expect(b.cpu.system).toEqual([25])
+    expect(b.cpu.kometa).toEqual([30])
+    expect(b.mem.system).toEqual([40])
+    expect(b.mem.kometa).toEqual([45])
+    expect(b.io.read).toEqual([10])
+    expect(b.io.write).toEqual([5])
+  })
+
+  it('appends across multiple ticks (accumulates a series)', () => {
+    updateRunSparklines({ status: 'running', cpu_percent: 10 })
+    updateRunSparklines({ status: 'running', cpu_percent: 20 })
+    updateRunSparklines({ status: 'running', cpu_percent: 30 })
+    expect(getSparkBuffers().cpu.kometa).toEqual([10, 20, 30])
+  })
+
+  it('does not push null when the buffer is empty (leading null is dropped)', () => {
+    // pushSparkValue skips a null value when the series is empty --
+    // a "gap" before any data is meaningless. Prove that the io
+    // buffers stay empty when the first tick has no disk rates.
+    updateRunSparklines({ status: 'running', cpu_percent: 50 })
+    // No disk_read_rate_mb_s / disk_write_rate_mb_s
+    expect(getSparkBuffers().io.read).toEqual([])
+    expect(getSparkBuffers().io.write).toEqual([])
+  })
+
+  it('duplicates the last sample when a null follows real data', () => {
+    // Tick 1: real data. Tick 2: null (missing). pushSparkValue
+    // repeats the previous sample so the line stays continuous
+    // rather than exhibiting a spurious dip to zero.
+    updateRunSparklines({
+      status: 'running',
+      cpu_percent: 50,
+      disk_read_rate_mb_s: 10,
+      disk_write_rate_mb_s: 3
+    })
+    updateRunSparklines({ status: 'running', cpu_percent: 55 })
+    // Missing disk rates -> re-push the prior samples
+    expect(getSparkBuffers().io.read).toEqual([10, 10])
+    expect(getSparkBuffers().io.write).toEqual([3, 3])
+  })
+
+  it('drops non-numeric disk rate values (same gap-null semantics)', () => {
+    updateRunSparklines({
+      status: 'running',
+      cpu_percent: 50,
+      disk_read_rate_mb_s: 'garbage',
+      disk_write_rate_mb_s: NaN
+    })
+    // Same as "missing" -- coerced to null, dropped when buffer empty
+    expect(getSparkBuffers().io.read).toEqual([])
+    expect(getSparkBuffers().io.write).toEqual([])
+  })
+
+  it('clamps negative disk rates to 0', () => {
+    // Negative rates are physically impossible but the server has
+    // been known to emit them for a first-sample-after-restart edge
+    // case. Max(0, x) safety-net.
+    updateRunSparklines({
+      status: 'running',
+      cpu_percent: 50,
+      disk_read_rate_mb_s: -100,
+      disk_write_rate_mb_s: -1
+    })
+    expect(getSparkBuffers().io.read).toEqual([0])
+    expect(getSparkBuffers().io.write).toEqual([0])
+  })
+
+  it('after populating, container is visible and polylines have points', () => {
+    updateRunSparklines({
+      status: 'running',
+      system_cpu_percent: 50, cpu_percent: 60,
+      system_memory_percent: 70, memory_percent: 80,
+      disk_read_rate_mb_s: 5, disk_write_rate_mb_s: 3
+    })
+    const container = document.getElementById('run-status-sparklines')
+    expect(container.classList.contains('d-none')).toBe(false)
+    // Every polyline should have a non-empty points attribute
+    const ids = [
+      'run-spark-cpu-system', 'run-spark-cpu-kometa',
+      'run-spark-mem-system', 'run-spark-mem-kometa',
+      'run-spark-io-read', 'run-spark-io-write'
+    ]
+    for (const id of ids) {
+      const pts = document.getElementById(id).getAttribute('points')
+      expect(pts, `polyline ${id} should have points`).toBeTruthy()
+      expect(pts.length, `polyline ${id} points not empty`).toBeGreaterThan(0)
+    }
+  })
+})

--- a/tests/js/kometa/state.test.js
+++ b/tests/js/kometa/state.test.js
@@ -115,6 +115,14 @@ describe('kometaState initial values', () => {
     expect(kometaState.kometaStatus).toBeNull()
   })
 
+  it('lastLogscanPayload starts as null', () => {
+    // The logscan header badge distinguishes "no data yet" (Pending)
+    // from "data with 0 issues" (No issues) -- both are legit states.
+    // Null (rather than {}) keeps that distinction sharp on first
+    // page load, before the first /logscan poll returns.
+    expect(kometaState.lastLogscanPayload).toBeNull()
+  })
+
   it('exports exactly the fields the runtime relies on (guards against typos)', () => {
     // Sorted alphabetically for a stable comparison
     expect(Object.keys(kometaState).sort()).toEqual([
@@ -137,6 +145,7 @@ describe('kometaState initial values', () => {
       'kometaUpdating',
       'kometaValidated',
       'kometaValidationInProgress',
+      'lastLogscanPayload',
       'showYAML'
     ])
   })


### PR DESCRIPTION
## What

Extracts the three sparkline functions + their private ring buffer state to a new module. Very self-contained — only one external caller (`updateRunStatus`), no shared state escapes the module.

`900-kometa.js`: 3149 → 3071 lines (**−78**).

## What moved

Extracted to `static/local-js/modules/kometa/_sparklines.js` (195 lines):

| Export | Role |
|---|---|
| `renderRunSparklines` | repaint all six SVG polylines, toggle `.d-none` on container |
| `resetRunSparklines` | empty all six buffers + re-render |
| `updateRunSparklines` | ingest one polling payload, push six samples + render (or reset if status ≠ 'running') |
| `getSparkBuffers` | test-only accessor for buffer state |

Encapsulated **inside** the module (no export, module-private):
- `sparkBuffers` — the six ring buffers, formerly a top-level `const runSparkState = {...}` in `900-kometa.js`
- Six DOM element lookups (`#run-status-sparklines`, `#run-spark-cpu-system`, etc.) done lazily on each render rather than cached at module load — cheap and keeps the module trivially unit-testable

## Design notes

1. **`sparkBuffers` is truly private** — it never needs to be read by anything outside this module. Adding it to `kometaState` would be leaky abstraction. Kept as a module-scoped const object; tests access it via `getSparkBuffers()` documented as 'test-only'.

2. **IO polylines share a dynamically-computed scale** (max of both read+write across current window). Preserves visual comparability when magnitudes differ — e.g. 50 MB/s read plus 3 MB/s write shouldn't flatten the write line. Original `ioMax` computation kept verbatim.

3. **Corrected stale comment.** Original code claimed 'null gap marker' semantics, but `pushSparkValue` actually repeats the previous sample when `null` is passed (or drops it when buffer is empty). The docstring in `_sparklines.js` now accurately describes this behavior — and the tests verify it.

## Cleanup: 4 unused imports removed from `900-kometa.js`

Once the sparkline functions moved, these helpers became unused:
- `clampPercent`
- `pushSparkValue`
- `buildSparklinePoints`
- `buildSparklinePointsScaled`

All four remain in `_util.js` and are now used only by `_sparklines.js`.

Also removed a stale block comment about 'pure geometry helpers extracted to _util.js' that lived next to the removed `runSparkState` declaration.

## Vitest coverage: 14 new tests

**`sparklines.test.js`**:
- **`renderRunSparklines`** (3): missing container = no-op, empty buffers hide container + clear polylines, populated buffers show + write polyline points
- **`resetRunSparklines`** (2): empties all six buffers, re-renders (adds `.d-none`)
- **`updateRunSparklines`** (9):
  - `null` / `undefined` data → resets
  - `status !== 'running'` → resets
  - all six samples get pushed on running status
  - accumulates across multiple ticks
  - null-first-sample dropped (verifies `pushSparkValue` behavior)
  - null-after-real duplicates prior sample (gap-avoidance)
  - non-numeric disk rates treated as null
  - negative disk rates clamped to 0
  - populated state → container visible + all 6 polylines have points

## Verification

- **929/929 Vitest pass** (was 915 after #1566; +14 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- ESLint clean, Node syntax clean

## What's next

- `_kometaUpdate.js` — branch override + update job polling flow (~800 lines, biggest remaining target)
- `_kometaRuntime.js` — `validateKometaRoot` + `probeKometaRoot`
- `_logs.js` / `_logscan.js` — log-tail polling + logscan fetch/analysis