### PR TITLE
Split 900-kometa.js part 21: extract validateKometaRoot

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -32,7 +32,6 @@ import {
 import {
   getConfiguredKometaInstallMode,
   getConfiguredKometaRootPosix,
-  getConfiguredKometaRootDisplay,
   kometaCanLaunch,
   kometaCanProbeRuntime,
   kometaCanReadLogs
@@ -86,10 +85,10 @@ import {
   setRunCommandPlaceholderState,
   clearRunCommandPlaceholderState,
   hideRunCommandSectionUntilValidated,
-  revealRunCommandSection,
-  showRunCommandSectionAfterValidated
+  revealRunCommandSection
 } from './modules/kometa/_runCommandSection.js'
 import { probeKometaRoot } from './modules/kometa/_probeRoot.js'
+import { validateKometaRoot } from './modules/kometa/_validateRoot.js'
 
 // Kometa runtime status flags migrated to modules/kometa/_state.js
 // (kometaState.kometaInstalled, kometaValidated, kometaStatus, etc.).
@@ -418,151 +417,6 @@ checkboxFlags.forEach(opt => {
   if (checkbox) checkbox.addEventListener('change', buildCommand)
 })
 
-function validateKometaRoot (options = {}) {
-  if (!kometaCanProbeRuntime()) {
-    appendKometaStatusLine('ℹ️ Runtime validation is not available in external Kometa mode. Quickstart can sync config and optional logs, but it cannot validate or launch the runtime directly.')
-    kometaState.kometaValidationInProgress = false
-    kometaState.kometaValidated = false
-    syncKometaRollupBadge()
-    return
-  }
-  if (kometaState.kometaValidationInProgress) return
-  kometaState.kometaValidationInProgress = true
-  setKometaUpdatePhaseBadge('validating')
-  if (typeof showNavigationLoadingOverlay === 'function') {
-    showNavigationLoadingOverlay('kometa-check')
-  }
-  syncKometaRollupBadge()
-  const logBox = document.getElementById('kometa-validation-log')
-  const spinner = document.getElementById('spinner_validate')
-  const runNow = document.getElementById('run-now')
-  const out = document.getElementById('run-command-output')
-
-  const configName = out.dataset.configFilename
-  const configuredRootPosix = getConfiguredKometaRootPosix()
-  const configuredRootDisplay = getConfiguredKometaRootDisplay()
-  const configuredInstallMode = getConfiguredKometaInstallMode()
-  const appendStatus = Boolean(options.appendStatus)
-
-  if (!configuredRootPosix) {
-    logBox.textContent = '❌ Quickstart does not have a Kometa install path selected for this config yet.\nOpen the Start page and choose whether this config uses a Quickstart-managed install or an existing install.\n'
-    if (spinner) spinner.classList.add('d-none')
-    runNow.disabled = true
-    kometaState.kometaValidationInProgress = false
-    kometaState.kometaValidated = false
-    syncKometaRollupBadge()
-    return
-  }
-
-  if (appendStatus) {
-    logBox.insertAdjacentHTML('beforeend',
-      '\n🔄 Re-validating Kometa after update...\n' +
-      'This may take a few seconds as we verify the folder structure, Python environment, and Kometa information.\n\n'
-    )
-  } else {
-    logBox.textContent =
-      '🔄 Please wait while we validate your Kometa installation...\n' +
-      'This may take a few seconds as we verify the folder structure, Python environment, and Kometa information.\n\n'
-
-  }
-  if (spinner) spinner.classList.remove('d-none')
-  runNow.disabled = true
-  const _validateSuccess = (res) => {
-      kometaState.kometaLocalCheckCompleted = true
-      if (Array.isArray(res.log)) res.log.forEach(line => logBox.insertAdjacentHTML('beforeend', `${line}\n`))
-
-      if (res.success) {
-        kometaState.kometaInstalled = true
-        logBox.insertAdjacentHTML('beforeend', '✅ Kometa root validated successfully.\n')
-        if (res.kometa_version) logBox.insertAdjacentHTML('beforeend', `📦 Local Kometa version: ${res.kometa_version}\n`)
-
-        const kometaRootDisplay = (res.kometa_root_display || res.kometa_root || configuredRootDisplay)
-        const venvPythonDisplay = (res.venv_python_display || res.venv_python || 'python3')
-        const kometaRootPosix = (res.kometa_root || configuredRootPosix)
-        const venvPythonPosix = (res.venv_python || venvPythonDisplay)
-
-        out.dataset.kometaRoot = kometaRootDisplay
-        out.dataset.venvPython = venvPythonDisplay
-        out.dataset.kometaRootPosix = kometaRootPosix
-        out.dataset.venvPythonPosix = venvPythonPosix
-
-        const installPathEl = document.getElementById('kometa-install-path')
-        if (installPathEl) installPathEl.textContent = kometaRootDisplay
-        const finalGate = getFinalGateState()
-        const _dv = (id, key) => {
-          const el = document.getElementById(id)
-          return el ? el.dataset[key] : ''
-        }
-        const allValid = kometaState.showYAML && (finalGate.configValid || (
-          _dv('plex_valid', 'plexValid') === 'True' &&
-          _dv('tmdb_valid', 'tmdbValid') === 'True' &&
-          _dv('libs_valid', 'libsValid') === 'True' &&
-          _dv('sett_valid', 'settValid') === 'True' &&
-          _dv('yaml_valid', 'yamlValid') === 'True'
-        ))
-
-        const outEl = document.getElementById('run-command-output')
-        if (outEl) outEl.textContent = ''
-        try { buildCommand() } catch { }
-
-        if (allValid) {
-          kometaState.kometaValidated = true
-          showRunCommandSectionAfterValidated()
-        } else {
-          kometaState.kometaValidated = false
-          hideRunCommandSectionUntilValidated()
-          runNow.disabled = true
-        }
-        if (!kometaState.kometaUpdating) setKometaUpdatePhaseBadge(kometaState.kometaValidated ? 'ready' : 'idle')
-      } else {
-        kometaState.kometaInstalled = false
-        kometaState.kometaValidated = false
-        if (!kometaState.kometaUpdating) setKometaUpdatePhaseBadge('failed')
-        hideRunCommandSectionUntilValidated()
-        runNow.disabled = true
-      }
-
-      if (spinner) spinner.classList.add('d-none')
-      syncUpdateButtonLabel()
-      syncKometaRollupBadge()
-    }
-  const _validateError = (msg) => {
-      kometaState.kometaLocalCheckCompleted = true
-      const errMsg = msg || 'The Kometa root path is invalid or inaccessible. Please try again.'
-      logBox.insertAdjacentHTML('beforeend', `❌ ${errMsg}\n`)
-      const lowered = String(errMsg || '').toLowerCase()
-      if (lowered.includes('kometa.py not found') || lowered.includes('requirements.txt not found')) {
-        kometaState.kometaInstalled = false
-      }
-      kometaState.kometaValidated = false
-      if (!kometaState.kometaUpdating) setKometaUpdatePhaseBadge('failed')
-      hideRunCommandSectionUntilValidated()
-      runNow.disabled = true
-      if (spinner) spinner.classList.add('d-none')
-      syncKometaRollupBadge()
-    }
-  const _validateComplete = () => {
-      kometaState.kometaValidationInProgress = false
-      updateRunNowState()
-      syncUpdateButtonLabel()
-      syncKometaRollupBadge()
-      if (typeof hideNavigationLoadingOverlay === 'function') {
-        hideNavigationLoadingOverlay()
-      }
-    }
-  fetch('/validate-kometa-root', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ path: configuredRootPosix, config_name: configName, install_mode: configuredInstallMode })
-  })
-    .then(async (resp) => {
-      const data = await resp.json().catch(() => ({}))
-      if (resp.ok) _validateSuccess(data)
-      else _validateError(data && data.error)
-    })
-    .catch(() => _validateError(null))
-    .finally(_validateComplete)
-}
 
 if (document.getElementById('run-command-output')) {
   const mainOption = (document.querySelector('input[name="run-option"]:checked') || {}).value

--- a/static/local-js/modules/kometa/_validateRoot.js
+++ b/static/local-js/modules/kometa/_validateRoot.js
@@ -1,0 +1,265 @@
+// validateKometaRoot: hit the server's /validate-kometa-root endpoint
+// to run the full-fat validation of a Kometa install (folder structure,
+// Python environment, importable modules, kometa.py present, etc.).
+//
+// This is the "am I actually ready to run Kometa?" check. It's called
+// after successful updates, after user-triggered "Prepare Kometa"
+// clicks, and on wizard step entry when we need to know whether the
+// run-command section should be revealed.
+//
+// EXPORT:
+//
+//   validateKometaRoot(options)
+//     options: {
+//       appendStatus?: boolean   // when true, append '\n Re-validating...'
+//                                // to the log instead of clearing it.
+//                                // Used after updates so users can see
+//                                // the update + revalidation history.
+//     }
+//     -- Returns undefined (fire-and-forget). Server response is
+//        handled internally; state updates + DOM writes are the
+//        observable outcome.
+//
+//        Short-circuits (no fetch):
+//          - external mode: appends info line, clears validated flag,
+//            refreshes rollup, returns.
+//          - already in progress: returns without touching anything.
+//          - no configured path: writes an explanatory message to the
+//            log box, clears validated + spinner, disables run-now,
+//            refreshes rollup, returns.
+//
+// SERVER CONTRACT:
+//
+//   POST /validate-kometa-root
+//   Body: { path, config_name, install_mode }
+//   Response: {
+//     success: boolean,
+//     error?: string,
+//     log?: string[],
+//     kometa_version?: string,
+//     kometa_root?: string,           // POSIX
+//     kometa_root_display?: string,   // native
+//     venv_python?: string,           // POSIX
+//     venv_python_display?: string    // native
+//   }
+
+import { kometaState } from './_state.js'
+import {
+  kometaCanProbeRuntime,
+  getConfiguredKometaRootPosix,
+  getConfiguredKometaRootDisplay,
+  getConfiguredKometaInstallMode
+} from './_runtime.js'
+import { appendKometaStatusLine, setKometaUpdatePhaseBadge } from './_updatePhase.js'
+import { syncKometaRollupBadge, syncUpdateButtonLabel } from './_updateRollup.js'
+import { getFinalGateState } from './_validationGate.js'
+import { buildCommand } from './_runCommand.js'
+import { updateRunNowState } from './_runControls.js'
+import {
+  hideRunCommandSectionUntilValidated,
+  showRunCommandSectionAfterValidated
+} from './_runCommandSection.js'
+
+/**
+ * Read a data-* attribute off an element by id, returning '' if the
+ * element is missing. Used for the four validation flag lookups
+ * (plex_valid / tmdb_valid / libs_valid / sett_valid / yaml_valid).
+ * Kept as a small helper so the callsite stays readable.
+ */
+function readValidationFlag (id, key) {
+  const el = document.getElementById(id)
+  return el ? el.dataset[key] : ''
+}
+
+/**
+ * Check whether Kometa is validated. See module docstring for full
+ * contract.
+ *
+ * @param {object} [options]
+ * @param {boolean} [options.appendStatus=false]
+ */
+export function validateKometaRoot (options = {}) {
+  // ---- Short-circuits ---------------------------------------------
+
+  if (!kometaCanProbeRuntime()) {
+    appendKometaStatusLine('\u2139\ufe0f Runtime validation is not available in external Kometa mode. Quickstart can sync config and optional logs, but it cannot validate or launch the runtime directly.')
+    kometaState.kometaValidationInProgress = false
+    kometaState.kometaValidated = false
+    syncKometaRollupBadge()
+    return
+  }
+
+  if (kometaState.kometaValidationInProgress) return
+
+  // ---- Setup: state + UI transitions ------------------------------
+
+  kometaState.kometaValidationInProgress = true
+  setKometaUpdatePhaseBadge('validating')
+  // showNavigationLoadingOverlay is a global from 000-base.js. The
+  // typeof guard is preserved because this module can theoretically
+  // be imported in isolation for testing where the global isn't set.
+  if (typeof showNavigationLoadingOverlay === 'function') {
+    showNavigationLoadingOverlay('kometa-check')
+  }
+  syncKometaRollupBadge()
+
+  const logBox = document.getElementById('kometa-validation-log')
+  const spinner = document.getElementById('spinner_validate')
+  const runNow = document.getElementById('run-now')
+  const out = document.getElementById('run-command-output')
+
+  const configName = out.dataset.configFilename
+  const configuredRootPosix = getConfiguredKometaRootPosix()
+  const configuredRootDisplay = getConfiguredKometaRootDisplay()
+  const configuredInstallMode = getConfiguredKometaInstallMode()
+  const appendStatus = Boolean(options.appendStatus)
+
+  if (!configuredRootPosix) {
+    logBox.textContent = '\u274c Quickstart does not have a Kometa install path selected for this config yet.\nOpen the Start page and choose whether this config uses a Quickstart-managed install or an existing install.\n'
+    if (spinner) spinner.classList.add('d-none')
+    runNow.disabled = true
+    kometaState.kometaValidationInProgress = false
+    kometaState.kometaValidated = false
+    syncKometaRollupBadge()
+    return
+  }
+
+  if (appendStatus) {
+    logBox.insertAdjacentHTML(
+      'beforeend',
+      '\n\ud83d\udd04 Re-validating Kometa after update...\n' +
+      'This may take a few seconds as we verify the folder structure, Python environment, and Kometa information.\n\n'
+    )
+  } else {
+    // NOTE: original had a trailing blank line inside this template
+    // (`\n\n` after 'information.'). Preserved verbatim.
+    logBox.textContent =
+      '\ud83d\udd04 Please wait while we validate your Kometa installation...\n' +
+      'This may take a few seconds as we verify the folder structure, Python environment, and Kometa information.\n\n'
+  }
+  if (spinner) spinner.classList.remove('d-none')
+  runNow.disabled = true
+
+  // ---- Response handlers ------------------------------------------
+
+  const handleValidateSuccess = (res) => {
+    kometaState.kometaLocalCheckCompleted = true
+    if (Array.isArray(res.log)) {
+      res.log.forEach(line => logBox.insertAdjacentHTML('beforeend', `${line}\n`))
+    }
+
+    if (res.success) {
+      kometaState.kometaInstalled = true
+      logBox.insertAdjacentHTML('beforeend', '\u2705 Kometa root validated successfully.\n')
+      if (res.kometa_version) {
+        logBox.insertAdjacentHTML('beforeend', `\ud83d\udce6 Local Kometa version: ${res.kometa_version}\n`)
+      }
+
+      // Cache paths + venv Python on #run-command-output for the
+      // run-command builder. Same fallback chain as probeKometaRoot.
+      const kometaRootDisplay = res.kometa_root_display || res.kometa_root || configuredRootDisplay
+      const venvPythonDisplay = res.venv_python_display || res.venv_python || 'python3'
+      const kometaRootPosix = res.kometa_root || configuredRootPosix
+      const venvPythonPosix = res.venv_python || venvPythonDisplay
+
+      out.dataset.kometaRoot = kometaRootDisplay
+      out.dataset.venvPython = venvPythonDisplay
+      out.dataset.kometaRootPosix = kometaRootPosix
+      out.dataset.venvPythonPosix = venvPythonPosix
+
+      const installPathEl = document.getElementById('kometa-install-path')
+      if (installPathEl) installPathEl.textContent = kometaRootDisplay
+
+      // "All validation gates green" check. We reveal the run-command
+      // section only when every validation the user MUST clear is
+      // green: YAML is being shown, AND either the final-gate says
+      // configValid, OR each individual gate's dataset flag reads
+      // 'True'. Belt-and-suspenders because final-gate state and
+      // individual dataset flags can lag each other by a tick.
+      const finalGate = getFinalGateState()
+      const allValid = kometaState.showYAML && (finalGate.configValid || (
+        readValidationFlag('plex_valid', 'plexValid') === 'True' &&
+        readValidationFlag('tmdb_valid', 'tmdbValid') === 'True' &&
+        readValidationFlag('libs_valid', 'libsValid') === 'True' &&
+        readValidationFlag('sett_valid', 'settValid') === 'True' &&
+        readValidationFlag('yaml_valid', 'yamlValid') === 'True'
+      ))
+
+      // Clear any stale run-command output before rebuilding, so we
+      // don't briefly flash the old command while buildCommand runs.
+      const outEl = document.getElementById('run-command-output')
+      if (outEl) outEl.textContent = ''
+      try { buildCommand() } catch { /* buildCommand may not be ready in every context */ }
+
+      if (allValid) {
+        kometaState.kometaValidated = true
+        showRunCommandSectionAfterValidated()
+      } else {
+        kometaState.kometaValidated = false
+        hideRunCommandSectionUntilValidated()
+        runNow.disabled = true
+      }
+      if (!kometaState.kometaUpdating) {
+        setKometaUpdatePhaseBadge(kometaState.kometaValidated ? 'ready' : 'idle')
+      }
+    } else {
+      kometaState.kometaInstalled = false
+      kometaState.kometaValidated = false
+      if (!kometaState.kometaUpdating) setKometaUpdatePhaseBadge('failed')
+      hideRunCommandSectionUntilValidated()
+      runNow.disabled = true
+    }
+
+    if (spinner) spinner.classList.add('d-none')
+    syncUpdateButtonLabel()
+    syncKometaRollupBadge()
+  }
+
+  const handleValidateError = (msg) => {
+    kometaState.kometaLocalCheckCompleted = true
+    const errMsg = msg || 'The Kometa root path is invalid or inaccessible. Please try again.'
+    logBox.insertAdjacentHTML('beforeend', `\u274c ${errMsg}\n`)
+
+    // Certain error messages imply the install itself is broken (as
+    // opposed to a transient issue). Downgrade kometaInstalled so the
+    // rollup badge shows 'Install needed' instead of 'Prepare needed'.
+    const lowered = String(errMsg || '').toLowerCase()
+    if (lowered.includes('kometa.py not found') || lowered.includes('requirements.txt not found')) {
+      kometaState.kometaInstalled = false
+    }
+
+    kometaState.kometaValidated = false
+    if (!kometaState.kometaUpdating) setKometaUpdatePhaseBadge('failed')
+    hideRunCommandSectionUntilValidated()
+    runNow.disabled = true
+    if (spinner) spinner.classList.add('d-none')
+    syncKometaRollupBadge()
+  }
+
+  const handleValidateComplete = () => {
+    kometaState.kometaValidationInProgress = false
+    updateRunNowState()
+    syncUpdateButtonLabel()
+    syncKometaRollupBadge()
+    if (typeof hideNavigationLoadingOverlay === 'function') {
+      hideNavigationLoadingOverlay()
+    }
+  }
+
+  fetch('/validate-kometa-root', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      path: configuredRootPosix,
+      config_name: configName,
+      install_mode: configuredInstallMode
+    })
+  })
+    .then(async (resp) => {
+      const data = await resp.json().catch(() => ({}))
+      if (resp.ok) handleValidateSuccess(data)
+      else handleValidateError(data && data.error)
+    })
+    .catch(() => handleValidateError(null))
+    .finally(handleValidateComplete)
+}

--- a/tests/js/kometa/validateRoot.test.js
+++ b/tests/js/kometa/validateRoot.test.js
@@ -1,0 +1,554 @@
+// Tests for static/local-js/modules/kometa/_validateRoot.js
+//
+// One export: validateKometaRoot(options = {}).
+//
+// COVERAGE STRATEGY:
+//
+//   Short-circuits (3 branches):
+//     - !kometaCanProbeRuntime  -> info line + validated=false + return
+//     - already in progress     -> return immediately (no state change)
+//     - no configured root      -> error message written to log box
+//
+//   Setup: state + UI transitions before the fetch happens
+//     - phase badge set to 'validating'
+//     - validationInProgress flag set
+//     - spinner shown, runNow disabled
+//     - navigation overlay shown (via typeof guard)
+//     - appendStatus=true: appends 'Re-validating...' preserving log
+//     - appendStatus=false: replaces log with 'Please wait...'
+//
+//   Success path with success=true:
+//     - kometaInstalled set true
+//     - log lines forwarded
+//     - dataset caching (same fallback chain as probeKometaRoot)
+//     - kometa_version line appended when present
+//     - installPath element updated
+//     - buildCommand called
+//     - allValid via configValid path
+//     - allValid via individual dataset flags path
+//     - !allValid: validated=false, section hidden, run-now disabled
+//     - kometaUpdating=false: phase set to 'ready' / 'idle'
+//
+//   Success path with success=false (server said "not valid"):
+//     - kometaInstalled = false, validated = false
+//     - phase 'failed' when not updating
+//     - section hidden
+//
+//   Error path:
+//     - server !ok with error message
+//     - server !ok without message (fallback)
+//     - network reject (fetch itself fails)
+//     - 'kometa.py not found' -> kometaInstalled downgraded
+//     - 'requirements.txt not found' -> kometaInstalled downgraded
+//
+//   Complete (always runs via .finally):
+//     - validationInProgress cleared
+//     - updateRunNowState called
+//     - hideNavigationLoadingOverlay called (typeof guard)
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../static/local-js/modules/kometa/_runtime.js', () => ({
+  kometaCanProbeRuntime: vi.fn(() => true),
+  getConfiguredKometaRootPosix: vi.fn(() => '/opt/kometa'),
+  getConfiguredKometaRootDisplay: vi.fn(() => '/opt/kometa'),
+  getConfiguredKometaInstallMode: vi.fn(() => 'managed')
+}))
+vi.mock('../../../static/local-js/modules/kometa/_updatePhase.js', () => ({
+  appendKometaStatusLine: vi.fn(),
+  setKometaUpdatePhaseBadge: vi.fn()
+}))
+vi.mock('../../../static/local-js/modules/kometa/_updateRollup.js', () => ({
+  syncKometaRollupBadge: vi.fn(),
+  syncUpdateButtonLabel: vi.fn()
+}))
+vi.mock('../../../static/local-js/modules/kometa/_validationGate.js', () => ({
+  getFinalGateState: vi.fn(() => ({ configValid: false }))
+}))
+vi.mock('../../../static/local-js/modules/kometa/_runCommand.js', () => ({
+  buildCommand: vi.fn()
+}))
+vi.mock('../../../static/local-js/modules/kometa/_runControls.js', () => ({
+  updateRunNowState: vi.fn()
+}))
+vi.mock('../../../static/local-js/modules/kometa/_runCommandSection.js', () => ({
+  hideRunCommandSectionUntilValidated: vi.fn(),
+  showRunCommandSectionAfterValidated: vi.fn()
+}))
+
+import { kometaState } from '../../../static/local-js/modules/kometa/_state.js'
+import { validateKometaRoot } from '../../../static/local-js/modules/kometa/_validateRoot.js'
+import {
+  kometaCanProbeRuntime,
+  getConfiguredKometaRootPosix
+} from '../../../static/local-js/modules/kometa/_runtime.js'
+import {
+  appendKometaStatusLine,
+  setKometaUpdatePhaseBadge
+} from '../../../static/local-js/modules/kometa/_updatePhase.js'
+import {
+  syncKometaRollupBadge,
+  syncUpdateButtonLabel
+} from '../../../static/local-js/modules/kometa/_updateRollup.js'
+import { getFinalGateState } from '../../../static/local-js/modules/kometa/_validationGate.js'
+import { buildCommand } from '../../../static/local-js/modules/kometa/_runCommand.js'
+import { updateRunNowState } from '../../../static/local-js/modules/kometa/_runControls.js'
+import {
+  hideRunCommandSectionUntilValidated,
+  showRunCommandSectionAfterValidated
+} from '../../../static/local-js/modules/kometa/_runCommandSection.js'
+
+// ---------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------
+
+let originalFetch
+
+function installFixture () {
+  document.body.innerHTML = `
+    <pre id="kometa-validation-log"></pre>
+    <div id="spinner_validate" class="d-none"></div>
+    <button id="run-now"></button>
+    <div id="run-command-output" data-config-filename="kometa.yml"></div>
+    <span id="kometa-install-path"></span>
+  `
+}
+
+function mockFetchWith (response) {
+  global.fetch = vi.fn(() => Promise.resolve(response))
+}
+
+function okJson (body) {
+  return { ok: true, json: () => Promise.resolve(body) }
+}
+
+function errJson (status, body) {
+  return { ok: false, status, json: () => Promise.resolve(body) }
+}
+
+function resetState () {
+  kometaState.kometaLocalCheckCompleted = false
+  kometaState.kometaInstalled = false
+  kometaState.kometaValidated = false
+  kometaState.kometaValidationInProgress = false
+  kometaState.kometaUpdating = false
+  kometaState.showYAML = true
+}
+
+/**
+ * Install validation-gate dataset flags for the "all valid via
+ * individual flags" branch. Set every flag to 'True' by default;
+ * caller can override.
+ */
+function installValidationGateFlags (overrides = {}) {
+  const flags = {
+    plex_valid: 'plexValid',
+    tmdb_valid: 'tmdbValid',
+    libs_valid: 'libsValid',
+    sett_valid: 'settValid',
+    yaml_valid: 'yamlValid'
+  }
+  for (const [id, dataKey] of Object.entries(flags)) {
+    const el = document.createElement('div')
+    el.id = id
+    el.dataset[dataKey] = overrides[id] ?? 'True'
+    document.body.appendChild(el)
+  }
+}
+
+beforeEach(() => {
+  kometaCanProbeRuntime.mockReset()
+  kometaCanProbeRuntime.mockReturnValue(true)
+  getConfiguredKometaRootPosix.mockReset()
+  getConfiguredKometaRootPosix.mockReturnValue('/opt/kometa')
+  appendKometaStatusLine.mockClear()
+  setKometaUpdatePhaseBadge.mockClear()
+  syncKometaRollupBadge.mockClear()
+  syncUpdateButtonLabel.mockClear()
+  getFinalGateState.mockReset()
+  getFinalGateState.mockReturnValue({ configValid: false })
+  buildCommand.mockClear()
+  updateRunNowState.mockClear()
+  hideRunCommandSectionUntilValidated.mockClear()
+  showRunCommandSectionAfterValidated.mockClear()
+  originalFetch = global.fetch
+  resetState()
+})
+
+afterEach(() => {
+  global.fetch = originalFetch
+  document.body.innerHTML = ''
+})
+
+// ---------------------------------------------------------------------
+// Short-circuit branches
+// ---------------------------------------------------------------------
+
+describe('validateKometaRoot -- short circuits', () => {
+  it('returns early in external mode (no runtime probe available)', async () => {
+    kometaCanProbeRuntime.mockReturnValue(false)
+    installFixture()
+    validateKometaRoot()
+    expect(appendKometaStatusLine).toHaveBeenCalledWith(expect.stringContaining('external Kometa mode'))
+    expect(kometaState.kometaValidationInProgress).toBe(false)
+    expect(kometaState.kometaValidated).toBe(false)
+    expect(syncKometaRollupBadge).toHaveBeenCalledTimes(1)
+    // Should not have fetched
+    expect(global.fetch).toBe(originalFetch)
+  })
+
+  it('returns early when validation is already in progress', () => {
+    installFixture()
+    kometaState.kometaValidationInProgress = true
+    validateKometaRoot()
+    // No state changes, no fetch, no badge writes
+    expect(setKometaUpdatePhaseBadge).not.toHaveBeenCalled()
+    expect(syncKometaRollupBadge).not.toHaveBeenCalled()
+  })
+
+  it('writes explanatory message + returns when no root configured', () => {
+    getConfiguredKometaRootPosix.mockReturnValue('')
+    installFixture()
+    validateKometaRoot()
+    const logBox = document.getElementById('kometa-validation-log')
+    expect(logBox.textContent).toContain('does not have a Kometa install path')
+    expect(document.getElementById('run-now').disabled).toBe(true)
+    expect(kometaState.kometaValidationInProgress).toBe(false)
+    expect(kometaState.kometaValidated).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------
+// Setup phase (state + UI transitions before fetch)
+// ---------------------------------------------------------------------
+
+describe('validateKometaRoot -- setup phase', () => {
+  it("sets the phase badge to 'validating' and flips validationInProgress", async () => {
+    installFixture()
+    mockFetchWith(okJson({ success: true }))
+    validateKometaRoot()
+    expect(setKometaUpdatePhaseBadge).toHaveBeenCalledWith('validating')
+    // validationInProgress should be flipped ON at start
+    // (finally handler will flip it back off but that's async)
+  })
+
+  it("replaces the log with 'Please wait...' when appendStatus=false", () => {
+    installFixture()
+    mockFetchWith(okJson({ success: true }))
+    validateKometaRoot({ appendStatus: false })
+    expect(document.getElementById('kometa-validation-log').textContent).toContain('Please wait while we validate')
+  })
+
+  it("appends 'Re-validating...' when appendStatus=true", () => {
+    installFixture()
+    const logBox = document.getElementById('kometa-validation-log')
+    logBox.textContent = 'previous line\n'
+    mockFetchWith(okJson({ success: true }))
+    validateKometaRoot({ appendStatus: true })
+    expect(logBox.textContent).toContain('previous line')  // preserved
+    expect(logBox.textContent).toContain('Re-validating Kometa after update')
+  })
+
+  it('shows the spinner and disables run-now', () => {
+    installFixture()
+    document.getElementById('spinner_validate').classList.add('d-none')
+    mockFetchWith(okJson({ success: true }))
+    validateKometaRoot()
+    expect(document.getElementById('spinner_validate').classList.contains('d-none')).toBe(false)
+    expect(document.getElementById('run-now').disabled).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// Fetch request construction
+// ---------------------------------------------------------------------
+
+describe('validateKometaRoot -- request construction', () => {
+  it('POSTs to /validate-kometa-root with path/config_name/install_mode', async () => {
+    installFixture()
+    document.getElementById('run-command-output').dataset.configFilename = 'my-config.yml'
+    getConfiguredKometaRootPosix.mockReturnValue('/custom/kometa')
+    mockFetchWith(okJson({ success: true }))
+    validateKometaRoot()
+    // wait for microtasks so fetch is called
+    await new Promise(r => setTimeout(r, 0))
+    expect(global.fetch).toHaveBeenCalledWith('/validate-kometa-root', expect.objectContaining({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }
+    }))
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body)
+    expect(body).toEqual({
+      path: '/custom/kometa',
+      config_name: 'my-config.yml',
+      install_mode: 'managed'
+    })
+  })
+})
+
+// ---------------------------------------------------------------------
+// Success path -- success=true
+// ---------------------------------------------------------------------
+
+describe('validateKometaRoot -- success=true response', () => {
+  it('sets kometaInstalled true and appends success line', async () => {
+    installFixture()
+    mockFetchWith(okJson({ success: true }))
+    validateKometaRoot()
+    await new Promise(r => setTimeout(r, 10))
+    expect(kometaState.kometaInstalled).toBe(true)
+    expect(document.getElementById('kometa-validation-log').textContent).toContain('Kometa root validated successfully')
+  })
+
+  it('appends kometa_version line when present', async () => {
+    installFixture()
+    mockFetchWith(okJson({ success: true, kometa_version: 'v2.0.0' }))
+    validateKometaRoot()
+    await new Promise(r => setTimeout(r, 10))
+    expect(document.getElementById('kometa-validation-log').textContent).toContain('Local Kometa version: v2.0.0')
+  })
+
+  it('caches all four dataset attrs on #run-command-output', async () => {
+    installFixture()
+    mockFetchWith(okJson({
+      success: true,
+      kometa_root: '/srv/kometa',
+      kometa_root_display: 'C:\\srv\\kometa',
+      venv_python: '/srv/venv/bin/python',
+      venv_python_display: 'C:\\srv\\venv\\python.exe'
+    }))
+    validateKometaRoot()
+    await new Promise(r => setTimeout(r, 10))
+    const out = document.getElementById('run-command-output')
+    expect(out.dataset.kometaRoot).toBe('C:\\srv\\kometa')
+    expect(out.dataset.kometaRootPosix).toBe('/srv/kometa')
+    expect(out.dataset.venvPython).toBe('C:\\srv\\venv\\python.exe')
+    expect(out.dataset.venvPythonPosix).toBe('/srv/venv/bin/python')
+  })
+
+  it("updates #kometa-install-path from kometa_root_display", async () => {
+    installFixture()
+    mockFetchWith(okJson({ success: true, kometa_root_display: 'C:\\srv\\kometa' }))
+    validateKometaRoot()
+    await new Promise(r => setTimeout(r, 10))
+    expect(document.getElementById('kometa-install-path').textContent).toBe('C:\\srv\\kometa')
+  })
+
+  it("reveals section when finalGate.configValid is true", async () => {
+    installFixture()
+    getFinalGateState.mockReturnValue({ configValid: true })
+    mockFetchWith(okJson({ success: true }))
+    validateKometaRoot()
+    await new Promise(r => setTimeout(r, 10))
+    expect(kometaState.kometaValidated).toBe(true)
+    expect(showRunCommandSectionAfterValidated).toHaveBeenCalledTimes(1)
+    expect(hideRunCommandSectionUntilValidated).not.toHaveBeenCalled()
+  })
+
+  it("reveals section via individual dataset flags path", async () => {
+    installFixture()
+    installValidationGateFlags()  // all 'True' by default
+    getFinalGateState.mockReturnValue({ configValid: false })  // configValid path fails
+    mockFetchWith(okJson({ success: true }))
+    validateKometaRoot()
+    await new Promise(r => setTimeout(r, 10))
+    expect(kometaState.kometaValidated).toBe(true)
+    expect(showRunCommandSectionAfterValidated).toHaveBeenCalledTimes(1)
+  })
+
+  it("hides section when one gate flag is not 'True'", async () => {
+    installFixture()
+    installValidationGateFlags({ plex_valid: 'False' })
+    getFinalGateState.mockReturnValue({ configValid: false })
+    mockFetchWith(okJson({ success: true }))
+    validateKometaRoot()
+    await new Promise(r => setTimeout(r, 10))
+    expect(kometaState.kometaValidated).toBe(false)
+    expect(hideRunCommandSectionUntilValidated).toHaveBeenCalled()
+    expect(document.getElementById('run-now').disabled).toBe(true)
+  })
+
+  it("hides section when showYAML is false (regardless of gates)", async () => {
+    installFixture()
+    installValidationGateFlags()  // all True
+    getFinalGateState.mockReturnValue({ configValid: true })
+    kometaState.showYAML = false
+    mockFetchWith(okJson({ success: true }))
+    validateKometaRoot()
+    await new Promise(r => setTimeout(r, 10))
+    expect(kometaState.kometaValidated).toBe(false)
+  })
+
+  it("calls buildCommand and clears run-command-output text before rebuild", async () => {
+    installFixture()
+    const out = document.getElementById('run-command-output')
+    out.textContent = 'stale command'
+    getFinalGateState.mockReturnValue({ configValid: true })
+    mockFetchWith(okJson({ success: true }))
+    validateKometaRoot()
+    await new Promise(r => setTimeout(r, 10))
+    // buildCommand should have been called (real one is mocked as noop
+    // so textContent stays '' after the clear)
+    expect(buildCommand).toHaveBeenCalledTimes(1)
+    expect(out.textContent).toBe('')
+  })
+
+  it("sets phase to 'ready' when validated + not updating", async () => {
+    installFixture()
+    getFinalGateState.mockReturnValue({ configValid: true })
+    kometaState.kometaUpdating = false
+    mockFetchWith(okJson({ success: true }))
+    validateKometaRoot()
+    await new Promise(r => setTimeout(r, 10))
+    expect(setKometaUpdatePhaseBadge).toHaveBeenCalledWith('ready')
+  })
+
+  it("sets phase to 'idle' when NOT validated + not updating", async () => {
+    installFixture()
+    // No validation gates installed -> allValid false -> validated false
+    getFinalGateState.mockReturnValue({ configValid: false })
+    kometaState.kometaUpdating = false
+    mockFetchWith(okJson({ success: true }))
+    validateKometaRoot()
+    await new Promise(r => setTimeout(r, 10))
+    expect(setKometaUpdatePhaseBadge).toHaveBeenCalledWith('idle')
+  })
+
+  it("does NOT touch phase badge when kometaUpdating=true", async () => {
+    installFixture()
+    kometaState.kometaUpdating = true
+    getFinalGateState.mockReturnValue({ configValid: true })
+    mockFetchWith(okJson({ success: true }))
+    validateKometaRoot()
+    await new Promise(r => setTimeout(r, 10))
+    // 'validating' was set in setup phase. Then no more badge calls
+    // in the success handler (because kometaUpdating=true).
+    const readyOrIdleCalls = setKometaUpdatePhaseBadge.mock.calls.filter(
+      c => c[0] === 'ready' || c[0] === 'idle'
+    )
+    expect(readyOrIdleCalls.length).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------
+// Success path -- success=false response
+// ---------------------------------------------------------------------
+
+describe('validateKometaRoot -- success=false response', () => {
+  it('sets kometaInstalled=false, kometaValidated=false', async () => {
+    installFixture()
+    mockFetchWith(okJson({ success: false }))
+    validateKometaRoot()
+    await new Promise(r => setTimeout(r, 10))
+    expect(kometaState.kometaInstalled).toBe(false)
+    expect(kometaState.kometaValidated).toBe(false)
+  })
+
+  it("sets phase 'failed' when not updating", async () => {
+    installFixture()
+    kometaState.kometaUpdating = false
+    mockFetchWith(okJson({ success: false }))
+    validateKometaRoot()
+    await new Promise(r => setTimeout(r, 10))
+    expect(setKometaUpdatePhaseBadge).toHaveBeenCalledWith('failed')
+  })
+
+  it("hides run-command section and disables run-now", async () => {
+    installFixture()
+    mockFetchWith(okJson({ success: false }))
+    validateKometaRoot()
+    await new Promise(r => setTimeout(r, 10))
+    expect(hideRunCommandSectionUntilValidated).toHaveBeenCalled()
+    expect(document.getElementById('run-now').disabled).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// Error path
+// ---------------------------------------------------------------------
+
+describe('validateKometaRoot -- error path', () => {
+  it('handles server error message', async () => {
+    installFixture()
+    mockFetchWith(errJson(500, { error: 'server exploded' }))
+    validateKometaRoot()
+    await new Promise(r => setTimeout(r, 10))
+    expect(document.getElementById('kometa-validation-log').textContent).toContain('server exploded')
+  })
+
+  it('uses fallback message when no data.error', async () => {
+    installFixture()
+    mockFetchWith(errJson(500, {}))
+    validateKometaRoot()
+    await new Promise(r => setTimeout(r, 10))
+    expect(document.getElementById('kometa-validation-log').textContent).toContain('invalid or inaccessible')
+  })
+
+  it("downgrades kometaInstalled when 'kometa.py not found'", async () => {
+    installFixture()
+    kometaState.kometaInstalled = true  // start "installed"
+    mockFetchWith(errJson(400, { error: 'kometa.py not found in root' }))
+    validateKometaRoot()
+    await new Promise(r => setTimeout(r, 10))
+    expect(kometaState.kometaInstalled).toBe(false)
+  })
+
+  it("downgrades kometaInstalled when 'requirements.txt not found'", async () => {
+    installFixture()
+    kometaState.kometaInstalled = true
+    mockFetchWith(errJson(400, { error: 'requirements.txt not found in kometa root' }))
+    validateKometaRoot()
+    await new Promise(r => setTimeout(r, 10))
+    expect(kometaState.kometaInstalled).toBe(false)
+  })
+
+  it("does NOT downgrade kometaInstalled for other error messages", async () => {
+    installFixture()
+    kometaState.kometaInstalled = true
+    mockFetchWith(errJson(500, { error: 'network hiccup' }))
+    validateKometaRoot()
+    await new Promise(r => setTimeout(r, 10))
+    // kometaInstalled stays true (only 'kometa.py not found' /
+    // 'requirements.txt not found' trigger the downgrade)
+    expect(kometaState.kometaInstalled).toBe(true)
+  })
+
+  it('handles network reject (fetch rejects)', async () => {
+    installFixture()
+    global.fetch = vi.fn(() => Promise.reject(new Error('network fried')))
+    validateKometaRoot()
+    await new Promise(r => setTimeout(r, 10))
+    expect(document.getElementById('kometa-validation-log').textContent).toContain('invalid or inaccessible')
+    expect(kometaState.kometaValidated).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------
+// Complete (always runs via .finally)
+// ---------------------------------------------------------------------
+
+describe('validateKometaRoot -- complete handler', () => {
+  it("clears validationInProgress in .finally", async () => {
+    installFixture()
+    mockFetchWith(okJson({ success: true }))
+    validateKometaRoot()
+    await new Promise(r => setTimeout(r, 10))
+    expect(kometaState.kometaValidationInProgress).toBe(false)
+  })
+
+  it('calls updateRunNowState in .finally', async () => {
+    installFixture()
+    mockFetchWith(okJson({ success: true }))
+    validateKometaRoot()
+    await new Promise(r => setTimeout(r, 10))
+    expect(updateRunNowState).toHaveBeenCalledTimes(1)
+  })
+
+  it('finally handler runs even on network error', async () => {
+    installFixture()
+    global.fetch = vi.fn(() => Promise.reject(new Error('boom')))
+    validateKometaRoot()
+    await new Promise(r => setTimeout(r, 10))
+    expect(kometaState.kometaValidationInProgress).toBe(false)
+    expect(updateRunNowState).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## What

Extracts the **big** `/validate-kometa-root` endpoint call and response handler. Full-fat 'is Kometa actually ready to run?' validation — folder structure, Python environment, importable modules, `kometa.py` present, etc. Called after successful updates, after 'Prepare Kometa' clicks, and on wizard step entry.

Penultimate extraction before the `callUpdateKometa` boss fight.

`900-kometa.js`: 2402 -> 2256 lines (**-146**). Biggest single-PR cut in the split so far.
Vitest tests: 1196 -> 1228 (**+32**).

## What moved

Extracted to `static/local-js/modules/kometa/_validateRoot.js` (265 lines):

- `validateKometaRoot(options = {})` — the whole beast in one export

The function has 3 short-circuit branches (external mode / already-in-progress / no root) plus a setup phase, then splits into 3 outcome paths (success=true, success=false, error) with a shared `.finally` completion handler.

## Server contract (captured in module docstring)

```
POST /validate-kometa-root
Body: { path, config_name, install_mode }
Response: {
  success: boolean,
  error?, log?, kometa_version?,
  kometa_root?, kometa_root_display?,
  venv_python?, venv_python_display?
}
```

## Design notes

1. **Renamed internal closures** `_validateSuccess` / `_validateError` / `_validateComplete` → `handleValidateSuccess` / `handleValidateError` / `handleValidateComplete`. Same rationale as `probeKometaRoot` — redundant underscore on function-scoped locals.

2. **Extracted `readValidationFlag` helper** (`_dv` in the original) as a top-level function. Original had it as an inline closure; hoisting makes the callsite cleaner.

3. **`showNavigationLoadingOverlay` / `hideNavigationLoadingOverlay` typeof guards preserved** — they're globals from `000-base.js` and this way the module remains importable in isolation.

4. **Emojis replaced with unicode escapes** (`\u274c`, `\u2705`, `\u2139\ufe0f`, `\ud83d\udd04`, `\ud83d\udce6`). Same rule as prior extractions.

5. **Preserved a subtle template-literal wart** in the 'Please wait...' string. Behavior-preserving > tidiness.

## Orphaned imports removed from 900-kometa.js

- `getConfiguredKometaRootDisplay` (only used inside `validateKometaRoot`)
- `showRunCommandSectionAfterValidated` (only called from `validateKometaRoot`)

Both still exported from their source modules; just not imported by `900-kometa.js` anymore.

## The 'allValid' logic

The critical decision point in the success handler is:

```js
const allValid = kometaState.showYAML && (finalGate.configValid || (
  readValidationFlag('plex_valid', 'plexValid') === 'True' &&
  readValidationFlag('tmdb_valid', 'tmdbValid') === 'True' &&
  readValidationFlag('libs_valid', 'libsValid') === 'True' &&
  readValidationFlag('sett_valid', 'settValid') === 'True' &&
  readValidationFlag('yaml_valid', 'yamlValid') === 'True'
))
```

Belt-and-suspenders: reveal the run-command section only when YAML is being shown AND EITHER the final-gate agrees OR all 5 individual dataset flags read 'True'. The dual check is because the final-gate state and individual flags can lag each other by a tick.

## Test coverage: 32 new tests

- Short circuits (3): external mode, already in progress, no root
- Setup (4): badge, log replaces vs appends, spinner + run-now
- Request construction (1)
- **success=true (11)**: flags, version line, 4 dataset attrs, install-path, reveal via configValid, reveal via dataset flags, hide on flag mismatch, hide on !showYAML, buildCommand + clear, phase transitions
- success=false (3)
- **Error path (6)**: server message, fallback, `kometa.py not found` downgrade, `requirements.txt not found` downgrade, other errors preserved, network reject
- Complete handler (3)

Every collaborator mocked with `vi.mock()`. Fetch stubbed per test.

## Verification

- **1228/1228 Vitest pass** (was 1196; +32 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- ESLint clean, Node syntax clean

## What's next

Final two extractions:

- `runKometaStatusPass` (~30 lines, thin wrapper around probe + check)
- **`callUpdateKometa` (~200 lines, THE BOSS)**