### PR TITLE
Split 900-kometa.js part 20: extract probeKometaRoot

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -89,6 +89,7 @@ import {
   revealRunCommandSection,
   showRunCommandSectionAfterValidated
 } from './modules/kometa/_runCommandSection.js'
+import { probeKometaRoot } from './modules/kometa/_probeRoot.js'
 
 // Kometa runtime status flags migrated to modules/kometa/_state.js
 // (kometaState.kometaInstalled, kometaValidated, kometaStatus, etc.).
@@ -561,67 +562,6 @@ function validateKometaRoot (options = {}) {
     })
     .catch(() => _validateError(null))
     .finally(_validateComplete)
-}
-
-function probeKometaRoot () {
-  const out = document.getElementById('run-command-output')
-  const configuredRootPosix = getConfiguredKometaRootPosix()
-  const configuredRootDisplay = getConfiguredKometaRootDisplay()
-  const configuredInstallMode = getConfiguredKometaInstallMode()
-  if (!configuredRootPosix) {
-    appendKometaStatusLine('❌ No Kometa install path is selected for this config yet.')
-    return Promise.resolve(null)
-  }
-
-  const _probeSuccess = (res) => {
-      kometaState.kometaLocalCheckCompleted = true
-      kometaState.kometaInstalled = !!res.kometa_installed
-      if (Array.isArray(res.log)) res.log.forEach(line => appendKometaStatusLine(line))
-
-      const kometaRootDisplay = (res.kometa_root_display || res.kometa_root || configuredRootDisplay)
-      const venvPythonDisplay = (res.venv_python_display || res.venv_python || 'python3')
-      const kometaRootPosix = (res.kometa_root || configuredRootPosix)
-      const venvPythonPosix = (res.venv_python || venvPythonDisplay)
-
-      out.dataset.kometaRoot = kometaRootDisplay
-      out.dataset.venvPython = venvPythonDisplay
-      out.dataset.kometaRootPosix = kometaRootPosix
-      out.dataset.venvPythonPosix = venvPythonPosix
-      const installPathEl = document.getElementById('kometa-install-path')
-      if (installPathEl) installPathEl.textContent = kometaRootDisplay
-      syncKometaSourceStatus({ localVersion: res.kometa_version || 'Unknown' })
-
-      if (!kometaState.kometaInstalled) {
-        kometaState.kometaValidated = false
-        hideRunCommandSectionUntilValidated()
-      }
-
-      syncUpdateButtonLabel()
-      syncKometaRollupBadge()
-    }
-  const _probeError = (msg) => {
-      kometaState.kometaLocalCheckCompleted = true
-      kometaState.kometaInstalled = false
-      kometaState.kometaValidated = false
-      const errMsg = msg || 'Unable to probe the Kometa path.'
-      appendKometaStatusLine(`❌ ${errMsg}`)
-      syncKometaSourceStatus({ localVersion: 'Unknown' })
-      hideRunCommandSectionUntilValidated()
-      syncUpdateButtonLabel()
-      syncKometaRollupBadge()
-    }
-  return fetch('/probe-kometa-root', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ path: configuredRootPosix, install_mode: configuredInstallMode })
-  })
-    .then(async (resp) => {
-      const data = await resp.json().catch(() => ({}))
-      if (resp.ok) _probeSuccess(data)
-      else _probeError(data && data.error)
-      return data
-    })
-    .catch(() => { _probeError(null); return null })
 }
 
 if (document.getElementById('run-command-output')) {

--- a/static/local-js/modules/kometa/_probeRoot.js
+++ b/static/local-js/modules/kometa/_probeRoot.js
@@ -1,0 +1,148 @@
+// probeKometaRoot: hit the server's /probe-kometa-root endpoint to
+// discover whether the currently-configured Kometa root has an
+// installed Kometa, and if so, what its version + venv Python are.
+//
+// This is called by runKometaStatusPass (still in 900-kometa.js for
+// now) as the FIRST step of any Kometa status refresh. Its job is:
+//   1. Ask the server "is Kometa installed at this path?"
+//   2. If yes, cache the display paths + venv python on the
+//      #run-command-output element (as data attrs) so the run-command
+//      builder can grab them later.
+//   3. Show or hide the run-command section accordingly.
+//
+// Errors do NOT reject the promise -- they fall through to the same
+// state-clearing path as an "install not found" response. Callers
+// don't need to attach a .catch; the promise always resolves.
+//
+// EXPORT:
+//
+//   probeKometaRoot()
+//     -- Returns a Promise. Resolves to:
+//        - null if no Kometa root is configured (silent, appends
+//          error line to status log)
+//        - the raw server response object on success or on server
+//          error (both are handled internally)
+//        - null on network / fetch reject
+//
+// SERVER CONTRACT:
+//
+//   POST /probe-kometa-root
+//   Body: { path: string, install_mode: 'managed' | 'existing' | 'external' }
+//   Response: {
+//     kometa_installed: boolean,
+//     kometa_root?: string,          // POSIX path (canonical)
+//     kometa_root_display?: string,  // native path (for display)
+//     venv_python?: string,          // POSIX venv python
+//     venv_python_display?: string,  // native venv python
+//     kometa_version?: string,       // e.g. 'v1.2.3' or 'Unknown'
+//     log?: string[],                // lines to feed into status log
+//     error?: string                 // present on failure
+//   }
+
+import { kometaState } from './_state.js'
+import {
+  getConfiguredKometaRootPosix,
+  getConfiguredKometaRootDisplay,
+  getConfiguredKometaInstallMode
+} from './_runtime.js'
+import { syncKometaSourceStatus } from './_kometaBranch.js'
+import { appendKometaStatusLine } from './_updatePhase.js'
+import {
+  syncUpdateButtonLabel,
+  syncKometaRollupBadge
+} from './_updateRollup.js'
+import { hideRunCommandSectionUntilValidated } from './_runCommandSection.js'
+
+/**
+ * Ask the server whether Kometa is installed at the configured path.
+ * See module docstring for full contract.
+ *
+ * @returns {Promise<object | null>}
+ */
+export function probeKometaRoot () {
+  const out = document.getElementById('run-command-output')
+  const configuredRootPosix = getConfiguredKometaRootPosix()
+  const configuredRootDisplay = getConfiguredKometaRootDisplay()
+  const configuredInstallMode = getConfiguredKometaInstallMode()
+
+  if (!configuredRootPosix) {
+    appendKometaStatusLine('\u274c No Kometa install path is selected for this config yet.')
+    return Promise.resolve(null)
+  }
+
+  // Success handler: server confirmed we can talk to the path. Note
+  // this runs even for a "Kometa NOT installed" response -- the
+  // server successfully responded, so the probe was technically
+  // successful; the payload just tells us "no install found".
+  const handleProbeSuccess = (res) => {
+    kometaState.kometaLocalCheckCompleted = true
+    kometaState.kometaInstalled = !!res.kometa_installed
+    if (Array.isArray(res.log)) res.log.forEach(line => appendKometaStatusLine(line))
+
+    // Cache the display paths + venv python on the run-command-output
+    // element as data attrs. The run-command builder reads these
+    // later to compose the actual `kometa.py` invocation.
+    const kometaRootDisplay = res.kometa_root_display || res.kometa_root || configuredRootDisplay
+    const venvPythonDisplay = res.venv_python_display || res.venv_python || 'python3'
+    const kometaRootPosix = res.kometa_root || configuredRootPosix
+    const venvPythonPosix = res.venv_python || venvPythonDisplay
+
+    out.dataset.kometaRoot = kometaRootDisplay
+    out.dataset.venvPython = venvPythonDisplay
+    out.dataset.kometaRootPosix = kometaRootPosix
+    out.dataset.venvPythonPosix = venvPythonPosix
+
+    const installPathEl = document.getElementById('kometa-install-path')
+    if (installPathEl) installPathEl.textContent = kometaRootDisplay
+
+    syncKometaSourceStatus({ localVersion: res.kometa_version || 'Unknown' })
+
+    // If Kometa isn't installed, the previously-cached "validated"
+    // flag is stale -- clear it and hide the run-command section
+    // until a real install happens.
+    if (!kometaState.kometaInstalled) {
+      kometaState.kometaValidated = false
+      hideRunCommandSectionUntilValidated()
+    }
+
+    syncUpdateButtonLabel()
+    syncKometaRollupBadge()
+  }
+
+  // Error handler: server returned !ok, OR fetch itself rejected
+  // (network error). Both cases funnel here so callers only see one
+  // failure mode.
+  const handleProbeError = (msg) => {
+    kometaState.kometaLocalCheckCompleted = true
+    kometaState.kometaInstalled = false
+    kometaState.kometaValidated = false
+    const errMsg = msg || 'Unable to probe the Kometa path.'
+    appendKometaStatusLine(`\u274c ${errMsg}`)
+    syncKometaSourceStatus({ localVersion: 'Unknown' })
+    hideRunCommandSectionUntilValidated()
+    syncUpdateButtonLabel()
+    syncKometaRollupBadge()
+  }
+
+  return fetch('/probe-kometa-root', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      path: configuredRootPosix,
+      install_mode: configuredInstallMode
+    })
+  })
+    .then(async (resp) => {
+      // .catch(() => ({})) so a non-JSON body doesn't crash the
+      // pipeline -- the empty object flows into handleProbeError
+      // which supplies a generic fallback message.
+      const data = await resp.json().catch(() => ({}))
+      if (resp.ok) handleProbeSuccess(data)
+      else handleProbeError(data && data.error)
+      return data
+    })
+    .catch(() => {
+      handleProbeError(null)
+      return null
+    })
+}

--- a/tests/js/kometa/probeRoot.test.js
+++ b/tests/js/kometa/probeRoot.test.js
@@ -1,0 +1,376 @@
+// Tests for static/local-js/modules/kometa/_probeRoot.js
+//
+// One export: probeKometaRoot().
+//
+// COVERAGE STRATEGY:
+//
+//   Short-circuits (1):
+//     - no configured root -> null resolve, error appended
+//
+//   Request construction (2):
+//     - URL / method / headers correct
+//     - body has path + install_mode
+//
+//   Success path (data-attr caching, state updates, DOM writes):
+//     - kometaState fields updated
+//     - log lines appended
+//     - dataset attrs written on #run-command-output
+//     - installPath element text set
+//     - source status synced
+//     - installed=false: validated cleared + hide called
+//     - installed=true: no hide-section call
+//     - kometaVersion fallback to 'Unknown'
+//     - display / posix fallbacks work
+//
+//   Error path (server + network):
+//     - non-ok response with error message
+//     - non-ok response without error message (fallback)
+//     - network reject
+//     - non-JSON body doesn't crash
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../static/local-js/modules/kometa/_runtime.js', () => ({
+  getConfiguredKometaRootPosix: vi.fn(() => '/opt/kometa'),
+  getConfiguredKometaRootDisplay: vi.fn(() => '/opt/kometa'),
+  getConfiguredKometaInstallMode: vi.fn(() => 'managed')
+}))
+vi.mock('../../../static/local-js/modules/kometa/_kometaBranch.js', () => ({
+  syncKometaSourceStatus: vi.fn()
+}))
+vi.mock('../../../static/local-js/modules/kometa/_updatePhase.js', () => ({
+  appendKometaStatusLine: vi.fn()
+}))
+vi.mock('../../../static/local-js/modules/kometa/_updateRollup.js', () => ({
+  syncUpdateButtonLabel: vi.fn(),
+  syncKometaRollupBadge: vi.fn()
+}))
+vi.mock('../../../static/local-js/modules/kometa/_runCommandSection.js', () => ({
+  hideRunCommandSectionUntilValidated: vi.fn()
+}))
+
+import { kometaState } from '../../../static/local-js/modules/kometa/_state.js'
+import { probeKometaRoot } from '../../../static/local-js/modules/kometa/_probeRoot.js'
+import { getConfiguredKometaRootPosix } from '../../../static/local-js/modules/kometa/_runtime.js'
+import { syncKometaSourceStatus } from '../../../static/local-js/modules/kometa/_kometaBranch.js'
+import { appendKometaStatusLine } from '../../../static/local-js/modules/kometa/_updatePhase.js'
+import {
+  syncUpdateButtonLabel,
+  syncKometaRollupBadge
+} from '../../../static/local-js/modules/kometa/_updateRollup.js'
+import { hideRunCommandSectionUntilValidated } from '../../../static/local-js/modules/kometa/_runCommandSection.js'
+
+// ---------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------
+
+let originalFetch
+
+function mockFetchWith (response) {
+  global.fetch = vi.fn(() => Promise.resolve(response))
+}
+
+function okJson (body) {
+  return { ok: true, json: () => Promise.resolve(body) }
+}
+
+function errJson (status, body) {
+  return { ok: false, status, json: () => Promise.resolve(body) }
+}
+
+function installFixture () {
+  document.body.innerHTML = `
+    <div id="run-command-output"></div>
+    <span id="kometa-install-path"></span>
+  `
+}
+
+function resetState () {
+  kometaState.kometaLocalCheckCompleted = false
+  kometaState.kometaInstalled = false
+  kometaState.kometaValidated = true
+}
+
+beforeEach(() => {
+  getConfiguredKometaRootPosix.mockReset()
+  getConfiguredKometaRootPosix.mockReturnValue('/opt/kometa')
+  syncKometaSourceStatus.mockClear()
+  appendKometaStatusLine.mockClear()
+  syncUpdateButtonLabel.mockClear()
+  syncKometaRollupBadge.mockClear()
+  hideRunCommandSectionUntilValidated.mockClear()
+  originalFetch = global.fetch
+  resetState()
+})
+
+afterEach(() => {
+  global.fetch = originalFetch
+  document.body.innerHTML = ''
+})
+
+// ---------------------------------------------------------------------
+// Short-circuit
+// ---------------------------------------------------------------------
+
+describe('probeKometaRoot -- no configured root', () => {
+  it('resolves null when no Kometa root is configured', async () => {
+    getConfiguredKometaRootPosix.mockReturnValue('')
+    installFixture()
+    const result = await probeKometaRoot()
+    expect(result).toBeNull()
+  })
+
+  it('appends an error line when no root configured', async () => {
+    getConfiguredKometaRootPosix.mockReturnValue('')
+    installFixture()
+    await probeKometaRoot()
+    expect(appendKometaStatusLine).toHaveBeenCalledWith(expect.stringContaining('No Kometa install path'))
+  })
+
+  it('does NOT hit the network when no root configured', async () => {
+    getConfiguredKometaRootPosix.mockReturnValue('')
+    installFixture()
+    global.fetch = vi.fn()
+    await probeKometaRoot()
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------
+// Request construction
+// ---------------------------------------------------------------------
+
+describe('probeKometaRoot -- request construction', () => {
+  it('POSTs to /probe-kometa-root with JSON body', async () => {
+    installFixture()
+    mockFetchWith(okJson({ kometa_installed: true }))
+    await probeKometaRoot()
+    expect(global.fetch).toHaveBeenCalledWith('/probe-kometa-root', expect.objectContaining({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }
+    }))
+  })
+
+  it('body includes path and install_mode', async () => {
+    installFixture()
+    getConfiguredKometaRootPosix.mockReturnValue('/custom/path')
+    mockFetchWith(okJson({ kometa_installed: true }))
+    await probeKometaRoot()
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body)
+    expect(body).toEqual({
+      path: '/custom/path',
+      install_mode: 'managed'
+    })
+  })
+})
+
+// ---------------------------------------------------------------------
+// Success path
+// ---------------------------------------------------------------------
+
+describe('probeKometaRoot -- success path state', () => {
+  it('sets kometaLocalCheckCompleted + kometaInstalled from response', async () => {
+    installFixture()
+    mockFetchWith(okJson({ kometa_installed: 1 }))  // truthy non-boolean
+    await probeKometaRoot()
+    expect(kometaState.kometaLocalCheckCompleted).toBe(true)
+    expect(kometaState.kometaInstalled).toBe(true)  // coerced via !!
+  })
+
+  it('forwards each log line via appendKometaStatusLine', async () => {
+    installFixture()
+    mockFetchWith(okJson({
+      kometa_installed: true,
+      log: ['line one', 'line two']
+    }))
+    await probeKometaRoot()
+    expect(appendKometaStatusLine).toHaveBeenCalledWith('line one')
+    expect(appendKometaStatusLine).toHaveBeenCalledWith('line two')
+  })
+
+  it('handles missing log field gracefully', async () => {
+    installFixture()
+    mockFetchWith(okJson({ kometa_installed: true }))
+    await probeKometaRoot()
+    // No log calls
+    expect(appendKometaStatusLine).not.toHaveBeenCalled()
+  })
+})
+
+describe('probeKometaRoot -- data attr caching on #run-command-output', () => {
+  it('sets all four dataset attrs from server response when present', async () => {
+    installFixture()
+    mockFetchWith(okJson({
+      kometa_installed: true,
+      kometa_root: '/srv/kometa',
+      kometa_root_display: 'C:\\srv\\kometa',
+      venv_python: '/srv/kometa-venv/bin/python',
+      venv_python_display: 'C:\\srv\\kometa-venv\\Scripts\\python.exe'
+    }))
+    await probeKometaRoot()
+    const out = document.getElementById('run-command-output')
+    expect(out.dataset.kometaRoot).toBe('C:\\srv\\kometa')
+    expect(out.dataset.kometaRootPosix).toBe('/srv/kometa')
+    expect(out.dataset.venvPython).toBe('C:\\srv\\kometa-venv\\Scripts\\python.exe')
+    expect(out.dataset.venvPythonPosix).toBe('/srv/kometa-venv/bin/python')
+  })
+
+  it('falls back to configured display path when kometa_root_display missing', async () => {
+    installFixture()
+    mockFetchWith(okJson({ kometa_installed: true }))
+    await probeKometaRoot()
+    const out = document.getElementById('run-command-output')
+    expect(out.dataset.kometaRoot).toBe('/opt/kometa')  // from getConfiguredKometaRootDisplay mock
+  })
+
+  it("falls back to 'python3' when no venv_python* fields", async () => {
+    installFixture()
+    mockFetchWith(okJson({ kometa_installed: true }))
+    await probeKometaRoot()
+    const out = document.getElementById('run-command-output')
+    expect(out.dataset.venvPython).toBe('python3')
+    // venvPythonPosix falls back to venvPythonDisplay when venv_python missing
+    expect(out.dataset.venvPythonPosix).toBe('python3')
+  })
+})
+
+describe('probeKometaRoot -- installPath element', () => {
+  it("writes the display path to #kometa-install-path", async () => {
+    installFixture()
+    mockFetchWith(okJson({
+      kometa_installed: true,
+      kometa_root_display: 'C:\\srv\\kometa'
+    }))
+    await probeKometaRoot()
+    expect(document.getElementById('kometa-install-path').textContent).toBe('C:\\srv\\kometa')
+  })
+
+  it('handles missing #kometa-install-path gracefully', async () => {
+    document.body.innerHTML = '<div id="run-command-output"></div>'  // no install-path element
+    mockFetchWith(okJson({ kometa_installed: true }))
+    await expect(probeKometaRoot()).resolves.toBeDefined()
+  })
+})
+
+describe('probeKometaRoot -- source status sync', () => {
+  it('passes kometa_version to syncKometaSourceStatus', async () => {
+    installFixture()
+    mockFetchWith(okJson({
+      kometa_installed: true,
+      kometa_version: 'v2.0.0'
+    }))
+    await probeKometaRoot()
+    expect(syncKometaSourceStatus).toHaveBeenCalledWith({ localVersion: 'v2.0.0' })
+  })
+
+  it("falls back to 'Unknown' when kometa_version missing", async () => {
+    installFixture()
+    mockFetchWith(okJson({ kometa_installed: true }))
+    await probeKometaRoot()
+    expect(syncKometaSourceStatus).toHaveBeenCalledWith({ localVersion: 'Unknown' })
+  })
+})
+
+describe('probeKometaRoot -- installed state branching', () => {
+  it("clears kometaValidated and hides run-command section when NOT installed", async () => {
+    installFixture()
+    kometaState.kometaValidated = true  // start validated
+    mockFetchWith(okJson({ kometa_installed: false }))
+    await probeKometaRoot()
+    expect(kometaState.kometaValidated).toBe(false)
+    expect(hideRunCommandSectionUntilValidated).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT clear kometaValidated when Kometa IS installed', async () => {
+    installFixture()
+    kometaState.kometaValidated = true
+    mockFetchWith(okJson({ kometa_installed: true }))
+    await probeKometaRoot()
+    expect(kometaState.kometaValidated).toBe(true)
+    expect(hideRunCommandSectionUntilValidated).not.toHaveBeenCalled()
+  })
+})
+
+describe('probeKometaRoot -- UI refresh calls', () => {
+  it('calls syncUpdateButtonLabel + syncKometaRollupBadge on success', async () => {
+    installFixture()
+    mockFetchWith(okJson({ kometa_installed: true }))
+    await probeKometaRoot()
+    expect(syncUpdateButtonLabel).toHaveBeenCalledTimes(1)
+    expect(syncKometaRollupBadge).toHaveBeenCalledTimes(1)
+  })
+
+  it('resolves to the server data on success', async () => {
+    installFixture()
+    const responseData = { kometa_installed: true, custom_field: 'preserved' }
+    mockFetchWith(okJson(responseData))
+    const result = await probeKometaRoot()
+    expect(result).toEqual(responseData)
+  })
+})
+
+// ---------------------------------------------------------------------
+// Error path
+// ---------------------------------------------------------------------
+
+describe('probeKometaRoot -- error path', () => {
+  it('handles non-ok response with server error message', async () => {
+    installFixture()
+    mockFetchWith(errJson(500, { error: 'kometa root missing' }))
+    await probeKometaRoot()
+    expect(appendKometaStatusLine).toHaveBeenCalledWith(expect.stringContaining('kometa root missing'))
+    expect(kometaState.kometaInstalled).toBe(false)
+    expect(kometaState.kometaValidated).toBe(false)
+    expect(hideRunCommandSectionUntilValidated).toHaveBeenCalled()
+  })
+
+  it("uses fallback message when server omits data.error", async () => {
+    installFixture()
+    mockFetchWith(errJson(500, {}))
+    await probeKometaRoot()
+    expect(appendKometaStatusLine).toHaveBeenCalledWith(expect.stringContaining('Unable to probe'))
+  })
+
+  it("uses fallback message when server response isn't JSON parseable", async () => {
+    installFixture()
+    // Simulate non-JSON body via json() rejection
+    global.fetch = vi.fn(() => Promise.resolve({
+      ok: false,
+      status: 500,
+      json: () => Promise.reject(new Error('not json'))
+    }))
+    await probeKometaRoot()
+    expect(appendKometaStatusLine).toHaveBeenCalledWith(expect.stringContaining('Unable to probe'))
+  })
+
+  it('handles network reject (fetch itself rejects)', async () => {
+    installFixture()
+    global.fetch = vi.fn(() => Promise.reject(new Error('network fried')))
+    const result = await probeKometaRoot()
+    expect(result).toBeNull()
+    expect(appendKometaStatusLine).toHaveBeenCalledWith(expect.stringContaining('Unable to probe'))
+    expect(kometaState.kometaInstalled).toBe(false)
+  })
+
+  it('syncs source status with Unknown on error', async () => {
+    installFixture()
+    mockFetchWith(errJson(500, {}))
+    await probeKometaRoot()
+    expect(syncKometaSourceStatus).toHaveBeenCalledWith({ localVersion: 'Unknown' })
+  })
+
+  it('still refreshes button label + rollup badge on error', async () => {
+    installFixture()
+    mockFetchWith(errJson(500, {}))
+    await probeKometaRoot()
+    expect(syncUpdateButtonLabel).toHaveBeenCalledTimes(1)
+    expect(syncKometaRollupBadge).toHaveBeenCalledTimes(1)
+  })
+
+  it("marks localCheckCompleted true even on error (so UI knows we tried)", async () => {
+    installFixture()
+    mockFetchWith(errJson(500, {}))
+    await probeKometaRoot()
+    expect(kometaState.kometaLocalCheckCompleted).toBe(true)
+  })
+})


### PR DESCRIPTION
## What

Extracts the `/probe-kometa-root` endpoint call. This is called by `runKometaStatusPass` as the **first** step of any Kometa status refresh: asks the server 'is Kometa installed at this path?' and caches the paths + venv Python on the `#run-command-output` element as dataset attrs for the run-command builder to use later.

Second-to-last dep before the `callUpdateKometa` boss fight.

`900-kometa.js`: 2462 -> 2402 lines (**-60**).
Vitest tests: 1170 -> 1196 (**+26**).

## What moved

Extracted to `static/local-js/modules/kometa/_probeRoot.js` (148 lines):

- `probeKometaRoot()` -- POSTs to `/probe-kometa-root`, sets state flags, caches paths as dataset attrs, syncs source status, hides run-command section if not installed

## Server contract (captured in module docstring)

```
POST /probe-kometa-root
Body: { path, install_mode }
Response: {
  kometa_installed: boolean,
  kometa_root?, kometa_root_display?,
  venv_python?, venv_python_display?,
  kometa_version?, log?, error?
}
```

## Design notes

1. **Errors NEVER reject the promise** -- they funnel through `handleProbeError`. Callers don't need `.catch`. Same as original.
2. **Non-JSON bodies don't crash** -- `response.json().catch(() => ({}))` supplies an empty object.
3. **Renamed internal closures** `_probeSuccess` / `_probeError` -> `handleProbeSuccess` / `handleProbeError`. Leading underscores were redundant on function-scoped locals. Behavior identical.
4. **Emoji replaced with unicode escape** (`\u274c`).

## Test coverage: 26 new tests

- Short circuits (3): no root -> null + error appended + no fetch
- Request construction (2): URL/method/headers, body fields
- Success state (3): flags coerced, log lines forwarded, missing log
- Dataset caching (3): all four attrs, display fallback, 'python3' fallback
- installPath element (2): written when present, missing element OK
- Source status (2): version passed, 'Unknown' fallback
- Installed branching (2): !installed -> hide + clear validated
- UI refresh (2): button + rollup on success, resolves to data
- Error path (7): server message, fallback, non-JSON body, network reject, source status Unknown, button+rollup still called, localCheckCompleted still true

Every collaborator mocked with `vi.mock()`.

## Verification

- **1196/1196 Vitest pass** (was 1170; +26 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- ESLint clean, Node syntax clean

## What's next

Two more extractions + the boss fight:

- `validateKometaRoot` (~120 lines)
- `runKometaStatusPass` (~30 lines)
- **`callUpdateKometa`** (~200 lines, THE BOSS)