### PR TITLE
Split 900-kometa.js part 16: extract update rollup badge + button label

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -72,6 +72,12 @@ import {
   setKometaStatusLog,
   appendKometaStatusLine
 } from './modules/kometa/_updatePhase.js'
+import {
+  syncKometaRollupBadge,
+  syncKometaUpdateAttention,
+  syncUpdateButtonLabel,
+  invalidateKometaUpdateStatus
+} from './modules/kometa/_updateRollup.js'
 
 // Kometa runtime status flags migrated to modules/kometa/_state.js
 // (kometaState.kometaInstalled, kometaValidated, kometaStatus, etc.).
@@ -124,7 +130,6 @@ const headerGrid = document.getElementById('header-style-grid')
 const headerGridCollapse = document.getElementById('header-style-grid-collapse')
 const headerStyleWait = document.getElementById('header-style-wait')
 const finalContentWrapper = document.getElementById('final-content-wrapper')
-const kometaActionsHeading = document.getElementById('kometa-actions-heading')
 const kometaActionsCollapse = document.getElementById('kometa-actions-collapse')
 const kometaActionsToggle = document.getElementById('kometa-actions-toggle')
 const runCommandCollapse = document.getElementById('run-command-output-collapse')
@@ -738,29 +743,6 @@ if (document.getElementById('run-command-output')) {
 initBootstrapTooltips(document, '[title]', { html: false, sanitize: true, placement: 'top', trigger: 'hover' })
 initBootstrapTooltips(document)
 
-function syncKometaUpdateAttention () {
-  if (kometaActionsHeading && kometaActionsToggle) {
-    const isCollapsed = kometaActionsToggle.classList.contains('collapsed')
-    const needsAttention = kometaState.kometaUpdateAvailable && isCollapsed
-    kometaActionsHeading.classList.toggle('kometa-update-attention', needsAttention)
-    kometaActionsToggle.classList.toggle('kometa-update-attention', needsAttention)
-  }
-  syncKometaRollupBadge()
-}
-
-function invalidateKometaUpdateStatus () {
-  kometaState.kometaUpdateAvailable = false
-  kometaState.kometaUpdateCheckCompleted = false
-  kometaState.kometaUpdateCheckSkipped = false
-  kometaState.kometaRemoteVersionStatus = ''
-  kometaState.kometaRemoteVersionChecked = false
-  kometaState.kometaRemoteVersionSkipped = false
-  document.getElementById('kometa-update-box').classList.add('d-none')
-  syncKometaSourceStatus()
-  syncUpdateButtonLabel()
-  syncKometaRollupBadge()
-}
-
 function runKometaStatusPass (forceRefresh = false) {
   const selection = getKometaBranchOverride()
   const effective = getEffectiveKometaBranch()
@@ -834,33 +816,6 @@ function pollKometaUpdateProgress () {
         done: data.done
       })
     })
-}
-
-function getKometaRollupStatus () {
-  if (kometaState.kometaUpdating) return { state: 'unknown', label: 'Updating...' }
-  if (kometaState.kometaValidationInProgress) return { state: 'unknown', label: 'Checking...' }
-  if (!kometaState.kometaLocalCheckCompleted) return { state: 'unknown', label: 'Not checked' }
-  if (!kometaState.kometaInstalled) return { state: 'error', label: 'Install needed' }
-  if (!kometaState.kometaUpdateCheckCompleted) {
-    return { state: kometaState.kometaValidated ? 'ok' : 'warn', label: kometaState.kometaValidated ? 'Prepared' : 'Prepare needed' }
-  }
-  if (kometaState.kometaUpdateCheckSkipped) return { state: 'unknown', label: 'Skipped while running' }
-  if (kometaState.kometaUpdateAvailable) return { state: 'warn', label: 'Update available' }
-  return { state: 'ok', label: 'Up to date' }
-}
-
-function syncKometaRollupBadge () {
-  const badge = document.getElementById('kometa-update-rollup-badge')
-  if (!badge) return
-  const { state, label } = getKometaRollupStatus()
-  badge.textContent = label
-  badge.classList.remove(
-    'qs-validation-rollup-badge--unknown',
-    'qs-validation-rollup-badge--ok',
-    'qs-validation-rollup-badge--warn',
-    'qs-validation-rollup-badge--error'
-  )
-  badge.classList.add(`qs-validation-rollup-badge--${state}`)
 }
 
 if (kometaActionsCollapse) {
@@ -1395,27 +1350,6 @@ function fetchRunProgress (forceFull = false) {
     .finally(() => {
       runProgressInFlight = false
     })
-}
-
-function getUpdateButtonLabel () {
-  const installMode = getConfiguredKometaInstallMode()
-  if (installMode === 'existing') {
-    return `<i class="bi bi-arrow-clockwise me-1"></i> ${kometaState.kometaUpdateCheckCompleted ? 'Recheck Existing Status' : 'Check Existing Status'}`
-  }
-  const force = forceUpdateToggle.checked
-  const label = force
-    ? (kometaState.kometaInstalled ? 'Force Update Kometa' : 'Force Install Kometa')
-    : (kometaState.kometaInstalled
-        ? (kometaState.kometaUpdateAvailable ? 'Update Available' : (kometaState.kometaUpdateCheckCompleted ? 'Up to date' : 'Check for Kometa Updates'))
-        : 'Install Kometa')
-  return `<i class="bi bi-arrow-clockwise me-1"></i> ${label}`
-}
-
-function syncUpdateButtonLabel () {
-  if (updateKometaBtn) {
-    updateKometaBtn.innerHTML = getUpdateButtonLabel()
-  }
-  syncKometaUpdateAttention()
 }
 
 function callUpdateKometa () {

--- a/static/local-js/modules/kometa/_updateRollup.js
+++ b/static/local-js/modules/kometa/_updateRollup.js
@@ -1,0 +1,269 @@
+// Kometa update rollup: the summary badge that lives in the accordion
+// header, the "attention" indicator that highlights the collapsed
+// header when an update is available, the update-button label sync,
+// and the state-invalidation helper called when we need to reset the
+// update flow (e.g. after a user action changes install mode).
+//
+// EXPORTS:
+//
+//   getKometaRollupStatus()   -- PURE fn: returns { state, label }
+//                                describing where in the update flow
+//                                we are (updating / checking / not
+//                                installed / prepared / up-to-date /
+//                                update-available / etc.)
+//   syncKometaRollupBadge()   -- write the rollup status onto the
+//                                #kometa-update-rollup-badge DOM
+//                                element (text + qs-validation-*
+//                                class)
+//   syncKometaUpdateAttention()
+//                             -- toggles the .kometa-update-attention
+//                                class on the accordion header when
+//                                an update is available AND the
+//                                accordion is collapsed. Always
+//                                refreshes the rollup badge as a
+//                                side effect.
+//   getUpdateButtonLabel()    -- builds the innerHTML string for the
+//                                #update-kometa-btn based on install
+//                                mode + force-toggle + kometaState
+//   syncUpdateButtonLabel()   -- write the label to the button (if it
+//                                exists), then refresh the attention
+//                                indicator
+//   invalidateKometaUpdateStatus()
+//                             -- reset all kometaState update fields,
+//                                hide the update-info box, and
+//                                refresh source-status + button label
+//                                + rollup badge
+//
+// DOM ELEMENTS TOUCHED (all lazy per-call):
+//
+//   #kometa-update-rollup-badge   -- the rollup summary
+//   #kometa-actions-heading       -- accordion header (attention)
+//   #kometa-actions-toggle        -- accordion toggle button (attention)
+//   #update-kometa-btn            -- the primary "Check / Update /
+//                                    Install Kometa" button
+//   #force-kometa-update          -- the "force" checkbox
+//   #kometa-update-box            -- the update-info panel that
+//                                    contains version diff + notes
+//
+// STATE TOUCHED:
+//
+//   Reads: kometaState.kometaUpdating,
+//          kometaState.kometaValidationInProgress,
+//          kometaState.kometaLocalCheckCompleted,
+//          kometaState.kometaInstalled,
+//          kometaState.kometaValidated,
+//          kometaState.kometaUpdateAvailable,
+//          kometaState.kometaUpdateCheckCompleted,
+//          kometaState.kometaUpdateCheckSkipped
+//   Writes: kometaState.kometaUpdateAvailable,
+//           kometaState.kometaUpdateCheckCompleted,
+//           kometaState.kometaUpdateCheckSkipped,
+//           kometaState.kometaRemoteVersionStatus,
+//           kometaState.kometaRemoteVersionChecked,
+//           kometaState.kometaRemoteVersionSkipped
+//   (invalidateKometaUpdateStatus is the only writer)
+
+import { kometaState } from './_state.js'
+import { getConfiguredKometaInstallMode } from './_runtime.js'
+import { syncKometaSourceStatus } from './_kometaBranch.js'
+
+// ---------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------
+
+/**
+ * All four qs-validation-rollup-badge--* classes. Removed en masse
+ * before adding the current state's class so the badge only has ONE
+ * status class at a time regardless of prior render.
+ */
+const ROLLUP_BADGE_CLASSES = [
+  'qs-validation-rollup-badge--unknown',
+  'qs-validation-rollup-badge--ok',
+  'qs-validation-rollup-badge--warn',
+  'qs-validation-rollup-badge--error'
+]
+
+// ---------------------------------------------------------------------
+// Rollup status (pure) + badge sync
+// ---------------------------------------------------------------------
+
+/**
+ * Return the current rollup status as { state, label }.
+ *
+ * PURE FUNCTION -- only reads kometaState, no DOM, no side effects.
+ * Priority order (first-match wins):
+ *
+ *   1. kometaUpdating          -> 'unknown' / 'Updating...'
+ *   2. kometaValidationInProgress -> 'unknown' / 'Checking...'
+ *   3. !kometaLocalCheckCompleted -> 'unknown' / 'Not checked'
+ *   4. !kometaInstalled           -> 'error'   / 'Install needed'
+ *   5. !kometaUpdateCheckCompleted -> depends on kometaValidated:
+ *         validated   -> 'ok'   / 'Prepared'
+ *         !validated  -> 'warn' / 'Prepare needed'
+ *   6. kometaUpdateCheckSkipped  -> 'unknown' / 'Skipped while running'
+ *   7. kometaUpdateAvailable     -> 'warn'    / 'Update available'
+ *   8. (fallback)                -> 'ok'      / 'Up to date'
+ *
+ * @returns {{state: 'unknown' | 'ok' | 'warn' | 'error', label: string}}
+ */
+export function getKometaRollupStatus () {
+  if (kometaState.kometaUpdating) return { state: 'unknown', label: 'Updating...' }
+  if (kometaState.kometaValidationInProgress) return { state: 'unknown', label: 'Checking...' }
+  if (!kometaState.kometaLocalCheckCompleted) return { state: 'unknown', label: 'Not checked' }
+  if (!kometaState.kometaInstalled) return { state: 'error', label: 'Install needed' }
+  if (!kometaState.kometaUpdateCheckCompleted) {
+    return {
+      state: kometaState.kometaValidated ? 'ok' : 'warn',
+      label: kometaState.kometaValidated ? 'Prepared' : 'Prepare needed'
+    }
+  }
+  if (kometaState.kometaUpdateCheckSkipped) return { state: 'unknown', label: 'Skipped while running' }
+  if (kometaState.kometaUpdateAvailable) return { state: 'warn', label: 'Update available' }
+  return { state: 'ok', label: 'Up to date' }
+}
+
+/**
+ * Write the rollup status onto the #kometa-update-rollup-badge
+ * element (text content + one of the four qs-validation-rollup-badge--*
+ * classes). No-op when the badge is missing.
+ */
+export function syncKometaRollupBadge () {
+  const badge = document.getElementById('kometa-update-rollup-badge')
+  if (!badge) return
+  const { state, label } = getKometaRollupStatus()
+  badge.textContent = label
+  badge.classList.remove(...ROLLUP_BADGE_CLASSES)
+  badge.classList.add(`qs-validation-rollup-badge--${state}`)
+}
+
+// ---------------------------------------------------------------------
+// Attention indicator
+// ---------------------------------------------------------------------
+
+/**
+ * Toggle the .kometa-update-attention class on the accordion header
+ * and toggle button when:
+ *   - An update is available AND
+ *   - The accordion is currently collapsed
+ *
+ * Rationale: when the accordion is open the user can already see the
+ * update state, so the pulsing attention indicator is redundant. Only
+ * highlight when collapsed.
+ *
+ * Always refreshes the rollup badge as a side effect -- callers that
+ * want to update BOTH the badge and the attention state can call
+ * this and get both in one shot.
+ *
+ * No-op when the heading or toggle element is missing (typical of
+ * pages other than the /kometa step).
+ */
+export function syncKometaUpdateAttention () {
+  const heading = document.getElementById('kometa-actions-heading')
+  const toggle = document.getElementById('kometa-actions-toggle')
+  if (heading && toggle) {
+    const isCollapsed = toggle.classList.contains('collapsed')
+    const needsAttention = kometaState.kometaUpdateAvailable && isCollapsed
+    heading.classList.toggle('kometa-update-attention', needsAttention)
+    toggle.classList.toggle('kometa-update-attention', needsAttention)
+  }
+  syncKometaRollupBadge()
+}
+
+// ---------------------------------------------------------------------
+// Update-button label
+// ---------------------------------------------------------------------
+
+/**
+ * Build the innerHTML string for the primary #update-kometa-btn.
+ *
+ * Two flavors:
+ *   - 'existing' install mode: 'Check' or 'Recheck Existing Status'
+ *     depending on whether we've already run a check this session.
+ *   - default (managed) install mode: 5-way state machine driven by
+ *     force-toggle + kometaInstalled + kometaUpdateAvailable +
+ *     kometaUpdateCheckCompleted. Force wins over everything.
+ *
+ * All labels include the bi-arrow-clockwise icon prefix.
+ *
+ * @returns {string} HTML string for the button's innerHTML
+ */
+export function getUpdateButtonLabel () {
+  const installMode = getConfiguredKometaInstallMode()
+  if (installMode === 'existing') {
+    const label = kometaState.kometaUpdateCheckCompleted
+      ? 'Recheck Existing Status'
+      : 'Check Existing Status'
+    return `<i class="bi bi-arrow-clockwise me-1"></i> ${label}`
+  }
+
+  // NOTE: the original code does `forceUpdateToggle.checked` without
+  // a null check. On pages where #force-kometa-update is absent that
+  // would throw a TypeError -- but every page that renders the
+  // update button also renders the force toggle, so it never fires
+  // in practice. Preserving the strict-lookup behavior verbatim; the
+  // hardening (Boolean(el && el.checked)) belongs in a follow-up.
+  const forceToggle = document.getElementById('force-kometa-update')
+  const force = forceToggle.checked
+
+  let label
+  if (force) {
+    label = kometaState.kometaInstalled ? 'Force Update Kometa' : 'Force Install Kometa'
+  } else if (!kometaState.kometaInstalled) {
+    label = 'Install Kometa'
+  } else if (kometaState.kometaUpdateAvailable) {
+    label = 'Update Available'
+  } else if (kometaState.kometaUpdateCheckCompleted) {
+    label = 'Up to date'
+  } else {
+    label = 'Check for Kometa Updates'
+  }
+  return `<i class="bi bi-arrow-clockwise me-1"></i> ${label}`
+}
+
+/**
+ * Write the current label to the update button (if it exists) and
+ * refresh the attention indicator + rollup badge.
+ *
+ * No-op DOM path when the button is missing; still refreshes the
+ * attention indicator (which itself is a no-op when the accordion
+ * elements aren't present).
+ */
+export function syncUpdateButtonLabel () {
+  const btn = document.getElementById('update-kometa-btn')
+  if (btn) btn.innerHTML = getUpdateButtonLabel()
+  syncKometaUpdateAttention()
+}
+
+// ---------------------------------------------------------------------
+// Update-status invalidation
+// ---------------------------------------------------------------------
+
+/**
+ * Reset every kometaState update field to its pre-check default and
+ * hide the update-info box. Refreshes the source-status panel, the
+ * update button label, and the rollup badge so the UI reflects the
+ * cleared state.
+ *
+ * Called when we know the update-check result is stale -- e.g. after
+ * the user switches install modes, or after a force-update kicks off
+ * and we want the "check" flow to restart from scratch.
+ *
+ * Note: does NOT reset kometaLocalCheckCompleted or kometaValidated
+ * -- those track "have we ever probed the local install?" which is
+ * independent of "is the remote update check current?".
+ */
+export function invalidateKometaUpdateStatus () {
+  kometaState.kometaUpdateAvailable = false
+  kometaState.kometaUpdateCheckCompleted = false
+  kometaState.kometaUpdateCheckSkipped = false
+  kometaState.kometaRemoteVersionStatus = ''
+  kometaState.kometaRemoteVersionChecked = false
+  kometaState.kometaRemoteVersionSkipped = false
+  // NOTE: original didn't null-check #kometa-update-box either --
+  // preserved verbatim. Every page that reaches this code path also
+  // renders the box.
+  document.getElementById('kometa-update-box').classList.add('d-none')
+  syncKometaSourceStatus()
+  syncUpdateButtonLabel()
+  syncKometaRollupBadge()
+}

--- a/tests/js/kometa/updateRollup.test.js
+++ b/tests/js/kometa/updateRollup.test.js
@@ -1,0 +1,406 @@
+// Tests for static/local-js/modules/kometa/_updateRollup.js
+//
+// Six exported functions:
+//
+//   getKometaRollupStatus     -- PURE, 8-branch state machine
+//   syncKometaRollupBadge     -- writes to DOM
+//   syncKometaUpdateAttention -- toggles class on accordion header
+//   getUpdateButtonLabel      -- PURE-ish (reads DOM for force toggle)
+//   syncUpdateButtonLabel     -- writes button innerHTML
+//   invalidateKometaUpdateStatus -- resets state + refreshes UI
+//
+// COVERAGE STRATEGY:
+//
+//   getKometaRollupStatus: one test per branch (8 branches).
+//   getUpdateButtonLabel:  one test per label (6 labels for managed +
+//                          2 for 'existing' mode).
+//   syncKometaRollupBadge / syncUpdateButtonLabel: DOM assertions
+//                          after calling with representative states.
+//   syncKometaUpdateAttention: 4 branches
+//                          (element missing / collapsed+available /
+//                           expanded+available / collapsed+unavailable).
+//   invalidateKometaUpdateStatus: state fields reset, box hidden,
+//                                 collaborators called.
+//
+// Collaborators (_kometaBranch.js syncKometaSourceStatus,
+// _runtime.js getConfiguredKometaInstallMode) are mocked with vi.mock
+// so this module's behavior is tested in isolation.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock collaborators BEFORE importing _updateRollup.js. vi.mock is
+// hoisted so the position of these calls doesn't matter, but keeping
+// them near the imports for readability.
+vi.mock('../../../static/local-js/modules/kometa/_kometaBranch.js', () => ({
+  syncKometaSourceStatus: vi.fn()
+}))
+vi.mock('../../../static/local-js/modules/kometa/_runtime.js', () => ({
+  getConfiguredKometaInstallMode: vi.fn(() => 'managed')  // default: managed
+}))
+
+import { kometaState } from '../../../static/local-js/modules/kometa/_state.js'
+import {
+  getKometaRollupStatus,
+  syncKometaRollupBadge,
+  syncKometaUpdateAttention,
+  getUpdateButtonLabel,
+  syncUpdateButtonLabel,
+  invalidateKometaUpdateStatus
+} from '../../../static/local-js/modules/kometa/_updateRollup.js'
+import { syncKometaSourceStatus } from '../../../static/local-js/modules/kometa/_kometaBranch.js'
+import { getConfiguredKometaInstallMode } from '../../../static/local-js/modules/kometa/_runtime.js'
+
+// ---------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------
+
+/**
+ * Reset every kometaState field this module reads/writes to sensible
+ * defaults so tests don't cross-contaminate.
+ */
+function resetState () {
+  kometaState.kometaUpdating = false
+  kometaState.kometaValidationInProgress = false
+  kometaState.kometaLocalCheckCompleted = true
+  kometaState.kometaInstalled = true
+  kometaState.kometaValidated = true
+  kometaState.kometaUpdateCheckCompleted = true
+  kometaState.kometaUpdateCheckSkipped = false
+  kometaState.kometaUpdateAvailable = false
+  kometaState.kometaRemoteVersionStatus = ''
+  kometaState.kometaRemoteVersionChecked = false
+  kometaState.kometaRemoteVersionSkipped = false
+}
+
+function installRollupBadge () {
+  document.body.innerHTML = '<span id="kometa-update-rollup-badge"></span>'
+  return document.getElementById('kometa-update-rollup-badge')
+}
+
+function installAccordion (opts = {}) {
+  const { collapsed = true } = opts
+  document.body.innerHTML = `
+    <div id="kometa-actions-heading" class=""></div>
+    <button id="kometa-actions-toggle" class="${collapsed ? 'collapsed' : ''}"></button>
+    <span id="kometa-update-rollup-badge"></span>
+  `
+}
+
+function installUpdateButton () {
+  document.body.innerHTML = `
+    <button id="update-kometa-btn"></button>
+    <input type="checkbox" id="force-kometa-update">
+  `
+  return document.getElementById('update-kometa-btn')
+}
+
+function installInvalidateFixture () {
+  document.body.innerHTML = `
+    <div id="kometa-update-box"></div>
+    <button id="update-kometa-btn"></button>
+    <input type="checkbox" id="force-kometa-update">
+    <span id="kometa-update-rollup-badge"></span>
+  `
+}
+
+beforeEach(() => {
+  syncKometaSourceStatus.mockClear()
+  getConfiguredKometaInstallMode.mockClear()
+  getConfiguredKometaInstallMode.mockReturnValue('managed')
+  resetState()
+})
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+// ---------------------------------------------------------------------
+// getKometaRollupStatus (pure, 8 branches)
+// ---------------------------------------------------------------------
+
+describe('getKometaRollupStatus -- state machine', () => {
+  it("returns 'Updating...' when kometaUpdating", () => {
+    kometaState.kometaUpdating = true
+    expect(getKometaRollupStatus()).toEqual({ state: 'unknown', label: 'Updating...' })
+  })
+
+  it("returns 'Checking...' when kometaValidationInProgress", () => {
+    kometaState.kometaValidationInProgress = true
+    expect(getKometaRollupStatus()).toEqual({ state: 'unknown', label: 'Checking...' })
+  })
+
+  it("returns 'Not checked' when localCheck not completed", () => {
+    kometaState.kometaLocalCheckCompleted = false
+    expect(getKometaRollupStatus()).toEqual({ state: 'unknown', label: 'Not checked' })
+  })
+
+  it("returns 'Install needed' when !kometaInstalled", () => {
+    kometaState.kometaInstalled = false
+    expect(getKometaRollupStatus()).toEqual({ state: 'error', label: 'Install needed' })
+  })
+
+  it("returns 'Prepared' (ok) when validated but no update check", () => {
+    kometaState.kometaUpdateCheckCompleted = false
+    kometaState.kometaValidated = true
+    expect(getKometaRollupStatus()).toEqual({ state: 'ok', label: 'Prepared' })
+  })
+
+  it("returns 'Prepare needed' (warn) when !validated and no update check", () => {
+    kometaState.kometaUpdateCheckCompleted = false
+    kometaState.kometaValidated = false
+    expect(getKometaRollupStatus()).toEqual({ state: 'warn', label: 'Prepare needed' })
+  })
+
+  it("returns 'Skipped while running' when update check was skipped", () => {
+    kometaState.kometaUpdateCheckSkipped = true
+    expect(getKometaRollupStatus()).toEqual({ state: 'unknown', label: 'Skipped while running' })
+  })
+
+  it("returns 'Update available' (warn) when update is available", () => {
+    kometaState.kometaUpdateAvailable = true
+    expect(getKometaRollupStatus()).toEqual({ state: 'warn', label: 'Update available' })
+  })
+
+  it("returns 'Up to date' (ok) as the fallback", () => {
+    // All flags in the 'happy' state via resetState()
+    expect(getKometaRollupStatus()).toEqual({ state: 'ok', label: 'Up to date' })
+  })
+
+  it('priority: kometaUpdating wins over everything else', () => {
+    kometaState.kometaUpdating = true
+    kometaState.kometaValidationInProgress = true
+    kometaState.kometaUpdateAvailable = true
+    expect(getKometaRollupStatus().label).toBe('Updating...')
+  })
+})
+
+// ---------------------------------------------------------------------
+// syncKometaRollupBadge (DOM writer)
+// ---------------------------------------------------------------------
+
+describe('syncKometaRollupBadge', () => {
+  it('is a no-op when the badge element is missing', () => {
+    expect(() => syncKometaRollupBadge()).not.toThrow()
+  })
+
+  it("writes label + ok class for the 'up to date' state", () => {
+    const badge = installRollupBadge()
+    syncKometaRollupBadge()
+    expect(badge.textContent).toBe('Up to date')
+    expect(badge.classList.contains('qs-validation-rollup-badge--ok')).toBe(true)
+  })
+
+  it("writes label + warn class for the 'update available' state", () => {
+    const badge = installRollupBadge()
+    kometaState.kometaUpdateAvailable = true
+    syncKometaRollupBadge()
+    expect(badge.textContent).toBe('Update available')
+    expect(badge.classList.contains('qs-validation-rollup-badge--warn')).toBe(true)
+  })
+
+  it("writes label + error class for the 'install needed' state", () => {
+    const badge = installRollupBadge()
+    kometaState.kometaInstalled = false
+    syncKometaRollupBadge()
+    expect(badge.textContent).toBe('Install needed')
+    expect(badge.classList.contains('qs-validation-rollup-badge--error')).toBe(true)
+  })
+
+  it('removes prior state class before adding new one', () => {
+    const badge = installRollupBadge()
+    badge.classList.add('qs-validation-rollup-badge--error')
+    syncKometaRollupBadge()  // will resolve to 'ok' via defaults
+    expect(badge.classList.contains('qs-validation-rollup-badge--error')).toBe(false)
+    expect(badge.classList.contains('qs-validation-rollup-badge--ok')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// syncKometaUpdateAttention
+// ---------------------------------------------------------------------
+
+describe('syncKometaUpdateAttention', () => {
+  it('is a no-op when accordion elements are missing (still calls rollup)', () => {
+    const badge = installRollupBadge()
+    kometaState.kometaUpdateAvailable = true
+    syncKometaUpdateAttention()
+    // Badge should still get refreshed even without accordion
+    expect(badge.textContent).toBe('Update available')
+  })
+
+  it('adds attention class when update is available AND accordion is collapsed', () => {
+    installAccordion({ collapsed: true })
+    kometaState.kometaUpdateAvailable = true
+    syncKometaUpdateAttention()
+    expect(document.getElementById('kometa-actions-heading').classList.contains('kometa-update-attention')).toBe(true)
+    expect(document.getElementById('kometa-actions-toggle').classList.contains('kometa-update-attention')).toBe(true)
+  })
+
+  it('does NOT add attention class when accordion is expanded', () => {
+    installAccordion({ collapsed: false })
+    kometaState.kometaUpdateAvailable = true
+    syncKometaUpdateAttention()
+    expect(document.getElementById('kometa-actions-heading').classList.contains('kometa-update-attention')).toBe(false)
+    expect(document.getElementById('kometa-actions-toggle').classList.contains('kometa-update-attention')).toBe(false)
+  })
+
+  it('does NOT add attention class when no update is available (even if collapsed)', () => {
+    installAccordion({ collapsed: true })
+    kometaState.kometaUpdateAvailable = false
+    syncKometaUpdateAttention()
+    expect(document.getElementById('kometa-actions-heading').classList.contains('kometa-update-attention')).toBe(false)
+  })
+
+  it('REMOVES a stale attention class when conditions no longer warrant it', () => {
+    installAccordion({ collapsed: false })
+    // Pre-set attention (simulates a prior render when it was warranted)
+    document.getElementById('kometa-actions-heading').classList.add('kometa-update-attention')
+    document.getElementById('kometa-actions-toggle').classList.add('kometa-update-attention')
+    kometaState.kometaUpdateAvailable = false
+    syncKometaUpdateAttention()
+    expect(document.getElementById('kometa-actions-heading').classList.contains('kometa-update-attention')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------
+// getUpdateButtonLabel (branches per install mode + force + state)
+// ---------------------------------------------------------------------
+
+describe("getUpdateButtonLabel -- 'existing' install mode", () => {
+  beforeEach(() => {
+    getConfiguredKometaInstallMode.mockReturnValue('existing')
+    document.body.innerHTML = ''  // no force toggle needed in this mode
+  })
+
+  it("returns 'Check Existing Status' when no check has completed", () => {
+    kometaState.kometaUpdateCheckCompleted = false
+    expect(getUpdateButtonLabel()).toContain('Check Existing Status')
+  })
+
+  it("returns 'Recheck Existing Status' when a check has completed", () => {
+    kometaState.kometaUpdateCheckCompleted = true
+    expect(getUpdateButtonLabel()).toContain('Recheck Existing Status')
+  })
+
+  it("prefixes the bi-arrow-clockwise icon", () => {
+    expect(getUpdateButtonLabel()).toContain('bi-arrow-clockwise')
+  })
+})
+
+describe('getUpdateButtonLabel -- managed install mode', () => {
+  beforeEach(() => {
+    // Ensure the force toggle exists but is unchecked by default
+    document.body.innerHTML = '<input type="checkbox" id="force-kometa-update">'
+    document.getElementById('force-kometa-update').checked = false
+  })
+
+  it("returns 'Install Kometa' when not installed and force is off", () => {
+    kometaState.kometaInstalled = false
+    expect(getUpdateButtonLabel()).toContain('Install Kometa')
+  })
+
+  it("returns 'Force Install Kometa' when not installed and force is on", () => {
+    kometaState.kometaInstalled = false
+    document.getElementById('force-kometa-update').checked = true
+    expect(getUpdateButtonLabel()).toContain('Force Install Kometa')
+  })
+
+  it("returns 'Force Update Kometa' when installed and force is on", () => {
+    document.getElementById('force-kometa-update').checked = true
+    expect(getUpdateButtonLabel()).toContain('Force Update Kometa')
+  })
+
+  it("returns 'Update Available' when installed, no force, update available", () => {
+    kometaState.kometaUpdateAvailable = true
+    expect(getUpdateButtonLabel()).toContain('Update Available')
+  })
+
+  it("returns 'Up to date' when installed, no force, no update, check completed", () => {
+    kometaState.kometaUpdateCheckCompleted = true
+    kometaState.kometaUpdateAvailable = false
+    expect(getUpdateButtonLabel()).toContain('Up to date')
+  })
+
+  it("returns 'Check for Kometa Updates' when installed but no check has run", () => {
+    kometaState.kometaUpdateCheckCompleted = false
+    expect(getUpdateButtonLabel()).toContain('Check for Kometa Updates')
+  })
+})
+
+// ---------------------------------------------------------------------
+// syncUpdateButtonLabel
+// ---------------------------------------------------------------------
+
+describe('syncUpdateButtonLabel', () => {
+  it('is a no-op when the button is missing (still refreshes attention/rollup)', () => {
+    installRollupBadge()  // ensure rollup can be refreshed
+    expect(() => syncUpdateButtonLabel()).not.toThrow()
+  })
+
+  it("writes the current label to the button's innerHTML", () => {
+    const btn = installUpdateButton()
+    // Add a rollup badge too so syncKometaUpdateAttention has something to refresh
+    const rollup = document.createElement('span')
+    rollup.id = 'kometa-update-rollup-badge'
+    document.body.appendChild(rollup)
+    syncUpdateButtonLabel()
+    expect(btn.innerHTML).toContain('Up to date')
+    expect(btn.innerHTML).toContain('bi-arrow-clockwise')
+  })
+})
+
+// ---------------------------------------------------------------------
+// invalidateKometaUpdateStatus
+// ---------------------------------------------------------------------
+
+describe('invalidateKometaUpdateStatus', () => {
+  it('resets every kometaState update field to defaults', () => {
+    installInvalidateFixture()
+    // Pre-set every field to 'dirty' values
+    kometaState.kometaUpdateAvailable = true
+    kometaState.kometaUpdateCheckCompleted = true
+    kometaState.kometaUpdateCheckSkipped = true
+    kometaState.kometaRemoteVersionStatus = 'v1.2.3'
+    kometaState.kometaRemoteVersionChecked = true
+    kometaState.kometaRemoteVersionSkipped = true
+
+    invalidateKometaUpdateStatus()
+
+    expect(kometaState.kometaUpdateAvailable).toBe(false)
+    expect(kometaState.kometaUpdateCheckCompleted).toBe(false)
+    expect(kometaState.kometaUpdateCheckSkipped).toBe(false)
+    expect(kometaState.kometaRemoteVersionStatus).toBe('')
+    expect(kometaState.kometaRemoteVersionChecked).toBe(false)
+    expect(kometaState.kometaRemoteVersionSkipped).toBe(false)
+  })
+
+  it('hides the update box', () => {
+    installInvalidateFixture()
+    const box = document.getElementById('kometa-update-box')
+    expect(box.classList.contains('d-none')).toBe(false)  // sanity
+    invalidateKometaUpdateStatus()
+    expect(box.classList.contains('d-none')).toBe(true)
+  })
+
+  it('calls syncKometaSourceStatus and refreshes the rollup badge', () => {
+    installInvalidateFixture()
+    invalidateKometaUpdateStatus()
+    expect(syncKometaSourceStatus).toHaveBeenCalledTimes(1)
+    // After invalidation, kometaUpdateCheckCompleted is false and
+    // kometaValidated stays true (independent state), so the rollup
+    // resolves to 'Prepared' (state=ok). We assert on the badge to
+    // prove the refresh happened -- no need to mock our own module's
+    // internal exports.
+    const badge = document.getElementById('kometa-update-rollup-badge')
+    expect(badge.textContent).toBe('Prepared')
+  })
+
+  it("preserves kometaLocalCheckCompleted and kometaValidated (they're independent)", () => {
+    installInvalidateFixture()
+    kometaState.kometaLocalCheckCompleted = true
+    kometaState.kometaValidated = true
+    invalidateKometaUpdateStatus()
+    expect(kometaState.kometaLocalCheckCompleted).toBe(true)
+    expect(kometaState.kometaValidated).toBe(true)
+  })
+})


### PR DESCRIPTION
## What

Second slice of the update-flow cluster. Extracts the rollup summary badge, the accordion-header attention indicator, the update-button label builder, and the state-invalidation helper.

`900-kometa.js`: 2713 -> 2647 lines (**-66**).
Vitest tests: 1060 -> 1095 (**+35**).

## What moved

Extracted to `static/local-js/modules/kometa/_updateRollup.js` (269 lines):

| Group | Exports |
|---|---|
| **Rollup status (PURE)** | `getKometaRollupStatus` |
| **Rollup badge** | `syncKometaRollupBadge` |
| **Attention indicator** | `syncKometaUpdateAttention` |
| **Update button** | `getUpdateButtonLabel`, `syncUpdateButtonLabel` |
| **Invalidation** | `invalidateKometaUpdateStatus` |

## Design highlights

1. **`getKometaRollupStatus` is PURE** -- 8-branch state machine returning `{state, label}`. Priority order: `updating > checking > not checked > install needed > (prepared|prepare needed) > skipped > update available > up to date`.

2. **`getUpdateButtonLabel` is PURE-ish** -- reads DOM only for the force toggle. Two flavors:
   - 'existing' install mode: Check / Recheck Existing Status
   - Managed mode: 5-branch state machine (Install / Force Install / Force Update / Update Available / Up to date / Check for Kometa Updates)

3. **`invalidateKometaUpdateStatus` does NOT reset `kometaLocalCheckCompleted` or `kometaValidated`** -- those track 'have we ever probed the local install?' which is independent of 'is the remote update check current?'. Explicit test guards this invariant.

## Behavior preservation

Two known-brittle patterns **preserved verbatim** (with comments):

1. `getUpdateButtonLabel`: `const force = forceUpdateToggle.checked` -- unconditional access, would throw if `#force-kometa-update` is missing. Every page that reaches this code renders the toggle, so no observed failures. Defensive hardening belongs in a follow-up.

2. `invalidateKometaUpdateStatus`: unconditional `document.getElementById('kometa-update-box').classList.add(...)` -- same story.

Also removed the orphaned `kometaActionsHeading` DOM ref from `900-kometa.js` (was only used by the extracted `syncKometaUpdateAttention`).

## Test coverage: 35 new tests

- `getKometaRollupStatus` (10): each of 8 branches + priority + fallback
- `syncKometaRollupBadge` (5)
- `syncKometaUpdateAttention` (5): 4 truth-table cells + stale-class removal
- `getUpdateButtonLabel` existing mode (3)
- `getUpdateButtonLabel` managed mode (6): all 6 label paths
- `syncUpdateButtonLabel` (2)
- `invalidateKometaUpdateStatus` (4): state reset, box hidden, collaborators called, preserved-fields invariant

Collaborators (`syncKometaSourceStatus` from `_kometaBranch.js`, `getConfiguredKometaInstallMode` from `_runtime.js`) mocked with `vi.mock()`.

## Verification

- **1095/1095 Vitest pass** (was 1060; +35 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- ESLint clean, Node syntax clean

## What's next

Continuing update-flow cluster:

- **`_updatePolling.js`** -- `stopKometaUpdatePolling`, `pollKometaUpdateProgress`
- **`_kometaUpdate.js`** -- `checkKometaUpdate`, `callUpdateKometa` (~300 lines, the boss fight)