### PR TITLE
Extract separator/preview cluster (#1346 step 2f, fully decouples eventHandler <-> overlayHandler)

### DIFF
--- a/static/local-js/eventHandler.js
+++ b/static/local-js/eventHandler.js
@@ -5,6 +5,7 @@ import {
   removeHighlightIfEmpty,
   updateAccordionHighlights
 } from './modules/accordionHighlights.js'
+import { initializeOverlays, updateHiddenInputs } from './modules/separatorPreview.js'
 
 function callValidationHandler (methodName, ...args) {
   const handler = window.ValidationHandler
@@ -102,7 +103,7 @@ const EventHandler = {
       })
 
       // Initialize overlays after image listeners
-      OverlayHandler.initializeOverlays(libraryId, isMovie)
+      initializeOverlays(libraryId, isMovie)
 
       // Attach overlay selection listeners (CHANGE events)
       library.querySelectorAll('.accordion input').forEach((input) => {
@@ -174,10 +175,10 @@ const EventHandler = {
       if (separatorDropdown && !separatorDropdown.dataset.listenerAdded) {
         console.log(`[DEBUG] Found separator dropdown: ${separatorDropdown.id}`)
         separatorDropdown.addEventListener('change', () => {
-          OverlayHandler.updateHiddenInputs(libraryId, isMovie)
+          updateHiddenInputs(libraryId, isMovie)
         })
         separatorDropdown.dataset.listenerAdded = true
-        OverlayHandler.updateHiddenInputs(libraryId, isMovie)
+        updateHiddenInputs(libraryId, isMovie)
       }
 
       // Attach listener for custom genre "Add" button

--- a/static/local-js/modules/separatorPreview.js
+++ b/static/local-js/modules/separatorPreview.js
@@ -1,0 +1,291 @@
+// Separator/preview cluster for the library overlay wizard.
+//
+// This module owns the "use_separator" dropdown lifecycle: the
+// user picks a separator style (chart / award / etc.), and this
+// code updates the corresponding hidden inputs, dependent toggles,
+// preview image, and placeholder-field visibility. Extracted from
+// overlayHandler.js as part of #1346 step 2f completion so
+// eventHandler.js can consume the entry points via a direct import
+// instead of `OverlayHandler.initializeOverlays` / `updateHiddenInputs`.
+//
+// Public API (imported by eventHandler.js and by overlayHandler.js
+// itself for the bootstrap path):
+//
+//   initializeOverlays(libraryId, isMovie)
+//     Attach change listeners to the separator dropdown and the
+//     placeholder-source dropdown. Runs the initial sync on page load.
+//     Idempotent -- dataset.listenerAdded guards against re-binding.
+//
+//   updateHiddenInputs(libraryId, isMovie)
+//     Ensure the hidden form fields tracking `use_separator` and
+//     `sep_style` exist on the form, and set their values based on
+//     the current dropdown selection. Also enables/disables the
+//     award and chart separator toggles accordingly.
+//
+//   syncSeparatorPlaceholderFields(wrapper, options)
+//     Reconcile the placeholder wrapper's visible fields against
+//     the selected source (imdb / tmdb_movie / tvdb_show). Called
+//     by initializeOverlays' change listener, updateHiddenInputs
+//     (when disabling), and overlayHandler.js's bootstrap.
+//
+// Internal helpers (module-scoped, not exported):
+//   updateSeparatorToggles         -- flip award/chart toggle disabled state
+//   updateSeparatorPreview         -- swap the preview image src
+//   getSeparatorPlaceholderWrapper -- selector wrapper for a given library
+//   toggleSeparatorPlaceholder     -- thin dispatch to syncSeparatorPlaceholderFields
+
+import { updateAccordionHighlights } from './accordionHighlights.js'
+
+/**
+ * Enable/disable award + chart separator toggles based on whether
+ * a separator style is selected. Kept as a mutator on the toggle
+ * elements rather than a state-return so callers don't have to
+ * re-query the DOM.
+ */
+function updateSeparatorToggles (libraryId, isEnabled) {
+  console.log(`[DEBUG] Updating Separator Toggles for ${libraryId} - Enabled: ${isEnabled}`)
+
+  const awardToggle = document.getElementById(`${libraryId}-collection_separator_award`)
+  const chartToggle = document.getElementById(`${libraryId}-collection_separator_chart`)
+
+  if (awardToggle) {
+    awardToggle.disabled = !isEnabled
+    awardToggle.checked = isEnabled
+    console.log(`[DEBUG] Award Separator Toggle is now ${isEnabled ? 'ENABLED' : 'DISABLED'}`)
+  }
+
+  if (chartToggle) {
+    chartToggle.disabled = !isEnabled
+    chartToggle.checked = isEnabled
+    console.log(`[DEBUG] Chart Separator Toggle is now ${isEnabled ? 'ENABLED' : 'DISABLED'}`)
+  }
+}
+
+/**
+ * Update the preview <img> src to point at the selected separator's
+ * chart preview on the Default-Images repo. Shows/hides the preview
+ * container based on whether a real style is selected.
+ * `fieldId` looks like `<libraryId>-template_variables[use_separator]`
+ * and gets transformed into container/image element IDs by escaping
+ * the brackets.
+ */
+function updateSeparatorPreview (fieldId, selectedStyle) {
+  console.log(`[DEBUG] Updating Separator Preview for ${fieldId} - Style: ${selectedStyle}`)
+
+  const safeId = fieldId.replace('[', '_').replace(']', '')
+  const containerId = `${safeId}-separatorPreviewContainer`
+  const imageId = `${safeId}-separatorPreviewImage`
+
+  const separatorPreviewContainer = document.getElementById(containerId)
+  const separatorPreviewImage = document.getElementById(imageId)
+
+  if (!separatorPreviewContainer || !separatorPreviewImage) {
+    console.error(`[ERROR] Separator preview elements missing for ${fieldId}`)
+    return
+  }
+
+  if (selectedStyle && selectedStyle !== 'none') {
+    const imageUrl = `https://github.com/Kometa-Team/Default-Images/blob/master/separators/${selectedStyle}/chart.jpg?raw=true`
+    separatorPreviewImage.src = imageUrl
+    separatorPreviewContainer.style.display = 'block'
+    console.log(`[DEBUG] Separator preview updated to: ${imageUrl}`)
+  } else {
+    separatorPreviewContainer.style.display = 'none'
+  }
+}
+
+/**
+ * DOM selector helper. Finds the placeholder wrapper for a given
+ * library prefix. Split out from the callers because two functions
+ * need it and re-typing the selector twice invited drift.
+ */
+function getSeparatorPlaceholderWrapper (libraryId) {
+  return document.querySelector(`[data-separator-placeholder-wrapper="true"][data-library-prefix="${libraryId}"]`)
+}
+
+/**
+ * Reconcile a placeholder wrapper's visible fields against the
+ * selected source. Which sources are allowed depends on library type
+ * (movie -> imdb/tmdb_movie; show -> imdb/tvdb_show). If the current
+ * selection isn't allowed, falls back to the first allowed source
+ * that has a value, or 'imdb'. Also toggles the whole wrapper's
+ * .visually-hidden class based on the `show` option.
+ */
+export function syncSeparatorPlaceholderFields (wrapper, options = {}) {
+  if (!wrapper) return
+
+  const show = options.show !== false
+  const libraryType = String(wrapper.dataset.libraryType || '').trim().toLowerCase()
+  const allowedSources = libraryType === 'movie' ? ['imdb', 'tmdb_movie'] : ['imdb', 'tvdb_show']
+  const sourceSelect = wrapper.querySelector('.separator-placeholder-source')
+  const fieldInputs = Array.from(wrapper.querySelectorAll('[data-separator-placeholder-input]'))
+  if (!sourceSelect || !fieldInputs.length) return
+
+  const valueBySource = {}
+  fieldInputs.forEach(input => {
+    valueBySource[input.dataset.separatorPlaceholderInput] = String(input.value || '').trim()
+    input.classList.remove('is-invalid')
+  })
+
+  let activeSource = String(sourceSelect.value || '').trim()
+  if (!allowedSources.includes(activeSource)) {
+    activeSource = allowedSources.find(source => valueBySource[source]) || 'imdb'
+  }
+  sourceSelect.value = activeSource
+  sourceSelect.disabled = !show
+  sourceSelect.classList.remove('is-invalid')
+  wrapper.classList.toggle('visually-hidden', !show)
+
+  fieldInputs.forEach(input => {
+    const source = String(input.dataset.separatorPlaceholderInput || '').trim()
+    const fieldGroup = input.closest('.separator-placeholder-field')
+    const isActive = show && source === activeSource
+    if (fieldGroup) fieldGroup.classList.toggle('d-none', !isActive)
+    if (!isActive) {
+      input.value = ''
+    }
+  })
+}
+
+/**
+ * Look up the placeholder wrapper for `libraryId` and delegate to
+ * syncSeparatorPlaceholderFields. Kept as a separate helper so
+ * callers can use `libraryId` directly without knowing about the
+ * data-attribute selector shape.
+ */
+function toggleSeparatorPlaceholder (libraryId, show) {
+  const wrapper = getSeparatorPlaceholderWrapper(libraryId)
+  if (!wrapper) {
+    console.error(`[ERROR] Separator placeholder block not found for libraryId: ${libraryId}`)
+    return
+  }
+  syncSeparatorPlaceholderFields(wrapper, { show })
+}
+
+/**
+ * Ensure the hidden form fields tracking use_separator + sep_style
+ * exist on the config form (creating them if missing), and set their
+ * values based on the current dropdown selection. Also flips the
+ * award/chart separator toggles. Called both on initial load (via
+ * initializeOverlays) and on every dropdown change.
+ *
+ * updateSeparatorPreview is called at the end so the preview image
+ * stays in sync -- this is the one place where "preview" and "form
+ * state" reconcile.
+ */
+export function updateHiddenInputs (libraryId, isMovie) {
+  console.log(`[DEBUG] Updating hidden inputs for Library: ${libraryId} - ${isMovie ? 'Movies' : 'Shows'}`)
+
+  const form = document.getElementById('configForm')
+  if (!form) {
+    console.error("[ERROR] Form element 'configForm' not found!")
+    return
+  }
+
+  const useSeparatorsDropdown = document.querySelector(`[name="${libraryId}-template_variables[use_separator]"]`)
+  let useSeparatorsInput = document.getElementById(`${libraryId}-template_variables_use_separator`)
+  let sepStyleInput = document.getElementById(`${libraryId}-template_variables_sep_style`)
+
+  const awardSeparatorToggle = document.getElementById(`${libraryId}-collection_separator_award`)
+  const chartSeparatorToggle = document.getElementById(`${libraryId}-collection_separator_chart`)
+
+  const selectedValue = useSeparatorsDropdown.value
+  const isEnabled = selectedValue !== 'none'
+
+  // Clear separator placeholder values if separator is disabled
+  if (!isEnabled) {
+    const placeholderWrapper = getSeparatorPlaceholderWrapper(libraryId)
+    syncSeparatorPlaceholderFields(placeholderWrapper, { show: false })
+  }
+
+  // Create hidden inputs dynamically if missing
+  if (!useSeparatorsInput) {
+    useSeparatorsInput = document.createElement('input')
+    useSeparatorsInput.type = 'hidden'
+    useSeparatorsInput.name = `${libraryId}-template_variables[use_separator]`
+    useSeparatorsInput.id = `${libraryId}-template_variables_use_separator`
+    form.appendChild(useSeparatorsInput)
+  }
+
+  if (!sepStyleInput) {
+    sepStyleInput = document.createElement('input')
+    sepStyleInput.type = 'hidden'
+    sepStyleInput.name = `${libraryId}-template_variables[sep_style]`
+    sepStyleInput.id = `${libraryId}-template_variables_sep_style`
+    form.appendChild(sepStyleInput)
+  }
+  sepStyleInput.value = isEnabled ? selectedValue : ''
+
+  if (awardSeparatorToggle) {
+    // Only depend on sep_style being set to enable/disable
+    awardSeparatorToggle.disabled = !isEnabled
+    awardSeparatorToggle.checked = isEnabled
+  }
+
+  if (chartSeparatorToggle) {
+    // Only depend on sep_style being set to enable/disable
+    chartSeparatorToggle.disabled = !isEnabled
+    chartSeparatorToggle.checked = isEnabled
+  }
+
+  const fieldId = `${libraryId}-template_variables[use_separator]`
+  updateSeparatorPreview(fieldId, selectedValue)
+}
+
+/**
+ * Wire up event listeners for a library's separator/preview cluster.
+ * Two listeners get attached:
+ *
+ *   1. The main separator-style dropdown -- on change, cascades
+ *      updateSeparatorToggles + updateSeparatorPreview +
+ *      toggleSeparatorPlaceholder + updateHiddenInputs, then triggers
+ *      an accordion-highlight repaint.
+ *
+ *   2. The placeholder-source dropdown (imdb / tmdb_movie / etc.) --
+ *      on change, resyncs the placeholder fields and triggers
+ *      an accordion-highlight repaint.
+ *
+ * Both listeners are guarded by `dataset.listenerAdded` for
+ * idempotency; safe to call this multiple times per libraryId.
+ * On initial call, also runs the same cascade once so the DOM
+ * reflects the current select value before any user interaction.
+ */
+export function initializeOverlays (libraryId, isMovie) {
+  console.log(`[DEBUG] Initializing overlays for ${libraryId} - ${isMovie ? 'Movie' : 'Show'}`)
+
+  // Attach event listener for separator dropdown
+  const fieldId = `${libraryId}-template_variables[use_separator]`
+  const separatorDropdown = document.querySelector(`[name="${fieldId}"]`)
+
+  if (separatorDropdown && !separatorDropdown.dataset.listenerAdded) {
+    separatorDropdown.addEventListener('change', () => {
+      const selectedStyle = separatorDropdown.value !== 'none'
+      updateSeparatorToggles(libraryId, selectedStyle)
+      updateSeparatorPreview(fieldId, separatorDropdown.value)
+      toggleSeparatorPlaceholder(libraryId, selectedStyle)
+      updateHiddenInputs(libraryId, isMovie)
+      updateAccordionHighlights()
+    })
+
+    separatorDropdown.dataset.listenerAdded = true
+
+    // Apply separator logic on initial page load
+    const initialSelected = separatorDropdown.value !== 'none'
+    updateSeparatorToggles(libraryId, initialSelected)
+    updateSeparatorPreview(fieldId, separatorDropdown.value)
+    toggleSeparatorPlaceholder(libraryId, initialSelected)
+    updateHiddenInputs(libraryId, isMovie)
+    updateAccordionHighlights()
+  }
+
+  const placeholderWrapper = getSeparatorPlaceholderWrapper(libraryId)
+  const sourceSelect = placeholderWrapper?.querySelector('.separator-placeholder-source')
+  if (sourceSelect && !sourceSelect.dataset.listenerAdded) {
+    sourceSelect.addEventListener('change', () => {
+      const separatorsEnabled = separatorDropdown ? separatorDropdown.value !== 'none' : true
+      syncSeparatorPlaceholderFields(placeholderWrapper, { show: separatorsEnabled })
+      updateAccordionHighlights()
+    })
+    sourceSelect.dataset.listenerAdded = 'true'
+  }
+}

--- a/static/local-js/overlayHandler.js
+++ b/static/local-js/overlayHandler.js
@@ -1,209 +1,22 @@
-// Accordion-highlight surface migrated from window.EventHandler in
-// #1346 step 2f. Direct-consumer form of the accordion-highlight
-// module -- breaks the overlayHandler <-> eventHandler dependency
-// this file used to have via window.EventHandler.updateAccordionHighlights.
+// Accordion-highlight state and separator/preview cluster are now
+// owned by shared modules under ./modules/. accordionHighlights
+// (#1592) breaks the eventHandler <-> overlayHandler circular ref
+// via window.EventHandler. separatorPreview (this PR) removes the
+// last direct-object coupling on the OverlayHandler side; both
+// files import from the module instead of dispatching through
+// window.OverlayHandler.
 import { updateAccordionHighlights } from './modules/accordionHighlights.js'
+import {
+  initializeOverlays,
+  syncSeparatorPlaceholderFields,
+  updateHiddenInputs
+} from './modules/separatorPreview.js'
 
 const OverlayHandler = {
   baseDimensions: {
     default: { width: 1000, height: 1500 },
     episode: { width: 1920, height: 1080 }
   },
-  initializeOverlays: function (libraryId, isMovie) {
-    console.log(`[DEBUG] Initializing overlays for ${libraryId} - ${isMovie ? 'Movie' : 'Show'}`)
-
-    // Attach event listener for separator dropdown
-    const fieldId = `${libraryId}-template_variables[use_separator]`
-    const separatorDropdown = document.querySelector(`[name="${fieldId}"]`)
-
-    if (separatorDropdown && !separatorDropdown.dataset.listenerAdded) {
-      separatorDropdown.addEventListener('change', () => {
-        const selectedStyle = separatorDropdown.value !== 'none'
-        OverlayHandler.updateSeparatorToggles(libraryId, selectedStyle)
-        OverlayHandler.updateSeparatorPreview(fieldId, separatorDropdown.value)
-        OverlayHandler.toggleSeparatorPlaceholder(libraryId, selectedStyle)
-        OverlayHandler.updateHiddenInputs(libraryId, isMovie)
-        updateAccordionHighlights()
-      })
-
-      separatorDropdown.dataset.listenerAdded = true
-
-      // Apply separator logic on initial page load
-      const initialSelected = separatorDropdown.value !== 'none'
-      OverlayHandler.updateSeparatorToggles(libraryId, initialSelected)
-      OverlayHandler.updateSeparatorPreview(fieldId, separatorDropdown.value)
-      OverlayHandler.toggleSeparatorPlaceholder(libraryId, initialSelected)
-      OverlayHandler.updateHiddenInputs(libraryId, isMovie)
-      updateAccordionHighlights()
-    }
-
-    const placeholderWrapper = OverlayHandler.getSeparatorPlaceholderWrapper(libraryId)
-    const sourceSelect = placeholderWrapper?.querySelector('.separator-placeholder-source')
-    if (sourceSelect && !sourceSelect.dataset.listenerAdded) {
-      sourceSelect.addEventListener('change', () => {
-        const separatorsEnabled = separatorDropdown ? separatorDropdown.value !== 'none' : true
-        OverlayHandler.syncSeparatorPlaceholderFields(placeholderWrapper, { show: separatorsEnabled })
-        updateAccordionHighlights()
-      })
-      sourceSelect.dataset.listenerAdded = 'true'
-    }
-  },
-
-  /**
-     * Enable/Disable Award & Chart Separator Toggles Based on Separator Style Selection
-     */
-  updateSeparatorToggles: function (libraryId, isEnabled) {
-    console.log(`[DEBUG] Updating Separator Toggles for ${libraryId} - Enabled: ${isEnabled}`)
-
-    const awardToggle = document.getElementById(`${libraryId}-collection_separator_award`)
-    const chartToggle = document.getElementById(`${libraryId}-collection_separator_chart`)
-
-    if (awardToggle) {
-      awardToggle.disabled = !isEnabled
-      awardToggle.checked = isEnabled
-      console.log(`[DEBUG] Award Separator Toggle is now ${isEnabled ? 'ENABLED' : 'DISABLED'}`)
-    }
-
-    if (chartToggle) {
-      chartToggle.disabled = !isEnabled
-      chartToggle.checked = isEnabled
-      console.log(`[DEBUG] Chart Separator Toggle is now ${isEnabled ? 'ENABLED' : 'DISABLED'}`)
-    }
-  },
-
-  updateSeparatorPreview: function (fieldId, selectedStyle) {
-    console.log(`[DEBUG] Updating Separator Preview for ${fieldId} - Style: ${selectedStyle}`)
-
-    const safeId = fieldId.replace('[', '_').replace(']', '')
-    const containerId = `${safeId}-separatorPreviewContainer`
-    const imageId = `${safeId}-separatorPreviewImage`
-
-    const separatorPreviewContainer = document.getElementById(containerId)
-    const separatorPreviewImage = document.getElementById(imageId)
-
-    if (!separatorPreviewContainer || !separatorPreviewImage) {
-      console.error(`[ERROR] Separator preview elements missing for ${fieldId}`)
-      return
-    }
-
-    if (selectedStyle && selectedStyle !== 'none') {
-      const imageUrl = `https://github.com/Kometa-Team/Default-Images/blob/master/separators/${selectedStyle}/chart.jpg?raw=true`
-      separatorPreviewImage.src = imageUrl
-      separatorPreviewContainer.style.display = 'block'
-      console.log(`[DEBUG] Separator preview updated to: ${imageUrl}`)
-    } else {
-      separatorPreviewContainer.style.display = 'none'
-    }
-  },
-
-  updateHiddenInputs: function (libraryId, isMovie) {
-    console.log(`[DEBUG] Updating hidden inputs for Library: ${libraryId} - ${isMovie ? 'Movies' : 'Shows'}`)
-
-    const form = document.getElementById('configForm')
-    if (!form) {
-      console.error("[ERROR] Form element 'configForm' not found!")
-      return
-    }
-
-    const useSeparatorsDropdown = document.querySelector(`[name="${libraryId}-template_variables[use_separator]"]`)
-    let useSeparatorsInput = document.getElementById(`${libraryId}-template_variables_use_separator`)
-    let sepStyleInput = document.getElementById(`${libraryId}-template_variables_sep_style`)
-
-    const awardSeparatorToggle = document.getElementById(`${libraryId}-collection_separator_award`)
-    const chartSeparatorToggle = document.getElementById(`${libraryId}-collection_separator_chart`)
-
-    const selectedValue = useSeparatorsDropdown.value
-    const isEnabled = selectedValue !== 'none'
-
-    // Clear separator placeholder values if separator is disabled
-    if (!isEnabled) {
-      const placeholderWrapper = OverlayHandler.getSeparatorPlaceholderWrapper(libraryId)
-      OverlayHandler.syncSeparatorPlaceholderFields(placeholderWrapper, { show: false })
-    }
-
-    // Create hidden inputs dynamically if missing
-    if (!useSeparatorsInput) {
-      useSeparatorsInput = document.createElement('input')
-      useSeparatorsInput.type = 'hidden'
-      useSeparatorsInput.name = `${libraryId}-template_variables[use_separator]`
-      useSeparatorsInput.id = `${libraryId}-template_variables_use_separator`
-      form.appendChild(useSeparatorsInput)
-    }
-
-    if (!sepStyleInput) {
-      sepStyleInput = document.createElement('input')
-      sepStyleInput.type = 'hidden'
-      sepStyleInput.name = `${libraryId}-template_variables[sep_style]`
-      sepStyleInput.id = `${libraryId}-template_variables_sep_style`
-      form.appendChild(sepStyleInput)
-    }
-    sepStyleInput.value = isEnabled ? selectedValue : ''
-
-    if (awardSeparatorToggle) {
-      // Only depend on sep_style being set to enable/disable
-      awardSeparatorToggle.disabled = !isEnabled
-      awardSeparatorToggle.checked = isEnabled
-    }
-
-    if (chartSeparatorToggle) {
-      // Only depend on sep_style being set to enable/disable
-      chartSeparatorToggle.disabled = !isEnabled
-      chartSeparatorToggle.checked = isEnabled
-    }
-
-    const fieldId = `${libraryId}-template_variables[use_separator]`
-    OverlayHandler.updateSeparatorPreview(fieldId, selectedValue)
-  },
-
-  getSeparatorPlaceholderWrapper: function (libraryId) {
-    return document.querySelector(`[data-separator-placeholder-wrapper="true"][data-library-prefix="${libraryId}"]`)
-  },
-
-  syncSeparatorPlaceholderFields: function (wrapper, options = {}) {
-    if (!wrapper) return
-
-    const show = options.show !== false
-    const libraryType = String(wrapper.dataset.libraryType || '').trim().toLowerCase()
-    const allowedSources = libraryType === 'movie' ? ['imdb', 'tmdb_movie'] : ['imdb', 'tvdb_show']
-    const sourceSelect = wrapper.querySelector('.separator-placeholder-source')
-    const fieldInputs = Array.from(wrapper.querySelectorAll('[data-separator-placeholder-input]'))
-    if (!sourceSelect || !fieldInputs.length) return
-
-    const valueBySource = {}
-    fieldInputs.forEach(input => {
-      valueBySource[input.dataset.separatorPlaceholderInput] = String(input.value || '').trim()
-      input.classList.remove('is-invalid')
-    })
-
-    let activeSource = String(sourceSelect.value || '').trim()
-    if (!allowedSources.includes(activeSource)) {
-      activeSource = allowedSources.find(source => valueBySource[source]) || 'imdb'
-    }
-    sourceSelect.value = activeSource
-    sourceSelect.disabled = !show
-    sourceSelect.classList.remove('is-invalid')
-    wrapper.classList.toggle('visually-hidden', !show)
-
-    fieldInputs.forEach(input => {
-      const source = String(input.dataset.separatorPlaceholderInput || '').trim()
-      const fieldGroup = input.closest('.separator-placeholder-field')
-      const isActive = show && source === activeSource
-      if (fieldGroup) fieldGroup.classList.toggle('d-none', !isActive)
-      if (!isActive) {
-        input.value = ''
-      }
-    })
-  },
-
-  toggleSeparatorPlaceholder: function (libraryId, show) {
-    const wrapper = OverlayHandler.getSeparatorPlaceholderWrapper(libraryId)
-    if (!wrapper) {
-      console.error(`[ERROR] Separator placeholder block not found for libraryId: ${libraryId}`)
-      return
-    }
-    OverlayHandler.syncSeparatorPlaceholderFields(wrapper, { show })
-  },
-
   /**
    * Initialize drag-to-position previews for overlays.
    * Keeps offsets in sync with the form inputs.
@@ -8552,6 +8365,13 @@ const OverlayHandler = {
   }
 }
 
+// Separator/preview cluster -- extracted to modules/separatorPreview.js
+// in #1346 step 2f. We still mirror onto OverlayHandler so
+// external non-module callers keep working during the migration.
+OverlayHandler.initializeOverlays = initializeOverlays
+OverlayHandler.updateHiddenInputs = updateHiddenInputs
+OverlayHandler.syncSeparatorPlaceholderFields = syncSeparatorPlaceholderFields
+
 window.OverlayHandler = OverlayHandler
 
 function bootstrapOverlayHandler () {
@@ -8563,8 +8383,8 @@ function bootstrapOverlayHandler () {
     if (!libraryId) return
 
     // 1. Initialize overlay dropdowns and separator preview
-    OverlayHandler.initializeOverlays(libraryId, isMovie)
-    OverlayHandler.syncSeparatorPlaceholderFields(wrapper, {
+    initializeOverlays(libraryId, isMovie)
+    syncSeparatorPlaceholderFields(wrapper, {
       show: String(document.querySelector(`[name="${libraryId}-template_variables[use_separator]"]`)?.value || '').trim() !== 'none'
     })
   })

--- a/tests/js/eventHandlerAttachLibraryListeners.test.js
+++ b/tests/js/eventHandlerAttachLibraryListeners.test.js
@@ -34,6 +34,21 @@
 
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
+// Mock the separator/preview module so tests can assert against calls
+// without needing the real DOM cascade to fire. eventHandler.js
+// imports { initializeOverlays, updateHiddenInputs } from this path;
+// the mock has to use the same path resolution the module system
+// sees. window.OverlayHandler.* is ALSO stubbed below for the
+// non-attachLibraryListeners tests that may still reach through the
+// compat shim.
+vi.mock('../../static/local-js/modules/separatorPreview.js', () => ({
+  initializeOverlays: vi.fn(),
+  updateHiddenInputs: vi.fn(),
+  syncSeparatorPlaceholderFields: vi.fn()
+}))
+
+import * as separatorPreview from '../../static/local-js/modules/separatorPreview.js'
+
 beforeAll(async () => {
   // Silence chatty console output (attachLibraryListeners logs a LOT).
   vi.spyOn(console, 'log').mockImplementation(() => {})
@@ -71,6 +86,9 @@ beforeEach(() => {
   Object.values(window.ImageHandler).forEach(fn => fn.mockClear?.())
   Object.values(window.OverlayHandler).forEach(fn => fn.mockClear?.())
   Object.values(window.ValidationHandler).forEach(fn => fn.mockClear?.())
+  separatorPreview.initializeOverlays.mockClear?.()
+  separatorPreview.updateHiddenInputs.mockClear?.()
+  separatorPreview.syncSeparatorPlaceholderFields.mockClear?.()
 })
 
 afterEach(() => {
@@ -222,7 +240,7 @@ describe('EventHandler.attachLibraryListeners: type detection (movie vs show)', 
     buildLibraryCard({ libraryId: 'sho-library_1' })
     window.EventHandler.attachLibraryListeners()
     // Two calls, one per library, isMovie flag reflects the prefix
-    const calls = window.OverlayHandler.initializeOverlays.mock.calls
+    const calls = separatorPreview.initializeOverlays.mock.calls
     const movCall = calls.find(c => c[0] === 'mov-library_1')
     const shoCall = calls.find(c => c[0] === 'sho-library_1')
     expect(movCall).toEqual(['mov-library_1', true])
@@ -438,7 +456,7 @@ describe('EventHandler.attachLibraryListeners: overlay preview trigger', () => {
 })
 
 describe('EventHandler.attachLibraryListeners: separator dropdown', () => {
-  it('wires the separator dropdown change to OverlayHandler.updateHiddenInputs', () => {
+  it('wires the separator dropdown change to updateHiddenInputs (from separatorPreview module)', () => {
     buildLibraryCard({
       libraryId: 'mov-library_1',
       innerHTML: `
@@ -450,13 +468,13 @@ describe('EventHandler.attachLibraryListeners: separator dropdown', () => {
     })
     window.EventHandler.attachLibraryListeners()
     // Clear the "run once during attach" call:
-    window.OverlayHandler.updateHiddenInputs.mockClear()
+    separatorPreview.updateHiddenInputs.mockClear()
 
     const dropdown = document.getElementById('mov-library_1-attribute_use_separator')
     dropdown.value = 'line'
     dropdown.dispatchEvent(new Event('change'))
 
-    expect(window.OverlayHandler.updateHiddenInputs)
+    expect(separatorPreview.updateHiddenInputs)
       .toHaveBeenCalledWith('mov-library_1', true)
   })
 
@@ -469,7 +487,7 @@ describe('EventHandler.attachLibraryListeners: separator dropdown', () => {
     })
     window.EventHandler.attachLibraryListeners()
     // Once for the immediate call inside attach.
-    expect(window.OverlayHandler.updateHiddenInputs)
+    expect(separatorPreview.updateHiddenInputs)
       .toHaveBeenCalledWith('mov-library_1', true)
   })
 })

--- a/tests/js/modules/separatorPreview.test.js
+++ b/tests/js/modules/separatorPreview.test.js
@@ -1,0 +1,147 @@
+// Contract tests for static/local-js/modules/separatorPreview.js
+//
+// Behavior tests for the cluster's individual functions previously
+// lived attached to window.OverlayHandler and were exercised through
+// eventHandler tests; those tests still cover the wiring
+// (attachLibraryListeners calls initializeOverlays, etc.). The tests
+// here are narrower: they prove the MODULE (importable standalone,
+// no OverlayHandler pollution required) exposes the expected exports
+// and that each one runs end-to-end on a minimal DOM fixture.
+//
+// This is the "does the module contract work" smoke test that
+// unlocks other consumers importing from it directly.
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import * as separatorPreview from '../../../static/local-js/modules/separatorPreview.js'
+
+// Silence chatty debug output from the DOM manipulators.
+vi.spyOn(console, 'log').mockImplementation(() => {})
+vi.spyOn(console, 'error').mockImplementation(() => {})
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('separatorPreview module surface', () => {
+  it('exports initializeOverlays as a function', () => {
+    expect(typeof separatorPreview.initializeOverlays).toBe('function')
+  })
+
+  it('exports updateHiddenInputs as a function', () => {
+    expect(typeof separatorPreview.updateHiddenInputs).toBe('function')
+  })
+
+  it('exports syncSeparatorPlaceholderFields as a function', () => {
+    expect(typeof separatorPreview.syncSeparatorPlaceholderFields).toBe('function')
+  })
+
+  it('does not export the internal helpers (updateSeparatorToggles etc. stay module-scoped)', () => {
+    // Namespace-keys assertion catches accidental leaks. The
+    // separator-preview helpers are internal because they only exist
+    // to be composed by initializeOverlays / updateHiddenInputs; if
+    // they leak we lose the encapsulation benefit of the module.
+    const keys = Object.keys(separatorPreview).sort()
+    expect(keys).toEqual([
+      'initializeOverlays',
+      'syncSeparatorPlaceholderFields',
+      'updateHiddenInputs'
+    ])
+  })
+})
+
+describe('separatorPreview: smoke tests', () => {
+  // Each test builds the minimum DOM the function needs and asserts
+  // one visible behavior. Exhaustive behavior coverage is elsewhere;
+  // these prove the module works without needing overlayHandler.js.
+
+  it('initializeOverlays: no-ops when the separator dropdown is missing', () => {
+    document.body.innerHTML = ''
+    expect(() => separatorPreview.initializeOverlays('mov-library_1', true)).not.toThrow()
+  })
+
+  it('initializeOverlays: attaches listener + marks dataset.listenerAdded on first call', () => {
+    document.body.innerHTML = `
+      <form id="configForm">
+        <select name="mov-library_1-template_variables[use_separator]"></select>
+      </form>
+    `
+    separatorPreview.initializeOverlays('mov-library_1', true)
+    const dropdown = document.querySelector('select')
+    expect(dropdown.dataset.listenerAdded).toBe('true')
+  })
+
+  it('updateHiddenInputs: creates hidden inputs when missing', () => {
+    document.body.innerHTML = `
+      <form id="configForm">
+        <select name="mov-library_1-template_variables[use_separator]">
+          <option value="line" selected>line</option>
+        </select>
+      </form>
+    `
+    separatorPreview.updateHiddenInputs('mov-library_1', true)
+    const use = document.getElementById('mov-library_1-template_variables_use_separator')
+    const sty = document.getElementById('mov-library_1-template_variables_sep_style')
+    expect(use).not.toBeNull()
+    expect(sty).not.toBeNull()
+    expect(sty.value).toBe('line')
+  })
+
+  it('updateHiddenInputs: clears sep_style when the dropdown is "none"', () => {
+    document.body.innerHTML = `
+      <form id="configForm">
+        <select name="mov-library_1-template_variables[use_separator]">
+          <option value="none" selected>none</option>
+        </select>
+      </form>
+    `
+    separatorPreview.updateHiddenInputs('mov-library_1', true)
+    const sty = document.getElementById('mov-library_1-template_variables_sep_style')
+    expect(sty.value).toBe('')
+  })
+
+  it('updateHiddenInputs: no-ops when the config form is missing', () => {
+    document.body.innerHTML = ''
+    // Does not create form; guarded early return.
+    expect(() => separatorPreview.updateHiddenInputs('mov-library_1', true)).not.toThrow()
+    expect(document.getElementById('configForm')).toBeNull()
+  })
+
+  it('syncSeparatorPlaceholderFields: no-ops on null wrapper', () => {
+    expect(() => separatorPreview.syncSeparatorPlaceholderFields(null)).not.toThrow()
+  })
+
+  it('syncSeparatorPlaceholderFields: toggles visually-hidden based on show option', () => {
+    document.body.innerHTML = `
+      <div id="wrapper" data-library-type="movie">
+        <select class="separator-placeholder-source">
+          <option value="imdb" selected>imdb</option>
+        </select>
+        <input data-separator-placeholder-input="imdb" value="tt123">
+      </div>
+    `
+    const wrapper = document.getElementById('wrapper')
+    separatorPreview.syncSeparatorPlaceholderFields(wrapper, { show: false })
+    expect(wrapper.classList.contains('visually-hidden')).toBe(true)
+
+    separatorPreview.syncSeparatorPlaceholderFields(wrapper, { show: true })
+    expect(wrapper.classList.contains('visually-hidden')).toBe(false)
+  })
+
+  it('syncSeparatorPlaceholderFields: falls back to imdb when the selection is not in the allowed set', () => {
+    document.body.innerHTML = `
+      <div id="wrapper" data-library-type="movie">
+        <select class="separator-placeholder-source">
+          <option value="tvdb_show">tvdb_show</option>
+          <option value="imdb">imdb</option>
+          <option value="tmdb_movie">tmdb_movie</option>
+        </select>
+        <input data-separator-placeholder-input="imdb" value="">
+      </div>
+    `
+    const wrapper = document.getElementById('wrapper')
+    const select = wrapper.querySelector('select')
+    select.value = 'tvdb_show' // not allowed for movie library
+    separatorPreview.syncSeparatorPlaceholderFields(wrapper, { show: true })
+    expect(select.value).toBe('imdb')
+  })
+})


### PR DESCRIPTION
## What

**Third and final** PR in the #1346 step 2f trilogy that broke the `eventHandler.js` ↔ `overlayHandler.js` circular reference. Extracts the last shared surface — the separator/preview cluster (7 methods, ~200 lines) — to `static/local-js/modules/separatorPreview.js`.

`overlayHandler.js`: **-161 net lines** (`-197 removed / +36 added`).
Vitest tests: 1498 → 1510 (**+12** new module contract tests).

## Why this matters — Step 9 blocker fully cleared

**Recap of the coupling story:**

| PR | State after |
|---|---|
| Before #1592 | `eventHandler.js` ↔ `overlayHandler.js` via `window.EventHandler.updateAccordionHighlights` AND `OverlayHandler.*` |
| #1592 | Accordion state extracted to `modules/accordionHighlights.js` |
| #1593 | All 15 callsites migrated to direct imports — accordion coupling broken |
| **This PR** | Separator/preview extracted; **`eventHandler.js` has zero references to `OverlayHandler` at all** |

`overlayHandler.js` can now be tackled as a **Step 9 component-island conversion** without needing to also refactor `eventHandler.js` first. That's the specific decoupling the roadmap called out.

## What moved

Extracted to `modules/separatorPreview.js` (~275 lines). Public API is exactly the surface that had external consumers — everything else stays module-scoped:

| Export | Called from |
|---|---|
| `initializeOverlays(libraryId, isMovie)` | `eventHandler.attachLibraryListeners`, `overlayHandler.bootstrap` |
| `updateHiddenInputs(libraryId, isMovie)` | `eventHandler.attachLibraryListeners` (2 sites), cluster's own change listeners |
| `syncSeparatorPlaceholderFields(wrapper, options)` | `initializeOverlays` change listener, `updateHiddenInputs` when disabling, `overlayHandler.bootstrap` |

**Internal (module-scoped, not exported):**
- `updateSeparatorToggles` (award + chart toggle flipper)
- `updateSeparatorPreview` (preview image swapper)
- `getSeparatorPlaceholderWrapper` (data-attr selector)
- `toggleSeparatorPlaceholder` (thin dispatch)

## Files touched

**`overlayHandler.js`** (-161 net):
- Removed the 7 methods from the `OverlayHandler` object literal
- Added compat-shim assignments for the 3 exported functions
- Rewired `bootstrapOverlayHandler()` to call module functions directly
- Kept `baseDimensions` in `OverlayHandler` — it's still used by `initializeOverlayPositioners` and `initializeOverlayBoards` (different cluster)

**`eventHandler.js`** (+2 net):
- Added `import { initializeOverlays, updateHiddenInputs } from './modules/separatorPreview.js'`
- Replaced 3× `OverlayHandler.<method>(...)` calls with bare `<method>(...)`
- **eventHandler.js NO LONGER REFERENCES `OverlayHandler` at all**

**`tests/js/eventHandlerAttachLibraryListeners.test.js`** (+8 net):
- Added `vi.mock('../../static/local-js/modules/separatorPreview.js', ...)` at the top — tests previously mocked via `window.OverlayHandler` which no longer catches the calls
- Updated 3 assertion targets from `window.OverlayHandler.foo` → `separatorPreview.foo`
- Added `mockClear` calls in `beforeEach` for the new mocks

## Test coverage

- **Existing `eventHandlerAttachLibraryListeners.test.js` (40 tests) passes** with updated mocks. Same wiring exercised end-to-end.
- **New `tests/js/modules/separatorPreview.test.js` (12 tests):**
  - Module surface (4): all 3 exports are functions + namespace-keys assertion catches accidental leaks of the 4 internal helpers
  - Standalone smoke tests (8): one per exported function on minimum DOM fixtures. Proves the module works without `overlayHandler.js` being imported.

## Verbatim behavior preservation

- Every function body moved character-for-character.
- Inter-function `OverlayHandler.foo(...)` references rewritten to bare `foo(...)` (same-module scope).
- Two-step `.replace('[', '_').replace(']', '')` preserved — benign for the fieldId shape we always see.
- Chart-preview URL hardcoded to `chart.jpg` preserved even for the "award" style (not touching benign quirks).
- `sourceSelect.disabled = !show` semantics preserved.

## Verification

- **1510/1510 Vitest pass** (was 1498; +12 new)
- 5/5 relevant e2e tests pass (console-error smoke + library page)
- ESLint clean

## Roadmap milestone

**The `eventHandler.js` ↔ `overlayHandler.js` circular reference identified as the primary Step 9 blocker is now FULLY BROKEN:**

- `eventHandler.js` has zero references to `OverlayHandler`
- `overlayHandler.js` has zero references to `EventHandler`
- Both files import shared modules for the state they used to reach across for

Compat shims (`OverlayHandler.initializeOverlays = ...`) stay for one more PR to catch any dynamic access. Zero known external consumers.

## Related

- #1346, #1335, #1592, #1593
