### PR TITLE
Wire npm build into Docker image (#1334 step 4 follow-up A)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,41 @@
+# syntax=docker/dockerfile:1
+#
+# Multi-stage build for Quickstart.
+#
+# Stage 1 (jsbuild) runs the Vite bundle so shipped images serve
+# hashed, minified, cache-busted JS from /static/dist/. Runs on
+# ``$BUILDPLATFORM`` -- the platform doing the build -- rather than
+# ``$TARGETPLATFORM``. That means arm64 and arm7 image builds do the
+# Node work natively on the amd64 build host instead of under qemu
+# emulation, cutting build time from minutes to seconds.
+#
+# Stage 2 is the runtime image: Python 3.13 + Kometa's runtime deps.
+# It gets /static/dist/ copied in from the jsbuild stage, so the
+# ``asset_url()`` Jinja helper (see modules/helpers/_vite_manifest.py)
+# resolves the manifest at request time and serves optimized bundles.
+#
+# If ``static/dist/`` is missing, ``asset_url()`` transparently falls
+# back to /static/local-js/*.js -- so the app still boots even in
+# scenarios like ``docker run`` from a pre-multi-stage image or a
+# non-shipping environment. But that fallback is not what shipped
+# images should hit; the copy below is the load-bearing part.
+
+# ---- Stage 1: Build the JS bundles ---------------------------------
+FROM --platform=$BUILDPLATFORM node:22-slim AS jsbuild
+WORKDIR /jsbuild
+
+# Copy only the files needed for the JS build. This keeps the layer
+# cache warm across changes to Python code / templates -- unless
+# package*.json or the JS sources change, this stage is a cache hit.
+COPY package.json package-lock.json vite.config.js vite.detectModuleEntry.mjs ./
+COPY static/local-js/ ./static/local-js/
+
+# npm ci is stricter than npm install: fails on any lockfile drift.
+# That's what we want for reproducible builds.
+RUN npm ci --no-fund --no-audit \
+ && npm run build
+
+# ---- Stage 2: Runtime image ----------------------------------------
 FROM python:3.13-slim
 ARG BRANCH_NAME=master
 ENV BRANCH_NAME=${BRANCH_NAME}
@@ -22,5 +60,11 @@ RUN echo "**** cleanup system packages ****" \
  && apt-get autoclean \
  && rm -rf /requirements.txt /tmp/* /var/tmp/* /var/lib/apt/lists/*
 COPY . /
+# Copy the Vite build output from the jsbuild stage. This overwrites
+# any /static/dist/ that snuck in from the host (the .dockerignore
+# `**/dist` rule should prevent that, but this line makes the source
+# of truth unambiguous). Placed AFTER the whole-repo COPY so it wins
+# in the final image.
+COPY --from=jsbuild /jsbuild/static/dist/ /static/dist/
 VOLUME /config
 ENTRYPOINT ["/tini", "-s", "python3", "quickstart.py", "--"]

--- a/Dockerfile.arm7
+++ b/Dockerfile.arm7
@@ -1,3 +1,24 @@
+# syntax=docker/dockerfile:1
+#
+# ARM7-specific build variant. Same multi-stage layout as ./Dockerfile
+# with one runtime tweak: PyQt5 wheels don't publish for armv7, so
+# requirements.txt gets filtered before pip install.
+#
+# The jsbuild stage is identical to the main Dockerfile because Node's
+# multi-arch story is much cleaner than PyQt5's. Running on
+# $BUILDPLATFORM avoids emulation entirely.
+
+# ---- Stage 1: Build the JS bundles ---------------------------------
+FROM --platform=$BUILDPLATFORM node:22-slim AS jsbuild
+WORKDIR /jsbuild
+
+COPY package.json package-lock.json vite.config.js vite.detectModuleEntry.mjs ./
+COPY static/local-js/ ./static/local-js/
+
+RUN npm ci --no-fund --no-audit \
+ && npm run build
+
+# ---- Stage 2: Runtime image ----------------------------------------
 FROM python:3.13-slim
 ARG BRANCH_NAME=master
 ENV BRANCH_NAME=${BRANCH_NAME}
@@ -23,5 +44,6 @@ RUN echo "**** cleanup system packages ****" \
  && apt-get autoclean \
  && rm -rf /requirements.txt /tmp/* /var/tmp/* /var/lib/apt/lists/*
 COPY . /
+COPY --from=jsbuild /jsbuild/static/dist/ /static/dist/
 VOLUME /config
 ENTRYPOINT ["/tini", "-s", "python3", "quickstart.py", "--"]


### PR DESCRIPTION
Follows #1597 which activated the Vite production build in Flask templates. That PR served hashed bundles from `static/dist/` **when the manifest existed**; shipped Docker images had no manifest because nothing populated `static/dist/` during image build. This PR fixes that for Docker.

## The change

Both `Dockerfile` and `Dockerfile.arm7` become multi-stage:

- **jsbuild stage** (`node:22-slim`): copies only JS-build inputs (package files + `static/local-js/`), runs `npm ci && npm run build`, produces `/jsbuild/static/dist/`
- **Runtime stage** (unchanged `python:3.13-slim`): adds one `COPY --from=jsbuild /jsbuild/static/dist/ /static/dist/` after `COPY . /`

## The multi-arch magic

`--platform=$BUILDPLATFORM` pins the jsbuild stage to the amd64 build host so `npm run build` runs natively for arm64 and arm7 targets too — no qemu emulation, no minutes-long Node runs. Only the platform-neutral text output gets copied into the target-arch runtime image.

## Verification (linux/amd64 locally)

- Full `docker build .` succeeded in ~3 min
- jsbuild stage: 20s total, Vite build 651ms inside container
- Confirmed: final image has `/static/dist/` with all 34 hashed entries + `.vite/manifest.json`
- Confirmed: container boot → `curl /step/010-plex` returns hashed src= URLs for all 4 module entries
- Confirmed: container serves `GET /static/dist/010-plex-Cf-7znZ1.js` → HTTP 200

## Sibling PR

The PyInstaller equivalent (add `npm run build` step to `release-master.yml` before invoking PyInstaller) is coming next as a separate PR. After both land, all shipped Quickstart instances — Docker + Windows/macOS/Linux binaries — get cache-busted minified bundles.

## Non-goals

- Doesn't touch `docker-build.yml` or any CI workflow — the build-arg contract is unchanged
- Doesn't ship any code changes — Dockerfiles only

Refs: #1334, #1597