### PR TITLE
Split 900-kometa.js part 14: extract run controls (Run Now + Recovery buttons)

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -17,7 +17,6 @@ import {
 import { kometaState } from './modules/kometa/_state.js'
 import {
   updateConfigOutputHeaderBadges,
-  updateRunCommandHeaderBadge,
   updateLogscanHeaderBadge,
   syncFinalAccordionRollups
 } from './modules/kometa/_headerBadges.js'
@@ -41,7 +40,6 @@ import {
 } from './modules/kometa/_runtime.js'
 import {
   buildCommand as _buildCommand,
-  isRunCommandValid,
   applyActiveRunCommandState,
   clearActiveRunCommandState
 } from './modules/kometa/_runCommand.js'
@@ -63,11 +61,19 @@ import {
   syncKometaSourceStatus,
   syncKometaBranchOverrideWarning
 } from './modules/kometa/_kometaBranch.js'
+import {
+  updateRunNowState,
+  syncIncompleteRunActions,
+  getCurrentRunCommand,
+  getRecoveryRunCommand
+} from './modules/kometa/_runControls.js'
 
 // Thin wrapper: buildCommand needs updateRunNowState and
-// syncFinalAccordionRollups callbacks, but both are still owned by
-// this file. Wrapping here keeps every call site simple
-// (`buildCommand()` with no args), matching the pre-extraction API.
+// syncFinalAccordionRollups callbacks. Both live in other modules
+// now, but wiring them through _runCommand.js as direct imports
+// would create a cycle:
+//   _runCommand.js -> _runControls.js -> _runCommand.js (isRunCommandValid)
+// So we keep the callbacks-bag bridge here.
 function buildCommand () {
   return _buildCommand({ updateRunNowState, syncFinalAccordionRollups })
 }
@@ -161,7 +167,7 @@ document.addEventListener('qs:maintenance-status', function (event) {
   syncKometaMaintenancePageBadge(event.detail || null)
 })
 
-updateValidationGate({ updateRunNowState, syncFinalAccordionRollups })
+updateValidationGate()
 
 if (tailSelect) {
   tailSize = tailSelect.value || tailSize
@@ -436,33 +442,6 @@ function resolveFreshnessGateAfterBulkValidation () {
   }
   const panel = document.getElementById('final-gate-panel')
   if (panel) panel.classList.add('d-none')
-}
-
-function updateRunNowState () {
-  const runNow = document.getElementById('run-now')
-  if (!runNow) {
-    updateRunCommandHeaderBadge()
-    syncIncompleteRunActions()
-    return
-  }
-
-  if (!kometaState.showYAML || kometaState.kometaValidationInProgress || kometaState.kometaUpdating || kometaState.kometaStatus === 'running' || !kometaState.kometaValidated) {
-    runNow.disabled = true
-    updateRunCommandHeaderBadge()
-    syncIncompleteRunActions()
-    return
-  }
-
-  if (!isRunCommandValid()) {
-    runNow.disabled = true
-    updateRunCommandHeaderBadge()
-    syncIncompleteRunActions()
-    return
-  }
-
-  runNow.disabled = false
-  updateRunCommandHeaderBadge()
-  syncIncompleteRunActions()
 }
 
 document.querySelectorAll('input[name="run-option"]').forEach(el => el.addEventListener('change', function () {
@@ -1055,49 +1034,6 @@ document.getElementById('copy-recovery-command')?.addEventListener('click', func
     .then(() => showCopyButtonSuccess('#copy-recovery-icon', '#copy-recovery-text'))
     .catch(() => showToast('error', 'Copy failed. Please copy manually.'))
 })
-
-function getCurrentRunCommand () {
-  const el = document.getElementById('run-command-output')
-  return el ? el.textContent.trim() : ''
-}
-
-function getRecoveryRunCommand () {
-  const el = document.getElementById('recovery-command-output')
-  return el ? el.textContent.trim() : ''
-}
-
-function syncIncompleteRunActions () {
-  const runRecovery = document.getElementById('run-recovery-command')
-  if (!runRecovery) return
-
-  const incompleteAlert = document.getElementById('incomplete-run-alert')
-  const recoveryCommand = getRecoveryRunCommand()
-  const alertVisible = Boolean(incompleteAlert) && !incompleteAlert.classList.contains('d-none')
-  const recoveryRunnable = Boolean(recoveryCommand) &&
-    alertVisible &&
-    !kometaState.kometaValidationInProgress &&
-    !kometaState.kometaUpdating &&
-    !kometaState.kometaPendingStart &&
-    kometaState.kometaStatus !== 'running'
-
-  runRecovery.classList.toggle('d-none', !alertVisible)
-  runRecovery.disabled = !recoveryRunnable
-  if (recoveryRunnable) {
-    runRecovery.removeAttribute('title')
-  } else if (!alertVisible) {
-    runRecovery.setAttribute('title', 'Recovery actions are only available when an incomplete-run recovery command is visible.')
-  } else if (kometaState.kometaValidationInProgress) {
-    runRecovery.setAttribute('title', 'Wait for Kometa validation to finish before starting a recovery run.')
-  } else if (kometaState.kometaUpdating) {
-    runRecovery.setAttribute('title', 'Wait for the Kometa update to finish before starting a recovery run.')
-  } else if (kometaState.kometaPendingStart) {
-    runRecovery.setAttribute('title', 'A Kometa start is already queued for the next Plex maintenance window.')
-  } else if (kometaState.kometaStatus === 'running') {
-    runRecovery.setAttribute('title', 'Kometa is already running.')
-  } else {
-    runRecovery.setAttribute('title', 'No recovery command is available for this incomplete run.')
-  }
-}
 
 function startKometaCommand (command, opts = {}) {
   const startMode = opts.startMode || 'current'
@@ -2587,7 +2523,7 @@ if (validateAllBtn) {
       return
     }
 
-    updateValidationGate({ updateRunNowState, syncFinalAccordionRollups })
+    updateValidationGate()
     const anyNewlyValidated = Object.keys(results).some(key => results[key]?.status === 'validated' && !previousStatuses[key])
     if (previouslyBlocked && kometaState.showYAML) {
       showToast('info', 'Validation complete. Refreshing YAML output...')

--- a/static/local-js/modules/kometa/_runControls.js
+++ b/static/local-js/modules/kometa/_runControls.js
@@ -1,0 +1,182 @@
+// Run controls: the "Run Now" button and the "Recovery Command" button.
+//
+// This module owns the two functions that decide whether these
+// buttons should be enabled / clickable, based on the current
+// kometaState:
+//
+//   updateRunNowState        -- enables/disables the primary Run Now
+//                               button based on the six-flag state
+//                               machine (validation + install +
+//                               running-status + run-command validity)
+//
+//   syncIncompleteRunActions -- shows/hides the recovery button and
+//                               sets a helpful title tooltip based on
+//                               why it's disabled (if disabled)
+//
+// Plus two trivial DOM-reader helpers used by both this module and
+// 900-kometa.js callers that need the current command text:
+//
+//   getCurrentRunCommand     -- text of the main run-command panel
+//   getRecoveryRunCommand    -- text of the recovery panel
+//
+// STATE FLOW:
+//
+//   validation + install + running-status flags live in kometaState.
+//   This module reads them via imports; never writes them.
+//
+//   The two "update button" functions get called from many places
+//   in 900-kometa.js (event handlers, polling callbacks, validation
+//   completion, etc.) -- all of which currently pass through the
+//   default kometaState. Once every caller is either extracted or
+//   uses kometaState directly, this module is fully self-contained.
+
+import { kometaState } from './_state.js'
+import { updateRunCommandHeaderBadge } from './_headerBadges.js'
+import { isRunCommandValid } from './_runCommand.js'
+
+// ---------------------------------------------------------------------
+// Command-text readers (trivial DOM accessors)
+// ---------------------------------------------------------------------
+
+/**
+ * The exact command shown in the main run-command panel. Trimmed of
+ * leading/trailing whitespace. Empty string if the panel is missing.
+ *
+ * @returns {string}
+ */
+export function getCurrentRunCommand () {
+  const el = document.getElementById('run-command-output')
+  return el ? el.textContent.trim() : ''
+}
+
+/**
+ * The command shown in the recovery panel (only visible when an
+ * interrupted run left recoverable state behind).
+ *
+ * @returns {string}
+ */
+export function getRecoveryRunCommand () {
+  const el = document.getElementById('recovery-command-output')
+  return el ? el.textContent.trim() : ''
+}
+
+// ---------------------------------------------------------------------
+// Run Now button
+// ---------------------------------------------------------------------
+
+/**
+ * Update the Run Now button's disabled state based on current
+ * validation + install + running-status flags.
+ *
+ * Disable rules (any one triggers disable):
+ *   - showYAML is false (config not passing)
+ *   - kometaValidationInProgress
+ *   - kometaUpdating
+ *   - kometaStatus === 'running'
+ *   - !kometaValidated
+ *   - !isRunCommandValid() (command panel shows a placeholder)
+ *
+ * Enabled only when every one of the above is favorable.
+ *
+ * Side effect: always refreshes the run-command header badge + the
+ * recovery button state (in one pass), so any caller of this function
+ * gets a consistent UI update.
+ *
+ * No-op DOM path (button missing): still refreshes badge + recovery
+ * so pages without the primary button still get their subsidiary
+ * UI updated.
+ */
+export function updateRunNowState () {
+  const runNow = document.getElementById('run-now')
+
+  // Even when the button is absent, keep the badge and recovery
+  // button in sync -- some pages / test fixtures render one but not
+  // the other.
+  if (!runNow) {
+    updateRunCommandHeaderBadge()
+    syncIncompleteRunActions()
+    return
+  }
+
+  // The five "disable because state isn't ready" conditions.
+  // Kept as separate booleans to preserve the original short-circuit
+  // ordering (in case future changes need to distinguish which flag
+  // triggered).
+  const notReady = (
+    !kometaState.showYAML ||
+    kometaState.kometaValidationInProgress ||
+    kometaState.kometaUpdating ||
+    kometaState.kometaStatus === 'running' ||
+    !kometaState.kometaValidated
+  )
+
+  if (notReady) {
+    runNow.disabled = true
+  } else if (!isRunCommandValid()) {
+    // State is ready but the command panel is showing '??' or empty.
+    runNow.disabled = true
+  } else {
+    runNow.disabled = false
+  }
+
+  updateRunCommandHeaderBadge()
+  syncIncompleteRunActions()
+}
+
+// ---------------------------------------------------------------------
+// Recovery button
+// ---------------------------------------------------------------------
+
+/**
+ * Show/hide the recovery-command button and set its tooltip to
+ * explain why it's disabled (when disabled).
+ *
+ * The button is:
+ *   - Hidden entirely (via .d-none) when there's no incomplete-run
+ *     recovery alert visible (i.e. nothing to recover).
+ *   - Visible but disabled when a recovery is possible in principle
+ *     but blocked by transient state (updating / running / pending).
+ *   - Enabled when a recovery command exists AND no blocker is active.
+ *
+ * The title attribute is set to a specific message for each disabled
+ * case so users get a clear reason why they can't click.
+ */
+export function syncIncompleteRunActions () {
+  const runRecovery = document.getElementById('run-recovery-command')
+  if (!runRecovery) return
+
+  const incompleteAlert = document.getElementById('incomplete-run-alert')
+  const recoveryCommand = getRecoveryRunCommand()
+  const alertVisible = Boolean(incompleteAlert) && !incompleteAlert.classList.contains('d-none')
+  const recoveryRunnable = Boolean(recoveryCommand) &&
+    alertVisible &&
+    !kometaState.kometaValidationInProgress &&
+    !kometaState.kometaUpdating &&
+    !kometaState.kometaPendingStart &&
+    kometaState.kometaStatus !== 'running'
+
+  runRecovery.classList.toggle('d-none', !alertVisible)
+  runRecovery.disabled = !recoveryRunnable
+
+  // Tooltip: only one of these applies at a time (checked in
+  // priority order). Priority order preserved from the pre-extraction
+  // version.
+  if (recoveryRunnable) {
+    runRecovery.removeAttribute('title')
+  } else if (!alertVisible) {
+    runRecovery.setAttribute('title', 'Recovery actions are only available when an incomplete-run recovery command is visible.')
+  } else if (kometaState.kometaValidationInProgress) {
+    runRecovery.setAttribute('title', 'Wait for Kometa validation to finish before starting a recovery run.')
+  } else if (kometaState.kometaUpdating) {
+    runRecovery.setAttribute('title', 'Wait for the Kometa update to finish before starting a recovery run.')
+  } else if (kometaState.kometaPendingStart) {
+    runRecovery.setAttribute('title', 'A Kometa start is already queued for the next Plex maintenance window.')
+  } else if (kometaState.kometaStatus === 'running') {
+    runRecovery.setAttribute('title', 'Kometa is already running.')
+  } else {
+    // Alert is visible, no blockers, but no recovery command in the
+    // panel. Unusual state (server said recovery is possible but the
+    // command wasn't populated).
+    runRecovery.setAttribute('title', 'No recovery command is available for this incomplete run.')
+  }
+}

--- a/static/local-js/modules/kometa/_validationGate.js
+++ b/static/local-js/modules/kometa/_validationGate.js
@@ -17,22 +17,16 @@
 //                             warning/download/YAML/run-controls
 //                             elements, populates the validation-messages
 //                             element with per-step links, and finally
-//                             delegates to two callback-style extension
-//                             points (updateRunNowState +
-//                             syncFinalAccordionRollups).
+//                             refreshes the run-now button + the
+//                             accordion rollups.
 //
-// EXTENSION POINTS:
+// UI COORDINATION:
 //
-//   updateValidationGate takes both callbacks as REQUIRED parameters.
-//   This is a temporary bridge pattern -- the "real" version once
-//   ALL of 900-kometa.js is split will be imports from the modules
-//   that own those functions. Until then, callers in 900-kometa.js
-//   pass the functions in explicitly.
-//
-//   Rationale: making the callbacks parameters (rather than importing
-//   them here) means _validationGate.js has ZERO imports from
-//   900-kometa.js, keeping the dependency graph acyclic. It also makes
-//   the module trivially testable -- vitest can pass vi.fn() spies.
+//   updateValidationGate calls updateRunNowState (from _runControls.js)
+//   and syncFinalAccordionRollups (from _headerBadges.js) as its final
+//   two steps. Both were callback parameters pre-#1571, migrated to
+//   direct imports once _runControls.js was extracted.
+////   the module trivially testable -- vitest can pass vi.fn() spies.
 //
 // PROTOCOL FOR "GATE STAGE":
 //
@@ -52,6 +46,8 @@
 
 import { kometaState } from './_state.js'
 import { readMetaFlag } from './_util.js'
+import { updateRunNowState } from './_runControls.js'
+import { syncFinalAccordionRollups } from './_headerBadges.js'
 
 /**
  * Read the current gate state from the server-populated
@@ -117,17 +113,12 @@ function rowFor (label, href) {
  * MUTATES kometaState.showYAML as a side-effect. Callers should treat
  * kometaState.showYAML as read-only after this returns.
  *
- * @param {{
- *   updateRunNowState: () => void,
- *   syncFinalAccordionRollups: () => void
- * }} callbacks  Extension points, see module docstring. Both are
- *               required; use no-op functions if the caller doesn't
- *               care about a particular hook. Tests should pass
- *               vi.fn() spies to verify orchestration order.
+ * Side effects at the end of every path:
+ *   - updateRunNowState() -- refresh the Run Now button state
+ *   - syncFinalAccordionRollups() -- refresh every section-header
+ *                                    rollup badge
  */
-export function updateValidationGate (callbacks) {
-  const { updateRunNowState, syncFinalAccordionRollups } = callbacks || {}
-
+export function updateValidationGate () {
   const validationMsgEl = document.getElementById('validation-messages')
   const runControls = document.getElementById('run-controls-container')
   const runNowEl = document.getElementById('run-now')
@@ -146,8 +137,8 @@ export function updateValidationGate (callbacks) {
     if (runControls) runControls.classList.add('d-none')
     if (runNowEl) runNowEl.disabled = true
     if (runNowLabelEl) runNowLabelEl.textContent = 'Run Now'
-    if (typeof updateRunNowState === 'function') updateRunNowState()
-    if (typeof syncFinalAccordionRollups === 'function') syncFinalAccordionRollups()
+    updateRunNowState()
+    syncFinalAccordionRollups()
     return
   }
 
@@ -194,6 +185,6 @@ export function updateValidationGate (callbacks) {
     // the runtime-state (Kometa installed?, not currently running?, etc.)
   }
 
-  if (typeof updateRunNowState === 'function') updateRunNowState()
-  if (typeof syncFinalAccordionRollups === 'function') syncFinalAccordionRollups()
+  updateRunNowState()
+  syncFinalAccordionRollups()
 }

--- a/tests/js/kometa/runControls.test.js
+++ b/tests/js/kometa/runControls.test.js
@@ -1,0 +1,346 @@
+// Tests for static/local-js/modules/kometa/_runControls.js
+//
+// Four exported functions:
+//
+//   getCurrentRunCommand    -- reads #run-command-output text
+//   getRecoveryRunCommand   -- reads #recovery-command-output text
+//   updateRunNowState       -- big state machine for the Run Now button
+//   syncIncompleteRunActions -- recovery button visibility + tooltip
+//
+// COVERAGE STRATEGY:
+//
+//   Command readers: trivial DOM readers, 2-3 tests each covering
+//     missing element / present-with-whitespace / present-empty.
+//
+//   updateRunNowState: state-machine with SEVEN paths through it:
+//     - button missing -> no-op DOM path, still calls side-effects
+//     - showYAML=false -> disabled
+//     - kometaValidationInProgress -> disabled
+//     - kometaUpdating -> disabled
+//     - kometaStatus=running -> disabled
+//     - !kometaValidated -> disabled
+//     - !isRunCommandValid() -> disabled
+//     - everything favorable -> enabled
+//     Plus: always calls updateRunCommandHeaderBadge +
+//           syncIncompleteRunActions.
+//
+//   syncIncompleteRunActions: five disabled-reason tooltip paths:
+//     - button missing -> no-op
+//     - alert hidden -> button hidden entirely
+//     - validation in progress -> disabled, specific tooltip
+//     - updating -> disabled, specific tooltip
+//     - pendingStart -> disabled, specific tooltip
+//     - status=running -> disabled, specific tooltip
+//     - runnable -> enabled, no tooltip
+//     - alert visible but no command text -> disabled, generic tooltip
+//
+// Collaborators (updateRunCommandHeaderBadge, isRunCommandValid) are
+// mocked via vi.mock() so this module's behavior is tested in isolation.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock collaborators BEFORE importing _runControls.js. vi.mock() is
+// hoisted so these apply regardless of position.
+vi.mock('../../../static/local-js/modules/kometa/_headerBadges.js', () => ({
+  updateRunCommandHeaderBadge: vi.fn()
+}))
+vi.mock('../../../static/local-js/modules/kometa/_runCommand.js', () => ({
+  isRunCommandValid: vi.fn(() => true)  // default: valid
+}))
+
+import { kometaState } from '../../../static/local-js/modules/kometa/_state.js'
+import {
+  getCurrentRunCommand,
+  getRecoveryRunCommand,
+  updateRunNowState,
+  syncIncompleteRunActions
+} from '../../../static/local-js/modules/kometa/_runControls.js'
+import { updateRunCommandHeaderBadge } from '../../../static/local-js/modules/kometa/_headerBadges.js'
+import { isRunCommandValid } from '../../../static/local-js/modules/kometa/_runCommand.js'
+
+// ---------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------
+
+/**
+ * Install the DOM elements touched by these functions. Everything is
+ * optional; omit for tests that verify missing-element no-ops.
+ */
+function installDom (opts = {}) {
+  const {
+    runNow = true,
+    runNowDisabled = true,
+    runCommandOutput = null,
+    recoveryCommandOutput = null,
+    recovery = true,
+    incompleteAlertVisible = false
+  } = opts
+
+  document.body.innerHTML = ''
+
+  if (runNow) {
+    const btn = document.createElement('button')
+    btn.id = 'run-now'
+    btn.disabled = runNowDisabled
+    document.body.appendChild(btn)
+  }
+
+  if (runCommandOutput !== null) {
+    const el = document.createElement('code')
+    el.id = 'run-command-output'
+    el.textContent = runCommandOutput
+    document.body.appendChild(el)
+  }
+
+  if (recoveryCommandOutput !== null) {
+    const el = document.createElement('code')
+    el.id = 'recovery-command-output'
+    el.textContent = recoveryCommandOutput
+    document.body.appendChild(el)
+  }
+
+  if (recovery) {
+    const btn = document.createElement('button')
+    btn.id = 'run-recovery-command'
+    document.body.appendChild(btn)
+  }
+
+  if (incompleteAlertVisible !== null) {
+    const alert = document.createElement('div')
+    alert.id = 'incomplete-run-alert'
+    if (!incompleteAlertVisible) alert.classList.add('d-none')
+    document.body.appendChild(alert)
+  }
+}
+
+/**
+ * Reset every kometaState field this module reads so tests don't
+ * cross-contaminate.
+ */
+function resetState () {
+  kometaState.showYAML = true
+  kometaState.kometaValidationInProgress = false
+  kometaState.kometaUpdating = false
+  kometaState.kometaStatus = 'idle'
+  kometaState.kometaValidated = true
+  kometaState.kometaPendingStart = false
+}
+
+beforeEach(() => {
+  updateRunCommandHeaderBadge.mockClear()
+  isRunCommandValid.mockClear()
+  isRunCommandValid.mockReturnValue(true)  // default: valid
+  resetState()
+})
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+// ---------------------------------------------------------------------
+// getCurrentRunCommand + getRecoveryRunCommand (trivial readers)
+// ---------------------------------------------------------------------
+
+describe('getCurrentRunCommand', () => {
+  it('returns empty string when #run-command-output is missing', () => {
+    expect(getCurrentRunCommand()).toBe('')
+  })
+
+  it('returns trimmed text content of #run-command-output', () => {
+    installDom({ runCommandOutput: '  python kometa.py --run  ' })
+    expect(getCurrentRunCommand()).toBe('python kometa.py --run')
+  })
+
+  it('returns empty string when the panel contains only whitespace', () => {
+    installDom({ runCommandOutput: '   \n   ' })
+    expect(getCurrentRunCommand()).toBe('')
+  })
+})
+
+describe('getRecoveryRunCommand', () => {
+  it('returns empty string when #recovery-command-output is missing', () => {
+    expect(getRecoveryRunCommand()).toBe('')
+  })
+
+  it('returns trimmed text content of #recovery-command-output', () => {
+    installDom({ recoveryCommandOutput: '\tpython kometa.py --resume\n' })
+    expect(getRecoveryRunCommand()).toBe('python kometa.py --resume')
+  })
+})
+
+// ---------------------------------------------------------------------
+// updateRunNowState
+// ---------------------------------------------------------------------
+
+describe('updateRunNowState -- no-op button path', () => {
+  it('when #run-now is missing, still refreshes badge + recovery', () => {
+    installDom({ runNow: false })
+    updateRunNowState()
+    expect(updateRunCommandHeaderBadge).toHaveBeenCalledTimes(1)
+    // syncIncompleteRunActions is called internally -- easiest way to
+    // detect this is that it looked at #run-recovery-command (which
+    // exists in the fixture). No exception = it ran.
+  })
+
+  it('when #run-now is missing, does NOT throw', () => {
+    installDom({ runNow: false })
+    expect(() => updateRunNowState()).not.toThrow()
+  })
+})
+
+describe('updateRunNowState -- disable reasons', () => {
+  it('disables when showYAML=false', () => {
+    installDom()
+    kometaState.showYAML = false
+    updateRunNowState()
+    expect(document.getElementById('run-now').disabled).toBe(true)
+  })
+
+  it('disables when kometaValidationInProgress=true', () => {
+    installDom({ runNowDisabled: false })
+    kometaState.kometaValidationInProgress = true
+    updateRunNowState()
+    expect(document.getElementById('run-now').disabled).toBe(true)
+  })
+
+  it('disables when kometaUpdating=true', () => {
+    installDom({ runNowDisabled: false })
+    kometaState.kometaUpdating = true
+    updateRunNowState()
+    expect(document.getElementById('run-now').disabled).toBe(true)
+  })
+
+  it("disables when kometaStatus='running'", () => {
+    installDom({ runNowDisabled: false })
+    kometaState.kometaStatus = 'running'
+    updateRunNowState()
+    expect(document.getElementById('run-now').disabled).toBe(true)
+  })
+
+  it('disables when kometaValidated=false', () => {
+    installDom({ runNowDisabled: false })
+    kometaState.kometaValidated = false
+    updateRunNowState()
+    expect(document.getElementById('run-now').disabled).toBe(true)
+  })
+
+  it('disables when isRunCommandValid() returns false', () => {
+    installDom({ runNowDisabled: false })
+    isRunCommandValid.mockReturnValue(false)
+    updateRunNowState()
+    expect(document.getElementById('run-now').disabled).toBe(true)
+  })
+})
+
+describe('updateRunNowState -- enable path', () => {
+  it('enables the button when every flag is favorable and command is valid', () => {
+    installDom({ runNowDisabled: true })  // start disabled to prove we flip it
+    isRunCommandValid.mockReturnValue(true)
+    updateRunNowState()
+    expect(document.getElementById('run-now').disabled).toBe(false)
+  })
+})
+
+describe('updateRunNowState -- side effects', () => {
+  it('always calls updateRunCommandHeaderBadge exactly once', () => {
+    installDom()
+    updateRunNowState()
+    expect(updateRunCommandHeaderBadge).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls updateRunCommandHeaderBadge in disable paths too', () => {
+    installDom()
+    kometaState.showYAML = false
+    updateRunNowState()
+    expect(updateRunCommandHeaderBadge).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ---------------------------------------------------------------------
+// syncIncompleteRunActions
+// ---------------------------------------------------------------------
+
+describe('syncIncompleteRunActions -- no-op path', () => {
+  it('when #run-recovery-command is missing, returns early without error', () => {
+    installDom({ recovery: false })
+    expect(() => syncIncompleteRunActions()).not.toThrow()
+  })
+})
+
+describe('syncIncompleteRunActions -- alert hidden', () => {
+  it('hides the recovery button when no incomplete-run alert is visible', () => {
+    installDom({ incompleteAlertVisible: false, recoveryCommandOutput: 'python kometa.py' })
+    syncIncompleteRunActions()
+    const btn = document.getElementById('run-recovery-command')
+    expect(btn.classList.contains('d-none')).toBe(true)
+    expect(btn.disabled).toBe(true)
+  })
+
+  it("sets tooltip explaining that no recovery alert is visible", () => {
+    installDom({ incompleteAlertVisible: false })
+    syncIncompleteRunActions()
+    const btn = document.getElementById('run-recovery-command')
+    expect(btn.getAttribute('title')).toContain('only available when an incomplete-run recovery command is visible')
+  })
+})
+
+describe('syncIncompleteRunActions -- alert visible but state blockers', () => {
+  it("sets 'wait for validation' tooltip when kometaValidationInProgress", () => {
+    installDom({ incompleteAlertVisible: true, recoveryCommandOutput: 'python kometa.py' })
+    kometaState.kometaValidationInProgress = true
+    syncIncompleteRunActions()
+    const btn = document.getElementById('run-recovery-command')
+    expect(btn.disabled).toBe(true)
+    expect(btn.getAttribute('title')).toContain('Wait for Kometa validation')
+  })
+
+  it("sets 'wait for update' tooltip when kometaUpdating", () => {
+    installDom({ incompleteAlertVisible: true, recoveryCommandOutput: 'python kometa.py' })
+    kometaState.kometaUpdating = true
+    syncIncompleteRunActions()
+    const btn = document.getElementById('run-recovery-command')
+    expect(btn.disabled).toBe(true)
+    expect(btn.getAttribute('title')).toContain('Wait for the Kometa update')
+  })
+
+  it("sets 'already queued' tooltip when kometaPendingStart", () => {
+    installDom({ incompleteAlertVisible: true, recoveryCommandOutput: 'python kometa.py' })
+    kometaState.kometaPendingStart = true
+    syncIncompleteRunActions()
+    const btn = document.getElementById('run-recovery-command')
+    expect(btn.disabled).toBe(true)
+    expect(btn.getAttribute('title')).toContain('start is already queued')
+  })
+
+  it("sets 'already running' tooltip when kometaStatus=running", () => {
+    installDom({ incompleteAlertVisible: true, recoveryCommandOutput: 'python kometa.py' })
+    kometaState.kometaStatus = 'running'
+    syncIncompleteRunActions()
+    const btn = document.getElementById('run-recovery-command')
+    expect(btn.disabled).toBe(true)
+    expect(btn.getAttribute('title')).toContain('already running')
+  })
+
+  it("sets 'no recovery command' tooltip when alert visible but recovery panel empty", () => {
+    installDom({ incompleteAlertVisible: true, recoveryCommandOutput: '' })
+    syncIncompleteRunActions()
+    const btn = document.getElementById('run-recovery-command')
+    expect(btn.disabled).toBe(true)
+    expect(btn.getAttribute('title')).toContain('No recovery command is available')
+  })
+})
+
+describe('syncIncompleteRunActions -- runnable', () => {
+  it('enables the button and clears title when everything is favorable', () => {
+    installDom({
+      incompleteAlertVisible: true,
+      recoveryCommandOutput: 'python kometa.py --resume'
+    })
+    // All state flags default to favorable in resetState()
+    syncIncompleteRunActions()
+    const btn = document.getElementById('run-recovery-command')
+    expect(btn.classList.contains('d-none')).toBe(false)
+    expect(btn.disabled).toBe(false)
+    expect(btn.hasAttribute('title')).toBe(false)
+  })
+})

--- a/tests/js/kometa/validationGate.test.js
+++ b/tests/js/kometa/validationGate.test.js
@@ -5,8 +5,9 @@
 //   updateValidationGate -- big orchestration: reads gate state +
 //                          per-page validation flags, mutates
 //                          kometaState.showYAML, toggles a swarm of
-//                          .d-none classes, calls the two extension
-//                          callbacks.
+//                          .d-none classes, calls updateRunNowState
+//                          and syncFinalAccordionRollups at every
+//                          exit path.
 //
 // COVERAGE STRATEGY:
 //
@@ -23,16 +24,35 @@
 //     Path D: stage='config' + all 5 flags true -> everything shown
 //     Path E: stage='config' + some flags missing -> validation msgs
 //     Path F: stage='config' + configValid + msg element missing (soft)
-//     Path G: callbacks are always invoked exactly once
+//     Path G: side-effect calls (updateRunNowState +
+//                                syncFinalAccordionRollups)
+//             fire exactly once at every exit point
 //     Path H: kometaState.showYAML is correctly toggled per branch
 //     Path I: run-now button label defaults to 'Run Now' in all branches
+//
+// updateRunNowState + syncFinalAccordionRollups are mocked via
+// vi.mock() so we can spy on invocation counts without needing to
+// build the full DOM those functions require.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the two collaborators BEFORE importing _validationGate.js.
+// vi.mock() is hoisted so this happens regardless of position, but
+// keeping it near the imports for readability.
+vi.mock('../../../static/local-js/modules/kometa/_runControls.js', () => ({
+  updateRunNowState: vi.fn()
+}))
+vi.mock('../../../static/local-js/modules/kometa/_headerBadges.js', () => ({
+  syncFinalAccordionRollups: vi.fn()
+}))
+
 import { kometaState } from '../../../static/local-js/modules/kometa/_state.js'
 import {
   getFinalGateState,
   updateValidationGate
 } from '../../../static/local-js/modules/kometa/_validationGate.js'
+import { updateRunNowState } from '../../../static/local-js/modules/kometa/_runControls.js'
+import { syncFinalAccordionRollups } from '../../../static/local-js/modules/kometa/_headerBadges.js'
 
 // ---------------------------------------------------------------------
 // Fixture DOM helpers
@@ -104,19 +124,17 @@ function installGateDom ({
   document.body.innerHTML = parts.join('\n')
 }
 
-// Standard spy callbacks bundle -- shared shape across tests
-function makeCallbacks () {
-  return {
-    updateRunNowState: vi.fn(),
-    syncFinalAccordionRollups: vi.fn()
-  }
-}
+beforeEach(() => {
+  // Clear mock call history (the module mocks themselves stay in
+  // place; only their invocation counts reset).
+  updateRunNowState.mockClear()
+  syncFinalAccordionRollups.mockClear()
+})
 
 afterEach(() => {
   document.body.innerHTML = ''
   // Reset showYAML to its default so tests don't cross-contaminate
   kometaState.showYAML = false
-  vi.restoreAllMocks()
 })
 
 // ---------------------------------------------------------------------
@@ -182,8 +200,8 @@ describe('updateValidationGate stage=todo', () => {
   it('hides YAML/run controls/downloads and sets showYAML=false', () => {
     installGateDom({ gate: { stage: 'todo' } })
     kometaState.showYAML = true // sanity: even if it was true before
-    const cb = makeCallbacks()
-    updateValidationGate(cb)
+
+    updateValidationGate()
     expect(kometaState.showYAML).toBe(false)
     expect(document.getElementById('validation-messages').classList.contains('d-none')).toBe(true)
     expect(document.getElementById('run-controls-container').classList.contains('d-none')).toBe(true)
@@ -194,10 +212,10 @@ describe('updateValidationGate stage=todo', () => {
 
   it('invokes both callbacks exactly once', () => {
     installGateDom({ gate: { stage: 'todo' } })
-    const cb = makeCallbacks()
-    updateValidationGate(cb)
-    expect(cb.updateRunNowState).toHaveBeenCalledTimes(1)
-    expect(cb.syncFinalAccordionRollups).toHaveBeenCalledTimes(1)
+
+    updateValidationGate()
+    expect(updateRunNowState).toHaveBeenCalledTimes(1)
+    expect(syncFinalAccordionRollups).toHaveBeenCalledTimes(1)
   })
 
   it('short-circuits: does not read per-page validation flags', () => {
@@ -208,7 +226,7 @@ describe('updateValidationGate stage=todo', () => {
       gate: { stage: 'todo', configValid: true },
       flags: { plex: true, tmdb: true, libs: true, sett: true, yaml: true }
     })
-    updateValidationGate(makeCallbacks())
+    updateValidationGate()
     expect(kometaState.showYAML).toBe(false)
   })
 })
@@ -216,11 +234,11 @@ describe('updateValidationGate stage=todo', () => {
 describe('updateValidationGate stage=freshness', () => {
   it('behaves identically to stage=todo', () => {
     installGateDom({ gate: { stage: 'freshness' } })
-    const cb = makeCallbacks()
-    updateValidationGate(cb)
+
+    updateValidationGate()
     expect(kometaState.showYAML).toBe(false)
-    expect(cb.updateRunNowState).toHaveBeenCalledTimes(1)
-    expect(cb.syncFinalAccordionRollups).toHaveBeenCalledTimes(1)
+    expect(updateRunNowState).toHaveBeenCalledTimes(1)
+    expect(syncFinalAccordionRollups).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -234,7 +252,7 @@ describe('updateValidationGate stage=config, all flags valid', () => {
       gate: { stage: 'config', configValid: false },
       flags: { plex: true, tmdb: true, libs: true, sett: true, yaml: true }
     })
-    updateValidationGate(makeCallbacks())
+    updateValidationGate()
     expect(kometaState.showYAML).toBe(true)
     expect(document.getElementById('validation-messages').classList.contains('d-none')).toBe(true)
     expect(document.getElementById('no-validation-warning').classList.contains('d-none')).toBe(true)
@@ -248,7 +266,7 @@ describe('updateValidationGate stage=config, all flags valid', () => {
       gate: { stage: 'config' },
       flags: { plex: true, tmdb: true, libs: true, sett: true, yaml: true }
     })
-    updateValidationGate(makeCallbacks())
+    updateValidationGate()
     // The gate itself doesn't enable the button -- that's updateRunNowState's job
     expect(document.getElementById('run-now').disabled).toBe(true)
     expect(document.getElementById('run-now-label').textContent).toBe('Run Now')
@@ -261,7 +279,7 @@ describe('updateValidationGate stage=config, configValid=true (server override)'
       gate: { stage: 'config', configValid: true },
       flags: { plex: false, tmdb: false, libs: false, sett: false, yaml: false }
     })
-    updateValidationGate(makeCallbacks())
+    updateValidationGate()
     expect(kometaState.showYAML).toBe(true)
   })
 })
@@ -276,7 +294,7 @@ describe('updateValidationGate stage=config, some flags missing', () => {
       gate: { stage: 'config' },
       flags: { plex: false, tmdb: true, libs: false, sett: true, yaml: true }
     })
-    updateValidationGate(makeCallbacks())
+    updateValidationGate()
     expect(kometaState.showYAML).toBe(false)
     const msg = document.getElementById('validation-messages')
     expect(msg.classList.contains('d-none')).toBe(false)
@@ -296,7 +314,7 @@ describe('updateValidationGate stage=config, some flags missing', () => {
       gate: { stage: 'config' },
       flags: { plex: true, tmdb: true, libs: true, sett: true, yaml: false }
     })
-    updateValidationGate(makeCallbacks())
+    updateValidationGate()
     expect(kometaState.showYAML).toBe(false)
     // With all page flags true but yaml false, no rows are pushed -->
     // messages list is empty --> the branch that hides validation-messages
@@ -310,7 +328,7 @@ describe('updateValidationGate stage=config, some flags missing', () => {
       gate: { stage: 'config' },
       flags: { plex: false }
     })
-    updateValidationGate(makeCallbacks())
+    updateValidationGate()
     expect(document.getElementById('no-validation-warning').classList.contains('d-none')).toBe(false)
     expect(document.getElementById('download-btn').classList.contains('d-none')).toBe(true)
     expect(document.getElementById('run-controls-container').classList.contains('d-none')).toBe(true)
@@ -328,7 +346,7 @@ describe('updateValidationGate robustness', () => {
       flags: { plex: false },
       omit: ['validation-messages']
     })
-    expect(() => updateValidationGate(makeCallbacks())).not.toThrow()
+    expect(() => updateValidationGate()).not.toThrow()
   })
 
   it('does not throw when run-now / run-now-label are missing', () => {
@@ -336,7 +354,7 @@ describe('updateValidationGate robustness', () => {
       gate: { stage: 'todo' },
       omit: ['run-now', 'run-now-label']
     })
-    expect(() => updateValidationGate(makeCallbacks())).not.toThrow()
+    expect(() => updateValidationGate()).not.toThrow()
   })
 
   it('does not throw when any warning/download/yaml element is missing', () => {
@@ -345,7 +363,7 @@ describe('updateValidationGate robustness', () => {
       flags: { plex: true, tmdb: true, libs: true, sett: true, yaml: true },
       omit: ['no-validation-warning', 'yaml-warnings', 'download-btn', 'yaml-content']
     })
-    expect(() => updateValidationGate(makeCallbacks())).not.toThrow()
+    expect(() => updateValidationGate()).not.toThrow()
   })
 
   it('handles callbacks being missing (undefined)', () => {


### PR DESCRIPTION
## What

Extracts the Run Now button state machine and the Recovery button visibility/tooltip logic. **This is the key unblocker for retiring the `updateValidationGate` callbacks-bag** — both callbacks now live in proper modules and can be imported directly.

`900-kometa.js`: 2907 → 2843 lines (**−64**).
Vitest tests: 986 → 1011 (**+25**). **Crossed 1000 tests!**

## What moved

Extracted to `static/local-js/modules/kometa/_runControls.js` (182 lines):

| Group | Exports |
|---|---|
| **Command readers** | `getCurrentRunCommand`, `getRecoveryRunCommand` |
| **Run Now button state machine** | `updateRunNowState` |
| **Recovery button** | `syncIncompleteRunActions` |

## The main event: retiring updateValidationGate's callbacks-bag

**Pre-#1571:**
```js
updateValidationGate({ updateRunNowState, syncFinalAccordionRollups })
```

Both callbacks lived in different files. **Now both are proper module exports** and `_validationGate.js` imports them directly. The `if typeof === function` guards are gone.

## Remaining callback-bag: buildCommand

The `buildCommand` callbacks-bag STAYS in `900-kometa.js`. Can't retire yet because doing so would create a cycle:

```
_runCommand.js ──imports──> _runControls.js  (updateRunNowState)
                          <── ─ imports ─── (isRunCommandValid)
```

Deferred, not forgotten. Next PR will move `isRunCommandValid` to a lower-level module to break the cycle.

## Design notes

1. **Preserved original short-circuit ordering** in `updateRunNowState`. Kept as `if/else if/else` instead of one big boolean — each disable reason has its own line for readability.

2. **Preserved tooltip priority order** in `syncIncompleteRunActions`. Priority matters when multiple flags are true (defensive):
   - `recoveryRunnable` → no title
   - `!alertVisible` → 'only available when...'
   - `kometaValidationInProgress` → 'Wait for Kometa validation'
   - `kometaUpdating` → 'Wait for the Kometa update'
   - `kometaPendingStart` → 'start is already queued'
   - `kometaStatus=running` → 'already running'
   - fallback → 'No recovery command is available'

3. **Zero circular deps** — `_runControls.js` imports from `_headerBadges.js` and `_runCommand.js`, but neither imports back.

## Test updates

**`validationGate.test.js`:** replaced `cb.updateRunNowState` / `cb.syncFinalAccordionRollups` with imports of the mocked module exports (`vi.mock()` for `_runControls.js` and `_headerBadges.js` at top).

**`runControls.test.js`** (new, 25 tests):
- Command readers (5)
- `updateRunNowState` (11): no-op path, 6 disable reasons, enable path, 2 side-effect assertions
- `syncIncompleteRunActions` (10): no-op, hidden, 5 state-blockers, no-command, runnable

Collaborators mocked with `vi.mock()` so this module's behavior is tested in isolation.

## Verification

- **1011/1011 Vitest pass** (was 986; +25 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- ESLint clean, Node syntax clean

## What's next

- Move `isRunCommandValid` to a shared spot (maybe `_util.js`) to break the last cycle. Retires the `buildCommand` callbacks-bag.
- `_kometaUpdate.js` — update job polling, `checkKometaUpdate`, `callUpdateKometa`, phase badges (~600 lines, biggest remaining target)
- `_kometaRuntime.js` — `validateKometaRoot` + `probeKometaRoot`