### PR TITLE
Split 900-kometa.js part 19: extract run-command section visibility

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -82,6 +82,13 @@ import {
   pollKometaUpdateProgress
 } from './modules/kometa/_updatePolling.js'
 import { checkKometaUpdate } from './modules/kometa/_updateCheck.js'
+import {
+  setRunCommandPlaceholderState,
+  clearRunCommandPlaceholderState,
+  hideRunCommandSectionUntilValidated,
+  revealRunCommandSection,
+  showRunCommandSectionAfterValidated
+} from './modules/kometa/_runCommandSection.js'
 
 // Kometa runtime status flags migrated to modules/kometa/_state.js
 // (kometaState.kometaInstalled, kometaValidated, kometaStatus, etc.).
@@ -373,66 +380,6 @@ if (showCliToggle) {
     const showCli = this.checked
     updateFlagLabels(showCli)
   })
-}
-
-function setRunCommandPlaceholderState () {
-  const panel = document.getElementById('run-command-panel-message')
-  const panelTitle = document.getElementById('run-command-panel-title')
-  const panelText = document.getElementById('run-command-panel-text')
-  const panelButton = document.getElementById('open-kometa-actions-panel-button')
-  const box = document.getElementById('run-command-box')
-
-  if (!panel) return
-
-  const installMode = getConfiguredKometaInstallMode()
-  let title = 'Run command is not ready yet'
-  let message = installMode === 'existing'
-    ? 'Open Prepare Kometa to validate the existing Kometa setup and check whether it needs a manual update before running.'
-    : 'Open Prepare Kometa to install, validate, or update the local Kometa setup before running.'
-  let showButton = true
-
-  if (!kometaState.showYAML) {
-    title = 'Fix validation before building the run command'
-    message = 'Resolve the current validation issues first. The run command will appear after the config validates cleanly.'
-    showButton = false
-  } else if (kometaState.kometaStatus === 'running') {
-    title = 'Kometa is currently running'
-    message = 'Run output and stop controls are active below. Prepare Kometa is locked until the current run finishes.'
-    showButton = false
-  } else if (kometaState.kometaUpdating) {
-    title = 'Kometa update in progress'
-    message = 'Wait for the current install or update to finish. The run command will appear automatically afterward.'
-  } else if (kometaState.kometaValidationInProgress) {
-    title = 'Preparing Kometa'
-    message = 'Quickstart is validating the Kometa folder and environment now. The run command will appear automatically when ready.'
-  } else if (!kometaState.kometaLocalCheckCompleted) {
-    title = 'Checking Kometa state'
-    message = 'Quickstart is probing the local Kometa path. Wait for that check to finish, then prepare Kometa if needed.'
-    showButton = false
-  } else if (!kometaState.kometaInstalled) {
-    title = 'Install Kometa to build the run command'
-    message = 'Kometa is not installed in the selected path yet. Open Prepare Kometa to install it first.'
-  } else if (!kometaState.kometaValidated) {
-    title = 'Validate Kometa to build the run command'
-    message = 'Next step: open Prepare Kometa, let Quickstart validate the Kometa folder and environment, then this command will be generated here.'
-  }
-
-  panelTitle.textContent = title
-  panelText.textContent = message
-  panelButton.classList.toggle('d-none', !showButton)
-  panel.classList.remove('d-none')
-  box.classList.add('d-none')
-  box.classList.remove('fade-in')
-}
-
-function clearRunCommandPlaceholderState () {
-  document.getElementById('run-command-panel-message').classList.add('d-none')
-  document.getElementById('run-command-placeholder').classList.add('d-none')
-  document.getElementById('open-kometa-actions-button').classList.add('d-none')
-  document.getElementById('run-command-box').classList.remove('d-none')
-  document.querySelector('#run-command-box .form-label').classList.remove('d-none')
-  document.querySelector('#run-command-box pre').classList.remove('d-none')
-  document.getElementById('copy-command').classList.remove('d-none')
 }
 
 function resolveFreshnessGateAfterBulkValidation () {
@@ -861,49 +808,6 @@ function startKometaCommand (command, opts = {}) {
     })
 }
 
-function hideRunCommandSectionUntilValidated () {
-  const accordion = document.getElementById('run-command-output-accordion')
-  if (accordion) accordion.classList.remove('d-none')
-  const collapse = document.getElementById('run-command-output-collapse')
-  if (collapse) collapse.classList.remove('show')
-  const headingBtn = document.querySelector('#run-command-output-heading .accordion-button')
-  if (headingBtn) {
-    headingBtn.classList.add('collapsed')
-    headingBtn.setAttribute('aria-expanded', 'false')
-  }
-  setRunCommandPlaceholderState()
-  {
-    const runNowBtn = document.getElementById('run-now')
-    if (runNowBtn) {
-      runNowBtn.disabled = true
-      runNowBtn.innerHTML = '<i class="bi bi-hourglass-split me-1"></i> Waiting...'
-    }
-  }
-}
-
-function revealRunCommandSection () {
-  const accordion = document.getElementById('run-command-output-accordion')
-  const box = document.getElementById('run-command-box')
-
-  clearRunCommandPlaceholderState()
-  accordion.classList.remove('d-none')
-  document.getElementById('run-command-output-collapse').classList.add('show')
-  document.querySelector('#run-command-output-heading .accordion-button').classList.remove('collapsed')
-  document.querySelector('#run-command-output-heading .accordion-button').setAttribute('aria-expanded', 'true')
-  box.classList.remove('d-none') // Reveal element (opacity still 0)
-  setTimeout(() => {
-    box.classList.add('fade-in') // Let browser register change, then fade in
-  }, 10)
-}
-
-function showRunCommandSectionAfterValidated () {
-  clearRunCommandPlaceholderState()
-  revealRunCommandSection()
-  const runNowEl = document.getElementById('run-now')
-  if (runNowEl) runNowEl.innerHTML = '<i class="bi bi-play-fill me-1"></i> <span id="run-now-label">Run Now</span>'
-  try { buildCommand() } catch {}
-  updateRunNowState()
-}
 function startPollingIfNeeded () {
   if (kometaState.kometaPollingStarted) return
   kometaState.kometaPollingStarted = true

--- a/static/local-js/modules/kometa/_runCommandSection.js
+++ b/static/local-js/modules/kometa/_runCommandSection.js
@@ -1,0 +1,245 @@
+// Run-command section visibility helpers.
+//
+// The "Run Command" section is the block at the bottom of the Kometa
+// wizard step that displays the actual shell command Quickstart will
+// run to invoke Kometa. It's hidden until Kometa is validated (so we
+// don't tempt users into running with a broken install).
+//
+// This module owns the show/hide/placeholder state machine for that
+// section. Five exported functions form a small ladder:
+//
+//   Ladder direction: hidden -> placeholder -> revealed
+//
+//   setRunCommandPlaceholderState()
+//     -- populate the placeholder panel with a title + message
+//        describing WHY the run command isn't ready yet. Reads a lot
+//        of kometaState (running / updating / validating / installed
+//        / etc.) to pick the right message.
+//
+//   clearRunCommandPlaceholderState()
+//     -- hide the placeholder panel + reveal the underlying run
+//        command box. Called before revealRunCommandSection to hand
+//        control from the placeholder to the actual command display.
+//
+//   hideRunCommandSectionUntilValidated()
+//     -- collapse the run-command accordion and swap in the
+//        placeholder. Also disables the "Run Now" button and puts it
+//        into a "Waiting..." state. Called from many places (probe
+//        errors, install-needed states, update in progress, etc.).
+//
+//   revealRunCommandSection()
+//     -- expand the accordion, remove d-none from the box, and
+//        trigger a CSS fade-in via a 10ms setTimeout. The setTimeout
+//        is essential: browsers won't animate a transition when the
+//        display state changes in the same tick as the class change.
+//
+//   showRunCommandSectionAfterValidated()
+//     -- convenience wrapper that unhides the section, resets the
+//        "Run Now" button label to its default, rebuilds the run
+//        command string, and refreshes the button's disabled state.
+//
+// STATE TOUCHED:
+//
+//   Reads: kometaState.showYAML, kometaState.kometaStatus,
+//          kometaState.kometaUpdating,
+//          kometaState.kometaValidationInProgress,
+//          kometaState.kometaLocalCheckCompleted,
+//          kometaState.kometaInstalled,
+//          kometaState.kometaValidated
+//   Writes: (none directly; state changes happen via other modules)
+//
+// DOM ELEMENTS TOUCHED (all lazy per-call):
+//
+//   #run-command-panel-message   -- the placeholder panel container
+//   #run-command-panel-title     -- placeholder title text
+//   #run-command-panel-text      -- placeholder body text
+//   #open-kometa-actions-panel-button
+//                                -- link to Prepare Kometa
+//   #run-command-box             -- the actual command display
+//   #run-command-placeholder     -- alt placeholder element
+//   #open-kometa-actions-button  -- alt link element
+//   #run-command-output-accordion
+//                                -- the Bootstrap accordion wrapper
+//   #run-command-output-collapse -- the accordion collapsable body
+//   #run-command-output-heading .accordion-button
+//                                -- accordion toggle button
+//   #run-now                     -- the "Run Now" button
+//   #copy-command                -- the copy-to-clipboard button
+//   #run-command-box .form-label -- the label above the command
+//   #run-command-box pre         -- the <pre> that holds the command
+
+import { kometaState } from './_state.js'
+import { getConfiguredKometaInstallMode } from './_runtime.js'
+import { buildCommand } from './_runCommand.js'
+import { updateRunNowState } from './_runControls.js'
+
+// ---------------------------------------------------------------------
+// Placeholder show / hide
+// ---------------------------------------------------------------------
+
+/**
+ * Populate the placeholder panel with a title + message describing
+ * WHY the run command isn't ready yet. No-op when the placeholder
+ * container is missing (typical of pages that don't render the run
+ * command section).
+ *
+ * Priority order (first match wins):
+ *   1. !showYAML             -> "Fix validation before..."
+ *   2. running               -> "Kometa is currently running"
+ *   3. kometaUpdating        -> "Kometa update in progress"
+ *   4. validationInProgress  -> "Preparing Kometa"
+ *   5. !localCheckCompleted  -> "Checking Kometa state"
+ *   6. !kometaInstalled      -> "Install Kometa to build..."
+ *   7. !kometaValidated      -> "Validate Kometa to build..."
+ *   8. (fallback)            -> mode-aware default message
+ *
+ * NOTE: original didn't null-check panelTitle / panelText / panelButton
+ * / box either -- preserved verbatim. Every page that renders
+ * #run-command-panel-message also renders the other four.
+ */
+export function setRunCommandPlaceholderState () {
+  const panel = document.getElementById('run-command-panel-message')
+  const panelTitle = document.getElementById('run-command-panel-title')
+  const panelText = document.getElementById('run-command-panel-text')
+  const panelButton = document.getElementById('open-kometa-actions-panel-button')
+  const box = document.getElementById('run-command-box')
+
+  if (!panel) return
+
+  const installMode = getConfiguredKometaInstallMode()
+  let title = 'Run command is not ready yet'
+  let message = installMode === 'existing'
+    ? 'Open Prepare Kometa to validate the existing Kometa setup and check whether it needs a manual update before running.'
+    : 'Open Prepare Kometa to install, validate, or update the local Kometa setup before running.'
+  let showButton = true
+
+  if (!kometaState.showYAML) {
+    title = 'Fix validation before building the run command'
+    message = 'Resolve the current validation issues first. The run command will appear after the config validates cleanly.'
+    showButton = false
+  } else if (kometaState.kometaStatus === 'running') {
+    title = 'Kometa is currently running'
+    message = 'Run output and stop controls are active below. Prepare Kometa is locked until the current run finishes.'
+    showButton = false
+  } else if (kometaState.kometaUpdating) {
+    title = 'Kometa update in progress'
+    message = 'Wait for the current install or update to finish. The run command will appear automatically afterward.'
+  } else if (kometaState.kometaValidationInProgress) {
+    title = 'Preparing Kometa'
+    message = 'Quickstart is validating the Kometa folder and environment now. The run command will appear automatically when ready.'
+  } else if (!kometaState.kometaLocalCheckCompleted) {
+    title = 'Checking Kometa state'
+    message = 'Quickstart is probing the local Kometa path. Wait for that check to finish, then prepare Kometa if needed.'
+    showButton = false
+  } else if (!kometaState.kometaInstalled) {
+    title = 'Install Kometa to build the run command'
+    message = 'Kometa is not installed in the selected path yet. Open Prepare Kometa to install it first.'
+  } else if (!kometaState.kometaValidated) {
+    title = 'Validate Kometa to build the run command'
+    message = 'Next step: open Prepare Kometa, let Quickstart validate the Kometa folder and environment, then this command will be generated here.'
+  }
+
+  panelTitle.textContent = title
+  panelText.textContent = message
+  panelButton.classList.toggle('d-none', !showButton)
+  panel.classList.remove('d-none')
+  box.classList.add('d-none')
+  box.classList.remove('fade-in')
+}
+
+/**
+ * Hide the placeholder + reveal the underlying run command box.
+ * Called before revealRunCommandSection to hand control from the
+ * placeholder to the actual command display.
+ *
+ * NOTE: original didn't null-check any of these -- preserved verbatim.
+ */
+export function clearRunCommandPlaceholderState () {
+  document.getElementById('run-command-panel-message').classList.add('d-none')
+  document.getElementById('run-command-placeholder').classList.add('d-none')
+  document.getElementById('open-kometa-actions-button').classList.add('d-none')
+  document.getElementById('run-command-box').classList.remove('d-none')
+  document.querySelector('#run-command-box .form-label').classList.remove('d-none')
+  document.querySelector('#run-command-box pre').classList.remove('d-none')
+  document.getElementById('copy-command').classList.remove('d-none')
+}
+
+// ---------------------------------------------------------------------
+// Full section show / hide
+// ---------------------------------------------------------------------
+
+/**
+ * Collapse the run-command accordion and swap in the placeholder.
+ * Also disables the "Run Now" button and puts it into a "Waiting..."
+ * state (so a distracted user can't click it while validation is
+ * pending).
+ *
+ * Every DOM lookup here IS null-checked (the accordion + collapse +
+ * heading + run-now button are optional per-page), which is why this
+ * helper is safer than the reveal side that assumes everything exists.
+ */
+export function hideRunCommandSectionUntilValidated () {
+  const accordion = document.getElementById('run-command-output-accordion')
+  if (accordion) accordion.classList.remove('d-none')
+  const collapse = document.getElementById('run-command-output-collapse')
+  if (collapse) collapse.classList.remove('show')
+  const headingBtn = document.querySelector('#run-command-output-heading .accordion-button')
+  if (headingBtn) {
+    headingBtn.classList.add('collapsed')
+    headingBtn.setAttribute('aria-expanded', 'false')
+  }
+  setRunCommandPlaceholderState()
+
+  const runNowBtn = document.getElementById('run-now')
+  if (runNowBtn) {
+    runNowBtn.disabled = true
+    runNowBtn.innerHTML = '<i class="bi bi-hourglass-split me-1"></i> Waiting...'
+  }
+}
+
+/**
+ * Expand the accordion, remove d-none from the box, and trigger a
+ * CSS fade-in via a 10ms setTimeout.
+ *
+ * The setTimeout is essential: browsers won't animate a transition
+ * when the display state changes in the same tick as the class
+ * change. The 10ms delay gives the browser a chance to register
+ * the display change before we add the 'fade-in' class.
+ *
+ * NOTE: assumes the accordion / collapse / heading elements exist
+ * (original code did too). Only defensively looks up #run-command-box
+ * because the fade-in adds a class.
+ */
+export function revealRunCommandSection () {
+  const accordion = document.getElementById('run-command-output-accordion')
+  const box = document.getElementById('run-command-box')
+
+  clearRunCommandPlaceholderState()
+  accordion.classList.remove('d-none')
+  document.getElementById('run-command-output-collapse').classList.add('show')
+  document.querySelector('#run-command-output-heading .accordion-button').classList.remove('collapsed')
+  document.querySelector('#run-command-output-heading .accordion-button').setAttribute('aria-expanded', 'true')
+  box.classList.remove('d-none') // Reveal element (opacity still 0)
+  setTimeout(() => {
+    box.classList.add('fade-in') // Let browser register change, then fade in
+  }, 10)
+}
+
+/**
+ * Convenience wrapper that unhides the section, resets the "Run Now"
+ * button label to its default, rebuilds the run command string, and
+ * refreshes the button's disabled state.
+ *
+ * Called after successful validation to hand the UI over to the
+ * "ready to run" state.
+ */
+export function showRunCommandSectionAfterValidated () {
+  clearRunCommandPlaceholderState()
+  revealRunCommandSection()
+  const runNowEl = document.getElementById('run-now')
+  if (runNowEl) {
+    runNowEl.innerHTML = '<i class="bi bi-play-fill me-1"></i> <span id="run-now-label">Run Now</span>'
+  }
+  try { buildCommand() } catch { /* swallow -- caller may not need a rebuild */ }
+  updateRunNowState()
+}

--- a/tests/js/kometa/runCommandSection.test.js
+++ b/tests/js/kometa/runCommandSection.test.js
@@ -1,0 +1,394 @@
+// Tests for static/local-js/modules/kometa/_runCommandSection.js
+//
+// Five exported functions:
+//
+//   setRunCommandPlaceholderState        -- populates placeholder
+//   clearRunCommandPlaceholderState      -- hides placeholder + reveals box
+//   hideRunCommandSectionUntilValidated  -- collapses accordion + shows placeholder
+//   revealRunCommandSection              -- expands accordion + fades in box
+//   showRunCommandSectionAfterValidated  -- convenience wrapper
+//
+// COVERAGE STRATEGY:
+//
+//   setRunCommandPlaceholderState: 8 branches (7 rule conditions + fallback)
+//   clearRunCommandPlaceholderState: DOM assertions
+//   hideRunCommandSectionUntilValidated: DOM writes + run-now button state
+//   revealRunCommandSection: DOM writes + fade-in setTimeout
+//   showRunCommandSectionAfterValidated: composition assertions
+//
+// Collaborators (getConfiguredKometaInstallMode, buildCommand,
+// updateRunNowState) are mocked via vi.mock.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../static/local-js/modules/kometa/_runtime.js', () => ({
+  getConfiguredKometaInstallMode: vi.fn(() => 'managed')
+}))
+vi.mock('../../../static/local-js/modules/kometa/_runCommand.js', () => ({
+  buildCommand: vi.fn()
+}))
+vi.mock('../../../static/local-js/modules/kometa/_runControls.js', () => ({
+  updateRunNowState: vi.fn()
+}))
+
+import { kometaState } from '../../../static/local-js/modules/kometa/_state.js'
+import {
+  setRunCommandPlaceholderState,
+  clearRunCommandPlaceholderState,
+  hideRunCommandSectionUntilValidated,
+  revealRunCommandSection,
+  showRunCommandSectionAfterValidated
+} from '../../../static/local-js/modules/kometa/_runCommandSection.js'
+import { getConfiguredKometaInstallMode } from '../../../static/local-js/modules/kometa/_runtime.js'
+import { buildCommand } from '../../../static/local-js/modules/kometa/_runCommand.js'
+import { updateRunNowState } from '../../../static/local-js/modules/kometa/_runControls.js'
+
+// ---------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------
+
+/**
+ * Install the placeholder fixture. This is what
+ * setRunCommandPlaceholderState + clearRunCommandPlaceholderState
+ * operate on.
+ */
+function installPlaceholderFixture () {
+  document.body.innerHTML = `
+    <div id="run-command-panel-message"></div>
+    <span id="run-command-panel-title"></span>
+    <span id="run-command-panel-text"></span>
+    <a id="open-kometa-actions-panel-button"></a>
+    <a id="open-kometa-actions-button"></a>
+    <div id="run-command-placeholder"></div>
+    <div id="run-command-box">
+      <label class="form-label"></label>
+      <pre></pre>
+    </div>
+    <button id="copy-command"></button>
+  `
+}
+
+/**
+ * Install the full section fixture including accordion + run-now
+ * button. Superset of the placeholder fixture.
+ */
+function installFullSectionFixture () {
+  document.body.innerHTML = `
+    <div id="run-command-panel-message"></div>
+    <span id="run-command-panel-title"></span>
+    <span id="run-command-panel-text"></span>
+    <a id="open-kometa-actions-panel-button"></a>
+    <a id="open-kometa-actions-button"></a>
+    <div id="run-command-placeholder"></div>
+    <div id="run-command-output-accordion" class="d-none">
+      <div id="run-command-output-heading">
+        <button class="accordion-button collapsed" aria-expanded="false"></button>
+      </div>
+      <div id="run-command-output-collapse">
+        <div id="run-command-box" class="d-none">
+          <label class="form-label"></label>
+          <pre></pre>
+        </div>
+      </div>
+    </div>
+    <button id="copy-command"></button>
+    <button id="run-now"></button>
+  `
+}
+
+/**
+ * Reset every state field this module reads so tests don't
+ * cross-contaminate. Defaults match the "happy validated" path so
+ * setRunCommandPlaceholderState hits the fallback branch by default.
+ */
+function resetState () {
+  kometaState.showYAML = true
+  kometaState.kometaStatus = 'idle'
+  kometaState.kometaUpdating = false
+  kometaState.kometaValidationInProgress = false
+  kometaState.kometaLocalCheckCompleted = true
+  kometaState.kometaInstalled = true
+  kometaState.kometaValidated = true
+}
+
+beforeEach(() => {
+  getConfiguredKometaInstallMode.mockReset()
+  getConfiguredKometaInstallMode.mockReturnValue('managed')
+  buildCommand.mockClear()
+  updateRunNowState.mockClear()
+  resetState()
+})
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  vi.useRealTimers()
+})
+
+// ---------------------------------------------------------------------
+// setRunCommandPlaceholderState -- 8 branches (7 rules + fallback)
+// ---------------------------------------------------------------------
+
+describe('setRunCommandPlaceholderState -- rule priority', () => {
+  it("is a no-op when the placeholder panel is missing", () => {
+    document.body.innerHTML = ''
+    expect(() => setRunCommandPlaceholderState()).not.toThrow()
+  })
+
+  it("Rule 1: !showYAML -> 'Fix validation before...'", () => {
+    installPlaceholderFixture()
+    kometaState.showYAML = false
+    setRunCommandPlaceholderState()
+    expect(document.getElementById('run-command-panel-title').textContent).toContain('Fix validation')
+    // showButton: false -> panel button hidden
+    expect(document.getElementById('open-kometa-actions-panel-button').classList.contains('d-none')).toBe(true)
+  })
+
+  it("Rule 2: kometaStatus='running' -> 'Kometa is currently running'", () => {
+    installPlaceholderFixture()
+    kometaState.kometaStatus = 'running'
+    setRunCommandPlaceholderState()
+    expect(document.getElementById('run-command-panel-title').textContent).toBe('Kometa is currently running')
+    expect(document.getElementById('open-kometa-actions-panel-button').classList.contains('d-none')).toBe(true)
+  })
+
+  it("Rule 3: kometaUpdating -> 'Kometa update in progress'", () => {
+    installPlaceholderFixture()
+    kometaState.kometaUpdating = true
+    setRunCommandPlaceholderState()
+    expect(document.getElementById('run-command-panel-title').textContent).toBe('Kometa update in progress')
+    // showButton: true (default)
+    expect(document.getElementById('open-kometa-actions-panel-button').classList.contains('d-none')).toBe(false)
+  })
+
+  it("Rule 4: kometaValidationInProgress -> 'Preparing Kometa'", () => {
+    installPlaceholderFixture()
+    kometaState.kometaValidationInProgress = true
+    setRunCommandPlaceholderState()
+    expect(document.getElementById('run-command-panel-title').textContent).toBe('Preparing Kometa')
+  })
+
+  it("Rule 5: !localCheckCompleted -> 'Checking Kometa state'", () => {
+    installPlaceholderFixture()
+    kometaState.kometaLocalCheckCompleted = false
+    setRunCommandPlaceholderState()
+    expect(document.getElementById('run-command-panel-title').textContent).toBe('Checking Kometa state')
+    expect(document.getElementById('open-kometa-actions-panel-button').classList.contains('d-none')).toBe(true)
+  })
+
+  it("Rule 6: !kometaInstalled -> 'Install Kometa to build...'", () => {
+    installPlaceholderFixture()
+    kometaState.kometaInstalled = false
+    setRunCommandPlaceholderState()
+    expect(document.getElementById('run-command-panel-title').textContent).toContain('Install Kometa')
+  })
+
+  it("Rule 7: !kometaValidated -> 'Validate Kometa to build...'", () => {
+    installPlaceholderFixture()
+    kometaState.kometaValidated = false
+    setRunCommandPlaceholderState()
+    expect(document.getElementById('run-command-panel-title').textContent).toContain('Validate Kometa')
+  })
+
+  it("Fallback: managed mode -> 'Run command is not ready yet' with managed message", () => {
+    installPlaceholderFixture()
+    // All state is 'happy' -> falls through to default
+    setRunCommandPlaceholderState()
+    expect(document.getElementById('run-command-panel-title').textContent).toBe('Run command is not ready yet')
+    expect(document.getElementById('run-command-panel-text').textContent).toContain('install, validate, or update')
+  })
+
+  it("Fallback: existing mode -> different default message", () => {
+    installPlaceholderFixture()
+    getConfiguredKometaInstallMode.mockReturnValue('existing')
+    setRunCommandPlaceholderState()
+    expect(document.getElementById('run-command-panel-title').textContent).toBe('Run command is not ready yet')
+    expect(document.getElementById('run-command-panel-text').textContent).toContain('validate the existing Kometa setup')
+  })
+
+  it('Priority: !showYAML wins over other conditions', () => {
+    installPlaceholderFixture()
+    kometaState.showYAML = false
+    kometaState.kometaStatus = 'running'  // would match rule 2
+    kometaState.kometaInstalled = false   // would match rule 6
+    setRunCommandPlaceholderState()
+    expect(document.getElementById('run-command-panel-title').textContent).toContain('Fix validation')
+  })
+
+  it('side effects: panel shown, box hidden, fade-in removed', () => {
+    installPlaceholderFixture()
+    const box = document.getElementById('run-command-box')
+    box.classList.add('fade-in')
+    setRunCommandPlaceholderState()
+    expect(document.getElementById('run-command-panel-message').classList.contains('d-none')).toBe(false)
+    expect(box.classList.contains('d-none')).toBe(true)
+    expect(box.classList.contains('fade-in')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------
+// clearRunCommandPlaceholderState
+// ---------------------------------------------------------------------
+
+describe('clearRunCommandPlaceholderState', () => {
+  it('hides placeholder + placeholder-lite + open-actions-button', () => {
+    installPlaceholderFixture()
+    clearRunCommandPlaceholderState()
+    expect(document.getElementById('run-command-panel-message').classList.contains('d-none')).toBe(true)
+    expect(document.getElementById('run-command-placeholder').classList.contains('d-none')).toBe(true)
+    expect(document.getElementById('open-kometa-actions-button').classList.contains('d-none')).toBe(true)
+  })
+
+  it('reveals the run-command box + its label + pre + copy button', () => {
+    installPlaceholderFixture()
+    // Start with things hidden
+    document.getElementById('run-command-box').classList.add('d-none')
+    document.querySelector('#run-command-box .form-label').classList.add('d-none')
+    document.querySelector('#run-command-box pre').classList.add('d-none')
+    document.getElementById('copy-command').classList.add('d-none')
+
+    clearRunCommandPlaceholderState()
+
+    expect(document.getElementById('run-command-box').classList.contains('d-none')).toBe(false)
+    expect(document.querySelector('#run-command-box .form-label').classList.contains('d-none')).toBe(false)
+    expect(document.querySelector('#run-command-box pre').classList.contains('d-none')).toBe(false)
+    expect(document.getElementById('copy-command').classList.contains('d-none')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------
+// hideRunCommandSectionUntilValidated
+// ---------------------------------------------------------------------
+
+describe('hideRunCommandSectionUntilValidated', () => {
+  it("removes d-none from the accordion so it's visible (in placeholder mode)", () => {
+    installFullSectionFixture()
+    document.getElementById('run-command-output-accordion').classList.add('d-none')
+    hideRunCommandSectionUntilValidated()
+    expect(document.getElementById('run-command-output-accordion').classList.contains('d-none')).toBe(false)
+  })
+
+  it('collapses the accordion body', () => {
+    installFullSectionFixture()
+    document.getElementById('run-command-output-collapse').classList.add('show')
+    hideRunCommandSectionUntilValidated()
+    expect(document.getElementById('run-command-output-collapse').classList.contains('show')).toBe(false)
+  })
+
+  it('marks the accordion button as collapsed', () => {
+    installFullSectionFixture()
+    const btn = document.querySelector('#run-command-output-heading .accordion-button')
+    btn.classList.remove('collapsed')
+    btn.setAttribute('aria-expanded', 'true')
+    hideRunCommandSectionUntilValidated()
+    expect(btn.classList.contains('collapsed')).toBe(true)
+    expect(btn.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('disables the run-now button and swaps in a Waiting... label', () => {
+    installFullSectionFixture()
+    hideRunCommandSectionUntilValidated()
+    const btn = document.getElementById('run-now')
+    expect(btn.disabled).toBe(true)
+    expect(btn.innerHTML).toContain('Waiting')
+    expect(btn.innerHTML).toContain('bi-hourglass-split')
+  })
+
+  it('invokes setRunCommandPlaceholderState to populate the placeholder', () => {
+    installFullSectionFixture()
+    kometaState.kometaInstalled = false  // rule 6
+    hideRunCommandSectionUntilValidated()
+    expect(document.getElementById('run-command-panel-title').textContent).toContain('Install Kometa')
+  })
+
+  it('handles missing accordion / collapse / heading gracefully (partial fixtures)', () => {
+    // Minimal fixture: just the placeholder + run-now button
+    installPlaceholderFixture()
+    document.body.appendChild(Object.assign(document.createElement('button'), { id: 'run-now' }))
+    expect(() => hideRunCommandSectionUntilValidated()).not.toThrow()
+  })
+
+  it('handles missing run-now button gracefully', () => {
+    installFullSectionFixture()
+    document.getElementById('run-now').remove()
+    expect(() => hideRunCommandSectionUntilValidated()).not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------
+// revealRunCommandSection
+// ---------------------------------------------------------------------
+
+describe('revealRunCommandSection', () => {
+  it('reveals the accordion + collapse + box (no fade-in yet)', () => {
+    installFullSectionFixture()
+    revealRunCommandSection()
+    expect(document.getElementById('run-command-output-accordion').classList.contains('d-none')).toBe(false)
+    expect(document.getElementById('run-command-output-collapse').classList.contains('show')).toBe(true)
+    expect(document.getElementById('run-command-box').classList.contains('d-none')).toBe(false)
+    // fade-in is added via setTimeout(10) -- not yet applied
+    expect(document.getElementById('run-command-box').classList.contains('fade-in')).toBe(false)
+  })
+
+  it('marks the accordion button as expanded', () => {
+    installFullSectionFixture()
+    revealRunCommandSection()
+    const btn = document.querySelector('#run-command-output-heading .accordion-button')
+    expect(btn.classList.contains('collapsed')).toBe(false)
+    expect(btn.getAttribute('aria-expanded')).toBe('true')
+  })
+
+  it('adds the fade-in class after a 10ms delay (via setTimeout)', () => {
+    vi.useFakeTimers()
+    installFullSectionFixture()
+    revealRunCommandSection()
+    const box = document.getElementById('run-command-box')
+    expect(box.classList.contains('fade-in')).toBe(false)
+    vi.advanceTimersByTime(15)
+    expect(box.classList.contains('fade-in')).toBe(true)
+  })
+
+  it('calls clearRunCommandPlaceholderState first (via side effects)', () => {
+    installFullSectionFixture()
+    // Give the placeholder something visible so we can verify it got cleared
+    document.getElementById('run-command-panel-message').classList.remove('d-none')
+    revealRunCommandSection()
+    expect(document.getElementById('run-command-panel-message').classList.contains('d-none')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// showRunCommandSectionAfterValidated
+// ---------------------------------------------------------------------
+
+describe('showRunCommandSectionAfterValidated', () => {
+  it("resets the run-now button to the default Run Now state", () => {
+    installFullSectionFixture()
+    showRunCommandSectionAfterValidated()
+    const btn = document.getElementById('run-now')
+    expect(btn.innerHTML).toContain('Run Now')
+    expect(btn.innerHTML).toContain('bi-play-fill')
+  })
+
+  it('invokes buildCommand() and updateRunNowState()', () => {
+    installFullSectionFixture()
+    showRunCommandSectionAfterValidated()
+    expect(buildCommand).toHaveBeenCalledTimes(1)
+    expect(updateRunNowState).toHaveBeenCalledTimes(1)
+  })
+
+  it('swallows errors from buildCommand()', () => {
+    installFullSectionFixture()
+    buildCommand.mockImplementationOnce(() => { throw new Error('build failed') })
+    expect(() => showRunCommandSectionAfterValidated()).not.toThrow()
+    // updateRunNowState should still be called (comes after buildCommand)
+    expect(updateRunNowState).toHaveBeenCalledTimes(1)
+  })
+
+  it("reveals the section (accordion visible, placeholder hidden)", () => {
+    installFullSectionFixture()
+    document.getElementById('run-command-output-accordion').classList.add('d-none')
+    showRunCommandSectionAfterValidated()
+    expect(document.getElementById('run-command-output-accordion').classList.contains('d-none')).toBe(false)
+    expect(document.getElementById('run-command-panel-message').classList.contains('d-none')).toBe(true)
+  })
+})


### PR DESCRIPTION
## What

Extracts the 5-function cluster that manages the run-command section's visibility state (hidden -> placeholder -> revealed ladder). Needed as a dependency for the eventual `callUpdateKometa` extraction, but useful on its own — this is UI plumbing that has nothing to do with Kometa update logic and belongs in its own module.

`900-kometa.js`: 2558 -> 2462 lines (**-96**).
Vitest tests: 1141 -> 1170 (**+29**).

## What moved

Extracted to `static/local-js/modules/kometa/_runCommandSection.js` (245 lines):

| Function | Description |
|---|---|
| `setRunCommandPlaceholderState` | Populate placeholder with title + message (priority-ordered rule chain) |
| `clearRunCommandPlaceholderState` | Hide placeholder + reveal underlying box |
| `hideRunCommandSectionUntilValidated` | Collapse accordion + show placeholder + disable Run Now |
| `revealRunCommandSection` | Expand accordion + fade-in the box |
| `showRunCommandSectionAfterValidated` | Convenience wrapper: reveal + reset button + rebuild command |

## Placeholder rule chain

Priority order (first match wins):

1. `!showYAML` → 'Fix validation before...' (button hidden)
2. `kometaStatus === 'running'` → 'Kometa is currently running' (button hidden)
3. `kometaUpdating` → 'Kometa update in progress'
4. `kometaValidationInProgress` → 'Preparing Kometa'
5. `!kometaLocalCheckCompleted` → 'Checking Kometa state' (button hidden)
6. `!kometaInstalled` → 'Install Kometa to build...'
7. `!kometaValidated` → 'Validate Kometa to build...'
8. Fallback → 'Run command is not ready yet' (message varies by `installMode`)

Kept as an if/else chain (not refactored to a data table) to preserve behavior verbatim.

## Behavior preservation

Several unconditional `getElementById` / `querySelector` calls preserved verbatim — would throw if elements were missing, but every page that renders the run-command section renders all of them.

One tiny cosmetic cleanup: `hideRunCommandSectionUntilValidated` had a no-op block scope `{ const runNowBtn = ... }` in the original. Removed during extraction since it was a stylistic quirk with zero behavioral impact.

## Test coverage: 29 new tests

- `setRunCommandPlaceholderState` (12): missing panel + each of 7 rules + both fallback flavors + priority test + side effects
- `clearRunCommandPlaceholderState` (2)
- `hideRunCommandSectionUntilValidated` (7): accordion state + button state + placeholder + partial-fixture safety
- `revealRunCommandSection` (4): elements revealed + fade-in via **fake timers** (verifies the 10ms delay)
- `showRunCommandSectionAfterValidated` (4): reset + buildCommand + updateRunNowState + error swallowing

Collaborators mocked with `vi.mock()`. Uses `vi.useFakeTimers()` for the setTimeout assertion.

## Verification

- **1170/1170 Vitest pass** (was 1141; +29 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- ESLint clean, Node syntax clean

## What's next

Continuing toward the `callUpdateKometa` boss fight:

1. `probeKometaRoot` (~55 lines)
2. `validateKometaRoot` (~120 lines)
3. `runKometaStatusPass` (~30 lines)
4. `callUpdateKometa` (~200 lines, the actual boss)