### PR TITLE
fix 2 failing tests

### DIFF
--- a/modules/process_control.py
+++ b/modules/process_control.py
@@ -240,10 +240,15 @@ def maintenance_guard_loop(app_in):
                             window_label = f" ({window_str})" if window_str else ""
                             helpers.ts_log(f"Kometa paused due to Plex maintenance window{window_label}.", level="INFO")
                             try:
-                                if not quickstart._write_quickstart_maintenance_marker(helpers.get_kometa_root_path(), "paused", window=window_str):
-                                    helpers.ts_log("Failed to append Quickstart paused maintenance marker to meta.log.", level="WARNING")
+                                if not quickstart._write_quickstart_maintenance_marker(
+                                    helpers.get_kometa_root_path(),
+                                    "paused",
+                                    window=window_str,
+                                    mirror_to_meta_log=True,
+                                ):
+                                    helpers.ts_log("Failed to record Quickstart paused maintenance marker.", level="WARNING")
                             except Exception:
-                                helpers.ts_log("Failed to append Quickstart paused maintenance marker to meta.log.", level="WARNING")
+                                helpers.ts_log("Failed to record Quickstart paused maintenance marker.", level="WARNING")
                             with MAINTENANCE_STATE_LOCK:
                                 MAINTENANCE_STATE["paused"] = True
                                 MAINTENANCE_STATE["paused_since"] = datetime.now(timezone.utc).isoformat()
@@ -269,10 +274,11 @@ def maintenance_guard_loop(app_in):
                                     "resumed",
                                     window=window_str,
                                     paused_seconds=paused_seconds,
+                                    mirror_to_meta_log=True,
                                 ):
-                                    helpers.ts_log("Failed to append Quickstart resumed maintenance marker to meta.log.", level="WARNING")
+                                    helpers.ts_log("Failed to record Quickstart resumed maintenance marker.", level="WARNING")
                             except Exception:
-                                helpers.ts_log("Failed to append Quickstart resumed maintenance marker to meta.log.", level="WARNING")
+                                helpers.ts_log("Failed to record Quickstart resumed maintenance marker.", level="WARNING")
                             with MAINTENANCE_STATE_LOCK:
                                 MAINTENANCE_STATE["paused"] = False
                                 MAINTENANCE_STATE["paused_since"] = None
@@ -313,10 +319,11 @@ def maintenance_guard_loop(app_in):
                             config_name=imagemaid_config_name,
                             window=window_str,
                             log_path=imagemaid_log_path,
+                            mirror_to_live_log=True,
                         ):
-                            helpers.ts_log("Failed to append Quickstart paused ImageMaid maintenance marker to the live log.", level="WARNING")
+                            helpers.ts_log("Failed to record Quickstart paused ImageMaid maintenance marker.", level="WARNING")
                     except Exception:
-                        helpers.ts_log("Failed to append Quickstart paused ImageMaid maintenance marker to the live log.", level="WARNING")
+                        helpers.ts_log("Failed to record Quickstart paused ImageMaid maintenance marker.", level="WARNING")
                     with MAINTENANCE_STATE_LOCK:
                         MAINTENANCE_STATE["imagemaid_paused"] = True
                         MAINTENANCE_STATE["imagemaid_paused_since"] = datetime.now(timezone.utc).isoformat()
@@ -346,10 +353,11 @@ def maintenance_guard_loop(app_in):
                         window=window_str,
                         log_path=imagemaid_log_path,
                         paused_seconds=imagemaid_paused_seconds,
+                        mirror_to_live_log=True,
                     ):
-                        helpers.ts_log("Failed to append Quickstart resumed ImageMaid maintenance marker to the live log.", level="WARNING")
+                        helpers.ts_log("Failed to record Quickstart resumed ImageMaid maintenance marker.", level="WARNING")
                 except Exception:
-                    helpers.ts_log("Failed to append Quickstart resumed ImageMaid maintenance marker to the live log.", level="WARNING")
+                    helpers.ts_log("Failed to record Quickstart resumed ImageMaid maintenance marker.", level="WARNING")
                 with MAINTENANCE_STATE_LOCK:
                     MAINTENANCE_STATE["imagemaid_paused"] = False
                     MAINTENANCE_STATE["imagemaid_paused_since"] = None

--- a/modules/process_markers.py
+++ b/modules/process_markers.py
@@ -388,10 +388,10 @@ def write_quickstart_run_marker(kometa_root, config_name=None, start_mode="curre
         return False
 
 
-def write_quickstart_maintenance_marker(kometa_root, event, window=None, paused_seconds=None):
+def _build_quickstart_maintenance_marker_line(event, window=None, paused_seconds=None):
     event_name = str(event or "").strip().lower()
     if event_name not in {"paused", "resumed"}:
-        return False
+        return None
     local_at = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
     parts = [
         "[Quickstart] Maintenance marker:",
@@ -403,8 +403,18 @@ def write_quickstart_maintenance_marker(kometa_root, event, window=None, paused_
         parts.append(f"window={str(window).strip()}")
     if event_name == "resumed" and isinstance(paused_seconds, (int, float)):
         parts.append(f"paused_seconds={max(0, int(paused_seconds))}")
-    line = " ".join(parts)
-    return _write_quickstart_marker_line(kometa_root, line, marker_kind="maintenance")
+    return " ".join(parts)
+
+
+def write_quickstart_maintenance_marker(kometa_root, event, window=None, paused_seconds=None, mirror_to_meta_log=False):
+    line = _build_quickstart_maintenance_marker_line(event, window=window, paused_seconds=paused_seconds)
+    if not line:
+        return False
+    pending_ok = _write_quickstart_marker_line(kometa_root, line, marker_kind="maintenance")
+    if mirror_to_meta_log:
+        meta_ok = append_quickstart_meta_log_line(kometa_root, line)
+        return bool(pending_ok and meta_ok)
+    return pending_ok
 
 
 def write_quickstart_imagemaid_run_marker(imagemaid_root, mode=None, config_name=None, log_path=None):
@@ -456,34 +466,59 @@ def write_quickstart_imagemaid_stop_marker(imagemaid_root, mode=None, config_nam
         return False
 
 
-def write_quickstart_imagemaid_maintenance_marker(imagemaid_root, event, mode=None, config_name=None, window=None, log_path=None, paused_seconds=None):
+def _build_quickstart_imagemaid_maintenance_marker_line(event, mode=None, config_name=None, window=None, paused_seconds=None, version_info=None):
     event_name = str(event or "").strip().lower()
     if event_name not in {"blocked_start", "paused", "resumed"}:
-        return False
+        return None
+    version_info = version_info if version_info is not None else _get_version_info()
+    qs_version = version_info.get("local_version") or "unknown"
+    qs_branch = version_info.get("branch") or "unknown"
+    safe_mode = (mode or "report").strip().lower() or "report"
+    safe_config = (config_name or "default").strip() or "default"
+    local_at = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+    parts = [
+        "[Quickstart] Maintenance marker:",
+        f"event={event_name}",
+        f"at={datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')}",
+        f"local_at={local_at}",
+        f"config={safe_config}",
+        "tool=imagemaid",
+        f"mode={safe_mode}",
+        f"quickstart={qs_version}",
+        f"branch={qs_branch}",
+    ]
+    if window:
+        parts.append(f"window={str(window).strip()}")
+    if event_name == "resumed" and isinstance(paused_seconds, (int, float)):
+        parts.append(f"paused_seconds={max(0, int(paused_seconds))}")
+    return " ".join(parts)
+
+
+def write_quickstart_imagemaid_maintenance_marker(
+    imagemaid_root,
+    event,
+    mode=None,
+    config_name=None,
+    window=None,
+    log_path=None,
+    paused_seconds=None,
+    mirror_to_live_log=False,
+):
     try:
-        version_info = _get_version_info()
-        qs_version = version_info.get("local_version") or "unknown"
-        qs_branch = version_info.get("branch") or "unknown"
-        safe_mode = (mode or "report").strip().lower() or "report"
-        safe_config = (config_name or "default").strip() or "default"
-        local_at = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
-        parts = [
-            "[Quickstart] Maintenance marker:",
-            f"event={event_name}",
-            f"at={datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')}",
-            f"local_at={local_at}",
-            f"config={safe_config}",
-            "tool=imagemaid",
-            f"mode={safe_mode}",
-            f"quickstart={qs_version}",
-            f"branch={qs_branch}",
-        ]
-        if window:
-            parts.append(f"window={str(window).strip()}")
-        if event_name == "resumed" and isinstance(paused_seconds, (int, float)):
-            parts.append(f"paused_seconds={max(0, int(paused_seconds))}")
-        line = " ".join(parts)
-        return _write_imagemaid_marker_line(imagemaid_root, line, log_path=log_path, marker_kind="maintenance")
+        line = _build_quickstart_imagemaid_maintenance_marker_line(
+            event,
+            mode=mode,
+            config_name=config_name,
+            window=window,
+            paused_seconds=paused_seconds,
+        )
+        if not line:
+            return False
+        pending_ok = _write_imagemaid_marker_line(imagemaid_root, line, log_path=log_path, marker_kind="maintenance")
+        if mirror_to_live_log:
+            live_ok = append_quickstart_imagemaid_log_line(imagemaid_root, line, log_path=log_path)
+            return bool(pending_ok and live_ok)
+        return pending_ok
     except Exception:
         return False
 

--- a/static/local-js/900-kometa.js
+++ b/static/local-js/900-kometa.js
@@ -170,6 +170,9 @@ document.addEventListener('qs:maintenance-status', function (event) {
 })
 
 updateValidationGate()
+document.addEventListener('DOMContentLoaded', function () {
+  syncIncompleteRunActions()
+}, { once: true })
 
 if (tailSelect) {
   tailSize = tailSelect.value || tailSize

--- a/tests/test_more_paths.py
+++ b/tests/test_more_paths.py
@@ -135,6 +135,7 @@ def test_maintenance_guard_pauses_running_imagemaid(monkeypatch, qs_module, tmp_
         assert kwargs["mode"] == "report"
         assert kwargs["config_name"] == "demo"
         assert kwargs["window"] == "02:00-05:00"
+        assert kwargs["mirror_to_live_log"] is True
         return True
 
     monkeypatch.setattr(qs_module, "_write_quickstart_imagemaid_maintenance_marker", fake_marker)
@@ -256,6 +257,7 @@ def test_maintenance_guard_resumes_paused_imagemaid(monkeypatch, qs_module, tmp_
         assert kwargs["window"] == "02:00-05:00"
         assert isinstance(kwargs["paused_seconds"], int)
         assert kwargs["paused_seconds"] >= 60
+        assert kwargs["mirror_to_live_log"] is True
         return True
 
     monkeypatch.setattr(qs_module, "_write_quickstart_imagemaid_maintenance_marker", fake_marker)

--- a/tests/test_process_markers.py
+++ b/tests/test_process_markers.py
@@ -65,6 +65,52 @@ def test_write_quickstart_stop_marker_writes_pending_journal_without_touching_me
     assert "reason=user_stop" in pending_text
 
 
+def test_write_quickstart_maintenance_marker_can_mirror_live_meta_log(tmp_path):
+    import modules.process_markers as process_markers
+
+    ok = process_markers.write_quickstart_maintenance_marker(
+        tmp_path,
+        "paused",
+        window="02:00-05:00",
+        mirror_to_meta_log=True,
+    )
+
+    assert ok is True
+    pending_path = process_markers.get_kometa_pending_marker_path(tmp_path)
+    meta_path = tmp_path / "config" / "logs" / "meta.log"
+    assert pending_path.exists()
+    assert meta_path.exists()
+    pending_text = pending_path.read_text(encoding="utf-8")
+    meta_text = meta_path.read_text(encoding="utf-8")
+    assert "event=paused" in pending_text
+    assert "event=paused" in meta_text
+
+
+def test_write_quickstart_imagemaid_maintenance_marker_can_mirror_live_log(tmp_path):
+    import modules.process_markers as process_markers
+
+    log_path = tmp_path / "config" / "logs" / "imagemaid.log"
+    ok = process_markers.write_quickstart_imagemaid_maintenance_marker(
+        tmp_path,
+        "paused",
+        mode="report",
+        config_name="demo",
+        window="02:00-05:00",
+        log_path=log_path,
+        mirror_to_live_log=True,
+    )
+
+    assert ok is True
+    pending_path = process_markers.get_imagemaid_pending_marker_path(tmp_path)
+    assert pending_path.exists()
+    assert log_path.exists()
+    pending_text = pending_path.read_text(encoding="utf-8")
+    log_text = log_path.read_text(encoding="utf-8")
+    assert "event=paused" in pending_text
+    assert "event=paused" in log_text
+    assert "tool=imagemaid" in log_text
+
+
 def test_flush_quickstart_pending_markers_falls_back_to_first_quickstart_line(monkeypatch, tmp_path, qs_module):
     log_dir = tmp_path / "config" / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

Fix Kometa recovery-button bootstrap timing and restore live maintenance markers.
This keeps Quickstart’s maintenance writers pending-first by default, but lets the maintenance guard mirror pause/resume markers into the live Kometa and ImageMaid logs when those events happen. It also re-runs the Kometa recovery-button sync on DOMContentLoaded, fixing the module bootstrap case where incomplete-run DOM appears after the first validation pass.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
