### PR TITLE
Split 900-kometa.js part 29: extract prepare-state toggler (-20 lines)

### DIFF
--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -92,6 +92,7 @@ import {
   updateLibraryVisibility
 } from './modules/kometa/_cliFlags.js'
 import { buildRunStatusText } from './modules/kometa/_runStatusFormat.js'
+import { setKometaPrepareRunningState } from './modules/kometa/_prepareState.js'
 
 // Kometa runtime status flags migrated to modules/kometa/_state.js
 // (kometaState.kometaInstalled, kometaValidated, kometaStatus, etc.).
@@ -135,7 +136,6 @@ const headerGridCollapse = document.getElementById('header-style-grid-collapse')
 const headerStyleWait = document.getElementById('header-style-wait')
 const finalContentWrapper = document.getElementById('final-content-wrapper')
 const kometaActionsCollapse = document.getElementById('kometa-actions-collapse')
-const kometaActionsToggle = document.getElementById('kometa-actions-toggle')
 const runCommandCollapse = document.getElementById('run-command-output-collapse')
 let headerStyleSubmitting = false
 
@@ -286,26 +286,6 @@ initBootstrapTooltips(document)
 if (kometaActionsCollapse) {
   kometaActionsCollapse.addEventListener('shown.bs.collapse', syncKometaUpdateAttention)
   kometaActionsCollapse.addEventListener('hidden.bs.collapse', syncKometaUpdateAttention)
-}
-
-function setKometaPrepareRunningState (isRunning) {
-  const accordion = document.getElementById('kometa-actions-accordion')
-  if (accordion) accordion.classList.toggle('opacity-50', Boolean(isRunning))
-  if (!kometaActionsCollapse || !kometaActionsToggle) return
-  if (isRunning && kometaActionsCollapse.classList.contains('show') && typeof bootstrap !== 'undefined' && bootstrap.Collapse) {
-    bootstrap.Collapse.getOrCreateInstance(kometaActionsCollapse, { toggle: false }).hide()
-  }
-  if (isRunning) {
-    kometaActionsToggle.classList.add('collapsed')
-    kometaActionsToggle.setAttribute('aria-expanded', 'false')
-    kometaActionsToggle.setAttribute('title', 'Kometa is running. Prepare Kometa is locked until the run finishes.')
-    kometaActionsToggle.disabled = true
-    kometaActionsToggle.classList.add('disabled')
-  } else {
-    kometaActionsToggle.removeAttribute('title')
-    kometaActionsToggle.disabled = false
-    kometaActionsToggle.classList.remove('disabled')
-  }
 }
 
 document.getElementById('copy-command')?.addEventListener('click', function() {

--- a/static/local-js/modules/kometa/_prepareState.js
+++ b/static/local-js/modules/kometa/_prepareState.js
@@ -1,0 +1,72 @@
+// "Prepare Kometa" running-state toggler.
+//
+// While Kometa is executing, we want to:
+//   - dim the accordion (visual "locked" state)
+//   - collapse it if currently expanded
+//   - disable the toggle button + add a tooltip explaining why
+//
+// When the run finishes, we undo all of that so the user can
+// re-open the actions and edit the run command.
+//
+// This module owns THAT one lifecycle transition. It does not own
+// the accordion's DOM elements themselves (they're rendered by
+// Jinja templates and the ids are shared with several other event
+// handlers in 900-kometa.js). Instead, the function lazy-resolves
+// its DOM references via document.getElementById each call. That
+// keeps this module stateless and cheap to import.
+//
+// PUBLIC API:
+//
+//   setKometaPrepareRunningState(isRunning)
+//     No-op if the accordion elements are missing (e.g. on a page
+//     where the "Prepare Kometa" section wasn't rendered). Requires
+//     Bootstrap's Collapse global to collapse a currently-expanded
+//     accordion; falls back to a no-collapse toggle when Bootstrap
+//     isn't loaded (still applies the disabled + dimmed styling).
+//
+// ELEMENT IDS (resolved lazily each call):
+//   #kometa-actions-accordion   - outer wrapper, gets .opacity-50 dim
+//   #kometa-actions-collapse    - the collapsible body
+//   #kometa-actions-toggle      - the toggle button
+
+/**
+ * Toggle the "Prepare Kometa" accordion between running/idle states.
+ *
+ * @param {boolean} isRunning  true while Kometa is running; false
+ *                              when the run finishes (or on a fresh
+ *                              page that isn't running).
+ */
+export function setKometaPrepareRunningState (isRunning) {
+  const accordion = document.getElementById('kometa-actions-accordion')
+  const collapse = document.getElementById('kometa-actions-collapse')
+  const toggle = document.getElementById('kometa-actions-toggle')
+
+  if (accordion) {
+    accordion.classList.toggle('opacity-50', Boolean(isRunning))
+  }
+
+  // Everything below needs both the collapse + toggle. If either is
+  // missing (unusual page layout), silently no-op.
+  if (!collapse || !toggle) return
+
+  // Hide the accordion body if it's currently open. Bootstrap's
+  // Collapse.hide() animates it out; without Bootstrap loaded we
+  // just skip the animation (the disabled styling below still
+  // applies).
+  const bootstrapAvailable = typeof bootstrap !== 'undefined' && bootstrap.Collapse
+  if (isRunning && collapse.classList.contains('show') && bootstrapAvailable) {
+    bootstrap.Collapse.getOrCreateInstance(collapse, { toggle: false }).hide()
+  }
+
+  if (isRunning) {
+    toggle.classList.add('collapsed')
+    toggle.setAttribute('aria-expanded', 'false')
+    toggle.setAttribute('title', 'Kometa is running. Prepare Kometa is locked until the run finishes.')
+    toggle.disabled = true
+    toggle.classList.add('disabled')
+  } else {
+    toggle.removeAttribute('title')
+    toggle.disabled = false
+    toggle.classList.remove('disabled')
+  }
+}

--- a/tests/js/kometa/prepareState.test.js
+++ b/tests/js/kometa/prepareState.test.js
@@ -1,0 +1,206 @@
+// Tests for static/local-js/modules/kometa/_prepareState.js
+//
+// Single export:
+//   setKometaPrepareRunningState(isRunning)
+//
+// COVERAGE:
+//
+//   Missing DOM (3):
+//     - no-op when the whole page is empty
+//     - no-op when accordion exists but collapse missing
+//     - no-op when accordion exists but toggle missing
+//     - (accordion missing but the rest present: opacity toggle
+//        skipped, rest still runs)
+//
+//   Running=true (5):
+//     - adds .opacity-50 to accordion
+//     - adds .collapsed to toggle
+//     - sets aria-expanded="false" on toggle
+//     - sets title attribute with the locked message
+//     - disables toggle + adds .disabled class
+//     - collapses an open accordion via Bootstrap when available
+//     - skips bootstrap.Collapse.hide() when accordion already collapsed
+//     - skips bootstrap.Collapse.hide() when Bootstrap global unavailable
+//
+//   Running=false (4):
+//     - removes .opacity-50 from accordion
+//     - removes title attribute
+//     - enables toggle + removes .disabled class
+//     - leaves aria-expanded / .collapsed alone (Bootstrap handles those
+//       via its own toggle click handler; the module deliberately
+//       doesn't touch them on the "released" path)
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  setKometaPrepareRunningState
+} from '../../../static/local-js/modules/kometa/_prepareState.js'
+
+function installAccordionDom () {
+  document.body.innerHTML = `
+    <div id="kometa-actions-accordion">
+      <button id="kometa-actions-toggle" aria-expanded="true">Prepare</button>
+      <div id="kometa-actions-collapse" class="collapse show"></div>
+    </div>
+  `
+}
+
+function tearDown () {
+  document.body.innerHTML = ''
+  delete global.bootstrap
+  vi.restoreAllMocks()
+}
+
+// ---------------------------------------------------------------------
+// Missing DOM
+// ---------------------------------------------------------------------
+
+describe('setKometaPrepareRunningState (missing DOM)', () => {
+  afterEach(tearDown)
+
+  it('no-ops when the page is empty', () => {
+    document.body.innerHTML = ''
+    expect(() => setKometaPrepareRunningState(true)).not.toThrow()
+    expect(() => setKometaPrepareRunningState(false)).not.toThrow()
+  })
+
+  it('no-ops (except opacity) when the collapse is missing', () => {
+    document.body.innerHTML = `
+      <div id="kometa-actions-accordion"></div>
+      <button id="kometa-actions-toggle"></button>
+    `
+    setKometaPrepareRunningState(true)
+    // Accordion opacity still toggled (that check happens first)
+    expect(document.getElementById('kometa-actions-accordion').classList.contains('opacity-50')).toBe(true)
+    // Toggle NOT disabled (function returned before reaching that block)
+    expect(document.getElementById('kometa-actions-toggle').disabled).toBe(false)
+  })
+
+  it('no-ops (except opacity) when the toggle is missing', () => {
+    document.body.innerHTML = `
+      <div id="kometa-actions-accordion"></div>
+      <div id="kometa-actions-collapse" class="collapse show"></div>
+    `
+    expect(() => setKometaPrepareRunningState(true)).not.toThrow()
+    expect(document.getElementById('kometa-actions-accordion').classList.contains('opacity-50')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// isRunning === true
+// ---------------------------------------------------------------------
+
+describe('setKometaPrepareRunningState (isRunning=true)', () => {
+  beforeEach(installAccordionDom)
+  afterEach(tearDown)
+
+  it('adds .opacity-50 to the accordion wrapper', () => {
+    setKometaPrepareRunningState(true)
+    expect(document.getElementById('kometa-actions-accordion').classList.contains('opacity-50')).toBe(true)
+  })
+
+  it('adds .collapsed class to the toggle', () => {
+    setKometaPrepareRunningState(true)
+    expect(document.getElementById('kometa-actions-toggle').classList.contains('collapsed')).toBe(true)
+  })
+
+  it('sets aria-expanded="false" on the toggle', () => {
+    setKometaPrepareRunningState(true)
+    expect(document.getElementById('kometa-actions-toggle').getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('sets the "locked" title attr on the toggle', () => {
+    setKometaPrepareRunningState(true)
+    expect(document.getElementById('kometa-actions-toggle').getAttribute('title'))
+      .toBe('Kometa is running. Prepare Kometa is locked until the run finishes.')
+  })
+
+  it('disables the toggle + adds .disabled class', () => {
+    setKometaPrepareRunningState(true)
+    const toggle = document.getElementById('kometa-actions-toggle')
+    expect(toggle.disabled).toBe(true)
+    expect(toggle.classList.contains('disabled')).toBe(true)
+  })
+
+  it('calls Bootstrap Collapse.hide() when accordion is open and Bootstrap is loaded', () => {
+    const hideSpy = vi.fn()
+    global.bootstrap = {
+      Collapse: {
+        getOrCreateInstance: vi.fn(() => ({ hide: hideSpy }))
+      }
+    }
+    setKometaPrepareRunningState(true)
+    expect(global.bootstrap.Collapse.getOrCreateInstance).toHaveBeenCalled()
+    expect(hideSpy).toHaveBeenCalled()
+  })
+
+  it('skips Collapse.hide() when accordion is already collapsed', () => {
+    // Remove .show to simulate a closed accordion
+    document.getElementById('kometa-actions-collapse').classList.remove('show')
+    const hideSpy = vi.fn()
+    global.bootstrap = {
+      Collapse: {
+        getOrCreateInstance: vi.fn(() => ({ hide: hideSpy }))
+      }
+    }
+    setKometaPrepareRunningState(true)
+    expect(hideSpy).not.toHaveBeenCalled()
+  })
+
+  it('skips Collapse.hide() when Bootstrap global is not available', () => {
+    // Ensure no bootstrap global
+    delete global.bootstrap
+    expect(() => setKometaPrepareRunningState(true)).not.toThrow()
+    // Toggle should still be locked
+    expect(document.getElementById('kometa-actions-toggle').disabled).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------
+// isRunning === false
+// ---------------------------------------------------------------------
+
+describe('setKometaPrepareRunningState (isRunning=false)', () => {
+  beforeEach(() => {
+    installAccordionDom()
+    // Start in the running/locked state so we can verify the release
+    document.getElementById('kometa-actions-accordion').classList.add('opacity-50')
+    const toggle = document.getElementById('kometa-actions-toggle')
+    toggle.disabled = true
+    toggle.classList.add('disabled')
+    toggle.setAttribute('title', 'Kometa is running. Prepare Kometa is locked until the run finishes.')
+  })
+  afterEach(tearDown)
+
+  it('removes .opacity-50 from the accordion wrapper', () => {
+    setKometaPrepareRunningState(false)
+    expect(document.getElementById('kometa-actions-accordion').classList.contains('opacity-50')).toBe(false)
+  })
+
+  it('removes the title attribute from the toggle', () => {
+    setKometaPrepareRunningState(false)
+    expect(document.getElementById('kometa-actions-toggle').hasAttribute('title')).toBe(false)
+  })
+
+  it('re-enables the toggle + removes .disabled class', () => {
+    setKometaPrepareRunningState(false)
+    const toggle = document.getElementById('kometa-actions-toggle')
+    expect(toggle.disabled).toBe(false)
+    expect(toggle.classList.contains('disabled')).toBe(false)
+  })
+
+  it('does not touch .collapsed / aria-expanded on release', () => {
+    // Set them to values that indicate "collapsed" so we can verify
+    // the function doesn't reset them (Bootstrap owns those attrs on
+    // release; our module deliberately doesn't touch them so the
+    // user's expand/collapse click won't be double-toggled).
+    const toggle = document.getElementById('kometa-actions-toggle')
+    toggle.classList.add('collapsed')
+    toggle.setAttribute('aria-expanded', 'false')
+
+    setKometaPrepareRunningState(false)
+
+    expect(toggle.classList.contains('collapsed')).toBe(true)
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+  })
+})


### PR DESCRIPTION
## What

Extracts `setKometaPrepareRunningState` (18 lines) to `static/local-js/modules/kometa/_prepareState.js`. This is the lifecycle toggle that dims the "Prepare Kometa" accordion, collapses it if open, and disables the toggle button while Kometa is running.

`900-kometa.js`: **1202 → 1182 lines (-20)**.
Vitest tests: 1469 → 1484 (**+15**).

## What moved

Extracted to `_prepareState.js` (75 lines):

- **`setKometaPrepareRunningState(isRunning)`**
  - `running=true`: adds `.opacity-50` to accordion, collapses it via Bootstrap (when currently expanded + Bootstrap loaded), sets `.collapsed` + `aria-expanded="false"` + locked-title on toggle, disables it.
  - `running=false`: removes `.opacity-50`, removes title attr, re-enables toggle + removes `.disabled`. **Deliberately does NOT reset `.collapsed`/`aria-expanded`** — Bootstrap owns those on the release path; our module would race with the user's expand click if it touched them.

## Lazy DOM resolution

The three DOM refs (`#kometa-actions-accordion`, `-collapse`, `-toggle`) are looked up via `document.getElementById` **on each call** rather than cached at module import time. Two reasons:

1. `-collapse` is also referenced by several other event handlers in `900-kometa.js` (bootstrap show/hide sync listeners), so it stays as a const there. Duplicating that const into the module would work but requires knowing the id in two places, or taking it as an arg (over-engineering for a hot-once-per-run-status-change function).
2. Lazy lookup makes the module trivially testable — tests set up DOM in `beforeEach` and call the function directly.

## Removed from `900-kometa.js`

- `const kometaActionsToggle = ...` (was only used inside the extracted function)

`kometaActionsCollapse` stays — it has 6 other callsites for show/hide sync listeners unrelated to the "Kometa is running" state.

## Verbatim-behavior preservation

- Same class toggles: `.opacity-50`, `.collapsed`, `.disabled`
- Same title attr text
- Same `aria-expanded="false"` behavior
- Same `Bootstrap.Collapse.hide()` call when accordion is open **AND** Bootstrap is loaded (both guards preserved)
- Same "leave collapsed/aria-expanded alone" semantics on release

## Test coverage: 15 new tests

- **Missing DOM (3)**: empty page no-op, collapse-missing only-opacity, toggle-missing only-opacity
- **isRunning=true (8)**: `.opacity-50` added, `.collapsed` added, `aria-expanded="false"`, title set, disabled + `.disabled`, Bootstrap Collapse.hide() called when open+loaded, SKIPPED when already collapsed, No throw when Bootstrap missing
- **isRunning=false (4)**: `.opacity-50` removed, title removed, re-enabled + `.disabled` removed, `.collapsed`/`aria-expanded` left alone

## Verification

- **1484/1484 Vitest pass** (was 1469; +15 new)
- `test_kometa_module_runs_without_console_errors` e2e: passes
- ESLint clean

## Milestone

`900-kometa.js` was **3822** at split baseline. Now **1182**.
Cumulative cut: **-2640 lines (69.1%)**.

Modules extracted from `900-kometa.js`: **27**.
Vitest tests: 611 → 1484 (**+873, +142.9%**).
