### PR TITLE
Split 900-kometa.js part 17: extract update-progress polling

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -78,6 +78,10 @@ import {
   syncUpdateButtonLabel,
   invalidateKometaUpdateStatus
 } from './modules/kometa/_updateRollup.js'
+import {
+  stopKometaUpdatePolling,
+  pollKometaUpdateProgress
+} from './modules/kometa/_updatePolling.js'
 
 // Kometa runtime status flags migrated to modules/kometa/_state.js
 // (kometaState.kometaInstalled, kometaValidated, kometaStatus, etc.).
@@ -782,39 +786,6 @@ function runKometaStatusPass (forceRefresh = false) {
     .catch(() => {
       if (!kometaState.kometaUpdating) setKometaUpdatePhaseBadge('failed')
       return null
-    })
-}
-
-function stopKometaUpdatePolling () {
-  if (kometaState.kometaUpdatePollInterval) {
-    clearInterval(kometaState.kometaUpdatePollInterval)
-    kometaState.kometaUpdatePollInterval = null
-  }
-}
-
-function pollKometaUpdateProgress () {
-  if (!kometaState.kometaUpdateJobId) return Promise.resolve(null)
-  return fetch(`/background-jobs/${encodeURIComponent(kometaState.kometaUpdateJobId)}?since=${encodeURIComponent(String(kometaState.kometaUpdateLogIndex))}`)
-    .then(async res => {
-      const data = await res.json()
-      if (!res.ok || !data.success || !data.job) throw new Error(data.error || 'Failed to fetch Kometa update progress.')
-      return data
-    })
-    .then(data => {
-      const job = data.job || {}
-      if (job.phase === 'queued') setKometaUpdatePhaseBadge('queued')
-      if (job.phase === 'error') setKometaUpdatePhaseBadge('failed')
-      const lines = Array.isArray(data.lines) ? data.lines : []
-      lines.forEach(line => appendKometaStatusLine(line))
-      if (typeof data.next_index === 'number') kometaState.kometaUpdateLogIndex = data.next_index
-      if (data.done) {
-        stopKometaUpdatePolling()
-      }
-      return Object.assign({}, job, {
-        lines,
-        next_index: data.next_index,
-        done: data.done
-      })
     })
 }
 

--- a/static/local-js/modules/kometa/_updatePolling.js
+++ b/static/local-js/modules/kometa/_updatePolling.js
@@ -1,0 +1,123 @@
+// Background-job polling for Kometa updates.
+//
+// When callUpdateKometa() (in 900-kometa.js) kicks off a
+// background job to download/extract/install Kometa, it stores the
+// job id in kometaState.kometaUpdateJobId and starts an interval that
+// calls pollKometaUpdateProgress() every few seconds. Each poll
+// fetches new log lines from the /background-jobs endpoint and feeds
+// them into the phase-inference pipeline (via appendKometaStatusLine).
+//
+// EXPORTS:
+//
+//   stopKometaUpdatePolling()
+//        -- clear the interval + null out kometaState.kometaUpdatePollInterval.
+//           Idempotent: safe to call when no polling is active.
+//
+//   pollKometaUpdateProgress()
+//        -- fetch the next batch of log lines for the current job.
+//           Auto-stops polling on `data.done`. Auto-updates the phase
+//           badge to 'queued' or 'failed' when the server reports
+//           those states.
+//
+//           Returns a Promise:
+//             - Resolves with a merged { ...job, lines, next_index, done }
+//               shape on success
+//             - Resolves with null when no kometaUpdateJobId is set
+//               (nothing to poll)
+//             - Rejects with an Error on network / JSON / success=false
+//
+// STATE TOUCHED:
+//
+//   Reads:  kometaState.kometaUpdateJobId,
+//           kometaState.kometaUpdateLogIndex,
+//           kometaState.kometaUpdatePollInterval
+//   Writes: kometaState.kometaUpdateLogIndex (advances on each poll),
+//           kometaState.kometaUpdatePollInterval (nulled on stop)
+//
+// SERVER CONTRACT:
+//
+//   GET /background-jobs/<job_id>?since=<log_index>
+//   Response body: {
+//     success: true,
+//     job: { phase: 'queued'|'running'|'completed'|'error', ... },
+//     lines: string[],            // new log lines since `since`
+//     next_index: number,         // pass this back as ?since= next time
+//     done: boolean               // true when server has no more lines
+//   }
+//
+//   On !success or missing job, we throw with data.error (server
+//   supplies a human-readable message).
+
+import { kometaState } from './_state.js'
+import { setKometaUpdatePhaseBadge, appendKometaStatusLine } from './_updatePhase.js'
+
+// ---------------------------------------------------------------------
+// Polling controls
+// ---------------------------------------------------------------------
+
+/**
+ * Clear the update-progress polling interval and null out the state
+ * handle. Idempotent -- safe to call when polling is already stopped.
+ */
+export function stopKometaUpdatePolling () {
+  if (kometaState.kometaUpdatePollInterval) {
+    clearInterval(kometaState.kometaUpdatePollInterval)
+    kometaState.kometaUpdatePollInterval = null
+  }
+}
+
+/**
+ * Fetch the next batch of log lines for the currently-running update
+ * job. See module docstring for full contract.
+ *
+ * Short-circuits with `Promise.resolve(null)` when no job id is set --
+ * useful for callers that call this from an interval and don't want
+ * to error out just because the user cleared / cancelled.
+ *
+ * @returns {Promise<object | null>}
+ */
+export function pollKometaUpdateProgress () {
+  if (!kometaState.kometaUpdateJobId) return Promise.resolve(null)
+
+  const jobId = encodeURIComponent(kometaState.kometaUpdateJobId)
+  const since = encodeURIComponent(String(kometaState.kometaUpdateLogIndex))
+
+  return fetch(`/background-jobs/${jobId}?since=${since}`)
+    .then(async res => {
+      const data = await res.json()
+      if (!res.ok || !data.success || !data.job) {
+        throw new Error(data.error || 'Failed to fetch Kometa update progress.')
+      }
+      return data
+    })
+    .then(data => {
+      const job = data.job || {}
+
+      // Auto-update the phase badge for the two "server-reported"
+      // phases. Other phases (downloading / extracting / etc.) get
+      // inferred from log-line text via appendKometaStatusLine's
+      // built-in phase inference.
+      if (job.phase === 'queued') setKometaUpdatePhaseBadge('queued')
+      if (job.phase === 'error') setKometaUpdatePhaseBadge('failed')
+
+      const lines = Array.isArray(data.lines) ? data.lines : []
+      lines.forEach(line => appendKometaStatusLine(line))
+
+      // Advance our cursor into the server-side log so the next poll
+      // asks for lines starting at this index.
+      if (typeof data.next_index === 'number') {
+        kometaState.kometaUpdateLogIndex = data.next_index
+      }
+
+      // Server-side signal that we've drained everything for this
+      // job -- stop the interval so we don't keep hammering the
+      // endpoint forever.
+      if (data.done) stopKometaUpdatePolling()
+
+      return Object.assign({}, job, {
+        lines,
+        next_index: data.next_index,
+        done: data.done
+      })
+    })
+}

--- a/tests/js/kometa/updatePolling.test.js
+++ b/tests/js/kometa/updatePolling.test.js
@@ -1,0 +1,369 @@
+// Tests for static/local-js/modules/kometa/_updatePolling.js
+//
+// Two exported functions:
+//
+//   stopKometaUpdatePolling     -- clears interval + nulls state
+//   pollKometaUpdateProgress    -- fetches next batch of log lines,
+//                                  updates phase badge, appends lines,
+//                                  advances cursor, auto-stops on done
+//
+// COVERAGE STRATEGY:
+//
+//   stopKometaUpdatePolling: idempotent + reset semantics.
+//   pollKometaUpdateProgress: 8 branches through the pipeline:
+//     - no job id -> resolves null
+//     - fetch rejects -> propagates
+//     - !res.ok -> rejects
+//     - !data.success -> rejects with server message
+//     - phase='queued' -> phase badge updated
+//     - phase='error' -> phase badge updated
+//     - data.lines forEach appended
+//     - data.next_index advances cursor
+//     - data.done -> stops polling
+//
+// _updatePhase.js exports mocked via vi.mock so we can spy on badge
+// / status line calls without needing real DOM.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../static/local-js/modules/kometa/_updatePhase.js', () => ({
+  setKometaUpdatePhaseBadge: vi.fn(),
+  appendKometaStatusLine: vi.fn()
+}))
+
+import { kometaState } from '../../../static/local-js/modules/kometa/_state.js'
+import {
+  stopKometaUpdatePolling,
+  pollKometaUpdateProgress
+} from '../../../static/local-js/modules/kometa/_updatePolling.js'
+import {
+  setKometaUpdatePhaseBadge,
+  appendKometaStatusLine
+} from '../../../static/local-js/modules/kometa/_updatePhase.js'
+
+// ---------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------
+
+let originalFetch
+
+function mockFetchOnce (response) {
+  global.fetch = vi.fn(() => Promise.resolve(response))
+}
+
+function makeOkResponse (body) {
+  return {
+    ok: true,
+    json: () => Promise.resolve(body)
+  }
+}
+
+function makeErrorResponse (status, body) {
+  return {
+    ok: false,
+    status,
+    json: () => Promise.resolve(body)
+  }
+}
+
+function resetState () {
+  kometaState.kometaUpdateJobId = null
+  kometaState.kometaUpdateLogIndex = 0
+  kometaState.kometaUpdatePollInterval = null
+}
+
+beforeEach(() => {
+  setKometaUpdatePhaseBadge.mockClear()
+  appendKometaStatusLine.mockClear()
+  originalFetch = global.fetch
+  resetState()
+})
+
+afterEach(() => {
+  global.fetch = originalFetch
+})
+
+// ---------------------------------------------------------------------
+// stopKometaUpdatePolling
+// ---------------------------------------------------------------------
+
+describe('stopKometaUpdatePolling', () => {
+  it('is a no-op when no interval is active', () => {
+    expect(() => stopKometaUpdatePolling()).not.toThrow()
+    expect(kometaState.kometaUpdatePollInterval).toBeNull()
+  })
+
+  it('clears the interval and nulls the state handle', () => {
+    // Install a real interval so we can verify it gets cleared
+    const clearIntervalSpy = vi.spyOn(global, 'clearInterval')
+    kometaState.kometaUpdatePollInterval = setInterval(() => {}, 10_000)
+    const handle = kometaState.kometaUpdatePollInterval
+    stopKometaUpdatePolling()
+    expect(clearIntervalSpy).toHaveBeenCalledWith(handle)
+    expect(kometaState.kometaUpdatePollInterval).toBeNull()
+    clearIntervalSpy.mockRestore()
+  })
+
+  it('is idempotent (safe to call twice)', () => {
+    kometaState.kometaUpdatePollInterval = setInterval(() => {}, 10_000)
+    stopKometaUpdatePolling()
+    expect(() => stopKometaUpdatePolling()).not.toThrow()
+    expect(kometaState.kometaUpdatePollInterval).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------
+// pollKometaUpdateProgress
+// ---------------------------------------------------------------------
+
+describe('pollKometaUpdateProgress -- short circuits', () => {
+  it('resolves null when no job id is set', async () => {
+    const result = await pollKometaUpdateProgress()
+    expect(result).toBeNull()
+    // Fetch should not be called
+    expect(global.fetch).toBe(originalFetch)  // still the untouched fetch
+  })
+})
+
+describe('pollKometaUpdateProgress -- URL construction', () => {
+  it('encodes the job id and since cursor into the URL', async () => {
+    kometaState.kometaUpdateJobId = 'job/with?special&chars'
+    kometaState.kometaUpdateLogIndex = 42
+    mockFetchOnce(makeOkResponse({
+      success: true,
+      job: { phase: 'running' },
+      lines: [],
+      next_index: 42,
+      done: false
+    }))
+    await pollKometaUpdateProgress()
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    const url = global.fetch.mock.calls[0][0]
+    expect(url).toContain('/background-jobs/')
+    expect(url).toContain(encodeURIComponent('job/with?special&chars'))
+    expect(url).toContain('since=42')
+  })
+})
+
+describe('pollKometaUpdateProgress -- error paths', () => {
+  it('rejects with a helpful message when res.ok is false', async () => {
+    kometaState.kometaUpdateJobId = 'abc'
+    mockFetchOnce(makeErrorResponse(500, { success: false, error: 'internal server error' }))
+    await expect(pollKometaUpdateProgress()).rejects.toThrow('internal server error')
+  })
+
+  it("rejects when the server returns success=false", async () => {
+    kometaState.kometaUpdateJobId = 'abc'
+    mockFetchOnce(makeOkResponse({ success: false, error: 'job vanished' }))
+    await expect(pollKometaUpdateProgress()).rejects.toThrow('job vanished')
+  })
+
+  it("rejects when the server returns success=true but no job object", async () => {
+    kometaState.kometaUpdateJobId = 'abc'
+    mockFetchOnce(makeOkResponse({ success: true, lines: [], next_index: 0 }))
+    await expect(pollKometaUpdateProgress()).rejects.toThrow('Failed to fetch Kometa update progress.')
+  })
+
+  it('uses a fallback error message when the server omits data.error', async () => {
+    kometaState.kometaUpdateJobId = 'abc'
+    mockFetchOnce(makeErrorResponse(503, { success: false }))
+    await expect(pollKometaUpdateProgress()).rejects.toThrow('Failed to fetch Kometa update progress.')
+  })
+
+  it('propagates network errors', async () => {
+    kometaState.kometaUpdateJobId = 'abc'
+    global.fetch = vi.fn(() => Promise.reject(new Error('network down')))
+    await expect(pollKometaUpdateProgress()).rejects.toThrow('network down')
+  })
+})
+
+describe('pollKometaUpdateProgress -- phase badge updates', () => {
+  it("updates badge to 'queued' when server reports phase=queued", async () => {
+    kometaState.kometaUpdateJobId = 'abc'
+    mockFetchOnce(makeOkResponse({
+      success: true,
+      job: { phase: 'queued' },
+      lines: [],
+      next_index: 0,
+      done: false
+    }))
+    await pollKometaUpdateProgress()
+    expect(setKometaUpdatePhaseBadge).toHaveBeenCalledWith('queued')
+  })
+
+  it("updates badge to 'failed' when server reports phase=error", async () => {
+    kometaState.kometaUpdateJobId = 'abc'
+    mockFetchOnce(makeOkResponse({
+      success: true,
+      job: { phase: 'error' },
+      lines: [],
+      next_index: 0,
+      done: false
+    }))
+    await pollKometaUpdateProgress()
+    expect(setKometaUpdatePhaseBadge).toHaveBeenCalledWith('failed')
+  })
+
+  it('does NOT update badge for other phases (they get inferred from log lines)', async () => {
+    kometaState.kometaUpdateJobId = 'abc'
+    mockFetchOnce(makeOkResponse({
+      success: true,
+      job: { phase: 'running' },
+      lines: [],
+      next_index: 0,
+      done: false
+    }))
+    await pollKometaUpdateProgress()
+    expect(setKometaUpdatePhaseBadge).not.toHaveBeenCalled()
+  })
+})
+
+describe('pollKometaUpdateProgress -- log line appending', () => {
+  it('calls appendKometaStatusLine for each line in data.lines', async () => {
+    kometaState.kometaUpdateJobId = 'abc'
+    mockFetchOnce(makeOkResponse({
+      success: true,
+      job: { phase: 'running' },
+      lines: ['line one', 'line two', 'line three'],
+      next_index: 3,
+      done: false
+    }))
+    await pollKometaUpdateProgress()
+    expect(appendKometaStatusLine).toHaveBeenCalledTimes(3)
+    expect(appendKometaStatusLine).toHaveBeenNthCalledWith(1, 'line one')
+    expect(appendKometaStatusLine).toHaveBeenNthCalledWith(2, 'line two')
+    expect(appendKometaStatusLine).toHaveBeenNthCalledWith(3, 'line three')
+  })
+
+  it('handles missing lines array gracefully (no calls)', async () => {
+    kometaState.kometaUpdateJobId = 'abc'
+    mockFetchOnce(makeOkResponse({
+      success: true,
+      job: { phase: 'running' },
+      next_index: 0,
+      done: false
+    }))
+    await pollKometaUpdateProgress()
+    expect(appendKometaStatusLine).not.toHaveBeenCalled()
+  })
+
+  it('handles non-array lines gracefully (no calls)', async () => {
+    kometaState.kometaUpdateJobId = 'abc'
+    mockFetchOnce(makeOkResponse({
+      success: true,
+      job: { phase: 'running' },
+      lines: null,
+      next_index: 0,
+      done: false
+    }))
+    await pollKometaUpdateProgress()
+    expect(appendKometaStatusLine).not.toHaveBeenCalled()
+  })
+})
+
+describe('pollKometaUpdateProgress -- cursor advancement', () => {
+  it('advances kometaUpdateLogIndex from next_index', async () => {
+    kometaState.kometaUpdateJobId = 'abc'
+    kometaState.kometaUpdateLogIndex = 0
+    mockFetchOnce(makeOkResponse({
+      success: true,
+      job: { phase: 'running' },
+      lines: ['a', 'b'],
+      next_index: 2,
+      done: false
+    }))
+    await pollKometaUpdateProgress()
+    expect(kometaState.kometaUpdateLogIndex).toBe(2)
+  })
+
+  it('does not advance when next_index is not a number', async () => {
+    kometaState.kometaUpdateJobId = 'abc'
+    kometaState.kometaUpdateLogIndex = 5
+    mockFetchOnce(makeOkResponse({
+      success: true,
+      job: { phase: 'running' },
+      lines: [],
+      next_index: null,
+      done: false
+    }))
+    await pollKometaUpdateProgress()
+    expect(kometaState.kometaUpdateLogIndex).toBe(5)  // unchanged
+  })
+})
+
+describe('pollKometaUpdateProgress -- done handling', () => {
+  it('stops polling when data.done is true', async () => {
+    kometaState.kometaUpdateJobId = 'abc'
+    kometaState.kometaUpdatePollInterval = setInterval(() => {}, 10_000)
+    const clearIntervalSpy = vi.spyOn(global, 'clearInterval')
+    mockFetchOnce(makeOkResponse({
+      success: true,
+      job: { phase: 'completed' },
+      lines: [],
+      next_index: 42,
+      done: true
+    }))
+    await pollKometaUpdateProgress()
+    expect(clearIntervalSpy).toHaveBeenCalled()
+    expect(kometaState.kometaUpdatePollInterval).toBeNull()
+    clearIntervalSpy.mockRestore()
+  })
+
+  it('does NOT stop polling when data.done is false', async () => {
+    kometaState.kometaUpdateJobId = 'abc'
+    kometaState.kometaUpdatePollInterval = setInterval(() => {}, 10_000)
+    const handleBefore = kometaState.kometaUpdatePollInterval
+    mockFetchOnce(makeOkResponse({
+      success: true,
+      job: { phase: 'running' },
+      lines: [],
+      next_index: 0,
+      done: false
+    }))
+    await pollKometaUpdateProgress()
+    expect(kometaState.kometaUpdatePollInterval).toBe(handleBefore)
+    // Clean up so we don't leak an interval
+    clearInterval(kometaState.kometaUpdatePollInterval)
+    kometaState.kometaUpdatePollInterval = null
+  })
+})
+
+describe('pollKometaUpdateProgress -- return shape', () => {
+  it('returns a merged {job, lines, next_index, done} object', async () => {
+    kometaState.kometaUpdateJobId = 'abc'
+    mockFetchOnce(makeOkResponse({
+      success: true,
+      job: { phase: 'running', started_at: 123 },
+      lines: ['x'],
+      next_index: 1,
+      done: false
+    }))
+    const result = await pollKometaUpdateProgress()
+    expect(result).toEqual({
+      phase: 'running',
+      started_at: 123,
+      lines: ['x'],
+      next_index: 1,
+      done: false
+    })
+  })
+
+  it('handles missing job field with an empty object fallback', async () => {
+    kometaState.kometaUpdateJobId = 'abc'
+    // Server returns success=true and a job field, but the job is
+    // an empty object -- the merge should still work.
+    mockFetchOnce(makeOkResponse({
+      success: true,
+      job: {},
+      lines: [],
+      next_index: 0,
+      done: false
+    }))
+    const result = await pollKometaUpdateProgress()
+    expect(result).toMatchObject({
+      lines: [],
+      next_index: 0,
+      done: false
+    })
+  })
+})


### PR DESCRIPTION
## What

Third slice of the update-flow cluster. Small one -- just two functions that manage the `/background-jobs` polling interval.

`900-kometa.js`: 2647 -> 2618 lines (**-29**).
Vitest tests: 1095 -> 1117 (**+22**).

## What moved

Extracted to `static/local-js/modules/kometa/_updatePolling.js` (123 lines):

| Function | Description |
|---|---|
| `stopKometaUpdatePolling` | Idempotent: `clearInterval` + null out state handle |
| `pollKometaUpdateProgress` | Fetch next batch of log lines, update badge, append lines, advance cursor, auto-stop on done |

## Server contract (captured in module docstring)

```
GET /background-jobs/<job_id>?since=<log_index>
Response: {
  success: true,
  job: { phase: 'queued'|'running'|'completed'|'error', ... },
  lines: string[],           // new log lines since `since`
  next_index: number,        // pass this back as ?since= next time
  done: boolean              // true when server has no more lines
}
```

## Design notes

1. Only **'queued' and 'error'** phases get server-side badge updates -- other phases (downloading / extracting / installing / etc.) come from log-line text via `appendKometaStatusLine`'s built-in phase inference. Preserves the split between 'server tells us the coarse phase' and 'log content tells us the fine phase'.

2. URL building extracted into local `jobId` + `since` consts for readability. Same behavior as the original inline template literal.

## Test coverage: 22 new tests

- `stopKometaUpdatePolling` (3): no-op when inactive, clears + nulls, idempotent
- `pollKometaUpdateProgress` short circuit (1): null when no job id
- URL construction (1): encodes job id + since cursor
- Error paths (5): `!res.ok`, `success=false`, no job field, fallback message, network error
- Phase badge updates (3): 'queued', 'error', no-update for others
- Log line appending (3): appended in order, missing lines, non-array
- Cursor advancement (2): advances from `next_index`, no-advance when not a number
- Done handling (2): stops polling on `done=true`, keeps polling on `false`
- Return shape (2): merged object, missing job fallback

`_updatePhase.js` exports mocked with `vi.mock()`. `global.fetch` stubbed per-test.

## Verification

- **1117/1117 Vitest pass** (was 1095; +22 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- ESLint clean, Node syntax clean

## What's next

The **boss fight**:

- **`_kometaUpdate.js`** -- `checkKometaUpdate`, `callUpdateKometa` (~200 lines of async orchestration involving fetch, polling, error handling, state transitions). Will need careful test planning to avoid a brittle mega-test.