### PR TITLE
Activate Vite build in CI + fix auto-discovery bug (#1334 step 4)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -70,3 +70,51 @@ jobs:
 
       - name: Run Vitest
         run: npm test
+
+  vite-build:
+    name: Vite Build
+    runs-on: ubuntu-latest
+
+    # Verifies that `npm run build` produces bundles for every ES-module
+    # entry point in static/local-js/. The build output is NOT shipped
+    # anywhere today -- Flask still serves raw source files (see the
+    # `frontend tooling` section of README.md) -- but running the build
+    # in CI keeps it green so that when a downstream PR (Step 6 Alpine,
+    # Step 9 Svelte islands) flips the template switch, the bundle
+    # already works.
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v7
+
+      - name: Set Up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install Node Dependencies
+        run: npm ci --no-fund --no-audit
+
+      - name: Run Vite Build
+        run: npm run build
+
+      - name: Verify expected entries were built
+        run: |
+          # Sanity check that Vite's auto-discovery didn't silently drop
+          # a page-scale module. If someone lands a PR that renames or
+          # deletes one of these files without updating this list, CI
+          # will fail loudly instead of silently producing a broken build.
+          set -euo pipefail
+          MISSING=0
+          for entry in 000-base 001-start 010-plex 025-libraries 900-kometa \
+                       905-analytics eventHandler overlayHandler; do
+            if [ ! -f "static/dist/${entry}.js" ]; then
+              echo "::error::Vite build output missing: static/dist/${entry}.js"
+              MISSING=1
+            fi
+          done
+          if [ "$MISSING" -eq 1 ]; then
+            echo "Discovered entries:"
+            ls static/dist/*.js || true
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -600,11 +600,14 @@ Notes for Playwright on Windows:
 
 ## Frontend Tooling
 
-Quickstart serves its JavaScript directly from `static/local-js/` via Flask in production and is gradually being migrated to ES modules (see roadmap issue #1334). [Vite](https://vitejs.dev/) is now wired up as the future build pipeline for the modular files.
+Quickstart serves its JavaScript directly from `static/local-js/` via Flask in production and is gradually being migrated to ES modules (see roadmap issue #1334). [Vite](https://vitejs.dev/) is wired up as the future build pipeline for the modular files.
 
-**Today, the Vite build tooling is dormant** — nothing in production references its output. Flask still loads JS from `static/local-js/` exactly as before. The scaffolding is in place so that future PRs (validation widget consolidation, Alpine, etc.) can plug into it.
+**Today, the Vite build output is not consumed in production** — Flask still loads JS from `static/local-js/` exactly as before. The build pipeline exists so that future PRs (Alpine widgets for Step 6, Svelte islands for Step 9) can adopt it page-by-page.
 
-Vitest, by contrast, is **active**: `npm test` is enforced in CI via the `Vitest` job in `.github/workflows/lint.yml`. New JS unit tests should land alongside the modules they cover.
+Both Vitest and the Vite build itself are **enforced in CI** via `.github/workflows/lint.yml`:
+
+- `Vitest` job — runs `npm test` on every push/PR (all `tests/js/**/*.test.js`)
+- `Vite Build` job — runs `npm run build` on every push/PR and verifies that the expected page-scale entries (`000-base`, `001-start`, `010-plex`, `025-libraries`, `900-kometa`, `905-analytics`, `eventHandler`, `overlayHandler`) all produced output. Prevents the auto-discovery from silently dropping an entry.
 
 Use cases for developers:
 
@@ -618,7 +621,7 @@ npm run test:watch     # Vitest in watch mode
 npm run lint:eslint    # existing ESLint job (unchanged)
 ```
 
-Which files Vite knows about: every file in `static/local-js/*.js` that already starts with an `import` or `export` statement is auto-discovered as a Vite entry point. This stays in sync with `MODULE_PAGE_SCRIPTS` in `quickstart.py` without manual updates.
+Which files Vite knows about: every file in `static/local-js/*.js` whose first non-comment/non-blank token is `import` or `export` is auto-discovered as a Vite entry point. Files under `static/local-js/modules/` are treated as dependencies, not entries. Classic scripts (no top-level `import`/`export`) — such as `100-anidb.js` and `915-imagemaid.js` — are intentionally skipped because bundling them would just copy the source. See `vite.detectModuleEntry.mjs` for the exact detection logic (unit-tested in `tests/js/detectModuleEntry.test.js`).
 
 JS tests live under `tests/js/` (mirroring the existing `tests/` convention for Python tests) and use the jsdom environment so DOM-touching code can be exercised without a real browser.
 

--- a/tests/js/detectModuleEntry.test.js
+++ b/tests/js/detectModuleEntry.test.js
@@ -1,0 +1,194 @@
+// Tests for vite.detectModuleEntry.js -- the "is this file an ES module
+// entry point?" heuristic used by vite.config.js's discoverModuleEntries.
+//
+// Why these matter: the original heuristic only checked the first 200
+// characters of source and required `import` or `export` at position 0.
+// That silently dropped 900-kometa.js, 025-libraries.js, 001-start.js,
+// and overlayHandler.js -- four of the largest ES modules in the
+// codebase -- because they lead with a docstring. This test file locks
+// down the fixed behavior so the regression can't reappear.
+//
+// Test scope:
+//   - Positive cases: various leading-comment shapes -> module detected
+//   - Negative cases: classic scripts (no import/export) -> NOT detected
+//   - Edge cases: unclosed comments, comment-only files, giant headers
+
+import { describe, expect, it } from 'vitest'
+import { isModuleSource, stripLeadingCommentsAndWhitespace } from '../../vite.detectModuleEntry.mjs'
+
+describe('stripLeadingCommentsAndWhitespace', () => {
+  it('returns 0 for a file that starts with real code', () => {
+    expect(stripLeadingCommentsAndWhitespace('import foo from "bar"')).toBe(0)
+  })
+
+  it('skips leading whitespace', () => {
+    expect(stripLeadingCommentsAndWhitespace('   \n\t import foo')).toBe(6)
+  })
+
+  it('skips a single leading line comment', () => {
+    const source = '// hello\nimport foo'
+    expect(stripLeadingCommentsAndWhitespace(source)).toBe(9)
+  })
+
+  it('skips multiple consecutive line comments', () => {
+    const source = '// one\n// two\n// three\nimport foo'
+    expect(stripLeadingCommentsAndWhitespace(source)).toBe(23)
+  })
+
+  it('skips a leading block comment', () => {
+    const source = '/* hello */import foo'
+    expect(stripLeadingCommentsAndWhitespace(source)).toBe(11)
+  })
+
+  it('skips a multi-line block comment', () => {
+    const source = '/*\n * docstring\n * spanning lines\n */\nimport foo'
+    // The offset points at the newline after `*/`, which whitespace
+    // consumption then eats.
+    const offset = stripLeadingCommentsAndWhitespace(source)
+    expect(source.slice(offset).startsWith('import')).toBe(true)
+  })
+
+  it('handles interleaved line + block + whitespace', () => {
+    const source = '// header\n/* copyright */\n\n// scope note\nexport function foo() {}'
+    const offset = stripLeadingCommentsAndWhitespace(source)
+    expect(source.slice(offset).startsWith('export')).toBe(true)
+  })
+
+  it('bails out (returns limit) on an unclosed block comment', () => {
+    // Defensive: if someone accidentally writes /* without */, we
+    // don't want an infinite loop. Return the scan limit so the
+    // caller sees "no real code found" and treats the file as a
+    // non-module (safer default than throwing).
+    const source = '/* forever...'
+    const offset = stripLeadingCommentsAndWhitespace(source)
+    expect(offset).toBeGreaterThanOrEqual(source.length)
+  })
+
+  it('bails out on a comment header that exceeds the 1kb scan window', () => {
+    // A file with 2kb of comments before the first real code will
+    // have detection give up somewhere in the comment. Treat that
+    // as "not a module" -- files with that much header noise are
+    // rare enough to accept the false negative.
+    const bigComment = '// ' + 'x'.repeat(2000) + '\nimport foo'
+    const offset = stripLeadingCommentsAndWhitespace(bigComment)
+    // The scanner returns the 1kb window limit; slice from there
+    // won't hit `import`, and isModuleSource() will return false.
+    expect(offset).toBeLessThanOrEqual(1024)
+  })
+
+  it('handles a file that is nothing but a comment', () => {
+    const source = '// I am but a lonely comment'
+    const offset = stripLeadingCommentsAndWhitespace(source)
+    // Whole file consumed -> offset === source.length.
+    expect(offset).toBe(source.length)
+  })
+
+  it('handles empty source', () => {
+    expect(stripLeadingCommentsAndWhitespace('')).toBe(0)
+  })
+})
+
+describe('isModuleSource', () => {
+  describe('positive cases (should be detected as modules)', () => {
+    it('detects a file that starts with `import`', () => {
+      expect(isModuleSource('import foo from "bar"')).toBe(true)
+    })
+
+    it('detects a file that starts with `export`', () => {
+      expect(isModuleSource('export function foo() {}')).toBe(true)
+    })
+
+    it('detects an ES module hidden behind a single-line comment', () => {
+      expect(isModuleSource('// this is a module\nimport foo from "bar"')).toBe(true)
+    })
+
+    it('detects an ES module hidden behind a multi-line docstring block', () => {
+      const source = [
+        '/*',
+        ' * This module does the thing.',
+        ' * See #1234 for details.',
+        ' */',
+        '',
+        'import { thing } from "./thing.js"'
+      ].join('\n')
+      expect(isModuleSource(source)).toBe(true)
+    })
+
+    it('detects a module with a long stack of // comments before the import', () => {
+      // Regression: 900-kometa.js leads with several `//` lines of context.
+      const source = [
+        '// Global flag so other handlers know an update is in progress',
+        'import {',
+        '  computeYamlLineCount,',
+        '  formatTimestampLocal',
+        '} from "./modules/kometaFormatters.js"'
+      ].join('\n')
+      expect(isModuleSource(source)).toBe(true)
+    })
+
+    it('detects a module with mixed comment styles before the import', () => {
+      const source = [
+        '/* copyright banner */',
+        '// scope note',
+        '',
+        '// implementation note',
+        'import foo from "./foo.js"'
+      ].join('\n')
+      expect(isModuleSource(source)).toBe(true)
+    })
+
+    it('detects `import{` (no space, minified-style)', () => {
+      expect(isModuleSource('import{foo}from"bar"')).toBe(true)
+    })
+
+    it('detects `export{` (no space, re-export style)', () => {
+      expect(isModuleSource('export{foo}from"bar"')).toBe(true)
+    })
+
+    it('detects `export default`', () => {
+      expect(isModuleSource('export default function foo() {}')).toBe(true)
+    })
+  })
+
+  describe('negative cases (should NOT be detected as modules)', () => {
+    it('rejects a classic script starting with const', () => {
+      expect(isModuleSource('const foo = 42')).toBe(false)
+    })
+
+    it('rejects a classic script starting with function', () => {
+      expect(isModuleSource('function foo() {}')).toBe(false)
+    })
+
+    it('rejects a classic script starting with an IIFE', () => {
+      expect(isModuleSource('(function () { /* ... */ })()')).toBe(false)
+    })
+
+    it('rejects a classic script starting with document lookup', () => {
+      // Regression: 100-anidb.js and 915-imagemaid.js start like this.
+      expect(isModuleSource('const el = document.getElementById("foo")')).toBe(false)
+    })
+
+    it('rejects a file that is nothing but a comment', () => {
+      expect(isModuleSource('// this file intentionally left blank')).toBe(false)
+    })
+
+    it('rejects empty source', () => {
+      expect(isModuleSource('')).toBe(false)
+    })
+
+    it('rejects a bare identifier that starts with `im...` but is not `import`', () => {
+      // Word boundary: `import` must be a complete word.
+      expect(isModuleSource('imports = { foo: 1 }')).toBe(false)
+    })
+
+    it('rejects a bare identifier that starts with `ex...` but is not `export`', () => {
+      expect(isModuleSource('exports.foo = 1')).toBe(false)
+    })
+
+    it('rejects a variable named import inside a comment then code', () => {
+      // The `// import { ... }` inside the comment must not trigger
+      // detection; the real code that follows is classic-script.
+      expect(isModuleSource('// example: import { foo } from "bar"\nconst x = 1')).toBe(false)
+    })
+  })
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,11 +1,11 @@
-// Vite scaffolding for Quickstart frontend (PR for #1334 Step 4).
+// Vite scaffolding for Quickstart frontend (#1334 Step 4).
 //
 // This config is intentionally dormant: nothing in production currently
 // references the build output. Flask still loads JS directly from
 // static/local-js/ via <script> tags in templates/000-base.html. The
-// purpose of this PR is to establish the toolchain so subsequent PRs
-// (Vitest, the validation widget consolidation, Alpine, etc.) have a
-// place to plug into.
+// purpose of this config is to establish the toolchain so future PRs
+// (Alpine widgets for Step 6, Svelte islands for Step 9) can plug into
+// it.
 //
 // What this config does today:
 //   - npm run dev      starts the Vite dev server on http://localhost:5173
@@ -18,17 +18,25 @@
 //   - change Dockerfile or quickstart.spec
 //   - replace the existing ESLint or pre-commit pipelines
 //
-// Multi-entry strategy: every file in static/local-js/*.js that is already
-// served as an ES module (per MODULE_PAGE_SCRIPTS in quickstart.py:410)
-// is registered as a Vite entry point. We discover the set from disk by
-// detecting top-level `import` statements rather than maintaining a
-// duplicate list here — that way the entry set stays in sync with the
-// actual module conversions without manual upkeep.
+// CI enforcement: `npm run build` runs as the `vite-build` job in
+// .github/workflows/lint.yml, so the build stays green even while
+// nothing consumes its output. When a downstream PR flips a template
+// switch, the bundle already works.
+//
+// Multi-entry strategy: every file in static/local-js/*.js whose first
+// non-comment/non-whitespace token is `import` or `export` is registered
+// as a Vite entry point. We discover the set from disk rather than
+// duplicating MODULE_PAGE_SCRIPTS in this file -- the entry set stays
+// in sync with the actual module conversions without manual upkeep.
+// The exact detection logic (which correctly skips leading docstrings
+// and block comments) lives in ./vite.detectModuleEntry.mjs and is
+// unit-tested under tests/js/detectModuleEntry.test.js.
 
 import { defineConfig } from 'vite'
 import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { isModuleSource } from './vite.detectModuleEntry.mjs'
 
 const rootDir = fileURLToPath(new URL('.', import.meta.url))
 const sourceDir = resolve(rootDir, 'static/local-js')
@@ -36,17 +44,26 @@ const outputDir = resolve(rootDir, 'static/dist')
 
 function discoverModuleEntries (dir) {
   // A file is treated as a module entry iff it lives directly in
-  // static/local-js/ AND begins with an `import` or `export` statement.
-  // Files in static/local-js/modules/ are not entry points — they are
+  // static/local-js/ AND its first non-comment/non-whitespace token is
+  // `import` or `export` (see vite.detectModuleEntry.mjs). This matches
+  // the browser's own definition of a module: source that syntactically
+  // declares import/export at the top level.
+  //
+  // Files in static/local-js/modules/ are NOT entry points -- they are
   // dependencies imported by other modules.
+  //
+  // Files that MODULE_PAGE_SCRIPTS lists but which don't actually use
+  // import/export (100-anidb.js, 915-imagemaid.js, imageHandler.js,
+  // validationHandler.js) are also skipped -- Vite building them
+  // would produce a byte-for-byte copy of the source, providing no
+  // value while cluttering static/dist/.
   const entries = {}
   for (const name of readdirSync(dir)) {
     const fullPath = join(dir, name)
     if (!statSync(fullPath).isFile()) continue
     if (!name.endsWith('.js')) continue
-    const head = readFileSync(fullPath, 'utf8').slice(0, 200).trimStart()
-    if (head.startsWith('import ') || head.startsWith('import{') ||
-        head.startsWith('export ') || head.startsWith('export{')) {
+    const source = readFileSync(fullPath, 'utf8')
+    if (isModuleSource(source)) {
       const entryName = name.replace(/\.js$/, '')
       entries[entryName] = fullPath
     }

--- a/vite.detectModuleEntry.mjs
+++ b/vite.detectModuleEntry.mjs
@@ -1,0 +1,58 @@
+// Helper for vite.config.js: given a source string, detect whether the
+// file is an ES module (i.e. its first non-comment/non-whitespace token
+// is `import` or `export`).
+//
+// Split out from vite.config.js so it can be unit-tested. The logic
+// looks trivial, but got a subtle bug in its first form (checked only
+// the first 200 chars, missed files with a leading docstring). This
+// module owns the definition of "what counts as a module entry point."
+//
+// Public API:
+//   stripLeadingCommentsAndWhitespace(source) -> number
+//     Returns the offset of the first character that is NOT a comment
+//     or whitespace. Consumes // line comments, /* block comments */,
+//     and any interleaved whitespace. Scans at most the first 1024
+//     characters -- if a file has more than 1kb of leading comments,
+//     it's suspicious anyway.
+//
+//   isModuleSource(source) -> boolean
+//     Returns true iff the first real token is `import` or `export`.
+
+const SCAN_LIMIT = 1024
+
+export function stripLeadingCommentsAndWhitespace (source) {
+  let i = 0
+  const limit = Math.min(source.length, SCAN_LIMIT)
+  while (i < limit) {
+    const ch = source[i]
+    if (ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r') {
+      i += 1
+      continue
+    }
+    if (ch === '/' && source[i + 1] === '/') {
+      // Line comment: skip to end of line (or end of scan window).
+      const nl = source.indexOf('\n', i + 2)
+      if (nl === -1 || nl >= limit) return limit
+      i = nl + 1
+      continue
+    }
+    if (ch === '/' && source[i + 1] === '*') {
+      // Block comment: skip to closing */ (or end of scan window).
+      const end = source.indexOf('*/', i + 2)
+      if (end === -1 || end >= limit) return limit
+      i = end + 2
+      continue
+    }
+    break
+  }
+  return i
+}
+
+export function isModuleSource (source) {
+  const offset = stripLeadingCommentsAndWhitespace(source)
+  // Look at the next word. We only need enough characters to
+  // disambiguate `import` / `export` from anything else -- 20 is
+  // plenty.
+  const head = source.slice(offset, offset + 20)
+  return /^(import|export)\b/.test(head)
+}


### PR DESCRIPTION
## What

Follow-up to the dormant Vite scaffolding from #1356. Adds CI enforcement for `npm run build` and **fixes a significant auto-discovery bug** that was silently dropping four of the largest ES modules in the codebase.

Also extracts the detection logic into a testable `.mjs` helper (29 new unit tests).

## 1. CI enforcement (`Vite Build` job)

Adds a `vite-build` job to `.github/workflows/lint.yml` that runs `npm run build` on every push/PR to develop/master.

The build output is still not consumed anywhere in production — Flask keeps serving raw source files from `static/local-js/` — but running the build in CI:

- Keeps the pipeline green while nothing consumes its output
- Provides a red-alert signal when someone lands a change that breaks bundling
- Makes the eventual "flip the switch" PR (a downstream Step 6 or Step 9 change) low-risk because we already know the bundle works today

The job also runs a **sanity check**: 8 page-scale entries (`000-base`, `001-start`, `010-plex`, `025-libraries`, `900-kometa`, `905-analytics`, `eventHandler`, `overlayHandler`) MUST appear in `static/dist/`. If someone accidentally deletes/renames one of them, or the auto-discovery starts silently dropping entries, CI fails with a clear error listing what's missing.

## 2. Fixed auto-discovery bug (docstring blindness)

The original `discoverModuleEntries` in `vite.config.js` checked only the first 200 characters of source and required `import` or `export` at position 0 (after `.trimStart()`). That silently dropped **four of the largest ES modules** in the codebase:

| File | Bundled size | Leading pattern |
|---|---|---|
| `900-kometa.js` | 200 kB | `// Global flag...` |
| `025-libraries.js` | 252 kB | `// Static ES-module...` |
| `overlayHandler.js` | 325 kB | `// Accordion-highlight state...` |
| `001-start.js` | 104 kB | `/* ============ */` |

**None of these appeared in `static/dist/` before this PR.** That's almost 900 kB of production JS that Vite thought didn't exist, which would have been a nasty surprise when a downstream PR tried to actually serve from `static/dist/`.

**Fix**: extract detection into `vite.detectModuleEntry.mjs` with a proper "strip leading comments and whitespace, then check for import/export at word boundary" scanner. Full behavior:

- Skips leading whitespace (spaces, tabs, newlines)
- Skips leading `// line comments`
- Skips leading `/* block comments */` (including multi-line)
- Handles interleaved comment styles
- Returns false on unclosed block comments (defensive; no infinite loop)
- Bails out at a 1kb scan window (rejects pathologically-large comment headers as false negatives)
- Matches `import` and `export` at word boundary (rejects identifiers like `imports` or `exports`)

## 3. Test coverage

New `tests/js/detectModuleEntry.test.js` — **29 tests** locking down the fixed behavior:

- **11 tests** for `stripLeadingCommentsAndWhitespace` covering the full comment-shape matrix + edge cases (unclosed, empty, giant header)
- **9 positive cases** for `isModuleSource`: import/export in various forms, hidden behind various comment styles, including a regression fixture for the `900-kometa.js` shape
- **9 negative cases**: classic scripts, IIFEs, comment-only files, word-boundary identifiers, empty source

**Vitest total: 1498 → 1527** (+29).

## Files touched

| File | Change |
|---|---|
| `.github/workflows/lint.yml` | +48 lines (new `vite-build` job) |
| `vite.config.js` | +47 / -19 (extract detection, refresh docstring) |
| `vite.detectModuleEntry.mjs` | **NEW**, 55 lines |
| `tests/js/detectModuleEntry.test.js` | **NEW**, 205 lines |
| `README.md` | +7 / -4 (refresh Frontend Tooling section) |

**On the `.mjs` suffix**: chosen so Node parses it as ESM without needing `"type": "module"` in `package.json` (which would break `eslint.config.js`, which uses CommonJS `module.exports`).

## Verification

- `npm run build` produces 26 entries + 10 shared chunks in ~500ms (was 20 entries + 8 chunks before the discovery fix; now catches the 4 previously-missed page-scale modules)
- **1527/1527 Vitest tests pass**
- **3/3 e2e console-error smoke tests pass**
- ESLint clean on all touched files
- CI verification script correctly identifies all 8 sentinel entries

## What this PR explicitly does NOT do

- Does not change `templates/000-base.html` (still serves raw source)
- Does not change `Dockerfile` / `quickstart.spec` (`dist/` not shipped)
- Does not delete `static/local-js/` (still the source of truth)
- Does not add any npm production dependencies (Alpine, Svelte, etc.) — those come in Step 6 and Step 9 when we actually need them, and **this PR is what unblocks them**

## Roadmap positioning

This PR moves the roadmap from "Step 4 partially done (scaffolded)" to **"Step 4 unblocks Steps 6 and 9."** The core Step 4 promise from #1334 is:

> Once the codebase is on ES modules, Vite is a thin layer on top that adds:
> - Bundle optimisation and tree shaking
> - TypeScript (optional, enabled when useful)
> - npm packages (Alpine, Svelte, Sortable, etc.) without CDN links
> - A dev server with hot reload
> - Vitest for JS unit testing

Vitest was already active (#1357). Dev server was already available. **Bundle optimization now works end-to-end for ALL page-scale modules**, including the four previously-dropped giants. When Step 6 needs Alpine, the first PR will just do `npm install alpinejs`, add an import to one module, and the bundle will Just Work — no further Vite plumbing required.

## Related

- #1334, #1356, #1357
