### PR TITLE
Split 900-kometa.js part 25: extract validation-display helpers (-109 lines)

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -80,6 +80,11 @@ import {
   clearRunProgress,
   fetchRunProgress
 } from './modules/kometa/_runProgress.js'
+import {
+  formatLocalTimestamp,
+  formatRelativeTimestamp,
+  updateValidationRow
+} from './modules/kometa/_validationDisplay.js'
 
 // Kometa runtime status flags migrated to modules/kometa/_state.js
 // (kometaState.kometaInstalled, kometaValidated, kometaStatus, etc.).
@@ -1087,42 +1092,6 @@ if (document.getElementById('header-style')) {
   })
 }
 
-const formatLocalTimestamp = (date) => {
-  const pad2 = (value) => String(value).padStart(2, '0')
-  return [
-    date.getFullYear(),
-    pad2(date.getMonth() + 1),
-    pad2(date.getDate())
-  ].join('-') + ' ' + [
-    pad2(date.getHours()),
-    pad2(date.getMinutes()),
-    pad2(date.getSeconds())
-  ].join(':')
-}
-
-const formatRelativeTimestamp = (date, now) => {
-  const base = now || new Date()
-  let diffMs = base - date
-  if (!Number.isFinite(diffMs) || diffMs < 0) diffMs = 0
-  const sec = Math.floor(diffMs / 1000)
-  if (sec < 60) return 'Just now'
-  const min = Math.floor(sec / 60)
-  if (min < 60) return `${min}m ago`
-  const hr = Math.floor(min / 60)
-  const minLeft = min % 60
-  if (hr < 24) return `${hr}h ${minLeft}m ago`
-  const days = Math.floor(hr / 24)
-  const hrLeft = hr % 24
-  if (days < 7) return `${days}d ${hrLeft}h ago`
-  const weeks = Math.floor(days / 7)
-  const dayLeft = days % 7
-  if (weeks < 5) return `${weeks}w ${dayLeft}d ago`
-  const months = Math.floor(days / 30)
-  if (months < 12) return `${months}mo ago`
-  const years = Math.floor(days / 365)
-  return `${years}y ago`
-}
-
 const now = new Date()
 document.querySelectorAll('[data-validation-iso]').forEach(el => {
   const raw = el.dataset.validationIso
@@ -1140,85 +1109,6 @@ document.querySelectorAll('[data-validation-iso-age]').forEach(el => {
     el.textContent = formatRelativeTimestamp(parsed, now)
   }
 })
-
-const validationReasonLabels = {
-  missing_credentials: 'Missing credentials',
-  missing_plex_validation: 'Plex not validated',
-  no_libraries: 'No libraries selected',
-  invalid_paths: 'Invalid paths',
-  missing_library_defaults: 'Missing library defaults',
-  missing_separator_placeholder: 'Missing separator placeholder',
-  invalid_fields: 'Invalid fields',
-  no_webhooks: 'No webhooks configured',
-  disabled: 'Disabled',
-  missing_settings: 'Settings missing',
-  missing_tokens: 'Missing tokens',
-  token_invalid: 'Invalid tokens',
-  account_locked: 'Account locked',
-  validation_error: 'Validation error'
-}
-
-function formatValidationResult (status, reason, details) {
-  if (!status) return ''
-  const label = status.charAt(0).toUpperCase() + status.slice(1)
-  if (!reason) return label
-  const pretty = validationReasonLabels[reason] || reason.replace(/_/g, ' ')
-  if (Array.isArray(details) && details.length) {
-    return `${label}: ${pretty}: ${details.join(', ')}`
-  }
-  if (details) {
-    return `${label}: ${pretty}: ${details}`
-  }
-  return `${label}: ${pretty}`
-}
-
-function updateValidationRow (key, result) {
-  const row = document.querySelector(`[data-validation-key="${key}"]`)
-  if (!row || !result) return
-
-  const pill = row.querySelector('.validation-status-pill')
-  const timestampEl = row.querySelector('.validation-timestamp')
-  const ageEl = row.querySelector('.validation-age')
-  const status = result.status
-  const validatedAt = result.validated_at || ''
-
-  if (pill) {
-    pill.classList.remove(
-      'rating-mapping-option-via--validated',
-      'rating-mapping-option-via--unvalidated',
-      'rating-mapping-option-via--neutral'
-    )
-    if (status === 'validated') {
-      pill.classList.add('rating-mapping-option-via--validated')
-    } else if (status === 'failed') {
-      pill.classList.add('rating-mapping-option-via--unvalidated')
-    } else if (status === 'skipped') {
-      pill.classList.add('rating-mapping-option-via--neutral')
-    }
-  }
-
-  if (validatedAt && timestampEl) {
-    timestampEl.dataset.validationIso = validatedAt
-    const parsed = new Date(validatedAt)
-    if (!Number.isNaN(parsed.getTime())) {
-      timestampEl.textContent = formatLocalTimestamp(parsed)
-    }
-  }
-
-  if (validatedAt && ageEl) {
-    ageEl.dataset.validationIsoAge = validatedAt
-    const parsed = new Date(validatedAt)
-    if (!Number.isNaN(parsed.getTime())) {
-      ageEl.textContent = formatRelativeTimestamp(parsed, new Date())
-    }
-  }
-
-  const resultEl = row.querySelector('.validation-result')
-  if (resultEl) {
-    const resultText = formatValidationResult(status, result.reason, result.details)
-    resultEl.textContent = resultText || (status ? status.charAt(0).toUpperCase() + status.slice(1) : '—')
-  }
-}
 
 const validateAllBtn = document.getElementById('validate-all-services')
 const validateAllStatus = document.getElementById('validate-all-status')

--- a/static/local-js/modules/kometa/_validationDisplay.js
+++ b/static/local-js/modules/kometa/_validationDisplay.js
@@ -1,0 +1,241 @@
+// Kometa validation-display helpers: pure formatters + a single
+// DOM-mutator (updateValidationRow) shared between the initial
+// page-load pass and the qs:bulk-validation-complete event handler.
+//
+// PURE FUNCTIONS (no DOM access, safe to test in isolation):
+//
+//   formatLocalTimestamp(date)
+//     Returns a fixed "YYYY-MM-DD HH:MM:SS" string using LOCAL time.
+//     Not toISOString (that's UTC); not toLocaleString (that's locale-
+//     dependent and would break snapshot tests). The wizard rows show
+//     this string as-is next to each validated service.
+//
+//   formatRelativeTimestamp(date, now)
+//     Returns "Just now" / "5m ago" / "2h 15m ago" / etc. Bounded
+//     lookup with cascading units (seconds -> minutes -> hours ->
+//     days -> weeks -> months -> years). Handles negative diffs by
+//     clamping to 0 (defensive against clock skew).
+//
+//   formatValidationResult(status, reason, details)
+//     Combines a status ("validated" / "failed" / "skipped") with an
+//     optional reason code from VALIDATION_REASON_LABELS and optional
+//     details string or array. Empty status returns ''.
+//
+// CONSTANTS:
+//
+//   VALIDATION_REASON_LABELS
+//     Maps validation reason codes ("missing_credentials",
+//     "no_libraries", etc.) to display labels. Any code not in the
+//     map falls through to a snake_case -> spaced form.
+//
+// SIDE-EFFECTFUL:
+//
+//   updateValidationRow(key, result)
+//     Mutates the DOM row matching [data-validation-key="{key}"] to
+//     reflect a new validation result. Updates the status pill class,
+//     the timestamp text, the relative-age text, and the result text
+//     block. Safe when the row or pieces are missing (no-op).
+//
+// This module has ZERO knowledge of the qs:bulk-validation-* event
+// flow -- that lives in 900-kometa.js because it's tightly bound to
+// page-load wiring and needs access to a bunch of other page-scoped
+// state (kometaState.showYAML, getFinalGateState, etc.). Keeping this
+// module pure/small maximizes test coverage.
+
+/**
+ * Two-digit zero-padded integer stringification. Private helper.
+ * @private
+ */
+function pad2 (value) {
+  return String(value).padStart(2, '0')
+}
+
+/**
+ * Format a Date as "YYYY-MM-DD HH:MM:SS" in local time.
+ *
+ * Deliberately not toISOString (UTC) or toLocaleString (locale-
+ * dependent). The wizard rows show this exact format.
+ *
+ * @param {Date} date  Any valid Date. Callers are expected to have
+ *                      already validated via Number.isNaN(getTime()).
+ * @returns {string}
+ */
+export function formatLocalTimestamp (date) {
+  return [
+    date.getFullYear(),
+    pad2(date.getMonth() + 1),
+    pad2(date.getDate())
+  ].join('-') + ' ' + [
+    pad2(date.getHours()),
+    pad2(date.getMinutes()),
+    pad2(date.getSeconds())
+  ].join(':')
+}
+
+/**
+ * Format a Date as a human-relative age string ("Just now",
+ * "5m ago", "2h 15m ago", "3d 4h ago", "2w 3d ago", "5mo ago",
+ * "2y ago").
+ *
+ * Uses cascading unit boundaries:
+ *   <60s      -> "Just now"
+ *   <60min    -> "Nm ago"
+ *   <24h      -> "Nh Mm ago"
+ *   <7d       -> "Nd Mh ago"
+ *   <5w       -> "Nw Md ago"
+ *   <12mo     -> "Nmo ago"
+ *   else      -> "Ny ago"
+ *
+ * Weeks/days handled with month approximation (30 days = 1mo,
+ * 365 days = 1y). Not calendar-accurate; deliberately loose.
+ *
+ * Negative diffs (clock skew, future timestamp) clamp to 0 -> "Just now".
+ *
+ * @param {Date}  date  The past date to describe.
+ * @param {Date} [now]  Reference "now" (defaults to `new Date()`).
+ *                       Injectable for deterministic tests.
+ * @returns {string}
+ */
+export function formatRelativeTimestamp (date, now) {
+  const base = now || new Date()
+  let diffMs = base - date
+  if (!Number.isFinite(diffMs) || diffMs < 0) diffMs = 0
+  const sec = Math.floor(diffMs / 1000)
+  if (sec < 60) return 'Just now'
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${min}m ago`
+  const hr = Math.floor(min / 60)
+  const minLeft = min % 60
+  if (hr < 24) return `${hr}h ${minLeft}m ago`
+  const days = Math.floor(hr / 24)
+  const hrLeft = hr % 24
+  if (days < 7) return `${days}d ${hrLeft}h ago`
+  const weeks = Math.floor(days / 7)
+  const dayLeft = days % 7
+  if (weeks < 5) return `${weeks}w ${dayLeft}d ago`
+  const months = Math.floor(days / 30)
+  if (months < 12) return `${months}mo ago`
+  const years = Math.floor(days / 365)
+  return `${years}y ago`
+}
+
+/**
+ * Human-readable labels for validation reason codes. Reason codes not
+ * in this map fall back to `code.replace(/_/g, ' ')`.
+ */
+export const VALIDATION_REASON_LABELS = {
+  missing_credentials: 'Missing credentials',
+  missing_plex_validation: 'Plex not validated',
+  no_libraries: 'No libraries selected',
+  invalid_paths: 'Invalid paths',
+  missing_library_defaults: 'Missing library defaults',
+  missing_separator_placeholder: 'Missing separator placeholder',
+  invalid_fields: 'Invalid fields',
+  no_webhooks: 'No webhooks configured',
+  disabled: 'Disabled',
+  missing_settings: 'Settings missing',
+  missing_tokens: 'Missing tokens',
+  token_invalid: 'Invalid tokens',
+  account_locked: 'Account locked',
+  validation_error: 'Validation error'
+}
+
+/**
+ * Format a validation result as a display string.
+ *
+ * Returns '' when status is falsy (used by callers to detect
+ * "nothing to show"). Otherwise the status is Title-Cased and
+ * optionally suffixed with a reason and details.
+ *
+ * Shape:
+ *   ""                           when status is falsy
+ *   "Validated"                  when reason is falsy
+ *   "Validated: <reason>"        when reason is set, no details
+ *   "Validated: <reason>: <d>"   when both are set (d = joined array or scalar)
+ *
+ * @param {string} status                   e.g. "validated" | "failed" | "skipped"
+ * @param {string} [reason]                 code looked up in VALIDATION_REASON_LABELS
+ * @param {(string|string[])} [details]     optional detail text or array of strings
+ * @returns {string}
+ */
+export function formatValidationResult (status, reason, details) {
+  if (!status) return ''
+  const label = status.charAt(0).toUpperCase() + status.slice(1)
+  if (!reason) return label
+  const pretty = VALIDATION_REASON_LABELS[reason] || reason.replace(/_/g, ' ')
+  if (Array.isArray(details) && details.length) {
+    return `${label}: ${pretty}: ${details.join(', ')}`
+  }
+  if (details) {
+    return `${label}: ${pretty}: ${details}`
+  }
+  return `${label}: ${pretty}`
+}
+
+/**
+ * Update the DOM row for a validation key with a fresh result.
+ *
+ * Looks up `[data-validation-key="{key}"]`. Silently no-ops if the
+ * row or `result` is missing.
+ *
+ * Updates (in order):
+ *   1. The .validation-status-pill CSS class (removes prior, adds one
+ *      of --validated / --unvalidated / --neutral based on status).
+ *   2. The .validation-timestamp textContent + dataset.validationIso
+ *      when result.validated_at is set + parseable.
+ *   3. The .validation-age textContent + dataset.validationIsoAge
+ *      (same logic).
+ *   4. The .validation-result textContent via formatValidationResult.
+ *      Falls back to Title-Cased status if formatValidationResult
+ *      returned '' but status is set. Falls back to em-dash if not.
+ *
+ * @param {string} key  Value of the row's data-validation-key attr.
+ * @param {object} result  { status, validated_at?, reason?, details? }
+ */
+export function updateValidationRow (key, result) {
+  const row = document.querySelector(`[data-validation-key="${key}"]`)
+  if (!row || !result) return
+
+  const pill = row.querySelector('.validation-status-pill')
+  const timestampEl = row.querySelector('.validation-timestamp')
+  const ageEl = row.querySelector('.validation-age')
+  const status = result.status
+  const validatedAt = result.validated_at || ''
+
+  if (pill) {
+    pill.classList.remove(
+      'rating-mapping-option-via--validated',
+      'rating-mapping-option-via--unvalidated',
+      'rating-mapping-option-via--neutral'
+    )
+    if (status === 'validated') {
+      pill.classList.add('rating-mapping-option-via--validated')
+    } else if (status === 'failed') {
+      pill.classList.add('rating-mapping-option-via--unvalidated')
+    } else if (status === 'skipped') {
+      pill.classList.add('rating-mapping-option-via--neutral')
+    }
+  }
+
+  if (validatedAt && timestampEl) {
+    timestampEl.dataset.validationIso = validatedAt
+    const parsed = new Date(validatedAt)
+    if (!Number.isNaN(parsed.getTime())) {
+      timestampEl.textContent = formatLocalTimestamp(parsed)
+    }
+  }
+
+  if (validatedAt && ageEl) {
+    ageEl.dataset.validationIsoAge = validatedAt
+    const parsed = new Date(validatedAt)
+    if (!Number.isNaN(parsed.getTime())) {
+      ageEl.textContent = formatRelativeTimestamp(parsed, new Date())
+    }
+  }
+
+  const resultEl = row.querySelector('.validation-result')
+  if (resultEl) {
+    const resultText = formatValidationResult(status, result.reason, result.details)
+    resultEl.textContent = resultText || (status ? status.charAt(0).toUpperCase() + status.slice(1) : '\u2014')
+  }
+}

--- a/tests/js/kometa/validationDisplay.test.js
+++ b/tests/js/kometa/validationDisplay.test.js
@@ -1,0 +1,344 @@
+// Tests for static/local-js/modules/kometa/_validationDisplay.js
+//
+// Four exports:
+//   - formatLocalTimestamp(date)
+//   - formatRelativeTimestamp(date, now?)
+//   - VALIDATION_REASON_LABELS (constant)
+//   - formatValidationResult(status, reason?, details?)
+//   - updateValidationRow(key, result)
+//
+// COVERAGE STRATEGY:
+//
+//   formatLocalTimestamp (4):
+//     - happy path: "YYYY-MM-DD HH:MM:SS"
+//     - zero-pads single-digit month/day/hours/minutes/seconds
+//     - uses local time (not UTC)
+//     - handles New Year's midnight
+//
+//   formatRelativeTimestamp (12):
+//     - Just now (<60s), custom now injectable
+//     - Nm ago (<60min)
+//     - Nh Mm ago (<24h)
+//     - Nd Mh ago (<7d)
+//     - Nw Md ago (<5w)
+//     - Nmo ago (<12mo)
+//     - Ny ago (year and above)
+//     - boundary conditions (exactly 60s, 60min, 24h, 7d, 5w, 12mo)
+//     - negative diff (clock skew) clamps to "Just now"
+//     - non-finite diff clamps to "Just now"
+//     - now defaults to `new Date()` when omitted
+//
+//   VALIDATION_REASON_LABELS (2):
+//     - contains all 14 documented reason codes
+//     - each label is a non-empty string
+//
+//   formatValidationResult (7):
+//     - empty status -> ''
+//     - status only -> Title-Cased status
+//     - status + known reason -> "Status: pretty"
+//     - status + unknown reason -> snake_case unquoted
+//     - status + reason + string details
+//     - status + reason + array details (comma-joined)
+//     - status + reason + empty array (no details suffix)
+//
+//   updateValidationRow (11):
+//     - no-op when row missing
+//     - no-op when result missing
+//     - sets --validated pill for 'validated' status
+//     - sets --unvalidated pill for 'failed' status
+//     - sets --neutral pill for 'skipped' status
+//     - removes prior pill classes before adding new one
+//     - populates timestamp + dataset when validated_at set
+//     - skips timestamp when validated_at empty
+//     - skips timestamp when validated_at unparseable
+//     - populates age element
+//     - populates result element via formatValidationResult
+//     - falls back to Title-Cased status when formatter returns ''
+//     - falls back to em-dash when both empty
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  formatLocalTimestamp,
+  formatRelativeTimestamp,
+  VALIDATION_REASON_LABELS,
+  formatValidationResult,
+  updateValidationRow
+} from '../../../static/local-js/modules/kometa/_validationDisplay.js'
+
+// ---------------------------------------------------------------------
+// formatLocalTimestamp
+// ---------------------------------------------------------------------
+
+describe('formatLocalTimestamp', () => {
+  it("formats a mid-2024 date as YYYY-MM-DD HH:MM:SS", () => {
+    // Local time; use a well-defined Date with local components
+    const d = new Date(2024, 6, 15, 14, 25, 37)  // July is month 6
+    expect(formatLocalTimestamp(d)).toBe('2024-07-15 14:25:37')
+  })
+
+  it("zero-pads single-digit month/day/hours/minutes/seconds", () => {
+    const d = new Date(2024, 0, 5, 3, 4, 9)  // Jan 5, 03:04:09
+    expect(formatLocalTimestamp(d)).toBe('2024-01-05 03:04:09')
+  })
+
+  it("uses local time rather than UTC", () => {
+    // Construct a date; local-time output should never end in 'Z'
+    // and should always show exact H:M:S from the local getter methods.
+    const d = new Date(2024, 5, 15, 12, 34, 56)  // June 15 local
+    const stamp = formatLocalTimestamp(d)
+    expect(stamp).not.toContain('Z')
+    expect(stamp).toContain('12:34:56')
+  })
+
+  it("handles New Year's midnight", () => {
+    const d = new Date(2024, 0, 1, 0, 0, 0)
+    expect(formatLocalTimestamp(d)).toBe('2024-01-01 00:00:00')
+  })
+})
+
+// ---------------------------------------------------------------------
+// formatRelativeTimestamp
+// ---------------------------------------------------------------------
+
+describe('formatRelativeTimestamp', () => {
+  // Fixed "now" for determinism
+  const NOW = new Date('2024-06-15T12:00:00Z')
+
+  function subMs (ms) { return new Date(NOW.getTime() - ms) }
+
+  it("returns 'Just now' when <60s ago", () => {
+    expect(formatRelativeTimestamp(subMs(30 * 1000), NOW)).toBe('Just now')
+  })
+
+  it("returns 'Nm ago' when <60min ago", () => {
+    expect(formatRelativeTimestamp(subMs(5 * 60 * 1000), NOW)).toBe('5m ago')
+  })
+
+  it("returns 'Nh Mm ago' when <24h ago", () => {
+    // 2h 30m
+    expect(formatRelativeTimestamp(subMs((2 * 60 + 30) * 60 * 1000), NOW)).toBe('2h 30m ago')
+  })
+
+  it("returns 'Nd Mh ago' when <7d ago", () => {
+    // 3 days + 4 hours
+    expect(formatRelativeTimestamp(subMs((3 * 24 + 4) * 60 * 60 * 1000), NOW)).toBe('3d 4h ago')
+  })
+
+  it("returns 'Nw Md ago' when <5w ago", () => {
+    // 2 weeks + 3 days
+    expect(formatRelativeTimestamp(subMs((2 * 7 + 3) * 24 * 60 * 60 * 1000), NOW)).toBe('2w 3d ago')
+  })
+
+  it("returns 'Nmo ago' when <12mo ago", () => {
+    // ~60 days = ~2 months (uses 30-day approximation)
+    expect(formatRelativeTimestamp(subMs(60 * 24 * 60 * 60 * 1000), NOW)).toBe('2mo ago')
+  })
+
+  it("returns 'Ny ago' when a year or more ago", () => {
+    // 800 days = ~2.2 years
+    expect(formatRelativeTimestamp(subMs(800 * 24 * 60 * 60 * 1000), NOW)).toBe('2y ago')
+  })
+
+  it("exactly 60s crosses into 'Nm ago' bucket", () => {
+    expect(formatRelativeTimestamp(subMs(60 * 1000), NOW)).toBe('1m ago')
+  })
+
+  it("exactly 60min crosses into 'Nh Mm ago' bucket", () => {
+    expect(formatRelativeTimestamp(subMs(60 * 60 * 1000), NOW)).toBe('1h 0m ago')
+  })
+
+  it("clamps future dates (negative diff) to 'Just now'", () => {
+    // Future date = negative diff -> clamped to 0 -> 'Just now'
+    const future = new Date(NOW.getTime() + 60 * 60 * 1000)
+    expect(formatRelativeTimestamp(future, NOW)).toBe('Just now')
+  })
+
+  it("clamps non-finite diff (invalid date) to 'Just now'", () => {
+    expect(formatRelativeTimestamp(new Date('invalid'), NOW)).toBe('Just now')
+  })
+
+  it("defaults 'now' to new Date() when omitted", () => {
+    // Use a very-recent past to guarantee 'Just now'
+    const veryRecent = new Date(Date.now() - 5000)
+    expect(formatRelativeTimestamp(veryRecent)).toBe('Just now')
+  })
+})
+
+// ---------------------------------------------------------------------
+// VALIDATION_REASON_LABELS
+// ---------------------------------------------------------------------
+
+describe('VALIDATION_REASON_LABELS', () => {
+  it("includes all 14 documented reason codes", () => {
+    const expectedKeys = [
+      'missing_credentials', 'missing_plex_validation', 'no_libraries',
+      'invalid_paths', 'missing_library_defaults', 'missing_separator_placeholder',
+      'invalid_fields', 'no_webhooks', 'disabled', 'missing_settings',
+      'missing_tokens', 'token_invalid', 'account_locked', 'validation_error'
+    ]
+    for (const k of expectedKeys) {
+      expect(VALIDATION_REASON_LABELS).toHaveProperty(k)
+    }
+  })
+
+  it("each label is a non-empty string", () => {
+    for (const [, label] of Object.entries(VALIDATION_REASON_LABELS)) {
+      expect(typeof label).toBe('string')
+      expect(label.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------
+// formatValidationResult
+// ---------------------------------------------------------------------
+
+describe('formatValidationResult', () => {
+  it("returns '' when status is falsy", () => {
+    expect(formatValidationResult(null)).toBe('')
+    expect(formatValidationResult(undefined)).toBe('')
+    expect(formatValidationResult('')).toBe('')
+  })
+
+  it("returns Title-Cased status only when no reason", () => {
+    expect(formatValidationResult('validated')).toBe('Validated')
+    expect(formatValidationResult('failed')).toBe('Failed')
+    expect(formatValidationResult('skipped')).toBe('Skipped')
+  })
+
+  it("appends known reason label", () => {
+    expect(formatValidationResult('failed', 'missing_credentials'))
+      .toBe('Failed: Missing credentials')
+  })
+
+  it("appends unknown reason with underscores spaced out", () => {
+    expect(formatValidationResult('failed', 'some_novel_reason'))
+      .toBe('Failed: some novel reason')
+  })
+
+  it("appends string details", () => {
+    expect(formatValidationResult('failed', 'invalid_paths', '/nope'))
+      .toBe('Failed: Invalid paths: /nope')
+  })
+
+  it("appends array details as comma-joined", () => {
+    expect(formatValidationResult('failed', 'invalid_paths', ['/a', '/b', '/c']))
+      .toBe('Failed: Invalid paths: /a, /b, /c')
+  })
+
+  it("empty array falls through to the string-branch (produces trailing colon)", () => {
+    // Note: [] is truthy in JS. The Array.isArray branch requires
+    // `details.length` which is 0 for an empty array, so it falls
+    // through to the `if (details)` branch which stringifies via
+    // template literal. Array#toString of [] is ''. Result: trailing
+    // ": " is preserved verbatim from the original 900-kometa.js impl.
+    expect(formatValidationResult('failed', 'invalid_paths', []))
+      .toBe('Failed: Invalid paths: ')
+  })
+})
+
+// ---------------------------------------------------------------------
+// updateValidationRow
+// ---------------------------------------------------------------------
+
+describe('updateValidationRow', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div data-validation-key="plex">
+        <span class="validation-status-pill rating-mapping-option-via--neutral"></span>
+        <span class="validation-timestamp"></span>
+        <span class="validation-age"></span>
+        <span class="validation-result"></span>
+      </div>
+    `
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it("no-ops when row is missing", () => {
+    expect(() => updateValidationRow('nonexistent', { status: 'validated' })).not.toThrow()
+  })
+
+  it("no-ops when result is missing", () => {
+    expect(() => updateValidationRow('plex', null)).not.toThrow()
+    // Original pill class should be unchanged
+    expect(document.querySelector('.validation-status-pill').classList.contains('rating-mapping-option-via--neutral')).toBe(true)
+  })
+
+  it("sets --validated pill class for status='validated'", () => {
+    updateValidationRow('plex', { status: 'validated' })
+    const pill = document.querySelector('.validation-status-pill')
+    expect(pill.classList.contains('rating-mapping-option-via--validated')).toBe(true)
+    expect(pill.classList.contains('rating-mapping-option-via--neutral')).toBe(false)
+  })
+
+  it("sets --unvalidated pill class for status='failed'", () => {
+    updateValidationRow('plex', { status: 'failed' })
+    expect(document.querySelector('.validation-status-pill').classList.contains('rating-mapping-option-via--unvalidated')).toBe(true)
+  })
+
+  it("sets --neutral pill class for status='skipped'", () => {
+    // Start with a different class to verify removal
+    document.querySelector('.validation-status-pill').className = 'validation-status-pill rating-mapping-option-via--validated'
+    updateValidationRow('plex', { status: 'skipped' })
+    expect(document.querySelector('.validation-status-pill').classList.contains('rating-mapping-option-via--neutral')).toBe(true)
+    expect(document.querySelector('.validation-status-pill').classList.contains('rating-mapping-option-via--validated')).toBe(false)
+  })
+
+  it("clears prior pill classes before adding new one (unknown status)", () => {
+    document.querySelector('.validation-status-pill').className = 'validation-status-pill rating-mapping-option-via--validated'
+    updateValidationRow('plex', { status: 'weird-unknown-status' })
+    // All three known classes should be gone; no new one added.
+    const pill = document.querySelector('.validation-status-pill')
+    expect(pill.classList.contains('rating-mapping-option-via--validated')).toBe(false)
+    expect(pill.classList.contains('rating-mapping-option-via--unvalidated')).toBe(false)
+    expect(pill.classList.contains('rating-mapping-option-via--neutral')).toBe(false)
+  })
+
+  it("populates timestamp and dataset when validated_at is a valid ISO", () => {
+    updateValidationRow('plex', { status: 'validated', validated_at: '2024-06-15T12:30:00' })
+    const ts = document.querySelector('.validation-timestamp')
+    expect(ts.dataset.validationIso).toBe('2024-06-15T12:30:00')
+    // Text should be a "YYYY-MM-DD HH:MM:SS" format
+    expect(ts.textContent).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/)
+  })
+
+  it("skips timestamp update when validated_at is empty", () => {
+    updateValidationRow('plex', { status: 'validated' })  // no validated_at
+    const ts = document.querySelector('.validation-timestamp')
+    expect(ts.dataset.validationIso).toBeUndefined()
+    expect(ts.textContent).toBe('')
+  })
+
+  it("skips timestamp text when validated_at is unparseable but sets dataset", () => {
+    updateValidationRow('plex', { status: 'validated', validated_at: 'not-a-date' })
+    const ts = document.querySelector('.validation-timestamp')
+    // dataset gets the raw string, but text stays empty
+    expect(ts.dataset.validationIso).toBe('not-a-date')
+    expect(ts.textContent).toBe('')
+  })
+
+  it("populates the age element with a relative timestamp", () => {
+    // Recent past -> 'Just now'-ish; use exact-match on the age text
+    // pattern rather than value to avoid clock-time flakiness.
+    const recent = new Date(Date.now() - 5000).toISOString()
+    updateValidationRow('plex', { status: 'validated', validated_at: recent })
+    const age = document.querySelector('.validation-age')
+    expect(age.dataset.validationIsoAge).toBe(recent)
+    expect(age.textContent).toBe('Just now')
+  })
+
+  it("populates the result element via formatValidationResult", () => {
+    updateValidationRow('plex', { status: 'failed', reason: 'missing_credentials' })
+    expect(document.querySelector('.validation-result').textContent).toBe('Failed: Missing credentials')
+  })
+
+  it("falls back to em-dash when formatValidationResult returns ''", () => {
+    // Empty status -> formatValidationResult returns '' -> fallback path
+    updateValidationRow('plex', { status: '' })
+    expect(document.querySelector('.validation-result').textContent).toBe('\u2014')
+  })
+})


### PR DESCRIPTION
## What

Extracts the pure validation-display formatters (`formatLocalTimestamp`, `formatRelativeTimestamp`, `formatValidationResult`, `updateValidationRow`) plus the `VALIDATION_REASON_LABELS` constant to `static/local-js/modules/kometa/_validationDisplay.js`.

The `qs:bulk-validation-*` event handlers (~150 lines) STAY in `900-kometa.js` because they're tightly bound to page-load state (`kometaState.showYAML`, `getFinalGateState`, DOM elements resolved at load time). They now import `updateValidationRow` from the new module.

`900-kometa.js`: **1642 → 1533 lines (-109)**.
Vitest tests: 1362 → 1399 (**+37**).

## What moved

Extracted to `_validationDisplay.js` (241 lines):

- `formatLocalTimestamp(date)` — "YYYY-MM-DD HH:MM:SS" local time
- `formatRelativeTimestamp(date, now?)` — cascading "Just now" → "Ny ago"
- `VALIDATION_REASON_LABELS` — 14 reason codes → labels
- `formatValidationResult(status, reason?, details?)` — combines into display string
- `updateValidationRow(key, result)` — mutates the DOM row

## What stayed

- Page-load "initial pass" over `[data-validation-iso]` and `[data-validation-iso-age]` (uses the imported formatters)
- `validateAllBtn` setup + 3 event handlers (`qs:bulk-validation-start` / `-complete` / `-error`)
- Rollup badge initial state
- `autoValidate` trigger for the freshness gate

These would be worth their own extract later but require callback injection for `kometaState.showYAML`, `getFinalGateState`, and `resolveFreshnessGateAfterBulkValidation` — bigger architectural change, leaving for a focused follow-up.

## Verbatim-behavior preservation

Discovered a subtle quirk while writing tests: empty array `[]` is truthy in JS, so `formatValidationResult('failed', 'invalid_paths', [])` falls through the `Array.isArray && details.length` guard (length=0) to the `if (details)` branch and produces `"Failed: Invalid paths: "` with a trailing colon. Preserved verbatim; **documented in the tests** so a future "clean-up" doesn't accidentally change output shape.

## Test coverage: 37 new tests

- `formatLocalTimestamp` (4)
- `formatRelativeTimestamp` (12) — all unit boundaries + clock skew defense
- `VALIDATION_REASON_LABELS` (2) — all 14 codes present + non-empty
- `formatValidationResult` (7) — including the empty-array quirk
- `updateValidationRow` (12) — pill states, timestamp variants, fallback shapes

## Verification

- **1399/1399 Vitest pass** (was 1362; +37 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- ESLint clean

## Milestone

`900-kometa.js` was **3822** at split baseline. Now **1533**.
Cumulative cut: **-2289 lines (59.9%)**.

Modules extracted from `900-kometa.js`: **23**.
Vitest tests: 611 → 1399 (**+788, +129.0%**).
