### PR TITLE
Split 900-kometa.js part 18: extract checkKometaUpdate

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -34,7 +34,6 @@ import {
   getConfiguredKometaRootPosix,
   getConfiguredKometaRootDisplay,
   kometaCanLaunch,
-  kometaCanCheckUpdateStatus,
   kometaCanProbeRuntime,
   kometaCanReadLogs
 } from './modules/kometa/_runtime.js'
@@ -82,6 +81,7 @@ import {
   stopKometaUpdatePolling,
   pollKometaUpdateProgress
 } from './modules/kometa/_updatePolling.js'
+import { checkKometaUpdate } from './modules/kometa/_updateCheck.js'
 
 // Kometa runtime status flags migrated to modules/kometa/_state.js
 // (kometaState.kometaInstalled, kometaValidated, kometaStatus, etc.).
@@ -675,66 +675,6 @@ function probeKometaRoot () {
       return data
     })
     .catch(() => { _probeError(null); return null })
-}
-
-function checkKometaUpdate (forceRefresh = false) {
-  if (!kometaCanCheckUpdateStatus()) {
-    appendKometaStatusLine('ℹ️ Update checks are not available in external Kometa mode.')
-    return Promise.resolve({
-      success: true,
-      update_check_completed: false,
-      kometa_update_check_skipped: true,
-      kometa_update_available: false
-    })
-  }
-  const configuredRootPosix = getConfiguredKometaRootPosix()
-  const configuredInstallMode = getConfiguredKometaInstallMode()
-  const branchOverride = getKometaBranchOverride()
-  if (!configuredRootPosix) return Promise.resolve(null)
-
-  return fetch('/check-kometa-update', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ path: configuredRootPosix, install_mode: configuredInstallMode, force: forceRefresh, branch_override: branchOverride })
-  })
-    .then(async res => {
-      const data = await res.json()
-      if (!res.ok) throw new Error(data.error || 'Failed to check Kometa update status.')
-      return data
-    })
-    .then(data => {
-      kometaState.kometaLocalCheckCompleted = true
-      kometaState.kometaInstalled = !!data.kometa_installed
-      kometaState.kometaUpdateCheckCompleted = !!data.update_check_completed
-      kometaState.kometaUpdateCheckSkipped = !!data.kometa_update_check_skipped
-      kometaState.kometaUpdateAvailable = !!data.kometa_update_available
-      if (Array.isArray(data.log)) data.log.forEach(line => appendKometaStatusLine(line))
-      syncKometaSourceStatus({
-        localVersion: data.local_version || kometaState.kometaLocalVersionStatus,
-        remoteVersion: data.remote_version || '',
-        checked: Boolean(data.update_check_completed),
-        skipped: Boolean(data.kometa_update_check_skipped)
-      })
-
-      if (data.local_version && data.remote_version && data.kometa_update_available) {
-        document.getElementById('kometa-update-box').classList.remove('d-none')
-        document.getElementById('kometa-local-version').textContent = data.local_version
-        document.getElementById('kometa-remote-version').textContent = data.remote_version
-      } else {
-        document.getElementById('kometa-update-box').classList.add('d-none')
-      }
-
-      syncUpdateButtonLabel()
-      syncKometaRollupBadge()
-      return data
-    })
-    .catch(err => {
-      appendKometaStatusLine(`❌ ${err.message || 'Failed to check Kometa update status.'}`)
-      syncKometaSourceStatus({ checked: false, skipped: false, remoteVersion: '' })
-      syncUpdateButtonLabel()
-      syncKometaRollupBadge()
-      throw err
-    })
 }
 
 if (document.getElementById('run-command-output')) {

--- a/static/local-js/modules/kometa/_updateCheck.js
+++ b/static/local-js/modules/kometa/_updateCheck.js
@@ -1,0 +1,152 @@
+// checkKometaUpdate: hit the server's /check-kometa-update endpoint,
+// interpret the response, and update kometaState + UI accordingly.
+//
+// This is the "check for updates" half of the update flow. The other
+// half -- actually PERFORMING the update (callUpdateKometa) -- lives
+// in 900-kometa.js for now and will be extracted separately.
+//
+// EXPORT:
+//
+//   checkKometaUpdate(forceRefresh = false)
+//     -- Runs the update check. Returns a Promise that resolves to
+//        the server's response data (or null when there's no
+//        configured Kometa root, or a synthetic 'skipped' object when
+//        the current mode can't be checked at all).
+//
+//        Side effects on success:
+//          - Updates kometaState.kometa{LocalCheckCompleted,
+//            Installed, UpdateCheckCompleted, UpdateCheckSkipped,
+//            UpdateAvailable}
+//          - Appends each server-supplied log line via
+//            appendKometaStatusLine
+//          - Syncs source-status panel with local/remote versions
+//          - Shows/hides #kometa-update-box based on whether an
+//            update is actually available (both versions known AND
+//            update flag set)
+//          - Refreshes update button label + rollup badge
+//
+//        Side effects on failure:
+//          - Appends a red-X error line to the status log
+//          - Clears source-status panel back to 'never checked'
+//          - Refreshes button label + rollup badge
+//          - Re-throws the error so callers can attach their own
+//            fallback UI
+//
+// SERVER CONTRACT:
+//
+//   POST /check-kometa-update
+//   Body: {
+//     path: string,             // configured Kometa root (POSIX)
+//     install_mode: string,     // 'managed' | 'existing' (never
+//                                 'external' -- see canCheck below)
+//     force: boolean,           // if true, skip cache and re-check
+//     branch_override: string   // 'auto' | 'master' | 'develop' | ...
+//   }
+//   Response: {
+//     kometa_installed: boolean,
+//     update_check_completed: boolean,
+//     kometa_update_check_skipped: boolean,
+//     kometa_update_available: boolean,
+//     local_version?: string,
+//     remote_version?: string,
+//     log?: string[]
+//   }
+
+import { kometaState } from './_state.js'
+import {
+  kometaCanCheckUpdateStatus,
+  getConfiguredKometaRootPosix,
+  getConfiguredKometaInstallMode
+} from './_runtime.js'
+import { getKometaBranchOverride, syncKometaSourceStatus } from './_kometaBranch.js'
+import { appendKometaStatusLine } from './_updatePhase.js'
+import { syncUpdateButtonLabel, syncKometaRollupBadge } from './_updateRollup.js'
+
+/**
+ * Run the update check. See module docstring for full behavior.
+ *
+ * @param {boolean} [forceRefresh=false]  Ask the server to bypass any
+ *                                        cached result and re-check.
+ * @returns {Promise<object | null>}
+ */
+export function checkKometaUpdate (forceRefresh = false) {
+  // External mode can't be update-checked; return a synthetic
+  // 'skipped' response so callers don't need to special-case it.
+  if (!kometaCanCheckUpdateStatus()) {
+    appendKometaStatusLine('\u2139\ufe0f Update checks are not available in external Kometa mode.')
+    return Promise.resolve({
+      success: true,
+      update_check_completed: false,
+      kometa_update_check_skipped: true,
+      kometa_update_available: false
+    })
+  }
+
+  const configuredRootPosix = getConfiguredKometaRootPosix()
+  const configuredInstallMode = getConfiguredKometaInstallMode()
+  const branchOverride = getKometaBranchOverride()
+
+  // No path selected yet -- silently resolve to null. Callers that
+  // wanted a check will see the null and know they need to prompt
+  // for a path first.
+  if (!configuredRootPosix) return Promise.resolve(null)
+
+  return fetch('/check-kometa-update', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      path: configuredRootPosix,
+      install_mode: configuredInstallMode,
+      force: forceRefresh,
+      branch_override: branchOverride
+    })
+  })
+    .then(async res => {
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to check Kometa update status.')
+      return data
+    })
+    .then(data => {
+      // Fold the response into kometaState so the rest of the UI
+      // (button labels, rollup badge, source status) reflects it.
+      kometaState.kometaLocalCheckCompleted = true
+      kometaState.kometaInstalled = !!data.kometa_installed
+      kometaState.kometaUpdateCheckCompleted = !!data.update_check_completed
+      kometaState.kometaUpdateCheckSkipped = !!data.kometa_update_check_skipped
+      kometaState.kometaUpdateAvailable = !!data.kometa_update_available
+
+      if (Array.isArray(data.log)) data.log.forEach(line => appendKometaStatusLine(line))
+
+      syncKometaSourceStatus({
+        localVersion: data.local_version || kometaState.kometaLocalVersionStatus,
+        remoteVersion: data.remote_version || '',
+        checked: Boolean(data.update_check_completed),
+        skipped: Boolean(data.kometa_update_check_skipped)
+      })
+
+      // Show the update-info box only when we have BOTH versions AND
+      // an update is actually available. In every other case
+      // (up-to-date, install missing, skipped) it stays hidden.
+      // NOTE: original didn't null-check any of these getElementById
+      // calls -- preserved verbatim (every page that reaches this
+      // path also renders the box).
+      if (data.local_version && data.remote_version && data.kometa_update_available) {
+        document.getElementById('kometa-update-box').classList.remove('d-none')
+        document.getElementById('kometa-local-version').textContent = data.local_version
+        document.getElementById('kometa-remote-version').textContent = data.remote_version
+      } else {
+        document.getElementById('kometa-update-box').classList.add('d-none')
+      }
+
+      syncUpdateButtonLabel()
+      syncKometaRollupBadge()
+      return data
+    })
+    .catch(err => {
+      appendKometaStatusLine(`\u274c ${err.message || 'Failed to check Kometa update status.'}`)
+      syncKometaSourceStatus({ checked: false, skipped: false, remoteVersion: '' })
+      syncUpdateButtonLabel()
+      syncKometaRollupBadge()
+      throw err
+    })
+}

--- a/tests/js/kometa/updateCheck.test.js
+++ b/tests/js/kometa/updateCheck.test.js
@@ -1,0 +1,405 @@
+// Tests for static/local-js/modules/kometa/_updateCheck.js
+//
+// One export: checkKometaUpdate(forceRefresh = false).
+//
+// COVERAGE STRATEGY:
+//
+//   Short circuits (2 branches):
+//     - kometaCanCheckUpdateStatus() false -> synthetic 'skipped' resolve
+//     - no configuredRootPosix -> null resolve
+//
+//   Fetch request:
+//     - correct URL / method / headers / body construction
+//     - forceRefresh forwarded as `force`
+//
+//   Success path (many state writes + DOM effects):
+//     - kometaState fields updated from response flags
+//     - server log lines forwarded to appendKometaStatusLine
+//     - syncKometaSourceStatus called with the right shape
+//     - #kometa-update-box shown when local + remote + available all set
+//     - #kometa-update-box hidden otherwise (3 variants)
+//     - syncUpdateButtonLabel + syncKometaRollupBadge called
+//
+//   Error path:
+//     - !res.ok -> rejects with server error message
+//     - !res.ok + no server message -> rejects with fallback
+//     - network reject propagates
+//     - error handler appends red-X line, clears source status, re-throws
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock every collaborator so this module's behavior is testable in
+// isolation. The signatures match what _updateCheck.js imports.
+vi.mock('../../../static/local-js/modules/kometa/_runtime.js', () => ({
+  kometaCanCheckUpdateStatus: vi.fn(() => true),
+  getConfiguredKometaRootPosix: vi.fn(() => '/opt/kometa'),
+  getConfiguredKometaInstallMode: vi.fn(() => 'managed')
+}))
+vi.mock('../../../static/local-js/modules/kometa/_kometaBranch.js', () => ({
+  getKometaBranchOverride: vi.fn(() => 'auto'),
+  syncKometaSourceStatus: vi.fn()
+}))
+vi.mock('../../../static/local-js/modules/kometa/_updatePhase.js', () => ({
+  appendKometaStatusLine: vi.fn()
+}))
+vi.mock('../../../static/local-js/modules/kometa/_updateRollup.js', () => ({
+  syncUpdateButtonLabel: vi.fn(),
+  syncKometaRollupBadge: vi.fn()
+}))
+
+import { kometaState } from '../../../static/local-js/modules/kometa/_state.js'
+import { checkKometaUpdate } from '../../../static/local-js/modules/kometa/_updateCheck.js'
+import {
+  kometaCanCheckUpdateStatus,
+  getConfiguredKometaRootPosix
+} from '../../../static/local-js/modules/kometa/_runtime.js'
+import {
+  getKometaBranchOverride,
+  syncKometaSourceStatus
+} from '../../../static/local-js/modules/kometa/_kometaBranch.js'
+import { appendKometaStatusLine } from '../../../static/local-js/modules/kometa/_updatePhase.js'
+import {
+  syncUpdateButtonLabel,
+  syncKometaRollupBadge
+} from '../../../static/local-js/modules/kometa/_updateRollup.js'
+
+// ---------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------
+
+let originalFetch
+
+function mockFetchWith (response) {
+  global.fetch = vi.fn(() => Promise.resolve(response))
+}
+
+function okJson (body) {
+  return { ok: true, json: () => Promise.resolve(body) }
+}
+
+function errJson (status, body) {
+  return { ok: false, status, json: () => Promise.resolve(body) }
+}
+
+function installUpdateBox () {
+  document.body.innerHTML = `
+    <div id="kometa-update-box" class="d-none"></div>
+    <span id="kometa-local-version"></span>
+    <span id="kometa-remote-version"></span>
+  `
+}
+
+function resetState () {
+  kometaState.kometaLocalCheckCompleted = false
+  kometaState.kometaInstalled = false
+  kometaState.kometaUpdateCheckCompleted = false
+  kometaState.kometaUpdateCheckSkipped = false
+  kometaState.kometaUpdateAvailable = false
+  kometaState.kometaLocalVersionStatus = 'Unknown'
+}
+
+beforeEach(() => {
+  kometaCanCheckUpdateStatus.mockReset()
+  kometaCanCheckUpdateStatus.mockReturnValue(true)
+  getConfiguredKometaRootPosix.mockReset()
+  getConfiguredKometaRootPosix.mockReturnValue('/opt/kometa')
+  getKometaBranchOverride.mockReset()
+  getKometaBranchOverride.mockReturnValue('auto')
+  syncKometaSourceStatus.mockClear()
+  appendKometaStatusLine.mockClear()
+  syncUpdateButtonLabel.mockClear()
+  syncKometaRollupBadge.mockClear()
+
+  originalFetch = global.fetch
+  resetState()
+})
+
+afterEach(() => {
+  global.fetch = originalFetch
+  document.body.innerHTML = ''
+})
+
+// ---------------------------------------------------------------------
+// Short-circuit branches
+// ---------------------------------------------------------------------
+
+describe('checkKometaUpdate -- short circuits', () => {
+  it("returns a synthetic 'skipped' response when canCheckUpdateStatus is false", async () => {
+    kometaCanCheckUpdateStatus.mockReturnValue(false)
+    const result = await checkKometaUpdate()
+    expect(result).toEqual({
+      success: true,
+      update_check_completed: false,
+      kometa_update_check_skipped: true,
+      kometa_update_available: false
+    })
+    // Should have appended the info line about external mode
+    expect(appendKometaStatusLine).toHaveBeenCalledWith(expect.stringContaining('external Kometa mode'))
+  })
+
+  it('resolves null when no Kometa root is configured', async () => {
+    getConfiguredKometaRootPosix.mockReturnValue('')
+    const result = await checkKometaUpdate()
+    expect(result).toBeNull()
+    // Should NOT have appended anything (silent)
+    expect(appendKometaStatusLine).not.toHaveBeenCalled()
+  })
+
+  it("null-config short-circuit does NOT hit the network", async () => {
+    getConfiguredKometaRootPosix.mockReturnValue('')
+    global.fetch = vi.fn()
+    await checkKometaUpdate()
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------
+// Fetch request construction
+// ---------------------------------------------------------------------
+
+describe('checkKometaUpdate -- request construction', () => {
+  it('POSTs to /check-kometa-update with JSON body', async () => {
+    installUpdateBox()
+    mockFetchWith(okJson({ kometa_installed: true }))
+    await checkKometaUpdate()
+    expect(global.fetch).toHaveBeenCalledWith('/check-kometa-update', expect.objectContaining({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }
+    }))
+  })
+
+  it('forwards path, install_mode, force, branch_override in the body', async () => {
+    installUpdateBox()
+    getConfiguredKometaRootPosix.mockReturnValue('/custom/path')
+    getKometaBranchOverride.mockReturnValue('develop')
+    mockFetchWith(okJson({ kometa_installed: true }))
+    await checkKometaUpdate(true)
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body)
+    expect(body).toEqual({
+      path: '/custom/path',
+      install_mode: 'managed',
+      force: true,
+      branch_override: 'develop'
+    })
+  })
+
+  it('defaults force to false when forceRefresh is omitted', async () => {
+    installUpdateBox()
+    mockFetchWith(okJson({ kometa_installed: true }))
+    await checkKometaUpdate()
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body)
+    expect(body.force).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------
+// Success path -- state updates
+// ---------------------------------------------------------------------
+
+describe('checkKometaUpdate -- success path state updates', () => {
+  it('folds response flags into kometaState (all boolean coerced)', async () => {
+    installUpdateBox()
+    mockFetchWith(okJson({
+      kometa_installed: 1,       // truthy non-boolean
+      update_check_completed: true,
+      kometa_update_check_skipped: false,
+      kometa_update_available: 'yes'  // truthy non-boolean
+    }))
+    await checkKometaUpdate()
+    expect(kometaState.kometaLocalCheckCompleted).toBe(true)
+    expect(kometaState.kometaInstalled).toBe(true)
+    expect(kometaState.kometaUpdateCheckCompleted).toBe(true)
+    expect(kometaState.kometaUpdateCheckSkipped).toBe(false)
+    expect(kometaState.kometaUpdateAvailable).toBe(true)
+  })
+
+  it('forwards every log line to appendKometaStatusLine', async () => {
+    installUpdateBox()
+    mockFetchWith(okJson({
+      kometa_installed: true,
+      log: ['line one', 'line two']
+    }))
+    await checkKometaUpdate()
+    expect(appendKometaStatusLine).toHaveBeenCalledWith('line one')
+    expect(appendKometaStatusLine).toHaveBeenCalledWith('line two')
+  })
+
+  it('handles missing log field gracefully (no appends)', async () => {
+    installUpdateBox()
+    mockFetchWith(okJson({ kometa_installed: true }))
+    await checkKometaUpdate()
+    expect(appendKometaStatusLine).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------
+// Success path -- source-status sync
+// ---------------------------------------------------------------------
+
+describe('checkKometaUpdate -- syncKometaSourceStatus payload', () => {
+  it('passes local_version + remote_version + checked + skipped', async () => {
+    installUpdateBox()
+    mockFetchWith(okJson({
+      kometa_installed: true,
+      update_check_completed: true,
+      kometa_update_check_skipped: false,
+      local_version: 'v1.0.0',
+      remote_version: 'v1.1.0'
+    }))
+    await checkKometaUpdate()
+    expect(syncKometaSourceStatus).toHaveBeenCalledWith({
+      localVersion: 'v1.0.0',
+      remoteVersion: 'v1.1.0',
+      checked: true,
+      skipped: false
+    })
+  })
+
+  it('falls back to kometaLocalVersionStatus when local_version is missing', async () => {
+    installUpdateBox()
+    kometaState.kometaLocalVersionStatus = 'v0.9.0-fallback'
+    mockFetchWith(okJson({
+      kometa_installed: true,
+      remote_version: 'v1.1.0'
+    }))
+    await checkKometaUpdate()
+    expect(syncKometaSourceStatus.mock.calls[0][0].localVersion).toBe('v0.9.0-fallback')
+  })
+
+  it("passes empty string for remoteVersion when missing", async () => {
+    installUpdateBox()
+    mockFetchWith(okJson({ kometa_installed: true }))
+    await checkKometaUpdate()
+    expect(syncKometaSourceStatus.mock.calls[0][0].remoteVersion).toBe('')
+  })
+})
+
+// ---------------------------------------------------------------------
+// Success path -- update-box visibility
+// ---------------------------------------------------------------------
+
+describe('checkKometaUpdate -- update box visibility', () => {
+  it('shows the update box when local + remote + available all set', async () => {
+    installUpdateBox()
+    mockFetchWith(okJson({
+      kometa_installed: true,
+      kometa_update_available: true,
+      local_version: 'v1.0.0',
+      remote_version: 'v1.1.0'
+    }))
+    await checkKometaUpdate()
+    const box = document.getElementById('kometa-update-box')
+    expect(box.classList.contains('d-none')).toBe(false)
+    expect(document.getElementById('kometa-local-version').textContent).toBe('v1.0.0')
+    expect(document.getElementById('kometa-remote-version').textContent).toBe('v1.1.0')
+  })
+
+  it('hides the update box when no update is available', async () => {
+    installUpdateBox()
+    document.getElementById('kometa-update-box').classList.remove('d-none')  // start visible
+    mockFetchWith(okJson({
+      kometa_installed: true,
+      kometa_update_available: false,
+      local_version: 'v1.0.0',
+      remote_version: 'v1.0.0'
+    }))
+    await checkKometaUpdate()
+    expect(document.getElementById('kometa-update-box').classList.contains('d-none')).toBe(true)
+  })
+
+  it('hides the update box when local_version is missing', async () => {
+    installUpdateBox()
+    mockFetchWith(okJson({
+      kometa_installed: true,
+      kometa_update_available: true,
+      remote_version: 'v1.1.0'
+    }))
+    await checkKometaUpdate()
+    expect(document.getElementById('kometa-update-box').classList.contains('d-none')).toBe(true)
+  })
+
+  it('hides the update box when remote_version is missing', async () => {
+    installUpdateBox()
+    mockFetchWith(okJson({
+      kometa_installed: true,
+      kometa_update_available: true,
+      local_version: 'v1.0.0'
+    }))
+    await checkKometaUpdate()
+    expect(document.getElementById('kometa-update-box').classList.contains('d-none')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// Success path -- UI refresh calls
+// ---------------------------------------------------------------------
+
+describe('checkKometaUpdate -- UI refresh after success', () => {
+  it('calls syncUpdateButtonLabel and syncKometaRollupBadge', async () => {
+    installUpdateBox()
+    mockFetchWith(okJson({ kometa_installed: true }))
+    await checkKometaUpdate()
+    expect(syncUpdateButtonLabel).toHaveBeenCalledTimes(1)
+    expect(syncKometaRollupBadge).toHaveBeenCalledTimes(1)
+  })
+
+  it('resolves to the server data', async () => {
+    installUpdateBox()
+    const responseData = { kometa_installed: true, custom_field: 'preserved' }
+    mockFetchWith(okJson(responseData))
+    const result = await checkKometaUpdate()
+    expect(result).toEqual(responseData)
+  })
+})
+
+// ---------------------------------------------------------------------
+// Error path
+// ---------------------------------------------------------------------
+
+describe('checkKometaUpdate -- error path', () => {
+  it('rejects with server error message when !res.ok', async () => {
+    installUpdateBox()
+    mockFetchWith(errJson(500, { error: 'server exploded' }))
+    await expect(checkKometaUpdate()).rejects.toThrow('server exploded')
+  })
+
+  it('rejects with fallback message when server omits data.error', async () => {
+    installUpdateBox()
+    mockFetchWith(errJson(500, {}))
+    await expect(checkKometaUpdate()).rejects.toThrow('Failed to check Kometa update status.')
+  })
+
+  it('propagates network errors', async () => {
+    installUpdateBox()
+    global.fetch = vi.fn(() => Promise.reject(new Error('network fried')))
+    await expect(checkKometaUpdate()).rejects.toThrow('network fried')
+  })
+
+  it('appends a red-X line on error', async () => {
+    installUpdateBox()
+    mockFetchWith(errJson(500, { error: 'boom' }))
+    await expect(checkKometaUpdate()).rejects.toThrow()
+    const lastCall = appendKometaStatusLine.mock.calls.at(-1)?.[0]
+    expect(lastCall).toContain('boom')
+    expect(lastCall).toContain('\u274c')  // red X emoji
+  })
+
+  it('clears source status on error', async () => {
+    installUpdateBox()
+    mockFetchWith(errJson(500, {}))
+    await expect(checkKometaUpdate()).rejects.toThrow()
+    expect(syncKometaSourceStatus).toHaveBeenCalledWith({
+      checked: false,
+      skipped: false,
+      remoteVersion: ''
+    })
+  })
+
+  it('still refreshes button label + rollup badge on error', async () => {
+    installUpdateBox()
+    mockFetchWith(errJson(500, {}))
+    await expect(checkKometaUpdate()).rejects.toThrow()
+    expect(syncUpdateButtonLabel).toHaveBeenCalledTimes(1)
+    expect(syncKometaRollupBadge).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## What

Extracts the 'check for updates' endpoint call and response handler. This is the smaller half of what was going to be the 'boss fight' extraction; `callUpdateKometa` still lives in `900-kometa.js` because it depends on three chunky in-file helpers (`runKometaStatusPass`, `validateKometaRoot`, `hideRunCommandSectionUntilValidated`) that are worth extracting on their own first.

`900-kometa.js`: 2618 -> 2558 lines (**-60**).
Vitest tests: 1117 -> 1141 (**+24**).

## What moved

Extracted to `static/local-js/modules/kometa/_updateCheck.js` (152 lines):

- `checkKometaUpdate(forceRefresh = false)` -- POSTs to `/check-kometa-update`, folds response into `kometaState`, forwards log lines, syncs source status, shows/hides update box, refreshes button + rollup

Two short-circuits:
- **External mode**: synthetic 'skipped' response (no network call)
- **No root configured**: silent null resolve (no network call)

Also removed the orphaned `kometaCanCheckUpdateStatus` import from `900-kometa.js` (`checkKometaUpdate` was its only local caller).

## Server contract (captured in module docstring)

```
POST /check-kometa-update
Body: { path, install_mode, force, branch_override }
Response: {
  kometa_installed, update_check_completed,
  kometa_update_check_skipped, kometa_update_available,
  local_version?, remote_version?, log?
}
```

## Design notes

1. **Preserved verbatim**: the three unconditional `getElementById` calls in the box-visibility branch would throw if any element were missing. Kept because every page that reaches this code path renders all three.
2. **Emoji replaced with unicode escapes** (`\u2139\ufe0f`, `\u274c`). Same rule as `_updatePhase.js` -- encoding-independent.
3. **Booleans coerced via `!!`** -- server sometimes returns truthy non-booleans (`1`, `'yes'`). Explicit coercion keeps `kometaState` fields strict.

## Test coverage: 24 new tests

- Short circuits (3): canCheck false, no root, no-fetch verification
- Request construction (3): URL/method/headers, body fields, force default
- State updates (3): fields coerced, log lines forwarded, missing log OK
- Source status sync (3): full payload, local fallback, empty remote
- Update box visibility (4): shown when all three set, 3 hide branches
- UI refresh calls (2): button + rollup on success, resolves to server data
- Error path (6): server message, fallback message, network reject, red-X line, source cleared, refresh still fires

Every collaborator mocked with `vi.mock()`.

## Verification

- **1141/1141 Vitest pass** (was 1117; +24 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- ESLint clean, Node syntax clean

## What's next

Before I can extract `callUpdateKometa`, its in-file deps need to be extracted first:

- `runKometaStatusPass` (~90 lines)
- `validateKometaRoot` (~120 lines)
- `hideRunCommandSectionUntilValidated` (~10 lines)

Plan: extract those three (possibly grouped as a 'kometa-actions' module) first, **then** `callUpdateKometa` becomes clean.