### PR TITLE
Split 900-kometa.js part 24: extract run-progress panel (-324 lines)

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -4,7 +4,6 @@ import {
   linkifyText,
   formatTimestampLocal,
   formatRunSeconds,
-  coerceRunSeconds,
   applyLogFilter,
   computeLogStats,
   copyTextToClipboard,
@@ -76,6 +75,11 @@ import {
 import { validateKometaRoot } from './modules/kometa/_validateRoot.js'
 import { runKometaStatusPass } from './modules/kometa/_statusPass.js'
 import { callUpdateKometa } from './modules/kometa/_kometaUpdate.js'
+import {
+  renderRunProgress,
+  clearRunProgress,
+  fetchRunProgress
+} from './modules/kometa/_runProgress.js'
 
 // Kometa runtime status flags migrated to modules/kometa/_state.js
 // (kometaState.kometaInstalled, kometaValidated, kometaStatus, etc.).
@@ -89,10 +93,7 @@ let lastLogStatsTotal = null
 let logStatsPollCounter = 0
 let logscanPollCounter = 0
 let finalLogscanAnalyzeTriggered = false
-let lastRunProgressPayload = null
 let logscanAnalyzeInFlight = false
-let runProgressInFlight = false
-let latestKometaStatusPayload = null
 
 const runLog = document.getElementById('run-output-log')
 const tailNotice = document.getElementById('run-output-notice')
@@ -579,331 +580,6 @@ function stopProgressPolling () {
     clearInterval(kometaState.kometaProgressInterval)
     kometaState.kometaProgressInterval = null
   }
-}
-
-const runPhaseOrder = [
-  { key: 'operations', label: 'Operations' },
-  { key: 'metadata', label: 'Metadata' },
-  { key: 'collections', label: 'Collections' },
-  { key: 'overlays', label: 'Overlays' },
-  { key: 'playlists', label: 'Playlists' }
-]
-
-function renderRunProgress (payload) {
-  const container = document.getElementById('run-progress')
-  if (!container) return
-
-  if (!payload || !Array.isArray(payload.libraries)) {
-    container.classList.add('d-none')
-    return
-  }
-
-  lastRunProgressPayload = payload
-  const libraries = payload.libraries
-  const total = payload.total_count || libraries.length
-  const completed = payload.completed_count != null
-    ? payload.completed_count
-    : libraries.filter(entry => entry.status === 'Done').length
-
-  const phaseOrderKeys = Array.isArray(payload.phase_order) && payload.phase_order.length
-    ? payload.phase_order
-    : runPhaseOrder.map(phase => phase.key)
-  const phaseCount = phaseOrderKeys.length || 1
-  const currentPhaseIndex = payload.phase_current
-    ? Math.max(0, phaseOrderKeys.indexOf(payload.phase_current))
-    : 0
-  const totalSteps = total * phaseCount
-  let completedSteps = completed * phaseCount
-  if (payload.current_library && total > 0) {
-    completedSteps = Math.min(totalSteps, completedSteps + currentPhaseIndex)
-  }
-  const percent = totalSteps > 0 ? Math.round((completedSteps / totalSteps) * 100) : 0
-  const bar = document.getElementById('run-progress-bar')
-  if (bar) {
-    bar.style.width = `${percent}%`
-    bar.setAttribute('aria-valuenow', String(percent))
-  }
-
-  const summary = document.getElementById('run-progress-summary')
-  if (summary) {
-    const current = payload.current_library ? ` | Current: ${payload.current_library}` : ''
-    const stepLabel = totalSteps > 0 ? ` | Step ${completedSteps}/${totalSteps}` : ''
-    let lastUpdated = ''
-    if (payload.last_log_at) {
-      const formatter = typeof window.QS_formatTimestamp === 'function' ? window.QS_formatTimestamp : null
-      const label = formatter ? formatter(payload.last_log_at) : new Date(payload.last_log_at).toLocaleString()
-      lastUpdated = ` | Last updated: ${label}`
-    }
-    summary.textContent = `${completed}/${total} libraries complete${current}${stepLabel}${lastUpdated}`
-  }
-
-  const prepRow = document.getElementById('run-prep-row')
-  if (prepRow) {
-    const prepLockedValue = coerceRunSeconds(payload.preparation_seconds)
-    const prepLiveValue = coerceRunSeconds(payload.preparation_elapsed_seconds)
-    const hasLockedPrep = typeof prepLockedValue === 'number'
-    const prepSeconds = hasLockedPrep ? prepLockedValue : prepLiveValue
-    if (prepSeconds != null) {
-      const prepLabel = formatRunSeconds(prepSeconds) || '0s'
-      const prepClass = hasLockedPrep ? 'text-bg-success' : 'text-bg-primary'
-      prepRow.innerHTML = `
-        <span class="me-2 fw-semibold">Preparation</span>
-        <span class="badge ${prepClass}">${prepLabel}</span>
-      `
-      prepRow.classList.remove('d-none')
-    } else {
-      prepRow.classList.add('d-none')
-    }
-  }
-
-  const maintenanceRow = document.getElementById('run-maintenance-row')
-  if (maintenanceRow) {
-    const statusData = latestKometaStatusPayload || {}
-    const progressMaintenance = payload && payload.maintenance_summary && typeof payload.maintenance_summary === 'object'
-      ? payload.maintenance_summary
-      : {}
-    const windowLabel = statusData.maintenance_window ? ` (${statusData.maintenance_window})` : ''
-    if (statusData.maintenance_paused) {
-      let pauseLabel = 'Paused'
-      const pausedSince = statusData.maintenance_paused_since ? new Date(statusData.maintenance_paused_since) : null
-      if (pausedSince && !Number.isNaN(pausedSince.getTime())) {
-        const elapsedSeconds = Math.max(0, Math.floor((Date.now() - pausedSince.getTime()) / 1000))
-        pauseLabel = formatRunSeconds(elapsedSeconds) || 'Paused'
-      }
-      maintenanceRow.innerHTML = `
-        <span class="me-2 fw-semibold">Maintenance</span>
-        <span class="badge text-bg-warning text-dark">Paused${windowLabel}</span>
-        <span class="badge text-bg-secondary">${pauseLabel}</span>
-      `
-      maintenanceRow.classList.remove('d-none')
-    } else if (statusData.maintenance_active) {
-      maintenanceRow.innerHTML = `
-        <span class="me-2 fw-semibold">Maintenance</span>
-        <span class="badge text-bg-warning text-dark">Window Active${windowLabel}</span>
-      `
-      maintenanceRow.classList.remove('d-none')
-    } else if (progressMaintenance.had_pause) {
-      const summaryWindow = progressMaintenance.window ? ` (${progressMaintenance.window})` : ''
-      const pauseCount = Number(progressMaintenance.pause_count || 0)
-      const pauseSeconds = Number(progressMaintenance.pause_seconds || 0)
-      const summaryLabel = pauseSeconds > 0
-        ? (formatRunSeconds(pauseSeconds) || `${pauseCount || 1} pause${(pauseCount || 1) === 1 ? '' : 's'}`)
-        : `${pauseCount || 1} pause${(pauseCount || 1) === 1 ? '' : 's'}`
-      const stateLabel = progressMaintenance.open_pause ? 'Paused (log)' : 'Completed'
-      maintenanceRow.innerHTML = `
-        <span class="me-2 fw-semibold">Maintenance</span>
-        <span class="badge text-bg-primary">${stateLabel}${summaryWindow}</span>
-        <span class="badge text-bg-secondary">${summaryLabel}</span>
-      `
-      maintenanceRow.classList.remove('d-none')
-    } else {
-      maintenanceRow.classList.add('d-none')
-    }
-  }
-
-  const allowed = Array.isArray(payload.allowed_phases) && payload.allowed_phases.length
-    ? new Set(payload.allowed_phases)
-    : null
-  const phaseLookup = new Map(runPhaseOrder.map(phase => [phase.key, phase.label]))
-  const phasesToShow = (Array.isArray(phaseOrderKeys) ? phaseOrderKeys : runPhaseOrder.map(phase => phase.key))
-    .filter(key => !allowed || allowed.has(key))
-    .map(key => ({ key, label: phaseLookup.get(key) || key }))
-  const phaseIndexLookup = new Map(phasesToShow.map((phase, idx) => [phase.key, idx]))
-
-  const headerRow = document.getElementById('run-library-header')
-  if (headerRow) {
-    const phaseHeaders = phasesToShow.map(phase => `<th class="text-end">${phase.label}</th>`).join('')
-    headerRow.innerHTML = `<th>Library</th><th>Type</th><th>Status</th>${phaseHeaders}`
-  }
-
-  const visibleLibraries = libraries.filter(entry => entry.status !== 'Skipped')
-  const rows = document.getElementById('run-library-rows')
-  if (rows) {
-    rows.innerHTML = visibleLibraries.map(entry => {
-      let klass = 'text-bg-secondary'
-      if (entry.status === 'Done') klass = 'text-bg-success'
-      else if (entry.status === 'In progress') klass = 'text-bg-primary'
-      else if (entry.status === 'Stopped') klass = 'text-bg-danger'
-      else if (entry.status === 'Skipped') klass = 'text-bg-dark'
-      const typeLabel = entry.type ? entry.type : '—'
-      const durations = entry.durations || {}
-      const currentPhaseForRow = payload.current_library === entry.name ? payload.phase_current : null
-      const explicitPhases = new Set(Object.keys(durations))
-      let lastSeenIndex = -1
-      explicitPhases.forEach(key => {
-        const idx = phaseIndexLookup.get(key)
-        if (idx != null && idx > lastSeenIndex) lastSeenIndex = idx
-      })
-      if (currentPhaseForRow) {
-        const idx = phaseIndexLookup.get(currentPhaseForRow)
-        if (idx != null && idx > lastSeenIndex) lastSeenIndex = idx
-      }
-      const inferredPhases = new Set()
-      if (entry.status !== 'Skipped' && lastSeenIndex >= 0) {
-        phasesToShow.forEach(phase => {
-          const idx = phaseIndexLookup.get(phase.key)
-          if (idx != null && idx < lastSeenIndex && !explicitPhases.has(phase.key)) {
-            inferredPhases.add(phase.key)
-          }
-        })
-      }
-
-      const durationCells = phasesToShow.map(phase => {
-        if (phase.key === 'playlists') {
-          const playlistTotal = typeof payload.playlist_total_seconds === 'number' ? payload.playlist_total_seconds : null
-          const running = Boolean(payload.playlist_running)
-          const elapsed = typeof payload.playlist_elapsed_seconds === 'number' ? payload.playlist_elapsed_seconds : null
-          const detected = Boolean(payload.playlists_detected)
-          if (running) {
-            const label = elapsed != null ? formatRunSeconds(elapsed) : 'Running'
-            return `<td class="text-end"><span class="badge text-bg-primary">${label || 'Running'}</span></td>`
-          }
-          if (playlistTotal != null && (playlistTotal > 0 || detected)) {
-            return `<td class="text-end"><span class="badge text-bg-success">${formatRunSeconds(playlistTotal) || '0s'}</span></td>`
-          }
-          if (payload.run_finished) {
-            return '<td class="text-end"><span class="badge text-bg-secondary">Not Configured</span></td>'
-          }
-          return '<td class="text-end text-muted small">—</td>'
-        }
-        const seconds = durations[phase.key]
-        const hasSeconds = typeof seconds === 'number' && Number.isFinite(seconds)
-        const isRunning = currentPhaseForRow === phase.key
-        const isExplicit = explicitPhases.has(phase.key)
-        const isInferred = inferredPhases.has(phase.key)
-        if (entry.status === 'Skipped') {
-          return '<td class="text-end text-muted small">—</td>'
-        }
-        if (isRunning) {
-          const elapsed = typeof payload.current_phase_elapsed_seconds === 'number'
-            ? formatRunSeconds(payload.current_phase_elapsed_seconds)
-            : (hasSeconds ? formatRunSeconds(seconds) : 'Running')
-          return `<td class="text-end"><span class="badge text-bg-primary">${elapsed || 'Running'}</span></td>`
-        }
-        if (isExplicit && hasSeconds) {
-          return `<td class="text-end"><span class="badge text-bg-success">${formatRunSeconds(seconds)}</span></td>`
-        }
-        if (isInferred) {
-          return '<td class="text-end"><span class="badge text-bg-secondary">Not Configured</span></td>'
-        }
-        return '<td class="text-end text-muted small">—</td>'
-      }).join('')
-      return `
-        <tr>
-          <td>${entry.name}</td>
-          <td>${typeLabel}</td>
-          <td><span class="badge ${klass}">${entry.status}</span></td>
-          ${durationCells}
-        </tr>
-      `
-    }).join('')
-  }
-
-  const footer = document.getElementById('run-library-footer')
-  const totalRow = document.getElementById('run-library-total-row')
-  if (footer && totalRow) {
-    if (!libraries.length || !phasesToShow.length) {
-      footer.classList.add('d-none')
-    } else {
-      const totals = new Map(phasesToShow.map(phase => [phase.key, 0]))
-      visibleLibraries.forEach(entry => {
-        if (entry.status === 'Skipped') return
-        const durations = entry.durations || {}
-        phasesToShow.forEach(phase => {
-          if (phase.key === 'playlists') {
-            return
-          }
-          const seconds = durations[phase.key]
-          if (typeof seconds === 'number' && Number.isFinite(seconds)) {
-            totals.set(phase.key, (totals.get(phase.key) || 0) + seconds)
-          }
-        })
-      })
-      if (phasesToShow.some(phase => phase.key === 'playlists')) {
-        const playlistTotal = typeof payload.playlist_total_seconds === 'number' ? payload.playlist_total_seconds : null
-        const playlistDetected = Boolean(payload.playlists_detected)
-        if (playlistTotal != null && (playlistTotal > 0 || playlistDetected)) {
-          totals.set('playlists', playlistTotal)
-        }
-      }
-      const prepSeconds = (() => {
-        const locked = coerceRunSeconds(payload.preparation_seconds)
-        if (typeof locked === 'number' && Number.isFinite(locked)) return locked
-        const live = coerceRunSeconds(payload.preparation_elapsed_seconds)
-        return typeof live === 'number' && Number.isFinite(live) ? live : 0
-      })()
-      let grandTotal = prepSeconds
-      totals.forEach((value) => {
-        if (typeof value === 'number' && Number.isFinite(value)) {
-          grandTotal += value
-        }
-      })
-      const totalCells = phasesToShow.map(phase => {
-        const totalSeconds = totals.get(phase.key)
-        if (phase.key === 'playlists' && typeof totalSeconds === 'number' && Number.isFinite(totalSeconds)) {
-          const detected = Boolean(payload.playlists_detected)
-          if (totalSeconds > 0 || detected) {
-            return `<td class="text-end"><span class="badge text-bg-success">${formatRunSeconds(totalSeconds) || '0s'}</span></td>`
-          }
-        }
-        if (typeof totalSeconds === 'number' && totalSeconds > 0) {
-          return `<td class="text-end"><span class="badge text-bg-success">${formatRunSeconds(totalSeconds)}</span></td>`
-        }
-        return '<td class="text-end text-muted small">—</td>'
-      }).join('')
-      const totalLabel = grandTotal > 0 ? `<span class="badge text-bg-success">${formatRunSeconds(grandTotal)}</span>` : '—'
-      totalRow.innerHTML = `<td class="fw-semibold">Total</td><td>—</td><td>${totalLabel}</td>${totalCells}`
-      footer.classList.remove('d-none')
-    }
-  }
-
-  container.classList.remove('d-none')
-}
-
-function clearRunProgress (resetCache = false) {
-  const container = document.getElementById('run-progress')
-  if (container) {
-    container.classList.add('d-none')
-  }
-  const maintenanceRow = document.getElementById('run-maintenance-row')
-  if (maintenanceRow) {
-    maintenanceRow.classList.add('d-none')
-  }
-  if (resetCache) {
-    lastRunProgressPayload = null
-  }
-}
-
-function fetchRunProgress (forceFull = false) {
-  if (runProgressInFlight) return Promise.resolve(null)
-  runProgressInFlight = true
-  const url = forceFull ? '/logscan/progress?size=all' : '/logscan/progress'
-  return fetch(url)
-    .then(res => {
-      if (!res.ok) return null
-      return res.json()
-    })
-    .then(data => {
-      if (!data) {
-        if (kometaState.kometaStatus === 'running' && lastRunProgressPayload) {
-          renderRunProgress(lastRunProgressPayload)
-        } else {
-          clearRunProgress(false)
-        }
-        return
-      }
-      renderRunProgress(data)
-    })
-    .catch(() => {
-      if (kometaState.kometaStatus === 'running' && lastRunProgressPayload) {
-        renderRunProgress(lastRunProgressPayload)
-      } else {
-        clearRunProgress(false)
-      }
-    })
-    .finally(() => {
-      runProgressInFlight = false
-    })
 }
 
 // Kometa Update Button Click
@@ -1759,8 +1435,8 @@ function performStopKometa () {
       clearInterval(kometaState.kometaInterval)
       clearInterval(kometaState.kometaStatusInterval)
       stopProgressPolling()
-      if (lastRunProgressPayload) {
-        const stoppedPayload = JSON.parse(JSON.stringify(lastRunProgressPayload))
+      if (kometaState.lastRunProgressPayload) {
+        const stoppedPayload = JSON.parse(JSON.stringify(kometaState.lastRunProgressPayload))
         const stoppedLibrary = stoppedPayload.current_library
         stoppedPayload.current_library = null
         stoppedPayload.phase_current = null
@@ -1775,7 +1451,7 @@ function performStopKometa () {
             return entry
           })
         }
-        lastRunProgressPayload = stoppedPayload
+        kometaState.lastRunProgressPayload = stoppedPayload
         renderRunProgress(stoppedPayload)
       }
       kometaState.kometaStatus = 'not started'
@@ -1837,7 +1513,7 @@ function checkKometaStatus () {
   return fetch('/kometa-status')
     .then(res => res.json())
     .then(data => {
-      latestKometaStatusPayload = data || null
+      kometaState.latestKometaStatusPayload = data || null
       kometaState.kometaStatus = data.status || null
       kometaState.kometaPendingStart = Boolean(data.pending_start && data.status !== 'running')
       const updateBtn = updateKometaBtn
@@ -1869,8 +1545,8 @@ function checkKometaStatus () {
       if (typeof window.QS_handleMaintenanceStatus === 'function') {
         window.QS_handleMaintenanceStatus(data)
       }
-      if (lastRunProgressPayload && data.status === 'running') {
-        renderRunProgress(lastRunProgressPayload)
+      if (kometaState.lastRunProgressPayload && data.status === 'running') {
+        renderRunProgress(kometaState.lastRunProgressPayload)
       }
 
       if (data.pending_start && data.status !== 'running') {

--- a/static/local-js/modules/kometa/_runProgress.js
+++ b/static/local-js/modules/kometa/_runProgress.js
@@ -1,0 +1,476 @@
+// Kometa run-progress: the live UI that shows library-by-library
+// progress during a `kometa.py` run.
+//
+// This module owns three things:
+//
+//   1. renderRunProgress(payload)
+//        Paints the entire #run-progress panel from a
+//        /logscan/progress response. This is the biggest and most
+//        complex function -- ~270 lines -- because it renders:
+//          - the top progress bar + summary line ("X/Y libraries...")
+//          - the "Preparation" badge row
+//          - the "Maintenance" badge row (paused / active / had_pause)
+//          - the per-library table with per-phase duration cells
+//          - the totals footer (sum per phase + grand total)
+//
+//   2. clearRunProgress(resetCache = false)
+//        Hides the panel + maintenance row. When resetCache=true also
+//        clears the module's memory of the last-rendered payload so
+//        the next render starts fresh.
+//
+//   3. fetchRunProgress(forceFull = false)
+//        Hits /logscan/progress and paints the result. On failure or
+//        empty response: redraws the last successful payload IF
+//        Kometa is still running (to avoid flickering the panel off
+//        during a transient network hiccup); otherwise clears.
+//
+// SHARED STATE (via _state.js):
+//
+//   kometaState.lastRunProgressPayload
+//     Last /logscan/progress response successfully rendered. Enables
+//     the "keep showing what we had" fallback in fetchRunProgress.
+//
+//   kometaState.runProgressInFlight
+//     Guard against overlapping /logscan/progress fetches.
+//
+//   kometaState.latestKometaStatusPayload
+//     READ ONLY here. Owned by checkKometaStatus in 900-kometa.js.
+//     Used by the Maintenance-row logic to decide whether to show
+//     Paused / Window Active / had_pause badges.
+//
+//   kometaState.kometaStatus
+//     READ ONLY here. Used by fetchRunProgress to decide whether a
+//     transient error should fall back to the cached payload
+//     (Kometa still running -> yes) or clear the panel (idle -> no).
+//
+// PHASE ORDER:
+//
+//   The 5-phase order (operations / metadata / collections / overlays
+//   / playlists) is exported as runPhaseOrder for tests that want to
+//   assert against phase labels. Server responses can override the
+//   order via payload.phase_order.
+//
+// TIMESTAMP FORMATTING:
+//
+//   The "Last updated" line uses window.QS_formatTimestamp when
+//   available (defined by shared JS in 000-base.js) so the whole app
+//   agrees on timestamp formatting. Falls back to
+//   Date#toLocaleString when the global isn't present -- keeps this
+//   module importable in test contexts.
+
+import { kometaState } from './_state.js'
+import { coerceRunSeconds, formatRunSeconds } from './_util.js'
+
+/**
+ * Canonical phase order for the run-progress panel. Server can
+ * override via payload.phase_order.
+ */
+export const runPhaseOrder = [
+  { key: 'operations', label: 'Operations' },
+  { key: 'metadata', label: 'Metadata' },
+  { key: 'collections', label: 'Collections' },
+  { key: 'overlays', label: 'Overlays' },
+  { key: 'playlists', label: 'Playlists' }
+]
+
+/**
+ * Paint the #run-progress panel from a /logscan/progress payload.
+ *
+ * No-ops (silently) when:
+ *   - #run-progress element is missing
+ *   - payload is falsy OR payload.libraries isn't an array
+ *
+ * See module docstring for the sections it renders.
+ *
+ * @param {object} payload  /logscan/progress response
+ */
+export function renderRunProgress (payload) {
+  const container = document.getElementById('run-progress')
+  if (!container) return
+
+  if (!payload || !Array.isArray(payload.libraries)) {
+    container.classList.add('d-none')
+    return
+  }
+
+  kometaState.lastRunProgressPayload = payload
+  const libraries = payload.libraries
+  const total = payload.total_count || libraries.length
+  const completed = payload.completed_count != null
+    ? payload.completed_count
+    : libraries.filter(entry => entry.status === 'Done').length
+
+  const phaseOrderKeys = Array.isArray(payload.phase_order) && payload.phase_order.length
+    ? payload.phase_order
+    : runPhaseOrder.map(phase => phase.key)
+  const phaseCount = phaseOrderKeys.length || 1
+  const currentPhaseIndex = payload.phase_current
+    ? Math.max(0, phaseOrderKeys.indexOf(payload.phase_current))
+    : 0
+  const totalSteps = total * phaseCount
+  let completedSteps = completed * phaseCount
+  if (payload.current_library && total > 0) {
+    completedSteps = Math.min(totalSteps, completedSteps + currentPhaseIndex)
+  }
+  const percent = totalSteps > 0 ? Math.round((completedSteps / totalSteps) * 100) : 0
+  const bar = document.getElementById('run-progress-bar')
+  if (bar) {
+    bar.style.width = `${percent}%`
+    bar.setAttribute('aria-valuenow', String(percent))
+  }
+
+  const summary = document.getElementById('run-progress-summary')
+  if (summary) {
+    const current = payload.current_library ? ` | Current: ${payload.current_library}` : ''
+    const stepLabel = totalSteps > 0 ? ` | Step ${completedSteps}/${totalSteps}` : ''
+    let lastUpdated = ''
+    if (payload.last_log_at) {
+      const formatter = typeof window.QS_formatTimestamp === 'function' ? window.QS_formatTimestamp : null
+      const label = formatter ? formatter(payload.last_log_at) : new Date(payload.last_log_at).toLocaleString()
+      lastUpdated = ` | Last updated: ${label}`
+    }
+    summary.textContent = `${completed}/${total} libraries complete${current}${stepLabel}${lastUpdated}`
+  }
+
+  renderPreparationRow(payload)
+  renderMaintenanceRow(payload)
+
+  const allowed = Array.isArray(payload.allowed_phases) && payload.allowed_phases.length
+    ? new Set(payload.allowed_phases)
+    : null
+  const phaseLookup = new Map(runPhaseOrder.map(phase => [phase.key, phase.label]))
+  const phasesToShow = (Array.isArray(phaseOrderKeys) ? phaseOrderKeys : runPhaseOrder.map(phase => phase.key))
+    .filter(key => !allowed || allowed.has(key))
+    .map(key => ({ key, label: phaseLookup.get(key) || key }))
+  const phaseIndexLookup = new Map(phasesToShow.map((phase, idx) => [phase.key, idx]))
+
+  const headerRow = document.getElementById('run-library-header')
+  if (headerRow) {
+    const phaseHeaders = phasesToShow.map(phase => `<th class="text-end">${phase.label}</th>`).join('')
+    headerRow.innerHTML = `<th>Library</th><th>Type</th><th>Status</th>${phaseHeaders}`
+  }
+
+  const visibleLibraries = libraries.filter(entry => entry.status !== 'Skipped')
+  renderLibraryRows(payload, visibleLibraries, phasesToShow, phaseIndexLookup)
+  renderLibraryFooter(payload, libraries, visibleLibraries, phasesToShow)
+
+  container.classList.remove('d-none')
+}
+
+/**
+ * "Preparation" badge row. Green when locked, blue when live-updating.
+ * Hidden when no preparation timing is available.
+ */
+function renderPreparationRow (payload) {
+  const prepRow = document.getElementById('run-prep-row')
+  if (!prepRow) return
+  const prepLockedValue = coerceRunSeconds(payload.preparation_seconds)
+  const prepLiveValue = coerceRunSeconds(payload.preparation_elapsed_seconds)
+  const hasLockedPrep = typeof prepLockedValue === 'number'
+  const prepSeconds = hasLockedPrep ? prepLockedValue : prepLiveValue
+  if (prepSeconds != null) {
+    const prepLabel = formatRunSeconds(prepSeconds) || '0s'
+    const prepClass = hasLockedPrep ? 'text-bg-success' : 'text-bg-primary'
+    prepRow.innerHTML = `
+        <span class="me-2 fw-semibold">Preparation</span>
+        <span class="badge ${prepClass}">${prepLabel}</span>
+      `
+    prepRow.classList.remove('d-none')
+  } else {
+    prepRow.classList.add('d-none')
+  }
+}
+
+/**
+ * "Maintenance" badge row. Priority (highest to lowest):
+ *   1. status.maintenance_paused  -> yellow "Paused (elapsed)" badge
+ *   2. status.maintenance_active  -> yellow "Window Active" badge
+ *   3. payload.maintenance_summary.had_pause -> blue "Completed / Paused (log)"
+ *   4. otherwise hidden
+ */
+function renderMaintenanceRow (payload) {
+  const maintenanceRow = document.getElementById('run-maintenance-row')
+  if (!maintenanceRow) return
+  const statusData = kometaState.latestKometaStatusPayload || {}
+  const progressMaintenance = payload && payload.maintenance_summary && typeof payload.maintenance_summary === 'object'
+    ? payload.maintenance_summary
+    : {}
+  const windowLabel = statusData.maintenance_window ? ` (${statusData.maintenance_window})` : ''
+  if (statusData.maintenance_paused) {
+    let pauseLabel = 'Paused'
+    const pausedSince = statusData.maintenance_paused_since ? new Date(statusData.maintenance_paused_since) : null
+    if (pausedSince && !Number.isNaN(pausedSince.getTime())) {
+      const elapsedSeconds = Math.max(0, Math.floor((Date.now() - pausedSince.getTime()) / 1000))
+      pauseLabel = formatRunSeconds(elapsedSeconds) || 'Paused'
+    }
+    maintenanceRow.innerHTML = `
+        <span class="me-2 fw-semibold">Maintenance</span>
+        <span class="badge text-bg-warning text-dark">Paused${windowLabel}</span>
+        <span class="badge text-bg-secondary">${pauseLabel}</span>
+      `
+    maintenanceRow.classList.remove('d-none')
+  } else if (statusData.maintenance_active) {
+    maintenanceRow.innerHTML = `
+        <span class="me-2 fw-semibold">Maintenance</span>
+        <span class="badge text-bg-warning text-dark">Window Active${windowLabel}</span>
+      `
+    maintenanceRow.classList.remove('d-none')
+  } else if (progressMaintenance.had_pause) {
+    const summaryWindow = progressMaintenance.window ? ` (${progressMaintenance.window})` : ''
+    const pauseCount = Number(progressMaintenance.pause_count || 0)
+    const pauseSeconds = Number(progressMaintenance.pause_seconds || 0)
+    const summaryLabel = pauseSeconds > 0
+      ? (formatRunSeconds(pauseSeconds) || `${pauseCount || 1} pause${(pauseCount || 1) === 1 ? '' : 's'}`)
+      : `${pauseCount || 1} pause${(pauseCount || 1) === 1 ? '' : 's'}`
+    const stateLabel = progressMaintenance.open_pause ? 'Paused (log)' : 'Completed'
+    maintenanceRow.innerHTML = `
+        <span class="me-2 fw-semibold">Maintenance</span>
+        <span class="badge text-bg-primary">${stateLabel}${summaryWindow}</span>
+        <span class="badge text-bg-secondary">${summaryLabel}</span>
+      `
+    maintenanceRow.classList.remove('d-none')
+  } else {
+    maintenanceRow.classList.add('d-none')
+  }
+}
+
+/**
+ * Per-library table rows. Each row: name / type / status badge /
+ * one duration cell per visible phase.
+ *
+ * Phase cells fall into 5 flavors:
+ *   - Playlists cell (special): live "Running Xs" while playlist is
+ *     running, green total when done, "Not Configured" when finished
+ *     with no playlists detected, em-dash otherwise
+ *   - Skipped library: em-dash
+ *   - Currently running phase: blue "Running (elapsed)" badge
+ *   - Explicit phase with seconds: green "Xs" badge
+ *   - Inferred completed phase (no seconds but past): "Not Configured"
+ *   - Default: em-dash
+ */
+function renderLibraryRows (payload, visibleLibraries, phasesToShow, phaseIndexLookup) {
+  const rows = document.getElementById('run-library-rows')
+  if (!rows) return
+  rows.innerHTML = visibleLibraries.map(entry => {
+    let klass = 'text-bg-secondary'
+    if (entry.status === 'Done') klass = 'text-bg-success'
+    else if (entry.status === 'In progress') klass = 'text-bg-primary'
+    else if (entry.status === 'Stopped') klass = 'text-bg-danger'
+    else if (entry.status === 'Skipped') klass = 'text-bg-dark'
+    const typeLabel = entry.type ? entry.type : '\u2014'
+    const durations = entry.durations || {}
+    const currentPhaseForRow = payload.current_library === entry.name ? payload.phase_current : null
+    const explicitPhases = new Set(Object.keys(durations))
+    let lastSeenIndex = -1
+    explicitPhases.forEach(key => {
+      const idx = phaseIndexLookup.get(key)
+      if (idx != null && idx > lastSeenIndex) lastSeenIndex = idx
+    })
+    if (currentPhaseForRow) {
+      const idx = phaseIndexLookup.get(currentPhaseForRow)
+      if (idx != null && idx > lastSeenIndex) lastSeenIndex = idx
+    }
+    // "Inferred" = phases before the last-seen index that don't have
+    // explicit durations. These get a "Not Configured" badge because
+    // if we didn't see them explicitly but we're past them, Kometa
+    // must have skipped them (config didn't enable them for this lib).
+    const inferredPhases = new Set()
+    if (entry.status !== 'Skipped' && lastSeenIndex >= 0) {
+      phasesToShow.forEach(phase => {
+        const idx = phaseIndexLookup.get(phase.key)
+        if (idx != null && idx < lastSeenIndex && !explicitPhases.has(phase.key)) {
+          inferredPhases.add(phase.key)
+        }
+      })
+    }
+
+    const durationCells = phasesToShow
+      .map(phase => renderPhaseCell(payload, entry, phase, durations, currentPhaseForRow, explicitPhases, inferredPhases))
+      .join('')
+
+    return `
+        <tr>
+          <td>${entry.name}</td>
+          <td>${typeLabel}</td>
+          <td><span class="badge ${klass}">${entry.status}</span></td>
+          ${durationCells}
+        </tr>
+      `
+  }).join('')
+}
+
+/**
+ * Render a single per-library, per-phase duration cell. See the
+ * "5 flavors" note in renderLibraryRows for the branching logic.
+ */
+function renderPhaseCell (payload, entry, phase, durations, currentPhaseForRow, explicitPhases, inferredPhases) {
+  // Playlists cell is special: it comes from top-level payload fields,
+  // not from per-library durations.
+  if (phase.key === 'playlists') {
+    const playlistTotal = typeof payload.playlist_total_seconds === 'number' ? payload.playlist_total_seconds : null
+    const running = Boolean(payload.playlist_running)
+    const elapsed = typeof payload.playlist_elapsed_seconds === 'number' ? payload.playlist_elapsed_seconds : null
+    const detected = Boolean(payload.playlists_detected)
+    if (running) {
+      const label = elapsed != null ? formatRunSeconds(elapsed) : 'Running'
+      return `<td class="text-end"><span class="badge text-bg-primary">${label || 'Running'}</span></td>`
+    }
+    if (playlistTotal != null && (playlistTotal > 0 || detected)) {
+      return `<td class="text-end"><span class="badge text-bg-success">${formatRunSeconds(playlistTotal) || '0s'}</span></td>`
+    }
+    if (payload.run_finished) {
+      return '<td class="text-end"><span class="badge text-bg-secondary">Not Configured</span></td>'
+    }
+    return '<td class="text-end text-muted small">\u2014</td>'
+  }
+  const seconds = durations[phase.key]
+  const hasSeconds = typeof seconds === 'number' && Number.isFinite(seconds)
+  const isRunning = currentPhaseForRow === phase.key
+  const isExplicit = explicitPhases.has(phase.key)
+  const isInferred = inferredPhases.has(phase.key)
+  if (entry.status === 'Skipped') {
+    return '<td class="text-end text-muted small">\u2014</td>'
+  }
+  if (isRunning) {
+    const elapsed = typeof payload.current_phase_elapsed_seconds === 'number'
+      ? formatRunSeconds(payload.current_phase_elapsed_seconds)
+      : (hasSeconds ? formatRunSeconds(seconds) : 'Running')
+    return `<td class="text-end"><span class="badge text-bg-primary">${elapsed || 'Running'}</span></td>`
+  }
+  if (isExplicit && hasSeconds) {
+    return `<td class="text-end"><span class="badge text-bg-success">${formatRunSeconds(seconds)}</span></td>`
+  }
+  if (isInferred) {
+    return '<td class="text-end"><span class="badge text-bg-secondary">Not Configured</span></td>'
+  }
+  return '<td class="text-end text-muted small">\u2014</td>'
+}
+
+/**
+ * Table footer: per-phase totals + grand total row. Hidden when
+ * there are no libraries or no visible phases.
+ *
+ * Grand total = preparation seconds (locked > live) + sum of per-phase
+ * totals across all visible non-Skipped libraries.
+ */
+function renderLibraryFooter (payload, libraries, visibleLibraries, phasesToShow) {
+  const footer = document.getElementById('run-library-footer')
+  const totalRow = document.getElementById('run-library-total-row')
+  if (!footer || !totalRow) return
+  if (!libraries.length || !phasesToShow.length) {
+    footer.classList.add('d-none')
+    return
+  }
+  const totals = new Map(phasesToShow.map(phase => [phase.key, 0]))
+  visibleLibraries.forEach(entry => {
+    if (entry.status === 'Skipped') return
+    const durations = entry.durations || {}
+    phasesToShow.forEach(phase => {
+      // Playlists total comes from payload, not from per-library durations.
+      if (phase.key === 'playlists') return
+      const seconds = durations[phase.key]
+      if (typeof seconds === 'number' && Number.isFinite(seconds)) {
+        totals.set(phase.key, (totals.get(phase.key) || 0) + seconds)
+      }
+    })
+  })
+  if (phasesToShow.some(phase => phase.key === 'playlists')) {
+    const playlistTotal = typeof payload.playlist_total_seconds === 'number' ? payload.playlist_total_seconds : null
+    const playlistDetected = Boolean(payload.playlists_detected)
+    if (playlistTotal != null && (playlistTotal > 0 || playlistDetected)) {
+      totals.set('playlists', playlistTotal)
+    }
+  }
+  const prepSeconds = (() => {
+    const locked = coerceRunSeconds(payload.preparation_seconds)
+    if (typeof locked === 'number' && Number.isFinite(locked)) return locked
+    const live = coerceRunSeconds(payload.preparation_elapsed_seconds)
+    return typeof live === 'number' && Number.isFinite(live) ? live : 0
+  })()
+  let grandTotal = prepSeconds
+  totals.forEach((value) => {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      grandTotal += value
+    }
+  })
+  const totalCells = phasesToShow.map(phase => {
+    const totalSeconds = totals.get(phase.key)
+    if (phase.key === 'playlists' && typeof totalSeconds === 'number' && Number.isFinite(totalSeconds)) {
+      const detected = Boolean(payload.playlists_detected)
+      if (totalSeconds > 0 || detected) {
+        return `<td class="text-end"><span class="badge text-bg-success">${formatRunSeconds(totalSeconds) || '0s'}</span></td>`
+      }
+    }
+    if (typeof totalSeconds === 'number' && totalSeconds > 0) {
+      return `<td class="text-end"><span class="badge text-bg-success">${formatRunSeconds(totalSeconds)}</span></td>`
+    }
+    return '<td class="text-end text-muted small">\u2014</td>'
+  }).join('')
+  const totalLabel = grandTotal > 0 ? `<span class="badge text-bg-success">${formatRunSeconds(grandTotal)}</span>` : '\u2014'
+  totalRow.innerHTML = `<td class="fw-semibold">Total</td><td>\u2014</td><td>${totalLabel}</td>${totalCells}`
+  footer.classList.remove('d-none')
+}
+
+/**
+ * Hide the run-progress panel + maintenance row.
+ *
+ * @param {boolean} [resetCache=false]  When true also clears
+ *   kometaState.lastRunProgressPayload so the next render starts
+ *   fresh. Callers set this true when a run ends; leave false when
+ *   the hide is transient (e.g. between polls).
+ */
+export function clearRunProgress (resetCache = false) {
+  const container = document.getElementById('run-progress')
+  if (container) container.classList.add('d-none')
+  const maintenanceRow = document.getElementById('run-maintenance-row')
+  if (maintenanceRow) maintenanceRow.classList.add('d-none')
+  if (resetCache) kometaState.lastRunProgressPayload = null
+}
+
+/**
+ * Fetch /logscan/progress and render. Guarded against overlapping
+ * fetches via kometaState.runProgressInFlight.
+ *
+ * Failure modes:
+ *   - overlap (already in flight): resolves null immediately, no fetch
+ *   - non-ok response: falls through to null branch (see below)
+ *   - null / empty payload OR fetch reject:
+ *       * if Kometa is still running AND we have a cached payload:
+ *         redraw the cached payload (avoid flicker)
+ *       * otherwise: clearRunProgress(false)
+ *
+ * @param {boolean} [forceFull=false]  When true asks the server for
+ *   the full library set (bypasses server-side windowing).
+ * @returns {Promise}
+ */
+export function fetchRunProgress (forceFull = false) {
+  if (kometaState.runProgressInFlight) return Promise.resolve(null)
+  kometaState.runProgressInFlight = true
+  const url = forceFull ? '/logscan/progress?size=all' : '/logscan/progress'
+  return fetch(url)
+    .then(res => {
+      if (!res.ok) return null
+      return res.json()
+    })
+    .then(data => {
+      if (!data) {
+        if (kometaState.kometaStatus === 'running' && kometaState.lastRunProgressPayload) {
+          renderRunProgress(kometaState.lastRunProgressPayload)
+        } else {
+          clearRunProgress(false)
+        }
+        return
+      }
+      renderRunProgress(data)
+    })
+    .catch(() => {
+      if (kometaState.kometaStatus === 'running' && kometaState.lastRunProgressPayload) {
+        renderRunProgress(kometaState.lastRunProgressPayload)
+      } else {
+        clearRunProgress(false)
+      }
+    })
+    .finally(() => {
+      kometaState.runProgressInFlight = false
+    })
+}

--- a/static/local-js/modules/kometa/_state.js
+++ b/static/local-js/modules/kometa/_state.js
@@ -213,5 +213,42 @@ export const kometaState = {
   //   'idle' | 'checking' | 'queued' | 'downloading' | 'extracting'
   //   | 'preserving' | 'venv' | 'dependencies' | 'validating'
   //   | 'ready' | 'failed'
-  kometaUpdatePhaseStatus: 'idle'
+  kometaUpdatePhaseStatus: 'idle',
+
+  // ---- Run-progress cache ------------------------------------------
+  //
+  // Cross-module state shared between _runProgress.js (writer) and
+  // 900-kometa.js (reader). Enables the 'refresh on transient error'
+  // pattern: when a /logscan/progress fetch fails or returns null AND
+  // Kometa is still running, we redraw the last successful payload
+  // instead of blanking the UI.
+  //
+  //   lastRunProgressPayload   -- last /logscan/progress response we
+  //                                actually rendered, or null if we
+  //                                haven't rendered yet this session.
+  //                                Reset to null by clearRunProgress
+  //                                (in _runProgress.js) when called
+  //                                with resetCache=true (i.e. when a
+  //                                run ends).
+  //   runProgressInFlight      -- guard against concurrent fetches.
+  //                                fetchRunProgress bails early if
+  //                                another fetch is already pending.
+  //                                Written only by fetchRunProgress.
+  lastRunProgressPayload: null,
+  runProgressInFlight: false,
+
+  // ---- Kometa status cache -----------------------------------------
+  //
+  // Latest /kometa-status response, kept so renderRunProgress
+  // (in _runProgress.js) can look up maintenance-window info without
+  // reissuing the status fetch. Written by checkKometaStatus (in
+  // 900-kometa.js) after every successful status poll.
+  //
+  //   null                     -- no successful status fetch yet
+  //   { maintenance_paused,    -- payload verbatim from server
+  //     maintenance_active,      (see /kometa-status endpoint)
+  //     maintenance_window,
+  //     maintenance_paused_since,
+  //     ... }
+  latestKometaStatusPayload: null
 }

--- a/tests/js/kometa/runProgress.test.js
+++ b/tests/js/kometa/runProgress.test.js
@@ -1,0 +1,626 @@
+// Tests for static/local-js/modules/kometa/_runProgress.js
+//
+// Three exports: renderRunProgress, clearRunProgress, fetchRunProgress
+// (plus runPhaseOrder constant).
+//
+// COVERAGE STRATEGY:
+//
+//   runPhaseOrder (1):
+//     - Exports the 5 canonical phases in order
+//
+//   renderRunProgress (many, grouped by concern):
+//
+//     Guard clauses (2):
+//       - missing #run-progress element: no-op
+//       - payload without libraries[]: hides container + returns
+//
+//     Cache update (1):
+//       - writes payload to kometaState.lastRunProgressPayload
+//
+//     Progress bar (3):
+//       - percent based on completed_count * phaseCount
+//       - progresses when current_library set
+//       - handles totalSteps=0 (percent=0, no crash)
+//
+//     Summary line (3):
+//       - libraries done + current_library
+//       - "Last updated" via formatter global
+//       - falls back to toLocaleString when no formatter global
+//
+//     Preparation row (3):
+//       - locked > live: green success badge
+//       - live only: blue primary badge
+//       - neither: hidden
+//
+//     Maintenance row (4):
+//       - paused via status: yellow + elapsed
+//       - active via status: yellow "Window Active"
+//       - progressMaintenance.had_pause: blue completed/paused summary
+//       - none of above: hidden
+//
+//     Phase headers + library rows (5):
+//       - respects payload.allowed_phases filter
+//       - server phase_order override
+//       - status classes: Done=success, In progress=primary, etc.
+//       - Skipped libraries filtered from visible rows
+//       - "Not Configured" for inferred earlier phases
+//
+//     Phase cells (special playlists handling) (4):
+//       - running -> blue elapsed
+//       - total > 0 or detected -> green
+//       - run_finished without playlists -> "Not Configured"
+//       - otherwise em-dash
+//
+//     Footer / grand total (3):
+//       - per-phase totals sum
+//       - grand total = prep + phase totals
+//       - hidden when no libraries or no visible phases
+//
+//   clearRunProgress (3):
+//     - hides container + maintenance row
+//     - resetCache=false: preserves lastRunProgressPayload
+//     - resetCache=true: clears lastRunProgressPayload
+//
+//   fetchRunProgress (7):
+//     - guards against concurrent fetches
+//     - forceFull=true: uses ?size=all URL
+//     - success: calls renderRunProgress with data
+//     - !ok response: null branch (running+cached -> re-render;
+//       else -> clear)
+//     - empty data + running + cached: re-renders cached
+//     - empty data + not running: clears
+//     - network reject: same fallback logic
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { kometaState } from '../../../static/local-js/modules/kometa/_state.js'
+import {
+  runPhaseOrder,
+  renderRunProgress,
+  clearRunProgress,
+  fetchRunProgress
+} from '../../../static/local-js/modules/kometa/_runProgress.js'
+
+// ---------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------
+
+function installFixture () {
+  document.body.innerHTML = `
+    <div id="run-progress" class="d-none">
+      <div id="run-progress-bar" style="width:0" aria-valuenow="0"></div>
+      <div id="run-progress-summary"></div>
+      <div id="run-prep-row" class="d-none"></div>
+      <div id="run-maintenance-row" class="d-none"></div>
+      <table>
+        <thead><tr id="run-library-header"></tr></thead>
+        <tbody id="run-library-rows"></tbody>
+        <tfoot id="run-library-footer" class="d-none">
+          <tr id="run-library-total-row"></tr>
+        </tfoot>
+      </table>
+    </div>
+  `
+}
+
+function resetState () {
+  kometaState.lastRunProgressPayload = null
+  kometaState.runProgressInFlight = false
+  kometaState.latestKometaStatusPayload = null
+  kometaState.kometaStatus = 'idle'
+}
+
+let originalFetch
+
+beforeEach(() => {
+  originalFetch = global.fetch
+  resetState()
+})
+
+afterEach(() => {
+  global.fetch = originalFetch
+  document.body.innerHTML = ''
+  delete window.QS_formatTimestamp
+})
+
+// Minimal payload builder. Callers override fields as needed.
+function makePayload (over = {}) {
+  return {
+    libraries: [{ name: 'Movies', type: 'movie', status: 'Done' }],
+    ...over
+  }
+}
+
+// ---------------------------------------------------------------------
+// runPhaseOrder
+// ---------------------------------------------------------------------
+
+describe('runPhaseOrder', () => {
+  it("exports the 5 canonical phases in order", () => {
+    expect(runPhaseOrder.map(p => p.key)).toEqual(['operations', 'metadata', 'collections', 'overlays', 'playlists'])
+    expect(runPhaseOrder.every(p => p.label && p.key)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// renderRunProgress -- guard clauses
+// ---------------------------------------------------------------------
+
+describe('renderRunProgress -- guard clauses', () => {
+  it("no-ops when #run-progress element is missing", () => {
+    document.body.innerHTML = ''  // no fixture
+    // Should not throw
+    expect(() => renderRunProgress(makePayload())).not.toThrow()
+  })
+
+  it("hides container + returns when payload is falsy", () => {
+    installFixture()
+    renderRunProgress(null)
+    expect(document.getElementById('run-progress').classList.contains('d-none')).toBe(true)
+    expect(kometaState.lastRunProgressPayload).toBeNull()  // not cached
+  })
+
+  it("hides container when payload.libraries isn't an array", () => {
+    installFixture()
+    renderRunProgress({ libraries: 'not-an-array' })
+    expect(document.getElementById('run-progress').classList.contains('d-none')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// renderRunProgress -- cache update
+// ---------------------------------------------------------------------
+
+describe('renderRunProgress -- cache update', () => {
+  it("writes valid payload to kometaState.lastRunProgressPayload", () => {
+    installFixture()
+    const payload = makePayload({ total_count: 3 })
+    renderRunProgress(payload)
+    expect(kometaState.lastRunProgressPayload).toBe(payload)
+  })
+})
+
+// ---------------------------------------------------------------------
+// renderRunProgress -- progress bar
+// ---------------------------------------------------------------------
+
+describe('renderRunProgress -- progress bar', () => {
+  it("sets bar width based on completed/total*phaseCount", () => {
+    installFixture()
+    // 2 libs done out of 4, 5 phases -> 10/20 = 50%
+    renderRunProgress(makePayload({
+      libraries: [
+        { name: 'A', status: 'Done' }, { name: 'B', status: 'Done' },
+        { name: 'C', status: 'In progress' }, { name: 'D', status: 'Not Started' }
+      ],
+      total_count: 4,
+      completed_count: 2
+    }))
+    const bar = document.getElementById('run-progress-bar')
+    expect(bar.style.width).toBe('50%')
+    expect(bar.getAttribute('aria-valuenow')).toBe('50')
+  })
+
+  it("advances beyond completed count when current_library set", () => {
+    installFixture()
+    // 1 done, 1 current at phase idx 2 (collections), 5 phases
+    // -> (1*5 + 2) / (2*5) = 7/10 = 70%
+    renderRunProgress(makePayload({
+      libraries: [
+        { name: 'A', status: 'Done' },
+        { name: 'B', status: 'In progress' }
+      ],
+      total_count: 2,
+      completed_count: 1,
+      current_library: 'B',
+      phase_current: 'collections'
+    }))
+    expect(document.getElementById('run-progress-bar').style.width).toBe('70%')
+  })
+
+  it("handles totalSteps=0 (empty run) without crashing", () => {
+    installFixture()
+    renderRunProgress(makePayload({
+      libraries: [],
+      total_count: 0,
+      completed_count: 0
+    }))
+    expect(document.getElementById('run-progress-bar').style.width).toBe('0%')
+  })
+})
+
+// ---------------------------------------------------------------------
+// renderRunProgress -- summary line
+// ---------------------------------------------------------------------
+
+describe('renderRunProgress -- summary line', () => {
+  it("includes libraries done + current_library + step counter", () => {
+    installFixture()
+    renderRunProgress(makePayload({
+      libraries: [{ name: 'A', status: 'Done' }, { name: 'B', status: 'In progress' }],
+      total_count: 2,
+      completed_count: 1,
+      current_library: 'B',
+      phase_current: 'operations'
+    }))
+    const text = document.getElementById('run-progress-summary').textContent
+    expect(text).toContain('1/2 libraries complete')
+    expect(text).toContain('Current: B')
+    expect(text).toContain('Step')
+  })
+
+  it("uses window.QS_formatTimestamp when present", () => {
+    installFixture()
+    window.QS_formatTimestamp = vi.fn(() => 'FORMATTED-STAMP')
+    renderRunProgress(makePayload({ last_log_at: '2024-01-01T00:00:00Z' }))
+    expect(window.QS_formatTimestamp).toHaveBeenCalled()
+    expect(document.getElementById('run-progress-summary').textContent).toContain('FORMATTED-STAMP')
+  })
+
+  it("falls back to toLocaleString when no formatter global", () => {
+    installFixture()
+    renderRunProgress(makePayload({ last_log_at: '2024-01-01T00:00:00Z' }))
+    expect(document.getElementById('run-progress-summary').textContent).toContain('Last updated:')
+  })
+})
+
+// ---------------------------------------------------------------------
+// renderRunProgress -- Preparation row
+// ---------------------------------------------------------------------
+
+describe('renderRunProgress -- Preparation row', () => {
+  it("shows green (locked) badge when preparation_seconds set", () => {
+    installFixture()
+    renderRunProgress(makePayload({ preparation_seconds: 42 }))
+    const prep = document.getElementById('run-prep-row')
+    expect(prep.classList.contains('d-none')).toBe(false)
+    expect(prep.innerHTML).toContain('text-bg-success')
+    expect(prep.innerHTML).toContain('Preparation')
+  })
+
+  it("shows blue (live) badge when only elapsed set", () => {
+    installFixture()
+    renderRunProgress(makePayload({ preparation_elapsed_seconds: 10 }))
+    const prep = document.getElementById('run-prep-row')
+    expect(prep.classList.contains('d-none')).toBe(false)
+    expect(prep.innerHTML).toContain('text-bg-primary')
+  })
+
+  it("hides row when neither preparation time is set", () => {
+    installFixture()
+    renderRunProgress(makePayload())
+    expect(document.getElementById('run-prep-row').classList.contains('d-none')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// renderRunProgress -- Maintenance row
+// ---------------------------------------------------------------------
+
+describe('renderRunProgress -- Maintenance row', () => {
+  it("shows Paused badge + elapsed when status.maintenance_paused", () => {
+    installFixture()
+    kometaState.latestKometaStatusPayload = {
+      maintenance_paused: true,
+      maintenance_window: '02:00-04:00',
+      maintenance_paused_since: new Date(Date.now() - 65000).toISOString()  // 65s ago
+    }
+    renderRunProgress(makePayload())
+    const row = document.getElementById('run-maintenance-row')
+    expect(row.classList.contains('d-none')).toBe(false)
+    expect(row.innerHTML).toContain('Paused')
+    expect(row.innerHTML).toContain('text-bg-warning')
+    expect(row.innerHTML).toContain('02:00-04:00')
+  })
+
+  it("shows Window Active when status.maintenance_active (not paused)", () => {
+    installFixture()
+    kometaState.latestKometaStatusPayload = {
+      maintenance_paused: false,
+      maintenance_active: true,
+      maintenance_window: '03:00-05:00'
+    }
+    renderRunProgress(makePayload())
+    const row = document.getElementById('run-maintenance-row')
+    expect(row.classList.contains('d-none')).toBe(false)
+    expect(row.innerHTML).toContain('Window Active')
+    expect(row.innerHTML).toContain('03:00-05:00')
+  })
+
+  it("shows Completed/Paused (log) from progress maintenance_summary", () => {
+    installFixture()
+    renderRunProgress(makePayload({
+      maintenance_summary: {
+        had_pause: true,
+        window: '01:00-03:00',
+        pause_count: 2,
+        pause_seconds: 120,
+        open_pause: false
+      }
+    }))
+    const row = document.getElementById('run-maintenance-row')
+    expect(row.classList.contains('d-none')).toBe(false)
+    expect(row.innerHTML).toContain('Completed')
+    expect(row.innerHTML).toContain('text-bg-primary')
+  })
+
+  it("hides row when no maintenance signal at all", () => {
+    installFixture()
+    renderRunProgress(makePayload())
+    expect(document.getElementById('run-maintenance-row').classList.contains('d-none')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// renderRunProgress -- Library table
+// ---------------------------------------------------------------------
+
+describe('renderRunProgress -- library table', () => {
+  it("filters phases by payload.allowed_phases", () => {
+    installFixture()
+    renderRunProgress(makePayload({
+      allowed_phases: ['metadata', 'collections']
+    }))
+    const header = document.getElementById('run-library-header').innerHTML
+    expect(header).toContain('Metadata')
+    expect(header).toContain('Collections')
+    expect(header).not.toContain('Operations')
+    expect(header).not.toContain('Playlists')
+  })
+
+  it("respects server-provided phase_order", () => {
+    installFixture()
+    renderRunProgress(makePayload({
+      phase_order: ['playlists', 'metadata']
+    }))
+    const header = document.getElementById('run-library-header').innerHTML
+    // In the order server sent
+    const playlistIdx = header.indexOf('Playlists')
+    const metadataIdx = header.indexOf('Metadata')
+    expect(playlistIdx).toBeGreaterThan(0)
+    expect(metadataIdx).toBeGreaterThan(playlistIdx)
+  })
+
+  it("uses status-specific badge classes", () => {
+    installFixture()
+    renderRunProgress(makePayload({
+      libraries: [
+        { name: 'A', status: 'Done' },
+        { name: 'B', status: 'In progress' },
+        { name: 'C', status: 'Stopped' },
+        { name: 'D', status: 'Not Started' }
+      ]
+    }))
+    const rows = document.getElementById('run-library-rows').innerHTML
+    expect(rows).toContain('text-bg-success')  // Done
+    expect(rows).toContain('text-bg-primary')  // In progress
+    expect(rows).toContain('text-bg-danger')   // Stopped
+    expect(rows).toContain('text-bg-secondary')  // Not Started
+  })
+
+  it("filters Skipped libraries from visible rows", () => {
+    installFixture()
+    renderRunProgress(makePayload({
+      libraries: [
+        { name: 'Visible', status: 'Done' },
+        { name: 'Hidden', status: 'Skipped' }
+      ]
+    }))
+    const rows = document.getElementById('run-library-rows').innerHTML
+    expect(rows).toContain('Visible')
+    expect(rows).not.toContain('Hidden')
+  })
+
+  it("shows 'Not Configured' for phases before the last-seen index", () => {
+    installFixture()
+    renderRunProgress(makePayload({
+      libraries: [{
+        name: 'Movies',
+        status: 'Done',
+        // Only metadata + overlays have durations; collections has no
+        // duration but is between them, so it should be 'Not Configured'
+        durations: { metadata: 5, overlays: 3 }
+      }]
+    }))
+    const rows = document.getElementById('run-library-rows').innerHTML
+    expect(rows).toContain('Not Configured')
+  })
+})
+
+// ---------------------------------------------------------------------
+// renderRunProgress -- Playlists cell
+// ---------------------------------------------------------------------
+
+describe('renderRunProgress -- Playlists cell', () => {
+  it("shows blue Running badge when playlist_running", () => {
+    installFixture()
+    renderRunProgress(makePayload({
+      playlist_running: true,
+      playlist_elapsed_seconds: 15
+    }))
+    const rows = document.getElementById('run-library-rows').innerHTML
+    // The playlists cell should be blue
+    expect(rows).toMatch(/text-bg-primary/)
+  })
+
+  it("shows green total when playlist_total_seconds > 0", () => {
+    installFixture()
+    renderRunProgress(makePayload({
+      playlist_total_seconds: 42,
+      playlists_detected: true
+    }))
+    const rows = document.getElementById('run-library-rows').innerHTML
+    expect(rows).toMatch(/text-bg-success/)  // playlists total
+  })
+
+  it("shows 'Not Configured' when run_finished + no playlists", () => {
+    installFixture()
+    renderRunProgress(makePayload({
+      run_finished: true,
+      playlist_total_seconds: 0,
+      playlists_detected: false
+    }))
+    const rows = document.getElementById('run-library-rows').innerHTML
+    expect(rows).toContain('Not Configured')
+  })
+
+  it("shows em-dash when no playlist info at all", () => {
+    installFixture()
+    renderRunProgress(makePayload())
+    const rows = document.getElementById('run-library-rows').innerHTML
+    expect(rows).toContain('\u2014')  // em-dash
+  })
+})
+
+// ---------------------------------------------------------------------
+// renderRunProgress -- footer / grand total
+// ---------------------------------------------------------------------
+
+describe('renderRunProgress -- footer/grand total', () => {
+  it("shows per-phase totals across all libraries", () => {
+    installFixture()
+    renderRunProgress(makePayload({
+      libraries: [
+        { name: 'A', status: 'Done', durations: { metadata: 10, collections: 5 } },
+        { name: 'B', status: 'Done', durations: { metadata: 20, collections: 15 } }
+      ],
+      total_count: 2,
+      completed_count: 2
+    }))
+    const footer = document.getElementById('run-library-footer')
+    expect(footer.classList.contains('d-none')).toBe(false)
+    // Metadata total = 30, Collections total = 20
+    const totalRow = document.getElementById('run-library-total-row').innerHTML
+    expect(totalRow).toContain('Total')
+  })
+
+  it("includes prep time in grand total", () => {
+    installFixture()
+    renderRunProgress(makePayload({
+      preparation_seconds: 100,
+      libraries: [
+        { name: 'A', status: 'Done', durations: { metadata: 10 } }
+      ]
+    }))
+    const totalRow = document.getElementById('run-library-total-row').innerHTML
+    // Grand total badge should be present (100+10=110s)
+    expect(totalRow).toContain('badge')
+  })
+
+  it("hides footer when no libraries", () => {
+    installFixture()
+    renderRunProgress(makePayload({ libraries: [] }))
+    expect(document.getElementById('run-library-footer').classList.contains('d-none')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// clearRunProgress
+// ---------------------------------------------------------------------
+
+describe('clearRunProgress', () => {
+  it("hides container + maintenance row", () => {
+    installFixture()
+    document.getElementById('run-progress').classList.remove('d-none')
+    document.getElementById('run-maintenance-row').classList.remove('d-none')
+    clearRunProgress()
+    expect(document.getElementById('run-progress').classList.contains('d-none')).toBe(true)
+    expect(document.getElementById('run-maintenance-row').classList.contains('d-none')).toBe(true)
+  })
+
+  it("preserves lastRunProgressPayload when resetCache=false", () => {
+    installFixture()
+    kometaState.lastRunProgressPayload = { libraries: [{ name: 'X' }] }
+    clearRunProgress(false)
+    expect(kometaState.lastRunProgressPayload).toEqual({ libraries: [{ name: 'X' }] })
+  })
+
+  it("clears lastRunProgressPayload when resetCache=true", () => {
+    installFixture()
+    kometaState.lastRunProgressPayload = { libraries: [{ name: 'X' }] }
+    clearRunProgress(true)
+    expect(kometaState.lastRunProgressPayload).toBeNull()
+  })
+
+  it("no-ops safely when elements missing", () => {
+    document.body.innerHTML = ''
+    expect(() => clearRunProgress(true)).not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------
+// fetchRunProgress
+// ---------------------------------------------------------------------
+
+describe('fetchRunProgress', () => {
+  it("bails immediately when runProgressInFlight=true", async () => {
+    installFixture()
+    kometaState.runProgressInFlight = true
+    global.fetch = vi.fn()
+    const result = await fetchRunProgress()
+    expect(result).toBeNull()
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it("uses ?size=all when forceFull=true", async () => {
+    installFixture()
+    global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve(makePayload()) }))
+    await fetchRunProgress(true)
+    expect(global.fetch).toHaveBeenCalledWith('/logscan/progress?size=all')
+  })
+
+  it("uses default URL when forceFull=false (default)", async () => {
+    installFixture()
+    global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve(makePayload()) }))
+    await fetchRunProgress()
+    expect(global.fetch).toHaveBeenCalledWith('/logscan/progress')
+  })
+
+  it("calls renderRunProgress on success", async () => {
+    installFixture()
+    const payload = makePayload({ total_count: 2 })
+    global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve(payload) }))
+    await fetchRunProgress()
+    // renderRunProgress cached the payload
+    expect(kometaState.lastRunProgressPayload).toBe(payload)
+  })
+
+  it("!ok response: falls to null branch (running+cached -> re-render)", async () => {
+    installFixture()
+    const cached = makePayload({ total_count: 5 })
+    kometaState.lastRunProgressPayload = cached
+    kometaState.kometaStatus = 'running'
+    global.fetch = vi.fn(() => Promise.resolve({ ok: false, json: () => Promise.resolve({}) }))
+    await fetchRunProgress()
+    // Cache unchanged (renderRunProgress re-wrote same object)
+    expect(kometaState.lastRunProgressPayload).toBe(cached)
+    // Container should be visible (re-rendered)
+    expect(document.getElementById('run-progress').classList.contains('d-none')).toBe(false)
+  })
+
+  it("!ok response: not running -> clears panel", async () => {
+    installFixture()
+    kometaState.kometaStatus = 'idle'
+    global.fetch = vi.fn(() => Promise.resolve({ ok: false, json: () => Promise.resolve({}) }))
+    await fetchRunProgress()
+    expect(document.getElementById('run-progress').classList.contains('d-none')).toBe(true)
+  })
+
+  it("network reject: same fallback logic (running+cached -> re-render)", async () => {
+    installFixture()
+    const cached = makePayload({ total_count: 5 })
+    kometaState.lastRunProgressPayload = cached
+    kometaState.kometaStatus = 'running'
+    global.fetch = vi.fn(() => Promise.reject(new Error('network')))
+    await fetchRunProgress()
+    // Panel visible because we re-rendered from cache
+    expect(document.getElementById('run-progress').classList.contains('d-none')).toBe(false)
+  })
+
+  it("clears runProgressInFlight in .finally", async () => {
+    installFixture()
+    global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve(makePayload()) }))
+    await fetchRunProgress()
+    expect(kometaState.runProgressInFlight).toBe(false)
+  })
+})

--- a/tests/js/kometa/state.test.js
+++ b/tests/js/kometa/state.test.js
@@ -180,6 +180,9 @@ describe('kometaState initial values', () => {
       'kometaValidated',
       'kometaValidationInProgress',
       'lastLogscanPayload',
+      'lastRunProgressPayload',
+      'latestKometaStatusPayload',
+      'runProgressInFlight',
       'showYAML'
     ])
   })


### PR DESCRIPTION
## What

Extracts `renderRunProgress` + `clearRunProgress` + `fetchRunProgress` plus the `runPhaseOrder` constant. These three functions form a cohesive unit that owns the entire live "Kometa run in progress" panel (`#run-progress`) — library-by-library progress table with per-phase duration cells, top progress bar, preparation/maintenance badge rows, and grand-total footer.

**BIGGEST SINGLE-PR CUT YET.**

`900-kometa.js`: 1966 → 1642 lines (**-324**).
Vitest tests: 1291 → 1333 (**+42**).

## What moved

Extracted to `static/local-js/modules/kometa/_runProgress.js` (476 lines):

- `renderRunProgress(payload)` — the ~270-line beast, refactored internally into 5 private helpers:
  - `renderPreparationRow`: green/blue prep-time badge
  - `renderMaintenanceRow`: paused/active/completed maintenance
  - `renderLibraryRows`: per-library table rows
  - `renderPhaseCell`: single phase-duration cell (5 flavors)
  - `renderLibraryFooter`: per-phase totals + grand total row
- `clearRunProgress(resetCache = false)` — hides panel; optional cache reset
- `fetchRunProgress(forceFull = false)` — POSTs `/logscan/progress`; falls back to cached payload on error if running
- `runPhaseOrder` (const) — 5 canonical phases exported for tests

## Shared state additions

Added 3 new fields to `_state.js`, all documented with reader/writer notes:

| Field | Writer | Reader |
|---|---|---|
| `lastRunProgressPayload` | `renderRunProgress` | `fetchRunProgress` + stop-handler in `900-kometa.js` |
| `runProgressInFlight` | `fetchRunProgress` | `fetchRunProgress` (concurrent-fetch guard) |
| `latestKometaStatusPayload` | `checkKometaStatus` (in `900-kometa.js`) | `renderMaintenanceRow` (in extracted module) |

Updated `tests/js/kometa/state.test.js` exports-list guard.

## Design decisions

1. **Broke the ~270-line `renderRunProgress` into 5 private helpers.** Original was a monolith. Split improved readability and made per-helper logic easier to reason about. Helpers are NOT exported — all logic still funnels through `renderRunProgress`.

2. **Moved 3 pieces of module-scoped state to `kometaState`.** Alternatives were exporting getter/setter pairs or using writable module-scoped `let` (awkward with ES modules' read-only bindings). Following the established `_state.js` pattern.

3. **Preserved `QS_formatTimestamp` global fallback.** Module tries `window.QS_formatTimestamp` first (defined in `000-base.js`), falls back to `Date#toLocaleString`.

## Removed orphaned import

- `coerceRunSeconds` from `900-kometa.js` — only used by `renderRunProgress`. Still exported from `_util.js`.

## Test coverage: 42 new tests

Organized by concern:

- **`runPhaseOrder`** (1): 5 canonical phases in order
- **Guard clauses** (3): missing element, falsy payload, non-array libraries
- **Cache update** (1)
- **Progress bar** (3): percent math, `current_library` advance, `totalSteps=0` safety
- **Summary line** (3): current+step counter, formatter global preferred, fallback
- **Preparation row** (3): locked/live/hidden
- **Maintenance row** (4): 3 state variants + hidden
- **Library table** (5): `allowed_phases` filter, `phase_order` override, badge classes, Skipped filter, "Not Configured" inference
- **Playlists cell** (4): all 4 states
- **Footer** (3): totals, grand total, hidden
- **`clearRunProgress`** (4): both hidden, cache preserve, cache reset, safe on missing
- **`fetchRunProgress`** (7): concurrent guard, both URL variants, success, `!ok` + running + cached, `!ok` + idle, reject fallback, `.finally`

Full-fixture DOM per test. Internal helpers tested through public entry (they're private for a reason). Only `global.fetch` mocked.

## Verification

- **1333/1333 Vitest pass** (was 1291; +42 new, plus 1 state.test.js guard updated)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- ESLint clean, Node syntax clean

## MILESTONE

`900-kometa.js` was **3822** at split baseline. Now **1642**. Cumulative cut: **-2180 lines (57.0%)**. **Over halfway extracted.**

Modules extracted: **22** total.
Vitest tests: 611 → 1333 (**+722, +118.2%**).
