### PR TITLE
Split 900-kometa.js part 13: extract Kometa branch/version management

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -53,6 +53,17 @@ import {
   disposeBootstrapTooltips,
   showCopyButtonSuccess
 } from './modules/kometa/_ui.js'
+import {
+  getKometaBranchOverride,
+  getEffectiveKometaBranch,
+  getKometaVersionSourceUrlValue,
+  getKometaZipSourceUrlValue,
+  loadSavedKometaBranchOverride,
+  saveKometaBranchOverride,
+  syncKometaSourceStatus,
+  syncKometaBranchRollupBadge,
+  syncKometaBranchOverrideWarning
+} from './modules/kometa/_kometaBranch.js'
 
 // Thin wrapper: buildCommand needs updateRunNowState and
 // syncFinalAccordionRollups callbacks, but both are still owned by
@@ -86,7 +97,6 @@ let lastRunProgressPayload = null
 let logscanAnalyzeInFlight = false
 let runProgressInFlight = false
 let latestKometaStatusPayload = null
-const KOMETA_BRANCH_OVERRIDE_STORAGE_KEY = 'qs-kometa-branch-override'
 
 const runLog = document.getElementById('run-output-log')
 const tailNotice = document.getElementById('run-output-notice')
@@ -107,13 +117,7 @@ const logscanSections = document.getElementById('logscan-sections')
 const updateKometaBtn = document.getElementById('update-kometa-btn')
 const forceUpdateToggle = document.getElementById('force-kometa-update')
 const kometaBranchOverride = document.getElementById('kometa-branch-override')
-const kometaBranchSelection = document.getElementById('kometa-branch-selection')
-const kometaEffectiveBranch = document.getElementById('kometa-effective-branch')
 const kometaUpdatePhaseBadge = document.getElementById('kometa-update-phase-badge')
-const kometaLocalVersionStatusEl = document.getElementById('kometa-local-version-status')
-const kometaRemoteVersionStatusEl = document.getElementById('kometa-remote-version-status')
-const kometaVersionSourceUrl = document.getElementById('kometa-version-source-url')
-const kometaZipSourceUrl = document.getElementById('kometa-zip-source-url')
 const kometaMaintenancePageBadge = document.getElementById('kometa-maintenance-page-badge')
 const runStatusRow = document.getElementById('run-status-row')
 const runStatusTimer = document.getElementById('run-status-timer')
@@ -132,13 +136,8 @@ const finalContentWrapper = document.getElementById('final-content-wrapper')
 const kometaActionsHeading = document.getElementById('kometa-actions-heading')
 const kometaActionsCollapse = document.getElementById('kometa-actions-collapse')
 const kometaActionsToggle = document.getElementById('kometa-actions-toggle')
-const kometaBranchOverrideWarning = document.getElementById('kometa-branch-override-warning')
 const runCommandCollapse = document.getElementById('run-command-output-collapse')
 let headerStyleSubmitting = false
-let kometaLocalVersionStatus = 'Unknown'
-let kometaRemoteVersionStatus = ''
-let kometaRemoteVersionChecked = false
-let kometaRemoteVersionSkipped = false
 let kometaUpdatePhaseStatus = 'idle'
 
 function syncKometaMaintenancePageBadge (data) {
@@ -739,7 +738,7 @@ function checkKometaUpdate (forceRefresh = false) {
       kometaState.kometaUpdateAvailable = !!data.kometa_update_available
       if (Array.isArray(data.log)) data.log.forEach(line => appendKometaStatusLine(line))
       syncKometaSourceStatus({
-        localVersion: data.local_version || kometaLocalVersionStatus,
+        localVersion: data.local_version || kometaState.kometaLocalVersionStatus,
         remoteVersion: data.remote_version || '',
         checked: Boolean(data.update_check_completed),
         skipped: Boolean(data.kometa_update_check_skipped)
@@ -784,90 +783,6 @@ function syncKometaUpdateAttention () {
     kometaActionsToggle.classList.toggle('kometa-update-attention', needsAttention)
   }
   syncKometaRollupBadge()
-}
-
-function getKometaBranchOverride () {
-  if (!kometaBranchOverride) return ''
-  const raw = (kometaBranchOverride.value || '').toString().trim().toLowerCase()
-  return ['master', 'develop', 'nightly'].includes(raw) ? raw : ''
-}
-
-function getQuickstartBranch () {
-  return ((updateKometaBtn && updateKometaBtn.dataset.qsBranch) || 'master').toString().trim().toLowerCase()
-}
-
-function getAutoKometaBranch () {
-  return getQuickstartBranch() === 'master' ? 'master' : 'nightly'
-}
-
-function getEffectiveKometaBranch () {
-  return getKometaBranchOverride() || getAutoKometaBranch()
-}
-
-function getKometaVersionSourceUrlValue (branch) {
-  return `https://raw.githubusercontent.com/Kometa-Team/Kometa/${branch}/VERSION`
-}
-
-function getKometaZipSourceUrlValue (branch) {
-  return `https://codeload.github.com/kometa-team/Kometa/zip/refs/heads/${branch}`
-}
-
-function loadSavedKometaBranchOverride () {
-  if (!kometaBranchOverride) return
-  try {
-    const saved = window.localStorage.getItem(KOMETA_BRANCH_OVERRIDE_STORAGE_KEY) || ''
-    if (['master', 'develop', 'nightly'].includes(saved)) {
-      kometaBranchOverride.value = saved
-    } else {
-      kometaBranchOverride.value = ''
-    }
-  } catch {
-    kometaBranchOverride.value = ''
-  }
-}
-
-function saveKometaBranchOverride () {
-  try {
-    const value = getKometaBranchOverride()
-    if (value) window.localStorage.setItem(KOMETA_BRANCH_OVERRIDE_STORAGE_KEY, value)
-    else window.localStorage.removeItem(KOMETA_BRANCH_OVERRIDE_STORAGE_KEY)
-  } catch {}
-}
-
-function syncKometaSourceStatus (options = {}) {
-  if (Object.prototype.hasOwnProperty.call(options, 'localVersion')) {
-    kometaLocalVersionStatus = options.localVersion || 'Unknown'
-  }
-  if (Object.prototype.hasOwnProperty.call(options, 'remoteVersion')) {
-    kometaRemoteVersionStatus = options.remoteVersion || ''
-  }
-  if (Object.prototype.hasOwnProperty.call(options, 'checked')) {
-    kometaRemoteVersionChecked = Boolean(options.checked)
-  }
-  if (Object.prototype.hasOwnProperty.call(options, 'skipped')) {
-    kometaRemoteVersionSkipped = Boolean(options.skipped)
-  }
-
-  const selected = getKometaBranchOverride()
-  const effective = getEffectiveKometaBranch()
-  const selectionLabel = selected ? `Override (${selected})` : 'Auto'
-
-  if (kometaBranchSelection) kometaBranchSelection.textContent = selectionLabel
-  if (kometaEffectiveBranch) kometaEffectiveBranch.textContent = effective
-  if (kometaLocalVersionStatusEl) kometaLocalVersionStatusEl.textContent = kometaLocalVersionStatus || 'Unknown'
-  if (kometaRemoteVersionStatusEl) {
-    if (kometaRemoteVersionSkipped) {
-      kometaRemoteVersionStatusEl.textContent = 'Skipped while running'
-    } else if (kometaRemoteVersionChecked) {
-      kometaRemoteVersionStatusEl.textContent = kometaRemoteVersionStatus || 'Unknown'
-    } else {
-      kometaRemoteVersionStatusEl.textContent = 'Not checked'
-    }
-  }
-
-  if (kometaVersionSourceUrl) kometaVersionSourceUrl.textContent = getKometaVersionSourceUrlValue(effective)
-  if (kometaZipSourceUrl) kometaZipSourceUrl.textContent = getKometaZipSourceUrlValue(effective)
-  syncKometaBranchRollupBadge()
 }
 
 function setKometaUpdatePhaseBadge (phase) {
@@ -993,18 +908,13 @@ function appendKometaStatusLine (line) {
   updateKometaUpdatePhaseFromLine(line)
 }
 
-function syncKometaBranchOverrideWarning () {
-  if (!kometaBranchOverrideWarning) return
-  kometaBranchOverrideWarning.classList.toggle('d-none', !getKometaBranchOverride())
-}
-
 function invalidateKometaUpdateStatus () {
   kometaState.kometaUpdateAvailable = false
   kometaState.kometaUpdateCheckCompleted = false
   kometaState.kometaUpdateCheckSkipped = false
-  kometaRemoteVersionStatus = ''
-  kometaRemoteVersionChecked = false
-  kometaRemoteVersionSkipped = false
+  kometaState.kometaRemoteVersionStatus = ''
+  kometaState.kometaRemoteVersionChecked = false
+  kometaState.kometaRemoteVersionSkipped = false
   document.getElementById('kometa-update-box').classList.add('d-none')
   syncKometaSourceStatus()
   syncUpdateButtonLabel()
@@ -1111,25 +1021,6 @@ function syncKometaRollupBadge () {
     'qs-validation-rollup-badge--error'
   )
   badge.classList.add(`qs-validation-rollup-badge--${state}`)
-}
-
-function syncKometaBranchRollupBadge () {
-  const badge = document.getElementById('kometa-branch-rollup-badge')
-  if (!badge) return
-
-  const selected = getKometaBranchOverride()
-  const effective = getEffectiveKometaBranch()
-  const label = (selected || 'auto').toUpperCase()
-
-  badge.textContent = label
-  badge.classList.remove('text-bg-secondary', 'text-bg-warning', 'text-dark')
-  if (selected) {
-    badge.classList.add('text-bg-warning', 'text-dark')
-    badge.setAttribute('title', `Kometa branch override selected: ${selected}. Effective branch: ${effective}.`)
-  } else {
-    badge.classList.add('text-bg-secondary')
-    badge.setAttribute('title', `Kometa branch mode: auto. Effective branch: ${effective}.`)
-  }
 }
 
 if (kometaActionsCollapse) {

--- a/static/local-js/modules/kometa/_kometaBranch.js
+++ b/static/local-js/modules/kometa/_kometaBranch.js
@@ -1,0 +1,282 @@
+// Kometa branch/version management.
+//
+// Kometa can be tracked on one of three upstream branches:
+//
+//   master   -- stable releases
+//   develop  -- pre-release / testing
+//   nightly  -- daily builds against develop
+//
+// By default we pick a branch based on Quickstart's OWN branch:
+//
+//   Quickstart on master   -> Kometa on master  ('stable follows stable')
+//   Quickstart on anything -> Kometa on nightly ('bleeding-edge follows
+//                                                bleeding-edge')
+//
+// The user can override that mapping via the #kometa-branch-override
+// <select>. The override persists in localStorage across page loads.
+//
+// This module owns the whole story: reading the override, resolving
+// the effective branch, computing the remote source URLs, persisting
+// choices, and rendering the associated UI (source status panel,
+// rollup badge, warning banner).
+//
+// EXPORTS:
+//
+//   getKometaBranchOverride()   -- current override selection
+//                                    ('' means 'auto')
+//   getQuickstartBranch()       -- our own branch, from a data-attr
+//   getAutoKometaBranch()       -- what auto-mode resolves to
+//   getEffectiveKometaBranch()  -- override || auto
+//   getKometaVersionSourceUrlValue(branch)
+//                               -- raw.githubusercontent URL for VERSION
+//   getKometaZipSourceUrlValue(branch)
+//                               -- codeload.github ZIP URL
+//   loadSavedKometaBranchOverride()
+//                               -- restore from localStorage on boot
+//   saveKometaBranchOverride()  -- persist current selection
+//   syncKometaSourceStatus(options)
+//                               -- update kometaState + repaint the
+//                                    source-status panel
+//   syncKometaBranchRollupBadge()
+//                               -- update the rollup badge
+//   syncKometaBranchOverrideWarning()
+//                               -- show/hide the 'override active'
+//                                    banner
+//
+// All DOM lookups are lazy (per-call). Zero cross-module callbacks;
+// everything the module needs is either in kometaState or the DOM.
+
+import { kometaState } from './_state.js'
+
+// ---------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------
+
+/**
+ * localStorage key for the branch override selection. Keep in sync
+ * with any place a user might clear their local Kometa state.
+ */
+export const KOMETA_BRANCH_OVERRIDE_STORAGE_KEY = 'qs-kometa-branch-override'
+
+/**
+ * Valid branch names the override <select> accepts. Anything else in
+ * localStorage or the <select>.value gets coerced to '' (auto).
+ */
+const VALID_BRANCHES = ['master', 'develop', 'nightly']
+
+// ---------------------------------------------------------------------
+// Branch resolution
+// ---------------------------------------------------------------------
+
+/**
+ * Current value of the branch-override <select>, normalized to one of
+ * 'master' | 'develop' | 'nightly' or '' (meaning 'let auto decide').
+ *
+ * @returns {'' | 'master' | 'develop' | 'nightly'}
+ */
+export function getKometaBranchOverride () {
+  const el = document.getElementById('kometa-branch-override')
+  if (!el) return ''
+  const raw = (el.value || '').toString().trim().toLowerCase()
+  return VALID_BRANCHES.includes(raw) ? raw : ''
+}
+
+/**
+ * Quickstart's OWN branch, read from the update button's data-attr.
+ * Defaults to 'master' if the attr is missing.
+ *
+ * @returns {string}
+ */
+export function getQuickstartBranch () {
+  const btn = document.getElementById('update-kometa-btn')
+  return ((btn && btn.dataset.qsBranch) || 'master').toString().trim().toLowerCase()
+}
+
+/**
+ * What auto-mode resolves to right now: 'master' iff Quickstart itself
+ * is on master, otherwise 'nightly'. (There's no 'develop' auto-mode
+ * -- develop is override-only.)
+ *
+ * @returns {'master' | 'nightly'}
+ */
+export function getAutoKometaBranch () {
+  return getQuickstartBranch() === 'master' ? 'master' : 'nightly'
+}
+
+/**
+ * The branch actually being used right now: the override if set,
+ * else the auto-resolved value.
+ *
+ * @returns {'master' | 'develop' | 'nightly'}
+ */
+export function getEffectiveKometaBranch () {
+  return getKometaBranchOverride() || getAutoKometaBranch()
+}
+
+// ---------------------------------------------------------------------
+// Remote source URLs
+// ---------------------------------------------------------------------
+
+/**
+ * raw.githubusercontent URL for the VERSION file on the given branch.
+ * @param {string} branch
+ * @returns {string}
+ */
+export function getKometaVersionSourceUrlValue (branch) {
+  return `https://raw.githubusercontent.com/Kometa-Team/Kometa/${branch}/VERSION`
+}
+
+/**
+ * codeload.github ZIP URL for the given branch. Used by the update
+ * download step.
+ * @param {string} branch
+ * @returns {string}
+ */
+export function getKometaZipSourceUrlValue (branch) {
+  return `https://codeload.github.com/kometa-team/Kometa/zip/refs/heads/${branch}`
+}
+
+// ---------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------
+
+/**
+ * Restore the branch override from localStorage on page load. If the
+ * stored value isn't a valid branch (or localStorage throws for any
+ * reason), coerce to '' (auto).
+ */
+export function loadSavedKometaBranchOverride () {
+  const el = document.getElementById('kometa-branch-override')
+  if (!el) return
+  try {
+    const saved = window.localStorage.getItem(KOMETA_BRANCH_OVERRIDE_STORAGE_KEY) || ''
+    el.value = VALID_BRANCHES.includes(saved) ? saved : ''
+  } catch {
+    el.value = ''
+  }
+}
+
+/**
+ * Persist the current branch override. Empty value ('' = auto) is
+ * stored as a removal so we don't leak stale keys.
+ *
+ * Wrapped in try/catch because localStorage can throw in private
+ * browsing / quota-exceeded scenarios; we're OK silently failing --
+ * the setting reverts to auto on next load.
+ */
+export function saveKometaBranchOverride () {
+  try {
+    const value = getKometaBranchOverride()
+    if (value) window.localStorage.setItem(KOMETA_BRANCH_OVERRIDE_STORAGE_KEY, value)
+    else window.localStorage.removeItem(KOMETA_BRANCH_OVERRIDE_STORAGE_KEY)
+  } catch {
+    // Ignore quota / private-browsing errors.
+  }
+}
+
+// ---------------------------------------------------------------------
+// UI sync
+// ---------------------------------------------------------------------
+
+/**
+ * Update the source-status panel (branch selection, effective branch,
+ * local/remote version, source URLs). Accepts a partial options bag
+ * so callers can update just the fields they know about.
+ *
+ * Options (all optional; unset fields keep their prior kometaState
+ * value):
+ *   localVersion   string -- writes to kometaLocalVersionStatus
+ *   remoteVersion  string -- writes to kometaRemoteVersionStatus
+ *   checked        bool   -- writes to kometaRemoteVersionChecked
+ *   skipped        bool   -- writes to kometaRemoteVersionSkipped
+ *
+ * Uses hasOwnProperty (not truthy checks) so a caller passing
+ * `{ localVersion: '' }` explicitly clears the field rather than
+ * being ignored.
+ *
+ * @param {{
+ *   localVersion?: string,
+ *   remoteVersion?: string,
+ *   checked?: boolean,
+ *   skipped?: boolean
+ * }} [options]
+ */
+export function syncKometaSourceStatus (options = {}) {
+  if (Object.prototype.hasOwnProperty.call(options, 'localVersion')) {
+    kometaState.kometaLocalVersionStatus = options.localVersion || 'Unknown'
+  }
+  if (Object.prototype.hasOwnProperty.call(options, 'remoteVersion')) {
+    kometaState.kometaRemoteVersionStatus = options.remoteVersion || ''
+  }
+  if (Object.prototype.hasOwnProperty.call(options, 'checked')) {
+    kometaState.kometaRemoteVersionChecked = Boolean(options.checked)
+  }
+  if (Object.prototype.hasOwnProperty.call(options, 'skipped')) {
+    kometaState.kometaRemoteVersionSkipped = Boolean(options.skipped)
+  }
+
+  const selected = getKometaBranchOverride()
+  const effective = getEffectiveKometaBranch()
+  const selectionLabel = selected ? `Override (${selected})` : 'Auto'
+
+  const branchSelection = document.getElementById('kometa-branch-selection')
+  const effectiveBranch = document.getElementById('kometa-effective-branch')
+  const localVersionEl = document.getElementById('kometa-local-version-status')
+  const remoteVersionEl = document.getElementById('kometa-remote-version-status')
+  const versionSourceUrl = document.getElementById('kometa-version-source-url')
+  const zipSourceUrl = document.getElementById('kometa-zip-source-url')
+
+  if (branchSelection) branchSelection.textContent = selectionLabel
+  if (effectiveBranch) effectiveBranch.textContent = effective
+  if (localVersionEl) localVersionEl.textContent = kometaState.kometaLocalVersionStatus || 'Unknown'
+
+  if (remoteVersionEl) {
+    if (kometaState.kometaRemoteVersionSkipped) {
+      remoteVersionEl.textContent = 'Skipped while running'
+    } else if (kometaState.kometaRemoteVersionChecked) {
+      remoteVersionEl.textContent = kometaState.kometaRemoteVersionStatus || 'Unknown'
+    } else {
+      remoteVersionEl.textContent = 'Not checked'
+    }
+  }
+
+  if (versionSourceUrl) versionSourceUrl.textContent = getKometaVersionSourceUrlValue(effective)
+  if (zipSourceUrl) zipSourceUrl.textContent = getKometaZipSourceUrlValue(effective)
+
+  syncKometaBranchRollupBadge()
+}
+
+/**
+ * Update the rollup badge next to the branch selector. Shows the
+ * uppercase branch name (or 'AUTO'), and paints it warning-yellow
+ * when an override is active vs. secondary-gray for auto.
+ */
+export function syncKometaBranchRollupBadge () {
+  const badge = document.getElementById('kometa-branch-rollup-badge')
+  if (!badge) return
+
+  const selected = getKometaBranchOverride()
+  const effective = getEffectiveKometaBranch()
+  const label = (selected || 'auto').toUpperCase()
+
+  badge.textContent = label
+  badge.classList.remove('text-bg-secondary', 'text-bg-warning', 'text-dark')
+  if (selected) {
+    badge.classList.add('text-bg-warning', 'text-dark')
+    badge.setAttribute('title', `Kometa branch override selected: ${selected}. Effective branch: ${effective}.`)
+  } else {
+    badge.classList.add('text-bg-secondary')
+    badge.setAttribute('title', `Kometa branch mode: auto. Effective branch: ${effective}.`)
+  }
+}
+
+/**
+ * Show/hide the 'branch override active' warning banner. When an
+ * override is set, we surface a visible reminder that the user is
+ * off the auto path.
+ */
+export function syncKometaBranchOverrideWarning () {
+  const warning = document.getElementById('kometa-branch-override-warning')
+  if (!warning) return
+  warning.classList.toggle('d-none', !getKometaBranchOverride())
+}

--- a/static/local-js/modules/kometa/_state.js
+++ b/static/local-js/modules/kometa/_state.js
@@ -168,5 +168,35 @@ export const kometaState = {
   // Written by the polling loop in 900-kometa.js after every
   // successful fetchLogscan(). Read by updateLogscanHeaderBadge (in
   // _headerBadges.js) when it's called without an explicit data arg.
-  lastLogscanPayload: null
+  lastLogscanPayload: null,
+
+  // ---- Kometa branch + version-check status ------------------------
+  //
+  // Written by syncKometaSourceStatus (in _kometaBranch.js) whenever
+  // checkKometaUpdate returns new data. Read by that same function
+  // on subsequent calls (so it can preserve unchanged fields) and by
+  // runKometaStatusPass (in 900-kometa.js) for the status-log lines.
+  //
+  //   kometaLocalVersionStatus     -- 'Unknown' | 'v1.2.3' | ...
+  //                                    string reflecting what the
+  //                                    local checkout reports
+  //   kometaRemoteVersionStatus    -- '' if not-yet-checked, else
+  //                                    'v1.2.4' | 'Unavailable' | ...
+  //   kometaRemoteVersionChecked   -- true iff we've actually fetched
+  //                                    the remote VERSION file this
+  //                                    session (as opposed to just
+  //                                    reading a stale cached value)
+  //   kometaRemoteVersionSkipped   -- true if the remote check was
+  //                                    intentionally skipped (e.g.
+  //                                    because Kometa is running --
+  //                                    we don't want to inflate load)
+  //
+  // The '' vs null vs 'Unknown' distinctions matter for the display
+  // logic in syncKometaSourceStatus: '' -> 'Not checked', 'Unknown'
+  // -> literal 'Unknown' text (server returned no version), non-empty
+  // string -> show it verbatim.
+  kometaLocalVersionStatus: 'Unknown',
+  kometaRemoteVersionStatus: '',
+  kometaRemoteVersionChecked: false,
+  kometaRemoteVersionSkipped: false
 }

--- a/tests/js/kometa/kometaBranch.test.js
+++ b/tests/js/kometa/kometaBranch.test.js
@@ -1,0 +1,457 @@
+// Tests for static/local-js/modules/kometa/_kometaBranch.js
+//
+// Coverage strategy per exported function:
+//
+//   getKometaBranchOverride      -- <select> read, valid/invalid values
+//   getQuickstartBranch          -- data-qs-branch attribute read
+//   getAutoKometaBranch          -- resolves through getQuickstartBranch
+//   getEffectiveKometaBranch     -- override wins over auto
+//   getKometaVersionSourceUrlValue / getKometaZipSourceUrlValue
+//                                -- URL building, pure
+//   loadSavedKometaBranchOverride -- localStorage read + validation
+//   saveKometaBranchOverride     -- localStorage write / remove
+//   syncKometaSourceStatus       -- kometaState writes + DOM updates
+//   syncKometaBranchRollupBadge  -- badge text + class swap
+//   syncKometaBranchOverrideWarning -- visibility toggle
+//
+// localStorage is stubbed via a fresh in-memory Map so tests don't
+// pollute the real one and don't depend on jsdom's mock semantics.
+// We swap window.localStorage wholesale with a fake object that
+// mirrors the getItem / setItem / removeItem surface backed by a Map,
+// then restore the original after each test.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { kometaState } from '../../../static/local-js/modules/kometa/_state.js'
+import {
+  getKometaBranchOverride,
+  getQuickstartBranch,
+  getAutoKometaBranch,
+  getEffectiveKometaBranch,
+  getKometaVersionSourceUrlValue,
+  getKometaZipSourceUrlValue,
+  loadSavedKometaBranchOverride,
+  saveKometaBranchOverride,
+  syncKometaSourceStatus,
+  syncKometaBranchRollupBadge,
+  syncKometaBranchOverrideWarning,
+  KOMETA_BRANCH_OVERRIDE_STORAGE_KEY
+} from '../../../static/local-js/modules/kometa/_kometaBranch.js'
+
+// ---------------------------------------------------------------------
+// Fake localStorage
+// ---------------------------------------------------------------------
+
+let storage
+let originalLocalStorage
+
+/**
+ * Build a fresh Map-backed fake localStorage and swap it in.
+ * Optionally the getItem/setItem/removeItem functions can throw --
+ * useful for testing the private-browsing / quota-exceeded paths.
+ */
+function installFakeLocalStorage ({ throwOnGet = false, throwOnSet = false } = {}) {
+  storage = new Map()
+  originalLocalStorage = window.localStorage
+  const fake = {
+    getItem: (k) => {
+      if (throwOnGet) throw new Error('quota exceeded')
+      return storage.get(k) ?? null
+    },
+    setItem: (k, v) => {
+      if (throwOnSet) throw new Error('quota exceeded')
+      storage.set(k, String(v))
+    },
+    removeItem: (k) => { storage.delete(k) },
+    clear: () => storage.clear(),
+    key: (i) => Array.from(storage.keys())[i] || null,
+    get length () { return storage.size }
+  }
+  Object.defineProperty(window, 'localStorage', {
+    value: fake,
+    writable: true,
+    configurable: true
+  })
+}
+
+function restoreLocalStorage () {
+  if (originalLocalStorage) {
+    Object.defineProperty(window, 'localStorage', {
+      value: originalLocalStorage,
+      writable: true,
+      configurable: true
+    })
+  }
+}
+
+// ---------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------
+
+function installBranchDom (opts = {}) {
+  const { qsBranch = 'master', overrideValue = '' } = opts
+  document.body.innerHTML = `
+    <button id="update-kometa-btn" data-qs-branch="${qsBranch}"></button>
+    <select id="kometa-branch-override">
+      <option value=""></option>
+      <option value="master">master</option>
+      <option value="develop">develop</option>
+      <option value="nightly">nightly</option>
+    </select>
+    <span id="kometa-branch-selection"></span>
+    <span id="kometa-effective-branch"></span>
+    <span id="kometa-local-version-status"></span>
+    <span id="kometa-remote-version-status"></span>
+    <span id="kometa-version-source-url"></span>
+    <span id="kometa-zip-source-url"></span>
+    <span id="kometa-branch-rollup-badge"></span>
+    <div id="kometa-branch-override-warning" class="d-none"></div>
+  `
+  const sel = document.getElementById('kometa-branch-override')
+  sel.value = overrideValue
+}
+
+beforeEach(() => {
+  installFakeLocalStorage()
+})
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  restoreLocalStorage()
+  vi.restoreAllMocks()
+  // Reset state fields this module writes to
+  kometaState.kometaLocalVersionStatus = 'Unknown'
+  kometaState.kometaRemoteVersionStatus = ''
+  kometaState.kometaRemoteVersionChecked = false
+  kometaState.kometaRemoteVersionSkipped = false
+})
+
+// ---------------------------------------------------------------------
+// getKometaBranchOverride
+// ---------------------------------------------------------------------
+
+describe('getKometaBranchOverride', () => {
+  it("returns '' when the <select> element is missing", () => {
+    document.body.innerHTML = ''
+    expect(getKometaBranchOverride()).toBe('')
+  })
+
+  it("returns '' when the select's value is empty", () => {
+    installBranchDom({ overrideValue: '' })
+    expect(getKometaBranchOverride()).toBe('')
+  })
+
+  it('accepts the three valid branch names', () => {
+    for (const branch of ['master', 'develop', 'nightly']) {
+      installBranchDom({ overrideValue: branch })
+      expect(getKometaBranchOverride()).toBe(branch)
+    }
+  })
+
+  it('normalizes case and whitespace', () => {
+    installBranchDom({ overrideValue: '' })
+    document.getElementById('kometa-branch-override').value = '  MASTER  '
+    // .value setter through the option list clamps to '' for unknown
+    // values, so we set it via a raw <option> match instead:
+    const sel = document.getElementById('kometa-branch-override')
+    const opt = document.createElement('option')
+    opt.value = '  MASTER  '
+    sel.appendChild(opt)
+    sel.value = '  MASTER  '
+    expect(getKometaBranchOverride()).toBe('master')
+  })
+
+  it("returns '' for unknown / garbage values", () => {
+    installBranchDom({ overrideValue: '' })
+    const sel = document.getElementById('kometa-branch-override')
+    const opt = document.createElement('option')
+    opt.value = 'trunk'
+    sel.appendChild(opt)
+    sel.value = 'trunk'
+    expect(getKometaBranchOverride()).toBe('')
+  })
+})
+
+// ---------------------------------------------------------------------
+// getQuickstartBranch
+// ---------------------------------------------------------------------
+
+describe('getQuickstartBranch', () => {
+  it("defaults to 'master' when the button is missing", () => {
+    document.body.innerHTML = ''
+    expect(getQuickstartBranch()).toBe('master')
+  })
+
+  it('reads data-qs-branch attribute and normalizes case', () => {
+    installBranchDom({ qsBranch: 'DEVELOP' })
+    expect(getQuickstartBranch()).toBe('develop')
+  })
+
+  it("defaults to 'master' when the attribute is empty", () => {
+    installBranchDom({ qsBranch: '' })
+    expect(getQuickstartBranch()).toBe('master')
+  })
+})
+
+// ---------------------------------------------------------------------
+// getAutoKometaBranch + getEffectiveKometaBranch
+// ---------------------------------------------------------------------
+
+describe('getAutoKometaBranch', () => {
+  it("returns 'master' when Quickstart is on master", () => {
+    installBranchDom({ qsBranch: 'master' })
+    expect(getAutoKometaBranch()).toBe('master')
+  })
+
+  it("returns 'nightly' when Quickstart is on anything else", () => {
+    installBranchDom({ qsBranch: 'develop' })
+    expect(getAutoKometaBranch()).toBe('nightly')
+    installBranchDom({ qsBranch: 'feature/xyz' })
+    expect(getAutoKometaBranch()).toBe('nightly')
+  })
+})
+
+describe('getEffectiveKometaBranch', () => {
+  it('returns the override when set', () => {
+    installBranchDom({ qsBranch: 'master', overrideValue: 'develop' })
+    expect(getEffectiveKometaBranch()).toBe('develop')
+  })
+
+  it('falls back to the auto-resolved branch when no override', () => {
+    installBranchDom({ qsBranch: 'master', overrideValue: '' })
+    expect(getEffectiveKometaBranch()).toBe('master')
+    installBranchDom({ qsBranch: 'develop', overrideValue: '' })
+    expect(getEffectiveKometaBranch()).toBe('nightly')
+  })
+
+  it('override wins over auto even when auto would agree', () => {
+    // Not a behavior difference, but proves the override is the sole
+    // source of truth when set.
+    installBranchDom({ qsBranch: 'master', overrideValue: 'master' })
+    expect(getEffectiveKometaBranch()).toBe('master')
+  })
+})
+
+// ---------------------------------------------------------------------
+// URL builders (pure)
+// ---------------------------------------------------------------------
+
+describe('getKometaVersionSourceUrlValue', () => {
+  it('builds the raw.githubusercontent URL for the given branch', () => {
+    expect(getKometaVersionSourceUrlValue('master')).toBe(
+      'https://raw.githubusercontent.com/Kometa-Team/Kometa/master/VERSION'
+    )
+    expect(getKometaVersionSourceUrlValue('develop')).toBe(
+      'https://raw.githubusercontent.com/Kometa-Team/Kometa/develop/VERSION'
+    )
+  })
+})
+
+describe('getKometaZipSourceUrlValue', () => {
+  it('builds the codeload ZIP URL for the given branch', () => {
+    expect(getKometaZipSourceUrlValue('nightly')).toBe(
+      'https://codeload.github.com/kometa-team/Kometa/zip/refs/heads/nightly'
+    )
+  })
+})
+
+// ---------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------
+
+describe('loadSavedKometaBranchOverride', () => {
+  it('restores a valid branch from localStorage', () => {
+    installBranchDom({ overrideValue: '' })
+    storage.set(KOMETA_BRANCH_OVERRIDE_STORAGE_KEY, 'develop')
+    loadSavedKometaBranchOverride()
+    expect(document.getElementById('kometa-branch-override').value).toBe('develop')
+  })
+
+  it('coerces an invalid stored value to empty (auto)', () => {
+    installBranchDom({ overrideValue: 'develop' })
+    storage.set(KOMETA_BRANCH_OVERRIDE_STORAGE_KEY, 'trunk-xyz')
+    loadSavedKometaBranchOverride()
+    expect(document.getElementById('kometa-branch-override').value).toBe('')
+  })
+
+  it('is a no-op when the <select> is missing', () => {
+    document.body.innerHTML = ''
+    expect(() => loadSavedKometaBranchOverride()).not.toThrow()
+  })
+
+  it('handles localStorage throwing (private browsing / quota)', () => {
+    installBranchDom({ overrideValue: 'develop' })
+    installFakeLocalStorage({ throwOnGet: true })  // re-swap with throwing fake
+    loadSavedKometaBranchOverride()
+    // Should coerce to '' rather than crash
+    expect(document.getElementById('kometa-branch-override').value).toBe('')
+  })
+})
+
+describe('saveKometaBranchOverride', () => {
+  it('writes a valid selection to localStorage', () => {
+    installBranchDom({ overrideValue: 'nightly' })
+    saveKometaBranchOverride()
+    expect(storage.get(KOMETA_BRANCH_OVERRIDE_STORAGE_KEY)).toBe('nightly')
+  })
+
+  it('removes the key when the selection is empty (auto)', () => {
+    installBranchDom({ overrideValue: '' })
+    storage.set(KOMETA_BRANCH_OVERRIDE_STORAGE_KEY, 'stale-value')
+    saveKometaBranchOverride()
+    expect(storage.has(KOMETA_BRANCH_OVERRIDE_STORAGE_KEY)).toBe(false)
+  })
+
+  it('silently ignores localStorage errors', () => {
+    installBranchDom({ overrideValue: 'master' })
+    installFakeLocalStorage({ throwOnSet: true })  // re-swap with throwing fake
+    expect(() => saveKometaBranchOverride()).not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------
+// syncKometaSourceStatus
+// ---------------------------------------------------------------------
+
+describe('syncKometaSourceStatus', () => {
+  it("writes options fields to kometaState (skipping unset ones)", () => {
+    installBranchDom()
+    syncKometaSourceStatus({ localVersion: 'v1.2.3' })
+    expect(kometaState.kometaLocalVersionStatus).toBe('v1.2.3')
+    // Others unchanged
+    expect(kometaState.kometaRemoteVersionStatus).toBe('')
+    expect(kometaState.kometaRemoteVersionChecked).toBe(false)
+    expect(kometaState.kometaRemoteVersionSkipped).toBe(false)
+  })
+
+  it('uses hasOwnProperty check (empty-string option clears field)', () => {
+    installBranchDom()
+    kometaState.kometaLocalVersionStatus = 'v1.2.3'  // pre-set
+    // Explicit '' should reset to 'Unknown' via the `|| 'Unknown'`
+    syncKometaSourceStatus({ localVersion: '' })
+    expect(kometaState.kometaLocalVersionStatus).toBe('Unknown')
+  })
+
+  it("renders selection label 'Auto' when no override", () => {
+    installBranchDom({ overrideValue: '' })
+    syncKometaSourceStatus()
+    expect(document.getElementById('kometa-branch-selection').textContent).toBe('Auto')
+  })
+
+  it("renders selection label 'Override (nightly)' when override set", () => {
+    installBranchDom({ overrideValue: 'nightly' })
+    syncKometaSourceStatus()
+    expect(document.getElementById('kometa-branch-selection').textContent).toBe('Override (nightly)')
+  })
+
+  it("renders effective branch computed from override", () => {
+    installBranchDom({ qsBranch: 'master', overrideValue: 'develop' })
+    syncKometaSourceStatus()
+    expect(document.getElementById('kometa-effective-branch').textContent).toBe('develop')
+  })
+
+  it("shows 'Not checked' remote status when checked=false and not skipped", () => {
+    installBranchDom()
+    syncKometaSourceStatus({ remoteVersion: 'v1.2.4', checked: false })
+    expect(document.getElementById('kometa-remote-version-status').textContent).toBe('Not checked')
+  })
+
+  it("shows 'Skipped while running' remote status when skipped=true", () => {
+    installBranchDom()
+    syncKometaSourceStatus({ remoteVersion: 'v1.2.4', checked: true, skipped: true })
+    expect(document.getElementById('kometa-remote-version-status').textContent).toBe('Skipped while running')
+  })
+
+  it("shows the remote version verbatim when checked=true", () => {
+    installBranchDom()
+    syncKometaSourceStatus({ remoteVersion: 'v1.2.4', checked: true, skipped: false })
+    expect(document.getElementById('kometa-remote-version-status').textContent).toBe('v1.2.4')
+  })
+
+  it("writes the effective-branch VERSION and ZIP URLs", () => {
+    installBranchDom({ qsBranch: 'master', overrideValue: 'develop' })
+    syncKometaSourceStatus()
+    expect(document.getElementById('kometa-version-source-url').textContent).toContain('/develop/VERSION')
+    expect(document.getElementById('kometa-zip-source-url').textContent).toContain('/heads/develop')
+  })
+
+  it('also refreshes the branch rollup badge (side effect)', () => {
+    installBranchDom({ qsBranch: 'master', overrideValue: 'nightly' })
+    syncKometaSourceStatus()
+    const badge = document.getElementById('kometa-branch-rollup-badge')
+    expect(badge.textContent).toBe('NIGHTLY')
+    expect(badge.classList.contains('text-bg-warning')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// syncKometaBranchRollupBadge
+// ---------------------------------------------------------------------
+
+describe('syncKometaBranchRollupBadge', () => {
+  it("shows 'AUTO' with secondary style when no override", () => {
+    installBranchDom({ overrideValue: '' })
+    syncKometaBranchRollupBadge()
+    const badge = document.getElementById('kometa-branch-rollup-badge')
+    expect(badge.textContent).toBe('AUTO')
+    expect(badge.classList.contains('text-bg-secondary')).toBe(true)
+    expect(badge.classList.contains('text-bg-warning')).toBe(false)
+  })
+
+  it("shows uppercase override name with warning style when set", () => {
+    installBranchDom({ overrideValue: 'develop' })
+    syncKometaBranchRollupBadge()
+    const badge = document.getElementById('kometa-branch-rollup-badge')
+    expect(badge.textContent).toBe('DEVELOP')
+    expect(badge.classList.contains('text-bg-warning')).toBe(true)
+    expect(badge.classList.contains('text-dark')).toBe(true)
+    expect(badge.classList.contains('text-bg-secondary')).toBe(false)
+  })
+
+  it('sets a title attribute describing the mode + effective branch', () => {
+    installBranchDom({ qsBranch: 'master', overrideValue: 'nightly' })
+    syncKometaBranchRollupBadge()
+    const title = document.getElementById('kometa-branch-rollup-badge').getAttribute('title')
+    expect(title).toContain('override selected: nightly')
+    expect(title).toContain('Effective branch: nightly')
+  })
+
+  it("auto-mode title mentions 'auto' and the effective branch", () => {
+    installBranchDom({ qsBranch: 'develop', overrideValue: '' })
+    syncKometaBranchRollupBadge()
+    const title = document.getElementById('kometa-branch-rollup-badge').getAttribute('title')
+    expect(title).toContain('mode: auto')
+    expect(title).toContain('Effective branch: nightly')
+  })
+
+  it('is a no-op when the badge is missing', () => {
+    installBranchDom()
+    document.getElementById('kometa-branch-rollup-badge').remove()
+    expect(() => syncKometaBranchRollupBadge()).not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------
+// syncKometaBranchOverrideWarning
+// ---------------------------------------------------------------------
+
+describe('syncKometaBranchOverrideWarning', () => {
+  it('hides the warning when no override is set', () => {
+    installBranchDom({ overrideValue: '' })
+    // Make sure warning was showing to prove the toggle
+    document.getElementById('kometa-branch-override-warning').classList.remove('d-none')
+    syncKometaBranchOverrideWarning()
+    expect(document.getElementById('kometa-branch-override-warning').classList.contains('d-none')).toBe(true)
+  })
+
+  it('shows the warning when an override is set', () => {
+    installBranchDom({ overrideValue: 'develop' })
+    syncKometaBranchOverrideWarning()
+    expect(document.getElementById('kometa-branch-override-warning').classList.contains('d-none')).toBe(false)
+  })
+
+  it('is a no-op when the warning element is missing', () => {
+    installBranchDom()
+    document.getElementById('kometa-branch-override-warning').remove()
+    expect(() => syncKometaBranchOverrideWarning()).not.toThrow()
+  })
+})

--- a/tests/js/kometa/state.test.js
+++ b/tests/js/kometa/state.test.js
@@ -123,6 +123,27 @@ describe('kometaState initial values', () => {
     expect(kometaState.lastLogscanPayload).toBeNull()
   })
 
+  it('Kometa branch/version fields start in their pre-check defaults', () => {
+    // These four fields drive the source-status panel in _kometaBranch.js.
+    //
+    //   kometaLocalVersionStatus  -- 'Unknown' (not '' or null) so
+    //                                 first-render shows 'Unknown'
+    //                                 verbatim; empty would fall back
+    //                                 to 'Unknown' anyway but that
+    //                                 obscures intent.
+    //   kometaRemoteVersionStatus -- '' (empty means 'never fetched');
+    //                                 combined with checked=false the
+    //                                 UI shows 'Not checked'.
+    //   kometaRemoteVersionChecked -- false until we've actually hit
+    //                                  the remote endpoint at least once.
+    //   kometaRemoteVersionSkipped -- false unless the check was
+    //                                  intentionally skipped (running).
+    expect(kometaState.kometaLocalVersionStatus).toBe('Unknown')
+    expect(kometaState.kometaRemoteVersionStatus).toBe('')
+    expect(kometaState.kometaRemoteVersionChecked).toBe(false)
+    expect(kometaState.kometaRemoteVersionSkipped).toBe(false)
+  })
+
   it('exports exactly the fields the runtime relies on (guards against typos)', () => {
     // Sorted alphabetically for a stable comparison
     expect(Object.keys(kometaState).sort()).toEqual([
@@ -131,9 +152,13 @@ describe('kometaState initial values', () => {
       'kometaInstalled',
       'kometaInterval',
       'kometaLocalCheckCompleted',
+      'kometaLocalVersionStatus',
       'kometaPendingStart',
       'kometaPollingStarted',
       'kometaProgressInterval',
+      'kometaRemoteVersionChecked',
+      'kometaRemoteVersionSkipped',
+      'kometaRemoteVersionStatus',
       'kometaStatus',
       'kometaStatusInterval',
       'kometaUpdateAvailable',


### PR DESCRIPTION
## What

Extracts the branch-override + version-check subsystem. This is the first part of the update-flow extraction (the rest — the update job polling — will follow).

`900-kometa.js`: 3025 → 2916 lines (**−109**). **Below 3000 for the first time!**

## What moved

Extracted to `static/local-js/modules/kometa/_kometaBranch.js` (282 lines):

| Group | Exports |
|---|---|
| **Branch resolution** | `getKometaBranchOverride`, `getQuickstartBranch`, `getAutoKometaBranch`, `getEffectiveKometaBranch` |
| **URL builders (pure)** | `getKometaVersionSourceUrlValue`, `getKometaZipSourceUrlValue` |
| **Persistence** | `loadSavedKometaBranchOverride`, `saveKometaBranchOverride`, `KOMETA_BRANCH_OVERRIDE_STORAGE_KEY` (const) |
| **UI sync** | `syncKometaSourceStatus`, `syncKometaBranchRollupBadge`, `syncKometaBranchOverrideWarning` |

Added to `kometaState` (in `modules/kometa/_state.js`):
- `kometaLocalVersionStatus: 'Unknown'`
- `kometaRemoteVersionStatus: ''`
- `kometaRemoteVersionChecked: false`
- `kometaRemoteVersionSkipped: false`

These four fields were top-level `let` vars in `900-kometa.js`. Migrated because `syncKometaSourceStatus` and `invalidateKometaUpdateStatus` both write them, and the module + `900-kometa.js` both need to read.

## Design notes

1. **DOM lookups are all lazy** (per-call `document.getElementById`). Zero cached DOM refs. Aligns with the pattern in `_sparklines.js` and `_ui.js`.

2. **`VALID_BRANCHES` is module-private**, not exported. Callers don't need to enumerate branches from outside.

3. **`syncKometaSourceStatus` uses `hasOwnProperty`** (not truthy checks) when reading options fields. Preserves the pre-migration behavior where `{ localVersion: '' }` explicitly clears the field to `'Unknown'`, while omitting `localVersion` leaves it alone.

4. **`syncKometaBranchRollupBadge` is now directly importable** by any module. The callbacks-bag wrapper in `_headerBadges.js` still exists (retiring it requires changes to `900-kometa.js` too) but that's a follow-up.

## Cleanup: 8 stale const declarations removed

Once the functions moved out, these became used only by extracted code:
- 7 DOM refs (`kometaBranchSelection`, `kometaEffectiveBranch`, `kometaLocalVersionStatusEl`, `kometaRemoteVersionStatusEl`, `kometaVersionSourceUrl`, `kometaZipSourceUrl`, `kometaBranchOverrideWarning`)
- `KOMETA_BRANCH_OVERRIDE_STORAGE_KEY` (now inside the new module)

`kometaBranchOverride` and `updateKometaBtn` STAY in `900-kometa.js` — still used by `callUpdateKometa` and event handlers targeted for a future PR.

## Testing pattern worth noting

localStorage is stubbed via a **Map-backed fake installed with `Object.defineProperty(window, 'localStorage', {...})`**. `vi.spyOn` doesn't play nice with jsdom's localStorage (property assignment is intercepted), so wholesale swap-and-restore is the cleanest pattern. Two helpers do the work:

```js
installFakeLocalStorage({ throwOnGet?, throwOnSet? })
restoreLocalStorage()
```

Reusable for any future test that needs to exercise localStorage error paths.

## Vitest coverage: 41 new tests

**`state.test.js`** (+1): Kometa branch/version fields start in pre-check defaults

**`kometaBranch.test.js`** (40 new):
- **Branch resolution** (13): missing elements, valid/invalid values, normalization, override wins, auto fallback, master vs non-master handling
- **URL builders** (2): version URL format, zip URL format
- **Persistence** (7): restore valid / coerce invalid, save valid / remove empty, missing element no-ops, localStorage error paths (getItem + setItem)
- **`syncKometaSourceStatus`** (10): partial options, `hasOwnProperty` semantics for `''`, selection labels, effective branch rendering, remote status states (not checked / skipped / checked), source URLs, badge-refresh side effect
- **`syncKometaBranchRollupBadge`** (5): auto vs override styling, title attributes, no-op when missing
- **`syncKometaBranchOverrideWarning`** (3): shows when override, hides when auto, no-op when missing

## Verification

- **988/988 Vitest pass** (was 947 after #1568; +41 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- 4 broader e2e tests (kometa/branch/update/version): pass
- ESLint clean, Node syntax clean

## What's next

- Retire the `syncKometaBranchRollupBadge` callbacks-bag in `_headerBadges.js`
- `_kometaUpdate.js` — update job polling, `checkKometaUpdate`, `callUpdateKometa`, phase badges (~600 lines)
- `_kometaRuntime.js` — `validateKometaRoot` + `probeKometaRoot`