### PR TITLE
correct branch reporting from container runs

### DIFF
--- a/modules/process_lifecycle.py
+++ b/modules/process_lifecycle.py
@@ -55,6 +55,30 @@ from modules.process_markers import (
 )
 from modules.process_run_context import update_imagemaid_run_context
 
+_KOMETA_RUNTIME_BRANCHES = {"master", "develop", "nightly"}
+
+
+def _normalize_kometa_runtime_branch(value):
+    branch = str(value or "").strip().lower()
+    return branch if branch in _KOMETA_RUNTIME_BRANCHES else None
+
+
+def _resolve_kometa_runtime_branch(kometa_root):
+    branch = _normalize_kometa_runtime_branch(helpers.get_kometa_local_branch(kometa_root))
+    if branch:
+        return branch
+    return _normalize_kometa_runtime_branch(helpers.detect_git_branch(kometa_root, default=None))
+
+
+def _build_kometa_runtime_env(kometa_root):
+    env = os.environ.copy()
+    branch = _resolve_kometa_runtime_branch(kometa_root)
+    if branch:
+        env["BRANCH_NAME"] = branch
+    else:
+        env.pop("BRANCH_NAME", None)
+    return env, branch
+
 
 def stop_process_tree(proc):
     try:
@@ -123,8 +147,20 @@ def launch_kometa_command(command, config_name=None, start_mode="current"):
     stamp_quickstart_config_marker(config_path, config_name)
 
     helpers.ts_log(f"argv={command_parts!r}", level="DEBUG")
+    runtime_env, runtime_branch = _build_kometa_runtime_env(kometa_root)
+    if runtime_branch:
+        helpers.ts_log(f"Kometa launch BRANCH_NAME={runtime_branch}", level="DEBUG")
+    else:
+        helpers.ts_log("Kometa launch BRANCH_NAME cleared", level="DEBUG")
 
-    proc = subprocess.Popen(command_parts, cwd=str(kometa_root), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True)
+    proc = subprocess.Popen(
+        command_parts,
+        cwd=str(kometa_root),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+        env=runtime_env,
+    )
 
     with open(helpers.get_kometa_pid_file(), "w", encoding="utf-8") as f:
         f.write(str(proc.pid))

--- a/tests/test_start_stop.py
+++ b/tests/test_start_stop.py
@@ -369,6 +369,82 @@ def test_launch_imagemaid_command_aborts_when_runtime_env_reset_fails(tmp_path, 
     assert "could not reset ImageMaid env file before launch" in result
 
 
+def test_launch_kometa_command_sets_branch_name_from_local_branch_metadata(tmp_path, monkeypatch, qs_module):
+    is_win = qs_module.sys.platform.startswith("win")
+    kometa_root = tmp_path / "kometa"
+    venv_dir = kometa_root / "kometa-venv" / ("Scripts" if is_win else "bin")
+    venv_dir.mkdir(parents=True, exist_ok=True)
+    (kometa_root / "kometa.py").write_text("print('kometa')\n", encoding="utf-8")
+    (venv_dir / ("python.exe" if is_win else "python3")).write_text("", encoding="utf-8")
+    (kometa_root / ".kometa_branch").write_text("nightly", encoding="utf-8")
+    pid_file = tmp_path / "kometa.pid"
+    config_path = kometa_root / "config" / "config.yml"
+    popen_calls = {}
+
+    class FakeProc:
+        pid = 4321
+
+    def fake_popen(command_parts, cwd=None, stdout=None, stderr=None, start_new_session=None, env=None):
+        popen_calls["command_parts"] = command_parts
+        popen_calls["cwd"] = cwd
+        popen_calls["start_new_session"] = start_new_session
+        popen_calls["env"] = env
+        return FakeProc()
+
+    monkeypatch.setenv("BRANCH_NAME", "develop")
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_root_path", lambda: kometa_root)
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_pid_file", lambda: str(pid_file))
+    monkeypatch.setattr(qs_module.helpers, "ts_log", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(qs_module.subprocess, "Popen", fake_popen)
+    monkeypatch.setitem(qs_module._launch_kometa_command.__globals__, "extract_kometa_config_path", lambda *_args, **_kwargs: config_path)
+    monkeypatch.setitem(qs_module._launch_kometa_command.__globals__, "stamp_quickstart_config_marker", lambda *_args, **_kwargs: None)
+    monkeypatch.setitem(qs_module._launch_kometa_command.__globals__, "schedule_quickstart_run_marker", lambda *_args, **_kwargs: None)
+
+    ok, result = qs_module._launch_kometa_command("python kometa.py --collections-only", config_name="cfg")
+
+    assert ok is True
+    assert result == 4321
+    assert pid_file.read_text(encoding="utf-8") == "4321"
+    assert popen_calls["cwd"] == str(kometa_root)
+    assert popen_calls["start_new_session"] is True
+    assert popen_calls["env"]["BRANCH_NAME"] == "nightly"
+
+
+def test_launch_kometa_command_clears_inherited_branch_name_without_local_metadata(tmp_path, monkeypatch, qs_module):
+    is_win = qs_module.sys.platform.startswith("win")
+    kometa_root = tmp_path / "kometa"
+    venv_dir = kometa_root / "kometa-venv" / ("Scripts" if is_win else "bin")
+    venv_dir.mkdir(parents=True, exist_ok=True)
+    (kometa_root / "kometa.py").write_text("print('kometa')\n", encoding="utf-8")
+    (venv_dir / ("python.exe" if is_win else "python3")).write_text("", encoding="utf-8")
+    pid_file = tmp_path / "kometa.pid"
+    config_path = kometa_root / "config" / "config.yml"
+    popen_calls = {}
+
+    class FakeProc:
+        pid = 4321
+
+    def fake_popen(command_parts, cwd=None, stdout=None, stderr=None, start_new_session=None, env=None):
+        popen_calls["env"] = env
+        return FakeProc()
+
+    monkeypatch.setenv("BRANCH_NAME", "develop")
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_root_path", lambda: kometa_root)
+    monkeypatch.setattr(qs_module.helpers, "get_kometa_pid_file", lambda: str(pid_file))
+    monkeypatch.setattr(qs_module.helpers, "detect_git_branch", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(qs_module.helpers, "ts_log", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(qs_module.subprocess, "Popen", fake_popen)
+    monkeypatch.setitem(qs_module._launch_kometa_command.__globals__, "extract_kometa_config_path", lambda *_args, **_kwargs: config_path)
+    monkeypatch.setitem(qs_module._launch_kometa_command.__globals__, "stamp_quickstart_config_marker", lambda *_args, **_kwargs: None)
+    monkeypatch.setitem(qs_module._launch_kometa_command.__globals__, "schedule_quickstart_run_marker", lambda *_args, **_kwargs: None)
+
+    ok, result = qs_module._launch_kometa_command("python kometa.py --collections-only", config_name="cfg")
+
+    assert ok is True
+    assert result == 4321
+    assert "BRANCH_NAME" not in popen_calls["env"]
+
+
 def test_start_imagemaid_blocked_during_maintenance(client, tmp_path, monkeypatch, qs_module):
     imagemaid_root = tmp_path / "imagemaid"
     log_dir = imagemaid_root / "config" / "logs"


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

**Title**

Fix managed Kometa branch reporting when Quickstart runs in a container

**Description**

This updates Quickstart’s Kometa launch path to stop leaking the container’s inherited `BRANCH_NAME` into managed Kometa runs. Quickstart now sets the child process branch env from the installed Kometa branch metadata when available, and clears it when it cannot determine a valid runtime branch, so `meta.log` and related branch-dependent behavior reflect the actual installed branch.

Adds regression coverage for both cases:
- managed branch metadata overriding an inherited container branch
- inherited `BRANCH_NAME` being cleared when no valid local branch is available

**Testing**

`venv\Scripts\python.exe -m pytest tests\test_start_stop.py`

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
