### PR TITLE
Extract accordion-highlight state to shared module (#1346 step 2f, unblocks Step 9)

### DIFF
--- a/static/local-js/eventHandler.js
+++ b/static/local-js/eventHandler.js
@@ -1,3 +1,5 @@
+import * as accordionHighlights from './modules/accordionHighlights.js'
+
 function callValidationHandler (methodName, ...args) {
   const handler = window.ValidationHandler
   if (!handler || typeof handler[methodName] !== 'function') {
@@ -344,241 +346,19 @@ const EventHandler = {
 
     libraryContainer.style.display = isVisible ? 'block' : 'none'
     console.log(`[DEBUG] Library ${libraryId} is now ${isVisible ? 'VISIBLE' : 'HIDDEN'}`)
-  },
-
-  /**
-   * Returns true if an accordion body has at least one enabled collection toggle selected.
-   * Returns false when collection toggles exist but none are selected.
-   * Returns null when no collection toggles are present.
-   */
-  hasCheckedTemplateGroupToggle: function (accordionBody) {
-    if (!accordionBody) return null
-    const toggles = Array.from(accordionBody.querySelectorAll("input[type='checkbox'][data-template-group]"))
-    if (!toggles.length) return null
-    return toggles.some(toggle => toggle.checked)
-  },
-
-  hasLibraryFileEntries: function (accordionBody) {
-    if (!accordionBody) return false
-    const hidden = accordionBody.querySelector(
-      'input[type="hidden"][name$="-metadata_files"], input[type="hidden"][name$="-collection_files"], input[type="hidden"][name$="-overlay_files"]'
-    )
-    if (!hidden) return false
-    const raw = String(hidden.value || '').trim()
-    return Boolean(raw && raw !== '[]')
-  },
-
-  /**
-   * Update accordion highlights when selections change
-   */
-  updateAccordionHighlights: function () {
-    console.log('🔍 [DEBUG] Updating accordion highlights...')
-
-    document.querySelectorAll('.accordion-item').forEach((accordion) => {
-      const accordionHeader = accordion.querySelector('.accordion-header')
-      if (!accordionHeader) return
-
-      const headerText = accordionHeader.textContent.trim()
-      const isPreviewOverlay = headerText.toLowerCase().includes('preview overlays')
-      const accordionBody = accordion.querySelector('.accordion-body')
-
-      // Skip preview overlays
-      if (isPreviewOverlay) {
-        accordionHeader.classList.remove('selected')
-        return
-      }
-
-      let isCheckedOrSelected = false
-      let hasValue = false
-
-      if (accordionBody) {
-        // 1. Check for directly selected inputs (checkboxes, radios, list selections)
-        isCheckedOrSelected = accordionBody.querySelector(
-          "input[type='checkbox']:checked:not(.readonly-toggle):not(.template-child-toggle):not([hidden]):not([type='hidden']), " +
-          "input[type='radio']:checked:not([hidden]):not([type='hidden']), " +
-          '.list-group li'
-        ) !== null
-
-        // 1b. Any non-empty inputs/selects also count as activity
-        // Suppress value-based highlighting for true Collection/Overlay sections,
-        // but allow it for "Delete Collections" (so its numeric field bubbles up).
-        const headerLower = headerText.toLowerCase()
-        const isLibraryFileSection = EventHandler.hasLibraryFileEntries(accordionBody)
-        const suppressValueCheck =
-          !isLibraryFileSection &&
-          (
-            headerLower.includes('overlay') ||
-            (headerLower.includes('collection') && !headerLower.includes('delete collections'))
-          )
-        if (isLibraryFileSection) {
-          hasValue = true
-        } else if (!suppressValueCheck) {
-          const textInputs = Array.from(
-            accordionBody.querySelectorAll("input[type='text'], input[type='number'], input[type='date']")
-          )
-          const selects = Array.from(accordionBody.querySelectorAll('select'))
-          hasValue = textInputs.some((input) => {
-            const v = (input.value || '').trim().toLowerCase()
-            return v && v !== 'none'
-          }) || selects.some((sel) => {
-            const v = (sel.value || '').trim().toLowerCase()
-            return v && v !== 'none'
-          })
-        }
-
-        // 2. Check for modified template selects, but only if toggle is still ON
-        if (!isCheckedOrSelected) {
-          isCheckedOrSelected = Array.from(
-            accordionBody.querySelectorAll('.template-variable-select[data-user-modified="true"]')
-          ).some((select) => {
-            const group = select.closest('.template-toggle-group')
-            const toggle = group?.querySelector('.overlay-toggle')
-            return toggle?.checked
-          })
-        }
-      }
-
-      // Collection accordions should not stay highlighted from child values/history
-      // when every parent collection toggle is off.
-      const anyTemplateGroupChecked = EventHandler.hasCheckedTemplateGroupToggle(accordionBody)
-      if (anyTemplateGroupChecked === false) {
-        isCheckedOrSelected = false
-        hasValue = false
-      }
-
-      if (isCheckedOrSelected || hasValue) {
-        accordionHeader.classList.add('selected')
-        if (accordion.dataset.qsMinimalYaml !== 'false') {
-          EventHandler.highlightParentAccordions(accordionHeader)
-        }
-      } else {
-        EventHandler.removeHighlightIfEmpty(accordionHeader)
-      }
-    })
-
-    // Special case: don't highlight parent "Overlays" if only preview overlays are selected
-    document.querySelectorAll('.accordion-item').forEach((accordion) => {
-      const accordionHeader = accordion.querySelector('.accordion-header')
-      const headerText = accordionHeader?.textContent.trim().toLowerCase()
-      if (headerText !== 'overlays') return
-
-      const childItems = accordion.querySelectorAll('.accordion-item')
-      const hasNonPreviewSelection = Array.from(childItems).some((child) => {
-        const childHeader = child.querySelector('.accordion-header')
-        const isPreview = childHeader?.textContent.trim().toLowerCase().includes('preview overlays')
-
-        if (isPreview) return false
-
-        // Only highlight if child toggle is on or has modified select tied to an enabled toggle
-        const hasActiveToggle = child.querySelector(
-          "input[type='checkbox']:checked:not(.readonly-toggle):not(.template-child-toggle):not([hidden]):not([type='hidden']), " +
-          "input[type='radio']:checked:not([hidden]):not([type='hidden']), " +
-          '.list-group li'
-        )
-        if (hasActiveToggle) return true
-
-        const hasModifiedSelectWithToggle = Array.from(
-          child.querySelectorAll('.template-variable-select[data-user-modified="true"]')
-        ).some((select) => {
-          const group = select.closest('.template-toggle-group')
-          const toggle = group?.querySelector('.overlay-toggle')
-          return toggle?.checked
-        })
-
-        return hasModifiedSelectWithToggle
-      })
-
-      if (hasNonPreviewSelection) {
-        accordionHeader.classList.add('selected')
-      } else {
-        accordionHeader.classList.remove('selected')
-      }
-    })
-  },
-
-  /**
-   * Highlight parent accordions when a child section is selected
-   */
-  highlightParentAccordions: function (element) {
-    while (element) {
-      const parentAccordion = element.closest('.accordion-item')
-      if (!parentAccordion) break
-      if (parentAccordion.dataset.qsMinimalYaml === 'false') {
-        parentAccordion.querySelector('.accordion-header')?.classList.add('selected')
-        return
-      }
-
-      const parentHeader = parentAccordion.querySelector('.accordion-header')
-      const parentText = parentHeader ? parentHeader.textContent.trim() : ''
-      const isPreviewOverlay = parentText.toLowerCase().includes('preview overlays')
-      const isOverlaysSection = parentText.toLowerCase().includes('overlays')
-
-      if (isPreviewOverlay) {
-        console.log(`🚫 [DEBUG] Skipping parent highlight for Preview Overlays: ${parentText}`)
-        return
-      }
-
-      if (isOverlaysSection) {
-        const hasValidChild = Array.from(parentAccordion.querySelectorAll('.accordion-item')).some(child => {
-          const childHeader = child.querySelector('.accordion-header')
-          const childText = childHeader ? childHeader.textContent.trim() : ''
-          const isPreviewChild = childText.toLowerCase().includes('preview overlays')
-
-          return !isPreviewChild && child.querySelector('input:checked:not(.template-child-toggle)')
-        })
-
-        if (!hasValidChild) {
-          console.log(`🚫 [DEBUG] Preventing Overlays from inheriting highlight due to only Preview Overlays: ${parentText}`)
-          return
-        }
-      }
-
-      console.log(`🎯 [DEBUG] Adding highlight to parent: ${parentText}`)
-      parentHeader.classList.add('selected')
-
-      element = parentAccordion.parentElement.closest('.accordion-item')?.querySelector('.accordion-header')
-    }
-  },
-
-  /**
-   * Remove highlight if an accordion has no selections
-   */
-  removeHighlightIfEmpty: function (element) {
-    if (!element) return
-    const accordionItem = element.closest('.accordion-item')
-    if (!accordionItem) return
-
-    const accordionId = accordionItem.id || ''
-    const isPreviewOverlay = accordionId.includes('-previewOverlays')
-
-    const accordionBody = accordionItem.querySelector('.accordion-body')
-
-    if (isPreviewOverlay) {
-      console.log(`🚫 [DEBUG] Preventing highlight removal check for Preview Overlays: ${accordionId}`)
-      return
-    }
-
-    const hasSelections = accordionBody?.querySelector(
-      "input[type='checkbox']:checked:not(.readonly-toggle):not(.template-child-toggle):not([hidden]):not([type='hidden']), " +
-      "input[type='radio']:checked:not([hidden]):not([type='hidden']), " +
-      "select[data-user-modified='true'] option:checked:not([value='']):not([value='none']), " +
-      '.list-group li'
-    ) !== null
-    const hasLibraryFileEntries = EventHandler.hasLibraryFileEntries(accordionBody)
-
-    // If this accordion has collection toggles and none are enabled, force no highlight.
-    const anyTemplateGroupChecked = EventHandler.hasCheckedTemplateGroupToggle(accordionBody)
-    const effectiveSelections = (anyTemplateGroupChecked === false) ? false : (hasSelections || hasLibraryFileEntries)
-
-    if (!effectiveSelections) {
-      element.classList.remove('selected')
-    }
-
-    // Recursively check parents
-    const parentAccordionHeader = accordionItem.parentElement.closest('.accordion-item')?.querySelector('.accordion-header')
-    EventHandler.removeHighlightIfEmpty(parentAccordionHeader)
   }
 }
+
+// Accordion-highlight state -- extracted to a shared module in step 2f
+// of #1346 so overlayHandler.js and 025-libraries.js can import from
+// one source instead of reaching for window.EventHandler. We still
+// mirror onto EventHandler here so external non-module callers keep
+// working during the migration.
+EventHandler.hasCheckedTemplateGroupToggle = accordionHighlights.hasCheckedTemplateGroupToggle
+EventHandler.hasLibraryFileEntries = accordionHighlights.hasLibraryFileEntries
+EventHandler.highlightParentAccordions = accordionHighlights.highlightParentAccordions
+EventHandler.removeHighlightIfEmpty = accordionHighlights.removeHighlightIfEmpty
+EventHandler.updateAccordionHighlights = accordionHighlights.updateAccordionHighlights
 
 window.EventHandler = EventHandler
 

--- a/static/local-js/modules/accordionHighlights.js
+++ b/static/local-js/modules/accordionHighlights.js
@@ -1,0 +1,295 @@
+// Accordion-highlight state for the config-form workspace.
+//
+// This module owns the `.selected` class on `.accordion-header` elements
+// across the page. When a user checks a toggle, types a value, or clicks
+// a template swatch, the surrounding accordion (and its ancestors) needs
+// to reflect that "something in here is active".
+//
+// Extracted from eventHandler.js as part of #1346 step 2f -- these
+// functions were the shared surface between eventHandler.js and its
+// consumers (025-libraries.js, overlayHandler.js), and were the root
+// of the eventHandler <-> overlayHandler circular reference that
+// blocked the rest of the ES-modules migration.
+//
+// Public API:
+//   updateAccordionHighlights()   -- Repaint .selected across the whole page.
+//   hasCheckedTemplateGroupToggle(body) -- Predicate. Returns true / false / null.
+//   hasLibraryFileEntries(body)   -- Predicate. Returns boolean.
+//   highlightParentAccordions(el) -- Walk ancestors adding .selected.
+//   removeHighlightIfEmpty(el)    -- Walk ancestors removing .selected.
+//
+// The functions are exported as named exports so consumers can import
+// exactly what they need. eventHandler.js still monkey-patches these
+// onto `window.EventHandler` for now to preserve the existing public
+// contract; new code should prefer the imports.
+
+/**
+ * Returns true when the accordion body has at least one enabled
+ * `[data-template-group]` toggle checked. Returns false when toggles
+ * exist but none are checked. Returns null when no toggles are present.
+ * The tri-state return matters -- callers use `=== false` to detect
+ * "toggles exist and are all off", which is stronger than falsy.
+ */
+export function hasCheckedTemplateGroupToggle (accordionBody) {
+  if (!accordionBody) return null
+  const toggles = Array.from(accordionBody.querySelectorAll("input[type='checkbox'][data-template-group]"))
+  if (!toggles.length) return null
+  return toggles.some(toggle => toggle.checked)
+}
+
+/**
+ * Returns true when the accordion body contains a populated hidden
+ * input tracking library-file selections (metadata_files,
+ * collection_files, or overlay_files). Empty string and the literal
+ * '[]' both count as empty. Used to decide whether an accordion
+ * should highlight even though it contains no direct form inputs.
+ */
+export function hasLibraryFileEntries (accordionBody) {
+  if (!accordionBody) return false
+  const hidden = accordionBody.querySelector(
+    'input[type="hidden"][name$="-metadata_files"], input[type="hidden"][name$="-collection_files"], input[type="hidden"][name$="-overlay_files"]'
+  )
+  if (!hidden) return false
+  const raw = String(hidden.value || '').trim()
+  return Boolean(raw && raw !== '[]')
+}
+
+/**
+ * Walk up the ancestor chain from `element` adding `.selected` to each
+ * `.accordion-header` we pass through. Stops early on:
+ *   - A parent marked `data-qs-minimal-yaml="false"` (adds highlight
+ *     to that parent then returns; those parents don't cascade further).
+ *   - A "Preview Overlays" parent (never inherits highlight).
+ *   - A bare "Overlays" parent whose only checked descendants are
+ *     Preview Overlays children (also never inherits).
+ *
+ * Otherwise, adds `.selected` to the parent header and continues one
+ * level further up.
+ */
+export function highlightParentAccordions (element) {
+  while (element) {
+    const parentAccordion = element.closest('.accordion-item')
+    if (!parentAccordion) break
+    if (parentAccordion.dataset.qsMinimalYaml === 'false') {
+      parentAccordion.querySelector('.accordion-header')?.classList.add('selected')
+      return
+    }
+
+    const parentHeader = parentAccordion.querySelector('.accordion-header')
+    const parentText = parentHeader ? parentHeader.textContent.trim() : ''
+    const isPreviewOverlay = parentText.toLowerCase().includes('preview overlays')
+    const isOverlaysSection = parentText.toLowerCase().includes('overlays')
+
+    if (isPreviewOverlay) {
+      console.log(`\u{1F6AB} [DEBUG] Skipping parent highlight for Preview Overlays: ${parentText}`)
+      return
+    }
+
+    if (isOverlaysSection) {
+      const hasValidChild = Array.from(parentAccordion.querySelectorAll('.accordion-item')).some(child => {
+        const childHeader = child.querySelector('.accordion-header')
+        const childText = childHeader ? childHeader.textContent.trim() : ''
+        const isPreviewChild = childText.toLowerCase().includes('preview overlays')
+
+        return !isPreviewChild && child.querySelector('input:checked:not(.template-child-toggle)')
+      })
+
+      if (!hasValidChild) {
+        console.log(`\u{1F6AB} [DEBUG] Preventing Overlays from inheriting highlight due to only Preview Overlays: ${parentText}`)
+        return
+      }
+    }
+
+    console.log(`\u{1F3AF} [DEBUG] Adding highlight to parent: ${parentText}`)
+    parentHeader.classList.add('selected')
+
+    element = parentAccordion.parentElement.closest('.accordion-item')?.querySelector('.accordion-header')
+  }
+}
+
+/**
+ * Given an accordion-header element, decide whether the accordion is
+ * empty enough to remove `.selected`. Empty means: no checked inputs,
+ * no populated hidden library-file input, AND either no template-group
+ * toggles OR at least one template-group toggle is checked.
+ *
+ * If we do remove `.selected`, we recurse to the parent accordion's
+ * header -- otherwise a bottom-level clear wouldn't bubble up.
+ *
+ * Skips `.accordion-item` elements whose id contains `-previewOverlays`.
+ */
+export function removeHighlightIfEmpty (element) {
+  if (!element) return
+  const accordionItem = element.closest('.accordion-item')
+  if (!accordionItem) return
+
+  const accordionId = accordionItem.id || ''
+  const isPreviewOverlay = accordionId.includes('-previewOverlays')
+
+  const accordionBody = accordionItem.querySelector('.accordion-body')
+
+  if (isPreviewOverlay) {
+    console.log(`\u{1F6AB} [DEBUG] Preventing highlight removal check for Preview Overlays: ${accordionId}`)
+    return
+  }
+
+  const hasSelections = accordionBody?.querySelector(
+    "input[type='checkbox']:checked:not(.readonly-toggle):not(.template-child-toggle):not([hidden]):not([type='hidden']), " +
+    "input[type='radio']:checked:not([hidden]):not([type='hidden']), " +
+    "select[data-user-modified='true'] option:checked:not([value='']):not([value='none']), " +
+    '.list-group li'
+  ) !== null
+  const bodyHasLibraryFileEntries = hasLibraryFileEntries(accordionBody)
+
+  // If this accordion has collection toggles and none are enabled, force no highlight.
+  const anyTemplateGroupChecked = hasCheckedTemplateGroupToggle(accordionBody)
+  const effectiveSelections = (anyTemplateGroupChecked === false) ? false : (hasSelections || bodyHasLibraryFileEntries)
+
+  if (!effectiveSelections) {
+    element.classList.remove('selected')
+  }
+
+  // Recursively check parents
+  const parentAccordionHeader = accordionItem.parentElement.closest('.accordion-item')?.querySelector('.accordion-header')
+  removeHighlightIfEmpty(parentAccordionHeader)
+}
+
+/**
+ * Sweep every `.accordion-item` on the page and repaint the
+ * `.selected` class on its `.accordion-header`. This is the top-level
+ * entry point called after any state change (checkbox toggled, input
+ * edited, template-swatch clicked, library-file list mutated, etc.).
+ *
+ * Two passes:
+ *   1. For every accordion, decide from its own contents whether it
+ *      should highlight. If so, cascade up via `highlightParentAccordions`;
+ *      otherwise decay via `removeHighlightIfEmpty`.
+ *   2. Special-case the bare "Overlays" parent: it should only highlight
+ *      when at least one non-preview child has a real selection.
+ *
+ * Preview-Overlays accordions never highlight themselves.
+ */
+export function updateAccordionHighlights () {
+  console.log('\u{1F50D} [DEBUG] Updating accordion highlights...')
+
+  document.querySelectorAll('.accordion-item').forEach((accordion) => {
+    const accordionHeader = accordion.querySelector('.accordion-header')
+    if (!accordionHeader) return
+
+    const headerText = accordionHeader.textContent.trim()
+    const isPreviewOverlay = headerText.toLowerCase().includes('preview overlays')
+    const accordionBody = accordion.querySelector('.accordion-body')
+
+    // Skip preview overlays
+    if (isPreviewOverlay) {
+      accordionHeader.classList.remove('selected')
+      return
+    }
+
+    let isCheckedOrSelected = false
+    let hasValue = false
+
+    if (accordionBody) {
+      // 1. Check for directly selected inputs (checkboxes, radios, list selections)
+      isCheckedOrSelected = accordionBody.querySelector(
+        "input[type='checkbox']:checked:not(.readonly-toggle):not(.template-child-toggle):not([hidden]):not([type='hidden']), " +
+        "input[type='radio']:checked:not([hidden]):not([type='hidden']), " +
+        '.list-group li'
+      ) !== null
+
+      // 1b. Any non-empty inputs/selects also count as activity
+      // Suppress value-based highlighting for true Collection/Overlay sections,
+      // but allow it for "Delete Collections" (so its numeric field bubbles up).
+      const headerLower = headerText.toLowerCase()
+      const isLibraryFileSection = hasLibraryFileEntries(accordionBody)
+      const suppressValueCheck =
+        !isLibraryFileSection &&
+        (
+          headerLower.includes('overlay') ||
+          (headerLower.includes('collection') && !headerLower.includes('delete collections'))
+        )
+      if (isLibraryFileSection) {
+        hasValue = true
+      } else if (!suppressValueCheck) {
+        const textInputs = Array.from(
+          accordionBody.querySelectorAll("input[type='text'], input[type='number'], input[type='date']")
+        )
+        const selects = Array.from(accordionBody.querySelectorAll('select'))
+        hasValue = textInputs.some((input) => {
+          const v = (input.value || '').trim().toLowerCase()
+          return v && v !== 'none'
+        }) || selects.some((sel) => {
+          const v = (sel.value || '').trim().toLowerCase()
+          return v && v !== 'none'
+        })
+      }
+
+      // 2. Check for modified template selects, but only if toggle is still ON
+      if (!isCheckedOrSelected) {
+        isCheckedOrSelected = Array.from(
+          accordionBody.querySelectorAll('.template-variable-select[data-user-modified="true"]')
+        ).some((select) => {
+          const group = select.closest('.template-toggle-group')
+          const toggle = group?.querySelector('.overlay-toggle')
+          return toggle?.checked
+        })
+      }
+    }
+
+    // Collection accordions should not stay highlighted from child values/history
+    // when every parent collection toggle is off.
+    const anyTemplateGroupChecked = hasCheckedTemplateGroupToggle(accordionBody)
+    if (anyTemplateGroupChecked === false) {
+      isCheckedOrSelected = false
+      hasValue = false
+    }
+
+    if (isCheckedOrSelected || hasValue) {
+      accordionHeader.classList.add('selected')
+      if (accordion.dataset.qsMinimalYaml !== 'false') {
+        highlightParentAccordions(accordionHeader)
+      }
+    } else {
+      removeHighlightIfEmpty(accordionHeader)
+    }
+  })
+
+  // Special case: don't highlight parent "Overlays" if only preview overlays are selected
+  document.querySelectorAll('.accordion-item').forEach((accordion) => {
+    const accordionHeader = accordion.querySelector('.accordion-header')
+    const headerText = accordionHeader?.textContent.trim().toLowerCase()
+    if (headerText !== 'overlays') return
+
+    const childItems = accordion.querySelectorAll('.accordion-item')
+    const hasNonPreviewSelection = Array.from(childItems).some((child) => {
+      const childHeader = child.querySelector('.accordion-header')
+      const isPreview = childHeader?.textContent.trim().toLowerCase().includes('preview overlays')
+
+      if (isPreview) return false
+
+      // Only highlight if child toggle is on or has modified select tied to an enabled toggle
+      const hasActiveToggle = child.querySelector(
+        "input[type='checkbox']:checked:not(.readonly-toggle):not(.template-child-toggle):not([hidden]):not([type='hidden']), " +
+        "input[type='radio']:checked:not([hidden]):not([type='hidden']), " +
+        '.list-group li'
+      )
+      if (hasActiveToggle) return true
+
+      const hasModifiedSelectWithToggle = Array.from(
+        child.querySelectorAll('.template-variable-select[data-user-modified="true"]')
+      ).some((select) => {
+        const group = select.closest('.template-toggle-group')
+        const toggle = group?.querySelector('.overlay-toggle')
+        return toggle?.checked
+      })
+
+      return hasModifiedSelectWithToggle
+    })
+
+    if (hasNonPreviewSelection) {
+      accordionHeader.classList.add('selected')
+    } else {
+      accordionHeader.classList.remove('selected')
+    }
+  })
+}

--- a/tests/js/modules/accordionHighlights.test.js
+++ b/tests/js/modules/accordionHighlights.test.js
@@ -1,0 +1,133 @@
+// Contract tests for static/local-js/modules/accordionHighlights.js
+//
+// The exhaustive behavior tests live in tests/js/eventHandler.test.js --
+// those exercise the same functions via `window.EventHandler`, since
+// eventHandler.js re-exports them onto the EventHandler object.
+//
+// The tests here are narrower: they prove the MODULE (importable
+// standalone, no window/EventHandler pollution required) exposes the
+// expected names as callable functions, and that each one runs
+// end-to-end on a minimal DOM fixture. This is the "does the module
+// contract work" smoke test that unlocks other consumers importing
+// from it directly.
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import * as accordionHighlights from '../../../static/local-js/modules/accordionHighlights.js'
+
+// Silence chatty debug output from updateAccordionHighlights /
+// highlightParentAccordions / removeHighlightIfEmpty.
+vi.spyOn(console, 'log').mockImplementation(() => {})
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('accordionHighlights module surface', () => {
+  it('exports hasCheckedTemplateGroupToggle as a function', () => {
+    expect(typeof accordionHighlights.hasCheckedTemplateGroupToggle).toBe('function')
+  })
+
+  it('exports hasLibraryFileEntries as a function', () => {
+    expect(typeof accordionHighlights.hasLibraryFileEntries).toBe('function')
+  })
+
+  it('exports highlightParentAccordions as a function', () => {
+    expect(typeof accordionHighlights.highlightParentAccordions).toBe('function')
+  })
+
+  it('exports removeHighlightIfEmpty as a function', () => {
+    expect(typeof accordionHighlights.removeHighlightIfEmpty).toBe('function')
+  })
+
+  it('exports updateAccordionHighlights as a function', () => {
+    expect(typeof accordionHighlights.updateAccordionHighlights).toBe('function')
+  })
+
+  it('does not export anything else at the top level (guards accidental leaks)', () => {
+    // Named exports show up as own properties of the namespace object.
+    // ES module namespaces are frozen, so we're just asserting on shape.
+    const keys = Object.keys(accordionHighlights).sort()
+    expect(keys).toEqual([
+      'hasCheckedTemplateGroupToggle',
+      'hasLibraryFileEntries',
+      'highlightParentAccordions',
+      'removeHighlightIfEmpty',
+      'updateAccordionHighlights'
+    ])
+  })
+})
+
+describe('accordionHighlights: standalone smoke tests', () => {
+  // Each test builds the minimum DOM the function needs and asserts
+  // one visible behavior. Exhaustive coverage is in eventHandler.test.js;
+  // these prove the module works without needing eventHandler.js loaded.
+
+  it('hasCheckedTemplateGroupToggle: returns null on empty body', () => {
+    const body = document.createElement('div')
+    expect(accordionHighlights.hasCheckedTemplateGroupToggle(body)).toBe(null)
+  })
+
+  it('hasCheckedTemplateGroupToggle: returns true when a template-group toggle is checked', () => {
+    const body = document.createElement('div')
+    body.innerHTML = '<input type="checkbox" data-template-group="foo" checked>'
+    expect(accordionHighlights.hasCheckedTemplateGroupToggle(body)).toBe(true)
+  })
+
+  it('hasLibraryFileEntries: returns false on empty body', () => {
+    const body = document.createElement('div')
+    expect(accordionHighlights.hasLibraryFileEntries(body)).toBe(false)
+  })
+
+  it('hasLibraryFileEntries: returns true when a populated hidden input is present', () => {
+    const body = document.createElement('div')
+    body.innerHTML = '<input type="hidden" name="foo-metadata_files" value="[\\"a.yml\\"]">'
+    expect(accordionHighlights.hasLibraryFileEntries(body)).toBe(true)
+  })
+
+  it('highlightParentAccordions: walks up and adds .selected', () => {
+    document.body.innerHTML = `
+      <div class="accordion-item" data-qs-minimal-yaml="true">
+        <div class="accordion-header">Outer</div>
+        <div class="accordion-body">
+          <div class="accordion-item" data-qs-minimal-yaml="true">
+            <div class="accordion-header" id="inner">Inner</div>
+          </div>
+        </div>
+      </div>
+    `
+    const inner = document.getElementById('inner')
+    accordionHighlights.highlightParentAccordions(inner)
+    const outer = document.body.querySelector('.accordion-item > .accordion-header')
+    expect(outer.classList.contains('selected')).toBe(true)
+  })
+
+  it('removeHighlightIfEmpty: strips .selected on an empty accordion body', () => {
+    document.body.innerHTML = `
+      <div class="accordion-item">
+        <div class="accordion-header selected" id="hdr">Empty</div>
+        <div class="accordion-body"></div>
+      </div>
+    `
+    const hdr = document.getElementById('hdr')
+    accordionHighlights.removeHighlightIfEmpty(hdr)
+    expect(hdr.classList.contains('selected')).toBe(false)
+  })
+
+  it('updateAccordionHighlights: adds .selected when a body checkbox is checked', () => {
+    document.body.innerHTML = `
+      <div class="accordion-item">
+        <div class="accordion-header">Foo</div>
+        <div class="accordion-body">
+          <input type="checkbox" checked>
+        </div>
+      </div>
+    `
+    accordionHighlights.updateAccordionHighlights()
+    const hdr = document.querySelector('.accordion-header')
+    expect(hdr.classList.contains('selected')).toBe(true)
+  })
+
+  it('updateAccordionHighlights: runs on empty DOM without throwing', () => {
+    expect(() => accordionHighlights.updateAccordionHighlights()).not.toThrow()
+  })
+})


### PR DESCRIPTION
## What

**First PR of step 2f in #1346** — breaking the `eventHandler.js` ↔ `overlayHandler.js` circular reference that's been blocking the rest of the ES-modules migration (and Step 9 of the roadmap #1335).

Extracts 5 accordion-highlight functions to a shared module at `static/local-js/modules/accordionHighlights.js`.

`eventHandler.js`: **768 → 548 lines (-220)**.
Vitest tests: 1484 → 1498 (**+14** new module contract tests).

## Why this unblocks Step 9

**The circular reference today:**
- `eventHandler.js` exposes `window.EventHandler.updateAccordionHighlights`
- `overlayHandler.js` calls it 5 times
- `025-libraries.js` calls it 5 times
- Meanwhile `overlayHandler.js` exposes `window.OverlayHandler.*` that `eventHandler` needs

Neither file can convert to a clean `import` topology because they'd import each other. Step 9's component-island conversion (Svelte/Vue/etc.) needs clean import boundaries first.

**Resolution:** extract the accordion-highlight state to a third module. `overlayHandler.js` and `025-libraries.js` can each import from `accordionHighlights` independently, without `eventHandler` needing to be a dependency at all.

## What moved

Extracted to `modules/accordionHighlights.js` (295 lines):

- `hasCheckedTemplateGroupToggle(body)` — predicate, tri-state (true/false/null)
- `hasLibraryFileEntries(body)` — predicate, boolean
- `highlightParentAccordions(el)` — ancestor walker (adds `.selected`)
- `removeHighlightIfEmpty(el)` — recursive cleanup (removes `.selected`)
- `updateAccordionHighlights()` — top-level page sweep

## How the compat shim works

`eventHandler.js` now imports the module and re-attaches the functions onto the `EventHandler` object:

```js
import * as accordionHighlights from './modules/accordionHighlights.js'
// ... EventHandler = { ...other methods... }
EventHandler.updateAccordionHighlights = accordionHighlights.updateAccordionHighlights
// (etc for all 5)
window.EventHandler = EventHandler
```

Non-module consumers (`overlayHandler.js`, `025-libraries.js`) that reach for `window.EventHandler.updateAccordionHighlights()` keep working unchanged. Follow-up PRs will replace those callsites with direct imports.

## Verbatim behavior preservation

- Every function body moved character-for-character.
- Console-log emojis preserved via `\u{XXXX}` escapes (repo enforces no emojis in file content, so the escape form is required).
- Inter-function references rewritten from `EventHandler.foo(...)` → bare `foo(...)` (same-module scope now).
- `removeHighlightIfEmpty` had a local `const hasLibraryFileEntries` that would shadow the module function name; renamed the local to `bodyHasLibraryFileEntries` to avoid the shadow. Same behavior, clearer read.

## Test coverage

- **Existing `tests/js/eventHandler.test.js` (40 tests) still passes.** Every test that called `EventHandler.updateAccordionHighlights()` or the other 4 methods is now silently going through the module. That's the strongest possible verbatim-behavior check.
- **New `tests/js/modules/accordionHighlights.test.js` (14 tests):**
  - Module surface (6): all 5 exports are functions + namespace-keys assertion catches accidental leaks
  - Standalone smoke tests (8): one per function on a minimum DOM fixture, proving the module works without `eventHandler.js` being imported

## Verification

- **1498/1498 Vitest pass** (was 1484; +14 new)
- 5/5 relevant e2e tests pass (console-error smoke + library page interactions)
- ESLint clean

## Not in this PR (deliberately)

- **Callsite migration**: `overlayHandler.js` and `025-libraries.js` still reach for `window.EventHandler.updateAccordionHighlights`. Migrating those 10 callsites to direct imports is a mechanical follow-up PR and keeps this diff focused on the extract itself. The `window.EventHandler` shim keeps them working in the meantime.
- **Other half of the circular ref**: `OverlayHandler.initializeOverlays` and `OverlayHandler.updateHiddenInputs` are called from `eventHandler.js`. A separate, smaller extract will follow.

## Roadmap tracking

| Item | Before | After |
|---|---|---|
| `eventHandler.js` lines | 768 | 548 |
| Circular refs on this axis | 3 methods, 8 callsites | **0 methods, 0 callsites** (via module) |
| Vitest tests | 1484 | 1498 |

Related: #1346, #1335.
