### PR TITLE
added and reorged universes

### DIFF
--- a/modules/output_collections.py
+++ b/modules/output_collections.py
@@ -16,13 +16,12 @@ variables (mirroring what ``output_playlists.py`` does for playlists):
    normalized dict.  Handles the ``this_month`` boolean and
    ``before`` / ``after`` numeric windows.
 
-3. **Franchise 'dynamic child override' expansion** --
+3. **Dynamic child override expansion** --
    ``_expand_franchise_dynamic_child_overrides`` walks a template_vars
-   dict, finds the ``child_*_overrides`` mapping keys declared in
-   ``FRANCHISE_DYNAMIC_CHILD_FIELD_SPECS``, and expands each mapping
-   into flat ``<prefix><suffix>`` keys on the parent dict.
-   ``_normalize_dynamic_child_override_value`` handles the per-kind
-   value coercion.
+   dict, finds the supported ``child_*_overrides`` mapping keys, and
+   expands each mapping into flat ``<prefix><suffix>`` keys on the
+   parent dict. ``_normalize_dynamic_child_override_value`` handles
+   the per-kind value coercion.
 
 4. **Settings-block ignore-list normalization** --
    ``_normalize_settings_section_value`` handles ignore_ids /
@@ -60,19 +59,36 @@ FRANCHISE_DYNAMIC_CHILD_FIELD_SPECS = {
     "child_name_overrides": ("name_", "string"),
     "child_summary_overrides": ("summary_", "string"),
     "child_sort_title_overrides": ("sort_title_", "string"),
+    "child_order_overrides": ("order_", "string"),
+    "child_schedule_overrides": ("schedule_", "string"),
+    "child_name_mapping_overrides": ("name_mapping_", "string"),
+    "child_delete_collections_named_overrides": ("delete_collections_named_", "string_list"),
+    "child_imdb_list_overrides": ("imdb_list_", "string_list"),
+    "child_mdblist_list_overrides": ("mdblist_list_", "string_list"),
+    "child_trakt_list_overrides": ("trakt_list_", "string_list"),
     "child_sync_mode_overrides": ("sync_mode_", "select"),
     "child_collection_order_overrides": ("collection_order_", "select"),
+    "child_cache_builders_overrides": ("cache_builders_", "string"),
     "child_url_poster_overrides": ("url_poster_", "string"),
+    "child_url_background_overrides": ("url_background_", "string"),
+    "child_url_logo_overrides": ("url_logo_", "string"),
+    "child_url_square_art_overrides": ("url_square_art_", "string"),
     "child_radarr_add_missing_overrides": ("radarr_add_missing_", "boolean"),
     "child_radarr_folder_overrides": ("radarr_folder_", "string"),
     "child_radarr_tag_overrides": ("radarr_tag_", "string_list"),
     "child_item_radarr_tag_overrides": ("item_radarr_tag_", "string_list"),
     "child_radarr_monitor_overrides": ("radarr_monitor_", "boolean"),
+    "child_radarr_upgrade_existing_overrides": ("radarr_upgrade_existing_", "boolean"),
+    "child_radarr_monitor_existing_overrides": ("radarr_monitor_existing_", "boolean"),
+    "child_radarr_search_overrides": ("radarr_search_", "boolean"),
     "child_sonarr_add_missing_overrides": ("sonarr_add_missing_", "boolean"),
     "child_sonarr_folder_overrides": ("sonarr_folder_", "string"),
     "child_sonarr_tag_overrides": ("sonarr_tag_", "string_list"),
     "child_item_sonarr_tag_overrides": ("item_sonarr_tag_", "string_list"),
     "child_sonarr_monitor_overrides": ("sonarr_monitor_", "select"),
+    "child_sonarr_upgrade_existing_overrides": ("sonarr_upgrade_existing_", "boolean"),
+    "child_sonarr_monitor_existing_overrides": ("sonarr_monitor_existing_", "boolean"),
+    "child_sonarr_search_overrides": ("sonarr_search_", "boolean"),
 }
 
 
@@ -169,6 +185,11 @@ def _normalize_collection_template_var_value(key, value):
     if key == "remove_suffix":
         list_values = _parse_comma_string_list(value)
         return ",".join(list_values) if list_values else None
+    if key in {"delete_collections_named", "trakt_list", "imdb_list", "mdblist_list"} or key.startswith(
+        ("delete_collections_named_", "trakt_list_", "imdb_list_", "mdblist_list_")
+    ):
+        list_values = _parse_string_list(value)
+        return list_values if list_values else None
     if key in {"radarr_tag", "sonarr_tag", "item_radarr_tag", "item_sonarr_tag"} or key.startswith(("radarr_tag_", "sonarr_tag_", "item_radarr_tag_", "item_sonarr_tag_")):
         list_values = _parse_string_list(value)
         return list_values if list_values else None
@@ -384,13 +405,12 @@ def _normalize_list_template_vars(template_vars):
 def _apply_template_var_normalizers(template_vars, raw_id):
     """Full normalization pass for a collection's template_variables dict.
 
-    Franchise collections receive an extra dynamic-child-override expansion
-    pass; every collection receives the legacy region key migration, list
-    normalization, and per-value normalization via
+    Collections with supported ``child_*_overrides`` mappings receive a
+    dynamic-child-override expansion pass; every collection receives the
+    legacy region key migration, list normalization, and per-value normalization via
     ``_normalize_collection_template_var_value``.
     """
-    if raw_id == "franchise":
-        _expand_franchise_dynamic_child_overrides(template_vars)
+    _expand_franchise_dynamic_child_overrides(template_vars)
     _migrate_legacy_region_keys(template_vars)
     _normalize_list_template_vars(template_vars)
     for template_key in list(template_vars.keys()):

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -3350,7 +3350,7 @@
       },
       {
         "id": "collection_cesar",
-        "label": "César Awards",
+        "label": "C\u00e9sar Awards",
         "url": "https://kometa.wiki/en/nightly/defaults/award/cesar",
         "image_url": "https://kometa.wiki/en/nightly/assets/images/defaults/posters/cesar.png",
         "media_types": [
@@ -3522,23 +3522,23 @@
           },
           {
             "key": "use_best",
-            "label": "César Best Film Winners",
-            "tooltip": "Collection of César Award Winners.",
+            "label": "C\u00e9sar Best Film Winners",
+            "tooltip": "Collection of C\u00e9sar Award Winners.",
             "type": "toggle",
             "default": true
           },
           {
             "key": "name_best",
-            "label": "César Best Film Winners Name",
+            "label": "C\u00e9sar Best Film Winners Name",
             "type": "text_input",
-            "tooltip": "Override the collection name for the César Best Film Winners collection. Leave blank to inherit the family Name Format value.",
+            "tooltip": "Override the collection name for the C\u00e9sar Best Film Winners collection. Leave blank to inherit the family Name Format value.",
             "placeholder": "Custom collection name format"
           },
           {
             "key": "summary_best",
-            "label": "César Best Film Winners Summary",
+            "label": "C\u00e9sar Best Film Winners Summary",
             "type": "text_input",
-            "tooltip": "Override the collection summary for the César Best Film Winners collection. Leave blank to inherit the family Summary Format value.",
+            "tooltip": "Override the collection summary for the C\u00e9sar Best Film Winners collection. Leave blank to inherit the family Summary Format value.",
             "placeholder": "Custom collection summary format"
           },
           {
@@ -3756,9 +3756,9 @@
           },
           {
             "key": "visible_home_best",
-            "label": "César Best Film Winners Visible Home",
+            "label": "C\u00e9sar Best Film Winners Visible Home",
             "type": "toggle",
-            "tooltip": "Changes the César Best Film Winners collection visible on Home Tab (Only works with Plex Pass)",
+            "tooltip": "Changes the C\u00e9sar Best Film Winners collection visible on Home Tab (Only works with Plex Pass)",
             "default": false,
             "media_types": [
               "movie"
@@ -3766,9 +3766,9 @@
           },
           {
             "key": "visible_library_best",
-            "label": "César Best Film Winners Visible Library",
+            "label": "C\u00e9sar Best Film Winners Visible Library",
             "type": "toggle",
-            "tooltip": "Changes the César Best Film Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "tooltip": "Changes the C\u00e9sar Best Film Winners collection visible on Library Recommended Tab (Only works with Plex Pass)",
             "default": false,
             "media_types": [
               "movie"
@@ -3776,9 +3776,9 @@
           },
           {
             "key": "visible_shared_best",
-            "label": "César Best Film Winners Visible Shared",
+            "label": "C\u00e9sar Best Film Winners Visible Shared",
             "type": "toggle",
-            "tooltip": "Changes the César Best Film Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "tooltip": "Changes the C\u00e9sar Best Film Winners collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
             "default": false,
             "media_types": [
               "movie"
@@ -3786,7 +3786,7 @@
           },
           {
             "key": "hub_priority_best",
-            "label": "César Best Film Winners Hub Priority",
+            "label": "C\u00e9sar Best Film Winners Hub Priority",
             "type": "text_input",
             "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
             "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
@@ -26953,35 +26953,40 @@
             "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
             "type": "text_input",
             "default": "040",
-            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
           },
           {
             "key": "sort_prefix",
             "label": "Sort Prefix",
             "type": "text_input",
             "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
-            "placeholder": "e.g. !"
+            "placeholder": "e.g. !",
+            "section": "naming"
           },
           {
             "key": "sort_title",
             "label": "Sort Title",
             "type": "text_input",
             "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom sort title format"
+            "placeholder": "Custom sort title format",
+            "section": "naming"
           },
           {
             "key": "name_format",
             "label": "Name Format",
             "type": "text_input",
             "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "naming"
           },
           {
             "key": "summary_format",
             "label": "Summary Format",
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "naming"
           },
           {
             "key": "limit",
@@ -26990,49 +26995,496 @@
             "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "basics"
           },
           {
             "key": "use_all",
             "label": "Use All Child Collections",
             "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "section": "basics"
           },
           {
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections.",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "section": "basics"
           },
           {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
+            "validation_preset": "universe_key",
+            "input_mode": "select",
             "tooltip": "Exclude specific Universes from these collections.",
-            "placeholder": "Add universe key (e.g. mcu)"
+            "placeholder": "Add universe key (e.g. mcu)",
+            "section": "scope_schedule"
+          },
+          {
+            "key": "schedule",
+            "label": "Schedule Default",
+            "type": "schedule",
+            "tooltip": "Override the default schedule applied to child universe collections. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
+            "placeholder": "e.g. weekly(sunday)",
+            "section": "scope_schedule"
+          },
+          {
+            "key": "name_mapping",
+            "label": "Name Mapping Default",
+            "type": "text_input",
+            "tooltip": "Override the default name_mapping applied to child universe collections. Use <<key_name>> as a placeholder when needed.",
+            "placeholder": "Custom name mapping",
+            "section": "naming"
+          },
+          {
+            "key": "delete_collections_named",
+            "label": "Delete Collections Named Default",
+            "type": "string_list",
+            "tooltip": "Set default collection titles that Kometa should delete before rebuilding child universe collections.",
+            "placeholder": "Add collection title to delete",
+            "section": "scope_schedule"
+          },
+          {
+            "key": "url_poster",
+            "label": "Poster URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default poster URL applied to child universe collections when no child-specific poster override is set.",
+            "placeholder": "https://example.com/poster.jpg",
+            "validation_preset": "url",
+            "section": "artwork"
+          },
+          {
+            "key": "url_background",
+            "label": "Background URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default background URL applied to child universe collections when no child-specific background override is set.",
+            "placeholder": "https://example.com/background.jpg",
+            "validation_preset": "url",
+            "section": "artwork"
+          },
+          {
+            "key": "url_logo",
+            "label": "Logo URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default logo URL applied to child universe collections when no child-specific logo override is set.",
+            "placeholder": "https://example.com/logo.png",
+            "validation_preset": "url",
+            "section": "artwork"
+          },
+          {
+            "key": "url_square_art",
+            "label": "Square Art URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default square art URL applied to child universe collections when no child-specific square art override is set.",
+            "placeholder": "https://example.com/square-art.png",
+            "validation_preset": "url",
+            "section": "artwork"
+          },
+          {
+            "key": "child_order_overrides",
+            "label": "Universe Sort Order Token Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to a custom internal order token used when building sort titles. Quickstart exports these as <code>order_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "Optional order token",
+            "dynamic_child_prefix": "order_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps"
+          },
+          {
+            "key": "child_schedule_overrides",
+            "label": "Universe Schedule Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to a custom schedule. Quickstart exports these as <code>schedule_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "weekly(sunday)",
+            "dynamic_child_prefix": "schedule_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps"
+          },
+          {
+            "key": "child_name_mapping_overrides",
+            "label": "Universe Name Mapping Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to a custom name_mapping value. Quickstart exports these as <code>name_mapping_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "Custom name mapping",
+            "dynamic_child_prefix": "name_mapping_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps"
+          },
+          {
+            "key": "child_delete_collections_named_overrides",
+            "label": "Universe Delete Collections Named Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to collection titles that should be deleted before rebuilding. Quickstart exports these as <code>delete_collections_named_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "Title 1, Title 2",
+            "dynamic_child_prefix": "delete_collections_named_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "child_override_maps"
+          },
+          {
+            "key": "child_imdb_list_overrides",
+            "label": "Universe IMDb List Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to one or more IMDb lists. Quickstart exports these as <code>imdb_list_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "https://www.imdb.com/list/ls123456789/",
+            "dynamic_child_prefix": "imdb_list_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "child_override_maps"
+          },
+          {
+            "key": "child_mdblist_list_overrides",
+            "label": "Universe MDBList Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to one or more MDBList sources. Quickstart exports these as <code>mdblist_list_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "https://mdblist.com/lists/example/list",
+            "dynamic_child_prefix": "mdblist_list_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "child_override_maps"
+          },
+          {
+            "key": "child_trakt_list_overrides",
+            "label": "Universe Trakt List Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to one or more Trakt lists. Quickstart exports these as <code>trakt_list_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "https://trakt.tv/users/example/lists/universe",
+            "dynamic_child_prefix": "trakt_list_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "child_override_maps"
+          },
+          {
+            "key": "child_sync_mode_overrides",
+            "label": "Universe Sync Mode Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to a sync mode override. Quickstart exports these as <code>sync_mode_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "append or sync",
+            "dynamic_child_prefix": "sync_mode_",
+            "dynamic_child_value_kind": "select",
+            "section": "child_override_maps"
+          },
+          {
+            "key": "child_collection_order_overrides",
+            "label": "Universe Collection Order Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to a collection order override. Quickstart exports these as <code>collection_order_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "custom, alpha, release, etc.",
+            "dynamic_child_prefix": "collection_order_",
+            "dynamic_child_value_kind": "select",
+            "section": "child_override_maps"
+          },
+          {
+            "key": "child_cache_builders_overrides",
+            "label": "Universe Cache Builders Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to a cache_builders override. Quickstart exports these as <code>cache_builders_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "0, 1, 2, etc.",
+            "dynamic_child_prefix": "cache_builders_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps"
+          },
+          {
+            "key": "child_url_poster_overrides",
+            "label": "Universe Poster URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to a custom poster URL. Quickstart exports these as <code>url_poster_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "https://example.com/poster.jpg",
+            "validation_preset": "url",
+            "dynamic_child_prefix": "url_poster_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork"
+          },
+          {
+            "key": "child_url_background_overrides",
+            "label": "Universe Background URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to a custom background URL. Quickstart exports these as <code>url_background_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "https://example.com/background.jpg",
+            "validation_preset": "url",
+            "dynamic_child_prefix": "url_background_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork"
+          },
+          {
+            "key": "child_url_logo_overrides",
+            "label": "Universe Logo URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to a custom logo URL. Quickstart exports these as <code>url_logo_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "https://example.com/logo.png",
+            "validation_preset": "url",
+            "dynamic_child_prefix": "url_logo_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork"
+          },
+          {
+            "key": "child_url_square_art_overrides",
+            "label": "Universe Square Art URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to custom square art. Quickstart exports these as <code>url_square_art_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "https://example.com/square-art.png",
+            "validation_preset": "url",
+            "dynamic_child_prefix": "url_square_art_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork"
+          },
+          {
+            "key": "child_radarr_folder_overrides",
+            "label": "Universe Radarr Folder Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to a Radarr root folder override. Quickstart exports these as <code>radarr_folder_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "C:\\Media\\Movies",
+            "dynamic_child_prefix": "radarr_folder_",
+            "dynamic_child_value_kind": "string",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation_override_maps"
+          },
+          {
+            "key": "child_radarr_tag_overrides",
+            "label": "Universe Radarr Tag Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to comma-separated Radarr tags. Quickstart exports these as <code>radarr_tag_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "4k,universe",
+            "dynamic_child_prefix": "radarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation_override_maps"
+          },
+          {
+            "key": "child_item_radarr_tag_overrides",
+            "label": "Universe Item Radarr Tag Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to comma-separated item Radarr tags. Quickstart exports these as <code>item_radarr_tag_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "collection,tracked",
+            "dynamic_child_prefix": "item_radarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation_override_maps"
+          },
+          {
+            "key": "child_radarr_upgrade_existing_overrides",
+            "label": "Universe Radarr Upgrade Existing Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to a Radarr upgrade_existing override. Quickstart exports these as <code>radarr_upgrade_existing_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "radarr_upgrade_existing_",
+            "dynamic_child_value_kind": "boolean",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation_override_maps"
+          },
+          {
+            "key": "child_radarr_monitor_existing_overrides",
+            "label": "Universe Radarr Monitor Existing Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to a Radarr monitor_existing override. Quickstart exports these as <code>radarr_monitor_existing_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "radarr_monitor_existing_",
+            "dynamic_child_value_kind": "boolean",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation_override_maps"
+          },
+          {
+            "key": "child_radarr_search_overrides",
+            "label": "Universe Radarr Search Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to a Radarr search override. Quickstart exports these as <code>radarr_search_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "radarr_search_",
+            "dynamic_child_value_kind": "boolean",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation_override_maps"
+          },
+          {
+            "key": "child_sonarr_folder_overrides",
+            "label": "Universe Sonarr Folder Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to a Sonarr root folder override. Quickstart exports these as <code>sonarr_folder_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "C:\\Media\\Shows",
+            "dynamic_child_prefix": "sonarr_folder_",
+            "dynamic_child_value_kind": "string",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation_override_maps"
+          },
+          {
+            "key": "child_sonarr_tag_overrides",
+            "label": "Universe Sonarr Tag Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to comma-separated Sonarr tags. Quickstart exports these as <code>sonarr_tag_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "tracked,universe",
+            "dynamic_child_prefix": "sonarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation_override_maps"
+          },
+          {
+            "key": "child_item_sonarr_tag_overrides",
+            "label": "Universe Item Sonarr Tag Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to comma-separated item Sonarr tags. Quickstart exports these as <code>item_sonarr_tag_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "watched,tracked",
+            "dynamic_child_prefix": "item_sonarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation_override_maps"
+          },
+          {
+            "key": "child_sonarr_upgrade_existing_overrides",
+            "label": "Universe Sonarr Upgrade Existing Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to a Sonarr upgrade_existing override. Quickstart exports these as <code>sonarr_upgrade_existing_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "sonarr_upgrade_existing_",
+            "dynamic_child_value_kind": "boolean",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation_override_maps"
+          },
+          {
+            "key": "child_sonarr_monitor_existing_overrides",
+            "label": "Universe Sonarr Monitor Existing Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to a Sonarr monitor_existing override. Quickstart exports these as <code>sonarr_monitor_existing_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "sonarr_monitor_existing_",
+            "dynamic_child_value_kind": "boolean",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation_override_maps"
+          },
+          {
+            "key": "child_sonarr_search_overrides",
+            "label": "Universe Sonarr Search Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a universe key to a Sonarr search override. Quickstart exports these as <code>sonarr_search_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Universe key (e.g. avp)",
+            "key_validation_preset": "universe_key",
+            "key_input_mode": "select",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "sonarr_search_",
+            "dynamic_child_value_kind": "boolean",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation_override_maps"
           },
           {
             "key": "use_avp",
             "label": "Alien / Predator",
             "tooltip": "Collection of Movies in the Alien / Predator Universe",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "section": "universe_avp"
           },
           {
             "key": "name_avp",
             "label": "Alien / Predator Name",
             "type": "text_input",
             "tooltip": "Override the collection name for the Alien / Predator collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "universe_avp"
           },
           {
             "key": "summary_avp",
             "label": "Alien / Predator Summary",
             "type": "text_input",
             "tooltip": "Override the collection summary for the Alien / Predator collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "universe_avp"
           },
           {
             "key": "minimum_items_avp",
@@ -27041,7 +27493,8 @@
             "tooltip": "Override the minimum_items value for the Alien / Predator collection. Leave blank to inherit the family Minimum Items value. Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "universe_avp"
           },
           {
             "key": "radarr_add_missing_avp",
@@ -27051,7 +27504,8 @@
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "universe_avp"
           },
           {
             "key": "sonarr_add_missing_avp",
@@ -27061,28 +27515,32 @@
             "type": "toggle",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "universe_avp"
           },
           {
             "key": "use_arrow",
             "label": "Arrowverse",
             "tooltip": "Collection of Movies in the The Arrow Universe",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "section": "universe_arrow"
           },
           {
             "key": "name_arrow",
             "label": "Arrowverse Name",
             "type": "text_input",
             "tooltip": "Override the collection name for the Arrowverse collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "universe_arrow"
           },
           {
             "key": "summary_arrow",
             "label": "Arrowverse Summary",
             "type": "text_input",
             "tooltip": "Override the collection summary for the Arrowverse collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "universe_arrow"
           },
           {
             "key": "minimum_items_arrow",
@@ -27091,7 +27549,8 @@
             "tooltip": "Override the minimum_items value for the Arrowverse collection. Leave blank to inherit the family Minimum Items value. Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "universe_arrow"
           },
           {
             "key": "radarr_add_missing_arrow",
@@ -27101,7 +27560,8 @@
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "universe_arrow"
           },
           {
             "key": "sonarr_add_missing_arrow",
@@ -27111,28 +27571,32 @@
             "type": "toggle",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "universe_arrow"
           },
           {
             "key": "use_dca",
             "label": "DC Animated Universe",
             "tooltip": "Collection of Movies in the DC Animated Universe",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "section": "universe_dca"
           },
           {
             "key": "name_dca",
             "label": "DC Animated Universe Name",
             "type": "text_input",
             "tooltip": "Override the collection name for the DC Animated Universe collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "universe_dca"
           },
           {
             "key": "summary_dca",
             "label": "DC Animated Universe Summary",
             "type": "text_input",
             "tooltip": "Override the collection summary for the DC Animated Universe collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "universe_dca"
           },
           {
             "key": "minimum_items_dca",
@@ -27141,7 +27605,8 @@
             "tooltip": "Override the minimum_items value for the DC Animated Universe collection. Leave blank to inherit the family Minimum Items value. Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "universe_dca"
           },
           {
             "key": "radarr_add_missing_dca",
@@ -27151,7 +27616,8 @@
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "universe_dca"
           },
           {
             "key": "sonarr_add_missing_dca",
@@ -27161,28 +27627,32 @@
             "type": "toggle",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "universe_dca"
           },
           {
             "key": "use_dcu",
             "label": "DC Extended Universe",
             "tooltip": "Collection of Movies in the DC Extended Universe",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "section": "universe_dcu"
           },
           {
             "key": "name_dcu",
             "label": "DC Extended Universe Name",
             "type": "text_input",
             "tooltip": "Override the collection name for the DC Extended Universe collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "universe_dcu"
           },
           {
             "key": "summary_dcu",
             "label": "DC Extended Universe Summary",
             "type": "text_input",
             "tooltip": "Override the collection summary for the DC Extended Universe collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "universe_dcu"
           },
           {
             "key": "minimum_items_dcu",
@@ -27191,7 +27661,8 @@
             "tooltip": "Override the minimum_items value for the DC Extended Universe collection. Leave blank to inherit the family Minimum Items value. Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "universe_dcu"
           },
           {
             "key": "radarr_add_missing_dcu",
@@ -27201,7 +27672,8 @@
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "universe_dcu"
           },
           {
             "key": "sonarr_add_missing_dcu",
@@ -27211,28 +27683,32 @@
             "type": "toggle",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "universe_dcu"
           },
           {
             "key": "use_fast",
             "label": "Fast & Furious",
             "tooltip": "Collection of Movies in the Fast & Furious Universe",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "section": "universe_fast"
           },
           {
             "key": "name_fast",
             "label": "Fast & Furious Name",
             "type": "text_input",
             "tooltip": "Override the collection name for the Fast & Furious collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "universe_fast"
           },
           {
             "key": "summary_fast",
             "label": "Fast & Furious Summary",
             "type": "text_input",
             "tooltip": "Override the collection summary for the Fast & Furious collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "universe_fast"
           },
           {
             "key": "minimum_items_fast",
@@ -27241,7 +27717,8 @@
             "tooltip": "Override the minimum_items value for the Fast & Furious collection. Leave blank to inherit the family Minimum Items value. Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "universe_fast"
           },
           {
             "key": "radarr_add_missing_fast",
@@ -27251,7 +27728,8 @@
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "universe_fast"
           },
           {
             "key": "sonarr_add_missing_fast",
@@ -27261,28 +27739,32 @@
             "type": "toggle",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "universe_fast"
           },
           {
             "key": "use_marvel",
             "label": "In Association with Marvel",
             "tooltip": "Collection of Movies in the Marvel Universe (but not part of MCU)",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "section": "universe_marvel"
           },
           {
             "key": "name_marvel",
             "label": "In Association with Marvel Name",
             "type": "text_input",
             "tooltip": "Override the collection name for the In Association with Marvel collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "universe_marvel"
           },
           {
             "key": "summary_marvel",
             "label": "In Association with Marvel Summary",
             "type": "text_input",
             "tooltip": "Override the collection summary for the In Association with Marvel collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "universe_marvel"
           },
           {
             "key": "minimum_items_marvel",
@@ -27291,7 +27773,8 @@
             "tooltip": "Override the minimum_items value for the In Association with Marvel collection. Leave blank to inherit the family Minimum Items value. Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "universe_marvel"
           },
           {
             "key": "radarr_add_missing_marvel",
@@ -27301,7 +27784,8 @@
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "universe_marvel"
           },
           {
             "key": "sonarr_add_missing_marvel",
@@ -27311,28 +27795,32 @@
             "type": "toggle",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "universe_marvel"
           },
           {
             "key": "use_mcu",
             "label": "Marvel Cinematic Universe",
             "tooltip": "Collection of Movies in the Marvel Cinematic Universe",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "section": "universe_mcu"
           },
           {
             "key": "name_mcu",
             "label": "Marvel Cinematic Universe Name",
             "type": "text_input",
             "tooltip": "Override the collection name for the Marvel Cinematic Universe collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "universe_mcu"
           },
           {
             "key": "summary_mcu",
             "label": "Marvel Cinematic Universe Summary",
             "type": "text_input",
             "tooltip": "Override the collection summary for the Marvel Cinematic Universe collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "universe_mcu"
           },
           {
             "key": "minimum_items_mcu",
@@ -27341,7 +27829,8 @@
             "tooltip": "Override the minimum_items value for the Marvel Cinematic Universe collection. Leave blank to inherit the family Minimum Items value. Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "universe_mcu"
           },
           {
             "key": "radarr_add_missing_mcu",
@@ -27351,7 +27840,8 @@
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "universe_mcu"
           },
           {
             "key": "sonarr_add_missing_mcu",
@@ -27361,28 +27851,32 @@
             "type": "toggle",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "universe_mcu"
           },
           {
             "key": "use_middle",
             "label": "Middle Earth",
             "tooltip": "Collection of Movies in the Middle Earth Universe",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "section": "universe_middle"
           },
           {
             "key": "name_middle",
             "label": "Middle Earth Name",
             "type": "text_input",
             "tooltip": "Override the collection name for the Middle Earth collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "universe_middle"
           },
           {
             "key": "summary_middle",
             "label": "Middle Earth Summary",
             "type": "text_input",
             "tooltip": "Override the collection summary for the Middle Earth collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "universe_middle"
           },
           {
             "key": "minimum_items_middle",
@@ -27391,7 +27885,8 @@
             "tooltip": "Override the minimum_items value for the Middle Earth collection. Leave blank to inherit the family Minimum Items value. Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "universe_middle"
           },
           {
             "key": "radarr_add_missing_middle",
@@ -27401,7 +27896,8 @@
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "universe_middle"
           },
           {
             "key": "sonarr_add_missing_middle",
@@ -27411,28 +27907,32 @@
             "type": "toggle",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "universe_middle"
           },
           {
             "key": "use_rocky",
             "label": "Rocky / Creed",
             "tooltip": "Collection of Movies in the Rocky / Creed Universe",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "section": "universe_rocky"
           },
           {
             "key": "name_rocky",
             "label": "Rocky / Creed Name",
             "type": "text_input",
             "tooltip": "Override the collection name for the Rocky / Creed collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "universe_rocky"
           },
           {
             "key": "summary_rocky",
             "label": "Rocky / Creed Summary",
             "type": "text_input",
             "tooltip": "Override the collection summary for the Rocky / Creed collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "universe_rocky"
           },
           {
             "key": "minimum_items_rocky",
@@ -27441,7 +27941,8 @@
             "tooltip": "Override the minimum_items value for the Rocky / Creed collection. Leave blank to inherit the family Minimum Items value. Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "universe_rocky"
           },
           {
             "key": "radarr_add_missing_rocky",
@@ -27451,7 +27952,8 @@
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "universe_rocky"
           },
           {
             "key": "sonarr_add_missing_rocky",
@@ -27461,28 +27963,32 @@
             "type": "toggle",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "universe_rocky"
           },
           {
             "key": "use_trek",
             "label": "Star Trek",
             "tooltip": "Collection of Movies in the Star Trek Universe",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "section": "universe_trek"
           },
           {
             "key": "name_trek",
             "label": "Star Trek Name",
             "type": "text_input",
             "tooltip": "Override the collection name for the Star Trek collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "universe_trek"
           },
           {
             "key": "summary_trek",
             "label": "Star Trek Summary",
             "type": "text_input",
             "tooltip": "Override the collection summary for the Star Trek collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "universe_trek"
           },
           {
             "key": "minimum_items_trek",
@@ -27491,7 +27997,8 @@
             "tooltip": "Override the minimum_items value for the Star Trek collection. Leave blank to inherit the family Minimum Items value. Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "universe_trek"
           },
           {
             "key": "radarr_add_missing_trek",
@@ -27501,7 +28008,8 @@
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "universe_trek"
           },
           {
             "key": "sonarr_add_missing_trek",
@@ -27511,28 +28019,32 @@
             "type": "toggle",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "universe_trek"
           },
           {
             "key": "use_star",
             "label": "Star Wars Universe",
             "tooltip": "Collection of Movies in the Star Wars Universe",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "section": "universe_star"
           },
           {
             "key": "name_star",
             "label": "Star Wars Universe Name",
             "type": "text_input",
             "tooltip": "Override the collection name for the Star Wars Universe collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "universe_star"
           },
           {
             "key": "summary_star",
             "label": "Star Wars Universe Summary",
             "type": "text_input",
             "tooltip": "Override the collection summary for the Star Wars Universe collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "universe_star"
           },
           {
             "key": "minimum_items_star",
@@ -27541,7 +28053,8 @@
             "tooltip": "Override the minimum_items value for the Star Wars Universe collection. Leave blank to inherit the family Minimum Items value. Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "universe_star"
           },
           {
             "key": "radarr_add_missing_star",
@@ -27551,7 +28064,8 @@
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "universe_star"
           },
           {
             "key": "sonarr_add_missing_star",
@@ -27561,28 +28075,32 @@
             "type": "toggle",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "universe_star"
           },
           {
             "key": "use_mummy",
             "label": "The Mummy Universe",
             "tooltip": "Collection of Movies in the The Mummy Universe",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "section": "universe_mummy"
           },
           {
             "key": "name_mummy",
             "label": "The Mummy Universe Name",
             "type": "text_input",
             "tooltip": "Override the collection name for the The Mummy Universe collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "universe_mummy"
           },
           {
             "key": "summary_mummy",
             "label": "The Mummy Universe Summary",
             "type": "text_input",
             "tooltip": "Override the collection summary for the The Mummy Universe collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "universe_mummy"
           },
           {
             "key": "minimum_items_mummy",
@@ -27591,7 +28109,8 @@
             "tooltip": "Override the minimum_items value for the The Mummy Universe collection. Leave blank to inherit the family Minimum Items value. Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "universe_mummy"
           },
           {
             "key": "radarr_add_missing_mummy",
@@ -27601,7 +28120,8 @@
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "universe_mummy"
           },
           {
             "key": "sonarr_add_missing_mummy",
@@ -27611,28 +28131,32 @@
             "type": "toggle",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "universe_mummy"
           },
           {
             "key": "use_askew",
             "label": "View Askewverse",
             "tooltip": "Collection of Movies in the The View Askew Universe",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "section": "universe_askew"
           },
           {
             "key": "name_askew",
             "label": "View Askewverse Name",
             "type": "text_input",
             "tooltip": "Override the collection name for the View Askewverse collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "universe_askew"
           },
           {
             "key": "summary_askew",
             "label": "View Askewverse Summary",
             "type": "text_input",
             "tooltip": "Override the collection summary for the View Askewverse collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "universe_askew"
           },
           {
             "key": "minimum_items_askew",
@@ -27641,7 +28165,8 @@
             "tooltip": "Override the minimum_items value for the View Askewverse collection. Leave blank to inherit the family Minimum Items value. Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "universe_askew"
           },
           {
             "key": "radarr_add_missing_askew",
@@ -27651,7 +28176,8 @@
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "universe_askew"
           },
           {
             "key": "sonarr_add_missing_askew",
@@ -27661,28 +28187,32 @@
             "type": "toggle",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "universe_askew"
           },
           {
             "key": "use_wizard",
             "label": "Wizarding World",
             "tooltip": "Collection of Movies in the Wizarding World Universe",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "section": "universe_wizard"
           },
           {
             "key": "name_wizard",
             "label": "Wizarding World Name",
             "type": "text_input",
             "tooltip": "Override the collection name for the Wizarding World collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "universe_wizard"
           },
           {
             "key": "summary_wizard",
             "label": "Wizarding World Summary",
             "type": "text_input",
             "tooltip": "Override the collection summary for the Wizarding World collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "universe_wizard"
           },
           {
             "key": "minimum_items_wizard",
@@ -27691,7 +28221,8 @@
             "tooltip": "Override the minimum_items value for the Wizarding World collection. Leave blank to inherit the family Minimum Items value. Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "universe_wizard"
           },
           {
             "key": "radarr_add_missing_wizard",
@@ -27701,7 +28232,8 @@
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "universe_wizard"
           },
           {
             "key": "sonarr_add_missing_wizard",
@@ -27711,28 +28243,32 @@
             "type": "toggle",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "universe_wizard"
           },
           {
             "key": "use_xmen",
             "label": "X-Men Universe",
             "tooltip": "Collection of Movies in the X-Men Universe",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "section": "universe_xmen"
           },
           {
             "key": "name_xmen",
             "label": "X-Men Universe Name",
             "type": "text_input",
             "tooltip": "Override the collection name for the X-Men Universe collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "universe_xmen"
           },
           {
             "key": "summary_xmen",
             "label": "X-Men Universe Summary",
             "type": "text_input",
             "tooltip": "Override the collection summary for the X-Men Universe collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "universe_xmen"
           },
           {
             "key": "minimum_items_xmen",
@@ -27741,7 +28277,8 @@
             "tooltip": "Override the minimum_items value for the X-Men Universe collection. Leave blank to inherit the family Minimum Items value. Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "universe_xmen"
           },
           {
             "key": "radarr_add_missing_xmen",
@@ -27751,7 +28288,8 @@
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "universe_xmen"
           },
           {
             "key": "sonarr_add_missing_xmen",
@@ -27761,7 +28299,8 @@
             "type": "toggle",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "universe_xmen"
           },
           {
             "key": "minimum_items",
@@ -27771,7 +28310,8 @@
             "input_type": "number",
             "min": 1,
             "step": 1,
-            "default": 2
+            "default": 2,
+            "section": "basics"
           },
           {
             "key": "ignore_ids",
@@ -27779,7 +28319,8 @@
             "type": "string_list",
             "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
             "placeholder": "Add numeric ID (e.g. 603)",
-            "validation_preset": "numeric_id"
+            "validation_preset": "numeric_id",
+            "section": "scope_schedule"
           },
           {
             "key": "ignore_imdb_ids",
@@ -27787,7 +28328,8 @@
             "type": "string_list",
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
-            "validation_preset": "imdb_id_plex"
+            "validation_preset": "imdb_id_plex",
+            "section": "scope_schedule"
           },
           {
             "key": "radarr_add_missing",
@@ -27797,7 +28339,8 @@
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "automation_defaults"
           },
           {
             "key": "sonarr_add_missing",
@@ -27807,7 +28350,8 @@
             "type": "toggle",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "automation_defaults"
           },
           {
             "key": "radarr_search",
@@ -27816,7 +28360,8 @@
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "automation_defaults"
           },
           {
             "key": "sonarr_search",
@@ -27825,7 +28370,8 @@
             "type": "toggle",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "automation_defaults"
           },
           {
             "key": "radarr_monitor",
@@ -27834,7 +28380,8 @@
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "automation_defaults"
           },
           {
             "key": "radarr_monitor_existing",
@@ -27843,7 +28390,8 @@
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "automation_defaults"
           },
           {
             "key": "sonarr_monitor_existing",
@@ -27852,7 +28400,8 @@
             "type": "toggle",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "automation_defaults"
           },
           {
             "key": "radarr_tag",
@@ -27862,7 +28411,8 @@
             "placeholder": "Add Radarr tag",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "automation_defaults"
           },
           {
             "key": "sonarr_tag",
@@ -27872,7 +28422,8 @@
             "placeholder": "Add Sonarr tag",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "automation_defaults"
           },
           {
             "key": "item_radarr_tag",
@@ -27882,7 +28433,8 @@
             "placeholder": "Add item Radarr tag",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "automation_defaults"
           },
           {
             "key": "item_sonarr_tag",
@@ -27892,7 +28444,8 @@
             "placeholder": "Add item Sonarr tag",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "automation_defaults"
           },
           {
             "key": "radarr_folder",
@@ -27902,7 +28455,8 @@
             "placeholder": "Enter Radarr root folder path",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "automation_defaults"
           },
           {
             "key": "sonarr_folder",
@@ -27912,7 +28466,8 @@
             "placeholder": "Enter Sonarr root folder path",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "automation_defaults"
           },
           {
             "key": "sonarr_monitor",
@@ -27955,7 +28510,8 @@
             ],
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "automation_defaults"
           },
           {
             "key": "radarr_upgrade_existing",
@@ -27964,7 +28520,8 @@
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "automation_defaults"
           },
           {
             "key": "sonarr_upgrade_existing",
@@ -27973,7 +28530,8 @@
             "type": "toggle",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "automation_defaults"
           },
           {
             "key": "sync_mode",
@@ -27990,7 +28548,8 @@
                 "value": "sync",
                 "label": "Sync"
               }
-            ]
+            ],
+            "section": "child_defaults"
           },
           {
             "key": "cache_builders",
@@ -28000,7 +28559,8 @@
             "default": 1,
             "input_type": "number",
             "min": 0,
-            "step": 1
+            "step": 1,
+            "section": "child_defaults"
           },
           {
             "key": "collection_mode",
@@ -28025,28 +28585,32 @@
                 "value": "show_items",
                 "label": "Show this Collection and its Items"
               }
-            ]
+            ],
+            "section": "child_defaults"
           },
           {
             "key": "visible_home",
             "label": "Visible Home",
             "type": "toggle",
             "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "child_defaults"
           },
           {
             "key": "visible_library",
             "label": "Visible Library",
             "type": "toggle",
             "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "child_defaults"
           },
           {
             "key": "visible_shared",
             "label": "Visible Shared",
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "child_defaults"
           },
           {
             "key": "hub_priority",
@@ -28063,28 +28627,32 @@
               "visible_library",
               "visible_shared"
             ],
-            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "child_defaults"
           },
           {
             "key": "visible_home_avp",
             "label": "Alien / Predator Visible Home",
             "type": "toggle",
             "tooltip": "Changes the Alien / Predator collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_avp"
           },
           {
             "key": "visible_library_avp",
             "label": "Alien / Predator Visible Library",
             "type": "toggle",
             "tooltip": "Changes the Alien / Predator collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_avp"
           },
           {
             "key": "visible_shared_avp",
             "label": "Alien / Predator Visible Shared",
             "type": "toggle",
             "tooltip": "Changes the Alien / Predator collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_avp"
           },
           {
             "key": "hub_priority_avp",
@@ -28101,28 +28669,32 @@
               "visible_library_avp",
               "visible_shared_avp"
             ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "universe_avp"
           },
           {
             "key": "visible_home_arrow",
             "label": "Arrowverse Visible Home",
             "type": "toggle",
             "tooltip": "Changes the Arrowverse collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_arrow"
           },
           {
             "key": "visible_library_arrow",
             "label": "Arrowverse Visible Library",
             "type": "toggle",
             "tooltip": "Changes the Arrowverse collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_arrow"
           },
           {
             "key": "visible_shared_arrow",
             "label": "Arrowverse Visible Shared",
             "type": "toggle",
             "tooltip": "Changes the Arrowverse collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_arrow"
           },
           {
             "key": "hub_priority_arrow",
@@ -28139,28 +28711,32 @@
               "visible_library_arrow",
               "visible_shared_arrow"
             ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "universe_arrow"
           },
           {
             "key": "visible_home_dca",
             "label": "DC Animated Universe Visible Home",
             "type": "toggle",
             "tooltip": "Changes the DC Animated Universe collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_dca"
           },
           {
             "key": "visible_library_dca",
             "label": "DC Animated Universe Visible Library",
             "type": "toggle",
             "tooltip": "Changes the DC Animated Universe collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_dca"
           },
           {
             "key": "visible_shared_dca",
             "label": "DC Animated Universe Visible Shared",
             "type": "toggle",
             "tooltip": "Changes the DC Animated Universe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_dca"
           },
           {
             "key": "hub_priority_dca",
@@ -28177,28 +28753,32 @@
               "visible_library_dca",
               "visible_shared_dca"
             ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "universe_dca"
           },
           {
             "key": "visible_home_dcu",
             "label": "DC Extended Universe Visible Home",
             "type": "toggle",
             "tooltip": "Changes the DC Extended Universe collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_dcu"
           },
           {
             "key": "visible_library_dcu",
             "label": "DC Extended Universe Visible Library",
             "type": "toggle",
             "tooltip": "Changes the DC Extended Universe collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_dcu"
           },
           {
             "key": "visible_shared_dcu",
             "label": "DC Extended Universe Visible Shared",
             "type": "toggle",
             "tooltip": "Changes the DC Extended Universe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_dcu"
           },
           {
             "key": "hub_priority_dcu",
@@ -28215,28 +28795,32 @@
               "visible_library_dcu",
               "visible_shared_dcu"
             ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "universe_dcu"
           },
           {
             "key": "visible_home_fast",
             "label": "Fast & Furious Visible Home",
             "type": "toggle",
             "tooltip": "Changes the Fast & Furious collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_fast"
           },
           {
             "key": "visible_library_fast",
             "label": "Fast & Furious Visible Library",
             "type": "toggle",
             "tooltip": "Changes the Fast & Furious collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_fast"
           },
           {
             "key": "visible_shared_fast",
             "label": "Fast & Furious Visible Shared",
             "type": "toggle",
             "tooltip": "Changes the Fast & Furious collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_fast"
           },
           {
             "key": "hub_priority_fast",
@@ -28253,28 +28837,32 @@
               "visible_library_fast",
               "visible_shared_fast"
             ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "universe_fast"
           },
           {
             "key": "visible_home_marvel",
             "label": "In Association with Marvel Visible Home",
             "type": "toggle",
             "tooltip": "Changes the In Association with Marvel collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_marvel"
           },
           {
             "key": "visible_library_marvel",
             "label": "In Association with Marvel Visible Library",
             "type": "toggle",
             "tooltip": "Changes the In Association with Marvel collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_marvel"
           },
           {
             "key": "visible_shared_marvel",
             "label": "In Association with Marvel Visible Shared",
             "type": "toggle",
             "tooltip": "Changes the In Association with Marvel collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_marvel"
           },
           {
             "key": "hub_priority_marvel",
@@ -28291,28 +28879,32 @@
               "visible_library_marvel",
               "visible_shared_marvel"
             ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "universe_marvel"
           },
           {
             "key": "visible_home_mcu",
             "label": "Marvel Cinematic Universe Visible Home",
             "type": "toggle",
             "tooltip": "Changes the Marvel Cinematic Universe collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_mcu"
           },
           {
             "key": "visible_library_mcu",
             "label": "Marvel Cinematic Universe Visible Library",
             "type": "toggle",
             "tooltip": "Changes the Marvel Cinematic Universe collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_mcu"
           },
           {
             "key": "visible_shared_mcu",
             "label": "Marvel Cinematic Universe Visible Shared",
             "type": "toggle",
             "tooltip": "Changes the Marvel Cinematic Universe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_mcu"
           },
           {
             "key": "hub_priority_mcu",
@@ -28329,28 +28921,32 @@
               "visible_library_mcu",
               "visible_shared_mcu"
             ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "universe_mcu"
           },
           {
             "key": "visible_home_middle",
             "label": "Middle Earth Visible Home",
             "type": "toggle",
             "tooltip": "Changes the Middle Earth collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_middle"
           },
           {
             "key": "visible_library_middle",
             "label": "Middle Earth Visible Library",
             "type": "toggle",
             "tooltip": "Changes the Middle Earth collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_middle"
           },
           {
             "key": "visible_shared_middle",
             "label": "Middle Earth Visible Shared",
             "type": "toggle",
             "tooltip": "Changes the Middle Earth collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_middle"
           },
           {
             "key": "hub_priority_middle",
@@ -28367,28 +28963,32 @@
               "visible_library_middle",
               "visible_shared_middle"
             ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "universe_middle"
           },
           {
             "key": "visible_home_rocky",
             "label": "Rocky / Creed Visible Home",
             "type": "toggle",
             "tooltip": "Changes the Rocky / Creed collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_rocky"
           },
           {
             "key": "visible_library_rocky",
             "label": "Rocky / Creed Visible Library",
             "type": "toggle",
             "tooltip": "Changes the Rocky / Creed collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_rocky"
           },
           {
             "key": "visible_shared_rocky",
             "label": "Rocky / Creed Visible Shared",
             "type": "toggle",
             "tooltip": "Changes the Rocky / Creed collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_rocky"
           },
           {
             "key": "hub_priority_rocky",
@@ -28405,28 +29005,32 @@
               "visible_library_rocky",
               "visible_shared_rocky"
             ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "universe_rocky"
           },
           {
             "key": "visible_home_trek",
             "label": "Star Trek Visible Home",
             "type": "toggle",
             "tooltip": "Changes the Star Trek collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_trek"
           },
           {
             "key": "visible_library_trek",
             "label": "Star Trek Visible Library",
             "type": "toggle",
             "tooltip": "Changes the Star Trek collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_trek"
           },
           {
             "key": "visible_shared_trek",
             "label": "Star Trek Visible Shared",
             "type": "toggle",
             "tooltip": "Changes the Star Trek collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_trek"
           },
           {
             "key": "hub_priority_trek",
@@ -28443,28 +29047,32 @@
               "visible_library_trek",
               "visible_shared_trek"
             ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "universe_trek"
           },
           {
             "key": "visible_home_star",
             "label": "Star Wars Universe Visible Home",
             "type": "toggle",
             "tooltip": "Changes the Star Wars Universe collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_star"
           },
           {
             "key": "visible_library_star",
             "label": "Star Wars Universe Visible Library",
             "type": "toggle",
             "tooltip": "Changes the Star Wars Universe collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_star"
           },
           {
             "key": "visible_shared_star",
             "label": "Star Wars Universe Visible Shared",
             "type": "toggle",
             "tooltip": "Changes the Star Wars Universe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_star"
           },
           {
             "key": "hub_priority_star",
@@ -28481,28 +29089,32 @@
               "visible_library_star",
               "visible_shared_star"
             ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "universe_star"
           },
           {
             "key": "visible_home_mummy",
             "label": "The Mummy Universe Visible Home",
             "type": "toggle",
             "tooltip": "Changes the The Mummy Universe collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_mummy"
           },
           {
             "key": "visible_library_mummy",
             "label": "The Mummy Universe Visible Library",
             "type": "toggle",
             "tooltip": "Changes the The Mummy Universe collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_mummy"
           },
           {
             "key": "visible_shared_mummy",
             "label": "The Mummy Universe Visible Shared",
             "type": "toggle",
             "tooltip": "Changes the The Mummy Universe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_mummy"
           },
           {
             "key": "hub_priority_mummy",
@@ -28519,28 +29131,32 @@
               "visible_library_mummy",
               "visible_shared_mummy"
             ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "universe_mummy"
           },
           {
             "key": "visible_home_askew",
             "label": "View Askewverse Visible Home",
             "type": "toggle",
             "tooltip": "Changes the View Askewverse collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_askew"
           },
           {
             "key": "visible_library_askew",
             "label": "View Askewverse Visible Library",
             "type": "toggle",
             "tooltip": "Changes the View Askewverse collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_askew"
           },
           {
             "key": "visible_shared_askew",
             "label": "View Askewverse Visible Shared",
             "type": "toggle",
             "tooltip": "Changes the View Askewverse collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_askew"
           },
           {
             "key": "hub_priority_askew",
@@ -28557,28 +29173,32 @@
               "visible_library_askew",
               "visible_shared_askew"
             ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "universe_askew"
           },
           {
             "key": "visible_home_wizard",
             "label": "Wizarding World Visible Home",
             "type": "toggle",
             "tooltip": "Changes the Wizarding World collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_wizard"
           },
           {
             "key": "visible_library_wizard",
             "label": "Wizarding World Visible Library",
             "type": "toggle",
             "tooltip": "Changes the Wizarding World collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_wizard"
           },
           {
             "key": "visible_shared_wizard",
             "label": "Wizarding World Visible Shared",
             "type": "toggle",
             "tooltip": "Changes the Wizarding World collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_wizard"
           },
           {
             "key": "hub_priority_wizard",
@@ -28595,28 +29215,32 @@
               "visible_library_wizard",
               "visible_shared_wizard"
             ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "universe_wizard"
           },
           {
             "key": "visible_home_xmen",
             "label": "X-Men Universe Visible Home",
             "type": "toggle",
             "tooltip": "Changes the X-Men Universe collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_xmen"
           },
           {
             "key": "visible_library_xmen",
             "label": "X-Men Universe Visible Library",
             "type": "toggle",
             "tooltip": "Changes the X-Men Universe collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_xmen"
           },
           {
             "key": "visible_shared_xmen",
             "label": "X-Men Universe Visible Shared",
             "type": "toggle",
             "tooltip": "Changes the X-Men Universe collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "universe_xmen"
           },
           {
             "key": "hub_priority_xmen",
@@ -28633,7 +29257,8 @@
               "visible_library_xmen",
               "visible_shared_xmen"
             ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "universe_xmen"
           },
           {
             "key": "collection_order",
@@ -28988,7 +29613,126 @@
                   "episode"
                 ]
               }
-            ]
+            ],
+            "section": "child_defaults"
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core defaults that affect the whole Universes family.",
+            "default_open": true
+          },
+          {
+            "id": "naming",
+            "label": "Naming",
+            "summary": "Family-level naming and sort-title templates for generated universe collections."
+          },
+          {
+            "id": "scope_schedule",
+            "label": "Scope & Schedule",
+            "summary": "Controls exclusions, ignored IDs, and when child collections run."
+          },
+          {
+            "id": "child_defaults",
+            "label": "Child Defaults",
+            "summary": "Default behavior applied to generated universe collections unless a child-specific override replaces it."
+          },
+          {
+            "id": "child_override_maps",
+            "label": "Child Override Maps",
+            "summary": "Per-universe override tables for source lists, naming, scheduling, ordering, and rebuild behavior."
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork",
+            "summary": "Family-wide artwork plus per-universe artwork override maps."
+          },
+          {
+            "id": "automation_defaults",
+            "label": "Automation Defaults",
+            "summary": "Default Radarr and Sonarr behavior for generated universe collections."
+          },
+          {
+            "id": "automation_override_maps",
+            "label": "Automation Override Maps",
+            "summary": "Per-universe Radarr and Sonarr override tables."
+          },
+          {
+            "id": "universe_avp",
+            "label": "Alien / Predator",
+            "summary": "Child collection settings and visibility overrides for Alien / Predator."
+          },
+          {
+            "id": "universe_arrow",
+            "label": "Arrowverse",
+            "summary": "Child collection settings and visibility overrides for Arrowverse."
+          },
+          {
+            "id": "universe_dca",
+            "label": "DC Animated Universe",
+            "summary": "Child collection settings and visibility overrides for DC Animated Universe."
+          },
+          {
+            "id": "universe_dcu",
+            "label": "DC Extended Universe",
+            "summary": "Child collection settings and visibility overrides for DC Extended Universe."
+          },
+          {
+            "id": "universe_fast",
+            "label": "Fast & Furious",
+            "summary": "Child collection settings and visibility overrides for Fast & Furious."
+          },
+          {
+            "id": "universe_marvel",
+            "label": "In Association with Marvel",
+            "summary": "Child collection settings and visibility overrides for In Association with Marvel."
+          },
+          {
+            "id": "universe_mcu",
+            "label": "Marvel Cinematic Universe",
+            "summary": "Child collection settings and visibility overrides for Marvel Cinematic Universe."
+          },
+          {
+            "id": "universe_middle",
+            "label": "Middle Earth",
+            "summary": "Child collection settings and visibility overrides for Middle Earth."
+          },
+          {
+            "id": "universe_rocky",
+            "label": "Rocky / Creed",
+            "summary": "Child collection settings and visibility overrides for Rocky / Creed."
+          },
+          {
+            "id": "universe_trek",
+            "label": "Star Trek",
+            "summary": "Child collection settings and visibility overrides for Star Trek."
+          },
+          {
+            "id": "universe_star",
+            "label": "Star Wars Universe",
+            "summary": "Child collection settings and visibility overrides for Star Wars Universe."
+          },
+          {
+            "id": "universe_mummy",
+            "label": "The Mummy Universe",
+            "summary": "Child collection settings and visibility overrides for The Mummy Universe."
+          },
+          {
+            "id": "universe_askew",
+            "label": "View Askewverse",
+            "summary": "Child collection settings and visibility overrides for View Askewverse."
+          },
+          {
+            "id": "universe_wizard",
+            "label": "Wizarding World",
+            "summary": "Child collection settings and visibility overrides for Wizarding World."
+          },
+          {
+            "id": "universe_xmen",
+            "label": "X-Men Universe",
+            "summary": "Child collection settings and visibility overrides for X-Men Universe."
           }
         ]
       },

--- a/static/local-js/025-libraries.js
+++ b/static/local-js/025-libraries.js
@@ -3518,8 +3518,9 @@ function inferTemplateStringListPreset (wrapper, input) {
   return 'generic_text'
 }
 
-function ensureTemplateStringListDatalist (wrapper, input, presetConfig, presetName) {
+function ensureTemplatePresetDatalist (wrapper, input, presetConfig, presetName) {
   if (!wrapper || !input || !presetConfig || !Array.isArray(presetConfig.suggestions) || !presetConfig.suggestions.length) return
+  if (String(input.tagName || '').toUpperCase() === 'SELECT') return
   if (presetConfig.suggestions.length > 50) return
   const existingListId = input.getAttribute('list')
   if (existingListId && document.getElementById(existingListId)) return
@@ -3537,6 +3538,69 @@ function ensureTemplateStringListDatalist (wrapper, input, presetConfig, presetN
     wrapper.appendChild(datalist)
   }
   input.setAttribute('list', datalistId)
+}
+
+function getTemplatePresetSelectableOptions (presetConfig) {
+  if (!presetConfig) return []
+  if (Array.isArray(presetConfig.selectOptions) && presetConfig.selectOptions.length) {
+    return presetConfig.selectOptions
+  }
+  if (presetConfig.allowedValues instanceof Set && presetConfig.allowedValues.size) {
+    return Array.from(presetConfig.allowedValues)
+  }
+  if (Array.isArray(presetConfig.allowedValues) && presetConfig.allowedValues.length) {
+    return presetConfig.allowedValues
+  }
+  if (Array.isArray(presetConfig.suggestions) && presetConfig.suggestions.length) {
+    return presetConfig.suggestions
+  }
+  return []
+}
+
+function parseTemplateSelectableOptions (wrapper, presetConfig, datasetKey = 'keyOptions') {
+  const raw = String(wrapper?.dataset?.[datasetKey] || '').trim()
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw)
+      if (Array.isArray(parsed)) {
+        return parsed
+          .map(option => {
+            if (option && typeof option === 'object') {
+              const value = String(option.value || '').trim()
+              const label = String(option.label || value).trim()
+              return value ? { value, label } : null
+            }
+            const value = String(option || '').trim()
+            return value ? { value, label: value } : null
+          })
+          .filter(Boolean)
+      }
+    } catch {}
+  }
+
+  return getTemplatePresetSelectableOptions(presetConfig)
+    .map(option => {
+      const value = String(option || '').trim()
+      return value ? { value, label: value } : null
+    })
+    .filter(Boolean)
+}
+
+function ensureTemplateSelectOptions (wrapper, selectInput, presetConfig, datasetKey = 'keyOptions') {
+  if (!wrapper || !selectInput || String(selectInput.tagName || '').toUpperCase() !== 'SELECT') return
+  const options = parseTemplateSelectableOptions(wrapper, presetConfig, datasetKey)
+  if (!options.length) return
+
+  const currentValue = String(selectInput.value || '').trim()
+  selectInput.querySelectorAll('option[data-template-generated-option="true"]').forEach(option => option.remove())
+  options.forEach(({ value, label }) => {
+    const option = document.createElement('option')
+    option.value = value
+    option.textContent = label
+    option.dataset.templateGeneratedOption = 'true'
+    selectInput.appendChild(option)
+  })
+  selectInput.value = currentValue
 }
 
 function setupTemplateStringListHandlers (scope) {
@@ -3695,12 +3759,13 @@ function setupTemplateStringListHandlers (scope) {
     if (wrapper.dataset.listenerAdded) return
     const hiddenId = wrapper.dataset.hiddenInput
     const hidden = hiddenId ? document.getElementById(hiddenId) : wrapper.querySelector('input[type="hidden"]')
-    const input = wrapper.querySelector('input[type="text"]')
+    const input = wrapper.querySelector('[data-template-string-input]')
     const addBtn = wrapper.querySelector('[data-template-string-add]')
     const list = wrapper.querySelector('[data-template-string-items]')
     const feedback = wrapper.querySelector('[data-template-string-feedback]')
     const templateVariableKey = String(wrapper.dataset.templateVariableKey || '').trim()
     const mutuallyExclusiveWith = String(wrapper.dataset.mutuallyExclusiveWith || '').trim()
+    const inputMode = String(wrapper.dataset.inputMode || 'text').trim().toLowerCase()
 
     if (!hidden || !input || !addBtn || !list) return
 
@@ -3708,7 +3773,10 @@ function setupTemplateStringListHandlers (scope) {
     const presetConfig = templateStringListPresetConfigs[presetName] || templateStringListPresetConfigs.generic_text
     const libraryName = String(wrapper.dataset.libraryName || '').trim()
     const mediaType = String(wrapper.dataset.mediaType || '').trim()
-    ensureTemplateStringListDatalist(wrapper, input, presetConfig, presetName)
+    ensureTemplatePresetDatalist(wrapper, input, presetConfig, presetName)
+    if (inputMode === 'select') {
+      ensureTemplateSelectOptions(wrapper, input, presetConfig, 'selectOptions')
+    }
 
     function parseStoredStringList (rawValue) {
       const raw = String(rawValue || '').trim()
@@ -3920,12 +3988,15 @@ function setupTemplateStringListHandlers (scope) {
       syncState(parseValues())
     })
     input.addEventListener('input', clearTransientFeedback)
-    input.addEventListener('keydown', (event) => {
-      if (event.key === 'Enter') {
-        event.preventDefault()
-        addValue()
-      }
-    })
+    input.addEventListener('change', clearTransientFeedback)
+    if (String(input.tagName || '').toUpperCase() !== 'SELECT') {
+      input.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') {
+          event.preventDefault()
+          addValue()
+        }
+      })
+    }
 
     wrapper.dataset.listenerAdded = 'true'
   })
@@ -3947,6 +4018,7 @@ function setupTemplateMappingListHandlers (scope) {
     const feedback = wrapper.querySelector('[data-template-mapping-feedback]')
     const validationPreset = String(wrapper.dataset.validationPreset || '').trim().toLowerCase()
     const keyValidationPreset = String(wrapper.dataset.keyValidationPreset || '').trim().toLowerCase()
+    const keyInputMode = String(wrapper.dataset.keyInputMode || 'text').trim().toLowerCase()
     const lookupDisplayMode = String(wrapper.dataset.lookupDisplayMode || 'stacked').trim().toLowerCase()
     const valueDisplayLabel = String(wrapper.dataset.valueDisplayLabel || '').trim()
     const valueKind = String(wrapper.dataset.mappingValueKind || 'string_list').trim().toLowerCase()
@@ -3957,6 +4029,10 @@ function setupTemplateMappingListHandlers (scope) {
       : null
 
     if (!hidden || !keyInput || !valueInput || !addBtn || !list) return
+    ensureTemplatePresetDatalist(wrapper, keyInput, keyPresetConfig, keyValidationPreset || 'mapping-key')
+    if (keyInputMode === 'select') {
+      ensureTemplateSelectOptions(wrapper, keyInput, keyPresetConfig, 'keyOptions')
+    }
 
     function getServiceValidationState (serviceName) {
       const el = document.getElementById(`qs-validate-${serviceName}`)
@@ -4326,20 +4402,24 @@ function setupTemplateMappingListHandlers (scope) {
     hidden.addEventListener('change', () => {
       syncState(parseStoredMapping(hidden.value))
     })
-    keyInput.addEventListener('input', () => {
+    const clearKeyFeedback = () => {
       setFeedback('')
       setKeyInputValidity({ valid: true })
-    })
+    }
+    keyInput.addEventListener('input', clearKeyFeedback)
+    keyInput.addEventListener('change', clearKeyFeedback)
     valueInput.addEventListener('input', () => {
       setFeedback('')
       setValueInputValidity({ valid: true })
     })
-    keyInput.addEventListener('keydown', (event) => {
-      if (event.key === 'Enter') {
-        event.preventDefault()
-        addEntry()
-      }
-    })
+    if (String(keyInput.tagName || '').toUpperCase() !== 'SELECT') {
+      keyInput.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') {
+          event.preventDefault()
+          addEntry()
+        }
+      })
+    }
     valueInput.addEventListener('keydown', (event) => {
       if (event.key === 'Enter') {
         event.preventDefault()
@@ -4997,12 +5077,16 @@ function mountCard (card, libraryId) {
   setupMappingListHandlers('genre_mapper', card)
   setupMappingListHandlers('content_rating_mapper', card)
   wireOverlayDetailToggles(card)
+  wireCollectionDetailToggles(card)
+  wireCollectionVariableSectionToggles(card)
   setupParentChildToggleVisibility(card)
   if (typeof setupParentChildToggleSync === 'function') {
     setupParentChildToggleSync()
   }
   setupAddMissingDependencies(card)
   wireOverlayTemplateSections(card)
+  wireCollectionTemplateSections(card)
+  wireCollectionVariableSections(card)
   if (typeof OverlayHandler !== 'undefined' && OverlayHandler.initializeOverlayBoards) {
     OverlayHandler.initializeOverlayBoards(card)
   }
@@ -5512,7 +5596,11 @@ document.querySelectorAll('.overlay-template-section').forEach((el) => {
 })
 
 wireOverlayDetailToggles()
+wireCollectionDetailToggles()
+wireCollectionVariableSectionToggles()
 wireOverlayTemplateSections()
+wireCollectionTemplateSections()
+wireCollectionVariableSections()
 wireRatingsOffsetSync()
 
 document.addEventListener('click', (e) => {
@@ -5903,23 +5991,34 @@ function toggleOverlayTemplateSection (checkbox) {
 
   if (templateSection) {
     if (checkbox.checked) {
-      templateSection.style.display = 'none'
+      setDetailSectionExpanded(templateSection, detailsToggle, false)
       if (detailActions) {
         detailActions.classList.remove('d-none')
       }
-      if (detailsToggle) {
-        detailsToggle.textContent = 'Show Details'
-      }
     } else {
-      templateSection.style.display = 'none'
+      setDetailSectionExpanded(templateSection, detailsToggle, false)
       if (detailActions) {
         detailActions.classList.add('d-none')
       }
-      if (detailsToggle) {
-        detailsToggle.textContent = 'Show Details'
-      }
     }
   }
+}
+
+function toggleCollectionTemplateSection (parentToggle) {
+  const groupContainer = parentToggle?.closest('.template-toggle-group[data-collection-config="true"]')
+  const templateSection = groupContainer?.querySelector('.collection-template-section')
+  const detailsToggle = groupContainer?.querySelector('.collection-details-toggle')
+  const detailActions = groupContainer?.querySelector('.collection-detail-actions')
+
+  if (!templateSection) return
+
+  setDetailSectionExpanded(templateSection, detailsToggle, false)
+  if (detailActions) {
+    detailActions.classList.toggle('d-none', !parentToggle?.checked)
+  }
+  groupContainer?.querySelectorAll('[data-collection-variable-section="true"]').forEach(section => {
+    updateCollectionVariableSectionSummary(section)
+  })
 }
 
 function setupCustomStringListHandlers (prefix, scope) {
@@ -7044,9 +7143,20 @@ function setupAddMissingDependencies (scope) {
   })
 }
 
-function wireOverlayDetailToggles (scope) {
+function setDetailSectionExpanded (section, toggle, expanded) {
+  if (!section) return
+  section.style.display = expanded ? 'block' : 'none'
+  section.dataset.detailVisible = expanded ? 'true' : 'false'
+  if (!toggle) return
+  const showLabel = String(toggle.dataset.showLabel || 'Show Details')
+  const hideLabel = String(toggle.dataset.hideLabel || 'Hide Details')
+  toggle.textContent = expanded ? hideLabel : showLabel
+  toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false')
+}
+
+function wireDetailToggles (selector, scope) {
   const root = scope || document
-  root.querySelectorAll('.overlay-details-toggle').forEach(btn => {
+  root.querySelectorAll(selector).forEach(btn => {
     if (btn.dataset.listenerAdded === 'true') return
     const targetId = btn.dataset.sectionId
     const section = targetId ? document.getElementById(targetId) : null
@@ -7054,12 +7164,137 @@ function wireOverlayDetailToggles (scope) {
 
     btn.addEventListener('click', () => {
       const isHidden = section.style.display === 'none'
-      section.style.display = isHidden ? 'block' : 'none'
-      btn.textContent = isHidden ? 'Hide Details' : 'Show Details'
+      setDetailSectionExpanded(section, btn, isHidden)
       updateAccordionHighlights()
     })
 
+    const defaultOpen = section.dataset.detailVisible === 'true' || section.dataset.defaultOpen === 'true'
+    setDetailSectionExpanded(section, btn, defaultOpen)
     btn.dataset.listenerAdded = 'true'
+  })
+}
+
+function wireOverlayDetailToggles (scope) {
+  wireDetailToggles('.overlay-details-toggle', scope)
+}
+
+function wireCollectionDetailToggles (scope) {
+  wireDetailToggles('.collection-details-toggle', scope)
+}
+
+function wireCollectionVariableSectionToggles (scope) {
+  wireDetailToggles('.collection-variable-section-toggle', scope)
+}
+
+function parseCollectionSectionStoredStringList (rawValue) {
+  const raw = String(rawValue || '').trim()
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw)
+    if (Array.isArray(parsed)) {
+      return parsed.map(item => String(item).trim()).filter(Boolean)
+    }
+  } catch {
+    // fall back to single-value handling
+  }
+  return [raw]
+}
+
+function parseCollectionSectionStoredMapping (rawValue) {
+  const raw = String(rawValue || '').trim()
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed
+    }
+  } catch {
+    // fall through to empty mapping
+  }
+  return {}
+}
+
+function isCollectionSectionFieldConfigured (fields) {
+  const enabledFields = Array.from(fields || []).filter(field => field && !field.disabled)
+  if (!enabledFields.length) return false
+
+  const visibleFields = enabledFields.filter(field => field.type !== 'hidden')
+  const checkboxField = visibleFields.find(field => field.type === 'checkbox')
+  if (checkboxField) {
+    const defaultRaw = String(checkboxField.dataset.default || '').trim().toLowerCase()
+    const currentChecked = checkboxField.checked
+    if (defaultRaw) {
+      const normalizedValue = String(checkboxField.value || 'true').trim().toLowerCase()
+      const defaultChecked = defaultRaw === 'true' || defaultRaw === normalizedValue
+      return currentChecked !== defaultChecked
+    }
+    return currentChecked
+  }
+
+  const radioFields = visibleFields.filter(field => field.type === 'radio')
+  if (radioFields.length) {
+    return radioFields.some(field => field.checked)
+  }
+
+  const primaryField = visibleFields[0] || enabledFields[0]
+  if (!primaryField) return false
+
+  if (primaryField.closest('[data-template-string-list]')) {
+    const values = parseCollectionSectionStoredStringList(primaryField.value)
+    const defaults = parseCollectionSectionStoredStringList(primaryField.dataset.default || '[]')
+    return JSON.stringify(values) !== JSON.stringify(defaults)
+  }
+
+  if (primaryField.closest('[data-template-mapping-list]')) {
+    const values = parseCollectionSectionStoredMapping(primaryField.value)
+    const defaults = parseCollectionSectionStoredMapping(primaryField.dataset.default || '{}')
+    return JSON.stringify(values) !== JSON.stringify(defaults)
+  }
+
+  const value = String(primaryField.value ?? '').trim()
+  const defaultValue = String(primaryField.dataset.default || '').trim()
+  if (!value) return false
+  return defaultValue ? value !== defaultValue : true
+}
+
+function updateCollectionVariableSectionSummary (section) {
+  if (!section) return
+  const summary = section.querySelector('[data-collection-section-summary]')
+  const body = section.querySelector('.collection-variable-section-body')
+  if (!summary || !body) return
+
+  const fieldsByName = new Map()
+  body.querySelectorAll('[name]').forEach(field => {
+    if (!field || field.disabled) return
+    const name = String(field.name || '').trim()
+    if (!name) return
+    if (!fieldsByName.has(name)) fieldsByName.set(name, [])
+    fieldsByName.get(name).push(field)
+  })
+
+  let configuredCount = 0
+  fieldsByName.forEach(fields => {
+    if (isCollectionSectionFieldConfigured(fields)) configuredCount += 1
+  })
+
+  summary.textContent = configuredCount === 0
+    ? 'Defaults'
+    : configuredCount === 1
+      ? '1 override'
+      : `${configuredCount} overrides`
+}
+
+function wireCollectionVariableSections (scope) {
+  const root = scope || document
+  root.querySelectorAll('[data-collection-variable-section="true"]').forEach(section => {
+    if (section.dataset.summaryBound === 'true') return
+
+    const refresh = () => updateCollectionVariableSectionSummary(section)
+    section.addEventListener('input', refresh)
+    section.addEventListener('change', refresh)
+    refresh()
+
+    section.dataset.summaryBound = 'true'
   })
 }
 
@@ -7077,6 +7312,20 @@ function wireOverlayTemplateSections (scope) {
   if (typeof setupParentChildToggleSync === 'function') {
     setupParentChildToggleSync()
   }
+}
+
+function wireCollectionTemplateSections (scope) {
+  const root = scope || document
+  root.querySelectorAll('.template-toggle-group[data-collection-config="true"]').forEach(group => {
+    if (group.dataset.collectionTemplateBound === 'true') return
+    const parentToggle = group.querySelector('[data-template-group]')
+    if (!parentToggle) return
+    parentToggle.addEventListener('change', function () {
+      toggleCollectionTemplateSection(this)
+    })
+    toggleCollectionTemplateSection(parentToggle)
+    group.dataset.collectionTemplateBound = 'true'
+  })
 }
 
 function showZoomPreviewModal (imageSrc) {

--- a/static/local-js/validationHandler.js
+++ b/static/local-js/validationHandler.js
@@ -79,6 +79,24 @@ export const ValidationHandler = {
 
   showAccordionForField: function (field) {
     if (!field) return
+    let detailSection = field.closest('[data-detail-section="true"]')
+    while (detailSection) {
+      const isHidden = detailSection.style.display === 'none' || detailSection.classList.contains('d-none') || detailSection.hidden
+      if (isHidden) {
+        const sectionId = detailSection.id
+        const toggle = sectionId
+          ? Array.from(document.querySelectorAll('[data-section-id]')).find(btn => btn.dataset.sectionId === sectionId)
+          : null
+        if (toggle && typeof toggle.click === 'function') {
+          toggle.click()
+        } else {
+          detailSection.style.display = 'block'
+          detailSection.hidden = false
+          detailSection.classList.remove('d-none')
+        }
+      }
+      detailSection = detailSection.parentElement?.closest('[data-detail-section="true"]')
+    }
     let collapse = field.closest('.accordion-collapse')
     while (collapse) {
       if (!collapse.classList.contains('show')) {

--- a/templates/partials/_macros.html
+++ b/templates/partials/_macros.html
@@ -1220,19 +1220,112 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                     {% endfor %}
                     {% set ordered_collection_items = prioritized_collection_items.priority + prioritized_collection_items.remaining %}
                     {% endif %}
-                    {% set season = namespace(open=false) %}
+                    {% set clean_id = collection.id.replace('collection_', '') %}
+                    {% set collection_details_id = library.id ~ '-template_collection_' ~ clean_id ~ '-details' %}
                     {% set has_plex_pass = telemetry is mapping and telemetry.get("plex_pass") is sameas true %}
+                    {% set visible_collection_items = [] %}
+                    {% for item in ordered_collection_items
+                        if (not item.media_types or library.type in item.media_types)
+                        and (not item.key.startswith('visible_') or telemetry.plex_pass) %}
+                    {% set _ = visible_collection_items.append(item) %}
+                    {% endfor %}
+                    {% set section_defs = collection.template_variable_sections if collection.template_variable_sections is defined else [] %}
+                    {% set render_groups = namespace(items=[]) %}
+                    {% if section_defs %}
+                    {% set known_section_ids = [] %}
+                    {% for section_def in section_defs if section_def.id is defined %}
+                    {% set _ = known_section_ids.append(section_def.id) %}
+                    {% set section_items = [] %}
+                    {% for item in visible_collection_items if item.section is defined and item.section == section_def.id %}
+                    {% set _ = section_items.append(item) %}
+                    {% endfor %}
+                    {% if section_items %}
+                    {% set _ = render_groups.items.append({
+                        'id': section_def.id,
+                        'label': section_def.label | default(section_def.id | replace('_', ' ') | title),
+                        'summary': section_def.summary | default(''),
+                        'default_open': section_def.default_open is sameas true,
+                        'fields': section_items,
+                        'flat': false
+                    }) %}
+                    {% endif %}
+                    {% endfor %}
+                    {% set unsectioned_items = [] %}
+                    {% for item in visible_collection_items %}
+                    {% if item.section is not defined or item.section not in known_section_ids %}
+                    {% set _ = unsectioned_items.append(item) %}
+                    {% endif %}
+                    {% endfor %}
+                    {% if unsectioned_items %}
+                    {% set _ = render_groups.items.append({
+                        'id': 'other',
+                        'label': 'Other',
+                        'summary': '',
+                        'default_open': false,
+                        'fields': unsectioned_items,
+                        'flat': false
+                    }) %}
+                    {% endif %}
+                    {% endif %}
+                    {% if not render_groups.items %}
+                    {% set _ = render_groups.items.append({
+                        'id': 'all',
+                        'label': 'Details',
+                        'summary': '',
+                        'default_open': true,
+                        'fields': visible_collection_items,
+                        'flat': true
+                    }) %}
+                    {% endif %}
                     <div class="child-toggle-wrapper ms-4 mt-2"
                         data-toggle-parent="{{ library.id }}-{{ collection.id }}" style="display: none;">
-                        <div class="d-flex align-items-center gap-2 flex-wrap mb-2">
+                        <div class="d-flex align-items-center gap-2 flex-wrap mb-2 collection-detail-actions">
+                            <button type="button"
+                                class="btn btn-sm btn-outline-secondary btn-overlay collection-details-toggle"
+                                data-section-id="{{ collection_details_id }}"
+                                data-show-label="Show Details"
+                                data-hide-label="Hide Details"
+                                aria-expanded="false">
+                                Show Details
+                            </button>
                             <button type="button" class="btn btn-sm btn-outline-secondary btn-overlay reset-offset-btn">
                                 Reset to Defaults
                             </button>
                         </div>
-                        {% for item in ordered_collection_items
-                        if (not item.media_types or library.type in item.media_types)
-                        and (not item.key.startswith('visible_') or telemetry.plex_pass) %}
-                        {% set clean_id = collection.id.replace('collection_', '') %}
+                        <div class="collection-template-section mt-2"
+                            id="{{ collection_details_id }}"
+                            data-detail-section="true"
+                            style="display: none;">
+                        {% for render_group in render_groups.items %}
+                        {% if not render_group.flat %}
+                        {% set section_body_id = collection_details_id ~ '-section-' ~ render_group.id %}
+                        <div class="border rounded p-2 mb-3 collection-variable-section" data-collection-variable-section="true"
+                            data-section-id="{{ render_group.id }}">
+                            <div class="d-flex align-items-center justify-content-between gap-2 flex-wrap mb-2">
+                                <div class="fw-semibold">{{ render_group.label }}</div>
+                                <div class="d-flex align-items-center gap-2">
+                                    <span class="small text-muted" data-collection-section-summary>Defaults</span>
+                                    <button type="button"
+                                        class="btn btn-sm btn-outline-secondary btn-overlay collection-variable-section-toggle"
+                                        data-section-id="{{ section_body_id }}"
+                                        data-show-label="Show"
+                                        data-hide-label="Hide"
+                                        aria-expanded="{{ 'true' if render_group.default_open else 'false' }}">
+                                        {{ 'Hide' if render_group.default_open else 'Show' }}
+                                    </button>
+                                </div>
+                            </div>
+                            {% if render_group.summary %}
+                            <div class="form-text mb-2">{{ render_group.summary }}</div>
+                            {% endif %}
+                            <div class="collection-variable-section-body"
+                                id="{{ section_body_id }}"
+                                data-detail-section="true"
+                                data-default-open="{{ 'true' if render_group.default_open else 'false' }}"
+                                style="display: {{ 'block' if render_group.default_open else 'none' }};">
+                        {% endif %}
+                        {% set season = namespace(open=false) %}
+                        {% for item in render_group.fields %}
                         {% set input_name = (library.id ~ '-template_collection_' ~ clean_id ~ '_' ~ item.key) if item.key is defined else '' %}
                         {% set field_requires_plex_pass = item.requires_plex_pass is defined and item.requires_plex_pass %}
                         {% set field_disabled = disable_toggle or (field_requires_plex_pass and not has_plex_pass) %}
@@ -1368,6 +1461,12 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                         {% else %}
                         {% set list_default_json = '[]' %}
                         {% endif %}
+                        {% set string_input_mode = item.input_mode | default('text') %}
+                        {% if item.options is defined %}
+                        {% set string_options_json = item.options | tojson %}
+                        {% else %}
+                        {% set string_options_json = '' %}
+                        {% endif %}
                         <div class="mb-2" data-template-string-list data-hidden-input="{{ input_name }}"
                             data-library-name="{{ library.name }}"
                             data-media-type="{{ library.type }}"
@@ -1375,7 +1474,9 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                             {% if item.mutually_exclusive_with %}data-mutually-exclusive-with="{{ item.mutually_exclusive_with }}"{% endif %}
                             {% if item.validation_preset %}data-validation-preset="{{ item.validation_preset }}"{% endif %}
                             {% if item.validation_mode %}data-validation-mode="{{ item.validation_mode }}"{% endif %}
-                            {% if item.validation_normalize %}data-validation-normalize="{{ item.validation_normalize }}"{% endif %}>
+                            {% if item.validation_normalize %}data-validation-normalize="{{ item.validation_normalize }}"{% endif %}
+                            data-input-mode="{{ string_input_mode }}"
+                            data-select-options='{{ string_options_json }}'>
                             <div class="input-group">
                                 <span class="input-group-text" id="{{ input_name }}_text" style="width: 170px;">
                                     {{ item.label }}
@@ -1387,11 +1488,20 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                     </span>
                                     {% endif %}
                                 </span>
+                                {% if string_input_mode == 'select' %}
+                                <select class="form-select" id="{{ input_name }}_input" data-template-string-input
+                                    aria-describedby="{{ input_name }}_text"
+                                    {% if disable_toggle %}disabled{% endif %}>
+                                    <option value="">{{ item.placeholder | default('Select a value') }}</option>
+                                </select>
+                                {% else %}
                                 <input type="text" class="form-control" id="{{ input_name }}_input"
+                                    data-template-string-input
                                     aria-describedby="{{ input_name }}_text"
                                     placeholder="{{ item.placeholder | default('Add value') }}"
                                     {% if item.validation_preset %}data-validation-preset="{{ item.validation_preset }}"{% endif %}
                                     {% if disable_toggle %}disabled{% endif %}>
+                                {% endif %}
                                 <button class="btn nav-button" type="button" data-template-string-add
                                     {% if disable_toggle %}disabled{% endif %}>Add</button>
                             </div>
@@ -1417,11 +1527,19 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                         {% set map_default_json = '{}' %}
                         {% endif %}
                         {% set label_width = item.label_width if item.label_width is defined else (320 if item.label|length > 24 else 170) %}
+                        {% set key_input_mode = item.key_input_mode | default('text') %}
+                        {% if item.key_options is defined %}
+                        {% set key_options_json = item.key_options | tojson %}
+                        {% else %}
+                        {% set key_options_json = '' %}
+                        {% endif %}
                         <div class="mb-2" data-template-mapping-list data-hidden-input="{{ input_name }}"
                             data-library-name="{{ library.name }}"
                             data-media-type="{{ library.type }}"
                             data-validation-preset="{{ item.validation_preset | default('') }}"
                             data-key-validation-preset="{{ item.key_validation_preset | default('') }}"
+                            data-key-input-mode="{{ key_input_mode }}"
+                            data-key-options='{{ key_options_json }}'
                             data-lookup-display-mode="{{ item.lookup_display_mode | default('stacked') }}"
                             data-value-display-label="{{ item.value_display_label | default('') }}"
                             data-mapping-value-kind="{{ item.dynamic_child_value_kind | default('string_list') }}">
@@ -1437,10 +1555,18 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                     </span>
                                     {% endif %}
                                 </span>
+                                {% if key_input_mode == 'select' %}
+                                <select class="form-select" data-template-mapping-key
+                                    aria-describedby="{{ input_name }}_text"
+                                    {% if disable_toggle %}disabled{% endif %}>
+                                    <option value="">{{ item.key_placeholder | default('Select a key') }}</option>
+                                </select>
+                                {% else %}
                                 <input type="text" class="form-control" data-template-mapping-key
                                     aria-describedby="{{ input_name }}_text"
                                     placeholder="{{ item.key_placeholder | default('Add key') }}"
                                     {% if disable_toggle %}disabled{% endif %}>
+                                {% endif %}
                                 <input type="text" class="form-control" data-template-mapping-value
                                     aria-describedby="{{ input_name }}_text"
                                     placeholder="{{ item.value_placeholder | default('Add comma-separated values') }}"
@@ -1503,7 +1629,7 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                             <input type="hidden" id="{{ input_name }}" name="{{ input_name }}" value="{{ stored_val }}"
                                 data-default="{{ item.default | default('', true) }}">
                         </div>
-                        {% elif item.key is defined and item.key.startswith('schedule_') %}
+                        {% elif item.type == 'schedule' or (item.key is defined and item.key.startswith('schedule_')) %}
                         {% set schedule_label = 'Schedule' %}
                         {% set schedule_tooltip = "Configure when this collection updates." %}
                         {% set label_width = 140 %}
@@ -1677,6 +1803,12 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                         {% if is_seasonal and season.open %}
                     </div>
                         {% endif %}
+                        {% if not render_group.flat %}
+                            </div>
+                        </div>
+                        {% endif %}
+                        {% endfor %}
+                        </div>
                     </div>
                     {% endif %}
                 </div>
@@ -1920,6 +2052,7 @@ tooltip_variant="info", container_class="border rounded p-3 mb-2") %}
                                                     {% endif %}
                                                 </div>
                                                 <div class="overlay-template-section mt-2" id="{{ details_id }}"
+                                                    data-detail-section="true"
                                                     style="display: none;">
                                                 {% set is_mapping = overlay.template_variables is mapping %}
                                                 {% set raw_tv_items = overlay.template_variables.items() if is_mapping else overlay.template_variables %}

--- a/tests/js/validationHandler.test.js
+++ b/tests/js/validationHandler.test.js
@@ -403,6 +403,26 @@ describe('ValidationHandler.showAccordionForField', () => {
     expect(() => window.ValidationHandler.showAccordionForField(undefined)).not.toThrow()
   })
 
+  it('opens a hidden detail section before focusing the invalid field', () => {
+    document.body.innerHTML = `
+      <button type="button" id="details-toggle" data-section-id="collection-details">Show Details</button>
+      <div id="collection-details" data-detail-section="true" style="display: none;">
+        <input class="is-invalid" id="target">
+      </div>
+    `
+    const field = document.getElementById('target')
+    const toggle = document.getElementById('details-toggle')
+    toggle.addEventListener('click', () => {
+      document.getElementById('collection-details').style.display = 'block'
+      toggle.textContent = 'Hide Details'
+    })
+
+    window.ValidationHandler.showAccordionForField(field)
+
+    expect(document.getElementById('collection-details').style.display).toBe('block')
+    expect(toggle.textContent).toBe('Hide Details')
+  })
+
   it('clicks the accordion button when the collapse is not shown', () => {
     document.body.innerHTML = `
       <div class="accordion-item">

--- a/tests/test_collection_details_contract.py
+++ b/tests/test_collection_details_contract.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MACROS_PATH = ROOT / "templates" / "partials" / "_macros.html"
+LIBRARIES_JS_PATH = ROOT / "static" / "local-js" / "025-libraries.js"
+VALIDATION_JS_PATH = ROOT / "static" / "local-js" / "validationHandler.js"
+
+
+def test_collection_macros_render_collapsible_detail_section():
+    macros = MACROS_PATH.read_text(encoding="utf-8")
+
+    assert "collection-details-toggle" in macros
+    assert "collection-detail-actions" in macros
+    assert 'class="collection-template-section mt-2"' in macros
+    assert 'data-detail-section="true"' in macros
+    assert 'data-collection-variable-section="true"' in macros
+    assert "collection-variable-section-toggle" in macros
+    assert "data-collection-section-summary" in macros
+
+
+def test_libraries_script_wires_collection_detail_toggles():
+    script = LIBRARIES_JS_PATH.read_text(encoding="utf-8")
+
+    assert "function toggleCollectionTemplateSection" in script
+    assert "function wireCollectionDetailToggles" in script
+    assert "function wireCollectionTemplateSections" in script
+    assert "wireCollectionDetailToggles(card)" in script
+    assert "wireCollectionTemplateSections(card)" in script
+    assert "function wireCollectionVariableSectionToggles" in script
+    assert "function wireCollectionVariableSections" in script
+    assert "function updateCollectionVariableSectionSummary" in script
+    assert "wireCollectionVariableSectionToggles(card)" in script
+    assert "wireCollectionVariableSections(card)" in script
+    assert "section.dataset.defaultOpen === 'true'" in script
+
+
+def test_validation_handler_opens_hidden_detail_sections():
+    script = VALIDATION_JS_PATH.read_text(encoding="utf-8")
+
+    assert '[data-detail-section="true"]' in script
+    assert "detailSection.style.display = 'block'" in script
+    assert "btn.dataset.sectionId === sectionId" in script

--- a/tests/test_collection_universe_contract.py
+++ b/tests/test_collection_universe_contract.py
@@ -1,0 +1,152 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+QS_COLLECTIONS_PATH = ROOT / "static" / "json" / "quickstart_collections.json"
+MACROS_PATH = ROOT / "templates" / "partials" / "_macros.html"
+
+
+def _load_universe_collection():
+    data = json.loads(QS_COLLECTIONS_PATH.read_text(encoding="utf-8"))
+    for group in data:
+        for collection in group.get("collections", []):
+            if collection.get("id") == "collection_universe":
+                return collection
+    raise AssertionError("Missing collection_universe")
+
+
+def _field_map(collection):
+    return {item["key"]: item for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key")}
+
+
+def test_universe_exposes_inherited_shared_family_level_fields():
+    collection = _load_universe_collection()
+    fields = _field_map(collection)
+
+    expected = {
+        "schedule": {"type": "schedule"},
+        "name_mapping": {"type": "text_input"},
+        "delete_collections_named": {"type": "string_list"},
+        "url_poster": {"type": "text_input", "validation_preset": "url"},
+        "url_background": {"type": "text_input", "validation_preset": "url"},
+        "url_logo": {"type": "text_input", "validation_preset": "url"},
+        "url_square_art": {"type": "text_input", "validation_preset": "url"},
+    }
+
+    for key, metadata in expected.items():
+        assert key in fields
+        for meta_key, meta_value in metadata.items():
+            assert fields[key].get(meta_key) == meta_value
+
+    exclude_field = fields["exclude"]
+    assert exclude_field["type"] == "string_list"
+    assert exclude_field["validation_preset"] == "universe_key"
+    assert exclude_field["input_mode"] == "select"
+
+    section_defs = collection.get("template_variable_sections") or []
+    section_ids = [section.get("id") for section in section_defs if isinstance(section, dict)]
+    assert section_ids[:8] == [
+        "basics",
+        "naming",
+        "scope_schedule",
+        "child_defaults",
+        "child_override_maps",
+        "artwork",
+        "automation_defaults",
+        "automation_override_maps",
+    ]
+    assert "universe_mcu" in section_ids
+    assert "universe_star" in section_ids
+    assert any(section.get("default_open") is True for section in section_defs if section.get("id") == "basics")
+
+    assert fields["collection_section"]["section"] == "basics"
+    assert fields["name_mapping"]["section"] == "naming"
+    assert fields["ignore_imdb_ids"]["section"] == "scope_schedule"
+    assert fields["visible_home"]["section"] == "child_defaults"
+    assert fields["child_imdb_list_overrides"]["section"] == "child_override_maps"
+    assert fields["url_poster"]["section"] == "artwork"
+    assert fields["radarr_folder"]["section"] == "automation_defaults"
+    assert fields["child_radarr_folder_overrides"]["section"] == "automation_override_maps"
+    assert fields["use_mcu"]["section"] == "universe_mcu"
+    assert fields["visible_home_mcu"]["section"] == "universe_mcu"
+
+
+def test_universe_uses_dynamic_child_override_surface_for_inherited_prefixes():
+    fields = _field_map(_load_universe_collection())
+
+    expected = {
+        "child_order_overrides": ("order_", "string", "universe_key", None),
+        "child_schedule_overrides": ("schedule_", "string", "universe_key", None),
+        "child_name_mapping_overrides": ("name_mapping_", "string", "universe_key", None),
+        "child_delete_collections_named_overrides": ("delete_collections_named_", "string_list", "universe_key", None),
+        "child_imdb_list_overrides": ("imdb_list_", "string_list", "universe_key", None),
+        "child_mdblist_list_overrides": ("mdblist_list_", "string_list", "universe_key", None),
+        "child_trakt_list_overrides": ("trakt_list_", "string_list", "universe_key", None),
+        "child_sync_mode_overrides": ("sync_mode_", "select", "universe_key", None),
+        "child_collection_order_overrides": ("collection_order_", "select", "universe_key", None),
+        "child_cache_builders_overrides": ("cache_builders_", "string", "universe_key", None),
+        "child_url_poster_overrides": ("url_poster_", "string", "universe_key", "url"),
+        "child_url_background_overrides": ("url_background_", "string", "universe_key", "url"),
+        "child_url_logo_overrides": ("url_logo_", "string", "universe_key", "url"),
+        "child_url_square_art_overrides": ("url_square_art_", "string", "universe_key", "url"),
+        "child_radarr_folder_overrides": ("radarr_folder_", "string", "universe_key", None),
+        "child_radarr_tag_overrides": ("radarr_tag_", "string_list", "universe_key", None),
+        "child_item_radarr_tag_overrides": ("item_radarr_tag_", "string_list", "universe_key", None),
+        "child_radarr_upgrade_existing_overrides": ("radarr_upgrade_existing_", "boolean", "universe_key", None),
+        "child_radarr_monitor_existing_overrides": ("radarr_monitor_existing_", "boolean", "universe_key", None),
+        "child_radarr_search_overrides": ("radarr_search_", "boolean", "universe_key", None),
+        "child_sonarr_folder_overrides": ("sonarr_folder_", "string", "universe_key", None),
+        "child_sonarr_tag_overrides": ("sonarr_tag_", "string_list", "universe_key", None),
+        "child_item_sonarr_tag_overrides": ("item_sonarr_tag_", "string_list", "universe_key", None),
+        "child_sonarr_upgrade_existing_overrides": ("sonarr_upgrade_existing_", "boolean", "universe_key", None),
+        "child_sonarr_monitor_existing_overrides": ("sonarr_monitor_existing_", "boolean", "universe_key", None),
+        "child_sonarr_search_overrides": ("sonarr_search_", "boolean", "universe_key", None),
+    }
+
+    for key, (child_prefix, value_kind, key_validation_preset, value_validation_preset) in expected.items():
+        assert key in fields
+        field = fields[key]
+        assert field["type"] == "mapping_list"
+        assert field["dynamic_child_prefix"] == child_prefix
+        assert field["dynamic_child_value_kind"] == value_kind
+        assert field.get("key_validation_preset") == key_validation_preset
+        assert field.get("key_input_mode") == "select"
+        if value_validation_preset is None:
+            assert "validation_preset" not in field
+        else:
+            assert field.get("validation_preset") == value_validation_preset
+        assert field.get("key_placeholder")
+        assert field.get("value_placeholder")
+
+    assert fields["child_radarr_folder_overrides"]["media_types"] == ["movie"]
+    assert fields["child_radarr_tag_overrides"]["media_types"] == ["movie"]
+    assert fields["child_item_radarr_tag_overrides"]["media_types"] == ["movie"]
+    assert fields["child_radarr_upgrade_existing_overrides"]["media_types"] == ["movie"]
+    assert fields["child_radarr_monitor_existing_overrides"]["media_types"] == ["movie"]
+    assert fields["child_radarr_search_overrides"]["media_types"] == ["movie"]
+
+    assert fields["child_sonarr_folder_overrides"]["media_types"] == ["show"]
+    assert fields["child_sonarr_tag_overrides"]["media_types"] == ["show"]
+    assert fields["child_item_sonarr_tag_overrides"]["media_types"] == ["show"]
+    assert fields["child_sonarr_upgrade_existing_overrides"]["media_types"] == ["show"]
+    assert fields["child_sonarr_monitor_existing_overrides"]["media_types"] == ["show"]
+    assert fields["child_sonarr_search_overrides"]["media_types"] == ["show"]
+
+
+def test_mapping_list_macro_supports_select_backed_keys():
+    text = MACROS_PATH.read_text(encoding="utf-8")
+
+    assert 'data-key-input-mode="{{ key_input_mode }}"' in text
+    assert "data-key-options='{{ key_options_json }}'" in text
+    assert "{% if key_input_mode == 'select' %}" in text
+    assert '<select class="form-select" data-template-mapping-key' in text
+
+
+def test_string_list_macro_supports_select_backed_inputs_and_schedule_type():
+    text = MACROS_PATH.read_text(encoding="utf-8")
+
+    assert 'data-input-mode="{{ string_input_mode }}"' in text
+    assert "data-select-options='{{ string_options_json }}'" in text
+    assert "{% if string_input_mode == 'select' %}" in text
+    assert '<select class="form-select" id="{{ input_name }}_input" data-template-string-input' in text
+    assert "{% elif item.type == 'schedule' or (item.key is defined and item.key.startswith('schedule_')) %}" in text

--- a/tests/test_importer_collection_files.py
+++ b/tests/test_importer_collection_files.py
@@ -274,3 +274,39 @@ def test_prepare_import_payload_collapses_franchise_dynamic_child_template_varia
     assert libraries_payload["sho-library_shows-template_collection_franchise_build_collection"] is False
     assert any("libraries.Movies.collection_files[0].template_variables.name_10" in line for line in report.lines)
     assert any("libraries.Shows.collection_files[0].template_variables.sonarr_monitor_1399" in line for line in report.lines)
+
+
+def test_prepare_import_payload_collapses_universe_dynamic_child_template_variables():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Movies": {
+                    "collection_files": [
+                        {
+                            "default": "universe",
+                            "template_variables": {
+                                "url_poster_avp": "https://example.com/avp.jpg",
+                                "schedule_arrow": "weekly(sunday)",
+                                "trakt_list_trek": ["https://trakt.tv/users/example/lists/star-trek"],
+                                "delete_collections_named_mummy": ["The Mummy Universe"],
+                                "radarr_folder_avp": r"C:\Media\Movies",
+                                "radarr_search_avp": False,
+                            },
+                        }
+                    ]
+                }
+            }
+        },
+        {"Movies"},
+        set(),
+    )
+
+    libraries_payload = payload["libraries"]["libraries"]
+    assert libraries_payload["mov-library_movies-collection_universe"] is True
+    assert libraries_payload["mov-library_movies-template_collection_universe_child_url_poster_overrides"] == '{"avp": "https://example.com/avp.jpg"}'
+    assert libraries_payload["mov-library_movies-template_collection_universe_child_schedule_overrides"] == '{"arrow": "weekly(sunday)"}'
+    assert libraries_payload["mov-library_movies-template_collection_universe_child_trakt_list_overrides"] == '{"trek": "https://trakt.tv/users/example/lists/star-trek"}'
+    assert libraries_payload["mov-library_movies-template_collection_universe_child_delete_collections_named_overrides"] == '{"mummy": "The Mummy Universe"}'
+    assert libraries_payload["mov-library_movies-template_collection_universe_child_radarr_folder_overrides"] == '{"avp": "C:\\\\Media\\\\Movies"}'
+    assert libraries_payload["mov-library_movies-template_collection_universe_child_radarr_search_overrides"] == '{"avp": "false"}'
+    assert any("libraries.Movies.collection_files[0].template_variables.url_poster_avp" in line for line in report.lines)

--- a/tests/test_output_collection_child_override_contract.py
+++ b/tests/test_output_collection_child_override_contract.py
@@ -1,0 +1,23 @@
+from modules import output_collections
+
+
+def test_apply_template_var_normalizers_expands_universe_dynamic_child_override_maps():
+    template_vars = {
+        "child_url_poster_overrides": '{"avp": "https://example.com/avp.jpg"}',
+        "child_schedule_overrides": '{"arrow": "weekly(sunday)"}',
+        "child_trakt_list_overrides": '{"trek": ["https://trakt.tv/users/example/lists/star-trek"]}',
+        "child_delete_collections_named_overrides": '{"mummy": ["The Mummy Universe"]}',
+        "child_radarr_folder_overrides": '{"avp": "C:\\\\Media\\\\Movies"}',
+        "child_radarr_search_overrides": '{"avp": "false"}',
+    }
+
+    output_collections._apply_template_var_normalizers(template_vars, "universe")
+
+    assert template_vars["url_poster_avp"] == "https://example.com/avp.jpg"
+    assert template_vars["schedule_arrow"] == "weekly(sunday)"
+    assert template_vars["trakt_list_trek"] == ["https://trakt.tv/users/example/lists/star-trek"]
+    assert template_vars["delete_collections_named_mummy"] == ["The Mummy Universe"]
+    assert template_vars["radarr_folder_avp"] == r"C:\Media\Movies"
+    assert template_vars["radarr_search_avp"] is False
+    assert "child_url_poster_overrides" not in template_vars
+    assert "child_schedule_overrides" not in template_vars


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

**Summary**
- expand `collection_universe` import/export support so shared family-level fields and dynamic child override maps are preserved instead of being reported as unmapped
- add missing universe coverage for poster/background/logo/square-art URLs, source override maps, and Radarr/Sonarr child overrides
- improve the Libraries UI for collection families by adding reusable collapsible collection detail sections and organizing Universes into schema-driven subsections instead of one long flat form
- replace free-text universe-key entry points with select-backed inputs where appropriate, and use the existing schedule builder pattern for universe schedules

**Details**
- added generic collection child-override export handling in `modules/output_collections.py`
- expanded `static/json/quickstart_collections.json` for Universe shared defaults, child override maps, and section metadata
- updated collection rendering in `_macros.html` so collection template variables can be grouped into reusable subsections with nested show/hide controls
- updated `025-libraries.js` to wire collection section toggles, compute per-section override summaries, and support select-backed template string/mapping inputs
- updated `validationHandler.js` so validation auto-opens hidden collection detail sections before focusing invalid fields

**Why**
- fixes Universe import gaps like `url_poster_*` child overrides and other shared/default variables being treated as unsupported
- makes the Universes UI scale before more collection families get missing template variables added
- reduces scrolling and makes it clearer which settings are family defaults vs per-universe overrides

**Testing**
- `venv\Scripts\python.exe -m pytest tests\test_collection_details_contract.py tests\test_collection_universe_contract.py tests\test_output_collection_child_override_contract.py tests\test_importer_collection_files.py -q`
- Jinja parse check for `templates/partials/_macros.html`
- `node --check static\local-js\025-libraries.js`

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
