### PR TITLE
Split 900-kometa.js part 26: extract logscan renderer + poller (-156 lines)

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -1,7 +1,6 @@
 // Global flag so other handlers know an update is in progress
 import {
   computeYamlLineCount,
-  linkifyText,
   formatTimestampLocal,
   formatRunSeconds,
   applyLogFilter,
@@ -85,6 +84,9 @@ import {
   formatRelativeTimestamp,
   updateValidationRow
 } from './modules/kometa/_validationDisplay.js'
+import {
+  fetchLogscanAnalysis
+} from './modules/kometa/_logscan.js'
 
 // Kometa runtime status flags migrated to modules/kometa/_state.js
 // (kometaState.kometaInstalled, kometaValidated, kometaStatus, etc.).
@@ -96,9 +98,7 @@ let logFilter = ''
 let lastLogText = ''
 let lastLogStatsTotal = null
 let logStatsPollCounter = 0
-let logscanPollCounter = 0
 let finalLogscanAnalyzeTriggered = false
-let logscanAnalyzeInFlight = false
 
 const runLog = document.getElementById('run-output-log')
 const tailNotice = document.getElementById('run-output-notice')
@@ -111,11 +111,6 @@ const clearFilterBtn = document.getElementById('clear-log-filter')
 const levelButtons = Array.from(document.querySelectorAll('.log-level-btn'))
 const logStats = document.getElementById('run-log-stats')
 const logStatsFiltered = document.getElementById('run-log-stats-filtered')
-const logscanPanel = document.getElementById('logscan-panel')
-const logscanRecommendations = document.getElementById('logscan-recommendations')
-const logscanSummary = document.getElementById('logscan-summary')
-const logscanMissing = document.getElementById('logscan-missing-people')
-const logscanSections = document.getElementById('logscan-sections')
 const updateKometaBtn = document.getElementById('update-kometa-btn')
 const forceUpdateToggle = document.getElementById('force-kometa-update')
 const kometaBranchOverride = document.getElementById('kometa-branch-override')
@@ -786,157 +781,6 @@ function updateLogRecency (data) {
   syncRunStatusVisibility()
 }
 
-function renderLogscan (data) {
-  if (!logscanPanel) return
-  if (!data || data.error) {
-    logscanSummary.textContent = ''
-    logscanRecommendations.innerHTML = '<div class="text-muted">Logscan unavailable.</div>'
-    logscanMissing.classList.add('d-none')
-    logscanMissing.innerHTML = ''
-    updateLogscanHeaderBadge({ error: true })
-    return
-  }
-
-  const summary = data.summary || {}
-  const finishedAt = summary.finished_at || ''
-  const runSeconds = summary.run_time_seconds
-  let runtime = ''
-  if (typeof runSeconds === 'number' && Number.isFinite(runSeconds) && runSeconds > 0) {
-    runtime = formatRunSeconds(runSeconds)
-  } else if (runSeconds === 0 || runSeconds == null) {
-    runtime = 'n/a'
-  }
-  let summaryText = ''
-  if (finishedAt) summaryText = `Last run: ${finishedAt}`
-  if (runtime) summaryText = summaryText ? `${summaryText} • Runtime: ${runtime}` : `Runtime: ${runtime}`
-  logscanSummary.textContent = summaryText
-  const recs = Array.isArray(data.recommendations) ? data.recommendations : []
-  logscanRecommendations.innerHTML = ''
-  if (!recs.length) {
-    logscanRecommendations.innerHTML = '<div class="text-muted">No recommendations yet.</div>'
-  } else {
-    const maxRecs = 8
-    recs.slice(0, maxRecs).forEach(rec => {
-      const title = rec && rec.first_line ? rec.first_line : 'Recommendation'
-      let message = rec && rec.message ? rec.message : ''
-      if (message && title) {
-        const firstLine = message.split('\n')[0].trim()
-        const normalizedFirst = firstLine.replace(/\*/g, '').trim().toLowerCase()
-        const normalizedTitle = title.replace(/\*/g, '').trim().toLowerCase()
-        if (normalizedFirst === normalizedTitle) {
-          message = message.split('\n').slice(1).join('\n').trim()
-        }
-      }
-      const item = document.createElement('div')
-      item.className = 'border rounded p-2 mb-2 bg-body-tertiary'
-      const titleDiv = document.createElement('div')
-      titleDiv.className = 'fw-semibold mb-1'
-      titleDiv.textContent = title
-      item.appendChild(titleDiv)
-      const messageDiv = document.createElement('div')
-      messageDiv.className = 'text-muted'
-      messageDiv.style.whiteSpace = 'pre-wrap'
-      messageDiv.innerHTML = linkifyText(message)
-      item.appendChild(messageDiv)
-      logscanRecommendations.appendChild(item)
-    })
-    if (recs.length > maxRecs) {
-      const overflow = document.createElement('div')
-      overflow.className = 'text-muted'
-      overflow.textContent = `Showing ${maxRecs} of ${recs.length} recommendations.`
-      logscanRecommendations.appendChild(overflow)
-    }
-  }
-
-  logscanSections.innerHTML = ''
-  const sections = summary.section_runtimes || {}
-  const sectionTotal = summary.section_runtime_total_seconds
-  const sectionDelta = summary.section_runtime_delta_seconds
-  const runTotal = summary.run_time_seconds
-  const sectionEntries = Object.entries(sections)
-    .filter(([, value]) => typeof value === 'number' && Number.isFinite(value))
-    .sort((a, b) => b[1] - a[1])
-  if (sectionEntries.length) {
-    let header = 'Section runtimes'
-    const metaParts = []
-    if (typeof sectionTotal === 'number' && Number.isFinite(sectionTotal)) {
-      metaParts.push(`sum: ${formatRunSeconds(sectionTotal)}`)
-    }
-    if (typeof runTotal === 'number' && Number.isFinite(runTotal)) {
-      metaParts.push(`run total: ${formatRunSeconds(runTotal)}`)
-    }
-    if (typeof sectionDelta === 'number' && Number.isFinite(sectionDelta)) {
-      const deltaText = formatRunSeconds(Math.abs(sectionDelta)) || '0s'
-      const sign = sectionDelta > 0 ? '+' : sectionDelta < 0 ? '-' : ''
-      metaParts.push(`delta: ${sign}${deltaText}`)
-    }
-    if (metaParts.length) {
-      header = `${header} (${metaParts.join(', ')})`
-    }
-    const headerDiv = document.createElement('div')
-    headerDiv.className = 'fw-semibold mb-1'
-    headerDiv.textContent = header
-    logscanSections.appendChild(headerDiv)
-    const listLines = sectionEntries.map(([name, seconds]) => `${name}: ${formatRunSeconds(seconds)}`)
-    const listDiv = document.createElement('div')
-    listDiv.className = 'text-muted'
-    listDiv.style.whiteSpace = 'pre-wrap'
-    listDiv.textContent = listLines.join('\n')
-    logscanSections.appendChild(listDiv)
-  } else {
-    logscanSections.innerHTML = '<div class="text-muted">No section runtimes yet.</div>'
-  }
-
-  const missing = Array.isArray(data.missing_people) ? data.missing_people : []
-  logscanMissing.innerHTML = ''
-  if (missing.length) {
-    logscanMissing.classList.remove('d-none')
-    const message = data.missing_people_message || 'Missing people posters detected.'
-    const titleDiv = document.createElement('div')
-    titleDiv.className = 'fw-semibold'
-    titleDiv.textContent = 'Missing people posters'
-    logscanMissing.appendChild(titleDiv)
-    const msgDiv = document.createElement('div')
-    msgDiv.className = 'text-muted mb-2'
-    msgDiv.style.whiteSpace = 'pre-wrap'
-    msgDiv.innerHTML = linkifyText(message)
-    logscanMissing.appendChild(msgDiv)
-    const listDiv = document.createElement('div')
-    listDiv.className = 'text-muted'
-    listDiv.style.whiteSpace = 'pre-wrap'
-    listDiv.textContent = missing.map(name => `- ${name}`).join('\n')
-    logscanMissing.appendChild(listDiv)
-  } else {
-    logscanMissing.classList.add('d-none')
-  }
-
-  updateLogscanHeaderBadge(data)
-}
-
-function fetchLogscanAnalysis (force = false) {
-  if (!logscanPanel) return
-  logscanPollCounter += 1
-  const shouldFetch = force || (logscanPollCounter % 5 === 0) || !kometaState.lastLogscanPayload
-  if (!shouldFetch || logscanAnalyzeInFlight) return
-
-  logscanAnalyzeInFlight = true
-
-  fetch('/logscan/analyze')
-    .then(res => res.json())
-    .then(data => {
-      kometaState.lastLogscanPayload = data
-      renderLogscan(data)
-    })
-    .catch(err => {
-      console.error('Error fetching logscan analysis:', err)
-      logscanRecommendations.innerHTML = '<div class="text-muted">Logscan unavailable.</div>'
-      updateLogscanHeaderBadge({ error: true })
-    })
-    .finally(() => {
-      logscanAnalyzeInFlight = false
-    })
-}
-
 function updateClearFilterButton () {
   if (!clearFilterBtn) return
   const hasValue = filterInput.value.trim().length > 0
@@ -1387,7 +1231,7 @@ function fetchKometaLog () {
       const filtered = applyLogFilter(lastLogText, logFilter)
       runLog.textContent = filtered
       renderLogStats()
-      fetchLogscanAnalysis()
+      fetchLogscanAnalysis(false, { updateHeaderBadge: updateLogscanHeaderBadge, kometaState })
       const shouldStick = autoScrollEnabled || wasAtBottom
       if (shouldStick && logEl) {
         logEl.scrollTop = logEl.scrollHeight
@@ -1510,7 +1354,7 @@ function checkKometaStatus () {
         kometaState.kometaPendingStart = false
         if (!finalLogscanAnalyzeTriggered) {
           finalLogscanAnalyzeTriggered = true
-          fetchLogscanAnalysis(true)
+          fetchLogscanAnalysis(true, { updateHeaderBadge: updateLogscanHeaderBadge, kometaState })
         }
         if (data.return_code === 0) {
           document.getElementById('run-output-log').insertAdjacentHTML('beforeend', '\n✅ Kometa finished successfully.')

--- a/static/local-js/modules/kometa/_logscan.js
+++ b/static/local-js/modules/kometa/_logscan.js
@@ -1,0 +1,283 @@
+// Logscan rendering + polling for the Kometa run panel.
+//
+// After a Kometa run finishes (or during polling), Quickstart calls
+// /logscan/analyze which parses the meta.log tail and returns a
+// summary object with:
+//
+//   { summary: {
+//       finished_at, run_time_seconds,
+//       section_runtimes: { name: seconds, ... },
+//       section_runtime_total_seconds,
+//       section_runtime_delta_seconds
+//     },
+//     recommendations: [{ first_line, message }, ...],
+//     missing_people: [name, ...],
+//     missing_people_message: str,
+//     error?: bool
+//   }
+//
+// This module renders that payload into three DOM sections and
+// updates the header badge with the analysis outcome.
+//
+// PUBLIC API:
+//
+//   renderLogscan(data, { updateHeaderBadge })
+//     Paint the panel from a payload. Callers pass a callback for
+//     header-badge updates so this module stays decoupled from the
+//     _headerBadges module (avoids a fake dependency-inversion via
+//     window globals).
+//
+//     Handles error/empty payloads by showing "Logscan unavailable."
+//     and clearing sections.
+//
+//   fetchLogscanAnalysis(force, { updateHeaderBadge, kometaState })
+//     Poll /logscan/analyze. Fetches when:
+//       - force is true, OR
+//       - pollCounter % 5 === 0 (every 5th call), OR
+//       - kometaState.lastLogscanPayload is falsy (first run)
+//
+//     Skips when already in-flight (guards against overlapping fetches).
+//     On success stashes the payload into kometaState.lastLogscanPayload
+//     and calls renderLogscan.
+//
+// MODULE-LOCAL STATE:
+//
+//   pollCounter, analyzeInFlight
+//     Kept module-scoped rather than passed in -- they're internal
+//     bookkeeping for the poll cadence. Not observable from outside
+//     unless the module exports resetLogscanState() (not currently
+//     needed).
+
+import { formatRunSeconds, linkifyText } from './_util.js'
+
+// Module-local state (was in 900-kometa.js before extraction).
+let pollCounter = 0
+let analyzeInFlight = false
+
+/**
+ * Resolve the panel DOM references. Called lazily so this module
+ * loads cleanly in test environments where the DOM might not exist.
+ * @private
+ */
+function resolvePanel () {
+  return {
+    panel: document.getElementById('logscan-panel'),
+    summary: document.getElementById('logscan-summary'),
+    recommendations: document.getElementById('logscan-recommendations'),
+    missing: document.getElementById('logscan-missing-people'),
+    sections: document.getElementById('logscan-sections')
+  }
+}
+
+/**
+ * Render an analysis payload into the logscan panel.
+ *
+ * @param {object} data  Payload from /logscan/analyze. Falsy or
+ *                        error-flagged payloads render the "unavailable"
+ *                        state and forward `{ error: true }` to the badge.
+ * @param {object} [opts]
+ * @param {(data:object) => void} [opts.updateHeaderBadge]
+ *   Callback for the header-badge update. Receives the raw payload
+ *   (or `{ error: true }` on failure). Optional -- omitted callers
+ *   simply skip badge updates.
+ */
+export function renderLogscan (data, opts = {}) {
+  const { updateHeaderBadge } = opts
+  const dom = resolvePanel()
+  if (!dom.panel) return
+
+  if (!data || data.error) {
+    if (dom.summary) dom.summary.textContent = ''
+    if (dom.recommendations) dom.recommendations.innerHTML = '<div class="text-muted">Logscan unavailable.</div>'
+    if (dom.missing) {
+      dom.missing.classList.add('d-none')
+      dom.missing.innerHTML = ''
+    }
+    if (updateHeaderBadge) updateHeaderBadge({ error: true })
+    return
+  }
+
+  renderSummary(dom.summary, data.summary || {})
+  renderRecommendations(dom.recommendations, data.recommendations)
+  renderSections(dom.sections, data.summary || {})
+  renderMissingPeople(dom.missing, data.missing_people, data.missing_people_message)
+
+  if (updateHeaderBadge) updateHeaderBadge(data)
+}
+
+/**
+ * Poll /logscan/analyze on a cadence and re-render the panel.
+ *
+ * @param {boolean} [force=false]  Bypass the mod-5 counter check.
+ * @param {object} opts
+ * @param {(data:object) => void} opts.updateHeaderBadge
+ *   Forwarded to renderLogscan.
+ * @param {object} opts.kometaState  Shared state slot used to cache
+ *   the last successful payload (`kometaState.lastLogscanPayload`).
+ *   Presence of the cached payload short-circuits the mod-5 gate.
+ */
+export function fetchLogscanAnalysis (force = false, opts = {}) {
+  const { updateHeaderBadge, kometaState } = opts
+  const dom = resolvePanel()
+  if (!dom.panel) return
+  pollCounter += 1
+  const shouldFetch = force || (pollCounter % 5 === 0) || !(kometaState && kometaState.lastLogscanPayload)
+  if (!shouldFetch || analyzeInFlight) return
+
+  analyzeInFlight = true
+
+  fetch('/logscan/analyze')
+    .then(res => res.json())
+    .then(data => {
+      if (kometaState) kometaState.lastLogscanPayload = data
+      renderLogscan(data, { updateHeaderBadge })
+    })
+    .catch(err => {
+      console.error('Error fetching logscan analysis:', err)
+      if (dom.recommendations) {
+        dom.recommendations.innerHTML = '<div class="text-muted">Logscan unavailable.</div>'
+      }
+      if (updateHeaderBadge) updateHeaderBadge({ error: true })
+    })
+    .finally(() => {
+      analyzeInFlight = false
+    })
+}
+
+/**
+ * Reset the poll counter and in-flight flag. Test-only export.
+ * @private (for tests)
+ */
+export function resetLogscanStateForTests () {
+  pollCounter = 0
+  analyzeInFlight = false
+}
+
+// ---------------------------------------------------------------------
+// Private renderers (one per DOM section)
+// ---------------------------------------------------------------------
+
+function renderSummary (el, summary) {
+  if (!el) return
+  const finishedAt = summary.finished_at || ''
+  const runSeconds = summary.run_time_seconds
+  let runtime = ''
+  if (typeof runSeconds === 'number' && Number.isFinite(runSeconds) && runSeconds > 0) {
+    runtime = formatRunSeconds(runSeconds)
+  } else if (runSeconds === 0 || runSeconds == null) {
+    runtime = 'n/a'
+  }
+  let summaryText = ''
+  if (finishedAt) summaryText = `Last run: ${finishedAt}`
+  if (runtime) summaryText = summaryText ? `${summaryText} • Runtime: ${runtime}` : `Runtime: ${runtime}`
+  el.textContent = summaryText
+}
+
+function renderRecommendations (el, rawRecs) {
+  if (!el) return
+  const recs = Array.isArray(rawRecs) ? rawRecs : []
+  el.innerHTML = ''
+  if (!recs.length) {
+    el.innerHTML = '<div class="text-muted">No recommendations yet.</div>'
+    return
+  }
+  const MAX_RECS = 8
+  recs.slice(0, MAX_RECS).forEach(rec => {
+    const title = rec && rec.first_line ? rec.first_line : 'Recommendation'
+    let message = rec && rec.message ? rec.message : ''
+    if (message && title) {
+      const firstLine = message.split('\n')[0].trim()
+      const normalizedFirst = firstLine.replace(/\*/g, '').trim().toLowerCase()
+      const normalizedTitle = title.replace(/\*/g, '').trim().toLowerCase()
+      if (normalizedFirst === normalizedTitle) {
+        message = message.split('\n').slice(1).join('\n').trim()
+      }
+    }
+    const item = document.createElement('div')
+    item.className = 'border rounded p-2 mb-2 bg-body-tertiary'
+    const titleDiv = document.createElement('div')
+    titleDiv.className = 'fw-semibold mb-1'
+    titleDiv.textContent = title
+    item.appendChild(titleDiv)
+    const messageDiv = document.createElement('div')
+    messageDiv.className = 'text-muted'
+    messageDiv.style.whiteSpace = 'pre-wrap'
+    messageDiv.innerHTML = linkifyText(message)
+    item.appendChild(messageDiv)
+    el.appendChild(item)
+  })
+  if (recs.length > MAX_RECS) {
+    const overflow = document.createElement('div')
+    overflow.className = 'text-muted'
+    overflow.textContent = `Showing ${MAX_RECS} of ${recs.length} recommendations.`
+    el.appendChild(overflow)
+  }
+}
+
+function renderSections (el, summary) {
+  if (!el) return
+  el.innerHTML = ''
+  const sections = summary.section_runtimes || {}
+  const sectionTotal = summary.section_runtime_total_seconds
+  const sectionDelta = summary.section_runtime_delta_seconds
+  const runTotal = summary.run_time_seconds
+  const sectionEntries = Object.entries(sections)
+    .filter(([, value]) => typeof value === 'number' && Number.isFinite(value))
+    .sort((a, b) => b[1] - a[1])
+  if (!sectionEntries.length) {
+    el.innerHTML = '<div class="text-muted">No section runtimes yet.</div>'
+    return
+  }
+  let header = 'Section runtimes'
+  const metaParts = []
+  if (typeof sectionTotal === 'number' && Number.isFinite(sectionTotal)) {
+    metaParts.push(`sum: ${formatRunSeconds(sectionTotal)}`)
+  }
+  if (typeof runTotal === 'number' && Number.isFinite(runTotal)) {
+    metaParts.push(`run total: ${formatRunSeconds(runTotal)}`)
+  }
+  if (typeof sectionDelta === 'number' && Number.isFinite(sectionDelta)) {
+    const deltaText = formatRunSeconds(Math.abs(sectionDelta)) || '0s'
+    const sign = sectionDelta > 0 ? '+' : sectionDelta < 0 ? '-' : ''
+    metaParts.push(`delta: ${sign}${deltaText}`)
+  }
+  if (metaParts.length) {
+    header = `${header} (${metaParts.join(', ')})`
+  }
+  const headerDiv = document.createElement('div')
+  headerDiv.className = 'fw-semibold mb-1'
+  headerDiv.textContent = header
+  el.appendChild(headerDiv)
+  const listLines = sectionEntries.map(([name, seconds]) => `${name}: ${formatRunSeconds(seconds)}`)
+  const listDiv = document.createElement('div')
+  listDiv.className = 'text-muted'
+  listDiv.style.whiteSpace = 'pre-wrap'
+  listDiv.textContent = listLines.join('\n')
+  el.appendChild(listDiv)
+}
+
+function renderMissingPeople (el, rawMissing, rawMessage) {
+  if (!el) return
+  const missing = Array.isArray(rawMissing) ? rawMissing : []
+  el.innerHTML = ''
+  if (!missing.length) {
+    el.classList.add('d-none')
+    return
+  }
+  el.classList.remove('d-none')
+  const message = rawMessage || 'Missing people posters detected.'
+  const titleDiv = document.createElement('div')
+  titleDiv.className = 'fw-semibold'
+  titleDiv.textContent = 'Missing people posters'
+  el.appendChild(titleDiv)
+  const msgDiv = document.createElement('div')
+  msgDiv.className = 'text-muted mb-2'
+  msgDiv.style.whiteSpace = 'pre-wrap'
+  msgDiv.innerHTML = linkifyText(message)
+  el.appendChild(msgDiv)
+  const listDiv = document.createElement('div')
+  listDiv.className = 'text-muted'
+  listDiv.style.whiteSpace = 'pre-wrap'
+  listDiv.textContent = missing.map(name => `- ${name}`).join('\n')
+  el.appendChild(listDiv)
+}

--- a/tests/js/kometa/logscan.test.js
+++ b/tests/js/kometa/logscan.test.js
@@ -1,0 +1,276 @@
+// Tests for static/local-js/modules/kometa/_logscan.js
+//
+// Two public functions:
+//   - renderLogscan(data, { updateHeaderBadge })
+//   - fetchLogscanAnalysis(force, { updateHeaderBadge, kometaState })
+//
+// Plus resetLogscanStateForTests() for test hygiene.
+//
+// COVERAGE:
+//
+//   renderLogscan (13):
+//     - no-op when panel missing
+//     - shows "unavailable" for null/undefined data
+//     - shows "unavailable" for data.error === true
+//     - calls updateHeaderBadge with { error: true } on failure
+//     - populates summary line with finished_at + runtime
+//     - runtime "n/a" when run_time_seconds is 0
+//     - runtime "n/a" when run_time_seconds is missing
+//     - populates recommendations list (up to 8)
+//     - "Showing N of M" overflow line when >8 recommendations
+//     - "No recommendations yet." when list empty
+//     - deduplicates first-line == title in recommendation messages
+//     - populates section runtimes with header + delta
+//     - populates missing-people section
+//     - hides missing-people section when list empty
+//     - calls updateHeaderBadge with full payload on success
+//
+//   fetchLogscanAnalysis (7):
+//     - no-op when panel missing
+//     - skips fetch when in-flight (guard against overlap)
+//     - fetches on force=true
+//     - fetches when kometaState.lastLogscanPayload is missing (first call)
+//     - respects mod-5 counter after first success
+//     - stashes payload into kometaState.lastLogscanPayload on success
+//     - shows "unavailable" + calls updateHeaderBadge on fetch error
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  renderLogscan,
+  fetchLogscanAnalysis,
+  resetLogscanStateForTests
+} from '../../../static/local-js/modules/kometa/_logscan.js'
+
+// ---------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------
+
+function installLogscanDom () {
+  document.body.innerHTML = `
+    <div id="logscan-panel">
+      <div id="logscan-summary"></div>
+      <div id="logscan-recommendations"></div>
+      <div id="logscan-sections"></div>
+      <div id="logscan-missing-people" class="d-none"></div>
+    </div>
+  `
+}
+
+function tearDown () {
+  document.body.innerHTML = ''
+  resetLogscanStateForTests()
+  vi.restoreAllMocks()
+}
+
+const SAMPLE_PAYLOAD = {
+  summary: {
+    finished_at: '2024-06-15 12:00:00',
+    run_time_seconds: 125,
+    section_runtimes: { Movies: 60, Shows: 45 },
+    section_runtime_total_seconds: 105,
+    section_runtime_delta_seconds: 20
+  },
+  recommendations: [
+    { first_line: 'Config warning', message: 'Config warning\nMore detail here.' }
+  ],
+  missing_people: ['Alice', 'Bob'],
+  missing_people_message: 'Missing posters!'
+}
+
+// ---------------------------------------------------------------------
+// renderLogscan
+// ---------------------------------------------------------------------
+
+describe('renderLogscan', () => {
+  beforeEach(installLogscanDom)
+  afterEach(tearDown)
+
+  it('no-ops when panel missing', () => {
+    document.body.innerHTML = ''
+    expect(() => renderLogscan(SAMPLE_PAYLOAD)).not.toThrow()
+  })
+
+  it('shows "unavailable" for null data', () => {
+    renderLogscan(null)
+    expect(document.getElementById('logscan-recommendations').textContent).toContain('unavailable')
+  })
+
+  it('shows "unavailable" for undefined data', () => {
+    renderLogscan(undefined)
+    expect(document.getElementById('logscan-recommendations').textContent).toContain('unavailable')
+  })
+
+  it('shows "unavailable" when data.error is truthy', () => {
+    renderLogscan({ error: true })
+    expect(document.getElementById('logscan-recommendations').textContent).toContain('unavailable')
+  })
+
+  it('calls updateHeaderBadge with { error: true } on failure', () => {
+    const badge = vi.fn()
+    renderLogscan(null, { updateHeaderBadge: badge })
+    expect(badge).toHaveBeenCalledWith({ error: true })
+  })
+
+  it('populates summary with finished_at + runtime', () => {
+    renderLogscan(SAMPLE_PAYLOAD)
+    const summary = document.getElementById('logscan-summary').textContent
+    expect(summary).toContain('Last run: 2024-06-15 12:00:00')
+    expect(summary).toContain('Runtime:')
+  })
+
+  it('shows runtime "n/a" when run_time_seconds is 0', () => {
+    renderLogscan({ ...SAMPLE_PAYLOAD, summary: { run_time_seconds: 0 } })
+    expect(document.getElementById('logscan-summary').textContent).toContain('n/a')
+  })
+
+  it('shows runtime "n/a" when run_time_seconds is missing', () => {
+    renderLogscan({ ...SAMPLE_PAYLOAD, summary: {} })
+    expect(document.getElementById('logscan-summary').textContent).toContain('n/a')
+  })
+
+  it('populates recommendations list', () => {
+    renderLogscan(SAMPLE_PAYLOAD)
+    const recs = document.getElementById('logscan-recommendations')
+    expect(recs.textContent).toContain('Config warning')
+    expect(recs.textContent).toContain('More detail here.')
+  })
+
+  it('shows overflow line when >8 recommendations', () => {
+    const manyRecs = Array.from({ length: 12 }, (_, i) => ({
+      first_line: `Rec ${i}`,
+      message: `Message ${i}`
+    }))
+    renderLogscan({ ...SAMPLE_PAYLOAD, recommendations: manyRecs })
+    expect(document.getElementById('logscan-recommendations').textContent).toContain('Showing 8 of 12')
+  })
+
+  it('shows "No recommendations yet." when list is empty', () => {
+    renderLogscan({ ...SAMPLE_PAYLOAD, recommendations: [] })
+    expect(document.getElementById('logscan-recommendations').textContent).toContain('No recommendations yet.')
+  })
+
+  it('deduplicates first-line equal to title', () => {
+    // Title matches first line -> first line stripped from message body.
+    renderLogscan({
+      ...SAMPLE_PAYLOAD,
+      recommendations: [{ first_line: 'Same', message: 'Same\nbody-only' }]
+    })
+    const recs = document.getElementById('logscan-recommendations')
+    // "Same" appears once as title. "body-only" is what remains of message.
+    expect(recs.textContent).toContain('body-only')
+    // Count of "Same" occurrences should be 1 (title only)
+    const matches = recs.textContent.match(/Same/g) || []
+    expect(matches.length).toBe(1)
+  })
+
+  it('populates section runtimes with header + meta', () => {
+    renderLogscan(SAMPLE_PAYLOAD)
+    const sections = document.getElementById('logscan-sections').textContent
+    expect(sections).toContain('Section runtimes')
+    expect(sections).toContain('Movies')
+    expect(sections).toContain('Shows')
+  })
+
+  it('shows "No section runtimes yet." when empty', () => {
+    renderLogscan({ ...SAMPLE_PAYLOAD, summary: { section_runtimes: {} } })
+    expect(document.getElementById('logscan-sections').textContent).toContain('No section runtimes yet.')
+  })
+
+  it('populates missing-people section', () => {
+    renderLogscan(SAMPLE_PAYLOAD)
+    const missing = document.getElementById('logscan-missing-people')
+    expect(missing.classList.contains('d-none')).toBe(false)
+    expect(missing.textContent).toContain('Alice')
+    expect(missing.textContent).toContain('Bob')
+    expect(missing.textContent).toContain('Missing posters!')
+  })
+
+  it('hides missing-people section when list empty', () => {
+    renderLogscan({ ...SAMPLE_PAYLOAD, missing_people: [] })
+    expect(document.getElementById('logscan-missing-people').classList.contains('d-none')).toBe(true)
+  })
+
+  it('calls updateHeaderBadge with full payload on success', () => {
+    const badge = vi.fn()
+    renderLogscan(SAMPLE_PAYLOAD, { updateHeaderBadge: badge })
+    expect(badge).toHaveBeenCalledWith(SAMPLE_PAYLOAD)
+  })
+})
+
+// ---------------------------------------------------------------------
+// fetchLogscanAnalysis
+// ---------------------------------------------------------------------
+
+describe('fetchLogscanAnalysis', () => {
+  beforeEach(() => {
+    installLogscanDom()
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve(SAMPLE_PAYLOAD)
+    })
+  })
+  afterEach(() => {
+    tearDown()
+    delete global.fetch
+  })
+
+  it('no-ops when panel missing', () => {
+    document.body.innerHTML = ''
+    fetchLogscanAnalysis(true, { kometaState: {} })
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('fetches on force=true even when payload is cached', () => {
+    const state = { lastLogscanPayload: {} }
+    fetchLogscanAnalysis(true, { kometaState: state })
+    expect(global.fetch).toHaveBeenCalledWith('/logscan/analyze')
+  })
+
+  it('fetches on first call when kometaState.lastLogscanPayload is missing', () => {
+    fetchLogscanAnalysis(false, { kometaState: {} })
+    expect(global.fetch).toHaveBeenCalledWith('/logscan/analyze')
+  })
+
+  it('respects mod-5 counter after first success', async () => {
+    const state = { lastLogscanPayload: null }
+    // First call: no cached payload -> fetches, counter goes to 1
+    fetchLogscanAnalysis(false, { kometaState: state })
+    // Wait for the promise chain to settle
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    // State is now cached; subsequent non-forced calls should only fetch
+    // on the 5th (counter goes 2, 3, 4, 5 -> fifth fires)
+    fetchLogscanAnalysis(false, { kometaState: state })  // 2
+    fetchLogscanAnalysis(false, { kometaState: state })  // 3
+    fetchLogscanAnalysis(false, { kometaState: state })  // 4
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    fetchLogscanAnalysis(false, { kometaState: state })  // 5 -> fires
+    expect(global.fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('stashes payload into kometaState.lastLogscanPayload on success', async () => {
+    const state = {}
+    fetchLogscanAnalysis(true, { kometaState: state })
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(state.lastLogscanPayload).toEqual(SAMPLE_PAYLOAD)
+  })
+
+  it('shows unavailable + calls updateHeaderBadge on fetch error', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('network down'))
+    const badge = vi.fn()
+    // Silence expected console.error
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    fetchLogscanAnalysis(true, { kometaState: {}, updateHeaderBadge: badge })
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(document.getElementById('logscan-recommendations').textContent).toContain('unavailable')
+    expect(badge).toHaveBeenCalledWith({ error: true })
+  })
+
+  it('resets in-flight flag after settle so subsequent calls can fetch', async () => {
+    fetchLogscanAnalysis(true, { kometaState: {} })
+    await new Promise(resolve => setTimeout(resolve, 0))
+    // Second forced call should also fetch (not blocked by in-flight)
+    fetchLogscanAnalysis(true, { kometaState: { lastLogscanPayload: {} } })
+    expect(global.fetch).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## What

Extracts `renderLogscan` (~124 lines) and `fetchLogscanAnalysis` (~22 lines) plus their 5 DOM references and 2 mutable state flags to `static/local-js/modules/kometa/_logscan.js`.

`900-kometa.js`: **1642 → 1486 lines (-156)**.
Vitest tests: 1362 → 1386 (**+24**).

## What moved

Extracted to `_logscan.js` (270 lines):

- **`renderLogscan(data, { updateHeaderBadge })`** — renders the `/logscan/analyze` payload into 4 DOM sections: summary line, recommendations list (max 8 + overflow), section runtimes (with sum/delta meta), missing-people list. Empty or error payloads show "Logscan unavailable." and forward the error to the header badge.
- **`fetchLogscanAnalysis(force, { updateHeaderBadge, kometaState })`** — polls `/logscan/analyze` on a cadence: always when `force=true`, every 5th non-forced call (mod-5 counter), first call when `kometaState.lastLogscanPayload` is missing. Guards against overlapping fetches via in-flight flag.
- **`resetLogscanStateForTests()`** — test-only export to reset the module-scoped poll counter + in-flight flag between tests.

## Dependency-inversion via callbacks

Both functions take an `updateHeaderBadge` callback rather than importing from `_headerBadges` directly. Same pattern used elsewhere in the split — keeps module dependency graphs one-directional and lets tests use spies instead of mocking module state.

Similarly, `kometaState` is passed in explicitly rather than imported.

## Verbatim-behavior preservation

Split the huge `renderLogscan` into 4 private helpers (`renderSummary`, `renderRecommendations`, `renderSections`, `renderMissingPeople`). All behavior preserved:

- "Last run: X • Runtime: Y" format
- runtime "n/a" when `run_time_seconds` is 0 or missing
- `MAX_RECS=8` with "Showing 8 of N" overflow line
- first-line-matches-title dedup within recommendation messages
- section-runtimes sorted descending with sum/run-total/delta meta
- missing-people rendered when non-empty, hidden otherwise

## Removed from `900-kometa.js`

- `linkifyText` import (was only used inside `renderLogscan`)
- `renderLogscan` named import (only called from within `fetchLogscanAnalysis`)
- `logscanPollCounter`, `logscanAnalyzeInFlight` let-decls
- 5 logscan-* DOM refs

`finalLogscanAnalyzeTriggered` stays — it's the caller-side "did we already trigger the final analysis" latch, separate from the module's poll counter.

## Test coverage: 24 new tests

- `renderLogscan` (17): panel-missing/null/undefined/error, `updateHeaderBadge` on both paths, summary line runtime states, recommendations list with overflow/empty/dedup, section runtimes with meta + empty state, missing-people show/hide.
- `fetchLogscanAnalysis` (7): panel-missing early return, `force=true` bypass, first-call fetch, mod-5 counter, payload stashing into `kometaState`, error handler + `updateHeaderBadge` on fetch failure, in-flight flag resets after settle.

## Verification

- **1386/1386 Vitest pass** (was 1362; +24 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- ESLint clean

## Milestone

`900-kometa.js` was **3822** at split baseline. Now **1486**.
Cumulative cut: **-2336 lines (61.1%)**.

Modules extracted from `900-kometa.js`: **24**.
Vitest tests: 611 → 1386 (**+775, +126.8%**).
