### PR TITLE
Cleanup: remove dead sync-success path and fix logBox[0] scroll bugs

### DIFF
--- a/static/local-js/modules/kometa/_kometaUpdate.js
+++ b/static/local-js/modules/kometa/_kometaUpdate.js
@@ -52,15 +52,6 @@
 //     #kometa-update-box       -- rollup badge box (hidden on success)
 //     #kometa-update-box-note  -- inline update note (existing mode)
 //
-// PRESERVED QUIRK:
-//
-//   The original has a latent bug: it calls `logBox[0].scrollTop`
-//   in several places, guarded by `if (logBox[0])`. But logBox is a
-//   single Element, not a jQuery-style array -- so `logBox[0]` is
-//   always undefined and those scroll-to-bottom calls never run.
-//   One place uses `logBox.scrollTop = logBox.scrollHeight` correctly
-//   (in the setup block). Behavior-preserving extraction keeps both.
-//
 // GLOBALS:
 //
 //   showToast() is a global function from 000-base.js. Declared in
@@ -244,9 +235,6 @@ export function callUpdateKometa () {
   kometaBranchOverrideSel.disabled = true
 
   logBox.insertAdjacentHTML('beforeend', '\nInitializing/Updating Kometa...\n')
-  // This one actually works because logBox IS a single element, not
-  // an array. Compare with the .scrollTop calls below that guard on
-  // `logBox[0]` and therefore never actually scroll.
   if (logBox) logBox.scrollTop = logBox.scrollHeight
 
   // ---- Heartbeat toast (every 30s) ------------------------------
@@ -319,8 +307,7 @@ export function callUpdateKometa () {
         setKometaUpdatePhaseBadge('failed')
         showToast('warning', data.error || 'Kometa is running; stop it before updating.')
         logBox.insertAdjacentHTML('beforeend', `${data.error || 'Update blocked: Kometa running.'}\n`)
-        // Preserved bug: logBox[0] is undefined, so this never runs.
-        if (logBox[0]) logBox[0].scrollTop = logBox[0].scrollHeight
+        logBox.scrollTop = logBox.scrollHeight
         return { success: false, log: data.log || [], blocked: true }
       }
       if (!res.ok) {
@@ -396,38 +383,28 @@ export function callUpdateKometa () {
           })
       }
 
-      // ---- Synchronous success path (no job_id) ----
-      if (data.success) {
-        kometaState.kometaLocalCheckCompleted = false
-        kometaState.kometaUpdateAvailable = false
-        el('kometa-update-box').classList.add('d-none')
-        syncUpdateButtonLabel()
-        const elapsed = formatElapsed(Date.now() - startTs)
-        if (data.up_to_date) {
-          showToast('info', 'Kometa is already up to date.')
-          postUpdateLabel = '<i class="bi bi-check-circle me-1"></i> Up to date'
-          logBox.insertAdjacentHTML('beforeend', 'Kometa is already up to date.\n')
-        } else {
-          showToast('success', `Kometa update completed in ${elapsed}.`)
-          logBox.insertAdjacentHTML('beforeend', 'Kometa update completed successfully.\n')
-        }
-        // Preserved bug: logBox[0] is undefined; this never runs.
-        if (logBox[0]) logBox[0].scrollTop = logBox[0].scrollHeight
-        validateKometaRoot({ appendStatus: true })
-      } else if (!data.blocked) {
-        // Synchronous failure that wasn't already-handled 409.
+      // ---- Synchronous failure path (success=false, not 409) ----
+      //
+      // NOTE: since we always send background=true, the endpoint's
+      // success path always includes a job_id and goes through the
+      // 'success && job_id' branch above. The `else if` here fires
+      // ONLY when data.success is false AND data.blocked isn't set --
+      // i.e. the server returned 200 with success=false (which the
+      // current endpoint doesn't do). Kept as a defensive fallback
+      // for future endpoint changes.
+      if (!data.success && !data.blocked) {
         showToast('error', data.error || 'Kometa update failed.')
         logBox.insertAdjacentHTML('beforeend', 'Kometa update failed.\n')
+        logBox.scrollTop = logBox.scrollHeight
         validateKometaRoot({ appendStatus: true })
-        if (logBox[0]) logBox[0].scrollTop = logBox[0].scrollHeight
       }
     })
     .catch(err => {
       console.error(err)
       showToast('error', 'Error during Kometa update.')
       logBox.insertAdjacentHTML('beforeend', 'Error occurred during Kometa update.\n')
+      logBox.scrollTop = logBox.scrollHeight
       setKometaUpdatePhaseBadge('failed')
-      if (logBox[0]) logBox[0].scrollTop = logBox[0].scrollHeight
       cleanupUI()
       syncKometaRollupBadge()
     })

--- a/tests/js/kometa/kometaUpdate.test.js
+++ b/tests/js/kometa/kometaUpdate.test.js
@@ -28,9 +28,7 @@
 //     - heartbeat toast fires immediately + every 30s
 //     - 409 response: warning toast, phase 'failed', doesn't throw
 //     - success + job_id: kicks off polling
-//     - synchronous success with up_to_date: 'up to date' path
-//     - synchronous success without up_to_date: 'completed in Xs'
-//     - synchronous failure: error toast
+//     - synchronous failure (defensive fallback): error toast
 //     - fetch throws: catch handler
 //
 //   cleanupUI (indirectly via completion):
@@ -535,53 +533,13 @@ describe('callUpdateKometa -- 409 response (Kometa running)', () => {
 })
 
 // ---------------------------------------------------------------------
-// Path 5: Synchronous success (no job_id)
-// ---------------------------------------------------------------------
-
-describe('callUpdateKometa -- synchronous success', () => {
-  it("shows 'up to date' info when up_to_date=true", async () => {
-    // NOTE: original code has a latent bug in the sync-success path
-    // (no job_id) -- it sets `postUpdateLabel` but NEVER calls
-    // cleanupUI. In production the server always returns job_id, so
-    // this path is effectively dead. We test what the original does:
-    // toast + validateKometaRoot call. The button label doesn't get
-    // the 'Up to date' text because that only happens inside cleanupUI.
-    installFixture()
-    mockFetchWith(okJson({ success: true, up_to_date: true }))
-    callUpdateKometa()
-    await flush()
-    expect(toastCalls.some(c => c[0] === 'info' && c[1].includes('already up to date'))).toBe(true)
-  })
-
-  it("shows success 'completed' when up_to_date=false", async () => {
-    installFixture()
-    mockFetchWith(okJson({ success: true, up_to_date: false }))
-    callUpdateKometa()
-    await flush()
-    expect(toastCalls.some(c => c[0] === 'success' && c[1].includes('completed'))).toBe(true)
-  })
-
-  it("hides kometa-update-box + clears updateAvailable", async () => {
-    installFixture()
-    kometaState.kometaUpdateAvailable = true
-    mockFetchWith(okJson({ success: true }))
-    callUpdateKometa()
-    await flush()
-    expect(document.getElementById('kometa-update-box').classList.contains('d-none')).toBe(true)
-    expect(kometaState.kometaUpdateAvailable).toBe(false)
-  })
-
-  it("calls validateKometaRoot with appendStatus=true", async () => {
-    installFixture()
-    mockFetchWith(okJson({ success: true }))
-    callUpdateKometa()
-    await flush()
-    expect(validateKometaRoot).toHaveBeenCalledWith({ appendStatus: true })
-  })
-})
-
-// ---------------------------------------------------------------------
-// Path 5: Synchronous failure
+// Path 5: Synchronous failure (defensive fallback)
+//
+// The endpoint currently never returns { success: false } with a 200
+// status when background=true -- non-success cases either return 409
+// (Kometa running) or non-2xx (which throws). The `if (!data.success
+// && !data.blocked)` branch is a defensive fallback for future
+// endpoint changes. Tests here simulate that hypothetical response.
 // ---------------------------------------------------------------------
 
 describe('callUpdateKometa -- synchronous failure', () => {


### PR DESCRIPTION
## What

Follow-up cleanup to the boss-fight extraction (#1581). Removes the 3 preserved quirks documented in `_kometaUpdate.js`:

1. **Dead `logBox[0].scrollTop` calls** — never executed because `logBox` is a single Element, not a jQuery-style array
2. **Dead synchronous-success branch** — unreachable because this caller always sends `background=true`
3. **Stale docstring quirks section**

`_kometaUpdate.js`: 434 → 411 lines (**-23**).
Tests: 46 → 42 (removed 4 dead sync-success tests).

## Why the sync-success path is dead

The Flask endpoint at `/update-kometa` branches on `data.get('background')`:

```python
if background:
    # returns { success: True, job_id, phase, ... }
else:
    # returns { success, log, up_to_date, ... }  # NO job_id
```

`callUpdateKometa` **always** sends `background: true` and is the **only** caller of `/update-kometa` in the entire codebase (verified with grep). Therefore:

- Server always returns a `job_id`
- The `if (data.success)` block (sync-success) is unreachable
- The `if (logBox[0]) logBox[0].scrollTop = ...` guards were dead

## What was removed

1. The entire `if (data.success)` sync-success block (~15 lines). `postUpdateLabel` was set but never consumed because `cleanupUI` wasn't called from this branch.
2. All 4 dead `if (logBox[0]) logBox[0].scrollTop = ...` lines.
3. Docstring "PRESERVED QUIRK" section.
4. Setup-block comment about the difference between working and dead scroll forms.

## What was KEPT

The `if (!data.success && !data.blocked)` (synchronous failure) branch stays as a **defensive fallback**. Currently unreachable via this caller, but would be the right behavior if the endpoint ever returned 200 with `success=false`. Documented inline.

## What was FIXED (not removed)

The 409 branch now correctly scrolls the log to the bottom:

```diff
- if (logBox[0]) logBox[0].scrollTop = logBox[0].scrollHeight  // dead
+ logBox.scrollTop = logBox.scrollHeight                        // works
```

Same fix added to `.catch` handler. Both places append a final log line before the user sees it, so scroll-to-bottom is the right UX.

## Test coverage adjustment

Removed the 4-test "synchronous success" describe block. Kept the 2-test "synchronous failure" block with a docstring explaining why (defensive fallback).

## Verification

- **1291/1291 Vitest pass** (was 1295; -4 dead-code tests removed)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- ESLint clean, Node syntax clean

## Zen note

Kudos to the original author for the defensive coding style (`if (logBox[0])` etc.) — it's the kind of thing that prevents production crashes when APIs change. In this case the guard happened to always evaluate false, but the instinct was right.
