### PR TITLE
Split 900-kometa.js part 22: extract runKometaStatusPass

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -51,9 +51,6 @@ import {
 } from './modules/kometa/_ui.js'
 import {
   getKometaBranchOverride,
-  getEffectiveKometaBranch,
-  getKometaVersionSourceUrlValue,
-  getKometaZipSourceUrlValue,
   loadSavedKometaBranchOverride,
   saveKometaBranchOverride,
   syncKometaSourceStatus,
@@ -67,28 +64,25 @@ import {
 } from './modules/kometa/_runControls.js'
 import {
   setKometaUpdatePhaseBadge,
-  setKometaStatusLog,
   appendKometaStatusLine
 } from './modules/kometa/_updatePhase.js'
 import {
   syncKometaRollupBadge,
   syncKometaUpdateAttention,
-  syncUpdateButtonLabel,
-  invalidateKometaUpdateStatus
+  syncUpdateButtonLabel
 } from './modules/kometa/_updateRollup.js'
 import {
   stopKometaUpdatePolling,
   pollKometaUpdateProgress
 } from './modules/kometa/_updatePolling.js'
-import { checkKometaUpdate } from './modules/kometa/_updateCheck.js'
 import {
   setRunCommandPlaceholderState,
   clearRunCommandPlaceholderState,
   hideRunCommandSectionUntilValidated,
   revealRunCommandSection
 } from './modules/kometa/_runCommandSection.js'
-import { probeKometaRoot } from './modules/kometa/_probeRoot.js'
 import { validateKometaRoot } from './modules/kometa/_validateRoot.js'
+import { runKometaStatusPass } from './modules/kometa/_statusPass.js'
 
 // Kometa runtime status flags migrated to modules/kometa/_state.js
 // (kometaState.kometaInstalled, kometaValidated, kometaStatus, etc.).
@@ -427,48 +421,6 @@ if (document.getElementById('run-command-output')) {
 
 initBootstrapTooltips(document, '[title]', { html: false, sanitize: true, placement: 'top', trigger: 'hover' })
 initBootstrapTooltips(document)
-
-function runKometaStatusPass (forceRefresh = false) {
-  const selection = getKometaBranchOverride()
-  const effective = getEffectiveKometaBranch()
-  const lines = [
-    '🔄 Refreshing Kometa status...',
-    `ℹ️ Selected Kometa branch mode: ${selection || 'auto'}`,
-    `ℹ️ Effective Kometa branch: ${effective}`,
-    `🌐 Remote VERSION source: ${getKometaVersionSourceUrlValue(effective)}`,
-    `📥 Kometa ZIP source: ${getKometaZipSourceUrlValue(effective)}`,
-    '',
-    '🔍 Checking Kometa path and local install state...'
-  ]
-  setKometaStatusLog(lines, 'checking')
-  invalidateKometaUpdateStatus()
-  return probeKometaRoot()
-    .then((res) => {
-      if (getConfiguredKometaInstallMode() === 'external') {
-        appendKometaStatusLine('')
-        appendKometaStatusLine('ℹ️ External Kometa mode detected. Quickstart will not perform runtime update checks in this mode.')
-        if (!kometaState.kometaUpdating) setKometaUpdatePhaseBadge('idle')
-        return res
-      }
-      if (!res || !res.kometa_installed) {
-        appendKometaStatusLine('')
-        appendKometaStatusLine('ℹ️ Remote update check skipped because Kometa is not installed.')
-        if (!kometaState.kometaUpdating) setKometaUpdatePhaseBadge('idle')
-        return res
-      }
-      appendKometaStatusLine('')
-      appendKometaStatusLine('🔎 Checking Kometa update status...')
-      return checkKometaUpdate(forceRefresh)
-    })
-    .then((result) => {
-      if (!kometaState.kometaUpdating) setKometaUpdatePhaseBadge(kometaState.kometaInstalled ? 'ready' : 'idle')
-      return result
-    })
-    .catch(() => {
-      if (!kometaState.kometaUpdating) setKometaUpdatePhaseBadge('failed')
-      return null
-    })
-}
 
 if (kometaActionsCollapse) {
   kometaActionsCollapse.addEventListener('shown.bs.collapse', syncKometaUpdateAttention)

--- a/static/local-js/modules/kometa/_statusPass.js
+++ b/static/local-js/modules/kometa/_statusPass.js
@@ -1,0 +1,106 @@
+// runKometaStatusPass: the "one-stop-shop" refresher for Kometa status.
+//
+// A single call to this function does the full status pipeline:
+//   1. Write a header block into the validation-log describing the
+//      selected branch mode, effective branch, and source URLs.
+//   2. Invalidate any cached update-check result (because we're
+//      about to overwrite it).
+//   3. Probe the Kometa root (probeKometaRoot) to see if it's installed.
+//   4. If external mode: append info line + return.
+//   5. If not installed: append info line + return.
+//   6. Otherwise: check for updates via checkKometaUpdate.
+//   7. Set the phase badge to 'ready' / 'idle' / 'failed' as
+//      appropriate, unless an update is currently in progress
+//      (updates own the badge during their lifecycle).
+//
+// This function is the main entry point users hit when they open the
+// Kometa wizard step or click "Recheck". It's also called by
+// callUpdateKometa in the 'check existing' + 'is-installed-no-force'
+// flavors.
+//
+// EXPORT:
+//
+//   runKometaStatusPass(forceRefresh = false)
+//     -- Returns a Promise. Resolves to whatever the last stage
+//        produced (probeKometaRoot response for short-circuit paths,
+//        checkKometaUpdate response for the full pipeline).
+//     -- .catch swallows errors and resolves to null (still marks
+//        the phase as 'failed' if we weren't updating).
+
+import { kometaState } from './_state.js'
+import { getConfiguredKometaInstallMode } from './_runtime.js'
+import {
+  getKometaBranchOverride,
+  getEffectiveKometaBranch,
+  getKometaVersionSourceUrlValue,
+  getKometaZipSourceUrlValue
+} from './_kometaBranch.js'
+import {
+  setKometaStatusLog,
+  appendKometaStatusLine,
+  setKometaUpdatePhaseBadge
+} from './_updatePhase.js'
+import { invalidateKometaUpdateStatus } from './_updateRollup.js'
+import { probeKometaRoot } from './_probeRoot.js'
+import { checkKometaUpdate } from './_updateCheck.js'
+
+/**
+ * Run a full Kometa status pass. See module docstring for pipeline.
+ *
+ * @param {boolean} [forceRefresh=false]  Passed through to
+ *                                        checkKometaUpdate to bypass
+ *                                        cached update results.
+ * @returns {Promise<object | null>}
+ */
+export function runKometaStatusPass (forceRefresh = false) {
+  const selection = getKometaBranchOverride()
+  const effective = getEffectiveKometaBranch()
+  const lines = [
+    '\ud83d\udd04 Refreshing Kometa status...',
+    `\u2139\ufe0f Selected Kometa branch mode: ${selection || 'auto'}`,
+    `\u2139\ufe0f Effective Kometa branch: ${effective}`,
+    `\ud83c\udf10 Remote VERSION source: ${getKometaVersionSourceUrlValue(effective)}`,
+    `\ud83d\udce5 Kometa ZIP source: ${getKometaZipSourceUrlValue(effective)}`,
+    '',
+    '\ud83d\udd0d Checking Kometa path and local install state...'
+  ]
+  setKometaStatusLog(lines, 'checking')
+  invalidateKometaUpdateStatus()
+
+  return probeKometaRoot()
+    .then((res) => {
+      // External mode never checks remote updates -- Quickstart
+      // isn't running the runtime, so there's nothing to update.
+      if (getConfiguredKometaInstallMode() === 'external') {
+        appendKometaStatusLine('')
+        appendKometaStatusLine('\u2139\ufe0f External Kometa mode detected. Quickstart will not perform runtime update checks in this mode.')
+        if (!kometaState.kometaUpdating) setKometaUpdatePhaseBadge('idle')
+        return res
+      }
+      // No install -> can't compare local vs remote version.
+      if (!res || !res.kometa_installed) {
+        appendKometaStatusLine('')
+        appendKometaStatusLine('\u2139\ufe0f Remote update check skipped because Kometa is not installed.')
+        if (!kometaState.kometaUpdating) setKometaUpdatePhaseBadge('idle')
+        return res
+      }
+      appendKometaStatusLine('')
+      appendKometaStatusLine('\ud83d\udd0e Checking Kometa update status...')
+      return checkKometaUpdate(forceRefresh)
+    })
+    .then((result) => {
+      // Only set the phase if we're NOT in the middle of an actual
+      // update -- updates own the badge during their lifecycle
+      // (queued -> downloading -> extracting -> etc.) and we don't
+      // want a stray 'ready' from a background status pass to
+      // clobber the current in-flight phase.
+      if (!kometaState.kometaUpdating) {
+        setKometaUpdatePhaseBadge(kometaState.kometaInstalled ? 'ready' : 'idle')
+      }
+      return result
+    })
+    .catch(() => {
+      if (!kometaState.kometaUpdating) setKometaUpdatePhaseBadge('failed')
+      return null
+    })
+}

--- a/tests/js/kometa/statusPass.test.js
+++ b/tests/js/kometa/statusPass.test.js
@@ -1,0 +1,302 @@
+// Tests for static/local-js/modules/kometa/_statusPass.js
+//
+// One export: runKometaStatusPass(forceRefresh = false).
+//
+// COVERAGE STRATEGY:
+//
+//   Setup (header block + invalidation):
+//     - status log gets the 7-line header
+//     - phase badge set to 'checking'
+//     - invalidateKometaUpdateStatus called
+//
+//   Pipeline branches (based on probe result + install mode):
+//     - probe rejects -> catch, phase 'failed', resolves null
+//     - external mode -> info line, phase 'idle', no update check
+//     - !res or !res.kometa_installed -> info line, phase 'idle',
+//       no update check
+//     - installed + not external -> checkKometaUpdate called
+//
+//   Post-pipeline (phase badge based on state):
+//     - installed -> phase 'ready'
+//     - !installed -> phase 'idle'
+//     - kometaUpdating -> no badge touch (updates own it)
+//
+//   Force refresh forwarding:
+//     - forceRefresh=true is passed to checkKometaUpdate
+//
+//   Return value:
+//     - resolves to probe result on short-circuit paths
+//     - resolves to checkKometaUpdate result on full pipeline
+//     - resolves to null on catch
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../static/local-js/modules/kometa/_runtime.js', () => ({
+  getConfiguredKometaInstallMode: vi.fn(() => 'managed')
+}))
+vi.mock('../../../static/local-js/modules/kometa/_kometaBranch.js', () => ({
+  getKometaBranchOverride: vi.fn(() => ''),
+  getEffectiveKometaBranch: vi.fn(() => 'master'),
+  getKometaVersionSourceUrlValue: vi.fn(() => 'https://example.com/VERSION'),
+  getKometaZipSourceUrlValue: vi.fn(() => 'https://example.com/master.zip')
+}))
+vi.mock('../../../static/local-js/modules/kometa/_updatePhase.js', () => ({
+  setKometaStatusLog: vi.fn(),
+  appendKometaStatusLine: vi.fn(),
+  setKometaUpdatePhaseBadge: vi.fn()
+}))
+vi.mock('../../../static/local-js/modules/kometa/_updateRollup.js', () => ({
+  invalidateKometaUpdateStatus: vi.fn()
+}))
+vi.mock('../../../static/local-js/modules/kometa/_probeRoot.js', () => ({
+  probeKometaRoot: vi.fn()
+}))
+vi.mock('../../../static/local-js/modules/kometa/_updateCheck.js', () => ({
+  checkKometaUpdate: vi.fn()
+}))
+
+import { kometaState } from '../../../static/local-js/modules/kometa/_state.js'
+import { runKometaStatusPass } from '../../../static/local-js/modules/kometa/_statusPass.js'
+import { getConfiguredKometaInstallMode } from '../../../static/local-js/modules/kometa/_runtime.js'
+import { getKometaBranchOverride } from '../../../static/local-js/modules/kometa/_kometaBranch.js'
+import {
+  setKometaStatusLog,
+  appendKometaStatusLine,
+  setKometaUpdatePhaseBadge
+} from '../../../static/local-js/modules/kometa/_updatePhase.js'
+import { invalidateKometaUpdateStatus } from '../../../static/local-js/modules/kometa/_updateRollup.js'
+import { probeKometaRoot } from '../../../static/local-js/modules/kometa/_probeRoot.js'
+import { checkKometaUpdate } from '../../../static/local-js/modules/kometa/_updateCheck.js'
+
+// ---------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------
+
+beforeEach(() => {
+  getConfiguredKometaInstallMode.mockReset()
+  getConfiguredKometaInstallMode.mockReturnValue('managed')
+  getKometaBranchOverride.mockReset()
+  getKometaBranchOverride.mockReturnValue('')
+  setKometaStatusLog.mockClear()
+  appendKometaStatusLine.mockClear()
+  setKometaUpdatePhaseBadge.mockClear()
+  invalidateKometaUpdateStatus.mockClear()
+  probeKometaRoot.mockReset()
+  checkKometaUpdate.mockReset()
+
+  kometaState.kometaUpdating = false
+  kometaState.kometaInstalled = false
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ---------------------------------------------------------------------
+// Setup phase
+// ---------------------------------------------------------------------
+
+describe('runKometaStatusPass -- setup phase', () => {
+  it("writes the 7-line header block to the status log with phase 'checking'", async () => {
+    probeKometaRoot.mockResolvedValue({ kometa_installed: false })
+    await runKometaStatusPass()
+    expect(setKometaStatusLog).toHaveBeenCalledTimes(1)
+    const [lines, phase] = setKometaStatusLog.mock.calls[0]
+    expect(Array.isArray(lines)).toBe(true)
+    expect(lines.length).toBe(7)
+    expect(phase).toBe('checking')
+    // Sanity: some expected content in the header
+    expect(lines.join(' ')).toContain('Refreshing Kometa status')
+    expect(lines.join(' ')).toContain('Selected Kometa branch mode')
+  })
+
+  it("calls invalidateKometaUpdateStatus at the start", async () => {
+    probeKometaRoot.mockResolvedValue({ kometa_installed: false })
+    await runKometaStatusPass()
+    expect(invalidateKometaUpdateStatus).toHaveBeenCalledTimes(1)
+  })
+
+  it("shows selected branch mode as 'auto' when getKometaBranchOverride returns empty", async () => {
+    getKometaBranchOverride.mockReturnValue('')
+    probeKometaRoot.mockResolvedValue({ kometa_installed: false })
+    await runKometaStatusPass()
+    const lines = setKometaStatusLog.mock.calls[0][0]
+    expect(lines.some(l => l.includes('Selected Kometa branch mode: auto'))).toBe(true)
+  })
+
+  it("shows selected branch mode when getKometaBranchOverride returns a value", async () => {
+    getKometaBranchOverride.mockReturnValue('develop')
+    probeKometaRoot.mockResolvedValue({ kometa_installed: false })
+    await runKometaStatusPass()
+    const lines = setKometaStatusLog.mock.calls[0][0]
+    expect(lines.some(l => l.includes('Selected Kometa branch mode: develop'))).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// Pipeline branches
+// ---------------------------------------------------------------------
+
+describe('runKometaStatusPass -- pipeline branches', () => {
+  it("skips update check in external mode (appends info line + phase 'idle')", async () => {
+    getConfiguredKometaInstallMode.mockReturnValue('external')
+    probeKometaRoot.mockResolvedValue({ kometa_installed: true })
+    await runKometaStatusPass()
+    expect(checkKometaUpdate).not.toHaveBeenCalled()
+    expect(appendKometaStatusLine).toHaveBeenCalledWith(expect.stringContaining('External Kometa mode detected'))
+    expect(setKometaUpdatePhaseBadge).toHaveBeenCalledWith('idle')
+  })
+
+  it("skips update check when probe returns null", async () => {
+    probeKometaRoot.mockResolvedValue(null)
+    await runKometaStatusPass()
+    expect(checkKometaUpdate).not.toHaveBeenCalled()
+    expect(appendKometaStatusLine).toHaveBeenCalledWith(expect.stringContaining('Kometa is not installed'))
+  })
+
+  it("skips update check when Kometa is not installed", async () => {
+    probeKometaRoot.mockResolvedValue({ kometa_installed: false })
+    await runKometaStatusPass()
+    expect(checkKometaUpdate).not.toHaveBeenCalled()
+    expect(appendKometaStatusLine).toHaveBeenCalledWith(expect.stringContaining('Kometa is not installed'))
+  })
+
+  it("calls checkKometaUpdate when installed + not external", async () => {
+    probeKometaRoot.mockResolvedValue({ kometa_installed: true })
+    checkKometaUpdate.mockResolvedValue({ update_check_completed: true })
+    await runKometaStatusPass()
+    expect(checkKometaUpdate).toHaveBeenCalledTimes(1)
+    expect(appendKometaStatusLine).toHaveBeenCalledWith(expect.stringContaining('Checking Kometa update status'))
+  })
+})
+
+// ---------------------------------------------------------------------
+// Force refresh forwarding
+// ---------------------------------------------------------------------
+
+describe('runKometaStatusPass -- forceRefresh forwarding', () => {
+  it("forwards forceRefresh=true to checkKometaUpdate", async () => {
+    probeKometaRoot.mockResolvedValue({ kometa_installed: true })
+    checkKometaUpdate.mockResolvedValue({})
+    await runKometaStatusPass(true)
+    expect(checkKometaUpdate).toHaveBeenCalledWith(true)
+  })
+
+  it("defaults forceRefresh to false when omitted", async () => {
+    probeKometaRoot.mockResolvedValue({ kometa_installed: true })
+    checkKometaUpdate.mockResolvedValue({})
+    await runKometaStatusPass()
+    expect(checkKometaUpdate).toHaveBeenCalledWith(false)
+  })
+})
+
+// ---------------------------------------------------------------------
+// Post-pipeline phase badge
+// ---------------------------------------------------------------------
+
+describe('runKometaStatusPass -- post-pipeline phase badge', () => {
+  it("sets phase 'ready' when installed after pipeline", async () => {
+    probeKometaRoot.mockResolvedValue({ kometa_installed: true })
+    checkKometaUpdate.mockImplementation(async () => {
+      kometaState.kometaInstalled = true
+      return {}
+    })
+    await runKometaStatusPass()
+    // Final phase call should be 'ready'
+    const badgeCalls = setKometaUpdatePhaseBadge.mock.calls.map(c => c[0])
+    expect(badgeCalls[badgeCalls.length - 1]).toBe('ready')
+  })
+
+  it("sets phase 'idle' when NOT installed after pipeline", async () => {
+    kometaState.kometaInstalled = false
+    probeKometaRoot.mockResolvedValue({ kometa_installed: true })
+    checkKometaUpdate.mockImplementation(async () => {
+      kometaState.kometaInstalled = false
+      return {}
+    })
+    await runKometaStatusPass()
+    const badgeCalls = setKometaUpdatePhaseBadge.mock.calls.map(c => c[0])
+    expect(badgeCalls[badgeCalls.length - 1]).toBe('idle')
+  })
+
+  it("does NOT touch phase badge when kometaUpdating=true", async () => {
+    kometaState.kometaUpdating = true
+    probeKometaRoot.mockResolvedValue({ kometa_installed: true })
+    checkKometaUpdate.mockResolvedValue({})
+    await runKometaStatusPass()
+    // The only phase call is the 'checking' one from setKometaStatusLog,
+    // NOT from anywhere in runKometaStatusPass -- statusLog phase is
+    // via setKometaStatusLog second arg, not setKometaUpdatePhaseBadge.
+    // So setKometaUpdatePhaseBadge should not have been called at all.
+    expect(setKometaUpdatePhaseBadge).not.toHaveBeenCalled()
+  })
+
+  it("does NOT touch phase badge on external-mode short-circuit when updating", async () => {
+    kometaState.kometaUpdating = true
+    getConfiguredKometaInstallMode.mockReturnValue('external')
+    probeKometaRoot.mockResolvedValue({ kometa_installed: true })
+    await runKometaStatusPass()
+    expect(setKometaUpdatePhaseBadge).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------
+// Catch path
+// ---------------------------------------------------------------------
+
+describe('runKometaStatusPass -- catch path', () => {
+  it("resolves null when probeKometaRoot rejects", async () => {
+    probeKometaRoot.mockRejectedValue(new Error('probe failed'))
+    const result = await runKometaStatusPass()
+    expect(result).toBeNull()
+  })
+
+  it("sets phase 'failed' on probe error (when not updating)", async () => {
+    probeKometaRoot.mockRejectedValue(new Error('probe failed'))
+    await runKometaStatusPass()
+    expect(setKometaUpdatePhaseBadge).toHaveBeenCalledWith('failed')
+  })
+
+  it("does NOT touch phase badge on error when updating", async () => {
+    kometaState.kometaUpdating = true
+    probeKometaRoot.mockRejectedValue(new Error('probe failed'))
+    await runKometaStatusPass()
+    expect(setKometaUpdatePhaseBadge).not.toHaveBeenCalled()
+  })
+
+  it("resolves null when checkKometaUpdate rejects", async () => {
+    probeKometaRoot.mockResolvedValue({ kometa_installed: true })
+    checkKometaUpdate.mockRejectedValue(new Error('check failed'))
+    const result = await runKometaStatusPass()
+    expect(result).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------
+// Return values
+// ---------------------------------------------------------------------
+
+describe('runKometaStatusPass -- return values', () => {
+  it("returns probe result on external short-circuit", async () => {
+    getConfiguredKometaInstallMode.mockReturnValue('external')
+    const probeResult = { kometa_installed: true, custom: 'x' }
+    probeKometaRoot.mockResolvedValue(probeResult)
+    const result = await runKometaStatusPass()
+    expect(result).toEqual(probeResult)
+  })
+
+  it("returns probe result on !installed short-circuit", async () => {
+    const probeResult = { kometa_installed: false }
+    probeKometaRoot.mockResolvedValue(probeResult)
+    const result = await runKometaStatusPass()
+    expect(result).toEqual(probeResult)
+  })
+
+  it("returns checkKometaUpdate result on full pipeline", async () => {
+    probeKometaRoot.mockResolvedValue({ kometa_installed: true })
+    const checkResult = { kometa_update_available: true, local_version: 'v1.0' }
+    checkKometaUpdate.mockResolvedValue(checkResult)
+    const result = await runKometaStatusPass()
+    expect(result).toEqual(checkResult)
+  })
+})


### PR DESCRIPTION
## What

Extracts the 'one-stop-shop' Kometa status refresher: writes a header block, invalidates cached update status, probes the root, then either short-circuits (external mode, not installed) or falls through to `checkKometaUpdate`. Also manages the phase badge based on final install state.

**The last dep for the `callUpdateKometa` boss fight.** Next PR will be THE BOSS.

`900-kometa.js`: 2256 -> 2208 lines (**-48**).
Vitest tests: 1228 -> 1249 (**+21**).

## What moved

Extracted to `static/local-js/modules/kometa/_statusPass.js` (106 lines):

- `runKometaStatusPass(forceRefresh = false)` — writes header, invalidates cache, probes root, branches to short-circuits or full update check, sets final phase, catches errors

## Pipeline

1. Write 7-line header via `setKometaStatusLog(lines, 'checking')`
2. `invalidateKometaUpdateStatus()`
3. `probeKometaRoot()`
4. Branch:
   - **external mode** → info line + phase 'idle' (skip check)
   - **!res or !installed** → info line + phase 'idle' (skip check)
   - **installed** → `checkKometaUpdate(forceRefresh)`
5. Set final phase: 'ready' if installed else 'idle'
6. `.catch` → phase 'failed', resolve null

**All phase-badge writes are gated on `!kometaUpdating`** — an in-flight update owns the badge and we don't want a background status pass to clobber 'downloading' or 'extracting'.

## Removed orphaned imports from 900-kometa.js

Seven imports were only used by `runKometaStatusPass`:

- `getEffectiveKometaBranch`, `getKometaVersionSourceUrlValue`, `getKometaZipSourceUrlValue` (from `_kometaBranch.js`)
- `setKometaStatusLog` (from `_updatePhase.js`)
- `invalidateKometaUpdateStatus` (from `_updateRollup.js`)
- `checkKometaUpdate` (from `_updateCheck.js`)
- `probeKometaRoot` (from `_probeRoot.js`)

Source modules still export them.

## Test coverage: 21 new tests

- Setup phase (4): header + phase 'checking', invalidate called, 'auto' fallback, override forwarded
- Pipeline branches (4): external / null probe / !installed / installed → checkKometaUpdate
- forceRefresh forwarding (2)
- Post-pipeline phase (4): 'ready' / 'idle' / no-touch-when-updating / no-touch-on-external-when-updating
- Catch path (4): probe reject → null, phase 'failed', no-touch-when-updating, check reject → null
- Return values (3): probe result on external, probe result on !installed, checkKometaUpdate result on full pipeline

Every collaborator mocked with `vi.mock()` for pure unit testing.

## Verification

- **1249/1249 Vitest pass** (was 1228; +21 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- ESLint clean, Node syntax clean

## What's next

**THE BOSS FIGHT:** `callUpdateKometa` (~200 lines). All dependencies extracted. Ready to go.