### PR TITLE
fixed

### DIFF
--- a/templates/110-radarr.html
+++ b/templates/110-radarr.html
@@ -211,7 +211,7 @@
     // Publish the saved dropdown selections on window so the shared
     // arrPageBase repopulation helper can restore them on silent
     // revalidation when the user returns to this page.
-    window.initialRadarrRootFolderPath = {{ data['radarr']['root_folder_path'] | tojson }};
-    window.initialRadarrQualityProfile = {{ data['radarr']['quality_profile'] | tojson }};
+    window.initialRadarrRootFolderPath = {{ data['radarr']['root_folder_path'] | default('', true) | tojson }};
+    window.initialRadarrQualityProfile = {{ data['radarr']['quality_profile'] | default('', true) | tojson }};
 </script>
 {% endblock %}

--- a/templates/120-sonarr.html
+++ b/templates/120-sonarr.html
@@ -264,8 +264,8 @@
     // Publish the saved dropdown selections on window so the shared
     // arrPageBase repopulation helper can restore them on silent
     // revalidation when the user returns to this page.
-    window.initialSonarrRootFolderPath = {{ data['sonarr']['root_folder_path'] | tojson }};
-    window.initialSonarrQualityProfile = {{ data['sonarr']['quality_profile'] | tojson }};
-    window.initialSonarrLanguageProfile = {{ data['sonarr']['language_profile'] | tojson }};
+    window.initialSonarrRootFolderPath = {{ data['sonarr']['root_folder_path'] | default('', true) | tojson }};
+    window.initialSonarrQualityProfile = {{ data['sonarr']['quality_profile'] | default('', true) | tojson }};
+    window.initialSonarrLanguageProfile = {{ data['sonarr']['language_profile'] | default('', true) | tojson }};
 </script>
 {% endblock %}

--- a/tests/e2e/test_wizard_e2e.py
+++ b/tests/e2e/test_wizard_e2e.py
@@ -1589,9 +1589,9 @@ def test_validation_handler_show_message_textcontent_by_default(page, live_serve
     # Pick a page that includes #validation-messages in its template.
     # 900-kometa has it (templates/900-kometa.html:272).
     page.goto(f"{live_server}/step/900-kometa", wait_until="domcontentloaded")
-    page.add_script_tag(path="static/local-js/validationHandler.js")
+    page.evaluate("""() => import(`/static/local-js/validationHandler.js?validation-handler-test=${Date.now()}`)""")
     page.evaluate("""
-        ValidationHandler.showValidationMessage(
+        window.ValidationHandler.showValidationMessage(
             'Plain <strong>text</strong> message', 'danger'
         )
     """)
@@ -1609,9 +1609,9 @@ def test_validation_handler_show_message_html_opt_in_renders_html(page, live_ser
     A link inside the message becomes a real anchor.
     """
     page.goto(f"{live_server}/step/900-kometa", wait_until="domcontentloaded")
-    page.add_script_tag(path="static/local-js/validationHandler.js")
+    page.evaluate("""() => import(`/static/local-js/validationHandler.js?validation-handler-test=${Date.now()}`)""")
     page.evaluate("""
-        ValidationHandler.showValidationMessage(
+        window.ValidationHandler.showValidationMessage(
             'Please <a href=\"javascript:void(0);\" data-jumpto-page=\"010-plex\">click here</a>.',
             'danger',
             { html: true }


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

**Title**

Harden Arr template globals and align ValidationHandler e2e tests with module loading

**PR Description**

## Summary

This is a follow-up hardening pass for the recent Arr dropdown restore work.

It fixes template rendering when saved Radarr/Sonarr dropdown values are missing, and updates the `ValidationHandler` e2e coverage to match the current ES module loading path.

## What changed

- Updated `110-radarr.html` and `120-sonarr.html` to default saved dropdown globals to `''` before `tojson`
- Prevented Jinja `Undefined` values from causing a 500 during template render
- Updated the `ValidationHandler` e2e tests to load the module via `import()` instead of injecting it as a classic script
- Updated those tests to call `window.ValidationHandler`, which is the actual backward-compat surface published by the module

## Why

The prior Arr restore fix was correct in concept, but it assumed the saved values always existed. On empty values, `tojson` received `Undefined`, which broke backend round-trip coverage.

Separately, the `ValidationHandler` tests were still written against the pre-module loading shape, so they no longer reflected how the app actually exposes that API.

## Testing

Ran:

```powershell
venv\Scripts\python.exe -m pytest tests\e2e\test_wizard_e2e.py -m e2e -k "config_switch_auto_saves_current_page or validation_handler_show_message_textcontent_by_default or validation_handler_show_message_html_opt_in_renders_html"
venv\Scripts\python.exe -m pytest tests\test_core_backend.py -k test_config_round_trip_all_steps
venv\Scripts\python.exe -m pytest tests\e2e\test_wizard_e2e.py -m e2e -k "arr_page_return_restores_saved_dropdown_selection or radarr_revalidate_on_load_repopulates_dropdowns or dropdown_populating_wizard_success_flow"
```

Results:

```text
3 passed, 70 deselected
1 passed, 202 deselected
5 passed, 68 deselected
```

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
