### PR TITLE
ESLint setup follow-up cleanups (closes #1345)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,9 +33,10 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22'
+          cache: 'npm'
 
       - name: Install Node Dependencies
-        run: npm install --no-fund --no-audit
+        run: npm ci --no-fund --no-audit
 
       - name: Cache Pre-commit Environments
         uses: actions/cache@v6

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -160,7 +160,6 @@ const retiredShimMessage = (name) =>
 module.exports = [
   {
     files: ['static/local-js/**/*.js'],
-    ignores: ['static/local-js/bootstrap.bundle.js'],
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'script',

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "quickstart-js-tooling",
   "private": true,
   "scripts": {
-    "lint:eslint": "eslint static/local-js --ext .js",
+    "lint:eslint": "eslint static/local-js",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",


### PR DESCRIPTION
Three small items from #1345 that never got knocked out. Items 3 (`/* global */` header cleanup) and 5 (`sourceType` module flip) landed incidentally during Step 2 (ES modules) work. These are the leftovers.

## Changes

**1. `package.json`** — drop `--ext .js` from the `lint:eslint` script. No-op under ESLint 9's flat config (silently ignored). Leftover from the `.eslintrc` era.

**2. `eslint.config.js`** — delete the dead `ignores: ['static/local-js/bootstrap.bundle.js']` entry. File doesn't exist in the repo. `.pre-commit-config.yaml`'s top-level exclude would cover it if it ever came back.

**3. `.github/workflows/lint.yml`** — fix the Lint job's Node setup to match what the Vitest and Vite-Build jobs (added later) already do:
- `cache: 'npm'` on `setup-node`
- `npm ci` instead of `npm install`

Saves ~2s per run and enforces lockfile integrity.

## Verification

- `npm run lint:eslint`: clean, no output changes
- pre-commit: 12/12 green
- Zero behavior changes; purely hygiene

## Total diff

+3 / -3 across 3 files.