### PR TITLE
Split 900-kometa.js part 12: extract generic UI helpers (tooltips + copy button)

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -48,6 +48,11 @@ import {
 import {
   updateRunSparklines
 } from './modules/kometa/_sparklines.js'
+import {
+  initBootstrapTooltips,
+  disposeBootstrapTooltips,
+  showCopyButtonSuccess
+} from './modules/kometa/_ui.js'
 
 // Thin wrapper: buildCommand needs updateRunNowState and
 // syncFinalAccordionRollups callbacks, but both are still owned by
@@ -187,43 +192,6 @@ function updateYamlLineCount () {
 
 updateYamlLineCount()
 yamlOutput?.addEventListener('input', updateYamlLineCount)
-
-function initBootstrapTooltips (scope, selector, options) {
-  if (typeof bootstrap === 'undefined' || !bootstrap.Tooltip) return
-  const root = scope || document
-  const query = selector || '[data-bs-toggle="tooltip"]'
-  const nodes = []
-  if (root && typeof root.matches === 'function' && root.matches(query)) nodes.push(root)
-  if (root && typeof root.querySelectorAll === 'function') {
-    root.querySelectorAll(query).forEach(el => nodes.push(el))
-  }
-  const seen = new Set()
-  nodes.forEach(el => {
-    if (!el || seen.has(el)) return
-    seen.add(el)
-    const existing = bootstrap.Tooltip.getInstance(el)
-    if (existing) existing.dispose()
-    bootstrap.Tooltip.getOrCreateInstance(el, Object.assign({ html: true, sanitize: false }, options || {}))
-  })
-}
-
-function disposeBootstrapTooltips (scope, selector) {
-  if (typeof bootstrap === 'undefined' || !bootstrap.Tooltip) return
-  const root = scope || document
-  const query = selector || '[data-bs-toggle="tooltip"]'
-  const nodes = []
-  if (root && typeof root.matches === 'function' && root.matches(query)) nodes.push(root)
-  if (root && typeof root.querySelectorAll === 'function') {
-    root.querySelectorAll(query).forEach(el => nodes.push(el))
-  }
-  const seen = new Set()
-  nodes.forEach(el => {
-    if (!el || seen.has(el)) return
-    seen.add(el)
-    const existing = bootstrap.Tooltip.getInstance(el)
-    if (existing) existing.dispose()
-  })
-}
 
 if (headerGridCollapse && headerGrid) {
   let gridLoaded = false
@@ -1187,20 +1155,6 @@ function setKometaPrepareRunningState (isRunning) {
     kometaActionsToggle.disabled = false
     kometaActionsToggle.classList.remove('disabled')
   }
-}
-
-function showCopyButtonSuccess (iconSelector, textSelector) {
-  const icon = document.querySelector(iconSelector)
-  const text = document.querySelector(textSelector)
-  if (!icon || !text) return
-  icon.classList.remove('bi-files', 'bi-clipboard')
-  icon.classList.add('bi-check2')
-  text.textContent = 'Copied'
-  setTimeout(() => {
-    icon.classList.remove('bi-check2')
-    icon.classList.add('bi-files')
-    text.textContent = 'Copy'
-  }, 1500)
 }
 
 document.getElementById('copy-command')?.addEventListener('click', function() {

--- a/static/local-js/modules/kometa/_ui.js
+++ b/static/local-js/modules/kometa/_ui.js
@@ -1,0 +1,164 @@
+// Small, generic UI helpers used across the Kometa page.
+//
+// This module holds functions that are:
+//   * Pure -- no shared mutable state, no cross-module coupling
+//   * Generic -- not specific to Kometa's data model, just DOM/UX
+//   * Small -- individually trivial, but centralized here so callers
+//     don't reinvent the wheel
+//
+// EXPORTS:
+//
+//   initBootstrapTooltips(scope, selector, options)
+//   disposeBootstrapTooltips(scope, selector)
+//     Bootstrap 5 tooltip lifecycle helpers. Both accept a scope
+//     (default: document) and a selector (default: [data-bs-toggle=
+//     "tooltip"]) and DTRT for a mix of scope-matches-selector and
+//     scope-contains-selector cases.
+//
+//   showCopyButtonSuccess(iconSelector, textSelector)
+//     Two-phase visual feedback for "copied to clipboard" buttons:
+//     swap the copy icon for a checkmark, change the label, then
+//     revert after 1.5s.
+//
+// The two tooltip helpers share the same DOM-traversal boilerplate
+// (find scope-matches or scope-contained-nodes, dedupe, iterate).
+// That shared logic lives in the private forEachTooltipTarget helper.
+
+// ---------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------
+
+/**
+ * Walk a scope + selector, calling `fn(el)` on each unique matching
+ * element. Handles the common "scope matches selector AND scope
+ * contains descendants matching selector" case cleanly.
+ *
+ * @param {Element | Document | null | undefined} scope
+ * @param {string} selector
+ * @param {(el: Element) => void} fn
+ */
+function forEachTooltipTarget (scope, selector, fn) {
+  const root = scope || document
+  const query = selector || '[data-bs-toggle="tooltip"]'
+  const seen = new Set()
+
+  if (root && typeof root.matches === 'function' && root.matches(query)) {
+    seen.add(root)
+    fn(root)
+  }
+  if (root && typeof root.querySelectorAll === 'function') {
+    root.querySelectorAll(query).forEach(el => {
+      if (!el || seen.has(el)) return
+      seen.add(el)
+      fn(el)
+    })
+  }
+}
+
+/**
+ * Returns the global Bootstrap.Tooltip class if it's present, or null
+ * if Bootstrap isn't loaded. Both public functions short-circuit on
+ * null, so pages that don't include Bootstrap don't blow up.
+ *
+ * Kept as a helper (rather than inlined) so the "is Bootstrap here?"
+ * check is stated in exactly one place.
+ *
+ * @returns {typeof bootstrap.Tooltip | null}
+ */
+function getBootstrapTooltipClass () {
+  if (typeof bootstrap === 'undefined' || !bootstrap.Tooltip) return null
+  return bootstrap.Tooltip
+}
+
+// ---------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------
+
+/**
+ * Initialize (or re-initialize) Bootstrap tooltips within a scope.
+ *
+ * If a tooltip instance already exists on an element, it's disposed
+ * first so option changes take effect. Every target ends up with a
+ * fresh Tooltip instance carrying the merged default + user options.
+ *
+ * Defaults:
+ *   html: true          allow HTML in the tooltip body
+ *   sanitize: false     don't strip HTML (we control the content)
+ *
+ * Callers can override either default via the options argument.
+ * Common overrides: `{ html: false, sanitize: true }` for user-
+ * generated content that needs escaping.
+ *
+ * No-op if Bootstrap isn't loaded on the page.
+ *
+ * @param {Element | Document} [scope=document]
+ * @param {string} [selector='[data-bs-toggle="tooltip"]']
+ * @param {object} [options]  Merged over the defaults above
+ */
+export function initBootstrapTooltips (scope, selector, options) {
+  const Tooltip = getBootstrapTooltipClass()
+  if (!Tooltip) return
+
+  const merged = Object.assign({ html: true, sanitize: false }, options || {})
+  forEachTooltipTarget(scope, selector, el => {
+    const existing = Tooltip.getInstance(el)
+    if (existing) existing.dispose()
+    Tooltip.getOrCreateInstance(el, merged)
+  })
+}
+
+/**
+ * Dispose Bootstrap tooltips within a scope. Useful before removing
+ * elements from the DOM to avoid leaked tooltip instances still
+ * holding references to detached nodes.
+ *
+ * No-op if Bootstrap isn't loaded, and per-element no-op if the
+ * element has no tooltip instance.
+ *
+ * @param {Element | Document} [scope=document]
+ * @param {string} [selector='[data-bs-toggle="tooltip"]']
+ */
+export function disposeBootstrapTooltips (scope, selector) {
+  const Tooltip = getBootstrapTooltipClass()
+  if (!Tooltip) return
+
+  forEachTooltipTarget(scope, selector, el => {
+    const existing = Tooltip.getInstance(el)
+    if (existing) existing.dispose()
+  })
+}
+
+/**
+ * Two-phase "Copied!" feedback on a copy-to-clipboard button:
+ *
+ *   Phase 1 (immediate): icon swaps to a checkmark, label becomes
+ *                        'Copied'.
+ *   Phase 2 (1.5s later): icon reverts to bi-files, label reverts
+ *                         to 'Copy'.
+ *
+ * Selector-driven so the same helper works for multiple copy
+ * buttons on the page (main run command, recovery command, etc.).
+ *
+ * No-op if either target selector matches nothing.
+ *
+ * @param {string} iconSelector  CSS selector for the icon <i>
+ * @param {string} textSelector  CSS selector for the label element
+ */
+export function showCopyButtonSuccess (iconSelector, textSelector) {
+  const icon = document.querySelector(iconSelector)
+  const text = document.querySelector(textSelector)
+  if (!icon || !text) return
+
+  // Some buttons use bi-files (multiple docs), others use bi-clipboard.
+  // Strip both to be safe; the revert step below only re-adds bi-files
+  // as that's the modal default. If a caller needs bi-clipboard
+  // preserved, they should manage that themselves after the timeout.
+  icon.classList.remove('bi-files', 'bi-clipboard')
+  icon.classList.add('bi-check2')
+  text.textContent = 'Copied'
+  setTimeout(() => {
+    icon.classList.remove('bi-check2')
+    icon.classList.add('bi-files')
+    text.textContent = 'Copy'
+  }, 1500)
+}

--- a/tests/js/kometa/ui.test.js
+++ b/tests/js/kometa/ui.test.js
@@ -1,0 +1,291 @@
+// Tests for static/local-js/modules/kometa/_ui.js
+//
+// The module exports three functions:
+//
+//   initBootstrapTooltips   -- creates/replaces Bootstrap tooltip
+//                              instances within a scope. Depends on
+//                              window.bootstrap.Tooltip.
+//   disposeBootstrapTooltips -- disposes existing tooltip instances.
+//   showCopyButtonSuccess    -- two-phase icon/text animation.
+//
+// The tooltip helpers are tested by stubbing a fake window.bootstrap
+// object (Vitest's jsdom doesn't ship Bootstrap). The stub tracks
+// getInstance / getOrCreateInstance / dispose calls so we can prove
+// the right lifecycle happened.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  initBootstrapTooltips,
+  disposeBootstrapTooltips,
+  showCopyButtonSuccess
+} from '../../../static/local-js/modules/kometa/_ui.js'
+
+// ---------------------------------------------------------------------
+// Bootstrap.Tooltip stub
+// ---------------------------------------------------------------------
+//
+// A minimal fake tracking:
+//   - which elements have "instances"
+//   - dispose / create call counts per element
+// so tests can assert on the sequence.
+
+class FakeTooltip {
+  constructor (el, opts) {
+    this.el = el
+    this.opts = opts
+    this.disposed = false
+    FakeTooltip._instances.set(el, this)
+    FakeTooltip.createCalls.push({ el, opts })
+  }
+
+  dispose () {
+    this.disposed = true
+    FakeTooltip._instances.delete(this.el)
+    FakeTooltip.disposeCalls.push(this.el)
+  }
+
+  static getInstance (el) {
+    return FakeTooltip._instances.get(el) || null
+  }
+
+  static getOrCreateInstance (el, opts) {
+    const existing = FakeTooltip._instances.get(el)
+    if (existing) return existing
+    return new FakeTooltip(el, opts)
+  }
+
+  static reset () {
+    FakeTooltip._instances = new Map()
+    FakeTooltip.createCalls = []
+    FakeTooltip.disposeCalls = []
+  }
+}
+FakeTooltip.reset()
+
+function installFakeBootstrap () {
+  FakeTooltip.reset()
+  globalThis.bootstrap = { Tooltip: FakeTooltip }
+}
+
+function removeBootstrap () {
+  delete globalThis.bootstrap
+}
+
+// ---------------------------------------------------------------------
+// initBootstrapTooltips
+// ---------------------------------------------------------------------
+
+describe('initBootstrapTooltips', () => {
+  beforeEach(() => {
+    installFakeBootstrap()
+    document.body.innerHTML = `
+      <div id="scope">
+        <button data-bs-toggle="tooltip" id="a" title="A"></button>
+        <button data-bs-toggle="tooltip" id="b" title="B"></button>
+        <button id="not-a-tooltip"></button>
+      </div>
+    `
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    removeBootstrap()
+  })
+
+  it('is a no-op when Bootstrap is not loaded', () => {
+    removeBootstrap()
+    // Should NOT throw
+    expect(() => initBootstrapTooltips()).not.toThrow()
+    expect(FakeTooltip.createCalls).toHaveLength(0)
+  })
+
+  it('creates tooltip instances on all matching elements in scope', () => {
+    initBootstrapTooltips(document)
+    expect(FakeTooltip.createCalls).toHaveLength(2)
+    const ids = FakeTooltip.createCalls.map(c => c.el.id).sort()
+    expect(ids).toEqual(['a', 'b'])
+  })
+
+  it('applies the html:true / sanitize:false defaults', () => {
+    initBootstrapTooltips(document)
+    for (const call of FakeTooltip.createCalls) {
+      expect(call.opts.html).toBe(true)
+      expect(call.opts.sanitize).toBe(false)
+    }
+  })
+
+  it('allows callers to override defaults via options arg', () => {
+    initBootstrapTooltips(document, null, { html: false, sanitize: true, placement: 'top' })
+    for (const call of FakeTooltip.createCalls) {
+      expect(call.opts.html).toBe(false)
+      expect(call.opts.sanitize).toBe(true)
+      expect(call.opts.placement).toBe('top')
+    }
+  })
+
+  it('honors a custom selector', () => {
+    document.body.innerHTML = `
+      <button class="tt" id="a"></button>
+      <button class="tt" id="b"></button>
+      <button data-bs-toggle="tooltip" id="c"></button>
+    `
+    initBootstrapTooltips(document, '.tt')
+    expect(FakeTooltip.createCalls).toHaveLength(2)
+    expect(FakeTooltip.createCalls.map(c => c.el.id).sort()).toEqual(['a', 'b'])
+  })
+
+  it('disposes existing instance before creating a new one (re-init)', () => {
+    // First call creates
+    initBootstrapTooltips(document)
+    expect(FakeTooltip.createCalls).toHaveLength(2)
+    expect(FakeTooltip.disposeCalls).toHaveLength(0)
+
+    // Second call must dispose then recreate
+    initBootstrapTooltips(document)
+    expect(FakeTooltip.disposeCalls).toHaveLength(2)
+    expect(FakeTooltip.createCalls).toHaveLength(4)
+  })
+
+  it('when scope IS a matching element, tooltip applies to scope itself', () => {
+    const btn = document.getElementById('a')
+    initBootstrapTooltips(btn)
+    expect(FakeTooltip.createCalls).toHaveLength(1)
+    expect(FakeTooltip.createCalls[0].el).toBe(btn)
+  })
+
+  it('deduplicates: scope-matches-selector AND scope-contains-descendant', () => {
+    // Structure a matcher that would double-count without the seen-set
+    document.body.innerHTML = `
+      <div class="wrap" id="parent">
+        <div class="wrap" id="child"></div>
+      </div>
+    `
+    const parent = document.getElementById('parent')
+    initBootstrapTooltips(parent, '.wrap')
+    // parent matches, AND parent.querySelectorAll('.wrap') finds child.
+    // Both should be captured exactly once each.
+    expect(FakeTooltip.createCalls).toHaveLength(2)
+    const ids = FakeTooltip.createCalls.map(c => c.el.id).sort()
+    expect(ids).toEqual(['child', 'parent'])
+  })
+
+  it('is a no-op when scope has no matching elements', () => {
+    document.body.innerHTML = '<div></div>'
+    initBootstrapTooltips(document)
+    expect(FakeTooltip.createCalls).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------
+// disposeBootstrapTooltips
+// ---------------------------------------------------------------------
+
+describe('disposeBootstrapTooltips', () => {
+  beforeEach(() => {
+    installFakeBootstrap()
+    document.body.innerHTML = `
+      <button data-bs-toggle="tooltip" id="a"></button>
+      <button data-bs-toggle="tooltip" id="b"></button>
+    `
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    removeBootstrap()
+  })
+
+  it('is a no-op when Bootstrap is not loaded', () => {
+    removeBootstrap()
+    expect(() => disposeBootstrapTooltips()).not.toThrow()
+  })
+
+  it('disposes all instances within scope', () => {
+    initBootstrapTooltips(document)
+    expect(FakeTooltip.createCalls).toHaveLength(2)
+
+    disposeBootstrapTooltips(document)
+    expect(FakeTooltip.disposeCalls).toHaveLength(2)
+    // And the instances are gone
+    expect(FakeTooltip.getInstance(document.getElementById('a'))).toBeNull()
+    expect(FakeTooltip.getInstance(document.getElementById('b'))).toBeNull()
+  })
+
+  it('is a no-op on elements with no existing instance', () => {
+    // No init call -- so no instances exist yet
+    disposeBootstrapTooltips(document)
+    expect(FakeTooltip.disposeCalls).toHaveLength(0)
+  })
+
+  it('scoped: only disposes tooltips inside the given scope', () => {
+    initBootstrapTooltips(document)
+    const scope = document.getElementById('a')
+    disposeBootstrapTooltips(scope)
+    // Only a was disposed; b still exists
+    expect(FakeTooltip.disposeCalls).toHaveLength(1)
+    expect(FakeTooltip.disposeCalls[0].id).toBe('a')
+    expect(FakeTooltip.getInstance(document.getElementById('b'))).not.toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------
+// showCopyButtonSuccess
+// ---------------------------------------------------------------------
+
+describe('showCopyButtonSuccess', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    document.body.innerHTML = `
+      <button>
+        <i id="icon" class="bi bi-files"></i>
+        <span id="text">Copy</span>
+      </button>
+    `
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    document.body.innerHTML = ''
+  })
+
+  it('phase 1: swaps icon to check2 and text to "Copied"', () => {
+    showCopyButtonSuccess('#icon', '#text')
+    const icon = document.getElementById('icon')
+    const text = document.getElementById('text')
+    expect(icon.classList.contains('bi-check2')).toBe(true)
+    expect(icon.classList.contains('bi-files')).toBe(false)
+    expect(text.textContent).toBe('Copied')
+  })
+
+  it('phase 2: after 1.5s, icon reverts to bi-files and text to "Copy"', () => {
+    showCopyButtonSuccess('#icon', '#text')
+
+    vi.advanceTimersByTime(1499)
+    // Still in phase 1
+    expect(document.getElementById('text').textContent).toBe('Copied')
+
+    vi.advanceTimersByTime(1)
+    // Now phase 2
+    expect(document.getElementById('icon').classList.contains('bi-check2')).toBe(false)
+    expect(document.getElementById('icon').classList.contains('bi-files')).toBe(true)
+    expect(document.getElementById('text').textContent).toBe('Copy')
+  })
+
+  it('also strips bi-clipboard (some buttons use that icon)', () => {
+    document.getElementById('icon').className = 'bi bi-clipboard'
+    showCopyButtonSuccess('#icon', '#text')
+    expect(document.getElementById('icon').classList.contains('bi-clipboard')).toBe(false)
+    expect(document.getElementById('icon').classList.contains('bi-check2')).toBe(true)
+  })
+
+  it('is a no-op when the icon selector matches nothing', () => {
+    expect(() => showCopyButtonSuccess('#nope', '#text')).not.toThrow()
+    // Text was NOT changed
+    expect(document.getElementById('text').textContent).toBe('Copy')
+  })
+
+  it('is a no-op when the text selector matches nothing', () => {
+    expect(() => showCopyButtonSuccess('#icon', '#nope')).not.toThrow()
+    // Icon was NOT changed
+    expect(document.getElementById('icon').classList.contains('bi-check2')).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

Small, self-contained extraction of three generic UI helpers with a **DRY refactor** along the way. Bootstrap-agnostic (short-circuits when Bootstrap is not loaded).

`900-kometa.js`: 3071 → 3025 lines (**−46**).

## What moved

Extracted to `static/local-js/modules/kometa/_ui.js` (164 lines):

| Export | Role |
|---|---|
| `initBootstrapTooltips(scope, selector, options)` | Create/replace Bootstrap tooltip instances within a scope |
| `disposeBootstrapTooltips(scope, selector)` | Dispose existing tooltip instances within a scope |
| `showCopyButtonSuccess(iconSelector, textSelector)` | Two-phase copy-to-clipboard feedback animation |

## DRY refactor

The two tooltip helpers had ~15 lines of identical DOM-traversal boilerplate. Refactored into a private `forEachTooltipTarget(scope, selector, fn)` helper. Both public functions now read as ~5-line thin wrappers around it.

Also centralized the 'is Bootstrap available?' probe into a private `getBootstrapTooltipClass()` helper so the null-check lives in exactly one place.

**Zero behavior change** — exact same public API + return values.

## Design notes

1. **Tests use a `FakeTooltip` class** installed on `globalThis.bootstrap` that tracks `getInstance` / `getOrCreateInstance` / `dispose` calls. Vitest's jsdom doesn't ship Bootstrap, so we couldn't rely on the real implementation anyway. The fake mirrors just enough of the API surface to prove the lifecycle contract.

2. **`showCopyButtonSuccess` uses fake timers** to test the two-phase transition. `vi.advanceTimersByTime(1499)` confirms we're still in phase 1; advancing 1 more ms confirms phase 2 fires exactly at the 1500ms boundary.

3. **The 'dedup: scope-matches-selector AND scope-contains-descendant' test** guards against a subtle bug: if the scope element itself matches the selector AND has descendant matches, we could double-instantiate. The `Set` + guard is exactly what prevents it. Test verifies this edge case.

## Vitest coverage: 18 new tests

**`ui.test.js`**:
- **`initBootstrapTooltips`** (9): no-op without Bootstrap, creates on matching, defaults `html:true`/`sanitize:false`, overridable options, custom selector, re-init disposes+recreates, scope-matches-self path, dedup path, no-op when no matches
- **`disposeBootstrapTooltips`** (4): no-op without Bootstrap, disposes in scope, no-op on no-existing-instance, scoping honored
- **`showCopyButtonSuccess`** (5): phase 1 icon+text, phase 2 timing at exact 1500ms boundary, strips `bi-clipboard` variant, no-op when icon missing, no-op when text missing

## Verification

- **947/947 Vitest pass** (was 929 after #1567; +18 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- ESLint clean, Node syntax clean

## What's next

- `_kometaUpdate.js` — branch override + update job polling flow (biggest remaining single target, ~800 lines)
- `_kometaRuntime.js` — `validateKometaRoot` + `probeKometaRoot`
- `_logs.js` / `_logscan.js` — log-tail polling + logscan fetch/analysis