### PR TITLE
fixed arr persistence

### DIFF
--- a/templates/110-radarr.html
+++ b/templates/110-radarr.html
@@ -208,8 +208,10 @@
 </div>
 </form>
 <script>
-    // Pass the initial values from Jinja to JavaScript
-    const initialRadarrRootFolderPath = "{{ data['radarr']['root_folder_path'] }}"
-    const initialRadarrQualityProfile = "{{ data['radarr']['quality_profile'] }}";
+    // Publish the saved dropdown selections on window so the shared
+    // arrPageBase repopulation helper can restore them on silent
+    // revalidation when the user returns to this page.
+    window.initialRadarrRootFolderPath = {{ data['radarr']['root_folder_path'] | tojson }};
+    window.initialRadarrQualityProfile = {{ data['radarr']['quality_profile'] | tojson }};
 </script>
 {% endblock %}

--- a/templates/120-sonarr.html
+++ b/templates/120-sonarr.html
@@ -261,9 +261,11 @@
 </div>
 </form>
 <script>
-    // Pass the initial values from Jinja to JavaScript
-    const initialSonarrRootFolderPath = "{{ data['sonarr']['root_folder_path'] }}"
-    const initialSonarrQualityProfile = "{{ data['sonarr']['quality_profile'] }}"
-    const initialSonarrLanguageProfile = "{{ data['sonarr']['language_profile'] }}";
+    // Publish the saved dropdown selections on window so the shared
+    // arrPageBase repopulation helper can restore them on silent
+    // revalidation when the user returns to this page.
+    window.initialSonarrRootFolderPath = {{ data['sonarr']['root_folder_path'] | tojson }};
+    window.initialSonarrQualityProfile = {{ data['sonarr']['quality_profile'] | tojson }};
+    window.initialSonarrLanguageProfile = {{ data['sonarr']['language_profile'] | tojson }};
 </script>
 {% endblock %}

--- a/tests/e2e/test_wizard_e2e.py
+++ b/tests/e2e/test_wizard_e2e.py
@@ -18,6 +18,21 @@ def _seed_config(name):
     )
 
 
+def _activate_config(page, live_server, name):
+    page.goto(f"{live_server}/step/001-start", wait_until="domcontentloaded")
+    page.evaluate(
+        """async (configName) => {
+          const res = await fetch('/switch-config', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name: configName })
+          })
+          if (!res.ok) throw new Error('failed to activate config')
+        }""",
+        name,
+    )
+
+
 def _ordered_stems():
     import modules.helpers as helpers
     import quickstart
@@ -518,6 +533,102 @@ def test_radarr_revalidate_on_load_repopulates_dropdowns(page, live_server):
     dropdown_values = page.locator("#radarr_root_folder_path").evaluate("el => Array.from(el.options).map(o => o.value)")
     assert "NO_MATCH_REVAL_FOLDER" in dropdown_values, f"expected revalidateOnLoad to repopulate dropdown; got {dropdown_values}"
     assert fetch_count["n"] >= 1, f"expected at least one silent fetch; got count={fetch_count['n']}"
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    "stem, section, endpoint, saved_section, response_data, expected_values",
+    [
+        (
+            "110-radarr",
+            "radarr",
+            "validate_radarr",
+            {
+                "url": "http://radarr.local",
+                "token": "saved-radarr-token",
+                "root_folder_path": "/movies",
+                "quality_profile": "HD-1080p",
+            },
+            {
+                "valid": True,
+                "root_folders": [{"path": "/movies"}, {"path": "/four-k"}],
+                "quality_profiles": [{"name": "HD-1080p"}, {"name": "4K"}],
+            },
+            {
+                "radarr_root_folder_path": "/movies",
+                "radarr_quality_profile": "HD-1080p",
+            },
+        ),
+        (
+            "120-sonarr",
+            "sonarr",
+            "validate_sonarr",
+            {
+                "url": "http://sonarr.local",
+                "token": "saved-sonarr-token",
+                "root_folder_path": "/tv",
+                "quality_profile": "HD-720p",
+                "language_profile": "English",
+            },
+            {
+                "valid": True,
+                "root_folders": [{"path": "/tv"}, {"path": "/anime"}],
+                "quality_profiles": [{"name": "HD-720p"}, {"name": "HD-1080p"}],
+                "language_profiles": [{"name": "English"}, {"name": "Japanese"}],
+            },
+            {
+                "sonarr_root_folder_path": "/tv",
+                "sonarr_quality_profile": "HD-720p",
+                "sonarr_language_profile": "English",
+            },
+        ),
+    ],
+)
+def test_arr_page_return_restores_saved_dropdown_selection(
+    page,
+    live_server,
+    app,
+    stem,
+    section,
+    endpoint,
+    saved_section,
+    response_data,
+    expected_values,
+):
+    """Returning to a validated Arr page should silently revalidate,
+    repopulate the dynamic dropdowns, and re-select the values saved in
+    the config. The earlier regression coverage only asserted that the
+    OPTIONS reappeared, which missed the broken saved-selection restore.
+    """
+
+    import modules.database as database
+    import quickstart
+
+    config_name = f"pytest_{section}_return_persisted_dropdowns"
+    _seed_config(config_name)
+    with app.app_context():
+        database.save_section_data(
+            name=config_name,
+            section=section,
+            validated=True,
+            user_entered=True,
+            data={section: saved_section, "validated_at": quickstart.utc_now_iso()},
+        )
+
+    fetch_count = {"n": 0}
+
+    def handle_validate(route):
+        fetch_count["n"] += 1
+        route.fulfill(status=200, json=response_data)
+
+    page.route(f"**/{endpoint}", handle_validate)
+    _activate_config(page, live_server, config_name)
+    page.goto(f"{live_server}/step/{stem}", wait_until="domcontentloaded")
+    page.wait_for_timeout(500)
+
+    assert fetch_count["n"] >= 1, "expected silent revalidate on page return"
+    for element_id, expected_value in expected_values.items():
+        expect(page.locator(f"#{element_id}")).to_have_value(expected_value)
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

**Title**

Fix Radarr/Sonarr saved dropdown selections not restoring on page return

**PR Description**

## Summary

This fixes a regression on the Radarr and Sonarr pages where saved selections like root folder path, quality profile, and language profile were not restored when returning to an already-validated page.

The silent revalidate flow was repopulating the dropdown options, but it was not re-selecting the saved values.

## Root cause

`arrPageBase.js` restores saved Arr selections by reading `window.initial...` values during dropdown repopulation.

The Radarr and Sonarr templates were injecting those saved values as top-level `const` bindings instead of `window` properties, so the shared helper could not see them on return.

## What changed

- Updated `110-radarr.html` to publish saved Radarr dropdown values on `window`
- Updated `120-sonarr.html` to publish saved Sonarr dropdown values on `window`
- Added an e2e regression that:
  - seeds a config with saved Arr selections
  - returns to the validated Radarr/Sonarr page
  - waits for silent revalidation
  - asserts the saved dropdown values are actually selected

## Why tests did not catch it

The existing tests only verified that the dropdown options were repopulated after revalidation.

They did not verify that the previously saved selection was restored, which is the specific behavior that was broken.

## Testing

Ran:

```powershell
venv\Scripts\python.exe -m pytest tests\e2e\test_wizard_e2e.py -m e2e -k "arr_page_return_restores_saved_dropdown_selection or radarr_revalidate_on_load_repopulates_dropdowns or dropdown_populating_wizard_success_flow"
```

Result:

```text
5 passed, 68 deselected
```

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
