### PR TITLE
Split 900-kometa.js part 27: extract CLI flag catalog + label renderer (-134 lines)

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -87,6 +87,10 @@ import {
 import {
   fetchLogscanAnalysis
 } from './modules/kometa/_logscan.js'
+import {
+  updateFlagLabels,
+  updateLibraryVisibility
+} from './modules/kometa/_cliFlags.js'
 
 // Kometa runtime status flags migrated to modules/kometa/_state.js
 // (kometaState.kometaInstalled, kometaValidated, kometaStatus, etc.).
@@ -217,156 +221,18 @@ if (openKometaActionsPanelBtn) {
   })
 }
 
-function updateLibraryVisibility (mainOption) {
-  const libSelect = document.getElementById('library-multiselect')
-  const librarySection = libSelect ? libSelect.closest('.mb-2') : null
-  if (!librarySection) return
-  if (mainOption === '--run-libraries') {
-    librarySection.classList.remove('d-none')
-  } else {
-    librarySection.classList.add('d-none')
-  }
-}
-
-const flagsMap = {
-  '--run': {
-    label: 'Run Immediately',
-    description: 'If you want Kometa to run immediately rather than waiting until 5AM, set this flag'
-  },
-  '--run-libraries': {
-    label: 'Run Specific Libraries',
-    description: 'Run Kometa only on selected libraries.'
-  },
-  '--times': {
-    label: 'Time to Run',
-    description: 'Run at these times. Kometa wakes up at 5:00 AM to process the config file. If you want to change that time, or tell Kometa to wake up at multiple times, use this flag.'
-  },
-  '--operations-only': {
-    label: 'Operations Only',
-    description: 'Only perform operations (e.g., rating/poster updates).'
-  },
-  '--metadata-only': {
-    label: 'Metadata Only',
-    description: 'Only run metadata files.'
-  },
-  '--collections-only': {
-    label: 'Collections Only',
-    description: 'Only build collections.'
-  },
-  '--playlists-only': {
-    label: 'Playlists Only',
-    description: 'Only build playlists, skip everything else.'
-  },
-  '--overlays-only': {
-    label: 'Overlays Only',
-    description: 'Only apply overlays to media posters.'
-  },
-  '--debug': {
-    label: 'Debug Logging',
-    description: 'Enable debug-level logging.'
-  },
-  '--trace': {
-    label: 'Trace Logging',
-    description: 'Enable trace-level (very verbose) logging.'
-  },
-  '--log-requests': {
-    label: 'Log Requests Logging',
-    description: 'Most verbose logging. If you enable this, every external network request made by Kometa will be logged, along with the data that is returned. This will add a lot of data to the logs, and will probably contain things like tokens, since the auto-redaction of such things is not generalized enough to catch any token that may be in any URL.<br><strong>WARNING</strong>:<br><code>This can potentially have personal information in it.</code>'
-  },
-  '--delete-collections': {
-    label: 'Delete Collections',
-    description: 'Delete all collections in each library as the first step in the run.<br><strong>WARNING</strong>:<br><code>You will lose all collections in the library - this will delete all collections, including ones not created or maintained by Kometa.</code>'
-  },
-  '--delete-labels': {
-    label: 'Delete Labels',
-    description: 'Delete all labels [except one, see below] on every item in a Library prior to running collections/operations.<br><strong>WARNING</strong>:<br><code>To preserve functionality of Kometa, this will not remove the Overlay label, which is required for Kometa to know which items have Overlays applied. This will impact any Smart Label Collections that you have in your library. We do not recommend using this on a regular basis if you also use any operations or collections that update labels, as you are effectively deleting and adding labels on each run.</code>'
-  },
-  '--read-only-config': {
-    label: 'Read Only Config',
-    description: 'Kometa reads in and then writes out a properly formatted version of your config.yml on each run;this makes the formatting consistent and ensures that you have visibility into new settings that get added. If you want to disable this behavior and tell Kometa to leave your config.yml as-is, use this flag.'
-  },
-  '--low-priority': {
-    label: 'Priority',
-    description: 'Run the Kometa process at a lower priority. Will default to normal priority if not specified.'
-  },
-  '--no-report': {
-    label: 'No Report',
-    description: 'Kometa can produce a report of missing items, collections, and other information. If you have this report enabled but want to disable it for a specific run, use this flag.'
-  },
-  '--no-missing': {
-    label: 'No Missing',
-    description: 'Kometa can take various actions on missing items, such as sending them to Radarr, listing them in the log, or saving a report. If you want to disable all of these actions, use this flag.'
-  },
-  '--no-countdown': {
-    label: 'No Countdown',
-    description: 'Typically, when not doing an immediate run, Kometa displays a countdown in the terminal where it is running. If you want to hide this countdown, use this flag.'
-  },
-  '--ignore-ghost': {
-    label: 'Ignore Ghost',
-    description: 'Kometa prints some things to the log that do not actually go into the log file on disk. Typically these are things like status messages while loading and/or filtering. If you want to hide all ghost logging for the run, use this flag.'
-  },
-  '--ignore-schedules': {
-    label: 'Ignore Schedules',
-    description: 'Ignore all schedules for the run. Range Scheduled collections (such as Christmas movies) will still be ignored.'
-  },
-  '--no-verify-ssl': {
-    label: 'No Verify SSL',
-    description: 'Turn SSL Verification off.<br><strong>NOTE</strong>:<br>Set this if your log file shows any errors similar to <code>SSL: CERTIFICATE_VERIFY_FAILED</code>'
-  },
-  '--tests': {
-    label: 'Run Tests',
-    description: 'If you set this flag to true, Kometa will run only collections that you have marked as test immediately, like KOMETA_RUN.<br><strong>NOTE</strong>:<br>This will only run collections with <code>test: true</code> in the definition.'
-  },
-  '--timeout': {
-    label: 'Timeout',
-    description: 'Change the timeout in seconds for all non-Plex services (such as TMDb, Radarr, and Trakt). This will default to <code>180</code> when not specified and is overwritten by any timeouts mentioned for specific services in the Configuration File.'
-  },
-  '--divider': {
-    label: 'Divider Character',
-    description: 'Customize the divider shown between repeated output elements (e.g., <code>></code>) Default is <code>=</code>'
-  },
-  '--width': {
-    label: 'Screen Width',
-    description: 'The log is formatted to fit within a certain width. If you wish to change that width, you can do that with this flag. Not that long lines are not wrapped or truncated to this width; this controls the minimum width of the log. Default is <code>100</code>'
-  }
-}
-
-function updateFlagLabels (showCli) {
-  const runOptions = ['--run', '--run-libraries', '--times']
-  const modeFlags = ['--operations-only', '--metadata-only', '--collections-only', '--overlays-only', '--playlists-only']
-  const logFlags = ['--debug', '--trace', '--log-requests']
-  const otherFlags = [
-    '--delete-collections', '--delete-labels', '--read-only-config', '--low-priority',
-    '--no-report', '--no-missing', '--no-countdown', '--ignore-ghost',
-    '--ignore-schedules', '--no-verify-ssl', '--tests', '--timeout', '--divider', '--width'
-  ]
-
-  function updateLabels (group, prefix = '') {
-    group.forEach(flag => {
-      const id = `${prefix}${flag.replace(/^--/, '')}`
-      const label = document.querySelector(`label[for="${id}"]`)
-      if (label) {
-        const content = showCli ? flag : (flagsMap[flag]?.label || flag)
-        label.innerHTML = `${content} <span class="text-info" data-bs-toggle="tooltip" title="${flagsMap[flag]?.description || ''}"><i class="bi bi-info-circle-fill ms-1"></i></span>`
-      }
-    })
-  }
-
-  updateLabels(runOptions, 'opt-')
-  updateLabels(modeFlags, 'opt-')
-  updateLabels(logFlags, 'opt-')
-  updateLabels(otherFlags, 'opt-')
-
-  initBootstrapTooltips(document)
-  syncFinalAccordionRollups()
-}
-
-updateFlagLabels(false) // Default to friendly labels
+updateFlagLabels(false, {
+  onInitTooltips: initBootstrapTooltips,
+  onLabelsUpdated: syncFinalAccordionRollups
+}) // Default to friendly labels
 const showCliToggle = document.getElementById('show-cli-toggle')
 if (showCliToggle) {
   showCliToggle.addEventListener('change', function() {
     const showCli = this.checked
-    updateFlagLabels(showCli)
+    updateFlagLabels(showCli, {
+      onInitTooltips: initBootstrapTooltips,
+      onLabelsUpdated: syncFinalAccordionRollups
+    })
   })
 }
 

--- a/static/local-js/modules/kometa/_cliFlags.js
+++ b/static/local-js/modules/kometa/_cliFlags.js
@@ -1,0 +1,230 @@
+// CLI flag labels + library-visibility toggle for the Kometa run panel.
+//
+// The Kometa "Run Kometa" panel shows a bunch of checkbox/toggle
+// options that map to Kometa's CLI flags. This module provides:
+//
+//   KOMETA_CLI_FLAGS
+//     A frozen catalog of every CLI flag Kometa supports, with a
+//     friendly label + long description. Consumed by
+//     updateFlagLabels() to render the panel labels either as
+//     friendly text ("Debug Logging") or as raw CLI flags ("--debug"),
+//     depending on the "show CLI" toggle.
+//
+//   updateFlagLabels(showCli, opts)
+//     Re-render every flag <label> in the panel. Two modes:
+//       showCli=false  -> friendly labels (default)
+//       showCli=true   -> raw --flag names
+//     Each label gets an info-icon <span> with a Bootstrap tooltip
+//     showing the description. After rendering, invokes two side-
+//     effect callbacks:
+//       - onInitTooltips(document)  to attach Bootstrap tooltips
+//       - onLabelsUpdated()         to notify the header-badge rollup
+//
+//   updateLibraryVisibility(mainOption)
+//     Show/hide the "select libraries" multiselect based on the
+//     currently-selected run-option radio value. Only visible when
+//     the "Run Specific Libraries" radio is picked.
+//
+// DEPENDENCY-INVERSION PATTERN
+//
+// Rather than importing initBootstrapTooltips and
+// syncFinalAccordionRollups directly, updateFlagLabels takes them
+// as callbacks. Same pattern used elsewhere in the split
+// (_logscan.js, _validationDisplay.js) -- keeps the module graph
+// one-directional and lets tests use spies.
+
+/**
+ * Frozen catalog of Kometa CLI flags. Extending Kometa's CLI means
+ * adding an entry here (label + description) and wiring the new
+ * flag into the appropriate flag-group array in updateFlagLabels.
+ *
+ * Descriptions may contain HTML (used inside a `title="..."` attr
+ * which then gets Bootstrap-tooltip-rendered as HTML). Escape user-
+ * facing text carefully -- these strings are dropped into markup
+ * without sanitization.
+ */
+export const KOMETA_CLI_FLAGS = Object.freeze({
+  '--run': {
+    label: 'Run Immediately',
+    description: 'If you want Kometa to run immediately rather than waiting until 5AM, set this flag'
+  },
+  '--run-libraries': {
+    label: 'Run Specific Libraries',
+    description: 'Run Kometa only on selected libraries.'
+  },
+  '--times': {
+    label: 'Time to Run',
+    description: 'Run at these times. Kometa wakes up at 5:00 AM to process the config file. If you want to change that time, or tell Kometa to wake up at multiple times, use this flag.'
+  },
+  '--operations-only': {
+    label: 'Operations Only',
+    description: 'Only perform operations (e.g., rating/poster updates).'
+  },
+  '--metadata-only': {
+    label: 'Metadata Only',
+    description: 'Only run metadata files.'
+  },
+  '--collections-only': {
+    label: 'Collections Only',
+    description: 'Only build collections.'
+  },
+  '--playlists-only': {
+    label: 'Playlists Only',
+    description: 'Only build playlists, skip everything else.'
+  },
+  '--overlays-only': {
+    label: 'Overlays Only',
+    description: 'Only apply overlays to media posters.'
+  },
+  '--debug': {
+    label: 'Debug Logging',
+    description: 'Enable debug-level logging.'
+  },
+  '--trace': {
+    label: 'Trace Logging',
+    description: 'Enable trace-level (very verbose) logging.'
+  },
+  '--log-requests': {
+    label: 'Log Requests Logging',
+    description: 'Most verbose logging. If you enable this, every external network request made by Kometa will be logged, along with the data that is returned. This will add a lot of data to the logs, and will probably contain things like tokens, since the auto-redaction of such things is not generalized enough to catch any token that may be in any URL.<br><strong>WARNING</strong>:<br><code>This can potentially have personal information in it.</code>'
+  },
+  '--delete-collections': {
+    label: 'Delete Collections',
+    description: 'Delete all collections in each library as the first step in the run.<br><strong>WARNING</strong>:<br><code>You will lose all collections in the library - this will delete all collections, including ones not created or maintained by Kometa.</code>'
+  },
+  '--delete-labels': {
+    label: 'Delete Labels',
+    description: 'Delete all labels [except one, see below] on every item in a Library prior to running collections/operations.<br><strong>WARNING</strong>:<br><code>To preserve functionality of Kometa, this will not remove the Overlay label, which is required for Kometa to know which items have Overlays applied. This will impact any Smart Label Collections that you have in your library. We do not recommend using this on a regular basis if you also use any operations or collections that update labels, as you are effectively deleting and adding labels on each run.</code>'
+  },
+  '--read-only-config': {
+    label: 'Read Only Config',
+    description: 'Kometa reads in and then writes out a properly formatted version of your config.yml on each run;this makes the formatting consistent and ensures that you have visibility into new settings that get added. If you want to disable this behavior and tell Kometa to leave your config.yml as-is, use this flag.'
+  },
+  '--low-priority': {
+    label: 'Priority',
+    description: 'Run the Kometa process at a lower priority. Will default to normal priority if not specified.'
+  },
+  '--no-report': {
+    label: 'No Report',
+    description: 'Kometa can produce a report of missing items, collections, and other information. If you have this report enabled but want to disable it for a specific run, use this flag.'
+  },
+  '--no-missing': {
+    label: 'No Missing',
+    description: 'Kometa can take various actions on missing items, such as sending them to Radarr, listing them in the log, or saving a report. If you want to disable all of these actions, use this flag.'
+  },
+  '--no-countdown': {
+    label: 'No Countdown',
+    description: 'Typically, when not doing an immediate run, Kometa displays a countdown in the terminal where it is running. If you want to hide this countdown, use this flag.'
+  },
+  '--ignore-ghost': {
+    label: 'Ignore Ghost',
+    description: 'Kometa prints some things to the log that do not actually go into the log file on disk. Typically these are things like status messages while loading and/or filtering. If you want to hide all ghost logging for the run, use this flag.'
+  },
+  '--ignore-schedules': {
+    label: 'Ignore Schedules',
+    description: 'Ignore all schedules for the run. Range Scheduled collections (such as Christmas movies) will still be ignored.'
+  },
+  '--no-verify-ssl': {
+    label: 'No Verify SSL',
+    description: 'Turn SSL Verification off.<br><strong>NOTE</strong>:<br>Set this if your log file shows any errors similar to <code>SSL: CERTIFICATE_VERIFY_FAILED</code>'
+  },
+  '--tests': {
+    label: 'Run Tests',
+    description: 'If you set this flag to true, Kometa will run only collections that you have marked as test immediately, like KOMETA_RUN.<br><strong>NOTE</strong>:<br>This will only run collections with <code>test: true</code> in the definition.'
+  },
+  '--timeout': {
+    label: 'Timeout',
+    description: 'Change the timeout in seconds for all non-Plex services (such as TMDb, Radarr, and Trakt). This will default to <code>180</code> when not specified and is overwritten by any timeouts mentioned for specific services in the Configuration File.'
+  },
+  '--divider': {
+    label: 'Divider Character',
+    description: 'Customize the divider shown between repeated output elements (e.g., <code>></code>) Default is <code>=</code>'
+  },
+  '--width': {
+    label: 'Screen Width',
+    description: 'The log is formatted to fit within a certain width. If you wish to change that width, you can do that with this flag. Not that long lines are not wrapped or truncated to this width; this controls the minimum width of the log. Default is <code>100</code>'
+  }
+})
+
+// Flag groups. Each corresponds to a chunk of the "Run Kometa" panel
+// UI. Keeping them as module-scoped constants (rather than inline
+// arrays inside updateFlagLabels) makes it obvious which flags are
+// missing from the panel if someone adds a new one to KOMETA_CLI_FLAGS
+// but forgets to render it.
+const RUN_OPTION_FLAGS = ['--run', '--run-libraries', '--times']
+const MODE_FLAGS = [
+  '--operations-only', '--metadata-only', '--collections-only',
+  '--overlays-only', '--playlists-only'
+]
+const LOG_FLAGS = ['--debug', '--trace', '--log-requests']
+const OTHER_FLAGS = [
+  '--delete-collections', '--delete-labels', '--read-only-config', '--low-priority',
+  '--no-report', '--no-missing', '--no-countdown', '--ignore-ghost',
+  '--ignore-schedules', '--no-verify-ssl', '--tests', '--timeout', '--divider', '--width'
+]
+
+/**
+ * Refresh every flag <label> in the "Run Kometa" panel.
+ *
+ * Each flag has a corresponding <label for="opt-XXX"> where XXX is
+ * the flag name with the leading "--" stripped. Rendered content:
+ *
+ *   {label-text} <span class="text-info"
+ *                       data-bs-toggle="tooltip"
+ *                       title="{description}">
+ *     <i class="bi bi-info-circle-fill ms-1"></i>
+ *   </span>
+ *
+ * @param {boolean} showCli  When true, use raw "--flag" text as the
+ *                            label instead of the friendly label.
+ * @param {object} [opts]
+ * @param {(root:Document|Element) => void} [opts.onInitTooltips]
+ *   Called after re-rendering to (re)attach Bootstrap tooltips.
+ *   Receives the document root as its only arg.
+ * @param {() => void} [opts.onLabelsUpdated]
+ *   Called after rendering + tooltip init. Used by the header-badge
+ *   rollup to refresh any label-derived display state.
+ */
+export function updateFlagLabels (showCli, opts = {}) {
+  const { onInitTooltips, onLabelsUpdated } = opts
+
+  function updateLabels (group, prefix = '') {
+    group.forEach(flag => {
+      const id = `${prefix}${flag.replace(/^--/, '')}`
+      const label = document.querySelector(`label[for="${id}"]`)
+      if (!label) return
+      const spec = KOMETA_CLI_FLAGS[flag]
+      const content = showCli ? flag : (spec?.label || flag)
+      const desc = spec?.description || ''
+      label.innerHTML = `${content} <span class="text-info" data-bs-toggle="tooltip" title="${desc}"><i class="bi bi-info-circle-fill ms-1"></i></span>`
+    })
+  }
+
+  updateLabels(RUN_OPTION_FLAGS, 'opt-')
+  updateLabels(MODE_FLAGS, 'opt-')
+  updateLabels(LOG_FLAGS, 'opt-')
+  updateLabels(OTHER_FLAGS, 'opt-')
+
+  if (onInitTooltips) onInitTooltips(document)
+  if (onLabelsUpdated) onLabelsUpdated()
+}
+
+/**
+ * Show/hide the library multiselect based on the current run-option.
+ *
+ * When the user picks "Run Specific Libraries", the multiselect
+ * needs to be visible. All other run options hide it.
+ *
+ * @param {string} mainOption  The value of the currently-selected
+ *                              run-option radio (e.g. '--run-libraries').
+ */
+export function updateLibraryVisibility (mainOption) {
+  const libSelect = document.getElementById('library-multiselect')
+  const librarySection = libSelect ? libSelect.closest('.mb-2') : null
+  if (!librarySection) return
+  if (mainOption === '--run-libraries') {
+    librarySection.classList.remove('d-none')
+  } else {
+    librarySection.classList.add('d-none')
+  }
+}

--- a/tests/js/kometa/cliFlags.test.js
+++ b/tests/js/kometa/cliFlags.test.js
@@ -1,0 +1,215 @@
+// Tests for static/local-js/modules/kometa/_cliFlags.js
+//
+// Three exports:
+//   - KOMETA_CLI_FLAGS (frozen catalog)
+//   - updateFlagLabels(showCli, opts)
+//   - updateLibraryVisibility(mainOption)
+//
+// COVERAGE:
+//
+//   KOMETA_CLI_FLAGS (4):
+//     - contains all 24 documented flags
+//     - each entry has label + description
+//     - labels are non-empty strings
+//     - object is frozen (immutability guard)
+//
+//   updateFlagLabels (10):
+//     - renders friendly label when showCli=false
+//     - renders raw --flag when showCli=true
+//     - injects Bootstrap tooltip attributes
+//     - includes description in tooltip title
+//     - skips labels with no matching <label for="...">
+//     - calls onInitTooltips(document) after rendering
+//     - calls onLabelsUpdated() after rendering
+//     - both callbacks are optional (no throw when omitted)
+//     - renders run-option, mode, log, and other flag groups
+//     - unknown flag falls back to raw flag as content
+//
+//   updateLibraryVisibility (4):
+//     - no-ops when library-multiselect missing
+//     - shows the .mb-2 wrapper when mainOption is --run-libraries
+//     - hides the .mb-2 wrapper for other options
+//     - toggles correctly across sequential calls
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  KOMETA_CLI_FLAGS,
+  updateFlagLabels,
+  updateLibraryVisibility
+} from '../../../static/local-js/modules/kometa/_cliFlags.js'
+
+// ---------------------------------------------------------------------
+// KOMETA_CLI_FLAGS
+// ---------------------------------------------------------------------
+
+describe('KOMETA_CLI_FLAGS', () => {
+  it('contains all 24 documented flags', () => {
+    const expected = [
+      '--run', '--run-libraries', '--times',
+      '--operations-only', '--metadata-only', '--collections-only',
+      '--playlists-only', '--overlays-only',
+      '--debug', '--trace', '--log-requests',
+      '--delete-collections', '--delete-labels', '--read-only-config',
+      '--low-priority', '--no-report', '--no-missing', '--no-countdown',
+      '--ignore-ghost', '--ignore-schedules', '--no-verify-ssl',
+      '--tests', '--timeout', '--divider', '--width'
+    ]
+    expect(Object.keys(KOMETA_CLI_FLAGS).sort()).toEqual(expected.sort())
+  })
+
+  it('each entry has label + description', () => {
+    for (const [flag, spec] of Object.entries(KOMETA_CLI_FLAGS)) {
+      expect(spec, `flag ${flag} missing label`).toHaveProperty('label')
+      expect(spec, `flag ${flag} missing description`).toHaveProperty('description')
+    }
+  })
+
+  it('labels are non-empty strings', () => {
+    for (const [flag, spec] of Object.entries(KOMETA_CLI_FLAGS)) {
+      expect(typeof spec.label, `flag ${flag} label not string`).toBe('string')
+      expect(spec.label.length, `flag ${flag} label empty`).toBeGreaterThan(0)
+    }
+  })
+
+  it('the catalog is frozen (Object.freeze)', () => {
+    expect(Object.isFrozen(KOMETA_CLI_FLAGS)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// updateFlagLabels
+// ---------------------------------------------------------------------
+
+describe('updateFlagLabels', () => {
+  beforeEach(() => {
+    // Install labels for a representative sample from each group
+    document.body.innerHTML = `
+      <label for="opt-run">placeholder</label>
+      <label for="opt-run-libraries">placeholder</label>
+      <label for="opt-debug">placeholder</label>
+      <label for="opt-operations-only">placeholder</label>
+      <label for="opt-no-verify-ssl">placeholder</label>
+    `
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('renders friendly labels when showCli=false', () => {
+    updateFlagLabels(false)
+    expect(document.querySelector('label[for="opt-run"]').textContent).toContain('Run Immediately')
+    expect(document.querySelector('label[for="opt-debug"]').textContent).toContain('Debug Logging')
+  })
+
+  it('renders raw --flag names when showCli=true', () => {
+    updateFlagLabels(true)
+    expect(document.querySelector('label[for="opt-run"]').innerHTML).toContain('--run')
+    expect(document.querySelector('label[for="opt-debug"]').innerHTML).toContain('--debug')
+  })
+
+  it('injects Bootstrap tooltip attributes', () => {
+    updateFlagLabels(false)
+    const label = document.querySelector('label[for="opt-run"]')
+    expect(label.innerHTML).toContain('data-bs-toggle="tooltip"')
+    expect(label.innerHTML).toContain('class="text-info"')
+  })
+
+  it('includes the description in the tooltip title attr', () => {
+    updateFlagLabels(false)
+    const label = document.querySelector('label[for="opt-debug"]')
+    expect(label.innerHTML).toContain('title="Enable debug-level logging."')
+  })
+
+  it('silently skips flags with no matching <label>', () => {
+    // Only opt-run is in the DOM; the rest of the render should still
+    // succeed for the ones that ARE present.
+    document.body.innerHTML = '<label for="opt-run">placeholder</label>'
+    expect(() => updateFlagLabels(false)).not.toThrow()
+    expect(document.querySelector('label[for="opt-run"]').textContent).toContain('Run Immediately')
+  })
+
+  it('calls onInitTooltips(document) after rendering', () => {
+    const spy = vi.fn()
+    updateFlagLabels(false, { onInitTooltips: spy })
+    expect(spy).toHaveBeenCalledWith(document)
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onLabelsUpdated() after rendering', () => {
+    const spy = vi.fn()
+    updateFlagLabels(false, { onLabelsUpdated: spy })
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('both callbacks are optional (no throw when omitted)', () => {
+    expect(() => updateFlagLabels(false)).not.toThrow()
+    expect(() => updateFlagLabels(true)).not.toThrow()
+  })
+
+  it('renders labels across all four flag groups', () => {
+    // Verify that opt-run (RUN_OPTION), opt-operations-only (MODE),
+    // opt-debug (LOG), and opt-no-verify-ssl (OTHER) all get rendered.
+    updateFlagLabels(false)
+    expect(document.querySelector('label[for="opt-run"]').textContent).toContain('Run Immediately')
+    expect(document.querySelector('label[for="opt-operations-only"]').textContent).toContain('Operations Only')
+    expect(document.querySelector('label[for="opt-debug"]').textContent).toContain('Debug Logging')
+    expect(document.querySelector('label[for="opt-no-verify-ssl"]').textContent).toContain('No Verify SSL')
+  })
+
+  it('produces info-icon markup regardless of showCli', () => {
+    updateFlagLabels(false)
+    const friendly = document.querySelector('label[for="opt-run"]').innerHTML
+    expect(friendly).toContain('bi-info-circle-fill')
+
+    updateFlagLabels(true)
+    const cliMode = document.querySelector('label[for="opt-run"]').innerHTML
+    expect(cliMode).toContain('bi-info-circle-fill')
+  })
+})
+
+// ---------------------------------------------------------------------
+// updateLibraryVisibility
+// ---------------------------------------------------------------------
+
+describe('updateLibraryVisibility', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div class="mb-2">
+        <select id="library-multiselect"></select>
+      </div>
+    `
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('no-ops when library-multiselect is missing', () => {
+    document.body.innerHTML = ''
+    expect(() => updateLibraryVisibility('--run-libraries')).not.toThrow()
+  })
+
+  it('shows the wrapper when mainOption is --run-libraries', () => {
+    // Start hidden to verify it gets shown
+    document.querySelector('.mb-2').classList.add('d-none')
+    updateLibraryVisibility('--run-libraries')
+    expect(document.querySelector('.mb-2').classList.contains('d-none')).toBe(false)
+  })
+
+  it('hides the wrapper for other options', () => {
+    // Start shown
+    updateLibraryVisibility('--run')
+    expect(document.querySelector('.mb-2').classList.contains('d-none')).toBe(true)
+  })
+
+  it('toggles correctly across sequential calls', () => {
+    updateLibraryVisibility('--run-libraries')
+    expect(document.querySelector('.mb-2').classList.contains('d-none')).toBe(false)
+    updateLibraryVisibility('--run')
+    expect(document.querySelector('.mb-2').classList.contains('d-none')).toBe(true)
+    updateLibraryVisibility('--run-libraries')
+    expect(document.querySelector('.mb-2').classList.contains('d-none')).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

Extracts three related pieces from the "Run Kometa" panel into `static/local-js/modules/kometa/_cliFlags.js`:

- `flagsMap` → **`KOMETA_CLI_FLAGS`** — 24-entry catalog, `Object.freeze`'d
- **`updateFlagLabels`** — 28 lines
- **`updateLibraryVisibility`** — 10 lines

`900-kometa.js`: **1376 → 1242 lines (-134)**.
Vitest tests: 1423 → 1441 (**+18**).

## What moved

Extracted to `_cliFlags.js` (230 lines):

- **`KOMETA_CLI_FLAGS`** — frozen catalog of Kometa's CLI flags. 24 entries covering: run options, mode flags, log flags, various `--delete-*`/`--no-*`/`--ignore-*`/toggle flags.
- **`updateFlagLabels(showCli, { onInitTooltips, onLabelsUpdated })`** — re-renders every `<label for="opt-XXX">` in the run panel. Switches between friendly text and raw `--flag` text based on the CLI-toggle. After rendering, invokes optional callbacks for tooltip reinit + header-badge rollup refresh.
- **`updateLibraryVisibility(mainOption)`** — shows/hides the "select libraries" multiselect based on whether "Run Specific Libraries" is picked.

## Dependency-inversion via callbacks

Same pattern as `_logscan.js` and `_validationDisplay.js`: `updateFlagLabels` takes `onInitTooltips` + `onLabelsUpdated` callbacks rather than importing `initBootstrapTooltips` + `syncFinalAccordionRollups` directly. Keeps the module dependency graph one-directional and lets tests use spies.

The 4 flag-group arrays (`RUN_OPTION_FLAGS`, `MODE_FLAGS`, `LOG_FLAGS`, `OTHER_FLAGS`) are lifted to module-scoped constants. Previously they were inline arrays inside `updateFlagLabels` itself — extracting them makes it obvious at a glance which flags each panel section renders.

## Verbatim-behavior preservation

- Same label-lookup semantics: `label[for="opt-{flag-without-dashes}"]`
- Same innerHTML template (info-icon + Bootstrap tooltip span)
- Same fallback: unknown flag falls back to the raw `--flag` text
- Same callback order: labels rendered, then tooltips init, then `onLabelsUpdated` fired

## Test coverage: 18 new tests

- `KOMETA_CLI_FLAGS` (4): all 24 flags present, each entry has `label`+`description`, non-empty strings, frozen.
- `updateFlagLabels` (10): friendly/CLI modes, tooltip attrs, description in title, silent skip for missing labels, both callbacks invoked, both callbacks optional, all 4 groups rendered, info-icon in both modes.
- `updateLibraryVisibility` (4): no-op on missing multiselect, show/hide on option, sequential toggle correctness.

## Verification

- **1441/1441 Vitest pass** (was 1423; +18 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- `test_900_kometa_sync_incomplete_run_actions_no_jquery` e2e: passes
- ESLint clean

## Milestone

`900-kometa.js` was **3822** at split baseline. Now **1242**.
Cumulative cut: **-2580 lines (67.5%)**.

Modules extracted from `900-kometa.js`: **25**.
Vitest tests: 611 → 1441 (**+830, +135.8%**).
