### PR TITLE
Split 900-kometa.js part 23: extract callUpdateKometa (THE BOSS FIGHT)

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -1,6 +1,5 @@
 // Global flag so other handlers know an update is in progress
 import {
-  formatElapsed,
   computeYamlLineCount,
   linkifyText,
   formatTimestampLocal,
@@ -30,8 +29,6 @@ import {
   updateValidationGate
 } from './modules/kometa/_validationGate.js'
 import {
-  getConfiguredKometaInstallMode,
-  getConfiguredKometaRootPosix,
   kometaCanLaunch,
   kometaCanProbeRuntime,
   kometaCanReadLogs
@@ -50,7 +47,6 @@ import {
   showCopyButtonSuccess
 } from './modules/kometa/_ui.js'
 import {
-  getKometaBranchOverride,
   loadSavedKometaBranchOverride,
   saveKometaBranchOverride,
   syncKometaSourceStatus,
@@ -72,10 +68,6 @@ import {
   syncUpdateButtonLabel
 } from './modules/kometa/_updateRollup.js'
 import {
-  stopKometaUpdatePolling,
-  pollKometaUpdateProgress
-} from './modules/kometa/_updatePolling.js'
-import {
   setRunCommandPlaceholderState,
   clearRunCommandPlaceholderState,
   hideRunCommandSectionUntilValidated,
@@ -83,6 +75,7 @@ import {
 } from './modules/kometa/_runCommandSection.js'
 import { validateKometaRoot } from './modules/kometa/_validateRoot.js'
 import { runKometaStatusPass } from './modules/kometa/_statusPass.js'
+import { callUpdateKometa } from './modules/kometa/_kometaUpdate.js'
 
 // Kometa runtime status flags migrated to modules/kometa/_state.js
 // (kometaState.kometaInstalled, kometaValidated, kometaStatus, etc.).
@@ -910,241 +903,6 @@ function fetchRunProgress (forceFull = false) {
     })
     .finally(() => {
       runProgressInFlight = false
-    })
-}
-
-function callUpdateKometa () {
-  const installMode = getConfiguredKometaInstallMode()
-  if (installMode === 'external') {
-    showToast('info', 'External Kometa mode cannot update the runtime. Quickstart can only sync config and optional logs in this mode.')
-    return
-  }
-  if (installMode === 'existing') {
-    updateKometaBtn.disabled = true
-    updateKometaBtn.innerHTML = '<i class="bi bi-arrow-repeat me-1"></i> Checking...'
-    runKometaStatusPass(true)
-      .then((data) => {
-        if (!data) return
-        if (data.kometa_update_available) {
-          showToast('warning', `Kometa update available: ${data.local_version} → ${data.remote_version}. Update this existing install manually outside Quickstart.`)
-          const noteEl = document.getElementById('kometa-update-box-note')
-          if (noteEl) {
-            noteEl.textContent = 'Update this existing Kometa install manually outside Quickstart before running.'
-          }
-        } else if (!data.kometa_update_check_skipped) {
-          showToast('success', 'Existing Kometa install checked. No newer version was detected.')
-        }
-      })
-      .catch(() => {
-        showToast('error', 'Failed to check existing Kometa status.')
-      })
-      .finally(() => {
-        updateKometaBtn.disabled = false
-        syncUpdateButtonLabel()
-      })
-    return
-  }
-  if (kometaState.kometaStatus === 'running') {
-    showToast('info', 'Kometa is currently running; update skipped.')
-    return
-  }
-
-  const btn = updateKometaBtn
-  const logBox = document.getElementById('kometa-validation-log')
-  const runNow = document.getElementById('run-now')
-  const stopNow = document.getElementById('stop-now')
-  const runBox = document.getElementById('run-command-box')
-  const qsBranch = btn.dataset.qsBranch || 'master'
-  const branchOverride = getKometaBranchOverride()
-  const configuredRootPosix = getConfiguredKometaRootPosix()
-  const configuredInstallMode = getConfiguredKometaInstallMode()
-  const forceUpdate = forceUpdateToggle.checked
-
-  if (kometaState.kometaInstalled && !forceUpdate && !kometaState.kometaUpdateAvailable) {
-    btn.disabled = true
-    btn.innerHTML = '<i class="bi bi-arrow-repeat me-1"></i> Checking...'
-    forceUpdateToggle.disabled = true
-    kometaBranchOverride.disabled = true
-    runKometaStatusPass(true)
-      .then((data) => {
-        if (!data) return
-        if (data.kometa_update_available) {
-          showToast('warning', `Kometa update available: ${data.local_version} → ${data.remote_version}.`)
-        } else if (!data.kometa_update_check_skipped) {
-          showToast('success', 'Kometa is already up to date.')
-        }
-      })
-      .catch(() => {
-        showToast('error', 'Failed to check Kometa update status.')
-      })
-      .finally(() => {
-        btn.disabled = false
-        forceUpdateToggle.disabled = false
-        kometaBranchOverride.disabled = false
-        syncUpdateButtonLabel()
-      })
-    return
-  }
-
-  kometaState.kometaUpdating = true
-  kometaState.kometaValidated = false
-  kometaState.kometaUpdateCheckSkipped = false
-  kometaState.kometaUpdateCheckCompleted = false
-  setKometaUpdatePhaseBadge('queued')
-  syncKometaRollupBadge()
-  hideRunCommandSectionUntilValidated()
-  syncFinalAccordionRollups()
-  const prevRunNowHtml = runNow.innerHTML
-  const prevRunNowDisabled = runNow.disabled
-
-  runBox.classList.add('opacity-50', 'position-relative')
-  runNow.disabled = true
-  runNow.innerHTML = '<i class="bi bi-hourglass me-1"></i> Updating...'
-  stopNow.disabled = true
-  const inProgressLabel = forceUpdate
-    ? (kometaState.kometaInstalled ? 'Force Updating...' : 'Force Installing...')
-    : (kometaState.kometaInstalled ? 'Checking for updates...' : 'Installing...')
-  btn.disabled = true
-  btn.innerHTML = `<i class="bi bi-arrow-repeat me-1"></i> ${inProgressLabel}`
-  forceUpdateToggle.disabled = true
-  kometaBranchOverride.disabled = true
-  logBox.insertAdjacentHTML('beforeend', '\nInitializing/Updating Kometa...\n')
-  if (logBox) logBox.scrollTop = logBox.scrollHeight
-
-  // progress heartbeat
-  const startTs = Date.now()
-  showToast('info', 'Still working on Kometa... (0 seconds elapsed)', 10000)
-  const heartbeatId = setInterval(() => {
-    const secs = Math.floor((Date.now() - startTs) / 1000)
-    showToast('info', `Still working on Kometa... (${secs} seconds elapsed)`, 10000)
-  }, 30000) // every 30s
-
-  let postUpdateLabel = null
-  const cleanupUI = () => {
-    clearInterval(heartbeatId)
-    stopKometaUpdatePolling()
-    kometaState.kometaUpdateJobId = null
-    kometaState.kometaUpdateLogIndex = 0
-    kometaState.kometaUpdating = false
-    runBox.classList.remove('opacity-50', 'position-relative')
-    runNow.disabled = prevRunNowDisabled
-    runNow.innerHTML = prevRunNowHtml
-    stopNow.disabled = false
-    btn.disabled = false
-    forceUpdateToggle.disabled = false
-    kometaBranchOverride.disabled = false
-    syncUpdateButtonLabel()
-    updateRunNowState()
-    syncFinalAccordionRollups()
-    if (postUpdateLabel) {
-      btn.innerHTML = postUpdateLabel
-      setTimeout(syncUpdateButtonLabel, 6000)
-    }
-  }
-
-  fetch('/update-kometa', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ branch: qsBranch, branch_override: branchOverride, path: configuredRootPosix, install_mode: configuredInstallMode, force: forceUpdate, background: true })
-  })
-    .then(async res => {
-      const data = await res.json()
-      if (res.status === 409) {
-        setKometaUpdatePhaseBadge('failed')
-        showToast('warning', data.error || 'Kometa is running; stop it before updating.')
-        logBox.insertAdjacentHTML('beforeend', `${data.error || 'Update blocked: Kometa running.'}\n`)
-        if (logBox[0]) logBox[0].scrollTop = logBox[0].scrollHeight
-        return { success: false, log: data.log || [], blocked: true }
-      }
-      if (!res.ok) {
-        throw new Error(data.error || 'Kometa update failed to start.')
-      }
-      return data
-    })
-    .then(data => {
-      if (!data) return
-      if (data.success && data.job_id) {
-        kometaState.kometaUpdateJobId = data.job_id
-        kometaState.kometaUpdateLogIndex = 0
-        stopKometaUpdatePolling()
-        const finalize = (progress) => {
-          if (!progress || !progress.done) return false
-          kometaState.kometaLocalCheckCompleted = false
-          kometaState.kometaUpdateAvailable = false
-          document.getElementById('kometa-update-box').classList.add('d-none')
-          syncUpdateButtonLabel()
-          const elapsed = formatElapsed(Date.now() - startTs)
-          const updateSucceeded = progress.update_success ?? progress.success
-          if (updateSucceeded) {
-            if (progress.up_to_date) {
-              showToast('info', 'Kometa is already up to date.')
-              postUpdateLabel = '<i class="bi bi-check-circle me-1"></i> Up to date'
-              appendKometaStatusLine('Kometa is already up to date.')
-              setKometaUpdatePhaseBadge('ready')
-            } else {
-              showToast('success', `Kometa update completed in ${elapsed}.`)
-              appendKometaStatusLine('Kometa update completed successfully.')
-              setKometaUpdatePhaseBadge('validating')
-            }
-            validateKometaRoot({ appendStatus: true })
-          } else {
-            showToast('error', 'Kometa update failed.')
-            appendKometaStatusLine('Kometa update failed.')
-            setKometaUpdatePhaseBadge('failed')
-            validateKometaRoot({ appendStatus: true })
-          }
-          cleanupUI()
-          syncKometaRollupBadge()
-          return true
-        }
-        return pollKometaUpdateProgress()
-          .then(progress => {
-            if (finalize(progress)) return
-            kometaState.kometaUpdatePollInterval = setInterval(() => {
-              pollKometaUpdateProgress()
-                .then(finalize)
-                .catch(err => {
-                  console.error(err)
-                  appendKometaStatusLine(`❌ ${err.message || 'Failed to fetch Kometa update progress.'}`)
-                  setKometaUpdatePhaseBadge('failed')
-                  stopKometaUpdatePolling()
-                  cleanupUI()
-                  syncKometaRollupBadge()
-                })
-            }, 800)
-          })
-      }
-      if (data.success) {
-        kometaState.kometaLocalCheckCompleted = false
-        kometaState.kometaUpdateAvailable = false
-        document.getElementById('kometa-update-box').classList.add('d-none')
-        syncUpdateButtonLabel()
-        const elapsed = formatElapsed(Date.now() - startTs)
-        if (data.up_to_date) {
-          showToast('info', 'Kometa is already up to date.')
-          postUpdateLabel = '<i class="bi bi-check-circle me-1"></i> Up to date'
-          logBox.insertAdjacentHTML('beforeend', 'Kometa is already up to date.\n')
-        } else {
-          showToast('success', `Kometa update completed in ${elapsed}.`)
-          logBox.insertAdjacentHTML('beforeend', 'Kometa update completed successfully.\n')
-        }
-        if (logBox[0]) logBox[0].scrollTop = logBox[0].scrollHeight
-        validateKometaRoot({ appendStatus: true })
-      } else if (!data.blocked) {
-        showToast('error', data.error || 'Kometa update failed.')
-        logBox.insertAdjacentHTML('beforeend', 'Kometa update failed.\n')
-        validateKometaRoot({ appendStatus: true })
-        if (logBox[0]) logBox[0].scrollTop = logBox[0].scrollHeight
-      }
-    })
-    .catch(err => {
-      console.error(err)
-      showToast('error', 'Error during Kometa update.')
-      logBox.insertAdjacentHTML('beforeend', 'Error occurred during Kometa update.\n')
-      setKometaUpdatePhaseBadge('failed')
-      if (logBox[0]) logBox[0].scrollTop = logBox[0].scrollHeight
-      cleanupUI()
-      syncKometaRollupBadge()
     })
 }
 

--- a/static/local-js/modules/kometa/_kometaUpdate.js
+++ b/static/local-js/modules/kometa/_kometaUpdate.js
@@ -1,0 +1,434 @@
+// callUpdateKometa: THE BOSS FIGHT.
+//
+// The main "update Kometa" entry point. Users hit this by clicking the
+// #update-kometa button. It has FIVE distinct execution paths:
+//
+//   1. External mode short-circuit
+//        Kometa lives outside Quickstart's control -- show a toast
+//        and bail. Quickstart can only sync config in this mode.
+//
+//   2. Existing mode branch
+//        User pointed Quickstart at their own Kometa install. We
+//        can *check* for updates but NOT apply them (that's their
+//        job manually). Runs runKometaStatusPass, shows toast based
+//        on result, updates a note element if update is available.
+//
+//   3. Running short-circuit
+//        Kometa is currently running (mid-run). Show a toast and
+//        bail -- we can't update a live install.
+//
+//   4. Already-installed-no-force branch
+//        Kometa is installed and user didn't tick 'force update'
+//        and we don't already know an update is available. Just
+//        runs runKometaStatusPass to check remote version, showing
+//        toast based on result. Doesn't actually apply anything.
+//
+//   5. The full update path (the main event)
+//        Sets phase 'queued', disables buttons, starts a heartbeat
+//        toast, POSTs /update-kometa with background=true, then
+//        polls /kometa-update-progress via pollKometaUpdateProgress
+//        on a setInterval. When the job completes, calls
+//        validateKometaRoot to re-verify the install.
+//
+// EXPORT:
+//
+//   callUpdateKometa()
+//     -- Returns undefined (fire-and-forget UI action).
+//        All observable outcomes are DOM writes, toasts, and state
+//        transitions handled internally.
+//
+// DOM ELEMENT DEPENDENCIES:
+//
+//   Looked up lazily on each call (not cached) so the module remains
+//   importable in test contexts where the DOM might be rebuilt
+//   between tests:
+//
+//     #update-kometa           -- main trigger button
+//     #force-update            -- checkbox (Force Update toggle)
+//     #kometa-branch-override  -- select (branch override dropdown)
+//     #kometa-validation-log   -- <pre> for status log
+//     #run-now, #stop-now      -- run controls
+//     #run-command-box         -- the wrapper that dims during update
+//     #kometa-update-box       -- rollup badge box (hidden on success)
+//     #kometa-update-box-note  -- inline update note (existing mode)
+//
+// PRESERVED QUIRK:
+//
+//   The original has a latent bug: it calls `logBox[0].scrollTop`
+//   in several places, guarded by `if (logBox[0])`. But logBox is a
+//   single Element, not a jQuery-style array -- so `logBox[0]` is
+//   always undefined and those scroll-to-bottom calls never run.
+//   One place uses `logBox.scrollTop = logBox.scrollHeight` correctly
+//   (in the setup block). Behavior-preserving extraction keeps both.
+//
+// GLOBALS:
+//
+//   showToast() is a global function from 000-base.js. Declared in
+//   eslint.config.js quickstartGlobals as readonly. Not imported
+//   because it isn't exported by any module.
+
+import { kometaState } from './_state.js'
+import {
+  getConfiguredKometaInstallMode,
+  getConfiguredKometaRootPosix
+} from './_runtime.js'
+import { getKometaBranchOverride } from './_kometaBranch.js'
+import {
+  setKometaUpdatePhaseBadge,
+  appendKometaStatusLine
+} from './_updatePhase.js'
+import {
+  syncKometaRollupBadge,
+  syncUpdateButtonLabel
+} from './_updateRollup.js'
+import { hideRunCommandSectionUntilValidated } from './_runCommandSection.js'
+import { syncFinalAccordionRollups } from './_headerBadges.js'
+import {
+  stopKometaUpdatePolling,
+  pollKometaUpdateProgress
+} from './_updatePolling.js'
+import { formatElapsed } from './_util.js'
+import { validateKometaRoot } from './_validateRoot.js'
+import { updateRunNowState } from './_runControls.js'
+import { runKometaStatusPass } from './_statusPass.js'
+
+/**
+ * Lazy DOM lookup helper. Returns the current live element (not a
+ * cached reference) so we play nicely with tests that swap the body.
+ */
+function el (id) {
+  return document.getElementById(id)
+}
+
+/**
+ * The 'existing' mode branch: user pointed Quickstart at their own
+ * Kometa install. Check for updates via runKometaStatusPass; show
+ * toast based on result. Do NOT actually apply anything (that's the
+ * user's job outside Quickstart).
+ */
+function handleExistingModeCheck () {
+  const btn = el('update-kometa')
+  btn.disabled = true
+  btn.innerHTML = '<i class="bi bi-arrow-repeat me-1"></i> Checking...'
+  runKometaStatusPass(true)
+    .then((data) => {
+      if (!data) return
+      if (data.kometa_update_available) {
+        showToast(
+          'warning',
+          `Kometa update available: ${data.local_version} \u2192 ${data.remote_version}. Update this existing install manually outside Quickstart.`
+        )
+        const noteEl = el('kometa-update-box-note')
+        if (noteEl) {
+          noteEl.textContent = 'Update this existing Kometa install manually outside Quickstart before running.'
+        }
+      } else if (!data.kometa_update_check_skipped) {
+        showToast('success', 'Existing Kometa install checked. No newer version was detected.')
+      }
+    })
+    .catch(() => {
+      showToast('error', 'Failed to check existing Kometa status.')
+    })
+    .finally(() => {
+      btn.disabled = false
+      syncUpdateButtonLabel()
+    })
+}
+
+/**
+ * The "already installed, no force, no known update" branch. Kometa
+ * is installed, user didn't tick force, we don't already know there's
+ * an update -- do a status-only pass, show a toast, no install work.
+ */
+function handleAlreadyInstalledNoForceCheck () {
+  const btn = el('update-kometa')
+  const forceUpdateToggle = el('force-update')
+  const kometaBranchOverrideSel = el('kometa-branch-override')
+  btn.disabled = true
+  btn.innerHTML = '<i class="bi bi-arrow-repeat me-1"></i> Checking...'
+  forceUpdateToggle.disabled = true
+  kometaBranchOverrideSel.disabled = true
+  runKometaStatusPass(true)
+    .then((data) => {
+      if (!data) return
+      if (data.kometa_update_available) {
+        showToast('warning', `Kometa update available: ${data.local_version} \u2192 ${data.remote_version}.`)
+      } else if (!data.kometa_update_check_skipped) {
+        showToast('success', 'Kometa is already up to date.')
+      }
+    })
+    .catch(() => {
+      showToast('error', 'Failed to check Kometa update status.')
+    })
+    .finally(() => {
+      btn.disabled = false
+      forceUpdateToggle.disabled = false
+      kometaBranchOverrideSel.disabled = false
+      syncUpdateButtonLabel()
+    })
+}
+
+/**
+ * Main entry. See module docstring for the five execution paths.
+ */
+export function callUpdateKometa () {
+  const installMode = getConfiguredKometaInstallMode()
+
+  // ---- Path 1: external mode ------------------------------------
+  if (installMode === 'external') {
+    showToast('info', 'External Kometa mode cannot update the runtime. Quickstart can only sync config and optional logs in this mode.')
+    return
+  }
+
+  // ---- Path 2: existing mode ------------------------------------
+  if (installMode === 'existing') {
+    handleExistingModeCheck()
+    return
+  }
+
+  // ---- Path 3: Kometa running -----------------------------------
+  if (kometaState.kometaStatus === 'running') {
+    showToast('info', 'Kometa is currently running; update skipped.')
+    return
+  }
+
+  // ---- Path 4: already installed, no force, no update needed ----
+  const btn = el('update-kometa')
+  const logBox = el('kometa-validation-log')
+  const runNow = el('run-now')
+  const stopNow = el('stop-now')
+  const runBox = el('run-command-box')
+  const forceUpdateToggle = el('force-update')
+  const kometaBranchOverrideSel = el('kometa-branch-override')
+  const qsBranch = btn.dataset.qsBranch || 'master'
+  const branchOverride = getKometaBranchOverride()
+  const configuredRootPosix = getConfiguredKometaRootPosix()
+  const configuredInstallMode = getConfiguredKometaInstallMode()
+  const forceUpdate = forceUpdateToggle.checked
+
+  if (kometaState.kometaInstalled && !forceUpdate && !kometaState.kometaUpdateAvailable) {
+    handleAlreadyInstalledNoForceCheck()
+    return
+  }
+
+  // ---- Path 5: THE FULL UPDATE PATH -----------------------------
+
+  // Flip state flags first so any concurrent status pass knows we
+  // own the badge / phase lifecycle from this point on.
+  kometaState.kometaUpdating = true
+  kometaState.kometaValidated = false
+  kometaState.kometaUpdateCheckSkipped = false
+  kometaState.kometaUpdateCheckCompleted = false
+  setKometaUpdatePhaseBadge('queued')
+  syncKometaRollupBadge()
+  hideRunCommandSectionUntilValidated()
+  syncFinalAccordionRollups()
+
+  // Snapshot run-now state so we can restore in cleanupUI. We want
+  // to restore, not force-reset, because if the user had a specific
+  // command queued we don't want to lose it silently.
+  const prevRunNowHtml = runNow.innerHTML
+  const prevRunNowDisabled = runNow.disabled
+
+  runBox.classList.add('opacity-50', 'position-relative')
+  runNow.disabled = true
+  runNow.innerHTML = '<i class="bi bi-hourglass me-1"></i> Updating...'
+  stopNow.disabled = true
+
+  const inProgressLabel = forceUpdate
+    ? (kometaState.kometaInstalled ? 'Force Updating...' : 'Force Installing...')
+    : (kometaState.kometaInstalled ? 'Checking for updates...' : 'Installing...')
+  btn.disabled = true
+  btn.innerHTML = `<i class="bi bi-arrow-repeat me-1"></i> ${inProgressLabel}`
+  forceUpdateToggle.disabled = true
+  kometaBranchOverrideSel.disabled = true
+
+  logBox.insertAdjacentHTML('beforeend', '\nInitializing/Updating Kometa...\n')
+  // This one actually works because logBox IS a single element, not
+  // an array. Compare with the .scrollTop calls below that guard on
+  // `logBox[0]` and therefore never actually scroll.
+  if (logBox) logBox.scrollTop = logBox.scrollHeight
+
+  // ---- Heartbeat toast (every 30s) ------------------------------
+  //
+  // The user should feel like something is happening even when the
+  // log is quiet (e.g. during ZIP download). Toast is fired once
+  // immediately, then every 30s until cleanup.
+  const startTs = Date.now()
+  showToast('info', 'Still working on Kometa... (0 seconds elapsed)', 10000)
+  const heartbeatId = setInterval(() => {
+    const secs = Math.floor((Date.now() - startTs) / 1000)
+    showToast('info', `Still working on Kometa... (${secs} seconds elapsed)`, 10000)
+  }, 30000)
+
+  // postUpdateLabel is set in the success handler and consumed by
+  // cleanupUI to briefly show a checkmark before the button resets.
+  let postUpdateLabel = null
+
+  const cleanupUI = () => {
+    clearInterval(heartbeatId)
+    stopKometaUpdatePolling()
+    kometaState.kometaUpdateJobId = null
+    kometaState.kometaUpdateLogIndex = 0
+    kometaState.kometaUpdating = false
+    runBox.classList.remove('opacity-50', 'position-relative')
+    runNow.disabled = prevRunNowDisabled
+    runNow.innerHTML = prevRunNowHtml
+    stopNow.disabled = false
+    btn.disabled = false
+    forceUpdateToggle.disabled = false
+    kometaBranchOverrideSel.disabled = false
+    syncUpdateButtonLabel()
+    updateRunNowState()
+    syncFinalAccordionRollups()
+    if (postUpdateLabel) {
+      btn.innerHTML = postUpdateLabel
+      // Reset the "success" label back to its dynamic form after 6s
+      // so a user glancing at the button later doesn't see a stale
+      // 'Up to date' badge.
+      setTimeout(syncUpdateButtonLabel, 6000)
+    }
+  }
+
+  // ---- The fetch pipeline ---------------------------------------
+  //
+  // Server semantics:
+  //   200 with { success: true, job_id }   -> background job started
+  //     -> poll via pollKometaUpdateProgress until done
+  //   200 with { success: true } (no job)  -> synchronous success
+  //   200 with { success: false }          -> synchronous failure
+  //   409                                   -> Kometa is running,
+  //                                            update blocked
+  //   other !ok                             -> throw
+
+  fetch('/update-kometa', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      branch: qsBranch,
+      branch_override: branchOverride,
+      path: configuredRootPosix,
+      install_mode: configuredInstallMode,
+      force: forceUpdate,
+      background: true
+    })
+  })
+    .then(async res => {
+      const data = await res.json()
+      if (res.status === 409) {
+        setKometaUpdatePhaseBadge('failed')
+        showToast('warning', data.error || 'Kometa is running; stop it before updating.')
+        logBox.insertAdjacentHTML('beforeend', `${data.error || 'Update blocked: Kometa running.'}\n`)
+        // Preserved bug: logBox[0] is undefined, so this never runs.
+        if (logBox[0]) logBox[0].scrollTop = logBox[0].scrollHeight
+        return { success: false, log: data.log || [], blocked: true }
+      }
+      if (!res.ok) {
+        throw new Error(data.error || 'Kometa update failed to start.')
+      }
+      return data
+    })
+    .then(data => {
+      if (!data) return
+
+      // ---- Background job path (has job_id) ----
+      if (data.success && data.job_id) {
+        kometaState.kometaUpdateJobId = data.job_id
+        kometaState.kometaUpdateLogIndex = 0
+        stopKometaUpdatePolling()
+
+        // finalize: called each time we get a progress update.
+        // Returns true when the job is done and we shouldn't schedule
+        // another poll; false when we need to keep polling.
+        const finalize = (progress) => {
+          if (!progress || !progress.done) return false
+          kometaState.kometaLocalCheckCompleted = false
+          kometaState.kometaUpdateAvailable = false
+          el('kometa-update-box').classList.add('d-none')
+          syncUpdateButtonLabel()
+          const elapsed = formatElapsed(Date.now() - startTs)
+          // Server may report success under 'update_success' (newer
+          // servers) or 'success' (older). Use nullish coalescing so
+          // 'update_success: false' takes precedence over 'success: true'.
+          const updateSucceeded = progress.update_success ?? progress.success
+          if (updateSucceeded) {
+            if (progress.up_to_date) {
+              showToast('info', 'Kometa is already up to date.')
+              postUpdateLabel = '<i class="bi bi-check-circle me-1"></i> Up to date'
+              appendKometaStatusLine('Kometa is already up to date.')
+              setKometaUpdatePhaseBadge('ready')
+            } else {
+              showToast('success', `Kometa update completed in ${elapsed}.`)
+              appendKometaStatusLine('Kometa update completed successfully.')
+              setKometaUpdatePhaseBadge('validating')
+            }
+            validateKometaRoot({ appendStatus: true })
+          } else {
+            showToast('error', 'Kometa update failed.')
+            appendKometaStatusLine('Kometa update failed.')
+            setKometaUpdatePhaseBadge('failed')
+            // We still validate on failure so the user sees WHY it
+            // failed (missing kometa.py, broken venv, etc.).
+            validateKometaRoot({ appendStatus: true })
+          }
+          cleanupUI()
+          syncKometaRollupBadge()
+          return true
+        }
+
+        // Do one immediate poll to catch super-fast completions,
+        // then schedule the recurring poll if we're not already done.
+        return pollKometaUpdateProgress()
+          .then(progress => {
+            if (finalize(progress)) return
+            kometaState.kometaUpdatePollInterval = setInterval(() => {
+              pollKometaUpdateProgress()
+                .then(finalize)
+                .catch(err => {
+                  console.error(err)
+                  appendKometaStatusLine(`\u274c ${err.message || 'Failed to fetch Kometa update progress.'}`)
+                  setKometaUpdatePhaseBadge('failed')
+                  stopKometaUpdatePolling()
+                  cleanupUI()
+                  syncKometaRollupBadge()
+                })
+            }, 800)
+          })
+      }
+
+      // ---- Synchronous success path (no job_id) ----
+      if (data.success) {
+        kometaState.kometaLocalCheckCompleted = false
+        kometaState.kometaUpdateAvailable = false
+        el('kometa-update-box').classList.add('d-none')
+        syncUpdateButtonLabel()
+        const elapsed = formatElapsed(Date.now() - startTs)
+        if (data.up_to_date) {
+          showToast('info', 'Kometa is already up to date.')
+          postUpdateLabel = '<i class="bi bi-check-circle me-1"></i> Up to date'
+          logBox.insertAdjacentHTML('beforeend', 'Kometa is already up to date.\n')
+        } else {
+          showToast('success', `Kometa update completed in ${elapsed}.`)
+          logBox.insertAdjacentHTML('beforeend', 'Kometa update completed successfully.\n')
+        }
+        // Preserved bug: logBox[0] is undefined; this never runs.
+        if (logBox[0]) logBox[0].scrollTop = logBox[0].scrollHeight
+        validateKometaRoot({ appendStatus: true })
+      } else if (!data.blocked) {
+        // Synchronous failure that wasn't already-handled 409.
+        showToast('error', data.error || 'Kometa update failed.')
+        logBox.insertAdjacentHTML('beforeend', 'Kometa update failed.\n')
+        validateKometaRoot({ appendStatus: true })
+        if (logBox[0]) logBox[0].scrollTop = logBox[0].scrollHeight
+      }
+    })
+    .catch(err => {
+      console.error(err)
+      showToast('error', 'Error during Kometa update.')
+      logBox.insertAdjacentHTML('beforeend', 'Error occurred during Kometa update.\n')
+      setKometaUpdatePhaseBadge('failed')
+      if (logBox[0]) logBox[0].scrollTop = logBox[0].scrollHeight
+      cleanupUI()
+      syncKometaRollupBadge()
+    })
+}

--- a/tests/js/kometa/kometaUpdate.test.js
+++ b/tests/js/kometa/kometaUpdate.test.js
@@ -1,0 +1,861 @@
+// Tests for static/local-js/modules/kometa/_kometaUpdate.js
+//
+// One export: callUpdateKometa().
+//
+// The boss. This function has FIVE distinct execution paths:
+//   1. External mode -> toast + bail
+//   2. Existing mode -> handleExistingModeCheck
+//   3. Kometa running -> toast + bail
+//   4. Already installed + no force + no update -> handleAlreadyInstalledNoForceCheck
+//   5. Full update path (the main event)
+//
+// COVERAGE STRATEGY:
+//
+//   Path 1-3 (short circuits):
+//     - external mode toast content
+//     - existing mode: check triggered, toast content varies by response
+//     - running mode: toast + bail
+//
+//   Path 4 (already-installed-no-force):
+//     - runKometaStatusPass called with true
+//     - buttons disabled during check, re-enabled in .finally
+//     - toast content varies by response
+//
+//   Path 5 (full update):
+//     - state flags flipped, phase 'queued', section hidden
+//     - button labels vary by (forceUpdate, installed) combination
+//     - fetch called with right body
+//     - heartbeat toast fires immediately + every 30s
+//     - 409 response: warning toast, phase 'failed', doesn't throw
+//     - success + job_id: kicks off polling
+//     - synchronous success with up_to_date: 'up to date' path
+//     - synchronous success without up_to_date: 'completed in Xs'
+//     - synchronous failure: error toast
+//     - fetch throws: catch handler
+//
+//   cleanupUI (indirectly via completion):
+//     - clears heartbeat, stops polling, resets buttons
+//     - postUpdateLabel sets button HTML + schedules reset
+//
+//   finalize (indirectly via completed job polling):
+//     - progress.done=false -> keep polling
+//     - progress.done=true + update_success -> success path
+//     - progress.done=true + up_to_date -> 'up to date' variant
+//     - progress.done=true + !update_success -> failure path
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../static/local-js/modules/kometa/_runtime.js', () => ({
+  getConfiguredKometaInstallMode: vi.fn(() => 'managed'),
+  getConfiguredKometaRootPosix: vi.fn(() => '/opt/kometa')
+}))
+vi.mock('../../../static/local-js/modules/kometa/_kometaBranch.js', () => ({
+  getKometaBranchOverride: vi.fn(() => '')
+}))
+vi.mock('../../../static/local-js/modules/kometa/_updatePhase.js', () => ({
+  setKometaUpdatePhaseBadge: vi.fn(),
+  appendKometaStatusLine: vi.fn()
+}))
+vi.mock('../../../static/local-js/modules/kometa/_updateRollup.js', () => ({
+  syncKometaRollupBadge: vi.fn(),
+  syncUpdateButtonLabel: vi.fn()
+}))
+vi.mock('../../../static/local-js/modules/kometa/_runCommandSection.js', () => ({
+  hideRunCommandSectionUntilValidated: vi.fn()
+}))
+vi.mock('../../../static/local-js/modules/kometa/_headerBadges.js', () => ({
+  syncFinalAccordionRollups: vi.fn()
+}))
+vi.mock('../../../static/local-js/modules/kometa/_updatePolling.js', () => ({
+  stopKometaUpdatePolling: vi.fn(),
+  pollKometaUpdateProgress: vi.fn()
+}))
+vi.mock('../../../static/local-js/modules/kometa/_util.js', () => ({
+  formatElapsed: vi.fn((ms) => `${Math.floor(ms / 1000)}s`)
+}))
+vi.mock('../../../static/local-js/modules/kometa/_validateRoot.js', () => ({
+  validateKometaRoot: vi.fn()
+}))
+vi.mock('../../../static/local-js/modules/kometa/_runControls.js', () => ({
+  updateRunNowState: vi.fn()
+}))
+vi.mock('../../../static/local-js/modules/kometa/_statusPass.js', () => ({
+  runKometaStatusPass: vi.fn()
+}))
+
+import { kometaState } from '../../../static/local-js/modules/kometa/_state.js'
+import { callUpdateKometa } from '../../../static/local-js/modules/kometa/_kometaUpdate.js'
+import {
+  getConfiguredKometaInstallMode,
+  getConfiguredKometaRootPosix
+} from '../../../static/local-js/modules/kometa/_runtime.js'
+import { getKometaBranchOverride } from '../../../static/local-js/modules/kometa/_kometaBranch.js'
+import {
+  setKometaUpdatePhaseBadge,
+  appendKometaStatusLine
+} from '../../../static/local-js/modules/kometa/_updatePhase.js'
+import {
+  syncKometaRollupBadge,
+  syncUpdateButtonLabel
+} from '../../../static/local-js/modules/kometa/_updateRollup.js'
+import { hideRunCommandSectionUntilValidated } from '../../../static/local-js/modules/kometa/_runCommandSection.js'
+import { syncFinalAccordionRollups } from '../../../static/local-js/modules/kometa/_headerBadges.js'
+import {
+  stopKometaUpdatePolling,
+  pollKometaUpdateProgress
+} from '../../../static/local-js/modules/kometa/_updatePolling.js'
+import { validateKometaRoot } from '../../../static/local-js/modules/kometa/_validateRoot.js'
+import { updateRunNowState } from '../../../static/local-js/modules/kometa/_runControls.js'
+import { runKometaStatusPass } from '../../../static/local-js/modules/kometa/_statusPass.js'
+
+// ---------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------
+
+let originalFetch
+let toastCalls
+
+function installFixture () {
+  document.body.innerHTML = `
+    <button id="update-kometa" data-qs-branch="master"></button>
+    <input id="force-update" type="checkbox">
+    <select id="kometa-branch-override"></select>
+    <pre id="kometa-validation-log"></pre>
+    <button id="run-now"></button>
+    <button id="stop-now"></button>
+    <div id="run-command-box"></div>
+    <div id="kometa-update-box"></div>
+    <div id="kometa-update-box-note"></div>
+  `
+}
+
+function mockFetchWith (response) {
+  global.fetch = vi.fn(() => Promise.resolve(response))
+}
+
+function okJson (body) {
+  return { ok: true, status: 200, json: () => Promise.resolve(body) }
+}
+
+function errJson (status, body) {
+  return { ok: false, status, json: () => Promise.resolve(body) }
+}
+
+function resetState () {
+  kometaState.kometaUpdating = false
+  kometaState.kometaValidated = false
+  kometaState.kometaInstalled = false
+  kometaState.kometaUpdateAvailable = false
+  kometaState.kometaStatus = 'idle'
+  kometaState.kometaUpdateCheckSkipped = false
+  kometaState.kometaUpdateCheckCompleted = false
+  kometaState.kometaUpdateJobId = null
+  kometaState.kometaUpdateLogIndex = 0
+  kometaState.kometaLocalCheckCompleted = false
+}
+
+beforeEach(() => {
+  getConfiguredKometaInstallMode.mockReset()
+  getConfiguredKometaInstallMode.mockReturnValue('managed')
+  getConfiguredKometaRootPosix.mockReset()
+  getConfiguredKometaRootPosix.mockReturnValue('/opt/kometa')
+  getKometaBranchOverride.mockReset()
+  getKometaBranchOverride.mockReturnValue('')
+  setKometaUpdatePhaseBadge.mockClear()
+  appendKometaStatusLine.mockClear()
+  syncKometaRollupBadge.mockClear()
+  syncUpdateButtonLabel.mockClear()
+  hideRunCommandSectionUntilValidated.mockClear()
+  syncFinalAccordionRollups.mockClear()
+  stopKometaUpdatePolling.mockClear()
+  pollKometaUpdateProgress.mockReset()
+  validateKometaRoot.mockClear()
+  updateRunNowState.mockClear()
+  runKometaStatusPass.mockReset()
+
+  // Track showToast calls -- it's a global, not an ESM import.
+  toastCalls = []
+  global.showToast = vi.fn((...args) => { toastCalls.push(args) })
+
+  originalFetch = global.fetch
+  resetState()
+})
+
+afterEach(() => {
+  global.fetch = originalFetch
+  delete global.showToast
+  document.body.innerHTML = ''
+  vi.useRealTimers()
+})
+
+// Yield to microtasks. Handy because callUpdateKometa returns
+// undefined (fire-and-forget) so we can't await it directly.
+const flush = () => new Promise(r => setTimeout(r, 10))
+
+// ---------------------------------------------------------------------
+// Path 1: External mode short-circuit
+// ---------------------------------------------------------------------
+
+describe('callUpdateKometa -- path 1: external mode', () => {
+  it("shows info toast and bails when install_mode is 'external'", async () => {
+    getConfiguredKometaInstallMode.mockReturnValue('external')
+    installFixture()
+    global.fetch = vi.fn()
+    callUpdateKometa()
+    expect(toastCalls[0][0]).toBe('info')
+    expect(toastCalls[0][1]).toContain('External Kometa mode cannot update')
+    expect(global.fetch).not.toHaveBeenCalled()
+    expect(runKometaStatusPass).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------
+// Path 2: Existing mode
+// ---------------------------------------------------------------------
+
+describe('callUpdateKometa -- path 2: existing mode', () => {
+  it('triggers runKometaStatusPass and disables button while checking', async () => {
+    getConfiguredKometaInstallMode.mockReturnValue('existing')
+    runKometaStatusPass.mockResolvedValue({ kometa_update_available: false })
+    installFixture()
+    callUpdateKometa()
+    // Button should be disabled synchronously
+    expect(document.getElementById('update-kometa').disabled).toBe(true)
+    expect(runKometaStatusPass).toHaveBeenCalledWith(true)
+    await flush()
+    // After completion, button re-enabled
+    expect(document.getElementById('update-kometa').disabled).toBe(false)
+  })
+
+  it("shows warning toast + updates note when existing update available", async () => {
+    getConfiguredKometaInstallMode.mockReturnValue('existing')
+    runKometaStatusPass.mockResolvedValue({
+      kometa_update_available: true,
+      local_version: 'v1.0',
+      remote_version: 'v2.0'
+    })
+    installFixture()
+    callUpdateKometa()
+    await flush()
+    expect(toastCalls.some(c => c[0] === 'warning' && c[1].includes('v1.0') && c[1].includes('v2.0'))).toBe(true)
+    expect(document.getElementById('kometa-update-box-note').textContent).toContain('Update this existing Kometa install manually')
+  })
+
+  it("shows success toast when existing install already up to date", async () => {
+    getConfiguredKometaInstallMode.mockReturnValue('existing')
+    runKometaStatusPass.mockResolvedValue({
+      kometa_update_available: false,
+      kometa_update_check_skipped: false
+    })
+    installFixture()
+    callUpdateKometa()
+    await flush()
+    expect(toastCalls.some(c => c[0] === 'success' && c[1].includes('No newer version'))).toBe(true)
+  })
+
+  it("does NOT toast when check was skipped", async () => {
+    getConfiguredKometaInstallMode.mockReturnValue('existing')
+    runKometaStatusPass.mockResolvedValue({
+      kometa_update_available: false,
+      kometa_update_check_skipped: true
+    })
+    installFixture()
+    callUpdateKometa()
+    await flush()
+    expect(toastCalls.some(c => c[0] === 'success')).toBe(false)
+  })
+
+  it("shows error toast when runKometaStatusPass rejects", async () => {
+    getConfiguredKometaInstallMode.mockReturnValue('existing')
+    runKometaStatusPass.mockRejectedValue(new Error('nope'))
+    installFixture()
+    callUpdateKometa()
+    await flush()
+    expect(toastCalls.some(c => c[0] === 'error' && c[1].includes('Failed to check'))).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// Path 3: Kometa running
+// ---------------------------------------------------------------------
+
+describe('callUpdateKometa -- path 3: Kometa running', () => {
+  it("shows info toast and bails when kometaStatus is 'running'", async () => {
+    kometaState.kometaStatus = 'running'
+    installFixture()
+    global.fetch = vi.fn()
+    callUpdateKometa()
+    expect(toastCalls[0][0]).toBe('info')
+    expect(toastCalls[0][1]).toContain('Kometa is currently running')
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------
+// Path 4: Already-installed-no-force
+// ---------------------------------------------------------------------
+
+describe('callUpdateKometa -- path 4: already installed, no force, no update', () => {
+  it("triggers status check + disables all controls", () => {
+    kometaState.kometaInstalled = true
+    kometaState.kometaUpdateAvailable = false
+    installFixture()
+    document.getElementById('force-update').checked = false
+    runKometaStatusPass.mockResolvedValue({})
+    callUpdateKometa()
+    expect(document.getElementById('update-kometa').disabled).toBe(true)
+    expect(document.getElementById('force-update').disabled).toBe(true)
+    expect(document.getElementById('kometa-branch-override').disabled).toBe(true)
+    expect(runKometaStatusPass).toHaveBeenCalledWith(true)
+  })
+
+  it("re-enables controls in .finally", async () => {
+    kometaState.kometaInstalled = true
+    installFixture()
+    document.getElementById('force-update').checked = false
+    runKometaStatusPass.mockResolvedValue({})
+    callUpdateKometa()
+    await flush()
+    expect(document.getElementById('update-kometa').disabled).toBe(false)
+    expect(document.getElementById('force-update').disabled).toBe(false)
+    expect(document.getElementById('kometa-branch-override').disabled).toBe(false)
+  })
+
+  it("shows 'update available' toast", async () => {
+    kometaState.kometaInstalled = true
+    installFixture()
+    document.getElementById('force-update').checked = false
+    runKometaStatusPass.mockResolvedValue({
+      kometa_update_available: true,
+      local_version: 'v1.0',
+      remote_version: 'v2.0'
+    })
+    callUpdateKometa()
+    await flush()
+    expect(toastCalls.some(c => c[0] === 'warning' && c[1].includes('v1.0'))).toBe(true)
+  })
+
+  it("shows 'already up to date' toast", async () => {
+    kometaState.kometaInstalled = true
+    installFixture()
+    document.getElementById('force-update').checked = false
+    runKometaStatusPass.mockResolvedValue({
+      kometa_update_available: false,
+      kometa_update_check_skipped: false
+    })
+    callUpdateKometa()
+    await flush()
+    expect(toastCalls.some(c => c[0] === 'success' && c[1].includes('already up to date'))).toBe(true)
+  })
+
+  it("shows error toast when status pass rejects", async () => {
+    kometaState.kometaInstalled = true
+    installFixture()
+    document.getElementById('force-update').checked = false
+    runKometaStatusPass.mockRejectedValue(new Error('nope'))
+    callUpdateKometa()
+    await flush()
+    expect(toastCalls.some(c => c[0] === 'error' && c[1].includes('Failed to check Kometa update'))).toBe(true)
+  })
+
+  it("skips path 4 when forceUpdate is checked (falls through to path 5)", async () => {
+    kometaState.kometaInstalled = true
+    installFixture()
+    document.getElementById('force-update').checked = true  // force!
+    mockFetchWith(okJson({ success: true, up_to_date: false }))
+    callUpdateKometa()
+    // Path 5 flipped kometaUpdating
+    expect(kometaState.kometaUpdating).toBe(true)
+    // fetch was called (path 5) rather than just runKometaStatusPass
+    expect(global.fetch).toHaveBeenCalled()
+    await flush()
+  })
+
+  it("skips path 4 when kometaUpdateAvailable=true", async () => {
+    kometaState.kometaInstalled = true
+    kometaState.kometaUpdateAvailable = true
+    installFixture()
+    document.getElementById('force-update').checked = false
+    mockFetchWith(okJson({ success: true }))
+    callUpdateKometa()
+    expect(kometaState.kometaUpdating).toBe(true)
+    await flush()
+  })
+})
+
+// ---------------------------------------------------------------------
+// Path 5: Full update -- setup
+// ---------------------------------------------------------------------
+
+describe('callUpdateKometa -- path 5: full update setup', () => {
+  it("flips state flags + phase 'queued' + hides section", () => {
+    installFixture()
+    mockFetchWith(okJson({ success: true }))
+    callUpdateKometa()
+    expect(kometaState.kometaUpdating).toBe(true)
+    expect(kometaState.kometaValidated).toBe(false)
+    expect(kometaState.kometaUpdateCheckSkipped).toBe(false)
+    expect(kometaState.kometaUpdateCheckCompleted).toBe(false)
+    expect(setKometaUpdatePhaseBadge).toHaveBeenCalledWith('queued')
+    expect(hideRunCommandSectionUntilValidated).toHaveBeenCalled()
+  })
+
+  it("disables buttons and updates run/stop/main labels", () => {
+    installFixture()
+    mockFetchWith(okJson({ success: true }))
+    callUpdateKometa()
+    expect(document.getElementById('run-now').disabled).toBe(true)
+    expect(document.getElementById('run-now').innerHTML).toContain('Updating')
+    expect(document.getElementById('stop-now').disabled).toBe(true)
+    expect(document.getElementById('update-kometa').disabled).toBe(true)
+    expect(document.getElementById('force-update').disabled).toBe(true)
+    expect(document.getElementById('kometa-branch-override').disabled).toBe(true)
+  })
+
+  it("main button label: 'Installing...' when not installed + not forced", () => {
+    kometaState.kometaInstalled = false
+    installFixture()
+    document.getElementById('force-update').checked = false
+    mockFetchWith(okJson({ success: true }))
+    callUpdateKometa()
+    expect(document.getElementById('update-kometa').innerHTML).toContain('Installing...')
+  })
+
+  it("main button label: 'Checking for updates...' when installed + not forced", () => {
+    kometaState.kometaInstalled = true
+    kometaState.kometaUpdateAvailable = true  // skip path 4
+    installFixture()
+    document.getElementById('force-update').checked = false
+    mockFetchWith(okJson({ success: true }))
+    callUpdateKometa()
+    expect(document.getElementById('update-kometa').innerHTML).toContain('Checking for updates...')
+  })
+
+  it("main button label: 'Force Installing...' when not installed + forced", () => {
+    kometaState.kometaInstalled = false
+    installFixture()
+    document.getElementById('force-update').checked = true
+    mockFetchWith(okJson({ success: true }))
+    callUpdateKometa()
+    expect(document.getElementById('update-kometa').innerHTML).toContain('Force Installing...')
+  })
+
+  it("main button label: 'Force Updating...' when installed + forced", () => {
+    kometaState.kometaInstalled = true
+    installFixture()
+    document.getElementById('force-update').checked = true
+    mockFetchWith(okJson({ success: true }))
+    callUpdateKometa()
+    expect(document.getElementById('update-kometa').innerHTML).toContain('Force Updating...')
+  })
+
+  it("appends 'Initializing/Updating' line + scrolls to bottom", () => {
+    installFixture()
+    mockFetchWith(okJson({ success: true }))
+    callUpdateKometa()
+    expect(document.getElementById('kometa-validation-log').textContent).toContain('Initializing/Updating Kometa')
+  })
+
+  it("fetches /update-kometa with right body", async () => {
+    installFixture()
+    document.getElementById('update-kometa').dataset.qsBranch = 'develop'
+    document.getElementById('force-update').checked = true
+    getKometaBranchOverride.mockReturnValue('feature-xyz')
+    getConfiguredKometaRootPosix.mockReturnValue('/srv/kometa')
+    getConfiguredKometaInstallMode.mockReturnValue('managed')
+    mockFetchWith(okJson({ success: true }))
+    callUpdateKometa()
+    expect(global.fetch).toHaveBeenCalledWith('/update-kometa', expect.objectContaining({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }
+    }))
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body)
+    expect(body).toEqual({
+      branch: 'develop',
+      branch_override: 'feature-xyz',
+      path: '/srv/kometa',
+      install_mode: 'managed',
+      force: true,
+      background: true
+    })
+    await flush()
+  })
+
+  it("shows initial heartbeat toast immediately", () => {
+    installFixture()
+    mockFetchWith(okJson({ success: true }))
+    callUpdateKometa()
+    expect(toastCalls.some(c => c[0] === 'info' && c[1].includes('Still working on Kometa'))).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// Path 5: Heartbeat interval
+// ---------------------------------------------------------------------
+
+describe('callUpdateKometa -- heartbeat toast', () => {
+  it("fires additional heartbeat toasts every 30 seconds", async () => {
+    vi.useFakeTimers()
+    installFixture()
+    // Never-resolving fetch so cleanup doesn't fire during our tick
+    global.fetch = vi.fn(() => new Promise(() => {}))
+    callUpdateKometa()
+    const startCount = toastCalls.filter(c => c[1].includes('Still working')).length
+    expect(startCount).toBe(1)  // initial
+    vi.advanceTimersByTime(30000)
+    expect(toastCalls.filter(c => c[1].includes('Still working')).length).toBe(2)
+    vi.advanceTimersByTime(30000)
+    expect(toastCalls.filter(c => c[1].includes('Still working')).length).toBe(3)
+  })
+})
+
+// ---------------------------------------------------------------------
+// Path 5: 409 response
+// ---------------------------------------------------------------------
+
+describe('callUpdateKometa -- 409 response (Kometa running)', () => {
+  it("shows warning + phase 'failed' + doesn't throw", async () => {
+    installFixture()
+    mockFetchWith(errJson(409, { error: 'Kometa is running' }))
+    callUpdateKometa()
+    await flush()
+    expect(toastCalls.some(c => c[0] === 'warning' && c[1].includes('Kometa is running'))).toBe(true)
+    expect(setKometaUpdatePhaseBadge).toHaveBeenCalledWith('failed')
+    // .blocked path -- so should NOT trigger the else-branch's error toast
+    expect(toastCalls.some(c => c[0] === 'error' && c[1].includes('failed'))).toBe(false)
+  })
+
+  it("uses default message when 409 has no error field", async () => {
+    installFixture()
+    mockFetchWith(errJson(409, {}))
+    callUpdateKometa()
+    await flush()
+    expect(toastCalls.some(c => c[0] === 'warning' && c[1].includes('Kometa is running'))).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// Path 5: Synchronous success (no job_id)
+// ---------------------------------------------------------------------
+
+describe('callUpdateKometa -- synchronous success', () => {
+  it("shows 'up to date' info when up_to_date=true", async () => {
+    // NOTE: original code has a latent bug in the sync-success path
+    // (no job_id) -- it sets `postUpdateLabel` but NEVER calls
+    // cleanupUI. In production the server always returns job_id, so
+    // this path is effectively dead. We test what the original does:
+    // toast + validateKometaRoot call. The button label doesn't get
+    // the 'Up to date' text because that only happens inside cleanupUI.
+    installFixture()
+    mockFetchWith(okJson({ success: true, up_to_date: true }))
+    callUpdateKometa()
+    await flush()
+    expect(toastCalls.some(c => c[0] === 'info' && c[1].includes('already up to date'))).toBe(true)
+  })
+
+  it("shows success 'completed' when up_to_date=false", async () => {
+    installFixture()
+    mockFetchWith(okJson({ success: true, up_to_date: false }))
+    callUpdateKometa()
+    await flush()
+    expect(toastCalls.some(c => c[0] === 'success' && c[1].includes('completed'))).toBe(true)
+  })
+
+  it("hides kometa-update-box + clears updateAvailable", async () => {
+    installFixture()
+    kometaState.kometaUpdateAvailable = true
+    mockFetchWith(okJson({ success: true }))
+    callUpdateKometa()
+    await flush()
+    expect(document.getElementById('kometa-update-box').classList.contains('d-none')).toBe(true)
+    expect(kometaState.kometaUpdateAvailable).toBe(false)
+  })
+
+  it("calls validateKometaRoot with appendStatus=true", async () => {
+    installFixture()
+    mockFetchWith(okJson({ success: true }))
+    callUpdateKometa()
+    await flush()
+    expect(validateKometaRoot).toHaveBeenCalledWith({ appendStatus: true })
+  })
+})
+
+// ---------------------------------------------------------------------
+// Path 5: Synchronous failure
+// ---------------------------------------------------------------------
+
+describe('callUpdateKometa -- synchronous failure', () => {
+  it("shows error toast when success=false and NOT blocked", async () => {
+    installFixture()
+    mockFetchWith(okJson({ success: false, error: 'boom' }))
+    callUpdateKometa()
+    await flush()
+    expect(toastCalls.some(c => c[0] === 'error' && c[1].includes('boom'))).toBe(true)
+    expect(validateKometaRoot).toHaveBeenCalledWith({ appendStatus: true })
+  })
+
+  it("uses default message when no error field", async () => {
+    installFixture()
+    mockFetchWith(okJson({ success: false }))
+    callUpdateKometa()
+    await flush()
+    expect(toastCalls.some(c => c[0] === 'error' && c[1].includes('Kometa update failed'))).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// Path 5: Fetch reject (network error)
+// ---------------------------------------------------------------------
+
+describe('callUpdateKometa -- fetch reject', () => {
+  it("shows error toast + phase 'failed' + cleans up", async () => {
+    installFixture()
+    global.fetch = vi.fn(() => Promise.reject(new Error('network down')))
+    // Silence expected console.error from the catch handler
+    const originalErr = console.error
+    console.error = vi.fn()
+    callUpdateKometa()
+    await flush()
+    console.error = originalErr
+    expect(toastCalls.some(c => c[0] === 'error' && c[1].includes('Error during Kometa update'))).toBe(true)
+    expect(setKometaUpdatePhaseBadge).toHaveBeenCalledWith('failed')
+    // Cleanup: state flag flipped back
+    expect(kometaState.kometaUpdating).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------
+// Path 5: Background job polling
+// ---------------------------------------------------------------------
+
+describe('callUpdateKometa -- background job polling', () => {
+  it("stores job_id and calls pollKometaUpdateProgress", async () => {
+    installFixture()
+    mockFetchWith(okJson({ success: true, job_id: 'JOB-123' }))
+    pollKometaUpdateProgress.mockResolvedValue({ done: false })
+    callUpdateKometa()
+    await flush()
+    expect(kometaState.kometaUpdateJobId).toBe('JOB-123')
+    expect(pollKometaUpdateProgress).toHaveBeenCalled()
+    expect(stopKometaUpdatePolling).toHaveBeenCalled()  // called before setting new interval
+  })
+
+  it("finalize immediately on done=true + update_success=true + up_to_date=true", async () => {
+    installFixture()
+    mockFetchWith(okJson({ success: true, job_id: 'JOB-1' }))
+    pollKometaUpdateProgress.mockResolvedValue({
+      done: true,
+      update_success: true,
+      up_to_date: true
+    })
+    callUpdateKometa()
+    await flush()
+    expect(toastCalls.some(c => c[0] === 'info' && c[1].includes('already up to date'))).toBe(true)
+    expect(setKometaUpdatePhaseBadge).toHaveBeenCalledWith('ready')
+    expect(appendKometaStatusLine).toHaveBeenCalledWith('Kometa is already up to date.')
+    expect(validateKometaRoot).toHaveBeenCalledWith({ appendStatus: true })
+  })
+
+  it("finalize on done=true + update_success=true (update, not up-to-date)", async () => {
+    installFixture()
+    mockFetchWith(okJson({ success: true, job_id: 'JOB-2' }))
+    pollKometaUpdateProgress.mockResolvedValue({
+      done: true,
+      update_success: true,
+      up_to_date: false
+    })
+    callUpdateKometa()
+    await flush()
+    expect(toastCalls.some(c => c[0] === 'success' && c[1].includes('completed'))).toBe(true)
+    expect(setKometaUpdatePhaseBadge).toHaveBeenCalledWith('validating')
+    expect(appendKometaStatusLine).toHaveBeenCalledWith('Kometa update completed successfully.')
+  })
+
+  it("finalize on done=true + update_success=false (failure)", async () => {
+    installFixture()
+    mockFetchWith(okJson({ success: true, job_id: 'JOB-3' }))
+    pollKometaUpdateProgress.mockResolvedValue({
+      done: true,
+      update_success: false
+    })
+    callUpdateKometa()
+    await flush()
+    expect(toastCalls.some(c => c[0] === 'error' && c[1].includes('Kometa update failed'))).toBe(true)
+    expect(setKometaUpdatePhaseBadge).toHaveBeenCalledWith('failed')
+    expect(validateKometaRoot).toHaveBeenCalledWith({ appendStatus: true })
+  })
+
+  it("prefers 'update_success' over 'success' when both present", async () => {
+    // Old servers used 'success', new servers use 'update_success'.
+    // If both present, update_success wins via ?? coalescing.
+    installFixture()
+    mockFetchWith(okJson({ success: true, job_id: 'JOB-4' }))
+    pollKometaUpdateProgress.mockResolvedValue({
+      done: true,
+      update_success: false,   // authoritative
+      success: true            // legacy
+    })
+    callUpdateKometa()
+    await flush()
+    expect(toastCalls.some(c => c[0] === 'error')).toBe(true)  // failure path
+  })
+
+  it("falls back to 'success' when 'update_success' is undefined", async () => {
+    installFixture()
+    mockFetchWith(okJson({ success: true, job_id: 'JOB-5' }))
+    pollKometaUpdateProgress.mockResolvedValue({
+      done: true,
+      // no update_success
+      success: true
+    })
+    callUpdateKometa()
+    await flush()
+    // Success path taken
+    expect(setKometaUpdatePhaseBadge).toHaveBeenCalledWith('validating')
+  })
+
+  it("schedules setInterval polling when initial poll returns done=false", async () => {
+    vi.useFakeTimers()
+    installFixture()
+    mockFetchWith(okJson({ success: true, job_id: 'JOB-6' }))
+    pollKometaUpdateProgress.mockResolvedValue({ done: false })
+    callUpdateKometa()
+    // Flush initial poll -- can't use flush() with fake timers
+    await vi.advanceTimersByTimeAsync(0)
+    await Promise.resolve()
+    // Now setInterval should be scheduled at 800ms
+    expect(kometaState.kometaUpdatePollInterval).toBeTruthy()
+  })
+
+  it("handles polling error via catch (phase 'failed', cleanup)", async () => {
+    vi.useFakeTimers()
+    installFixture()
+    mockFetchWith(okJson({ success: true, job_id: 'JOB-7' }))
+    // First poll succeeds with done=false to trigger interval
+    pollKometaUpdateProgress
+      .mockResolvedValueOnce({ done: false })
+      // Second poll (via interval) rejects
+      .mockRejectedValueOnce(new Error('poll fail'))
+    // Silence console.error for this test only
+    const originalErr = console.error
+    console.error = vi.fn()
+    callUpdateKometa()
+    await vi.advanceTimersByTimeAsync(0)
+    await Promise.resolve()
+    // Trigger the interval poll
+    await vi.advanceTimersByTimeAsync(800)
+    await Promise.resolve()
+    await Promise.resolve()
+    console.error = originalErr
+    // Cleanup ran
+    expect(kometaState.kometaUpdating).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------
+// cleanupUI (via job_id + done=true completion)
+// ---------------------------------------------------------------------
+//
+// IMPORTANT: cleanupUI is only invoked via the background-job path
+// (fetch returns job_id, then poll returns done=true) OR the fetch
+// catch handler. The synchronous-success path in the original code
+// SETS postUpdateLabel but never calls cleanupUI -- a latent bug we
+// preserve. All cleanup tests go through the job_id + done=true path.
+
+describe('callUpdateKometa -- cleanupUI', () => {
+  it("clears state flags + re-enables buttons on completion", async () => {
+    installFixture()
+    mockFetchWith(okJson({ success: true, job_id: 'JOB-C1' }))
+    pollKometaUpdateProgress.mockResolvedValue({
+      done: true,
+      update_success: true,
+      up_to_date: true
+    })
+    callUpdateKometa()
+    await flush()
+    expect(kometaState.kometaUpdating).toBe(false)
+    expect(kometaState.kometaUpdateJobId).toBeNull()
+    expect(document.getElementById('run-now').disabled).toBe(false)
+    expect(document.getElementById('stop-now').disabled).toBe(false)
+    expect(document.getElementById('update-kometa').disabled).toBe(false)
+    expect(document.getElementById('force-update').disabled).toBe(false)
+    expect(document.getElementById('kometa-branch-override').disabled).toBe(false)
+  })
+
+  it("restores run-now's previous HTML + disabled state", async () => {
+    installFixture()
+    const runNow = document.getElementById('run-now')
+    runNow.innerHTML = '<i>Original Label</i>'
+    runNow.disabled = false
+    mockFetchWith(okJson({ success: true, job_id: 'JOB-C2' }))
+    pollKometaUpdateProgress.mockResolvedValue({
+      done: true,
+      update_success: true
+    })
+    callUpdateKometa()
+    // Snapshot taken; button now shows "Updating..."
+    expect(runNow.innerHTML).toContain('Updating')
+    await flush()
+    // Restored
+    expect(runNow.innerHTML).toBe('<i>Original Label</i>')
+    expect(runNow.disabled).toBe(false)
+  })
+
+  it("sets postUpdateLabel on 'up to date' branch and schedules reset via setTimeout", async () => {
+    vi.useFakeTimers()
+    installFixture()
+    mockFetchWith(okJson({ success: true, job_id: 'JOB-C3' }))
+    pollKometaUpdateProgress.mockResolvedValue({
+      done: true,
+      update_success: true,
+      up_to_date: true
+    })
+    callUpdateKometa()
+    // Advance microtasks for fetch chain
+    await vi.advanceTimersByTimeAsync(0)
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(document.getElementById('update-kometa').innerHTML).toContain('Up to date')
+    // The setTimeout to reset button label is scheduled at 6000ms
+    syncUpdateButtonLabel.mockClear()
+    await vi.advanceTimersByTimeAsync(6000)
+    expect(syncUpdateButtonLabel).toHaveBeenCalled()
+  })
+
+  it("calls updateRunNowState + syncFinalAccordionRollups in cleanup", async () => {
+    installFixture()
+    mockFetchWith(okJson({ success: true, job_id: 'JOB-C4' }))
+    pollKometaUpdateProgress.mockResolvedValue({
+      done: true,
+      update_success: true
+    })
+    callUpdateKometa()
+    await flush()
+    expect(updateRunNowState).toHaveBeenCalled()
+    // syncFinalAccordionRollups is called at least twice: once during
+    // setup, once during cleanup.
+    expect(syncFinalAccordionRollups.mock.calls.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it("stops the heartbeat interval on cleanup", async () => {
+    vi.useFakeTimers()
+    installFixture()
+    mockFetchWith(okJson({ success: true, job_id: 'JOB-C5' }))
+    pollKometaUpdateProgress.mockResolvedValue({
+      done: true,
+      update_success: true
+    })
+    callUpdateKometa()
+    // Flush the fetch + poll chain
+    await vi.advanceTimersByTimeAsync(0)
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+    // Heartbeat should now be cleared. Advancing 60s shouldn't add new toasts.
+    const before = toastCalls.filter(c => c[1].includes('Still working')).length
+    await vi.advanceTimersByTimeAsync(60000)
+    const after = toastCalls.filter(c => c[1].includes('Still working')).length
+    expect(after).toBe(before)
+  })
+})


### PR DESCRIPTION
## THE BOSS FIGHT

Extracts the ~230-line `callUpdateKometa` function — the main 'update Kometa' entry point. This has **FIVE distinct execution paths** and is the biggest, most complex extraction in the whole split.

`900-kometa.js`: 2208 -> 1966 lines (**-242**). **BELOW 2000!**
Vitest tests: 1249 -> 1295 (**+46**).

## What moved

Extracted to `static/local-js/modules/kometa/_kometaUpdate.js` (434 lines):

- `callUpdateKometa()` — main entry with 5 execution paths
- `handleExistingModeCheck()` — existing-mode branch (helper, ~25 lines)
- `handleAlreadyInstalledNoForceCheck()` — skip branch (helper, ~20 lines)

## The 5 paths

1. **External mode** → toast + bail
2. **Existing mode** → `handleExistingModeCheck` (status check, no install)
3. **Kometa running** → toast + bail
4. **Installed + no force + no update** → `handleAlreadyInstalledNoForceCheck` (status check)
5. **Full update path** → flip state, disable buttons, POST `/update-kometa`, poll job progress, validate on completion

## Design decisions

1. **Extracted 2 helper functions** from the original monolith to keep main body readable and provide natural test seams
2. **`el()` lazy DOM lookup helper** — original cached refs at module load; extracted uses on-demand for test-fixture friendliness
3. **`showToast` as global** — declared in `eslint.config.js` `quickstartGlobals`, not exported by any module
4. **`formatElapsed` imported from `_util.js`** where it already lives

## Preserved quirks (documented in module docstring)

1. **LATENT BUG**: `logBox[0].scrollTop` calls guarded by `if (logBox[0])` never actually scroll — `logBox` is a single Element, not a jQuery-style array. `logBox[0]` is always undefined. Preserved as-is; a future cleanup PR can remove.
2. **DEAD SYNC-SUCCESS PATH**: When server returns `{ success: true }` without `job_id`, we set `postUpdateLabel` but NEVER call `cleanupUI`. In production the server always returns `job_id`. Preserved with docstring note.
3. **`update_success ?? success`**: newer servers use `progress.update_success`, older use `progress.success`. Nullish coalescing makes new field authoritative.

## Removed 6 orphaned imports from 900-kometa.js

- `formatElapsed` (from `_util.js`)
- `getConfiguredKometaInstallMode`, `getConfiguredKometaRootPosix` (from `_runtime.js`)
- `getKometaBranchOverride` (from `_kometaBranch.js`)
- `stopKometaUpdatePolling`, `pollKometaUpdateProgress` (from `_updatePolling.js`) — entire block

## Test coverage: 46 new tests

Systematic coverage of every branch:

- **Path 1** external mode (1)
- **Path 2** existing mode (5)
- **Path 3** running (1)
- **Path 4** already-installed-no-force (6)
- **Path 5 setup** (8): state flags, buttons, 4 label combos, log line, fetch body, initial heartbeat
- **Heartbeat interval** (1): fake timers, 30s cadence verified
- **409 response** (2)
- **Sync success** (4)
- **Sync failure** (2)
- **Fetch reject** (1)
- **Background job polling** (8): 4 done-branches, both fallback flags, setInterval scheduled, poll error catch
- **cleanupUI via job_id** (5): state cleared, run-now restored, postUpdateLabel + setTimeout, updateRunNowState call, heartbeat cleared

All 15 collaborators mocked with `vi.mock()`. `showToast` tracked via `toastCalls` array. Fake timers used for heartbeat + polling interval + `setTimeout` tests.

## Verification

- **1295/1295 Vitest pass** (was 1249; +46 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- ESLint clean, Node syntax clean

## MILESTONE

**`900-kometa.js` was 3822 lines at the start of this refactor.** Now **1966**. Cumulative cut: **-1856 lines (48.6%)**. Vitest test count has more than doubled: 611 -> 1295 (**+112.0%**).