### PR TITLE
Wire npm build into PyInstaller release matrix (#1334 step 4 follow-up B)

### DIFF
--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -52,6 +52,21 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Build the Vite bundles BEFORE PyInstaller runs so the shipped
+      # binary includes static/dist/ (hashed, minified JS + manifest).
+      # See modules/helpers/_vite_manifest.py for how templates consume
+      # this at request time; roadmap #1334 Step 4.
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Build JS Bundles
+        run: |
+          npm ci --no-fund --no-audit
+          npm run build
+
       - name: Setup Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/validate-pull.yml
+++ b/.github/workflows/validate-pull.yml
@@ -297,6 +297,21 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
 
+      # Build the Vite bundles BEFORE PyInstaller runs so the shipped
+      # binary includes static/dist/ (hashed, minified JS + manifest).
+      # See modules/helpers/_vite_manifest.py for how templates consume
+      # this at request time; roadmap #1334 Step 4.
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Build JS Bundles
+        run: |
+          npm ci --no-fund --no-audit
+          npm run build
+
       - name: Setup Python
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
Sibling of #1598 (Docker npm build). Both PRs complete Step 4 for the shipped-image side: after they land, **all shipped Quickstart instances** — Docker + Windows/macOS/Linux binaries — ship with hashed, minified JS bundles.

## The change

Two workflows get a Node setup + JS build step inserted between `Check Out Repo` and `Setup Python`:

1. `.github/workflows/validate-pull.yml` (PR-validation build)
2. `.github/workflows/release-notification.yml` (release build)

Both matrices run on Windows, Ubuntu, and macOS. The Node build works identically on all three — Vite output is platform-neutral text files.

## Why this is enough (no .spec changes)

`quickstart.spec` already ships everything under `static/` via:

```python
('static', 'static'),
```

which is a directory copy. Once `static/dist/` exists on disk before `pyinstaller` runs, it gets baked into the binary automatically.

## Verification (local Linux PyInstaller build)

- `pyinstaller -y ./quickstart.spec -- --build linux` succeeded in ~98s
- Resulting binary (171 MB) contains all 34 hashed `static/dist/*.js` entries + `.vite/manifest.json` (verified via `strings dist/Quickstart | grep static/dist/`)
- Ran the binary; `curl /step/010-plex` returns hashed src= URLs:
  - `/static/dist/000-base-DKccW2Od.js`
  - `/static/dist/001-start-D30u5e_F.js`
  - `/static/dist/010-plex-Cf-7znZ1.js`
- Same hashes as Docker (#1598) and local dev. Manifest agreement across all three shipping vectors.

## The whole Step 4 arc

| PR | State |
|---|---|
| #1596 | Activate Vite build in CI |
| #1597 | Serve built assets from templates (source fallback) |
| **#1598** | Docker multi-stage build with Node stage |
| **#1599 (this PR)** | PyInstaller release matrix gets `npm run build` step |

After all four land, users get cache-busted, minified, ~40-50% smaller JS bundles on every deployed platform.

## Non-goals

- No `.spec` changes — the existing `('static', 'static')` `datas` entry ships `static/dist/` automatically once it exists on disk
- No template / Python code changes — #1597 handled that
- No Docker changes — that's #1598

Refs: #1334, #1596, #1597, #1598