### PR TITLE
Fix #1584: Sonarr wizard strands unvalidated users with invalid paths

### DIFF
--- a/static/local-js/120-sonarr.js
+++ b/static/local-js/120-sonarr.js
@@ -1,15 +1,14 @@
 import { createApiKeyValidator } from './modules/createApiKeyValidator.js'
 import { populateArrDropdown, buildArrPreSubmit } from './modules/arrPageBase.js'
 
-// Sonarr wizard — uses createApiKeyValidator for the credential flow,
+// Sonarr wizard -- uses createApiKeyValidator for the credential flow,
 // arrPageBase helpers for the dropdown-populate and form-submit gate.
 //
-// NOTE: skipWhenUnvalidated is FALSE here — a pre-existing bug (#1584)
-// that predates the Step 6 factory migration. Sonarr's path-validation
-// runs unconditionally, so an unvalidated user with any invalid path
-// field elsewhere on the page cannot navigate away. Compare Radarr,
-// which correctly returns true early. Fix in #1584 will flip this
-// flag to true.
+// skipWhenUnvalidated=true matches Radarr: an unvalidated user can
+// navigate away from the Sonarr page without a path check blocking
+// them. Previously Sonarr ran the path check unconditionally, which
+// stranded users with any invalid path field elsewhere on the page
+// (bug #1584 -- pre-existed the Step 6 factory migration by years).
 
 function populateSonarrDropdowns (data) {
   populateArrDropdown('sonarr_root_folder_path', data.root_folders, 'path', 'path', 'initialSonarrRootFolderPath')
@@ -24,7 +23,7 @@ const validateSonarrPage = buildArrPreSubmit({
     { elementId: 'sonarr_quality_profile', errorMessage: 'Please select a valid Quality Profile.' },
     { elementId: 'sonarr_language_profile', errorMessage: 'Please select a valid Language Profile.' }
   ],
-  skipWhenUnvalidated: false  // Preserves buggy pre-existing behavior; see #1584.
+  skipWhenUnvalidated: true  // Matches Radarr; fixes #1584.
 })
 
 createApiKeyValidator({

--- a/static/local-js/modules/arrPageBase.js
+++ b/static/local-js/modules/arrPageBase.js
@@ -19,16 +19,19 @@
 //   buildArrPreSubmit    — the "validated OR skip + collect errors"
 //                          form-submit gate builder
 //
-// BEHAVIOR NOTE — Sonarr asymmetry preserved verbatim
+// BEHAVIOR NOTE -- skipWhenUnvalidated (historical context)
 //
-//   Radarr short-circuits (`return true`) when the wizard isn't
-//   validated, letting the user skip the page without a path-check.
-//   Sonarr does NOT short-circuit; its path check runs even for
-//   unvalidated users. This pre-existing asymmetry is a known bug
-//   (#1584) that predates the Step 6 factory work. buildArrPreSubmit
-//   supports both shapes via the `skipWhenUnvalidated` option so the
-//   extract is behavior-preserving. Fix #1584 will flip Sonarr's
-//   option to true.
+//   Radarr has always short-circuited (`return true`) when the wizard
+//   isn't validated, letting the user skip the page without a path
+//   check. Sonarr USED to NOT short-circuit -- its path check ran
+//   even for unvalidated users, which stranded users with any invalid
+//   path elsewhere. That was bug #1584 (predated the Step 6 factory
+//   migration by years). Fixed by flipping Sonarr's option to true.
+//
+//   Both consumers now pass `skipWhenUnvalidated: true`. The option
+//   is kept as an escape hatch for future non-arr wizards that might
+//   want the different shape, but if it stays 100% unused it can be
+//   collapsed in a future YAGNI pass.
 
 import { populateDropdown, setStatusMessageLines } from './dropdownHelpers.js'
 
@@ -84,9 +87,8 @@ export function populateArrDropdown (elementId, data, valueField, textField, ini
  *   to check and what to say if it's empty. Order matters — errors
  *   render in the order given.
  * @param {boolean} [config.skipWhenUnvalidated=false]  When true, an
- *   unvalidated wizard skips ALL checks (dropdowns + path). Preserves
- *   the Radarr behavior. Sonarr passes false (see BEHAVIOR NOTE above);
- *   fix in issue #1584.
+ *   unvalidated wizard skips ALL checks (dropdowns + path). Both
+ *   Radarr and Sonarr now pass true; see BEHAVIOR NOTE above.
  * @param {string} [config.pathErrorMessage]  Override the path-error
  *   text. Defaults to the phrasing both wizards used verbatim.
  * @returns {() => boolean}

--- a/tests/e2e/test_wizard_e2e.py
+++ b/tests/e2e/test_wizard_e2e.py
@@ -521,6 +521,58 @@ def test_radarr_revalidate_on_load_repopulates_dropdowns(page, live_server):
 
 
 @pytest.mark.e2e
+def test_sonarr_allows_skip_when_unvalidated(page, live_server):
+    """Regression test for #1584.
+
+    An unvalidated Sonarr user should be able to navigate away from
+    the page without any path or dropdown check blocking them --
+    matching Radarr's behavior.
+
+    Historically Sonarr's onPreSubmit ran the path check unconditionally,
+    so a user who had NOT validated Sonarr but had any invalid path
+    field elsewhere was stranded. The fix flips arrPageBase's
+    `skipWhenUnvalidated` to true for Sonarr, matching Radarr.
+
+    This test loads the Sonarr page WITHOUT validating, then dispatches
+    a form submit. The submit must NOT be preventDefault-blocked.
+    """
+    page.goto(f"{live_server}/step/120-sonarr", wait_until="domcontentloaded")
+
+    # Precondition: sonarr is NOT validated. Rendered value may be
+    # 'false' or 'False' depending on how Jinja stringified the bool;
+    # the wizard code lowercases before comparing, so either is fine.
+    initial_validated = page.locator("#sonarr_validated").input_value()
+    assert initial_validated.lower() != "true", f"precondition: sonarr_validated should not be true; got {initial_validated!r}"
+
+    # Force PathValidation.validateAll to return false. This is the
+    # exact condition that used to strand unvalidated Sonarr users:
+    # some path field elsewhere on the page failed validation. Stub
+    # it out to guarantee the failing branch is exercised regardless
+    # of what path fields the Sonarr template happens to render.
+    page.evaluate("""
+        () => {
+            window.PathValidation = {
+                validateAll: () => false,
+                attach: () => {}
+            }
+        }
+    """)
+
+    # Dispatch a real form submit; the gate should return true and NOT
+    # preventDefault. In the buggy pre-fix code, the path check ran and
+    # returned false because at least one path field was invalid.
+    blocked = page.evaluate("""
+        () => {
+            const form = document.getElementById('configForm');
+            const evt = new Event('submit', { cancelable: true });
+            form.dispatchEvent(evt);
+            return evt.defaultPrevented;
+        }
+    """)
+    assert blocked is False, "expected an unvalidated Sonarr page to allow navigation " "(regression #1584); form submit was blocked instead"
+
+
+@pytest.mark.e2e
 def test_plex_validator_success_populates_extra_state(page, live_server):
     """Plex's onValidationSuccess hook copies db_cache + 4 library lists
     into hidden form inputs and reveals the "hidden" section. Verify

--- a/tests/js/modules/arrPageBase.test.js
+++ b/tests/js/modules/arrPageBase.test.js
@@ -31,8 +31,8 @@
 //       - unvalidated + missing dropdowns -> returns true (skip)
 //       - validated -> proceeds with normal checks
 //
-//     skipWhenUnvalidated=false (Sonarr shape, buggy per #1584) (3):
-//       - unvalidated + invalid paths -> returns false (blocks!)
+//     skipWhenUnvalidated=false (escape-hatch shape, historically Sonarr) (3):
+//       - unvalidated + invalid paths -> returns false (blocks)
 //       - unvalidated + empty dropdowns -> returns true (dropdowns
 //         only checked when validated)
 //       - validated -> proceeds with normal checks
@@ -211,11 +211,11 @@ describe('buildArrPreSubmit -- skipWhenUnvalidated=true (Radarr shape)', () => {
   })
 })
 
-describe('buildArrPreSubmit -- skipWhenUnvalidated=false (Sonarr shape, buggy #1584)', () => {
+describe('buildArrPreSubmit -- skipWhenUnvalidated=false (escape-hatch shape)', () => {
   beforeEach(installArrFixture)
   afterEach(() => { document.body.innerHTML = ''; delete window.PathValidation })
 
-  it("returns FALSE when unvalidated + paths invalid (the bug)", () => {
+  it("returns false when unvalidated + paths invalid (path check runs)", () => {
     window.PathValidation = { validateAll: () => false }
     const gate = buildArrPreSubmit({
       validatedFieldId: 'thing_validated',
@@ -223,7 +223,7 @@ describe('buildArrPreSubmit -- skipWhenUnvalidated=false (Sonarr shape, buggy #1
       skipWhenUnvalidated: false
     })
     setValidated(false)
-    expect(gate()).toBe(false)  // <-- documents the buggy behavior
+    expect(gate()).toBe(false)  // path check runs regardless of validated flag
     expect(document.getElementById('statusMessage').style.display).toBe('block')
     expect(document.getElementById('statusMessage').textContent).toContain('path')
   })


### PR DESCRIPTION
## Fixes #1584

An unvalidated Sonarr user (fresh page, no Validate click) whose page happens to have any invalid path field elsewhere was unable to navigate away. The onPreSubmit gate ran the path check unconditionally and blocked the form submit.

Radarr has always had the correct behavior: short-circuit with `return true` when the wizard isn't validated, letting the user skip the page cleanly. The asymmetry predated the Step 6 factory migration (#1370) by years and was preserved verbatim through the extract in PR #1585 via a `skipWhenUnvalidated` config option.

## The fix

```diff
 // 120-sonarr.js
-  skipWhenUnvalidated: false  // Preserves buggy pre-existing behavior; see #1584.
+  skipWhenUnvalidated: true  // Matches Radarr; fixes #1584.
```

Also updated `arrPageBase.js` docstrings to reflect that both consumers now pass `true`. The option is retained as an escape hatch for future non-arr wizards; if it stays 100% unused it can be collapsed in a later YAGNI pass.

## Regression test

New e2e: `tests/e2e/test_wizard_e2e.py::test_sonarr_allows_skip_when_unvalidated`

- Loads Sonarr page WITHOUT validating.
- Stubs `PathValidation.validateAll` to return `false` (guarantees the failing branch is exercised regardless of what path fields the template happens to render).
- Dispatches a real form submit.
- Asserts `event.defaultPrevented` is `false`.

**Verified the test genuinely catches the bug** — temporarily reverted the fix, test failed; reapplied it, test passed.

## Verification

- **1362/1362 Vitest pass** (Vitest suite unchanged from #1585)
- **5/5 radarr/sonarr e2e pass** (+1 new regression test)
- ESLint clean

## Dependency

**Stacked on #1585.** Requires the `skipWhenUnvalidated` option to exist. Please merge #1585 first, then this PR will rebase cleanly onto develop.
