### PR TITLE
added support for csv strings

### DIFF
--- a/modules/importer_playlists.py
+++ b/modules/importer_playlists.py
@@ -150,14 +150,7 @@ def parse_playlist_config(config_data: dict, report: ImportReport) -> PlaylistIm
             )
             continue
         libs = tv.get("libraries")
-        if not isinstance(libs, list):
-            report.add(
-                "unmapped",
-                f"playlist_files[{idx}].template_variables.libraries",
-                "Missing playlist library entries.",
-            )
-            continue
-        entry_libs = [str(lib).strip() for lib in libs if str(lib).strip()]
+        entry_libs = _coerce_import_string_list(libs)
         if not entry_libs:
             report.add(
                 "unmapped",

--- a/tests/test_importer_edge_cases.py
+++ b/tests/test_importer_edge_cases.py
@@ -38,6 +38,29 @@ def test_prepare_import_payload_maps_playlist_files_to_library_toggles():
     assert any("libraries.Movies.playlist_files" in line for line in report.lines)
 
 
+def test_prepare_import_payload_accepts_comma_separated_playlist_libraries():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {"Movies": {}, "TV Shows": {}},
+            "playlist_files": [
+                {
+                    "default": "playlist",
+                    "template_variables": {"libraries": "Movies, TV Shows"},
+                }
+            ],
+        },
+        {"Movies", "TV Shows"},
+        set(),
+    )
+
+    libraries = payload["libraries"]["libraries"]
+    assert libraries["mov-library_movies-library"] == "Movies"
+    assert libraries["mov-library_movies-playlist"] == "true"
+    assert libraries["mov-library_tvshows-library"] == "TV Shows"
+    assert libraries["mov-library_tvshows-playlist"] == "true"
+    assert any("playlist_files[0].template_variables.libraries" in line for line in report.lines)
+
+
 def test_prepare_import_payload_maps_playlist_template_variables_into_libraries_payload():
     payload, report = importer.prepare_import_payload(
         {


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

**Summary**
- accept comma-separated `playlist_files[*].template_variables.libraries` values during import, not just YAML lists
- normalize that field through the shared string-list coercion path so importer behavior matches Kometa’s accepted config shapes while preserving current export behavior
- add a regression test covering `libraries: Movies, TV Shows` import

**Why**
Kometa allows `libraries` to be either:
- a comma-separated string
- a list of library mapping names

Quickstart was only accepting the list form on import, which made valid configs round-trip inconsistently.

**Testing**
- `venv\Scripts\python.exe -m pytest tests\test_importer_edge_cases.py -q`
- `venv\Scripts\python.exe -m pytest tests\test_ratings_yaml_contract.py -q`

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
