### PR TITLE
Convert 4 namespace-object files to ES modules (#1346 finish)

### DIFF
--- a/static/local-js/imageHandler.js
+++ b/static/local-js/imageHandler.js
@@ -1,4 +1,7 @@
-const ImageHandler = {
+// ES module (#1346 Step 2 finish). Also publishes `window.ImageHandler`
+// for the eventHandler/overlayHandler consumers that still read from window.
+// New JS consumers should prefer the named export.
+export const ImageHandler = {
   BUILTIN_PREVIEW_IMAGES: new Set([
     'overlay_alignment_guide.png',
     'overlay_alignment_guide_episodes.png'
@@ -564,6 +567,7 @@ const ImageHandler = {
 }
 
 window.ImageHandler = ImageHandler
+export default ImageHandler
 
 // Global listener to refresh image preview only if toggle is in preview overlay section
 document.querySelectorAll('.form-check-input').forEach((input) => {

--- a/static/local-js/pathValidation.js
+++ b/static/local-js/pathValidation.js
@@ -1,4 +1,7 @@
-const PathValidation = (() => {
+// ES module (#1346 Step 2 finish). Also publishes `window.PathValidation`
+// for classic-script consumers that can't use `import` (e.g. 915-imagemaid.js).
+// New JS consumers should prefer the named export.
+export const PathValidation = (() => {
   let rules = []
   let meta = { platform: 'linux', is_docker: false }
   let loadPromise = null
@@ -256,3 +259,4 @@ const PathValidation = (() => {
 })()
 
 window.PathValidation = PathValidation
+export default PathValidation

--- a/static/local-js/urlValidation.js
+++ b/static/local-js/urlValidation.js
@@ -1,4 +1,7 @@
-const URLValidation = (() => {
+// ES module (#1346 Step 2 finish). Also publishes `window.URLValidation`
+// for classic-script consumers that can't use `import`. New JS consumers
+// should prefer the named export.
+export const URLValidation = (() => {
   const urlKeyPattern = /(^|[_-])url([_-]|$)/i
   const placeholderValues = new Set(['http://', 'https://'])
 
@@ -125,6 +128,7 @@ const URLValidation = (() => {
 })()
 
 window.URLValidation = URLValidation
+export default URLValidation
 
 function isValidHostname (hostname) {
   const host = String(hostname || '').toLowerCase()

--- a/static/local-js/validationHandler.js
+++ b/static/local-js/validationHandler.js
@@ -1,7 +1,14 @@
-const librariesValidatedAtInput = document.getElementById('libraries_validated_at')
+// ES module (#1346 Step 2 finish). Also publishes `window.ValidationHandler`
+// for the eventHandler/overlayHandler consumers that still read from window.
+// New JS consumers should prefer the named export.
+//
+// `export`ing the first `const` marker satisfies vite.detectModuleEntry's
+// "first non-comment token is import/export" rule; the real public API is
+// `ValidationHandler` further down.
+export const librariesValidatedAtInput = document.getElementById('libraries_validated_at')
 let librariesTouched = false
 
-const ValidationHandler = {
+export const ValidationHandler = {
   updateValidationState: function () {
     console.log('[DEBUG] Running validation state update.')
 
@@ -352,6 +359,7 @@ const ValidationHandler = {
 }
 
 window.ValidationHandler = ValidationHandler
+export default ValidationHandler
 
 // Restore previously selected libraries
 ValidationHandler.restoreSelectedLibraries()

--- a/tests/js/imageHandler.test.js
+++ b/tests/js/imageHandler.test.js
@@ -1,7 +1,9 @@
 // Tests for static/local-js/imageHandler.js (#1335 Step 8 - coverage push).
 //
-// imageHandler.js is a classic script (attaches ImageHandler to window)
-// with several side effects at import time:
+// imageHandler.js is an ES module (#1346 Step 2 finish) that also
+// attaches `ImageHandler` to `window` for backward compat with the
+// eventHandler/overlayHandler consumers. Several side effects run at
+// import time:
 //   - Reads `document.querySelectorAll('.form-check-input')` to attach a
 //     change listener. Empty result when the DOM has no such elements, so
 //     we're safe as long as the DOM is empty (or has none of those) at

--- a/tests/js/validationHandler.test.js
+++ b/tests/js/validationHandler.test.js
@@ -1,10 +1,11 @@
 // Tests for static/local-js/validationHandler.js (#1335 Step 8 — coverage push).
 //
-// validationHandler.js is a classic script (not an ES module): it attaches
-// `ValidationHandler` to `window` and runs a few side effects at import
-// time (restoreSelectedLibraries, updateValidationState, plus document
-// change/input listeners). Same shape as pathValidation / urlValidation,
-// so we use the same side-effect-import pattern:
+// validationHandler.js is an ES module (#1346 Step 2 finish) that also
+// attaches `ValidationHandler` to `window` for classic-script consumers.
+// It runs a few side effects at import time (restoreSelectedLibraries,
+// updateValidationState, plus document change/input listeners). Same
+// shape as pathValidation / urlValidation / imageHandler, so we use
+// the same side-effect-import pattern:
 //
 //   1. Seed a minimal DOM the module's init calls can safely walk
 //   2. `await import('.../validationHandler.js')`

--- a/tests/test_vite_manifest.py
+++ b/tests/test_vite_manifest.py
@@ -143,10 +143,11 @@ class TestAssetUrlWithManifest:
     def test_returns_dist_path_for_chunk_keyed_by_source(self, fake_manifest):
         """Non-entry chunks that are still keyed with a source path resolve too.
 
-        (Vite emits entries for e.g. ``imageHandler.js`` even though it's not
-        declared as an entry, if a real entry dynamically imports it. The
-        template never references these directly, but if it ever did the
-        lookup should still work.)
+        (Vite emits entries for shared chunks under ``static/local-js/modules/``
+        keyed by their source path even though they're not declared as
+        entries -- a real entry dynamically imports them. The template never
+        references these directly, but if it ever did the lookup should
+        still work.)
         """
         fake_manifest.write_text(
             json.dumps(

--- a/vite.config.js
+++ b/vite.config.js
@@ -53,10 +53,15 @@ function discoverModuleEntries (dir) {
   // dependencies imported by other modules.
   //
   // Files that MODULE_PAGE_SCRIPTS lists but which don't actually use
-  // import/export (100-anidb.js, 915-imagemaid.js, imageHandler.js,
-  // validationHandler.js) are also skipped -- Vite building them
-  // would produce a byte-for-byte copy of the source, providing no
-  // value while cluttering static/dist/.
+  // import/export (100-anidb.js, 915-imagemaid.js) are skipped -- Vite
+  // building them would produce a byte-for-byte copy of the source,
+  // providing no value while cluttering static/dist/.
+  //
+  // As of #1346 finish, imageHandler.js, pathValidation.js,
+  // urlValidation.js, and validationHandler.js DO use `export` and
+  // therefore are entry points. They also keep their `window.*` shims
+  // for backward compat with classic-script consumers (see
+  // 915-imagemaid.js) and consumers not yet migrated to `import`.
   const entries = {}
   for (const name of readdirSync(dir)) {
     const fullPath = join(dir, name)


### PR DESCRIPTION
The last four holdouts from Step 2 (`imageHandler`, `pathValidation`, `urlValidation`, `validationHandler`) had the *shape* of ES modules already — single namespace object, no top-level cross-file coupling — but were declared as classic scripts because they published via `window.*` instead of `export`. This PR adds `export` alongside the existing `window.*` shims.

**Zero consumer-side changes required.**

## What changed

Per file, two-line diff:

```js
export const X = ...   // was: const X = ...
...
window.X = X
export default X       // added
```

`validationHandler.js` needed the `export` lifted onto the first top-level `const` (two DOM lookups came before the object literal) so Vite's `isModuleSource()` — which checks the first non-comment token — picks it up as a module entry.

## Why the shim-preserving approach

Each file has multiple consumer classes:
- Classic scripts (`915-imagemaid.js`) that can't use `import`
- ES-module consumers already dynamically-importing for side effects (`025-libraries.js`)
- Bare-name callers via ESLint-declared globals (`eventHandler.js`, `overlayHandler.js`)

Migrating all consumers to `import { X } from '...'` is a larger, riskier refactor. This PR does the cheap, safe half: mark the files as modules so Vite bundles them, hashes them, and includes them in the manifest. The `window.*` shims stay as the migration bridge. Consumer-side migration is a future PR — or gets rolled into Step 9 (component islands) where these files are prime rewrite candidates anyway.

## Verification

- `npm run build`: all four files appear as `isEntry=True` in `static/dist/.vite/manifest.json` with proper content hashes
- `npm test`: **1527/1527** tests pass
- `pytest tests/test_vite_manifest.py`: **18/18** pass
- pre-commit: **12/12** green

## Doc updates

- `vite.config.js` — comment updated: only `100-anidb.js` and `915-imagemaid.js` remain as "intentionally not modules"
- Vitest test comments for `imageHandler` and `validationHandler` updated from "classic script" to "ES module that also attaches X to window"
- `tests/test_vite_manifest.py` — test comment refactored (previously used `imageHandler` as an example of a non-entry chunk; no longer accurate)

## Files still classic (correctly)

| File | Why |
|---|---|
| `100-anidb.js` | 20-line self-contained page script, no exports, no consumers |
| `910-sponsor.js` | empty |
| `915-imagemaid.js` | 1404-line self-contained page script, no cross-file consumers |
| `templateStringList.js` | IIFE, no consumers |
| `rgbaPicker.js` | pure DOM delegation, no exports |

These are exactly the files Vite's auto-discovery correctly skips — bundling them would produce byte-for-byte copies.

**Closes the last outstanding scope of #1346.**