### PR TITLE
Roadmap Step 6 finish: extract arrPageBase.js from Radarr/Sonarr

### DIFF
--- a/static/local-js/110-radarr.js
+++ b/static/local-js/110-radarr.js
@@ -1,51 +1,25 @@
 import { createApiKeyValidator } from './modules/createApiKeyValidator.js'
-import { populateDropdown, setStatusMessageLines } from './modules/dropdownHelpers.js'
+import { populateArrDropdown, buildArrPreSubmit } from './modules/arrPageBase.js'
 
-// Per-wizard helpers: populate the two dropdowns from a validate response.
-// initialRadarrRootFolderPath and initialRadarrQualityProfile are window
-// globals injected by the rendered template (current selections from the
-// saved config), used to pre-select after dropdown population.
+// Radarr wizard — uses createApiKeyValidator for the credential flow,
+// arrPageBase helpers for the dropdown-populate and form-submit gate.
+//
+// See modules/arrPageBase.js for the shared shape between this file
+// and 120-sonarr.js.
+
 function populateRadarrDropdowns (data) {
-  populateDropdown(
-    'radarr_root_folder_path', data.root_folders, 'path', 'path',
-    typeof initialRadarrRootFolderPath !== 'undefined' ? initialRadarrRootFolderPath : ''
-  )
-  populateDropdown(
-    'radarr_quality_profile', data.quality_profiles, 'name', 'name',
-    typeof initialRadarrQualityProfile !== 'undefined' ? initialRadarrQualityProfile : ''
-  )
+  populateArrDropdown('radarr_root_folder_path', data.root_folders, 'path', 'path', 'initialRadarrRootFolderPath')
+  populateArrDropdown('radarr_quality_profile', data.quality_profiles, 'name', 'name', 'initialRadarrQualityProfile')
 }
 
-// Pre-submit guard: navigation is allowed only if the user has either
-// (a) never validated Radarr (page is being skipped) or (b) validated
-// AND selected a root folder + quality profile. Path validation from
-// PathValidation (set up elsewhere) also blocks if any path field is
-// invalid.
-function validateRadarrPage () {
-  const validated = document.getElementById('radarr_validated').value.toLowerCase() === 'true'
-  if (!validated) return true // unvalidated user can skip the page
-
-  const rootFolderPath = document.getElementById('radarr_root_folder_path').value
-  const qualityProfile = document.getElementById('radarr_quality_profile').value
-  const pathsValid = (typeof PathValidation !== 'undefined' && PathValidation.validateAll)
-    ? PathValidation.validateAll()
-    : true
-
-  const errors = []
-  if (!rootFolderPath) errors.push('Please select a valid Root Folder Path.')
-  if (!qualityProfile) errors.push('Please select a valid Quality Profile.')
-  if (!pathsValid) errors.push('Please fix invalid path fields before continuing.')
-
-  const statusMessage = document.getElementById('statusMessage')
-  if (errors.length) {
-    setStatusMessageLines(statusMessage, errors)
-    statusMessage.style.color = '#ea868f'
-    statusMessage.style.display = 'block'
-    return false
-  }
-  statusMessage.style.display = 'none'
-  return true
-}
+const validateRadarrPage = buildArrPreSubmit({
+  validatedFieldId: 'radarr_validated',
+  dropdowns: [
+    { elementId: 'radarr_root_folder_path', errorMessage: 'Please select a valid Root Folder Path.' },
+    { elementId: 'radarr_quality_profile', errorMessage: 'Please select a valid Quality Profile.' }
+  ],
+  skipWhenUnvalidated: true  // Radarr: an unvalidated user can skip the page cleanly.
+})
 
 createApiKeyValidator({
   fieldId: 'radarr_token',

--- a/static/local-js/120-sonarr.js
+++ b/static/local-js/120-sonarr.js
@@ -1,56 +1,31 @@
 import { createApiKeyValidator } from './modules/createApiKeyValidator.js'
-import { populateDropdown, setStatusMessageLines } from './modules/dropdownHelpers.js'
+import { populateArrDropdown, buildArrPreSubmit } from './modules/arrPageBase.js'
 
-// Per-wizard helpers: populate the three dropdowns from a validate response.
-// initialSonarrRootFolderPath/QualityProfile/LanguageProfile are window
-// globals injected by the rendered template (current selections from the
-// saved config), used to pre-select after dropdown population.
+// Sonarr wizard — uses createApiKeyValidator for the credential flow,
+// arrPageBase helpers for the dropdown-populate and form-submit gate.
+//
+// NOTE: skipWhenUnvalidated is FALSE here — a pre-existing bug (#1584)
+// that predates the Step 6 factory migration. Sonarr's path-validation
+// runs unconditionally, so an unvalidated user with any invalid path
+// field elsewhere on the page cannot navigate away. Compare Radarr,
+// which correctly returns true early. Fix in #1584 will flip this
+// flag to true.
+
 function populateSonarrDropdowns (data) {
-  populateDropdown(
-    'sonarr_root_folder_path', data.root_folders, 'path', 'path',
-    typeof initialSonarrRootFolderPath !== 'undefined' ? initialSonarrRootFolderPath : ''
-  )
-  populateDropdown(
-    'sonarr_quality_profile', data.quality_profiles, 'name', 'name',
-    typeof initialSonarrQualityProfile !== 'undefined' ? initialSonarrQualityProfile : ''
-  )
-  populateDropdown(
-    'sonarr_language_profile', data.language_profiles, 'name', 'name',
-    typeof initialSonarrLanguageProfile !== 'undefined' ? initialSonarrLanguageProfile : ''
-  )
+  populateArrDropdown('sonarr_root_folder_path', data.root_folders, 'path', 'path', 'initialSonarrRootFolderPath')
+  populateArrDropdown('sonarr_quality_profile', data.quality_profiles, 'name', 'name', 'initialSonarrQualityProfile')
+  populateArrDropdown('sonarr_language_profile', data.language_profiles, 'name', 'name', 'initialSonarrLanguageProfile')
 }
 
-// Pre-submit guard: navigation is allowed only if the user has either
-// (a) never validated Sonarr or (b) validated AND selected all three
-// dropdowns. Path validation from PathValidation (set up elsewhere)
-// also blocks if any path field is invalid.
-function validateSonarrPage () {
-  const validated = document.getElementById('sonarr_validated').value.toLowerCase() === 'true'
-  const rootFolderPath = document.getElementById('sonarr_root_folder_path').value
-  const qualityProfile = document.getElementById('sonarr_quality_profile').value
-  const languageProfile = document.getElementById('sonarr_language_profile').value
-  const pathsValid = (typeof PathValidation !== 'undefined' && PathValidation.validateAll)
-    ? PathValidation.validateAll()
-    : true
-
-  const errors = []
-  if (validated) {
-    if (!rootFolderPath) errors.push('Please select a valid Root Folder Path.')
-    if (!qualityProfile) errors.push('Please select a valid Quality Profile.')
-    if (!languageProfile) errors.push('Please select a valid Language Profile.')
-  }
-  if (!pathsValid) errors.push('Please fix invalid path fields before continuing.')
-
-  const statusMessage = document.getElementById('statusMessage')
-  if (errors.length) {
-    setStatusMessageLines(statusMessage, errors)
-    statusMessage.style.color = '#ea868f'
-    statusMessage.style.display = 'block'
-    return false
-  }
-  statusMessage.style.display = 'none'
-  return true
-}
+const validateSonarrPage = buildArrPreSubmit({
+  validatedFieldId: 'sonarr_validated',
+  dropdowns: [
+    { elementId: 'sonarr_root_folder_path', errorMessage: 'Please select a valid Root Folder Path.' },
+    { elementId: 'sonarr_quality_profile', errorMessage: 'Please select a valid Quality Profile.' },
+    { elementId: 'sonarr_language_profile', errorMessage: 'Please select a valid Language Profile.' }
+  ],
+  skipWhenUnvalidated: false  // Preserves buggy pre-existing behavior; see #1584.
+})
 
 createApiKeyValidator({
   fieldId: 'sonarr_token',

--- a/static/local-js/modules/arrPageBase.js
+++ b/static/local-js/modules/arrPageBase.js
@@ -1,0 +1,142 @@
+// Shared helpers for the Radarr and Sonarr wizards.
+//
+// These two wizards share the same shape:
+//
+//   1. User enters URL + Token, clicks Validate.
+//   2. Server returns dropdown data (root folders, quality profiles,
+//      language profiles).
+//   3. Wizard populates 2 or 3 dropdowns from the response, pre-
+//      selecting values from window-level "initial*" globals injected
+//      by the rendered template.
+//   4. On form submit, block navigation if the user has validated AND
+//      any required dropdown is empty, OR if any path field is invalid.
+//
+// The wizard-specific glue (dropdown IDs, field-name mappings, and the
+// error-message wording) lives in the wizard file. THIS module owns
+// the two mechanical patterns that repeated verbatim across both:
+//
+//   populateArrDropdown  — safe-read of `initial*` global + populate
+//   buildArrPreSubmit    — the "validated OR skip + collect errors"
+//                          form-submit gate builder
+//
+// BEHAVIOR NOTE — Sonarr asymmetry preserved verbatim
+//
+//   Radarr short-circuits (`return true`) when the wizard isn't
+//   validated, letting the user skip the page without a path-check.
+//   Sonarr does NOT short-circuit; its path check runs even for
+//   unvalidated users. This pre-existing asymmetry is a known bug
+//   (#1584) that predates the Step 6 factory work. buildArrPreSubmit
+//   supports both shapes via the `skipWhenUnvalidated` option so the
+//   extract is behavior-preserving. Fix #1584 will flip Sonarr's
+//   option to true.
+
+import { populateDropdown, setStatusMessageLines } from './dropdownHelpers.js'
+
+const STATUS_COLOR_ERROR = '#ea868f'
+
+/**
+ * Populate a single arr-wizard dropdown, pre-selecting the value from
+ * a template-injected window global. Wraps populateDropdown with the
+ * `typeof initial !== 'undefined'` safety dance that both wizards did
+ * verbatim.
+ *
+ * The `initialGlobalName` string is looked up via `window[name]` at
+ * call time so a globalName that was never injected (e.g. the user's
+ * first visit) reads as `undefined` and falls through to empty-string.
+ *
+ * @param {string} elementId          Dropdown <select> element id.
+ * @param {Array}  data                Options data from the validate response.
+ * @param {string} valueField          Object key for <option> value.
+ * @param {string} textField           Object key for <option> textContent.
+ * @param {string} initialGlobalName   Name of the window global holding the
+ *                                     currently-persisted selection, if any.
+ */
+export function populateArrDropdown (elementId, data, valueField, textField, initialGlobalName) {
+  const initial = (initialGlobalName && typeof window[initialGlobalName] !== 'undefined')
+    ? window[initialGlobalName]
+    : ''
+  populateDropdown(elementId, data, valueField, textField, initial)
+}
+
+/**
+ * Build the form-submit gate for an arr wizard.
+ *
+ * Returns a function suitable for passing to createApiKeyValidator's
+ * `onPreSubmit`. When called, it:
+ *
+ *   1. Reads validatedField's current value.
+ *   2. If NOT validated AND skipWhenUnvalidated is true -> return true
+ *      (allow navigation; user is skipping the page).
+ *   3. If validated -> collect one error per required dropdown that
+ *      is empty.
+ *   4. Add the path-validation error if PathValidation is loaded AND
+ *      any path field failed.
+ *   5. If any errors: render them via setStatusMessageLines and return
+ *      false (block navigation).
+ *   6. Otherwise: hide the status message and return true.
+ *
+ * @param {object} config
+ * @param {string} config.validatedFieldId   Element id of the hidden validated flag.
+ * @param {string} config.statusMessageId    Element id of the status callout.
+ *                                            Defaults to 'statusMessage'.
+ * @param {Array<{elementId: string, errorMessage: string}>} config.dropdowns
+ *   Ordered list of required dropdowns. Each entry says which element
+ *   to check and what to say if it's empty. Order matters — errors
+ *   render in the order given.
+ * @param {boolean} [config.skipWhenUnvalidated=false]  When true, an
+ *   unvalidated wizard skips ALL checks (dropdowns + path). Preserves
+ *   the Radarr behavior. Sonarr passes false (see BEHAVIOR NOTE above);
+ *   fix in issue #1584.
+ * @param {string} [config.pathErrorMessage]  Override the path-error
+ *   text. Defaults to the phrasing both wizards used verbatim.
+ * @returns {() => boolean}
+ */
+export function buildArrPreSubmit (config) {
+  const {
+    validatedFieldId,
+    statusMessageId = 'statusMessage',
+    dropdowns,
+    skipWhenUnvalidated = false,
+    pathErrorMessage = 'Please fix invalid path fields before continuing.'
+  } = config
+
+  if (!validatedFieldId) throw new Error('buildArrPreSubmit: validatedFieldId is required')
+  if (!Array.isArray(dropdowns)) throw new Error('buildArrPreSubmit: dropdowns must be an array')
+
+  return function validateArrPage () {
+    const validatedEl = document.getElementById(validatedFieldId)
+    const validated = validatedEl && validatedEl.value.toLowerCase() === 'true'
+
+    // Radarr-style skip: unvalidated user can leave the page without
+    // any further checks. Sonarr opts OUT of this (see #1584).
+    if (skipWhenUnvalidated && !validated) return true
+
+    const pathsValid = (typeof window.PathValidation !== 'undefined' && window.PathValidation.validateAll)
+      ? window.PathValidation.validateAll()
+      : true
+
+    const errors = []
+    // Dropdown checks only apply when the wizard is validated — an
+    // unvalidated user (in the Sonarr-style non-short-circuiting mode)
+    // has no dropdown data to select from yet.
+    if (validated) {
+      for (const { elementId, errorMessage } of dropdowns) {
+        const el = document.getElementById(elementId)
+        if (!el || !el.value) errors.push(errorMessage)
+      }
+    }
+    if (!pathsValid) errors.push(pathErrorMessage)
+
+    const statusMessage = document.getElementById(statusMessageId)
+    if (errors.length) {
+      if (statusMessage) {
+        setStatusMessageLines(statusMessage, errors)
+        statusMessage.style.color = STATUS_COLOR_ERROR
+        statusMessage.style.display = 'block'
+      }
+      return false
+    }
+    if (statusMessage) statusMessage.style.display = 'none'
+    return true
+  }
+}

--- a/tests/js/modules/arrPageBase.test.js
+++ b/tests/js/modules/arrPageBase.test.js
@@ -1,0 +1,462 @@
+// Tests for static/local-js/modules/arrPageBase.js
+//
+// Two exports:
+//   - populateArrDropdown(elementId, data, valueField, textField, initialGlobalName)
+//     Thin wrapper over populateDropdown that safely reads a window
+//     global for pre-selection.
+//
+//   - buildArrPreSubmit({ validatedFieldId, statusMessageId, dropdowns,
+//                          skipWhenUnvalidated, pathErrorMessage })
+//     Returns a form-submit gate function.
+//
+// COVERAGE STRATEGY:
+//
+//   populateArrDropdown (7):
+//     - passes through to populateDropdown correctly
+//     - safe when initialGlobalName is missing / undefined / empty
+//     - uses global value when set
+//     - handles null/undefined data (from populateDropdown)
+//     - doesn't crash on missing element
+//     - handles non-string initialGlobalName gracefully
+//     - each call reads global at call time (not cached)
+//
+//   buildArrPreSubmit (many, grouped):
+//
+//     Config validation (2):
+//       - throws without validatedFieldId
+//       - throws without dropdowns array
+//
+//     skipWhenUnvalidated=true (Radarr shape) (3):
+//       - unvalidated + invalid paths -> returns true (skip)
+//       - unvalidated + missing dropdowns -> returns true (skip)
+//       - validated -> proceeds with normal checks
+//
+//     skipWhenUnvalidated=false (Sonarr shape, buggy per #1584) (3):
+//       - unvalidated + invalid paths -> returns false (blocks!)
+//       - unvalidated + empty dropdowns -> returns true (dropdowns
+//         only checked when validated)
+//       - validated -> proceeds with normal checks
+//
+//     Dropdown checks (4):
+//       - all filled -> no dropdown errors
+//       - one empty -> one error in correct order
+//       - all empty -> errors in declaration order
+//       - missing element treated as empty
+//
+//     Path validation (4):
+//       - PathValidation missing entirely -> passes
+//       - PathValidation.validateAll missing -> passes
+//       - validateAll returns true -> no error
+//       - validateAll returns false -> error added
+//
+//     Status message rendering (3):
+//       - status message shown with combined errors
+//       - status message hidden when no errors
+//       - graceful when status element missing
+//
+//     Custom overrides (3):
+//       - custom statusMessageId used
+//       - custom pathErrorMessage used
+//       - defaults applied when overrides omitted
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  populateArrDropdown,
+  buildArrPreSubmit
+} from '../../../static/local-js/modules/arrPageBase.js'
+
+// ---------------------------------------------------------------------
+// populateArrDropdown
+// ---------------------------------------------------------------------
+
+describe('populateArrDropdown', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<select id="d"></select>'
+    delete window.testInitialValue
+    delete window.otherGlobal
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    delete window.testInitialValue
+    delete window.otherGlobal
+  })
+
+  it("populates the dropdown from data and pre-selects the global value", () => {
+    window.testInitialValue = '/b'
+    populateArrDropdown('d', [{ p: '/a' }, { p: '/b' }, { p: '/c' }], 'p', 'p', 'testInitialValue')
+    expect(document.getElementById('d').value).toBe('/b')
+  })
+
+  it("falls back to empty string when the global is undefined", () => {
+    populateArrDropdown('d', [{ p: '/a' }], 'p', 'p', 'neverDefined')
+    // Value stays as placeholder (empty)
+    expect(document.getElementById('d').value).toBe('')
+    // But the option is present
+    expect(document.getElementById('d').children.length).toBe(2)
+  })
+
+  it("falls back to empty string when initialGlobalName is empty string", () => {
+    populateArrDropdown('d', [{ p: '/a' }], 'p', 'p', '')
+    expect(document.getElementById('d').value).toBe('')
+  })
+
+  it("falls back to empty string when initialGlobalName is undefined", () => {
+    populateArrDropdown('d', [{ p: '/a' }], 'p', 'p', undefined)
+    expect(document.getElementById('d').value).toBe('')
+  })
+
+  it("handles null data (passes through to populateDropdown)", () => {
+    // Should not throw; leaves just the placeholder.
+    expect(() => populateArrDropdown('d', null, 'p', 'p', 'testInitialValue')).not.toThrow()
+    expect(document.getElementById('d').children.length).toBe(1)
+  })
+
+  it("does not throw when the element is missing", () => {
+    expect(() => populateArrDropdown('nonexistent', [{ p: 'x' }], 'p', 'p', 'testInitialValue')).not.toThrow()
+  })
+
+  it("reads the global at call time, not at import time", () => {
+    // Call once with global unset:
+    populateArrDropdown('d', [{ p: '/a' }, { p: '/b' }], 'p', 'p', 'testInitialValue')
+    expect(document.getElementById('d').value).toBe('')
+
+    // Now set it and re-populate:
+    window.testInitialValue = '/b'
+    populateArrDropdown('d', [{ p: '/a' }, { p: '/b' }], 'p', 'p', 'testInitialValue')
+    expect(document.getElementById('d').value).toBe('/b')
+  })
+})
+
+// ---------------------------------------------------------------------
+// buildArrPreSubmit
+// ---------------------------------------------------------------------
+
+function installArrFixture () {
+  document.body.innerHTML = `
+    <input type="hidden" id="thing_validated" value="false">
+    <select id="dropdown_one"><option value="">--</option></select>
+    <select id="dropdown_two"><option value="">--</option></select>
+    <select id="dropdown_three"><option value="">--</option></select>
+    <div id="statusMessage" style="display:none"></div>
+    <div id="customStatus" style="display:none"></div>
+  `
+}
+
+function setValidated (value) {
+  document.getElementById('thing_validated').value = value ? 'true' : 'false'
+}
+
+function pickDropdown (id, value) {
+  const el = document.getElementById(id)
+  const option = document.createElement('option')
+  option.value = value
+  option.textContent = value
+  el.appendChild(option)
+  el.value = value
+}
+
+const DEFAULT_DROPDOWNS = [
+  { elementId: 'dropdown_one', errorMessage: 'Pick one!' },
+  { elementId: 'dropdown_two', errorMessage: 'Pick two!' }
+]
+
+describe('buildArrPreSubmit -- config validation', () => {
+  it("throws without validatedFieldId", () => {
+    expect(() => buildArrPreSubmit({ dropdowns: DEFAULT_DROPDOWNS })).toThrow(/validatedFieldId/)
+  })
+
+  it("throws when dropdowns is not an array", () => {
+    expect(() => buildArrPreSubmit({ validatedFieldId: 'thing_validated', dropdowns: 'nope' })).toThrow(/dropdowns/)
+  })
+})
+
+describe('buildArrPreSubmit -- skipWhenUnvalidated=true (Radarr shape)', () => {
+  beforeEach(installArrFixture)
+  afterEach(() => { document.body.innerHTML = ''; delete window.PathValidation })
+
+  it("returns true when unvalidated, ignoring bad paths and empty dropdowns", () => {
+    window.PathValidation = { validateAll: () => false }  // paths invalid
+    const gate = buildArrPreSubmit({
+      validatedFieldId: 'thing_validated',
+      dropdowns: DEFAULT_DROPDOWNS,
+      skipWhenUnvalidated: true
+    })
+    setValidated(false)
+    expect(gate()).toBe(true)
+    // Status message NOT shown because we short-circuited entirely.
+    expect(document.getElementById('statusMessage').style.display).toBe('none')
+  })
+
+  it("returns true when unvalidated even with empty dropdowns", () => {
+    const gate = buildArrPreSubmit({
+      validatedFieldId: 'thing_validated',
+      dropdowns: DEFAULT_DROPDOWNS,
+      skipWhenUnvalidated: true
+    })
+    setValidated(false)
+    expect(gate()).toBe(true)
+  })
+
+  it("proceeds with checks when validated", () => {
+    const gate = buildArrPreSubmit({
+      validatedFieldId: 'thing_validated',
+      dropdowns: DEFAULT_DROPDOWNS,
+      skipWhenUnvalidated: true
+    })
+    setValidated(true)
+    // Both dropdowns empty -> should block
+    expect(gate()).toBe(false)
+  })
+})
+
+describe('buildArrPreSubmit -- skipWhenUnvalidated=false (Sonarr shape, buggy #1584)', () => {
+  beforeEach(installArrFixture)
+  afterEach(() => { document.body.innerHTML = ''; delete window.PathValidation })
+
+  it("returns FALSE when unvalidated + paths invalid (the bug)", () => {
+    window.PathValidation = { validateAll: () => false }
+    const gate = buildArrPreSubmit({
+      validatedFieldId: 'thing_validated',
+      dropdowns: DEFAULT_DROPDOWNS,
+      skipWhenUnvalidated: false
+    })
+    setValidated(false)
+    expect(gate()).toBe(false)  // <-- documents the buggy behavior
+    expect(document.getElementById('statusMessage').style.display).toBe('block')
+    expect(document.getElementById('statusMessage').textContent).toContain('path')
+  })
+
+  it("returns true when unvalidated + valid paths (dropdowns not checked)", () => {
+    window.PathValidation = { validateAll: () => true }
+    const gate = buildArrPreSubmit({
+      validatedFieldId: 'thing_validated',
+      dropdowns: DEFAULT_DROPDOWNS,
+      skipWhenUnvalidated: false
+    })
+    setValidated(false)
+    // Dropdowns empty but not checked because !validated; paths OK -> allow.
+    expect(gate()).toBe(true)
+  })
+
+  it("proceeds normally when validated (same as Radarr shape)", () => {
+    const gate = buildArrPreSubmit({
+      validatedFieldId: 'thing_validated',
+      dropdowns: DEFAULT_DROPDOWNS,
+      skipWhenUnvalidated: false
+    })
+    setValidated(true)
+    expect(gate()).toBe(false)  // empty dropdowns -> blocks
+  })
+})
+
+describe('buildArrPreSubmit -- dropdown checks (validated user)', () => {
+  beforeEach(() => {
+    installArrFixture()
+    setValidated(true)
+  })
+  afterEach(() => { document.body.innerHTML = ''; delete window.PathValidation })
+
+  it("no errors when all dropdowns filled", () => {
+    pickDropdown('dropdown_one', '/first')
+    pickDropdown('dropdown_two', '/second')
+    const gate = buildArrPreSubmit({
+      validatedFieldId: 'thing_validated',
+      dropdowns: DEFAULT_DROPDOWNS,
+      skipWhenUnvalidated: true
+    })
+    expect(gate()).toBe(true)
+  })
+
+  it("one empty dropdown -> one error", () => {
+    pickDropdown('dropdown_one', '/first')
+    // dropdown_two stays empty
+    const gate = buildArrPreSubmit({
+      validatedFieldId: 'thing_validated',
+      dropdowns: DEFAULT_DROPDOWNS,
+      skipWhenUnvalidated: true
+    })
+    expect(gate()).toBe(false)
+    const status = document.getElementById('statusMessage')
+    expect(status.textContent).toContain('Pick two!')
+    expect(status.textContent).not.toContain('Pick one!')
+  })
+
+  it("errors render in declaration order", () => {
+    const gate = buildArrPreSubmit({
+      validatedFieldId: 'thing_validated',
+      dropdowns: [
+        { elementId: 'dropdown_one', errorMessage: 'ALPHA' },
+        { elementId: 'dropdown_two', errorMessage: 'BETA' },
+        { elementId: 'dropdown_three', errorMessage: 'GAMMA' }
+      ],
+      skipWhenUnvalidated: true
+    })
+    expect(gate()).toBe(false)
+    const text = document.getElementById('statusMessage').textContent
+    // ALPHA appears before BETA appears before GAMMA
+    expect(text.indexOf('ALPHA')).toBeLessThan(text.indexOf('BETA'))
+    expect(text.indexOf('BETA')).toBeLessThan(text.indexOf('GAMMA'))
+  })
+
+  it("missing dropdown element counts as empty (error added)", () => {
+    document.getElementById('dropdown_two').remove()
+    const gate = buildArrPreSubmit({
+      validatedFieldId: 'thing_validated',
+      dropdowns: DEFAULT_DROPDOWNS,
+      skipWhenUnvalidated: true
+    })
+    // dropdown_one still empty + dropdown_two missing -> 2 errors
+    expect(gate()).toBe(false)
+    const text = document.getElementById('statusMessage').textContent
+    expect(text).toContain('Pick one!')
+    expect(text).toContain('Pick two!')
+  })
+})
+
+describe('buildArrPreSubmit -- path validation', () => {
+  beforeEach(() => {
+    installArrFixture()
+    setValidated(true)
+    pickDropdown('dropdown_one', '/x')
+    pickDropdown('dropdown_two', '/y')
+  })
+  afterEach(() => { document.body.innerHTML = ''; delete window.PathValidation })
+
+  it("PathValidation missing entirely -> passes (no error)", () => {
+    delete window.PathValidation
+    const gate = buildArrPreSubmit({
+      validatedFieldId: 'thing_validated',
+      dropdowns: DEFAULT_DROPDOWNS,
+      skipWhenUnvalidated: true
+    })
+    expect(gate()).toBe(true)
+  })
+
+  it("PathValidation without validateAll -> passes (no error)", () => {
+    window.PathValidation = {}  // no validateAll fn
+    const gate = buildArrPreSubmit({
+      validatedFieldId: 'thing_validated',
+      dropdowns: DEFAULT_DROPDOWNS,
+      skipWhenUnvalidated: true
+    })
+    expect(gate()).toBe(true)
+  })
+
+  it("validateAll=true -> no error", () => {
+    window.PathValidation = { validateAll: () => true }
+    const gate = buildArrPreSubmit({
+      validatedFieldId: 'thing_validated',
+      dropdowns: DEFAULT_DROPDOWNS,
+      skipWhenUnvalidated: true
+    })
+    expect(gate()).toBe(true)
+  })
+
+  it("validateAll=false -> path error added", () => {
+    window.PathValidation = { validateAll: () => false }
+    const gate = buildArrPreSubmit({
+      validatedFieldId: 'thing_validated',
+      dropdowns: DEFAULT_DROPDOWNS,
+      skipWhenUnvalidated: true
+    })
+    expect(gate()).toBe(false)
+    expect(document.getElementById('statusMessage').textContent).toContain('path')
+  })
+})
+
+describe('buildArrPreSubmit -- status message rendering', () => {
+  beforeEach(() => {
+    installArrFixture()
+    setValidated(true)
+  })
+  afterEach(() => { document.body.innerHTML = '' })
+
+  it("shows message with combined errors and red color", () => {
+    const gate = buildArrPreSubmit({
+      validatedFieldId: 'thing_validated',
+      dropdowns: DEFAULT_DROPDOWNS,
+      skipWhenUnvalidated: true
+    })
+    expect(gate()).toBe(false)
+    const status = document.getElementById('statusMessage')
+    expect(status.style.display).toBe('block')
+    expect(status.style.color).toBe('rgb(234, 134, 143)')  // #ea868f
+  })
+
+  it("hides message when no errors", () => {
+    pickDropdown('dropdown_one', '/x')
+    pickDropdown('dropdown_two', '/y')
+    const status = document.getElementById('statusMessage')
+    status.style.display = 'block'  // stale from a previous submit
+    const gate = buildArrPreSubmit({
+      validatedFieldId: 'thing_validated',
+      dropdowns: DEFAULT_DROPDOWNS,
+      skipWhenUnvalidated: true
+    })
+    expect(gate()).toBe(true)
+    expect(status.style.display).toBe('none')
+  })
+
+  it("no crash when status element missing", () => {
+    document.getElementById('statusMessage').remove()
+    const gate = buildArrPreSubmit({
+      validatedFieldId: 'thing_validated',
+      dropdowns: DEFAULT_DROPDOWNS,
+      skipWhenUnvalidated: true
+    })
+    // Should still return false; just can't render the message.
+    expect(() => gate()).not.toThrow()
+    expect(gate()).toBe(false)
+  })
+})
+
+describe('buildArrPreSubmit -- custom overrides', () => {
+  beforeEach(() => {
+    installArrFixture()
+    setValidated(true)
+  })
+  afterEach(() => { document.body.innerHTML = '' })
+
+  it("uses custom statusMessageId", () => {
+    const gate = buildArrPreSubmit({
+      validatedFieldId: 'thing_validated',
+      statusMessageId: 'customStatus',
+      dropdowns: DEFAULT_DROPDOWNS,
+      skipWhenUnvalidated: true
+    })
+    expect(gate()).toBe(false)
+    expect(document.getElementById('customStatus').style.display).toBe('block')
+    expect(document.getElementById('statusMessage').style.display).toBe('none')  // untouched
+  })
+
+  it("uses custom pathErrorMessage", () => {
+    window.PathValidation = { validateAll: () => false }
+    pickDropdown('dropdown_one', '/x')
+    pickDropdown('dropdown_two', '/y')
+    const gate = buildArrPreSubmit({
+      validatedFieldId: 'thing_validated',
+      dropdowns: DEFAULT_DROPDOWNS,
+      skipWhenUnvalidated: true,
+      pathErrorMessage: 'CUSTOM PATH WARNING'
+    })
+    expect(gate()).toBe(false)
+    expect(document.getElementById('statusMessage').textContent).toContain('CUSTOM PATH WARNING')
+    delete window.PathValidation
+  })
+
+  it("uses default statusMessageId and pathErrorMessage when omitted", () => {
+    window.PathValidation = { validateAll: () => false }
+    pickDropdown('dropdown_one', '/x')
+    pickDropdown('dropdown_two', '/y')
+    const gate = buildArrPreSubmit({
+      validatedFieldId: 'thing_validated',
+      dropdowns: DEFAULT_DROPDOWNS,
+      skipWhenUnvalidated: true
+    })
+    expect(gate()).toBe(false)
+    expect(document.getElementById('statusMessage').textContent).toContain('Please fix invalid path fields')
+    delete window.PathValidation
+  })
+})


### PR DESCRIPTION
## What

Extracts the last remaining duplication between `110-radarr.js` and `120-sonarr.js` -- the "populate initial-value-aware dropdown" and "pre-submit gate" patterns -- into a shared `modules/arrPageBase.js` module.

This finishes the mechanical work called for in **Roadmap Step 6** (issue #1335): the "shared validation widget" goal. Alpine.js was NOT installed; the factory/helper module pattern (established across PRs #1367-#1370) met the duplication-elimination goal without a framework dependency.

## Line counts

| File | Before | After | Δ |
|---|---:|---:|---:|
| `110-radarr.js` | 69 | 43 | **-38%** |
| `120-sonarr.js` | 74 | 49 | **-34%** |
| `modules/arrPageBase.js` | — | 142 | NEW |
| `tests/js/modules/arrPageBase.test.js` | — | (29 tests) | NEW |
| **Vitest tests** | **1333** | **1362** | **+29** |

## What moved to `arrPageBase.js`

1.  **`populateArrDropdown(elementId, data, valueField, textField, initialGlobalName)`**
    Thin wrapper over `populateDropdown` that safely reads the `initialXxxRootFolderPath` / `initialXxxQualityProfile` / `initialXxxLanguageProfile` window globals injected by the rendered template. Handles the `typeof x !== 'undefined'` dance both wizards did verbatim.

2.  **`buildArrPreSubmit({ validatedFieldId, statusMessageId, dropdowns, skipWhenUnvalidated, pathErrorMessage })`**
    Returns a form-submit gate function. Reads validatedField, collects one error per empty required dropdown (when validated), adds a path-validation error if PathValidation reports invalid paths, renders errors via `setStatusMessageLines`, and returns true/false to allow/block navigation.

## `skipWhenUnvalidated` preserves a pre-existing bug (#1584)

Radarr has always short-circuited (`return true`) when the wizard isn't validated, letting the user skip the page without a path-validation check. Sonarr has never done this -- its path check runs unconditionally.

This is a real bug: an unvalidated Sonarr user with any invalid path field elsewhere cannot navigate away from the Sonarr page. Filed as **#1584** for a targeted fix in its own PR.

Rather than "silently fix" the bug during a mechanical extraction, `buildArrPreSubmit` accepts `skipWhenUnvalidated` as an option:

- Radarr passes `true` (correct behavior)
- Sonarr passes `false` (preserves buggy behavior)

Fix #1584 will flip Sonarr's option to `true`.

## Test coverage: 29 new tests

- **`populateArrDropdown` (7):** happy path, missing/undefined/empty globals, null data, missing element, reads global at call time
- **`buildArrPreSubmit` config validation (2):** throws without `validatedFieldId` / non-array `dropdowns`
- **`skipWhenUnvalidated=true` (3):** unvalidated skips everything, validated proceeds
- **`skipWhenUnvalidated=false` (3):** documents the #1584 buggy behavior explicitly
- **Dropdown checks (4):** all filled, one empty, order preserved, missing element
- **Path validation (4):** missing PathValidation, missing validateAll, true/false cases
- **Status rendering (3):** red color, hidden when clear, safe when missing
- **Custom overrides (3):** custom statusMessageId, custom pathErrorMessage, defaults

## Verification

- **1362/1362 Vitest pass** (was 1333; +29 new)
- **4/4 Radarr/Sonarr e2e tests pass** (`test_dropdown_populating_wizard_success_flow` x2, `test_radarr_pre_submit_blocks_navigation_when_dropdowns_unset`, `test_radarr_revalidate_on_load_repopulates_dropdowns`)
- ESLint clean, Node syntax clean

## Roadmap impact

With this PR, **Roadmap Step 6 is functionally complete.** All 15 credential-style wizard files now delegate to shared modules:

- `createApiKeyValidator.js` -- credential validation flow
- `createOauthValidator.js` -- OAuth-PIN flows (Plex, Trakt, MAL)
- `oauthValidationHelpers.js` -- shared OAuth utilities
- `validationPageBase.js` -- `setToggleButtonIcon` + refresh callout
- `dropdownHelpers.js` -- `populateDropdown` + `setStatusMessageLines`
- **`arrPageBase.js` -- Radarr/Sonarr shared patterns (NEW)**

Alpine.js was **not** installed. The 13× `setToggleButtonIcon` / 15× `refreshValidationCallout` duplication is gone; wizards shrank from ~150 lines to ~15-50; the reactive framework the roadmap suggested turned out not to be necessary. Update to issue #1335 forthcoming.
