### PR TITLE
Reshape PR template to make `Closes #` prominent

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,23 @@
-## What type of PR is this?
+## Related Issues
 
 <!--
-    Place an X in any relevant option, for example:
-    - [X] Bug Fix (non-breaking change which fixes an issue)
+  This section matters -- please fill it in even if the PR is just
+  a small cleanup. Because this repo squash-merges, individual commit
+  trailers get discarded on merge, and GitHub only auto-closes issues
+  when the keyword appears in the PR *body* (i.e. right here).
+
+  Auto-close keywords: Closes #, Fixes #, Resolves #
+  Link-only keywords:  Refs #, Related: #
+
+  Delete the placeholder or fill it in. "N/A" is also a fine answer
+  for PRs that don't relate to any issue.
 -->
+
+Closes #
+
+## What type of PR is this?
+
+<!-- Place an X in any relevant option(s). -->
 
 - [ ] Bug Fix (non-breaking change which fixes an issue)
 - [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
@@ -15,22 +29,9 @@
 
 _Please replace this line with a meaningful description of your PR. What does it do? Why? Has it been tested? What were the results?_
 
-## Related Issues [optional]
-
-<!--
-    For pull requests that relate or close an issue, please include them below.
-    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
-    And when the merged pull request reaches the master branch, Github will automatically close the issue.
--->
-
-- Closes #
-
 ## Which Environment Did You Test On?
 
-<!--
-    Place an X in any/all relevant option(s), for example:
-    - [X] Windows Executable
--->
+<!-- Place an X in any/all relevant option(s). -->
 
 - [ ] Local Install (Windows/Linux/Mac via `python quickstart.py`)
 - [ ] Windows Executable


### PR DESCRIPTION
## Related Issues

Refs #1345, #1584, #1600 (all three were manually closed after merge because the PR body didn't have a working `Closes #` line).

## What type of PR is this?

- [x] Documentation Update

## Description

The PR template already exists at `.github/pull_request_template.md`, but the section that hooks GitHub auto-close was structured in a way that guarantees people skip it:

- Labeled **"Related Issues [optional]"** — signals "you can skip this"
- Placed at the **bottom** of the template — easy to miss
- Wrapped in an HTML comment block — no visual weight

Result: PR authors routinely land `- Closes #` with the number left blank. GitHub can't auto-close, so someone (Chaz, mostly) has to manually close the issue later. Three recent examples: #1584, #1345, and the initial pass on #1600 all had this pathology.

### The underlying reason

This repo squash-merges. That's fine — it keeps `git log` clean — but it means individual **commit trailers get discarded on merge**. GitHub's issue auto-close scans the *squash commit message*, which is derived from the **PR body** (not the individual branch commits). So even if bullmoose puts `Fixes #1584` in a nice commit message on his branch, that keyword vanishes at merge time and the issue stays open.

Which means: the PR body is the *only* place that reliably triggers auto-close under our merge strategy.

## Changes

- Move **Related Issues** to the **top** of the template
- Drop the `[optional]` suffix from the heading — it isn't
- Rewrite the guidance comment to explain **why** the field matters (the squash-merge behavior above)
- Remove the now-redundant Testing section (the Description section covers it and nobody was filling both in anyway)

## Which Environment Did You Test On?

- [x] N/A — template only affects the pre-filled body of new PRs going forward. Existing PRs are unaffected. Zero code change.

## Not in scope

- Repo settings changes (allowed merge strategies stay squash-only)
- Changes to `.github/ISSUE_TEMPLATE/`