### PR TITLE
Cleanup: move isRunCommandValid to _util.js; retire buildCommand callbacks-bag

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -39,7 +39,7 @@ import {
   kometaCanReadLogs
 } from './modules/kometa/_runtime.js'
 import {
-  buildCommand as _buildCommand,
+  buildCommand,
   applyActiveRunCommandState,
   clearActiveRunCommandState
 } from './modules/kometa/_runCommand.js'
@@ -67,16 +67,6 @@ import {
   getCurrentRunCommand,
   getRecoveryRunCommand
 } from './modules/kometa/_runControls.js'
-
-// Thin wrapper: buildCommand needs updateRunNowState and
-// syncFinalAccordionRollups callbacks. Both live in other modules
-// now, but wiring them through _runCommand.js as direct imports
-// would create a cycle:
-//   _runCommand.js -> _runControls.js -> _runCommand.js (isRunCommandValid)
-// So we keep the callbacks-bag bridge here.
-function buildCommand () {
-  return _buildCommand({ updateRunNowState, syncFinalAccordionRollups })
-}
 
 // Kometa runtime status flags migrated to modules/kometa/_state.js
 // (kometaState.kometaInstalled, kometaValidated, kometaStatus, etc.).

--- a/static/local-js/modules/kometa/_headerBadges.js
+++ b/static/local-js/modules/kometa/_headerBadges.js
@@ -47,9 +47,8 @@
 //   setHeaderRollupBadge accepts any string; unknown values fall back
 //   to 'unknown' to keep the badge visually consistent.
 
-import { formatHeaderStyleLabel, isValidTimesFormat, computeYamlLineCount } from './_util.js'
+import { formatHeaderStyleLabel, isValidTimesFormat, computeYamlLineCount, isRunCommandValid } from './_util.js'
 import { kometaState } from './_state.js'
-import { isRunCommandValid } from './_runCommand.js'
 import { syncKometaBranchRollupBadge } from './_kometaBranch.js'
 
 // ---------------------------------------------------------------------

--- a/static/local-js/modules/kometa/_runCommand.js
+++ b/static/local-js/modules/kometa/_runCommand.js
@@ -19,9 +19,9 @@
 //   buildCommand                     -- the big assembler (~120 lines).
 //                                        Returns true/false/undefined
 //                                        depending on validation state.
-//   isRunCommandValid                -- true iff the run-command-output
-//                                        element has non-empty, non-'??'
-//                                        text content
+//
+// NOTE: isRunCommandValid moved to _util.js in PR #1572 to break a
+// cycle. Import from './_util.js' if you need it.
 //
 //   getRunCommandModeLabel           -- label above the command panel
 //   getRunCommandModeBadgeLabel      -- text of the mode indicator badge
@@ -36,11 +36,11 @@
 //
 // Design notes:
 //
-//   1. buildCommand takes callbacks (updateRunNowState,
-//      syncFinalAccordionRollups) as required properties of an
-//      options bag. Same hybrid pattern as _validationGate.js --
-//      once those functions themselves migrate to their own modules,
-//      the callbacks retire in favor of direct imports.
+//   1. buildCommand imports updateRunNowState (from _runControls.js)
+//      and syncFinalAccordionRollups (from _headerBadges.js) directly.
+//      These were callback parameters pre-#1572 to avoid a cycle with
+//      _runControls.js (which needed isRunCommandValid from here).
+//      Moving isRunCommandValid to _util.js in #1572 broke the cycle.
 //
 //   2. isWindowsPlatform is computed lazily via a private helper
 //      each call rather than cached at module load. Trivial cost,
@@ -56,6 +56,8 @@
 import { kometaState } from './_state.js'
 import { quoteIfNeeded, isValidTimesFormat } from './_util.js'
 import { toggleTimesInputVisibility, checkMaintenanceWarning } from './_maintenanceWindow.js'
+import { updateRunNowState } from './_runControls.js'
+import { syncFinalAccordionRollups } from './_headerBadges.js'
 
 // ---------------------------------------------------------------------
 // Private helpers
@@ -86,19 +88,6 @@ function normalizeMode (mode) {
 // ---------------------------------------------------------------------
 // Command validity + labels
 // ---------------------------------------------------------------------
-
-/**
- * True iff the run-command panel currently shows a real command
- * (non-empty, not a "??" placeholder for missing paths).
- *
- * @returns {boolean}
- */
-export function isRunCommandValid () {
-  const el = document.getElementById('run-command-output')
-  if (!el) return false
-  const cmd = (el.textContent || '').trim()
-  return Boolean(cmd) && !cmd.startsWith('??')
-}
 
 /**
  * The user-facing label above the run-command panel. Matches the
@@ -222,18 +211,16 @@ const CHECKBOX_FLAGS = [
  *                     divider)
  *   undefined    -- no run-command-output in the DOM (short-circuit)
  *
- * @param {{
- *   updateRunNowState: () => void,
- *   syncFinalAccordionRollups: () => void
- * }} callbacks  Both hooks are required (see module docstring).
+ * Side effects at every non-short-circuit exit:
+ *   - updateRunNowState() -- refresh the Run Now button
+ *   - syncFinalAccordionRollups() -- refresh header badges
  *
  * @returns {boolean | undefined}
  */
-export function buildCommand (callbacks) {
-  const { updateRunNowState, syncFinalAccordionRollups } = callbacks || {}
+export function buildCommand () {
   const notify = () => {
-    if (typeof updateRunNowState === 'function') updateRunNowState()
-    if (typeof syncFinalAccordionRollups === 'function') syncFinalAccordionRollups()
+    updateRunNowState()
+    syncFinalAccordionRollups()
   }
 
   const runCmdOutput = document.getElementById('run-command-output')

--- a/static/local-js/modules/kometa/_runControls.js
+++ b/static/local-js/modules/kometa/_runControls.js
@@ -31,8 +31,8 @@
 //   uses kometaState directly, this module is fully self-contained.
 
 import { kometaState } from './_state.js'
+import { isRunCommandValid } from './_util.js'
 import { updateRunCommandHeaderBadge } from './_headerBadges.js'
-import { isRunCommandValid } from './_runCommand.js'
 
 // ---------------------------------------------------------------------
 // Command-text readers (trivial DOM accessors)

--- a/static/local-js/modules/kometa/_util.js
+++ b/static/local-js/modules/kometa/_util.js
@@ -402,3 +402,25 @@ export function setMetaFlag (id, datasetKey, attrKey, value) {
   if (el.dataset) el.dataset[datasetKey] = serialized
   el.setAttribute(`data-${attrKey}`, serialized)
 }
+
+// ---------------------------------------------------------------------
+// Run-command DOM helpers
+// ---------------------------------------------------------------------
+
+/**
+ * True iff the run-command panel currently shows a real command
+ * (non-empty, not a "??" placeholder for missing paths).
+ *
+ * Lives here (rather than in _runCommand.js) because it's a pure DOM
+ * read with zero dependencies, and moving it up to _util.js lets both
+ * _runCommand.js AND _runControls.js import it without creating a
+ * cycle. See PR #1571's design notes for the cycle history.
+ *
+ * @returns {boolean}
+ */
+export function isRunCommandValid () {
+  const el = document.getElementById('run-command-output')
+  if (!el) return false
+  const cmd = (el.textContent || '').trim()
+  return Boolean(cmd) && !cmd.startsWith('??')
+}

--- a/tests/js/kometa/runCommand.test.js
+++ b/tests/js/kometa/runCommand.test.js
@@ -1,8 +1,7 @@
 // Tests for static/local-js/modules/kometa/_runCommand.js
 //
-// The module exports seven functions. Coverage strategy:
+// The module exports six functions. Coverage strategy:
 //
-//   isRunCommandValid            trivial DOM read, 4 tests
 //   getRunCommandModeLabel       pure fn, 3 tests
 //   getRunCommandModeBadgeLabel  pure fn, 3 tests
 //   getRunCommandModeBadgeClass  pure fn, 3 tests
@@ -10,18 +9,34 @@
 //   clearActiveRunCommandState   inverse, 3 tests
 //   buildCommand                 big one, 25+ tests covering every
 //                                validation branch
+//
+// NOTE: isRunCommandValid moved to _util.js in PR #1572; its tests
+// moved to util.test.js. See _runCommand.js docstring for the cycle
+// history.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock collaborators BEFORE importing _runCommand.js so buildCommand's
+// direct imports of updateRunNowState + syncFinalAccordionRollups are
+// spy-able without needing a full DOM.
+vi.mock('../../../static/local-js/modules/kometa/_runControls.js', () => ({
+  updateRunNowState: vi.fn()
+}))
+vi.mock('../../../static/local-js/modules/kometa/_headerBadges.js', () => ({
+  syncFinalAccordionRollups: vi.fn()
+}))
+
 import { kometaState } from '../../../static/local-js/modules/kometa/_state.js'
 import {
   buildCommand,
-  isRunCommandValid,
   getRunCommandModeLabel,
   getRunCommandModeBadgeLabel,
   getRunCommandModeBadgeClass,
   applyActiveRunCommandState,
   clearActiveRunCommandState
 } from '../../../static/local-js/modules/kometa/_runCommand.js'
+import { updateRunNowState } from '../../../static/local-js/modules/kometa/_runControls.js'
+import { syncFinalAccordionRollups } from '../../../static/local-js/modules/kometa/_headerBadges.js'
 
 // ---------------------------------------------------------------------
 // Fixture DOM helpers
@@ -115,44 +130,17 @@ function installRunCommandDom (opts = {}) {
   `
 }
 
-function makeCallbacks () {
-  return {
-    updateRunNowState: vi.fn(),
-    syncFinalAccordionRollups: vi.fn()
-  }
-}
+beforeEach(() => {
+  // Reset mock call counts before each test (the module mocks
+  // themselves persist; only invocation counts get cleared).
+  updateRunNowState.mockClear()
+  syncFinalAccordionRollups.mockClear()
+})
 
 afterEach(() => {
   document.body.innerHTML = ''
   kometaState.activeRunCommandOverride = null
   kometaState.activeRunCommandMode = null
-  vi.restoreAllMocks()
-})
-
-// ---------------------------------------------------------------------
-// isRunCommandValid
-// ---------------------------------------------------------------------
-
-describe('isRunCommandValid', () => {
-  it('is true when the run-command-output has real content', () => {
-    document.body.innerHTML = '<div id="run-command-output">python kometa.py --config config.yml</div>'
-    expect(isRunCommandValid()).toBe(true)
-  })
-
-  it("is false when the content starts with '??' placeholder", () => {
-    document.body.innerHTML = '<div id="run-command-output">?? no kometa root ??</div>'
-    expect(isRunCommandValid()).toBe(false)
-  })
-
-  it('is false when the content is empty/whitespace', () => {
-    document.body.innerHTML = '<div id="run-command-output">   </div>'
-    expect(isRunCommandValid()).toBe(false)
-  })
-
-  it('is false when the element is missing', () => {
-    document.body.innerHTML = ''
-    expect(isRunCommandValid()).toBe(false)
-  })
 })
 
 // ---------------------------------------------------------------------
@@ -297,8 +285,8 @@ describe('clearActiveRunCommandState', () => {
 describe('buildCommand basic path (no flags)', () => {
   it('assembles python + kometa.py + --config with quoting', () => {
     installRunCommandDom()
-    const cb = makeCallbacks()
-    const result = buildCommand(cb)
+
+    const result = buildCommand()
     expect(result).toBe(true)
     const out = document.getElementById('run-command-output')
     expect(out.dataset.builtCommand).toBe('/venv/bin/python /opt/kometa/kometa.py --config /opt/kometa/config/config.yml')
@@ -307,19 +295,19 @@ describe('buildCommand basic path (no flags)', () => {
 
   it('invokes both callbacks exactly once on the success path', () => {
     installRunCommandDom()
-    const cb = makeCallbacks()
-    buildCommand(cb)
-    expect(cb.updateRunNowState).toHaveBeenCalledTimes(1)
-    expect(cb.syncFinalAccordionRollups).toHaveBeenCalledTimes(1)
+
+    buildCommand()
+    expect(updateRunNowState).toHaveBeenCalledTimes(1)
+    expect(syncFinalAccordionRollups).toHaveBeenCalledTimes(1)
   })
 
   it('short-circuits (returns undefined) when run-command-output is missing', () => {
     document.body.innerHTML = '<div id="qs-env"></div>' // no run-command-output
-    const cb = makeCallbacks()
-    const result = buildCommand(cb)
+
+    const result = buildCommand()
     expect(result).toBeUndefined()
     // Callbacks should NOT have been called
-    expect(cb.updateRunNowState).not.toHaveBeenCalled()
+    expect(updateRunNowState).not.toHaveBeenCalled()
   })
 
   it('quotes paths containing spaces', () => {
@@ -327,7 +315,7 @@ describe('buildCommand basic path (no flags)', () => {
       venvPython: '/opt/my venv/bin/python',
       kometaRoot: '/opt/my kometa'
     })
-    buildCommand(makeCallbacks())
+    buildCommand()
     const out = document.getElementById('run-command-output').dataset.builtCommand
     expect(out).toContain('"/opt/my venv/bin/python"')
     expect(out).toContain('"/opt/my kometa/kometa.py"')
@@ -340,7 +328,7 @@ describe('buildCommand basic path (no flags)', () => {
       venvPython: 'C:/venv/Scripts/python.exe',
       kometaRoot: 'C:/Kometa'
     })
-    buildCommand(makeCallbacks())
+    buildCommand()
     const out = document.getElementById('run-command-output').dataset.builtCommand
     expect(out).toContain('C:\\venv\\Scripts\\python.exe')
     expect(out).toContain('C:\\Kometa\\kometa.py')
@@ -354,7 +342,7 @@ describe('buildCommand basic path (no flags)', () => {
     const out = document.getElementById('run-command-output')
     out.textContent = 'FROZEN COMMAND'
     kometaState.activeRunCommandOverride = 'FROZEN COMMAND'
-    buildCommand(makeCallbacks())
+    buildCommand()
     expect(out.textContent).toBe('FROZEN COMMAND')
     // But dataset.builtCommand should still be updated
     expect(out.dataset.builtCommand).toBe('/venv/bin/python /opt/kometa/kometa.py --config /opt/kometa/config/config.yml')
@@ -362,7 +350,7 @@ describe('buildCommand basic path (no flags)', () => {
 
   it('uses default python3 when venv-python attr is missing', () => {
     installRunCommandDom({ venvPython: '' })
-    buildCommand(makeCallbacks())
+    buildCommand()
     const out = document.getElementById('run-command-output').dataset.builtCommand
     expect(out.startsWith('python3 ')).toBe(true)
   })
@@ -372,7 +360,7 @@ describe('buildCommand mainOption --times', () => {
   it('appends quoted times string when valid', () => {
     installRunCommandDom({ runOption: '--times' })
     document.getElementById('times-input').value = '06:00|15:00'
-    buildCommand(makeCallbacks())
+    buildCommand()
     const out = document.getElementById('run-command-output').dataset.builtCommand
     expect(out).toContain('--times "06:00|15:00"')
   })
@@ -380,22 +368,22 @@ describe('buildCommand mainOption --times', () => {
   it("returns false and shows 'Invalid time format' on bad input", () => {
     installRunCommandDom({ runOption: '--times' })
     document.getElementById('times-input').value = 'not a time'
-    const cb = makeCallbacks()
-    const result = buildCommand(cb)
+
+    const result = buildCommand()
     expect(result).toBe(false)
     expect(document.getElementById('times-error').classList.contains('d-none')).toBe(false)
     expect(document.getElementById('run-command-output').textContent).toContain('Invalid time format')
     // Callbacks should still fire on the failure path (so run-now
     // gets disabled and the accordion rollup updates)
-    expect(cb.updateRunNowState).toHaveBeenCalledTimes(1)
-    expect(cb.syncFinalAccordionRollups).toHaveBeenCalledTimes(1)
+    expect(updateRunNowState).toHaveBeenCalledTimes(1)
+    expect(syncFinalAccordionRollups).toHaveBeenCalledTimes(1)
   })
 
   it('hides the times-error div when the value becomes valid', () => {
     installRunCommandDom({ runOption: '--times' })
     document.getElementById('times-input').value = '06:00'
     document.getElementById('times-error').classList.remove('d-none') // stale
-    buildCommand(makeCallbacks())
+    buildCommand()
     expect(document.getElementById('times-error').classList.contains('d-none')).toBe(true)
   })
 })
@@ -405,7 +393,7 @@ describe('buildCommand mainOption --run-libraries', () => {
     installRunCommandDom({ runOption: '--run-libraries' })
     const sel = document.getElementById('library-multiselect')
     Array.from(sel.options).forEach(o => { o.selected = true })
-    buildCommand(makeCallbacks())
+    buildCommand()
     const out = document.getElementById('run-command-output').dataset.builtCommand
     expect(out).toContain('--run-libraries "Movies|TV Shows"')
   })
@@ -413,7 +401,7 @@ describe('buildCommand mainOption --run-libraries', () => {
   it('returns false with a warning when no libraries are selected', () => {
     installRunCommandDom({ runOption: '--run-libraries' })
     // Nothing selected
-    const result = buildCommand(makeCallbacks())
+    const result = buildCommand()
     expect(result).toBe(false)
     expect(document.getElementById('run-command-output').textContent).toContain('Please select at least one library')
   })
@@ -422,13 +410,13 @@ describe('buildCommand mainOption --run-libraries', () => {
 describe('buildCommand mode/log flags', () => {
   it('appends the selected mode flag', () => {
     installRunCommandDom({ modeFlag: '--dry-run' })
-    buildCommand(makeCallbacks())
+    buildCommand()
     expect(document.getElementById('run-command-output').dataset.builtCommand).toContain('--dry-run')
   })
 
   it('appends the selected log flag', () => {
     installRunCommandDom({ logFlag: '--debug' })
-    buildCommand(makeCallbacks())
+    buildCommand()
     expect(document.getElementById('run-command-output').dataset.builtCommand).toContain('--debug')
   })
 })
@@ -439,7 +427,7 @@ describe('buildCommand no-value checkboxes', () => {
     document.getElementById('opt-delete-collections').checked = true
     document.getElementById('opt-read-only-config').checked = true
     document.getElementById('opt-no-verify-ssl').checked = true
-    buildCommand(makeCallbacks())
+    buildCommand()
     const out = document.getElementById('run-command-output').dataset.builtCommand
     expect(out).toContain('--delete-collections')
     expect(out).toContain('--read-only-config')
@@ -452,7 +440,7 @@ describe('buildCommand no-value checkboxes', () => {
   it('is silent when a checkbox element is missing (no throw)', () => {
     installRunCommandDom()
     document.getElementById('opt-tests').remove()
-    expect(() => buildCommand(makeCallbacks())).not.toThrow()
+    expect(() => buildCommand()).not.toThrow()
   })
 })
 
@@ -461,7 +449,7 @@ describe('buildCommand --timeout validation', () => {
     installRunCommandDom()
     document.getElementById('opt-timeout').checked = true
     document.getElementById('opt-timeout-val').value = '60'
-    buildCommand(makeCallbacks())
+    buildCommand()
     expect(document.getElementById('run-command-output').dataset.builtCommand).toContain('--timeout 60')
   })
 
@@ -469,7 +457,7 @@ describe('buildCommand --timeout validation', () => {
     installRunCommandDom()
     document.getElementById('opt-timeout').checked = true
     document.getElementById('opt-timeout-val').value = 'abc'
-    expect(buildCommand(makeCallbacks())).toBe(false)
+    expect(buildCommand()).toBe(false)
     expect(document.getElementById('timeout-error').classList.contains('d-none')).toBe(false)
   })
 
@@ -477,14 +465,14 @@ describe('buildCommand --timeout validation', () => {
     installRunCommandDom()
     document.getElementById('opt-timeout').checked = true
     document.getElementById('opt-timeout-val').value = '0'
-    expect(buildCommand(makeCallbacks())).toBe(false)
+    expect(buildCommand()).toBe(false)
   })
 
   it('is a no-op when the timeout checkbox is unchecked', () => {
     installRunCommandDom()
     document.getElementById('opt-timeout').checked = false
     document.getElementById('opt-timeout-val').value = 'garbage but should be ignored'
-    expect(buildCommand(makeCallbacks())).toBe(true)
+    expect(buildCommand()).toBe(true)
     expect(document.getElementById('run-command-output').dataset.builtCommand).not.toContain('--timeout')
   })
 })
@@ -494,7 +482,7 @@ describe('buildCommand --width validation', () => {
     installRunCommandDom()
     document.getElementById('opt-width').checked = true
     document.getElementById('opt-width-val').value = '120'
-    buildCommand(makeCallbacks())
+    buildCommand()
     expect(document.getElementById('run-command-output').dataset.builtCommand).toContain('--width 120')
   })
 
@@ -502,26 +490,26 @@ describe('buildCommand --width validation', () => {
     installRunCommandDom()
     document.getElementById('opt-width').checked = true
     document.getElementById('opt-width-val').value = '80'
-    expect(buildCommand(makeCallbacks())).toBe(false)
+    expect(buildCommand()).toBe(false)
   })
 
   it('rejects widths over 300', () => {
     installRunCommandDom()
     document.getElementById('opt-width').checked = true
     document.getElementById('opt-width-val').value = '400'
-    expect(buildCommand(makeCallbacks())).toBe(false)
+    expect(buildCommand()).toBe(false)
   })
 
   it('accepts boundary values 90 and 300', () => {
     installRunCommandDom()
     document.getElementById('opt-width').checked = true
     document.getElementById('opt-width-val').value = '90'
-    expect(buildCommand(makeCallbacks())).toBe(true)
+    expect(buildCommand()).toBe(true)
 
     installRunCommandDom()
     document.getElementById('opt-width').checked = true
     document.getElementById('opt-width-val').value = '300'
-    expect(buildCommand(makeCallbacks())).toBe(true)
+    expect(buildCommand()).toBe(true)
   })
 })
 
@@ -530,7 +518,7 @@ describe('buildCommand --divider validation', () => {
     installRunCommandDom()
     document.getElementById('opt-divider').checked = true
     document.getElementById('opt-divider-val').value = '='
-    buildCommand(makeCallbacks())
+    buildCommand()
     expect(document.getElementById('run-command-output').dataset.builtCommand).toContain('--divider "="')
   })
 
@@ -538,14 +526,14 @@ describe('buildCommand --divider validation', () => {
     installRunCommandDom()
     document.getElementById('opt-divider').checked = true
     document.getElementById('opt-divider-val').value = '=='
-    expect(buildCommand(makeCallbacks())).toBe(false)
+    expect(buildCommand()).toBe(false)
   })
 
   it('rejects empty divider even when checkbox is checked', () => {
     installRunCommandDom()
     document.getElementById('opt-divider').checked = true
     document.getElementById('opt-divider-val').value = ''
-    expect(buildCommand(makeCallbacks())).toBe(false)
+    expect(buildCommand()).toBe(false)
   })
 })
 

--- a/tests/js/kometa/runControls.test.js
+++ b/tests/js/kometa/runControls.test.js
@@ -44,7 +44,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 vi.mock('../../../static/local-js/modules/kometa/_headerBadges.js', () => ({
   updateRunCommandHeaderBadge: vi.fn()
 }))
-vi.mock('../../../static/local-js/modules/kometa/_runCommand.js', () => ({
+// _util.js exports many pure helpers; we only want to stub
+// isRunCommandValid. importActual pulls the real module and we
+// spread its exports so the rest keep working (readMetaFlag,
+// computeYamlLineCount, etc., in case _runControls.js or its
+// transitive deps use them).
+vi.mock('../../../static/local-js/modules/kometa/_util.js', async (importActual) => ({
+  ...(await importActual()),
   isRunCommandValid: vi.fn(() => true)  // default: valid
 }))
 
@@ -56,7 +62,7 @@ import {
   syncIncompleteRunActions
 } from '../../../static/local-js/modules/kometa/_runControls.js'
 import { updateRunCommandHeaderBadge } from '../../../static/local-js/modules/kometa/_headerBadges.js'
-import { isRunCommandValid } from '../../../static/local-js/modules/kometa/_runCommand.js'
+import { isRunCommandValid } from '../../../static/local-js/modules/kometa/_util.js'
 
 // ---------------------------------------------------------------------
 // Fixtures

--- a/tests/js/kometa/util.test.js
+++ b/tests/js/kometa/util.test.js
@@ -32,7 +32,8 @@ import {
   pushSparkValue,
   buildSparklinePoints,
   buildSparklinePointsScaled,
-  copyTextToClipboard
+  copyTextToClipboard,
+  isRunCommandValid
 } from '../../../static/local-js/modules/kometa/_util.js'
 
 afterEach(() => {
@@ -572,5 +573,36 @@ describe('copyTextToClipboard', () => {
         value: originalClipboard
       })
     }
+  })
+})
+
+// ---------------------------------------------------------------------
+// isRunCommandValid (moved from _runCommand.js in PR #1572)
+// ---------------------------------------------------------------------
+//
+// A "valid" run command has non-empty text and doesn't start with the
+// '??' placeholder sentinel that server-side rendering uses when
+// required config paths are still missing. All four combinations of
+// (present/missing element) x (valid/invalid content) are covered.
+
+describe('isRunCommandValid', () => {
+  it('is true when the run-command-output has real content', () => {
+    document.body.innerHTML = '<div id="run-command-output">python kometa.py --config config.yml</div>'
+    expect(isRunCommandValid()).toBe(true)
+  })
+
+  it("is false when the content starts with '??' placeholder", () => {
+    document.body.innerHTML = '<div id="run-command-output">?? no kometa root ??</div>'
+    expect(isRunCommandValid()).toBe(false)
+  })
+
+  it('is false when the content is empty/whitespace', () => {
+    document.body.innerHTML = '<div id="run-command-output">   </div>'
+    expect(isRunCommandValid()).toBe(false)
+  })
+
+  it('is false when the element is missing', () => {
+    document.body.innerHTML = ''
+    expect(isRunCommandValid()).toBe(false)
   })
 })


### PR DESCRIPTION
## What

Final callback-bag retirement in `900-kometa.js`. Moving `isRunCommandValid` to the lowest-level module (`_util.js`) broke the last dep cycle: `_runCommand.js → _runControls.js → _runCommand.js`.

`900-kometa.js`: 2843 → 2833 lines (**−10**).
Vitest tests: 1011 (**unchanged**; +4 in `util.test.js`, −4 in `runCommand.test.js` for the moved tests).

## What moved

`isRunCommandValid` (6-line pure DOM read):
`_runCommand.js` → `_util.js`

Its tests:
`runCommand.test.js` → `util.test.js`

`_util.js` already declares itself the home for 'referentially transparent OR only touching document-level DOM APIs' functions. `isRunCommandValid` fits that contract perfectly (zero state, zero cached refs, one `document.getElementById` call).

## Callbacks-bag retirement: buildCommand

**Pre-#1572:**
```js
// in 900-kometa.js:
function buildCommand () {
  return _buildCommand({ updateRunNowState, syncFinalAccordionRollups })
}
```

**Post-#1572:**
```js
// in _runCommand.js:
import { updateRunNowState } from './_runControls.js'
import { syncFinalAccordionRollups } from './_headerBadges.js'
export function buildCommand () { ... }
```

Why we couldn't retire it before: `_runControls.js` imported `isRunCommandValid` **FROM** `_runCommand.js`, so `_runCommand.js` couldn't import `updateRunNowState` **FROM** `_runControls.js` (cycle).

Why we can retire it now: both `_runCommand.js` AND `_runControls.js` import `isRunCommandValid` from `_util.js`. `_util.js` is a leaf module with zero back-imports. Cycle broken.

## Zero callbacks-bags remaining in 900-kometa.js 

```bash
$ grep -nE 'callbacks|callback bag' static/local-js/900-kometa.js
(no output)
```

Every extracted module now uses direct imports for its collaborators. This closes the callback-bag chapter of the refactor.

## Test updates

**`runCommand.test.js`:**
- Removed `isRunCommandValid` section (4 tests, moved to `util.test.js`)
- Added `vi.mock()` for `_runControls.js` and `_headerBadges.js` at top
- Replaced `buildCommand(makeCallbacks())` with `buildCommand()` (~24 sites) via sed
- Removed `makeCallbacks()` helper
- Renamed `cb.updateRunNowState` → `updateRunNowState` (direct imports of mocked exports)
- Added `beforeEach` `mockClear()` for both mocks

**`util.test.js`:**
- Added import of `isRunCommandValid`
- Added 4 tests for `isRunCommandValid` at end of file (89 → 93)

**`runControls.test.js`:**
- Fixed `vi.mock` target: was `_runCommand.js`, changed to `_util.js` (since `isRunCommandValid` moved)
- Used `vi.importActual` to preserve `_util.js`'s other exports

## Verification

- **1011/1011 Vitest pass**
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- ESLint clean, Node syntax clean

## What's next

- **`_kometaUpdate.js`** — biggest remaining single target (~600 lines): update job polling, `checkKometaUpdate`, `callUpdateKometa`, phase badges
- **`_kometaRuntime.js`** — `validateKometaRoot` + `probeKometaRoot`