### PR TITLE
Split 900-kometa.js part 28: extract run-status formatters (-40 lines)

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -91,6 +91,7 @@ import {
   updateFlagLabels,
   updateLibraryVisibility
 } from './modules/kometa/_cliFlags.js'
+import { buildRunStatusText } from './modules/kometa/_runStatusFormat.js'
 
 // Kometa runtime status flags migrated to modules/kometa/_state.js
 // (kometaState.kometaInstalled, kometaValidated, kometaStatus, etc.).
@@ -571,53 +572,12 @@ function syncRunStatusVisibility () {
 
 function updateRunStatus (data) {
   if (!runStatusRow) return
-  if (data && data.status === 'running') {
-    const startedAt = formatTimestampLocal(data.started_at)
-    const elapsed = formatRunSeconds(data.elapsed_seconds)
-    const formatMem = (valueMb) => {
-      if (typeof valueMb !== 'number' || !Number.isFinite(valueMb)) return 'n/a'
-      if (valueMb >= 1024) return `${(valueMb / 1024).toFixed(1)} GB`
-      return `${valueMb.toFixed(1)} MB`
-    }
-    const cpuText = (typeof data.cpu_percent === 'number' && Number.isFinite(data.cpu_percent))
-      ? `${data.cpu_percent.toFixed(1)}%`
-      : 'n/a'
-    const memRss = formatMem(data.memory_rss_mb)
-    const memPct = (typeof data.memory_percent === 'number' && Number.isFinite(data.memory_percent))
-      ? `${data.memory_percent.toFixed(1)}%`
-      : 'n/a'
-    const sysCpu = (typeof data.system_cpu_percent === 'number' && Number.isFinite(data.system_cpu_percent))
-      ? `${data.system_cpu_percent.toFixed(1)}%`
-      : 'n/a'
-    const sysUsed = formatMem(data.system_memory_used_mb)
-    const sysTotal = formatMem(data.system_memory_total_mb)
-    const sysPct = (typeof data.system_memory_percent === 'number' && Number.isFinite(data.system_memory_percent))
-      ? `${data.system_memory_percent.toFixed(1)}%`
-      : 'n/a'
-    const formatDiskMb = (valueMb) => {
-      if (typeof valueMb !== 'number' || !Number.isFinite(valueMb)) return 'n/a'
-      if (valueMb >= 1024) return `${(valueMb / 1024).toFixed(1)} GB`
-      return `${valueMb.toFixed(1)} MB`
-    }
-    const formatDiskRate = (valueMbS) => {
-      if (typeof valueMbS !== 'number' || !Number.isFinite(valueMbS)) return 'n/a'
-      if (valueMbS >= 1024) return `${(valueMbS / 1024).toFixed(2)} GB/s`
-      return `${valueMbS.toFixed(2)} MB/s`
-    }
-    const hasDiskData = [data.disk_read_mb, data.disk_write_mb, data.disk_read_rate_mb_s, data.disk_write_rate_mb_s]
-      .some(value => typeof value === 'number' && Number.isFinite(value))
-    const diskText = hasDiskData
-      ? ` | Disk: R ${formatDiskRate(data.disk_read_rate_mb_s)} • W ${formatDiskRate(data.disk_write_rate_mb_s)} • ${formatDiskMb(data.disk_read_mb)} read • ${formatDiskMb(data.disk_write_mb)} written`
-      : ''
-    runStatusTimer.textContent = `Running since: ${startedAt} • Elapsed: ${elapsed || 'n/a'}`
-    runStatusMetrics.textContent = `Kometa: ${cpuText} CPU • ${memRss} (${memPct}) | System: ${sysCpu} CPU • ${sysUsed} / ${sysTotal} (${sysPct})${diskText}`
-  } else if (data && data.status === 'done') {
-    runStatusTimer.textContent = 'Kometa run complete.'
-    runStatusMetrics.textContent = ''
-  } else {
-    runStatusTimer.textContent = ''
-    runStatusMetrics.textContent = ''
-  }
+  const { timerText, metricsText } = buildRunStatusText(data, {
+    formatStartedAt: formatTimestampLocal,
+    formatElapsed: formatRunSeconds
+  })
+  runStatusTimer.textContent = timerText
+  runStatusMetrics.textContent = metricsText
   updateRunSparklines(data)
   syncRunStatusVisibility()
 }

--- a/static/local-js/modules/kometa/_runStatusFormat.js
+++ b/static/local-js/modules/kometa/_runStatusFormat.js
@@ -1,0 +1,127 @@
+// Formatters for the "run status" bar shown while Kometa is running.
+//
+// While Kometa is executing, /kometa-status returns a live snapshot
+// with CPU/memory/disk metrics for the Kometa process AND the host
+// system, plus started-at + elapsed-seconds. Rendering this into the
+// UI's timer + metrics rows involves a bunch of tiny formatting
+// helpers -- all pure, all easy to test in isolation.
+//
+// PUBLIC API:
+//
+//   formatMemoryMB(valueMb)
+//     Format a memory number in MB. Returns "N.N MB" below 1024,
+//     "N.N GB" at or above 1024, "n/a" for non-finite input.
+//
+//   formatDiskRateMBs(valueMbS)
+//     Same idea but for disk throughput. Two decimal places.
+//     "MB/s" or "GB/s" suffix.
+//
+//   formatPercent(value)
+//     Format a percentage. "N.N%" for finite numbers, "n/a" otherwise.
+//
+//   buildRunStatusText(data, { formatStartedAt, formatElapsed })
+//     Compose the two text lines shown in the run-status bar:
+//       { timerText, metricsText, stage }
+//     `stage` is 'running' | 'done' | 'idle' and determines which
+//     text lines are populated.
+//
+//     Callers inject `formatStartedAt` (typically formatTimestampLocal)
+//     and `formatElapsed` (typically formatRunSeconds) so this module
+//     doesn't depend on _util.js -- pure functions all the way down.
+
+/**
+ * Format a memory value in MB. Auto-scales to GB at 1024 MB.
+ * @param {number} valueMb
+ * @returns {string}
+ */
+export function formatMemoryMB (valueMb) {
+  if (typeof valueMb !== 'number' || !Number.isFinite(valueMb)) return 'n/a'
+  if (valueMb >= 1024) return `${(valueMb / 1024).toFixed(1)} GB`
+  return `${valueMb.toFixed(1)} MB`
+}
+
+/**
+ * Format a disk throughput value in MB/s. Two decimals; scales to GB/s at 1024.
+ * @param {number} valueMbS
+ * @returns {string}
+ */
+export function formatDiskRateMBs (valueMbS) {
+  if (typeof valueMbS !== 'number' || !Number.isFinite(valueMbS)) return 'n/a'
+  if (valueMbS >= 1024) return `${(valueMbS / 1024).toFixed(2)} GB/s`
+  return `${valueMbS.toFixed(2)} MB/s`
+}
+
+/**
+ * Format a percentage as "N.N%" or "n/a" for non-finite input.
+ * @param {number} value
+ * @returns {string}
+ */
+export function formatPercent (value) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 'n/a'
+  return `${value.toFixed(1)}%`
+}
+
+/**
+ * Compose the run-status bar text lines from a /kometa-status payload.
+ *
+ * Three possible states:
+ *
+ *   data.status === 'running'
+ *     Renders the live snapshot: started-at, elapsed, CPU/mem/disk
+ *     for both Kometa and the host system.
+ *
+ *   data.status === 'done'
+ *     Renders "Kometa run complete." with empty metrics.
+ *
+ *   Any other status / null / undefined
+ *     Both lines are empty (caller typically hides the row).
+ *
+ * @param {object|null} data
+ * @param {object} opts
+ * @param {(iso:string) => string} opts.formatStartedAt
+ *   Format the started_at timestamp for the timer line. Typically
+ *   `formatTimestampLocal` from _util.js.
+ * @param {(seconds:number) => string} opts.formatElapsed
+ *   Format the elapsed-seconds count. Typically `formatRunSeconds`
+ *   from _util.js. Falsy return value is replaced with 'n/a'.
+ * @returns {{ timerText:string, metricsText:string, stage:string }}
+ *   stage is 'running' | 'done' | 'idle'.
+ */
+export function buildRunStatusText (data, opts) {
+  const { formatStartedAt, formatElapsed } = opts
+
+  if (data && data.status === 'running') {
+    const startedAt = formatStartedAt(data.started_at)
+    const elapsed = formatElapsed(data.elapsed_seconds)
+    const cpuText = formatPercent(data.cpu_percent)
+    const memRss = formatMemoryMB(data.memory_rss_mb)
+    const memPct = formatPercent(data.memory_percent)
+    const sysCpu = formatPercent(data.system_cpu_percent)
+    const sysUsed = formatMemoryMB(data.system_memory_used_mb)
+    const sysTotal = formatMemoryMB(data.system_memory_total_mb)
+    const sysPct = formatPercent(data.system_memory_percent)
+    const hasDiskData = [
+      data.disk_read_mb, data.disk_write_mb,
+      data.disk_read_rate_mb_s, data.disk_write_rate_mb_s
+    ].some(value => typeof value === 'number' && Number.isFinite(value))
+    const diskText = hasDiskData
+      ? ` | Disk: R ${formatDiskRateMBs(data.disk_read_rate_mb_s)} • W ${formatDiskRateMBs(data.disk_write_rate_mb_s)} • ${formatMemoryMB(data.disk_read_mb)} read • ${formatMemoryMB(data.disk_write_mb)} written`
+      : ''
+
+    return {
+      timerText: `Running since: ${startedAt} • Elapsed: ${elapsed || 'n/a'}`,
+      metricsText: `Kometa: ${cpuText} CPU • ${memRss} (${memPct}) | System: ${sysCpu} CPU • ${sysUsed} / ${sysTotal} (${sysPct})${diskText}`,
+      stage: 'running'
+    }
+  }
+
+  if (data && data.status === 'done') {
+    return {
+      timerText: 'Kometa run complete.',
+      metricsText: '',
+      stage: 'done'
+    }
+  }
+
+  return { timerText: '', metricsText: '', stage: 'idle' }
+}

--- a/tests/js/kometa/runStatusFormat.test.js
+++ b/tests/js/kometa/runStatusFormat.test.js
@@ -1,0 +1,243 @@
+// Tests for static/local-js/modules/kometa/_runStatusFormat.js
+//
+// Four exports (all pure functions):
+//   - formatMemoryMB(valueMb)
+//   - formatDiskRateMBs(valueMbS)
+//   - formatPercent(value)
+//   - buildRunStatusText(data, { formatStartedAt, formatElapsed })
+//
+// COVERAGE:
+//
+//   formatMemoryMB (6):
+//     - 0 MB -> "0.0 MB"
+//     - <1024 MB -> "N.N MB"
+//     - >=1024 MB -> "N.N GB"
+//     - exactly 1024 -> "1.0 GB"
+//     - non-finite (NaN / Infinity / undefined / string) -> "n/a"
+//
+//   formatDiskRateMBs (5):
+//     - <1024 MB/s -> "N.NN MB/s" (2 decimals)
+//     - >=1024 MB/s -> "N.NN GB/s"
+//     - 0 MB/s -> "0.00 MB/s"
+//     - non-finite -> "n/a"
+//     - preserves 2-decimal precision (unlike memory 1-decimal)
+//
+//   formatPercent (5):
+//     - 0 -> "0.0%"
+//     - normal float -> "N.N%"
+//     - >100% (spillover) -> exact echo, no clamp
+//     - negative -> exact echo
+//     - non-finite -> "n/a"
+//
+//   buildRunStatusText (11):
+//     - stage='idle' when data is null/undefined/unknown status
+//     - stage='done' for status='done' with completion text
+//     - stage='running' for status='running' with full metrics
+//     - injects formatStartedAt output into timer line
+//     - injects formatElapsed output into timer line
+//     - falls back to 'n/a' when formatElapsed returns falsy
+//     - includes disk block when any disk metric is finite
+//     - omits disk block when all disk metrics missing
+//     - handles all-nulls for CPU / memory (shows n/a everywhere)
+//     - preserves bullet + section separators verbatim
+//     - "done" and "idle" have empty metricsText
+
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  formatMemoryMB,
+  formatDiskRateMBs,
+  formatPercent,
+  buildRunStatusText
+} from '../../../static/local-js/modules/kometa/_runStatusFormat.js'
+
+// ---------------------------------------------------------------------
+// formatMemoryMB
+// ---------------------------------------------------------------------
+
+describe('formatMemoryMB', () => {
+  it('formats 0 as "0.0 MB"', () => {
+    expect(formatMemoryMB(0)).toBe('0.0 MB')
+  })
+
+  it('formats sub-1024 as "N.N MB" with 1 decimal', () => {
+    expect(formatMemoryMB(512.7)).toBe('512.7 MB')
+    expect(formatMemoryMB(1)).toBe('1.0 MB')
+  })
+
+  it('formats >=1024 as GB with 1 decimal', () => {
+    expect(formatMemoryMB(2048)).toBe('2.0 GB')
+    expect(formatMemoryMB(1536)).toBe('1.5 GB')
+  })
+
+  it('formats exactly 1024 as "1.0 GB"', () => {
+    expect(formatMemoryMB(1024)).toBe('1.0 GB')
+  })
+
+  it('returns "n/a" for non-finite values', () => {
+    expect(formatMemoryMB(NaN)).toBe('n/a')
+    expect(formatMemoryMB(Infinity)).toBe('n/a')
+    expect(formatMemoryMB(-Infinity)).toBe('n/a')
+  })
+
+  it('returns "n/a" for non-numeric values', () => {
+    expect(formatMemoryMB(undefined)).toBe('n/a')
+    expect(formatMemoryMB(null)).toBe('n/a')
+    expect(formatMemoryMB('512')).toBe('n/a')
+  })
+})
+
+// ---------------------------------------------------------------------
+// formatDiskRateMBs
+// ---------------------------------------------------------------------
+
+describe('formatDiskRateMBs', () => {
+  it('formats sub-1024 as "N.NN MB/s" (2 decimals)', () => {
+    expect(formatDiskRateMBs(12.345)).toBe('12.35 MB/s')
+    expect(formatDiskRateMBs(0.5)).toBe('0.50 MB/s')
+  })
+
+  it('formats >=1024 as "N.NN GB/s"', () => {
+    expect(formatDiskRateMBs(2048)).toBe('2.00 GB/s')
+    expect(formatDiskRateMBs(1500)).toBe('1.46 GB/s')
+  })
+
+  it('formats 0 as "0.00 MB/s"', () => {
+    expect(formatDiskRateMBs(0)).toBe('0.00 MB/s')
+  })
+
+  it('returns "n/a" for non-finite values', () => {
+    expect(formatDiskRateMBs(NaN)).toBe('n/a')
+    expect(formatDiskRateMBs(undefined)).toBe('n/a')
+    expect(formatDiskRateMBs(null)).toBe('n/a')
+  })
+
+  it('uses 2-decimal precision (distinct from memory 1-decimal)', () => {
+    // Explicit contrast with formatMemoryMB
+    expect(formatDiskRateMBs(1.5)).toBe('1.50 MB/s')
+    expect(formatMemoryMB(1.5)).toBe('1.5 MB')
+  })
+})
+
+// ---------------------------------------------------------------------
+// formatPercent
+// ---------------------------------------------------------------------
+
+describe('formatPercent', () => {
+  it('formats 0 as "0.0%"', () => {
+    expect(formatPercent(0)).toBe('0.0%')
+  })
+
+  it('formats normal floats with 1 decimal', () => {
+    expect(formatPercent(45.67)).toBe('45.7%')
+    expect(formatPercent(99.9)).toBe('99.9%')
+  })
+
+  it('echoes >100% without clamping (spillover allowed)', () => {
+    // system_cpu_percent can exceed 100 on multi-core systems
+    expect(formatPercent(250.5)).toBe('250.5%')
+  })
+
+  it('echoes negative values without clamping', () => {
+    expect(formatPercent(-1.5)).toBe('-1.5%')
+  })
+
+  it('returns "n/a" for non-finite / non-numeric', () => {
+    expect(formatPercent(NaN)).toBe('n/a')
+    expect(formatPercent(undefined)).toBe('n/a')
+    expect(formatPercent(null)).toBe('n/a')
+    expect(formatPercent('50')).toBe('n/a')
+  })
+})
+
+// ---------------------------------------------------------------------
+// buildRunStatusText
+// ---------------------------------------------------------------------
+
+describe('buildRunStatusText', () => {
+  const STARTED = vi.fn((iso) => `formatted(${iso})`)
+  const ELAPSED = vi.fn((sec) => `${sec}s`)
+  const opts = { formatStartedAt: STARTED, formatElapsed: ELAPSED }
+
+  it('returns stage=idle for null data', () => {
+    expect(buildRunStatusText(null, opts)).toEqual({
+      timerText: '', metricsText: '', stage: 'idle'
+    })
+  })
+
+  it('returns stage=idle for undefined data', () => {
+    expect(buildRunStatusText(undefined, opts)).toEqual({
+      timerText: '', metricsText: '', stage: 'idle'
+    })
+  })
+
+  it('returns stage=idle for unknown status', () => {
+    expect(buildRunStatusText({ status: 'starting' }, opts).stage).toBe('idle')
+  })
+
+  it('returns stage=done with completion text for status=done', () => {
+    const result = buildRunStatusText({ status: 'done' }, opts)
+    expect(result.stage).toBe('done')
+    expect(result.timerText).toBe('Kometa run complete.')
+    expect(result.metricsText).toBe('')
+  })
+
+  it('returns stage=running for status=running', () => {
+    const data = { status: 'running', started_at: 'T', elapsed_seconds: 30 }
+    expect(buildRunStatusText(data, opts).stage).toBe('running')
+  })
+
+  it('injects formatStartedAt output into timer line', () => {
+    const data = { status: 'running', started_at: 'ISO_STAMP', elapsed_seconds: 10 }
+    expect(buildRunStatusText(data, opts).timerText).toContain('formatted(ISO_STAMP)')
+  })
+
+  it('injects formatElapsed output into timer line', () => {
+    const data = { status: 'running', started_at: 'T', elapsed_seconds: 45 }
+    expect(buildRunStatusText(data, opts).timerText).toContain('45s')
+  })
+
+  it('falls back to "n/a" when formatElapsed returns empty string', () => {
+    const emptyElapsed = { formatStartedAt: STARTED, formatElapsed: () => '' }
+    const data = { status: 'running', started_at: 'T', elapsed_seconds: 0 }
+    expect(buildRunStatusText(data, emptyElapsed).timerText).toContain('Elapsed: n/a')
+  })
+
+  it('includes disk block when any disk metric is finite', () => {
+    const data = {
+      status: 'running',
+      started_at: 'T',
+      elapsed_seconds: 10,
+      disk_read_rate_mb_s: 12.5,
+      disk_write_rate_mb_s: 3.4
+    }
+    expect(buildRunStatusText(data, opts).metricsText).toContain('Disk:')
+    expect(buildRunStatusText(data, opts).metricsText).toContain('12.50 MB/s')
+  })
+
+  it('omits disk block when all disk metrics are missing', () => {
+    const data = { status: 'running', started_at: 'T', elapsed_seconds: 10 }
+    expect(buildRunStatusText(data, opts).metricsText).not.toContain('Disk:')
+  })
+
+  it('shows n/a for missing CPU / memory / percent', () => {
+    const data = { status: 'running', started_at: 'T', elapsed_seconds: 10 }
+    const text = buildRunStatusText(data, opts).metricsText
+    // n/a should appear multiple times (kometa cpu, mem, mem%, sys cpu, sys used, sys total, sys%)
+    expect((text.match(/n\/a/g) || []).length).toBeGreaterThanOrEqual(6)
+  })
+
+  it('preserves bullet + pipe separators verbatim', () => {
+    const data = {
+      status: 'running',
+      started_at: 'T',
+      elapsed_seconds: 10,
+      cpu_percent: 25.5,
+      memory_rss_mb: 500,
+      memory_percent: 12.3
+    }
+    const text = buildRunStatusText(data, opts).metricsText
+    expect(text).toContain('•')  // section separator
+    expect(text).toContain('|')  // major separator between Kometa/System
+  })
+})


### PR DESCRIPTION
## What

Extracts the pure formatting logic from `updateRunStatus()` into `static/local-js/modules/kometa/_runStatusFormat.js` as four pure functions. **Shrinks `updateRunStatus` from 49 lines to 11 lines** by delegating the compose-the-text-lines work.

`900-kometa.js`: **1376 → 1336 lines (-40)**.
Vitest tests: 1423 → 1451 (**+28**).

## What moved

Extracted to `_runStatusFormat.js` (128 lines):

- **`formatMemoryMB(valueMb)`** — "N.N MB" below 1024, "N.N GB" at/above 1024, "n/a" for non-finite. **Deduplicates** the identical inline `formatMem()` and `formatDiskMb()` helpers that were defined twice inside `updateRunStatus` (DRY win).
- **`formatDiskRateMBs(valueMbS)`** — "N.NN MB/s" or "N.NN GB/s" (two decimals; distinct from memory's one-decimal precision). "n/a" for non-finite.
- **`formatPercent(value)`** — "N.N%" for finite numbers, "n/a" otherwise. Deliberately does NOT clamp to [0, 100] — `system_cpu_percent` can exceed 100 on multi-core boxes and negative values are echoed verbatim rather than silently swallowed.
- **`buildRunStatusText(data, { formatStartedAt, formatElapsed })`** — composes the timer + metrics lines for the run-status bar. Returns `{ timerText, metricsText, stage }` where `stage` is `'running' | 'done' | 'idle'`. Callers inject `formatStartedAt` + `formatElapsed` so this module stays free of any `_util.js` dependency — pure functions all the way down.

## Callsite in `900-kometa.js`

```js
function updateRunStatus (data) {
  if (!runStatusRow) return
  const { timerText, metricsText } = buildRunStatusText(data, {
    formatStartedAt: formatTimestampLocal,
    formatElapsed: formatRunSeconds
  })
  runStatusTimer.textContent = timerText
  runStatusMetrics.textContent = metricsText
  updateRunSparklines(data)
  syncRunStatusVisibility()
}
```

Was 49 lines with three nested formatter definitions and a giant if/else block. Now 11 lines that clearly say "get text, set text, tell sparklines, sync visibility."

## Verbatim-behavior preservation

- Same timer line format: `"Running since: X • Elapsed: Y"`
- Same metrics format: `"Kometa: A CPU • B (C%) | System: D CPU • E / F (G%){optional disk}"`
- Same "done" text: `"Kometa run complete."`
- Same idle-empty behavior for unknown/null status
- Disk block appears iff **any** of 4 disk metrics is finite (was `.some(isFinite)`; still is)
- Same "n/a" fallback for elapsed when `formatElapsed` returns falsy

## Test coverage: 28 new tests

- `formatMemoryMB` (6): 0, sub-1024, GB scaling, exact 1024 boundary, non-finite, non-numeric
- `formatDiskRateMBs` (5): sub-1024, GB scaling, 0, non-finite, 2-decimal precision (contrast with memory)
- `formatPercent` (5): 0, normal, >100% spillover, negative, non-finite
- `buildRunStatusText` (12): all three stages, callback injection correctness, disk-block on/off, n/a fallbacks, separator preservation

## Verification

- **1451/1451 Vitest pass** (was 1423; +28 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- ESLint clean

## Milestone

`900-kometa.js` was **3822** at split baseline. Now **1336**.
Cumulative cut: **-2486 lines (65.0%)**.

Modules extracted from `900-kometa.js`: **25**.
Vitest tests: 611 → 1451 (**+840, +137.5%**).

## Not stacked with #1589

This PR is based on develop (not #1589) because the changes touch completely different regions of `900-kometa.js` (`updateRunStatus` at ~line 706 vs. CLI-flags at ~line 220). Both should merge cleanly in either order; if #1589 lands first this branch will need a trivial one-line rebase where the import block sits.
