### PR TITLE
Cleanup: retire syncKometaBranchRollupBadge callbacks-bag in _headerBadges.js

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -19,7 +19,7 @@ import {
   updateConfigOutputHeaderBadges,
   updateRunCommandHeaderBadge,
   updateLogscanHeaderBadge,
-  syncFinalAccordionRollups as _syncFinalAccordionRollups
+  syncFinalAccordionRollups
 } from './modules/kometa/_headerBadges.js'
 import {
   updateHeaderStyleLabel,
@@ -61,7 +61,6 @@ import {
   loadSavedKometaBranchOverride,
   saveKometaBranchOverride,
   syncKometaSourceStatus,
-  syncKometaBranchRollupBadge,
   syncKometaBranchOverrideWarning
 } from './modules/kometa/_kometaBranch.js'
 
@@ -71,14 +70,6 @@ import {
 // (`buildCommand()` with no args), matching the pre-extraction API.
 function buildCommand () {
   return _buildCommand({ updateRunNowState, syncFinalAccordionRollups })
-}
-
-// Thin wrapper: the extracted syncFinalAccordionRollups still needs
-// to call syncKometaBranchRollupBadge, which lives here (it depends
-// on branch-override helpers not yet migrated to _kometaUpdate.js).
-// Wrapping here keeps every call site simple.
-function syncFinalAccordionRollups () {
-  _syncFinalAccordionRollups({ syncKometaBranchRollupBadge })
 }
 
 // Kometa runtime status flags migrated to modules/kometa/_state.js

--- a/static/local-js/modules/kometa/_headerBadges.js
+++ b/static/local-js/modules/kometa/_headerBadges.js
@@ -31,12 +31,8 @@
 //
 //   Orchestrator:
 //
-//     syncFinalAccordionRollups({ syncKometaBranchRollupBadge })
-//                                     -- one call to refresh every
-//                                        badge on the page. Takes a
-//                                        callbacks bag for functions
-//                                        that still live in
-//                                        900-kometa.js.
+//     syncFinalAccordionRollups()     -- one call to refresh every
+//                                        badge on the page.
 //
 // COLOR CLASSES:
 //
@@ -54,6 +50,7 @@
 import { formatHeaderStyleLabel, isValidTimesFormat, computeYamlLineCount } from './_util.js'
 import { kometaState } from './_state.js'
 import { isRunCommandValid } from './_runCommand.js'
+import { syncKometaBranchRollupBadge } from './_kometaBranch.js'
 
 // ---------------------------------------------------------------------
 // Core primitives
@@ -318,16 +315,8 @@ export function updateLogscanHeaderBadge (data) {
 /**
  * Refresh every section-header rollup badge on the page. One call
  * to bring the whole accordion into sync with current state.
- *
- * The `syncKometaBranchRollupBadge` function still lives in
- * 900-kometa.js (it depends on branch-override helpers that haven't
- * been extracted yet), so we take it as a callback. When those
- * helpers migrate to _kometaUpdate.js, this callback retires in favor
- * of a direct import.
- *
- * @param {{ syncKometaBranchRollupBadge: () => void }} [callbacks]
  */
-export function syncFinalAccordionRollups (callbacks) {
+export function syncFinalAccordionRollups () {
   updateModeHeaderBadge()
   updateRunOptionHeaderBadge()
   updateModeFlagsHeaderBadge()
@@ -336,7 +325,5 @@ export function syncFinalAccordionRollups (callbacks) {
   updateConfigOutputHeaderBadges()
   updateRunCommandHeaderBadge()
   updateLogscanHeaderBadge()
-  if (callbacks && typeof callbacks.syncKometaBranchRollupBadge === 'function') {
-    callbacks.syncKometaBranchRollupBadge()
-  }
+  syncKometaBranchRollupBadge()
 }

--- a/tests/js/kometa/headerBadges.test.js
+++ b/tests/js/kometa/headerBadges.test.js
@@ -28,7 +28,7 @@
 //   updateOtherFlagsHeaderBadge -- 0/some/all core flags, extras
 //                            (timeout/divider/width) counted separately
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
   setHeaderRollupBadge,
   prettifyFlag,
@@ -656,20 +656,28 @@ describe('syncFinalAccordionRollups', () => {
     installBadge('config-output-rollup-badge')
     installBadge('run-command-rollup-badge')
     installBadge('logscan-rollup-badge')
+    // The branch rollup badge is written by syncKometaBranchRollupBadge
+    // (imported from _kometaBranch.js). The DOM contract there requires
+    // BOTH the badge element AND the #kometa-branch-override <select>
+    // to exist (the badge reads the current override).
+    const badgeEl = document.createElement('span')
+    badgeEl.id = 'kometa-branch-rollup-badge'
+    document.body.appendChild(badgeEl)
+    const overrideSel = document.createElement('select')
+    overrideSel.id = 'kometa-branch-override'
+    const emptyOpt = document.createElement('option')
+    emptyOpt.value = ''
+    overrideSel.appendChild(emptyOpt)
+    overrideSel.value = ''
+    document.body.appendChild(overrideSel)
   })
 
-  it('invokes syncKometaBranchRollupBadge callback exactly once', () => {
-    const cb = vi.fn()
-    syncFinalAccordionRollups({ syncKometaBranchRollupBadge: cb })
-    expect(cb).toHaveBeenCalledTimes(1)
-  })
-
-  it('does not throw when callbacks arg is undefined', () => {
+  it('takes no arguments (retired callbacks-bag API)', () => {
+    // Post-#1569 the orchestrator no longer accepts callbacks;
+    // syncKometaBranchRollupBadge is imported directly from
+    // _kometaBranch.js. Passing an argument should be harmless
+    // (ignored) but the canonical call is no-args.
     expect(() => syncFinalAccordionRollups()).not.toThrow()
-  })
-
-  it('does not throw when syncKometaBranchRollupBadge is not a function', () => {
-    expect(() => syncFinalAccordionRollups({ syncKometaBranchRollupBadge: 42 })).not.toThrow()
   })
 
   it('refreshes every rollup badge on the page (touches all 10 ids)', () => {
@@ -685,10 +693,11 @@ describe('syncFinalAccordionRollups', () => {
       'config-output-lines-badge',
       'config-output-rollup-badge',
       'run-command-rollup-badge',
-      'logscan-rollup-badge'
+      'logscan-rollup-badge',
+      'kometa-branch-rollup-badge'
     ]
     for (const id of ids) document.getElementById(id).textContent = 'SENTINEL'
-    syncFinalAccordionRollups({ syncKometaBranchRollupBadge: () => {} })
+    syncFinalAccordionRollups()
     for (const id of ids) {
       expect(document.getElementById(id).textContent).not.toBe('SENTINEL')
     }


### PR DESCRIPTION
## What

Follow-up cleanup after #1569 extracted `syncKometaBranchRollupBadge` to `_kometaBranch.js`. The orchestrator can now import it directly instead of taking it as a callback.

`900-kometa.js`: 2916 → 2907 lines (**−9**). Small numerically, but eliminates the last cross-module callback for `syncFinalAccordionRollups`.

## What changed

**`_headerBadges.js`:**
- Imports `syncKometaBranchRollupBadge` from `./_kometaBranch.js`
- `syncFinalAccordionRollups()` no longer accepts a callbacks arg
- Module docstring updated to remove callback discussion

**`900-kometa.js`:**
- Retires the thin `syncFinalAccordionRollups` wrapper (was passing the local `syncKometaBranchRollupBadge` as a callback — no longer needed since it lives in `_kometaBranch.js` now)
- Imports `syncFinalAccordionRollups` directly (no more `as _...` alias)
- Drops `syncKometaBranchRollupBadge` from the import list (was only used by the retired wrapper)

## Design notes

The 'callbacks bag' pattern is a bridge for functions that live in different files during an in-progress extraction. Each bag retires when the callee migrates to its own module.

**Retired here:** `syncKometaBranchRollupBadge` (possible because #1569 moved it out)

**Remaining callback bags in `900-kometa.js`:**
- `buildCommand({ updateRunNowState, syncFinalAccordionRollups })` — will retire when `updateRunNowState` migrates
- `updateValidationGate({ updateRunNowState, syncFinalAccordionRollups })` — same trigger

Zero circular-dep risk: `_kometaBranch.js` does NOT import from `_headerBadges.js`, so the fresh `_headerBadges.js → _kometaBranch.js` edge is a straight tree.

## Test updates

**`headerBadges.test.js`:**
- Removed 3 tests that exercised the callback API:
  - 'invokes syncKometaBranchRollupBadge callback exactly once'
  - 'does not throw when callbacks arg is undefined'
  - 'does not throw when syncKometaBranchRollupBadge is not a function'
- Consolidated into 1 new test: 'takes no arguments (retired callbacks-bag API)'
- Updated 'refreshes every rollup badge' to install the branch badge + `#kometa-branch-override` `<select>` in the fixture, and added `kometa-branch-rollup-badge` to the id list
- Removed unused `vi` import from vitest

Net: 60 → 58 tests in `headerBadges.test.js` (−2); full suite went 988 → 986 (−2).

## Verification

- **986/986 Vitest pass**
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- ESLint clean, Node syntax clean