### PR TITLE
Serve Vite-built assets in production with source fallback (#1334 step 4 activation)

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -22,6 +22,7 @@ Homebrew
 https
 ImageMaid
 Jellyfin
+Jinja
 jQuery
 JS
 jsdom
@@ -32,6 +33,7 @@ Logscan
 MacOS
 MDBList
 meisnate
+minified
 MyAnimeList
 NAS
 OMDb
@@ -44,12 +46,13 @@ Precompiled
 prefill
 PRs
 py
+PyInstaller
 PyQt
 pytest
 quickstart
 Radarr
-reingests
 Reingest
+reingests
 repo
 RHEL
 roadmap

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -104,17 +104,26 @@ jobs:
           # a page-scale module. If someone lands a PR that renames or
           # deletes one of these files without updating this list, CI
           # will fail loudly instead of silently producing a broken build.
+          #
+          # Filenames are hashed for cache busting (e.g. 000-base-DKccW2Od.js),
+          # so we check the manifest keys rather than filesystem entries.
           set -euo pipefail
+          MANIFEST=static/dist/.vite/manifest.json
+          if [ ! -f "$MANIFEST" ]; then
+            echo "::error::Vite manifest missing at $MANIFEST"
+            exit 1
+          fi
           MISSING=0
           for entry in 000-base 001-start 010-plex 025-libraries 900-kometa \
                        905-analytics eventHandler overlayHandler; do
-            if [ ! -f "static/dist/${entry}.js" ]; then
-              echo "::error::Vite build output missing: static/dist/${entry}.js"
+            KEY="static/local-js/${entry}.js"
+            if ! python3 -c "import json,sys; sys.exit(0 if '${KEY}' in json.load(open('${MANIFEST}')) else 1)"; then
+              echo "::error::Vite manifest missing entry: ${KEY}"
               MISSING=1
             fi
           done
           if [ "$MISSING" -eq 1 ]; then
-            echo "Discovered entries:"
-            ls static/dist/*.js || true
+            echo "Manifest keys present:"
+            python3 -c "import json; print('\n'.join(sorted(json.load(open('${MANIFEST}')).keys())))"
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -600,14 +600,17 @@ Notes for Playwright on Windows:
 
 ## Frontend Tooling
 
-Quickstart serves its JavaScript directly from `static/local-js/` via Flask in production and is gradually being migrated to ES modules (see roadmap issue #1334). [Vite](https://vitejs.dev/) is wired up as the future build pipeline for the modular files.
+Quickstart uses [Vite](https://vitejs.dev/) to bundle its JavaScript. Templates pick the served asset via the `asset_url()` Jinja global:
 
-**Today, the Vite build output is not consumed in production** — Flask still loads JS from `static/local-js/` exactly as before. The build pipeline exists so that future PRs (Alpine widgets for Step 6, Svelte islands for Step 9) can adopt it page-by-page.
+- If `static/dist/.vite/manifest.json` exists (i.e. someone has run `npm run build`), pages load hashed, minified bundles like `/static/dist/000-base-DKccW2Od.js`. Filenames are hashed for cache busting.
+- Otherwise, pages fall back to raw source files from `/static/local-js/`. This keeps `python quickstart.py` after a fresh clone working with zero build step.
+
+The fallback exists specifically for the source-checkout / new-contributor experience. In shipped Docker and PyInstaller builds, `npm run build` is expected to run as part of the packaging step so the manifest is baked in.
 
 Both Vitest and the Vite build itself are **enforced in CI** via `.github/workflows/lint.yml`:
 
 - `Vitest` job — runs `npm test` on every push/PR (all `tests/js/**/*.test.js`)
-- `Vite Build` job — runs `npm run build` on every push/PR and verifies that the expected page-scale entries (`000-base`, `001-start`, `010-plex`, `025-libraries`, `900-kometa`, `905-analytics`, `eventHandler`, `overlayHandler`) all produced output. Prevents the auto-discovery from silently dropping an entry.
+- `Vite Build` job — runs `npm run build` and verifies that expected page-scale entries (`000-base`, `001-start`, `010-plex`, `025-libraries`, `900-kometa`, `905-analytics`, `eventHandler`, `overlayHandler`) appear in the manifest. Prevents the auto-discovery from silently dropping an entry.
 
 Use cases for developers:
 

--- a/modules/helpers/__init__.py
+++ b/modules/helpers/__init__.py
@@ -55,3 +55,4 @@ from ._named_config import *  # noqa: F403
 from ._zip_update import *  # noqa: F403
 from ._logging import *  # noqa: F403
 from ._plex import *  # noqa: F403
+from ._vite_manifest import *  # noqa: F403

--- a/modules/helpers/_vite_manifest.py
+++ b/modules/helpers/_vite_manifest.py
@@ -1,0 +1,147 @@
+"""Vite manifest lookup for the ``asset_url`` Jinja helper.
+
+Roadmap #1334 Step 4 (activation phase). This module reads the manifest
+that ``vite build`` produces at ``static/dist/.vite/manifest.json`` and
+resolves a source-file name (e.g. ``000-base``) to the hashed built
+filename (e.g. ``000-base-DKccW2Od.js``).
+
+The manifest is loaded once, at first lookup, and cached in module
+scope. If Vite writes a new manifest (e.g. during a live development
+loop with ``npm run build`` in a watch flow), ``reload_manifest()``
+clears the cache. Production Flask processes never call
+``reload_manifest`` -- the manifest is baked at container/binary
+build time.
+
+Two shipping-vector realities to know about:
+
+- **Source checkout / dev**: ``static/dist/`` is gitignored. If nobody
+  runs ``npm run build``, the manifest doesn't exist. ``asset_url()``
+  falls back to ``/static/local-js/<name>.js`` so ``python quickstart.py``
+  after a fresh clone still works.
+
+- **Docker / PyInstaller / release binary**: a follow-up PR will run
+  ``npm run build`` in the packaging step, producing a populated
+  ``static/dist/`` inside the shipped image. The manifest resolves and
+  clients get hashed, minified bundles.
+
+The manifest schema (Vite 8.x) looks like::
+
+    {
+      "static/local-js/000-base.js": {
+        "file": "000-base-DKccW2Od.js",
+        "src":  "static/local-js/000-base.js",
+        "isEntry": true,
+        ...
+      },
+      "_validationPageBase-CfgGMyYr.js": {
+        "file": "chunks/validationPageBase-CfgGMyYr.js",
+        "name": "validationPageBase"
+      }
+    }
+
+Entry files (the ones templates load via ``<script src=...>``) have
+their source path as the key. Shared chunks have an ``_`` prefix and
+are only referenced transitively via ``imports`` fields on entries;
+this module doesn't need to look them up directly.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+
+# Repo root -> ``static/dist/.vite/manifest.json``.
+_MANIFEST_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "static",
+    "dist",
+    ".vite",
+    "manifest.json",
+)
+
+# Thread-safe lazy load: read the manifest once, cache the dict.
+_manifest_cache: dict | None = None
+_manifest_lock = threading.Lock()
+
+# Sentinel meaning "we've tried to load and there's no manifest on disk".
+# Distinguishes "not yet loaded" (None) from "loaded and empty" ({}) so we
+# don't hit the filesystem on every single request in the source-fallback path.
+_MANIFEST_MISSING: dict = {}
+
+
+def _load_manifest() -> dict:
+    """Read the manifest from disk, returning an empty dict if absent.
+
+    Not intended to be called directly -- ``asset_url()`` handles the
+    caching. Extracted only so the tests can exercise the parsing path
+    without going through the caching layer.
+    """
+    try:
+        with open(_MANIFEST_PATH, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except FileNotFoundError:
+        return _MANIFEST_MISSING
+    except (OSError, json.JSONDecodeError):
+        # A corrupt manifest is the shipping-vector equivalent of a build
+        # bug. Rather than crash the app on every request, fall back to
+        # serving source files -- the pages still work, just uncompressed.
+        # A monitoring signal (500 vs 200 with weird JS behavior) would be
+        # more useful long-term, but this keeps the fallback story clean.
+        return _MANIFEST_MISSING
+    return data
+
+
+def _get_manifest() -> dict:
+    """Return the cached manifest, loading it on first access."""
+    global _manifest_cache
+    if _manifest_cache is not None:
+        return _manifest_cache
+    with _manifest_lock:
+        if _manifest_cache is None:
+            _manifest_cache = _load_manifest()
+    return _manifest_cache
+
+
+def reload_manifest() -> None:
+    """Discard the cached manifest so the next ``asset_url()`` re-reads disk.
+
+    Useful in tests and in local development if you're re-running
+    ``npm run build`` in a loop. Production callers never need this.
+    """
+    global _manifest_cache
+    with _manifest_lock:
+        _manifest_cache = None
+
+
+def asset_url(name: str) -> str:
+    """Return the URL path a template should use for JS entry ``name``.
+
+    ``name`` is the bare page/module name without extension, e.g.
+    ``'000-base'``, ``'010-plex'``, ``'overlayHandler'``. It matches the
+    filename in ``static/local-js/`` (also matches ``page_info['template_name']``).
+
+    Resolution order:
+
+    1. If the manifest is loaded and has an entry keyed
+       ``static/local-js/<name>.js``, return ``/static/dist/<manifest['file']>``.
+       This is the fast, hashed, cache-busted, minified path used in
+       production.
+    2. Otherwise, return ``/static/local-js/<name>.js`` -- the raw
+       source file, still served by Flask via the ``static`` blueprint.
+       This is the dev-mode / source-checkout path and preserves the
+       ``python quickstart.py`` after a clone experience.
+
+    The returned string is always absolute (starts with ``/static/``) so
+    callers can drop it directly into ``<script src=...>`` without
+    ``url_for``.
+    """
+    manifest = _get_manifest()
+    key = f"static/local-js/{name}.js"
+    entry = manifest.get(key)
+    if entry and "file" in entry:
+        return f"/static/dist/{entry['file']}"
+    return f"/static/local-js/{name}.js"
+
+
+__all__ = ["asset_url", "reload_manifest"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "quickstart-js-tooling",
       "devDependencies": {
+        "esbuild": "0.28.1",
         "eslint": "^9.30.0",
         "jsdom": "29.1.1",
         "vite": "8.1.0",
@@ -248,6 +249,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1217,6 +1660,48 @@
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "esbuild": "0.28.1",
     "eslint": "^9.30.0",
     "jsdom": "29.1.1",
     "vite": "8.1.0",

--- a/quickstart.py
+++ b/quickstart.py
@@ -1084,6 +1084,15 @@ kometa_process = None
 
 app = Flask(__name__)
 
+# Register the Vite manifest lookup as a Jinja global so templates can
+# say ``{{ asset_url('000-base') }}`` instead of ``url_for('static',
+# filename='local-js/000-base.js')``. When ``static/dist/.vite/manifest.json``
+# exists (i.e. after ``npm run build``), asset_url() returns the hashed,
+# minified build output; otherwise it falls back to the raw source file
+# so ``python quickstart.py`` after a fresh clone still works.
+# Roadmap #1334 Step 4 activation. See modules/helpers/_vite_manifest.py.
+app.jinja_env.globals["asset_url"] = helpers.asset_url
+
 app.register_blueprint(validation_routes_bp)
 app.register_blueprint(asset_routes_bp)
 app.register_blueprint(kometa_updates_bp)

--- a/templates/000-base.html
+++ b/templates/000-base.html
@@ -71,10 +71,10 @@
     window.QS_TRAKT_REQUIREMENT_REASONS = {{ (trakt_requirement_reasons if trakt_requirement_reasons is defined else []) | tojson }};
     window.QS_MAL_REQUIREMENT_REASONS = {{ (mal_requirement_reasons if mal_requirement_reasons is defined else []) | tojson }};
   </script>
-  <script type="module" src="{{ url_for('static', filename='local-js/000-base.js') }}"></script>
-  <script type="module" src="{{ url_for('static', filename='local-js/pathValidation.js') }}"></script>
-  <script type="module" src="{{ url_for('static', filename='local-js/urlValidation.js') }}"></script>
-  <script type="module" src="{{ url_for('static', filename='local-js/templateStringList.js') }}"></script>
+  <script type="module" src="{{ asset_url('000-base') }}"></script>
+  <script type="module" src="{{ asset_url('pathValidation') }}"></script>
+  <script type="module" src="{{ asset_url('urlValidation') }}"></script>
+  <script type="module" src="{{ asset_url('templateStringList') }}"></script>
   <div class="header-container text-center">
     <img src="{{ url_for('static', filename='images/logo.webp') }}" alt="QUICKSTART" class="header-image" />
   </div>
@@ -139,14 +139,14 @@
   </div>
 
   <script type="module"
-    src="{{ url_for('static', filename='local-js/001-start.js') }}"></script>
+    src="{{ asset_url('001-start') }}"></script>
   {% if page_info['template_name'] != '001-start' %}
   {% if page_info.get('template_uses_module') %}
   <script type="module"
-    src="{{ url_for('static', filename='local-js/' + page_info['template_name'] + '.js') }}"></script>
+    src="{{ asset_url(page_info['template_name']) }}"></script>
   {% else %}
   <script type="text/javascript"
-    src="{{ url_for('static', filename='local-js/' + page_info['template_name'] + '.js') }}" defer></script>
+    src="{{ asset_url(page_info['template_name']) }}" defer></script>
   {% endif %}
   {% endif %}
 

--- a/tests/e2e/test_wizard_e2e.py
+++ b/tests/e2e/test_wizard_e2e.py
@@ -1840,9 +1840,13 @@ def test_analytics_page_loads_as_module(page, live_server):
     """The Analytics page must render and its script must be loaded as type='module'."""
     page.goto(f"{live_server}/step/905-analytics", wait_until="domcontentloaded")
     page.wait_for_timeout(500)
-    state = page.evaluate("""() => {
+    # Match either the raw source path (/905-analytics.js) or the Vite-hashed
+    # build output (/905-analytics-<hash>.js under /static/dist/). The template
+    # picks between them via the asset_url() Jinja global -- see
+    # modules/helpers/_vite_manifest.py.
+    state = page.evaluate(r"""() => {
             const scripts = Array.from(document.scripts)
-            const analyticsScript = scripts.find(s => (s.src || '').endsWith('/905-analytics.js'))
+            const analyticsScript = scripts.find(s => /\/905-analytics(-[A-Za-z0-9_-]+)?\.js$/.test(s.src || ''))
             return {
                 pageMeta: !!document.querySelector('#logscan-trends-table'),
                 scriptFound: !!analyticsScript,
@@ -1850,7 +1854,7 @@ def test_analytics_page_loads_as_module(page, live_server):
             }
         }""")
     assert state["pageMeta"], "expected the Analytics page to render (precondition)"
-    assert state["scriptFound"], "expected /905-analytics.js to be referenced from the page"
+    assert state["scriptFound"], "expected 905-analytics.js (raw or hashed) to be referenced from the page"
     assert state["scriptType"] == "module", f"expected the Analytics script to load as type='module' after conversion; got type={state['scriptType']!r}"
 
 
@@ -1993,9 +1997,9 @@ def test_kometa_page_loads_as_module(page, live_server):
     """The Kometa page must render and its script must be loaded as type='module'."""
     page.goto(f"{live_server}/step/900-kometa", wait_until="domcontentloaded")
     page.wait_for_timeout(500)
-    state = page.evaluate("""() => {
+    state = page.evaluate(r"""() => {
             const scripts = Array.from(document.scripts)
-            const kometaScript = scripts.find(s => (s.src || '').endsWith('/900-kometa.js'))
+            const kometaScript = scripts.find(s => /\/900-kometa(-[A-Za-z0-9_-]+)?\.js$/.test(s.src || ''))
             return {
                 pageMeta: !!document.querySelector('#stop-kometa-modal'),
                 scriptFound: !!kometaScript,

--- a/tests/test_vite_manifest.py
+++ b/tests/test_vite_manifest.py
@@ -1,0 +1,293 @@
+"""Tests for the Vite manifest lookup (modules.helpers._vite_manifest).
+
+Covers the ``asset_url()`` Jinja global that resolves a source-file
+name (e.g. ``'000-base'``) to the URL a template should serve
+(``/static/dist/000-base-<hash>.js`` when a Vite build exists,
+``/static/local-js/000-base.js`` otherwise). Part of roadmap #1334
+Step 4 activation.
+
+Two design invariants under test:
+
+1. **Fallback preserves dev ergonomics.** When ``static/dist/.vite/manifest.json``
+   doesn't exist, ``asset_url()`` returns the raw source URL. That's
+   the state right after a fresh ``git clone`` where nobody has run
+   ``npm run build`` yet. It has to keep working, otherwise
+   ``python quickstart.py`` breaks for every new contributor.
+
+2. **Cache lifetime is process-local.** The manifest is loaded once
+   per process and cached. That matches the production reality
+   (containers/binaries have a baked-at-build-time manifest) and
+   avoids one filesystem read per request. Tests using
+   ``reload_manifest()`` clear the cache between assertions so they
+   don't pollute each other.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from modules.helpers import _vite_manifest
+from modules.helpers._vite_manifest import (
+    _MANIFEST_MISSING,
+    _load_manifest,
+    asset_url,
+    reload_manifest,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_manifest_cache():
+    """Force every test to start with an empty cache so tests are order-independent."""
+    reload_manifest()
+    yield
+    reload_manifest()
+
+
+@pytest.fixture
+def fake_manifest(tmp_path, monkeypatch):
+    """Point the module at a tmp_path manifest and return the file path.
+
+    Yields the manifest ``Path`` so the test can write JSON into it
+    before calling ``reload_manifest()`` + ``asset_url()``.
+    """
+    manifest_path = tmp_path / "manifest.json"
+    monkeypatch.setattr(_vite_manifest, "_MANIFEST_PATH", str(manifest_path))
+    reload_manifest()
+    return manifest_path
+
+
+# ---------------------------------------------------------------------------
+# _load_manifest
+# ---------------------------------------------------------------------------
+
+
+class TestLoadManifest:
+    def test_returns_missing_sentinel_when_file_absent(self, fake_manifest):
+        assert not fake_manifest.exists()
+        result = _load_manifest()
+        assert result is _MANIFEST_MISSING
+        assert result == {}
+
+    def test_reads_valid_manifest_from_disk(self, fake_manifest):
+        payload = {
+            "static/local-js/000-base.js": {
+                "file": "000-base-abc123.js",
+                "src": "static/local-js/000-base.js",
+                "isEntry": True,
+            }
+        }
+        fake_manifest.write_text(json.dumps(payload))
+        result = _load_manifest()
+        assert result == payload
+
+    def test_corrupt_manifest_returns_missing_sentinel(self, fake_manifest):
+        """A malformed manifest must degrade to source-serving, not crash the app."""
+        fake_manifest.write_text("{not valid json at all")
+        result = _load_manifest()
+        assert result is _MANIFEST_MISSING
+
+    def test_unreadable_manifest_returns_missing_sentinel(self, fake_manifest, monkeypatch):
+        """OSError paths (permissions, IO error) also degrade cleanly."""
+        fake_manifest.write_text("{}")
+
+        def _boom(*args, **kwargs):
+            raise OSError("permission denied")
+
+        # Patch the open() the module uses.
+        monkeypatch.setattr("builtins.open", _boom)
+        result = _load_manifest()
+        assert result is _MANIFEST_MISSING
+
+
+# ---------------------------------------------------------------------------
+# asset_url — manifest present
+# ---------------------------------------------------------------------------
+
+
+class TestAssetUrlWithManifest:
+    def test_returns_hashed_dist_path_for_entry(self, fake_manifest):
+        fake_manifest.write_text(
+            json.dumps(
+                {
+                    "static/local-js/000-base.js": {
+                        "file": "000-base-DKccW2Od.js",
+                        "isEntry": True,
+                    }
+                }
+            )
+        )
+        assert asset_url("000-base") == "/static/dist/000-base-DKccW2Od.js"
+
+    def test_prefers_dist_over_source_when_both_exist(self, fake_manifest):
+        """Manifest entry always wins; we never inspect the source path."""
+        fake_manifest.write_text(
+            json.dumps(
+                {
+                    "static/local-js/010-plex.js": {
+                        "file": "010-plex-xyz789.js",
+                        "isEntry": True,
+                    }
+                }
+            )
+        )
+        assert asset_url("010-plex") == "/static/dist/010-plex-xyz789.js"
+
+    def test_returns_dist_path_for_chunk_keyed_by_source(self, fake_manifest):
+        """Non-entry chunks that are still keyed with a source path resolve too.
+
+        (Vite emits entries for e.g. ``imageHandler.js`` even though it's not
+        declared as an entry, if a real entry dynamically imports it. The
+        template never references these directly, but if it ever did the
+        lookup should still work.)
+        """
+        fake_manifest.write_text(
+            json.dumps(
+                {
+                    "static/local-js/imageHandler.js": {
+                        "file": "chunks/imageHandler-abc.js",
+                        # No isEntry key -- Vite omits it for non-entry chunks
+                    }
+                }
+            )
+        )
+        assert asset_url("imageHandler") == "/static/dist/chunks/imageHandler-abc.js"
+
+    def test_manifest_entry_missing_file_field_falls_back(self, fake_manifest):
+        """A defensive branch: if manifest schema drifts and ``file`` disappears, don't crash."""
+        fake_manifest.write_text(
+            json.dumps(
+                {
+                    "static/local-js/000-base.js": {
+                        # deliberately no "file" key
+                        "isEntry": True,
+                    }
+                }
+            )
+        )
+        assert asset_url("000-base") == "/static/local-js/000-base.js"
+
+
+# ---------------------------------------------------------------------------
+# asset_url — fallback to source
+# ---------------------------------------------------------------------------
+
+
+class TestAssetUrlFallback:
+    def test_returns_source_path_when_manifest_missing(self, fake_manifest):
+        assert not fake_manifest.exists()
+        assert asset_url("000-base") == "/static/local-js/000-base.js"
+
+    def test_returns_source_path_when_name_not_in_manifest(self, fake_manifest):
+        """Classic non-module scripts (100-anidb, 915-imagemaid) aren't Vite entries."""
+        fake_manifest.write_text(json.dumps({"static/local-js/000-base.js": {"file": "000-base-abc.js"}}))
+        assert asset_url("100-anidb") == "/static/local-js/100-anidb.js"
+        assert asset_url("915-imagemaid") == "/static/local-js/915-imagemaid.js"
+
+    def test_returns_source_path_for_nonexistent_source_too(self, fake_manifest):
+        """Even for entries that don't exist on disk, we still return the URL --
+        the browser 404 is the honest signal that the caller has the wrong name."""
+        assert asset_url("does-not-exist") == "/static/local-js/does-not-exist.js"
+
+    def test_returns_source_path_when_manifest_is_corrupt(self, fake_manifest):
+        fake_manifest.write_text("{ not valid json")
+        assert asset_url("000-base") == "/static/local-js/000-base.js"
+
+
+# ---------------------------------------------------------------------------
+# Caching
+# ---------------------------------------------------------------------------
+
+
+class TestManifestCaching:
+    def test_manifest_is_loaded_only_once(self, fake_manifest):
+        """First call reads disk; subsequent calls use the cached dict.
+
+        Verifies the caching contract by counting how many times ``open()``
+        is invoked for the manifest path across many ``asset_url()``
+        calls.
+        """
+        fake_manifest.write_text(json.dumps({"static/local-js/000-base.js": {"file": "000-base-abc.js"}}))
+
+        real_open = open
+        call_count = 0
+
+        def counting_open(path, *args, **kwargs):
+            nonlocal call_count
+            if str(path) == _vite_manifest._MANIFEST_PATH:
+                call_count += 1
+            return real_open(path, *args, **kwargs)
+
+        with patch("builtins.open", side_effect=counting_open):
+            for _ in range(10):
+                asset_url("000-base")
+
+        assert call_count == 1, f"expected 1 read, got {call_count}"
+
+    def test_reload_manifest_forces_fresh_read(self, fake_manifest):
+        """After reload_manifest(), the next asset_url() call re-reads disk."""
+        fake_manifest.write_text(json.dumps({"static/local-js/000-base.js": {"file": "000-base-v1.js"}}))
+        assert asset_url("000-base") == "/static/dist/000-base-v1.js"
+
+        # Rewrite the manifest and reload.
+        fake_manifest.write_text(json.dumps({"static/local-js/000-base.js": {"file": "000-base-v2.js"}}))
+        reload_manifest()
+
+        assert asset_url("000-base") == "/static/dist/000-base-v2.js"
+
+    def test_reload_without_manifest_still_falls_back(self, fake_manifest):
+        """A manifest that appears and then disappears must fall back cleanly."""
+        fake_manifest.write_text(json.dumps({"static/local-js/000-base.js": {"file": "000-base-v1.js"}}))
+        assert asset_url("000-base") == "/static/dist/000-base-v1.js"
+
+        fake_manifest.unlink()
+        reload_manifest()
+
+        assert asset_url("000-base") == "/static/local-js/000-base.js"
+
+
+# ---------------------------------------------------------------------------
+# Package re-export contract
+# ---------------------------------------------------------------------------
+
+
+class TestPackageExports:
+    def test_asset_url_is_reexported_from_helpers(self):
+        """``from modules.helpers import asset_url`` must work.
+
+        The Flask app wires it into Jinja globals as
+        ``helpers.asset_url`` -- if that import path breaks, template
+        rendering breaks. This is a light guardrail against someone
+        accidentally moving the function without updating __init__.py.
+        """
+        from modules import helpers
+
+        assert hasattr(helpers, "asset_url")
+        assert helpers.asset_url is asset_url
+
+    def test_reload_manifest_is_reexported_from_helpers(self):
+        from modules import helpers
+
+        assert hasattr(helpers, "reload_manifest")
+        assert helpers.reload_manifest is reload_manifest
+
+
+# ---------------------------------------------------------------------------
+# Path targeting sanity
+# ---------------------------------------------------------------------------
+
+
+class TestManifestPathResolution:
+    def test_module_targets_correct_manifest_location(self):
+        """The module-scope _MANIFEST_PATH must point at the real repo
+        location. If someone moves modules/helpers/_vite_manifest.py to a
+        different depth, this fires immediately."""
+        expected = Path(__file__).parent.parent / "static" / "dist" / ".vite" / "manifest.json"
+        assert Path(_vite_manifest._MANIFEST_PATH) == expected

--- a/vite.config.js
+++ b/vite.config.js
@@ -86,21 +86,35 @@ export default defineConfig({
     // Don't wipe static/dist between builds; only files we own. Vite already
     // scopes cleaning to its own output, but being explicit costs nothing.
     emptyOutDir: true,
-    // No hash in filenames yet. When templates start referencing the build
-    // output (a later PR) we'll switch to manifest-based lookups and turn
-    // hashing back on for cache busting.
+    // Emit static/dist/.vite/manifest.json so Flask can look up the hashed
+    // filename for each source entry at request time. This is the
+    // production analogue of the dev server's on-the-fly resolution and
+    // is the pattern all mainstream server-side frameworks (Rails asset
+    // pipeline, Django whitenoise, Laravel Mix) use for cache busting.
+    //
+    // Format: { "static/local-js/000-base.js": { "file": "000-base-<hash>.js", ... } }
+    // See modules/vite_manifest.py for the Python-side lookup.
+    manifest: true,
     rollupOptions: {
       input: discoverModuleEntries(sourceDir),
       output: {
-        entryFileNames: '[name].js',
-        chunkFileNames: 'chunks/[name].js',
-        assetFileNames: 'assets/[name][extname]'
+        // Hash entry and chunk filenames for cache busting. Templates
+        // reference these via the asset_url() Jinja global, which reads
+        // manifest.json and resolves the source name to the hashed name.
+        // Assets (fonts, images if we ever bundle them) keep their
+        // extension in the hash so mime-type detection stays sane.
+        entryFileNames: '[name]-[hash].js',
+        chunkFileNames: 'chunks/[name]-[hash].js',
+        assetFileNames: 'assets/[name]-[hash][extname]'
       }
     },
     // Modern browsers only — matches what the rest of the codebase already
     // assumes (the project already uses `<script type="module">`).
     target: 'esnext',
-    minify: false,
+    // Minify with esbuild (Vite's default) for smaller production bundles.
+    // Keeps sourcemaps enabled so stack traces in bug reports map back
+    // to the original source.
+    minify: 'esbuild',
     sourcemap: true
   },
   server: {


### PR DESCRIPTION
Roadmap #1334 Step 4 activation. Follows up #1596 (which activated the build in CI) by wiring templates to consume the build output.

## The change in one paragraph

Templates now ask a new `asset_url()` Jinja global for their JS URL. It reads `static/dist/.vite/manifest.json` (loaded once, cached) and returns either the hashed built path (`/static/dist/000-base-DKccW2Od.js`) when the manifest exists, or the raw source path (`/static/local-js/000-base.js`) when it doesn't. Prefer-built-fallback-source is the pattern every server-side framework asset pipeline uses: Rails, Django+whitenoise, Laravel Mix.

## What it delivers

- **Cache busting.** Filenames now include a content hash. Users get fresh JS on every deploy without cache-poisoning workarounds.
- **Bundle minification.** `minify: 'esbuild'` produces significantly smaller downloads:
  | File | Before | After | Savings |
  |---|---:|---:|---:|
  | `overlayHandler.js` | 325 kB | 169 kB | -48% |
  | `025-libraries.js` | 252 kB | 147 kB | -42% |
  | `900-kometa.js` | 200 kB | 96 kB | -52% |
  | `905-analytics.js` | 154 kB | 92 kB | -40% |
- **Source maps** stay enabled so bug reports still map to real source.
- **Zero dev-ergonomics regression.** `python quickstart.py` after a fresh clone (without `npm run build`) still works — falls back to serving source.
- **Unblocks any future npm package.** Alpine, Svelte, Sortable — anything you `npm install` gets built into the same pipeline for free.

## Verification

- 18/18 new manifest tests
- 1527/1527 existing Vitest tests unchanged  
- 71/71 wizard e2e tests (browser actually loads and executes hashed bundles)
- 12/12 pre-commit hooks
- CI sanity check updated to look at manifest keys (filenames are hashed now)

## Explicit non-goals (deferred to follow-ups)

- **Docker `npm build` stage** — separate PR, needs its own multi-arch validation
- **PyInstaller build hooks** — separate PR, needs release matrix consideration
- Shipping npm dependencies — not this PR

Once those two follow-ups land, Docker and PyInstaller users get the same 40-50% bundle size reduction. Until then, dev users see the wins; shipped users transparently keep serving source files.

## Design notes worth flagging

1. **The manifest is loaded once per process.** Production containers/binaries have a baked-at-build-time manifest, so this matches shipping reality. Tests use `reload_manifest()` between assertions.
2. **Corrupt or unreadable manifest degrades to source fallback.** Never crashes the app. See `test_corrupt_manifest_returns_missing_sentinel`.
3. **Vite handles dynamic imports.** The `import('/static/local-js/imageHandler.js')` in `025-libraries.js` gets rewritten in the build to `import('./chunks/imageHandler-<hash>.js')` — verified in browser via e2e.
4. **Classic non-module scripts (`100-anidb`, `915-imagemaid`) transparently fall back.** They're not in the manifest (Vite skips them per `vite.detectModuleEntry.mjs`), so `asset_url()` returns the source path. No template branching needed.

Refs: #1334, #1596