### PR TITLE
added seasonal

### DIFF
--- a/modules/importer_value_coercion.py
+++ b/modules/importer_value_coercion.py
@@ -209,6 +209,10 @@ def _serialize_dynamic_child_mapping_value(value: Any, value_kind: str) -> str:
         return str(value or "").strip()
     if kind == "boolean":
         return _coerce_import_bool_text(value)
+    if kind == "json":
+        if isinstance(value, (dict, list)):
+            return json.dumps(value, ensure_ascii=True)
+        return str(value or "").strip()
     return str(value or "").strip()
 
 

--- a/modules/output_collections.py
+++ b/modules/output_collections.py
@@ -62,11 +62,16 @@ FRANCHISE_DYNAMIC_CHILD_FIELD_SPECS = {
     "child_order_overrides": ("order_", "string"),
     "child_schedule_overrides": ("schedule_", "string"),
     "child_name_mapping_overrides": ("name_mapping_", "string"),
+    "child_emoji_overrides": ("emoji_", "string"),
     "child_sort_by_overrides": ("sort_by_", "select"),
     "child_delete_collections_named_overrides": ("delete_collections_named_", "string_list"),
     "child_discover_with_overrides": ("discover_with_", "string"),
+    "child_tmdb_collection_overrides": ("tmdb_collection_", "string_list"),
+    "child_tmdb_movie_overrides": ("tmdb_movie_", "string_list"),
     "child_imdb_list_overrides": ("imdb_list_", "string_list"),
+    "child_imdb_search_overrides": ("imdb_search_", "json"),
     "child_mdblist_list_overrides": ("mdblist_list_", "string_list"),
+    "child_letterboxd_list_overrides": ("letterboxd_list_", "string_list"),
     "child_trakt_list_overrides": ("trakt_list_", "string_list"),
     "child_sync_mode_overrides": ("sync_mode_", "select"),
     "child_collection_order_overrides": ("collection_order_", "select"),
@@ -166,6 +171,29 @@ def _parse_tmdb_person_window(value):
     return normalized or (raw_text if raw_text is not None else value)
 
 
+def _parse_json_object_value(value):
+    if value is None:
+        return None
+    if isinstance(value, (dict, list)):
+        return value
+    if not isinstance(value, str):
+        return value
+
+    raw_text = value.strip()
+    if not raw_text:
+        return None
+
+    try:
+        parsed = json.loads(raw_text)
+    except Exception:
+        try:
+            parsed = ast.literal_eval(raw_text)
+        except Exception:
+            return value
+
+    return parsed if isinstance(parsed, (dict, list)) else value
+
+
 # --- collection template var normalization --------------------------------
 
 
@@ -182,13 +210,15 @@ def _normalize_collection_template_var_value(key, value):
     if key == "title_override":
         mapping_values = _parse_string_mapping(value)
         return mapping_values if mapping_values else None
+    if key == "imdb_search" or key.startswith("imdb_search_"):
+        return _parse_json_object_value(value)
     if key in {"tmdb_birthday", "tmdb_deathday"}:
         return _parse_tmdb_person_window(value)
     if key == "remove_suffix":
         list_values = _parse_comma_string_list(value)
         return ",".join(list_values) if list_values else None
-    if key in {"delete_collections_named", "trakt_list", "imdb_list", "mdblist_list"} or key.startswith(
-        ("delete_collections_named_", "trakt_list_", "imdb_list_", "mdblist_list_")
+    if key in {"delete_collections_named", "trakt_list", "imdb_list", "mdblist_list", "letterboxd_list", "tmdb_collection", "tmdb_movie"} or key.startswith(
+        ("delete_collections_named_", "trakt_list_", "imdb_list_", "mdblist_list_", "letterboxd_list_", "tmdb_collection_", "tmdb_movie_")
     ):
         list_values = _parse_string_list(value)
         return list_values if list_values else None
@@ -212,6 +242,8 @@ def _normalize_dynamic_child_override_value(value_kind, raw_value):
     if kind == "boolean":
         bool_value = _coerce_bool(raw_value)
         return bool_value if bool_value is not None else raw_value
+    if kind == "json":
+        return _parse_json_object_value(raw_value)
     return raw_value
 
 

--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -50920,42 +50920,8 @@
             "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
             "type": "text_input",
             "default": "000",
-            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
-          },
-          {
-            "key": "sort_prefix",
-            "label": "Sort Prefix",
-            "type": "text_input",
-            "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
-            "placeholder": "e.g. !"
-          },
-          {
-            "key": "sort_title",
-            "label": "Sort Title",
-            "type": "text_input",
-            "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom sort title format"
-          },
-          {
-            "key": "name_format",
-            "label": "Name Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_format",
-            "label": "Summary Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "title_format",
-            "label": "Title Format",
-            "type": "text_input",
-            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom dynamic collection title format"
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
           },
           {
             "key": "limit",
@@ -50964,2492 +50930,96 @@
             "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "basics"
           },
           {
             "key": "use_all",
             "label": "Use All Child Collections",
             "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "section": "basics"
           },
           {
             "key": "use_separator",
             "label": "Use Separator",
             "tooltip": "Create a separator collection before this set of collections. Kometa defaults Seasonal to off unless you enable it.",
             "type": "toggle",
-            "default": false
+            "default": false,
+            "section": "basics"
           },
           {
-            "key": "use_aapi",
-            "label": "Asian American Pacific Islander Movies",
-            "tooltip": "Movies related to Asian American Pacific Islander Month",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_aapi",
-            "label": "Asian American Pacific Islander Movies Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Asian American Pacific Islander Movies collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_aapi",
-            "label": "Asian American Pacific Islander Movies Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Asian American Pacific Islander Movies collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "sync_mode_aapi",
-            "label": "Asian American Pacific Islander Movies Sync Mode",
-            "type": "select",
-            "tooltip": "Override the sync_mode for the Asian American Pacific Islander Movies collection. Leave blank to inherit the family Sync Mode value.",
-            "options": [
-              {
-                "value": "",
-                "label": "Use Family Default"
-              },
-              {
-                "value": "append",
-                "label": "Append"
-              },
-              {
-                "value": "sync",
-                "label": "Sync"
-              }
-            ],
-            "default": ""
-          },
-          {
-            "key": "limit_aapi",
-            "label": "Asian American Pacific Islander Movies Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Asian American Pacific Islander Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_aapi",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "schedule_aapi",
-            "label": "Schedule - Asian American Pacific Islander Month",
-            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
-            "type": "text_input",
-            "default": "range(04/30-05/31)",
-            "label_width": 240
-          },
-          {
-            "key": "use_black_history",
-            "label": "Black History Month Movies",
-            "tooltip": "Movies related to Black History Month",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_black_history",
-            "label": "Black History Month Movies Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Black History Month Movies collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_black_history",
-            "label": "Black History Month Movies Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Black History Month Movies collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "sync_mode_black_history",
-            "label": "Black History Month Movies Sync Mode",
-            "type": "select",
-            "tooltip": "Override the sync_mode for the Black History Month Movies collection. Leave blank to inherit the family Sync Mode value.",
-            "options": [
-              {
-                "value": "",
-                "label": "Use Family Default"
-              },
-              {
-                "value": "append",
-                "label": "Append"
-              },
-              {
-                "value": "sync",
-                "label": "Sync"
-              }
-            ],
-            "default": ""
-          },
-          {
-            "key": "limit_black_history",
-            "label": "Black History Month Movies Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Black History Month Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_black_history",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "schedule_black_history",
-            "label": "Schedule - Black History Month",
-            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
-            "type": "text_input",
-            "default": "range(02/01-03/01)",
-            "label_width": 240
-          },
-          {
-            "key": "use_christmas",
-            "label": "Christmas Movies",
-            "tooltip": "Movies related to Christmas",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_christmas",
-            "label": "Christmas Movies Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Christmas Movies collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_christmas",
-            "label": "Christmas Movies Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Christmas Movies collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "sync_mode_christmas",
-            "label": "Christmas Movies Sync Mode",
-            "type": "select",
-            "tooltip": "Override the sync_mode for the Christmas Movies collection. Leave blank to inherit the family Sync Mode value.",
-            "options": [
-              {
-                "value": "",
-                "label": "Use Family Default"
-              },
-              {
-                "value": "append",
-                "label": "Append"
-              },
-              {
-                "value": "sync",
-                "label": "Sync"
-              }
-            ],
-            "default": ""
-          },
-          {
-            "key": "limit_christmas",
-            "label": "Christmas Movies Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Christmas Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_christmas",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "schedule_christmas",
-            "label": "Schedule - Christmas",
-            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
-            "type": "text_input",
-            "default": "range(12/01-12/31)",
-            "label_width": 240
-          },
-          {
-            "key": "use_disabilities",
-            "label": "Disability Month Movies",
-            "tooltip": "Movies related to Disability Awareness Month",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_disabilities",
-            "label": "Disability Month Movies Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Disability Month Movies collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_disabilities",
-            "label": "Disability Month Movies Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Disability Month Movies collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "sync_mode_disabilities",
-            "label": "Disability Month Movies Sync Mode",
-            "type": "select",
-            "tooltip": "Override the sync_mode for the Disability Month Movies collection. Leave blank to inherit the family Sync Mode value.",
-            "options": [
-              {
-                "value": "",
-                "label": "Use Family Default"
-              },
-              {
-                "value": "append",
-                "label": "Append"
-              },
-              {
-                "value": "sync",
-                "label": "Sync"
-              }
-            ],
-            "default": ""
-          },
-          {
-            "key": "limit_disabilities",
-            "label": "Disability Month Movies Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Disability Month Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_disabilities",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "schedule_disabilities",
-            "label": "Schedule - Disability Awareness Day",
-            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
-            "type": "text_input",
-            "default": "range(12/02-12/04)",
-            "label_width": 240
-          },
-          {
-            "key": "use_easter",
-            "label": "Easter Movies",
-            "tooltip": "Movies related to Easter",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_easter",
-            "label": "Easter Movies Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Easter Movies collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_easter",
-            "label": "Easter Movies Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Easter Movies collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "sync_mode_easter",
-            "label": "Easter Movies Sync Mode",
-            "type": "select",
-            "tooltip": "Override the sync_mode for the Easter Movies collection. Leave blank to inherit the family Sync Mode value.",
-            "options": [
-              {
-                "value": "",
-                "label": "Use Family Default"
-              },
-              {
-                "value": "append",
-                "label": "Append"
-              },
-              {
-                "value": "sync",
-                "label": "Sync"
-              }
-            ],
-            "default": ""
-          },
-          {
-            "key": "limit_easter",
-            "label": "Easter Movies Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Easter Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_easter",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "schedule_easter",
-            "label": "Schedule - Easter",
-            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
-            "type": "text_input",
-            "default": "range(03/20-04/30)",
-            "label_width": 240
-          },
-          {
-            "key": "use_father",
-            "label": "Father's Day Movies",
-            "tooltip": "Movies related to Father's Day",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_father",
-            "label": "Father's Day Movies Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Father's Day Movies collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_father",
-            "label": "Father's Day Movies Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Father's Day Movies collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "sync_mode_father",
-            "label": "Father's Day Movies Sync Mode",
-            "type": "select",
-            "tooltip": "Override the sync_mode for the Father's Day Movies collection. Leave blank to inherit the family Sync Mode value.",
-            "options": [
-              {
-                "value": "",
-                "label": "Use Family Default"
-              },
-              {
-                "value": "append",
-                "label": "Append"
-              },
-              {
-                "value": "sync",
-                "label": "Sync"
-              }
-            ],
-            "default": ""
-          },
-          {
-            "key": "limit_father",
-            "label": "Father's Day Movies Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Father's Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_father",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "schedule_father",
-            "label": "Schedule - Father's Day",
-            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
-            "type": "text_input",
-            "default": "range(06/15-06/20)",
-            "label_width": 240
-          },
-          {
-            "key": "use_halloween",
-            "label": "Halloween Movies",
-            "tooltip": "Movies related to Halloween",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_halloween",
-            "label": "Halloween Movies Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Halloween Movies collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_halloween",
-            "label": "Halloween Movies Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Halloween Movies collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "sync_mode_halloween",
-            "label": "Halloween Movies Sync Mode",
-            "type": "select",
-            "tooltip": "Override the sync_mode for the Halloween Movies collection. Leave blank to inherit the family Sync Mode value.",
-            "options": [
-              {
-                "value": "",
-                "label": "Use Family Default"
-              },
-              {
-                "value": "append",
-                "label": "Append"
-              },
-              {
-                "value": "sync",
-                "label": "Sync"
-              }
-            ],
-            "default": ""
-          },
-          {
-            "key": "limit_halloween",
-            "label": "Halloween Movies Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Halloween Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_halloween",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "schedule_halloween",
-            "label": "Schedule - Halloween",
-            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
-            "type": "text_input",
-            "default": "range(10/01-10/31)",
-            "label_width": 240
-          },
-          {
-            "key": "use_independence",
-            "label": "Independence Day Movies",
-            "tooltip": "Movies related to Independence Day",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_independence",
-            "label": "Independence Day Movies Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Independence Day Movies collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_independence",
-            "label": "Independence Day Movies Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Independence Day Movies collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "sync_mode_independence",
-            "label": "Independence Day Movies Sync Mode",
-            "type": "select",
-            "tooltip": "Override the sync_mode for the Independence Day Movies collection. Leave blank to inherit the family Sync Mode value.",
-            "options": [
-              {
-                "value": "",
-                "label": "Use Family Default"
-              },
-              {
-                "value": "append",
-                "label": "Append"
-              },
-              {
-                "value": "sync",
-                "label": "Sync"
-              }
-            ],
-            "default": ""
-          },
-          {
-            "key": "limit_independence",
-            "label": "Independence Day Movies Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Independence Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_independence",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "schedule_independence",
-            "label": "Schedule - Independence Day",
-            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
-            "type": "text_input",
-            "default": "range(06/23-07/11)",
-            "label_width": 240
-          },
-          {
-            "key": "use_labor",
-            "label": "Labor Day Movies",
-            "tooltip": "Movies related to Labor Day",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_labor",
-            "label": "Labor Day Movies Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Labor Day Movies collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_labor",
-            "label": "Labor Day Movies Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Labor Day Movies collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "sync_mode_labor",
-            "label": "Labor Day Movies Sync Mode",
-            "type": "select",
-            "tooltip": "Override the sync_mode for the Labor Day Movies collection. Leave blank to inherit the family Sync Mode value.",
-            "options": [
-              {
-                "value": "",
-                "label": "Use Family Default"
-              },
-              {
-                "value": "append",
-                "label": "Append"
-              },
-              {
-                "value": "sync",
-                "label": "Sync"
-              }
-            ],
-            "default": ""
-          },
-          {
-            "key": "limit_labor",
-            "label": "Labor Day Movies Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Labor Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_labor",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "schedule_labor",
-            "label": "Schedule - Labor Day",
-            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
+            "key": "sort_prefix",
+            "label": "Sort Prefix",
             "type": "text_input",
-            "default": "range(09/01-09/10)",
-            "label_width": 240
+            "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
+            "placeholder": "e.g. !",
+            "section": "naming"
           },
           {
-            "key": "use_lgbtq",
-            "label": "LGBTQ Month Movies",
-            "tooltip": "Movies related to LGBTQ Pride Month",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_lgbtq",
-            "label": "LGBTQ Month Movies Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the LGBTQ Month Movies collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_lgbtq",
-            "label": "LGBTQ Month Movies Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the LGBTQ Month Movies collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "sync_mode_lgbtq",
-            "label": "LGBTQ Month Movies Sync Mode",
-            "type": "select",
-            "tooltip": "Override the sync_mode for the LGBTQ Month Movies collection. Leave blank to inherit the family Sync Mode value.",
-            "options": [
-              {
-                "value": "",
-                "label": "Use Family Default"
-              },
-              {
-                "value": "append",
-                "label": "Append"
-              },
-              {
-                "value": "sync",
-                "label": "Sync"
-              }
-            ],
-            "default": ""
-          },
-          {
-            "key": "limit_lgbtq",
-            "label": "LGBTQ Month Movies Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the LGBTQ Month Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_lgbtq",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "schedule_lgbtq",
-            "label": "Schedule - LGBTQ+ Pride Month",
-            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
-            "type": "text_input",
-            "default": "range(05/31-06/30)",
-            "label_width": 240
-          },
-          {
-            "key": "use_memorial",
-            "label": "Memorial Day Movies",
-            "tooltip": "Movies related to Memorial Day",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_memorial",
-            "label": "Memorial Day Movies Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Memorial Day Movies collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_memorial",
-            "label": "Memorial Day Movies Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Memorial Day Movies collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "sync_mode_memorial",
-            "label": "Memorial Day Movies Sync Mode",
-            "type": "select",
-            "tooltip": "Override the sync_mode for the Memorial Day Movies collection. Leave blank to inherit the family Sync Mode value.",
-            "options": [
-              {
-                "value": "",
-                "label": "Use Family Default"
-              },
-              {
-                "value": "append",
-                "label": "Append"
-              },
-              {
-                "value": "sync",
-                "label": "Sync"
-              }
-            ],
-            "default": ""
-          },
-          {
-            "key": "limit_memorial",
-            "label": "Memorial Day Movies Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Memorial Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_memorial",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "schedule_memorial",
-            "label": "Schedule - Memorial Day",
-            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
-            "type": "text_input",
-            "default": "range(5/18-6/7)",
-            "label_width": 240
-          },
-          {
-            "key": "use_mother",
-            "label": "Mother's Day Movies",
-            "tooltip": "Movies related to Mother's Day",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_mother",
-            "label": "Mother's Day Movies Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Mother's Day Movies collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_mother",
-            "label": "Mother's Day Movies Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Mother's Day Movies collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "sync_mode_mother",
-            "label": "Mother's Day Movies Sync Mode",
-            "type": "select",
-            "tooltip": "Override the sync_mode for the Mother's Day Movies collection. Leave blank to inherit the family Sync Mode value.",
-            "options": [
-              {
-                "value": "",
-                "label": "Use Family Default"
-              },
-              {
-                "value": "append",
-                "label": "Append"
-              },
-              {
-                "value": "sync",
-                "label": "Sync"
-              }
-            ],
-            "default": ""
-          },
-          {
-            "key": "limit_mother",
-            "label": "Mother's Day Movies Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Mother's Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_mother",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "schedule_mother",
-            "label": "Schedule - Mother's Day",
-            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
-            "type": "text_input",
-            "default": "range(05/05-05/10)",
-            "label_width": 240
-          },
-          {
-            "key": "use_latinx",
-            "label": "National Hispanic Heritage Movies",
-            "tooltip": "Movies related to National Hispanic Heritage Month",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_latinx",
-            "label": "National Hispanic Heritage Movies Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the National Hispanic Heritage Movies collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_latinx",
-            "label": "National Hispanic Heritage Movies Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the National Hispanic Heritage Movies collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "sync_mode_latinx",
-            "label": "National Hispanic Heritage Movies Sync Mode",
-            "type": "select",
-            "tooltip": "Override the sync_mode for the National Hispanic Heritage Movies collection. Leave blank to inherit the family Sync Mode value.",
-            "options": [
-              {
-                "value": "",
-                "label": "Use Family Default"
-              },
-              {
-                "value": "append",
-                "label": "Append"
-              },
-              {
-                "value": "sync",
-                "label": "Sync"
-              }
-            ],
-            "default": ""
-          },
-          {
-            "key": "limit_latinx",
-            "label": "National Hispanic Heritage Movies Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the National Hispanic Heritage Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_latinx",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "schedule_latinx",
-            "label": "Schedule - National Hispanic Heritage Month",
-            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
-            "type": "text_input",
-            "default": "range(09/15-10/15)",
-            "label_width": 240
-          },
-          {
-            "key": "use_years",
-            "label": "New Year's Day Movies",
-            "tooltip": "Movies related to New Year's Day",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_years",
-            "label": "New Year's Day Movies Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the New Year's Day Movies collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_years",
-            "label": "New Year's Day Movies Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the New Year's Day Movies collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "sync_mode_years",
-            "label": "New Year's Day Movies Sync Mode",
-            "type": "select",
-            "tooltip": "Override the sync_mode for the New Year's Day Movies collection. Leave blank to inherit the family Sync Mode value.",
-            "options": [
-              {
-                "value": "",
-                "label": "Use Family Default"
-              },
-              {
-                "value": "append",
-                "label": "Append"
-              },
-              {
-                "value": "sync",
-                "label": "Sync"
-              }
-            ],
-            "default": ""
-          },
-          {
-            "key": "limit_years",
-            "label": "New Year's Day Movies Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the New Year's Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_years",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "schedule_years",
-            "label": "Schedule - New Year's Day",
-            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
-            "type": "text_input",
-            "default": "range(12/26-01/04)",
-            "label_width": 240
-          },
-          {
-            "key": "use_patrick",
-            "label": "St. Patrick's Day Movies",
-            "tooltip": "Movies related to St. Patrick's Day",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_patrick",
-            "label": "St. Patrick's Day Movies Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the St. Patrick's Day Movies collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_patrick",
-            "label": "St. Patrick's Day Movies Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the St. Patrick's Day Movies collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "sync_mode_patrick",
-            "label": "St. Patrick's Day Movies Sync Mode",
-            "type": "select",
-            "tooltip": "Override the sync_mode for the St. Patrick's Day Movies collection. Leave blank to inherit the family Sync Mode value.",
-            "options": [
-              {
-                "value": "",
-                "label": "Use Family Default"
-              },
-              {
-                "value": "append",
-                "label": "Append"
-              },
-              {
-                "value": "sync",
-                "label": "Sync"
-              }
-            ],
-            "default": ""
-          },
-          {
-            "key": "limit_patrick",
-            "label": "St. Patrick's Day Movies Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the St. Patrick's Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_patrick",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "schedule_patrick",
-            "label": "Schedule - St. Patrick's Day",
-            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
-            "type": "text_input",
-            "default": "range(03/01-03/18)",
-            "label_width": 240
-          },
-          {
-            "key": "use_thanksgiving",
-            "label": "Thanksgiving Movies",
-            "tooltip": "Movies related to Thanksgiving",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_thanksgiving",
-            "label": "Thanksgiving Movies Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Thanksgiving Movies collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_thanksgiving",
-            "label": "Thanksgiving Movies Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Thanksgiving Movies collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "sync_mode_thanksgiving",
-            "label": "Thanksgiving Movies Sync Mode",
-            "type": "select",
-            "tooltip": "Override the sync_mode for the Thanksgiving Movies collection. Leave blank to inherit the family Sync Mode value.",
-            "options": [
-              {
-                "value": "",
-                "label": "Use Family Default"
-              },
-              {
-                "value": "append",
-                "label": "Append"
-              },
-              {
-                "value": "sync",
-                "label": "Sync"
-              }
-            ],
-            "default": ""
-          },
-          {
-            "key": "limit_thanksgiving",
-            "label": "Thanksgiving Movies Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Thanksgiving Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_thanksgiving",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "schedule_thanksgiving",
-            "label": "Schedule - Thanksgiving",
-            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
-            "type": "text_input",
-            "default": "range(11/01-11/30)",
-            "label_width": 240
-          },
-          {
-            "key": "use_valentine",
-            "label": "Valentine's Day Movies",
-            "tooltip": "Movies related to Valentine's Day",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_valentine",
-            "label": "Valentine's Day Movies Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Valentine's Day Movies collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_valentine",
-            "label": "Valentine's Day Movies Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Valentine's Day Movies collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "sync_mode_valentine",
-            "label": "Valentine's Day Movies Sync Mode",
-            "type": "select",
-            "tooltip": "Override the sync_mode for the Valentine's Day Movies collection. Leave blank to inherit the family Sync Mode value.",
-            "options": [
-              {
-                "value": "",
-                "label": "Use Family Default"
-              },
-              {
-                "value": "append",
-                "label": "Append"
-              },
-              {
-                "value": "sync",
-                "label": "Sync"
-              }
-            ],
-            "default": ""
-          },
-          {
-            "key": "limit_valentine",
-            "label": "Valentine's Day Movies Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Valentine's Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_valentine",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "schedule_valentine",
-            "label": "Schedule - Valentine's Day",
-            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
-            "type": "text_input",
-            "default": "range(02/01-02/29)",
-            "label_width": 240
-          },
-          {
-            "key": "use_veteran",
-            "label": "Veteran's Day Movies",
-            "tooltip": "Movies related to Veteran's Day",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_veteran",
-            "label": "Veteran's Day Movies Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Veteran's Day Movies collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_veteran",
-            "label": "Veteran's Day Movies Summary",
+            "key": "sort_title",
+            "label": "Sort Title",
             "type": "text_input",
-            "tooltip": "Override the collection summary for the Veteran's Day Movies collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "sync_mode_veteran",
-            "label": "Veteran's Day Movies Sync Mode",
-            "type": "select",
-            "tooltip": "Override the sync_mode for the Veteran's Day Movies collection. Leave blank to inherit the family Sync Mode value.",
-            "options": [
-              {
-                "value": "",
-                "label": "Use Family Default"
-              },
-              {
-                "value": "append",
-                "label": "Append"
-              },
-              {
-                "value": "sync",
-                "label": "Sync"
-              }
-            ],
-            "default": ""
+            "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom sort title format",
+            "section": "naming"
           },
           {
-            "key": "limit_veteran",
-            "label": "Veteran's Day Movies Limit",
+            "key": "name_format",
+            "label": "Name Format",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Veteran's Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_veteran",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
+            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection name format",
+            "section": "naming"
           },
           {
-            "key": "schedule_veteran",
-            "label": "Schedule - Veteran's Day",
-            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
+            "key": "summary_format",
+            "label": "Summary Format",
             "type": "text_input",
-            "default": "range(11/01-11/30)",
-            "label_width": 240
-          },
-          {
-            "key": "use_women",
-            "label": "Women's History Month Movies",
-            "tooltip": "Movies related to Women's History Month",
-            "type": "toggle",
-            "default": true
+            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection summary format",
+            "section": "naming"
           },
           {
-            "key": "name_women",
-            "label": "Women's History Month Movies Name",
+            "key": "title_format",
+            "label": "Title Format",
             "type": "text_input",
-            "tooltip": "Override the collection name for the Women's History Month Movies collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format",
+            "section": "naming"
           },
           {
-            "key": "summary_women",
-            "label": "Women's History Month Movies Summary",
+            "key": "name_mapping",
+            "label": "Name Mapping Default",
             "type": "text_input",
-            "tooltip": "Override the collection summary for the Women's History Month Movies collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
+            "tooltip": "Override the default name_mapping applied to child seasonal collections. Use <<key_name>> as a placeholder when needed.",
+            "placeholder": "Custom name mapping",
+            "section": "naming"
           },
           {
-            "key": "sync_mode_women",
-            "label": "Women's History Month Movies Sync Mode",
-            "type": "select",
-            "tooltip": "Override the sync_mode for the Women's History Month Movies collection. Leave blank to inherit the family Sync Mode value.",
-            "options": [
-              {
-                "value": "",
-                "label": "Use Family Default"
-              },
-              {
-                "value": "append",
-                "label": "Append"
-              },
-              {
-                "value": "sync",
-                "label": "Sync"
-              }
-            ],
-            "default": ""
-          },
-          {
-            "key": "limit_women",
-            "label": "Women's History Month Movies Limit",
+            "key": "emoji",
+            "label": "Emoji Default",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Women's History Month Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
+            "tooltip": "Override the default emoji prefix applied to child seasonal collections. Leave blank to keep the default seasonal prefix behavior.",
+            "placeholder": "e.g. \ud83c\udf83",
+            "section": "naming"
           },
           {
-            "key": "radarr_add_missing_women",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "schedule_women",
-            "label": "Schedule - Women's History Month",
-            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
-            "type": "text_input",
-            "default": "range(02/28-03/31)",
-            "label_width": 240
+            "key": "schedule",
+            "label": "Schedule Default",
+            "type": "schedule",
+            "tooltip": "Override the default schedule applied to child seasonal collections. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
+            "placeholder": "e.g. weekly(sunday)",
+            "section": "scope_schedule"
           },
           {
-            "key": "exclude",
-            "label": "Exclude",
+            "key": "delete_collections_named",
+            "label": "Delete Collections Named Default",
             "type": "string_list",
-            "tooltip": "Exclude specific seasonal collections from these collections.",
-            "placeholder": "Add seasonal key (e.g. halloween)"
-          },
-          {
-            "key": "minimum_items",
-            "label": "Minimum Items",
-            "type": "text_input",
-            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "ignore_ids",
-            "label": "Ignore IDs",
-            "type": "string_list",
-            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
-            "placeholder": "Add numeric ID (e.g. 603)",
-            "validation_preset": "numeric_id"
-          },
-          {
-            "key": "ignore_imdb_ids",
-            "label": "Ignore IMDb IDs",
-            "type": "string_list",
-            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
-            "placeholder": "Add IMDb ID (e.g. tt1234567)",
-            "validation_preset": "imdb_id_plex"
-          },
-          {
-            "key": "radarr_add_missing",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "radarr_search",
-            "label": "Search media when added to Radarr",
-            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "radarr_monitor",
-            "label": "Monitor media when added to Radarr",
-            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "radarr_monitor_existing",
-            "label": "Set existing media from collections to monitored in Radarr",
-            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "radarr_tag",
-            "label": "Radarr Tag",
-            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
-            "type": "string_list",
-            "placeholder": "Add Radarr tag",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "item_radarr_tag",
-            "label": "Item Radarr Tag",
-            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
-            "type": "string_list",
-            "placeholder": "Add item Radarr tag",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "radarr_folder",
-            "label": "Radarr Root Folder",
-            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
-            "type": "text_input",
-            "placeholder": "Enter Radarr root folder path",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "radarr_upgrade_existing",
-            "label": "Upgrade existing media in Radarr",
-            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sync_mode",
-            "label": "Sync Mode",
-            "type": "select",
-            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
-            "default": "sync",
-            "options": [
-              {
-                "value": "append",
-                "label": "Append"
-              },
-              {
-                "value": "sync",
-                "label": "Sync"
-              }
-            ]
-          },
-          {
-            "key": "cache_builders",
-            "label": "Cache Builders",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
-            "default": 1,
-            "input_type": "number",
-            "min": 0,
-            "step": 1
-          },
-          {
-            "key": "collection_mode",
-            "label": "Collection Mode",
-            "type": "select",
-            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
-            "default": "default",
-            "options": [
-              {
-                "value": "default",
-                "label": "Library Default"
-              },
-              {
-                "value": "hide",
-                "label": "Hide Collection"
-              },
-              {
-                "value": "hide_items",
-                "label": "Hide Items in this Collection"
-              },
-              {
-                "value": "show_items",
-                "label": "Show this Collection and its Items"
-              }
-            ]
-          },
-          {
-            "key": "visible_home",
-            "label": "Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library",
-            "label": "Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared",
-            "label": "Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority",
-            "label": "Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home",
-              "visible_library",
-              "visible_shared"
-            ],
-            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_aapi",
-            "label": "Asian American Pacific Islander Movies Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Asian American Pacific Islander Movies collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_aapi",
-            "label": "Asian American Pacific Islander Movies Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Asian American Pacific Islander Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_aapi",
-            "label": "Asian American Pacific Islander Movies Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Asian American Pacific Islander Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_aapi",
-            "label": "Asian American Pacific Islander Movies Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_aapi",
-              "visible_library_aapi",
-              "visible_shared_aapi"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_black_history",
-            "label": "Black History Month Movies Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Black History Month Movies collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_black_history",
-            "label": "Black History Month Movies Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Black History Month Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_black_history",
-            "label": "Black History Month Movies Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Black History Month Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_black_history",
-            "label": "Black History Month Movies Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_black_history",
-              "visible_library_black_history",
-              "visible_shared_black_history"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_christmas",
-            "label": "Christmas Movies Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Christmas Movies collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_christmas",
-            "label": "Christmas Movies Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Christmas Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_christmas",
-            "label": "Christmas Movies Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Christmas Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_christmas",
-            "label": "Christmas Movies Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_christmas",
-              "visible_library_christmas",
-              "visible_shared_christmas"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_disabilities",
-            "label": "Disability Month Movies Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Disability Month Movies collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_disabilities",
-            "label": "Disability Month Movies Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Disability Month Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_disabilities",
-            "label": "Disability Month Movies Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Disability Month Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_disabilities",
-            "label": "Disability Month Movies Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_disabilities",
-              "visible_library_disabilities",
-              "visible_shared_disabilities"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_easter",
-            "label": "Easter Movies Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Easter Movies collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_easter",
-            "label": "Easter Movies Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Easter Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_easter",
-            "label": "Easter Movies Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Easter Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_easter",
-            "label": "Easter Movies Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_easter",
-              "visible_library_easter",
-              "visible_shared_easter"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_father",
-            "label": "Father's Day Movies Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Father's Day Movies collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_father",
-            "label": "Father's Day Movies Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Father's Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_father",
-            "label": "Father's Day Movies Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Father's Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_father",
-            "label": "Father's Day Movies Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_father",
-              "visible_library_father",
-              "visible_shared_father"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_halloween",
-            "label": "Halloween Movies Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Halloween Movies collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_halloween",
-            "label": "Halloween Movies Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Halloween Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_halloween",
-            "label": "Halloween Movies Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Halloween Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_halloween",
-            "label": "Halloween Movies Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_halloween",
-              "visible_library_halloween",
-              "visible_shared_halloween"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_independence",
-            "label": "Independence Day Movies Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Independence Day Movies collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_independence",
-            "label": "Independence Day Movies Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Independence Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_independence",
-            "label": "Independence Day Movies Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Independence Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_independence",
-            "label": "Independence Day Movies Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_independence",
-              "visible_library_independence",
-              "visible_shared_independence"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_labor",
-            "label": "Labor Day Movies Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Labor Day Movies collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_labor",
-            "label": "Labor Day Movies Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Labor Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_labor",
-            "label": "Labor Day Movies Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Labor Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_labor",
-            "label": "Labor Day Movies Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_labor",
-              "visible_library_labor",
-              "visible_shared_labor"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_lgbtq",
-            "label": "LGBTQ Month Movies Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the LGBTQ Month Movies collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_lgbtq",
-            "label": "LGBTQ Month Movies Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the LGBTQ Month Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_lgbtq",
-            "label": "LGBTQ Month Movies Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the LGBTQ Month Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_lgbtq",
-            "label": "LGBTQ Month Movies Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_lgbtq",
-              "visible_library_lgbtq",
-              "visible_shared_lgbtq"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_memorial",
-            "label": "Memorial Day Movies Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Memorial Day Movies collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_memorial",
-            "label": "Memorial Day Movies Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Memorial Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_memorial",
-            "label": "Memorial Day Movies Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Memorial Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_memorial",
-            "label": "Memorial Day Movies Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_memorial",
-              "visible_library_memorial",
-              "visible_shared_memorial"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_mother",
-            "label": "Mother's Day Movies Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Mother's Day Movies collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_mother",
-            "label": "Mother's Day Movies Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Mother's Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_mother",
-            "label": "Mother's Day Movies Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Mother's Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_mother",
-            "label": "Mother's Day Movies Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_mother",
-              "visible_library_mother",
-              "visible_shared_mother"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_latinx",
-            "label": "National Hispanic Heritage Movies Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the National Hispanic Heritage Movies collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_latinx",
-            "label": "National Hispanic Heritage Movies Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the National Hispanic Heritage Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_latinx",
-            "label": "National Hispanic Heritage Movies Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the National Hispanic Heritage Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_latinx",
-            "label": "National Hispanic Heritage Movies Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_latinx",
-              "visible_library_latinx",
-              "visible_shared_latinx"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_years",
-            "label": "New Year's Day Movies Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the New Year's Day Movies collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_years",
-            "label": "New Year's Day Movies Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the New Year's Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_years",
-            "label": "New Year's Day Movies Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the New Year's Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_years",
-            "label": "New Year's Day Movies Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_years",
-              "visible_library_years",
-              "visible_shared_years"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_patrick",
-            "label": "St. Patrick's Day Movies Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the St. Patrick's Day Movies collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_patrick",
-            "label": "St. Patrick's Day Movies Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the St. Patrick's Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_patrick",
-            "label": "St. Patrick's Day Movies Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the St. Patrick's Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_patrick",
-            "label": "St. Patrick's Day Movies Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_patrick",
-              "visible_library_patrick",
-              "visible_shared_patrick"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_thanksgiving",
-            "label": "Thanksgiving Movies Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Thanksgiving Movies collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_thanksgiving",
-            "label": "Thanksgiving Movies Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Thanksgiving Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_thanksgiving",
-            "label": "Thanksgiving Movies Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Thanksgiving Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_thanksgiving",
-            "label": "Thanksgiving Movies Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_thanksgiving",
-              "visible_library_thanksgiving",
-              "visible_shared_thanksgiving"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_valentine",
-            "label": "Valentine's Day Movies Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Valentine's Day Movies collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_valentine",
-            "label": "Valentine's Day Movies Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Valentine's Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_valentine",
-            "label": "Valentine's Day Movies Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Valentine's Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_valentine",
-            "label": "Valentine's Day Movies Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_valentine",
-              "visible_library_valentine",
-              "visible_shared_valentine"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_veteran",
-            "label": "Veteran's Day Movies Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Veteran's Day Movies collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_veteran",
-            "label": "Veteran's Day Movies Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Veteran's Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_veteran",
-            "label": "Veteran's Day Movies Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Veteran's Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_veteran",
-            "label": "Veteran's Day Movies Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_veteran",
-              "visible_library_veteran",
-              "visible_shared_veteran"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_home_women",
-            "label": "Women's History Month Movies Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Women's History Month Movies collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_library_women",
-            "label": "Women's History Month Movies Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Women's History Month Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "visible_shared_women",
-            "label": "Women's History Month Movies Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Women's History Month Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false,
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "hub_priority_women",
-            "label": "Women's History Month Movies Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_women",
-              "visible_library_women",
-              "visible_shared_women"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
-            "media_types": [
-              "movie"
-            ]
+            "tooltip": "Set collection titles that should be deleted before rebuilding generated seasonal collections. This acts as the family default for holiday-specific delete settings.",
+            "placeholder": "Add collection title to delete",
+            "section": "scope_schedule"
           },
           {
             "key": "sort_by",
@@ -53786,7 +51356,3249 @@
                   "episode"
                 ]
               }
+            ],
+            "section": "builder_defaults"
+          },
+          {
+            "key": "tmdb_collection",
+            "label": "TMDb Collection Default",
+            "type": "string_list",
+            "tooltip": "Default TMDb collection IDs used when a holiday does not provide its own TMDb collection builder list.",
+            "placeholder": "Add TMDb collection ID (e.g. 8091)",
+            "validation_preset": "numeric_id",
+            "section": "builder_defaults"
+          },
+          {
+            "key": "tmdb_movie",
+            "label": "TMDb Movie Default",
+            "type": "string_list",
+            "tooltip": "Default TMDb movie IDs used when a holiday does not provide its own TMDb movie builder list.",
+            "placeholder": "Add TMDb movie ID (e.g. 603)",
+            "validation_preset": "numeric_id",
+            "section": "builder_defaults"
+          },
+          {
+            "key": "imdb_list",
+            "label": "IMDb List Default",
+            "type": "string_list",
+            "tooltip": "Default IMDb lists used when a holiday does not provide its own IMDb list sources. IMDb list IDs and full URLs are both accepted.",
+            "placeholder": "Add IMDb list URL or ID",
+            "section": "builder_defaults"
+          },
+          {
+            "key": "imdb_search",
+            "label": "IMDb Search Default",
+            "type": "text_input",
+            "tooltip": "Default IMDb search object used when a holiday does not provide its own search configuration. Enter JSON like {\"list.any\":[\"ls123456789\"],\"limit\":500}.",
+            "placeholder": "{\"list.any\":[\"ls123456789\"],\"limit\":500}",
+            "section": "builder_defaults"
+          },
+          {
+            "key": "trakt_list",
+            "label": "Trakt List Default",
+            "type": "string_list",
+            "tooltip": "Default Trakt lists used when a holiday does not provide its own Trakt list sources.",
+            "placeholder": "Add Trakt list URL",
+            "section": "builder_defaults"
+          },
+          {
+            "key": "mdblist_list",
+            "label": "MDBList Default",
+            "type": "string_list",
+            "tooltip": "Default MDBList sources used when a holiday does not provide its own MDBList list sources.",
+            "placeholder": "Add MDBList URL",
+            "section": "builder_defaults"
+          },
+          {
+            "key": "letterboxd_list",
+            "label": "Letterboxd Default",
+            "type": "string_list",
+            "tooltip": "Default Letterboxd lists used when a holiday does not provide its own Letterboxd list sources.",
+            "placeholder": "Add Letterboxd list URL",
+            "section": "builder_defaults"
+          },
+          {
+            "key": "child_name_mapping_overrides",
+            "label": "Seasonal Name Mapping Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a seasonal key to a custom name_mapping value. Quickstart exports these as <code>name_mapping_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Seasonal key (e.g. halloween)",
+            "key_validation_preset": "seasonal_key",
+            "key_input_mode": "select",
+            "value_placeholder": "Custom name mapping",
+            "dynamic_child_prefix": "name_mapping_",
+            "dynamic_child_value_kind": "string",
+            "section": "builder_override_maps"
+          },
+          {
+            "key": "child_emoji_overrides",
+            "label": "Seasonal Emoji Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a seasonal key to a custom emoji prefix. Quickstart exports these as <code>emoji_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Seasonal key (e.g. halloween)",
+            "key_validation_preset": "seasonal_key",
+            "key_input_mode": "select",
+            "value_placeholder": "\ud83c\udf83",
+            "dynamic_child_prefix": "emoji_",
+            "dynamic_child_value_kind": "string",
+            "section": "builder_override_maps"
+          },
+          {
+            "key": "child_sort_by_overrides",
+            "label": "Seasonal Sort By Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a seasonal key to a smart filter sort override. Quickstart exports these as <code>sort_by_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Seasonal key (e.g. halloween)",
+            "key_validation_preset": "seasonal_key",
+            "key_input_mode": "select",
+            "value_placeholder": "title.asc, release.desc, random, etc.",
+            "dynamic_child_prefix": "sort_by_",
+            "dynamic_child_value_kind": "select",
+            "section": "builder_override_maps"
+          },
+          {
+            "key": "child_delete_collections_named_overrides",
+            "label": "Seasonal Delete Collections Named Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a seasonal key to collection titles that should be deleted before rebuilding. Quickstart exports these as <code>delete_collections_named_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Seasonal key (e.g. halloween)",
+            "key_validation_preset": "seasonal_key",
+            "key_input_mode": "select",
+            "value_placeholder": "Title 1, Title 2",
+            "dynamic_child_prefix": "delete_collections_named_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "builder_override_maps"
+          },
+          {
+            "key": "child_tmdb_collection_overrides",
+            "label": "Seasonal TMDb Collection Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a seasonal key to one or more TMDb collection IDs. Quickstart exports these as <code>tmdb_collection_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Seasonal key (e.g. halloween)",
+            "key_validation_preset": "seasonal_key",
+            "key_input_mode": "select",
+            "value_placeholder": "8091, 1733",
+            "dynamic_child_prefix": "tmdb_collection_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "builder_override_maps"
+          },
+          {
+            "key": "child_tmdb_movie_overrides",
+            "label": "Seasonal TMDb Movie Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a seasonal key to one or more TMDb movie IDs. Quickstart exports these as <code>tmdb_movie_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Seasonal key (e.g. halloween)",
+            "key_validation_preset": "seasonal_key",
+            "key_input_mode": "select",
+            "value_placeholder": "603, 12244",
+            "dynamic_child_prefix": "tmdb_movie_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "builder_override_maps"
+          },
+          {
+            "key": "child_imdb_list_overrides",
+            "label": "Seasonal IMDb List Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a seasonal key to one or more IMDb lists. Quickstart exports these as <code>imdb_list_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Seasonal key (e.g. halloween)",
+            "key_validation_preset": "seasonal_key",
+            "key_input_mode": "select",
+            "value_placeholder": "https://www.imdb.com/list/ls123456789/ or ls123456789",
+            "dynamic_child_prefix": "imdb_list_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "builder_override_maps"
+          },
+          {
+            "key": "child_imdb_search_overrides",
+            "label": "Seasonal IMDb Search Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a seasonal key to a JSON IMDb search object. Quickstart exports these as <code>imdb_search_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Seasonal key (e.g. halloween)",
+            "key_validation_preset": "seasonal_key",
+            "key_input_mode": "select",
+            "value_placeholder": "{\"list.any\":[\"ls123456789\"],\"limit\":500}",
+            "dynamic_child_prefix": "imdb_search_",
+            "dynamic_child_value_kind": "json",
+            "section": "builder_override_maps"
+          },
+          {
+            "key": "child_trakt_list_overrides",
+            "label": "Seasonal Trakt List Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a seasonal key to one or more Trakt lists. Quickstart exports these as <code>trakt_list_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Seasonal key (e.g. halloween)",
+            "key_validation_preset": "seasonal_key",
+            "key_input_mode": "select",
+            "value_placeholder": "https://trakt.tv/users/example/lists/seasonal",
+            "dynamic_child_prefix": "trakt_list_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "builder_override_maps"
+          },
+          {
+            "key": "child_mdblist_list_overrides",
+            "label": "Seasonal MDBList Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a seasonal key to one or more MDBList sources. Quickstart exports these as <code>mdblist_list_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Seasonal key (e.g. halloween)",
+            "key_validation_preset": "seasonal_key",
+            "key_input_mode": "select",
+            "value_placeholder": "https://mdblist.com/lists/example/list",
+            "dynamic_child_prefix": "mdblist_list_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "builder_override_maps"
+          },
+          {
+            "key": "child_letterboxd_list_overrides",
+            "label": "Seasonal Letterboxd Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a seasonal key to one or more Letterboxd lists. Quickstart exports these as <code>letterboxd_list_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Seasonal key (e.g. halloween)",
+            "key_validation_preset": "seasonal_key",
+            "key_input_mode": "select",
+            "value_placeholder": "https://letterboxd.com/example/list/seasonal/",
+            "dynamic_child_prefix": "letterboxd_list_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "builder_override_maps"
+          },
+          {
+            "key": "url_poster",
+            "label": "Poster URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default poster URL applied to child seasonal collections when no holiday-specific poster override is set.",
+            "placeholder": "https://example.com/poster.jpg",
+            "validation_preset": "url",
+            "section": "artwork"
+          },
+          {
+            "key": "url_background",
+            "label": "Background URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default background URL applied to child seasonal collections when no holiday-specific background override is set.",
+            "placeholder": "https://example.com/background.jpg",
+            "validation_preset": "url",
+            "section": "artwork"
+          },
+          {
+            "key": "url_logo",
+            "label": "Logo URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default logo URL applied to child seasonal collections when no holiday-specific logo override is set.",
+            "placeholder": "https://example.com/logo.png",
+            "validation_preset": "url",
+            "section": "artwork"
+          },
+          {
+            "key": "url_square_art",
+            "label": "Square Art URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default square art URL applied to child seasonal collections when no holiday-specific square art override is set.",
+            "placeholder": "https://example.com/square-art.png",
+            "validation_preset": "url",
+            "section": "artwork"
+          },
+          {
+            "key": "child_url_poster_overrides",
+            "label": "Seasonal Poster URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a seasonal key to a custom poster URL. Quickstart exports these as <code>url_poster_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Seasonal key (e.g. halloween)",
+            "key_validation_preset": "seasonal_key",
+            "key_input_mode": "select",
+            "value_placeholder": "https://example.com/poster.jpg",
+            "dynamic_child_prefix": "url_poster_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_url_background_overrides",
+            "label": "Seasonal Background URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a seasonal key to a custom background URL. Quickstart exports these as <code>url_background_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Seasonal key (e.g. halloween)",
+            "key_validation_preset": "seasonal_key",
+            "key_input_mode": "select",
+            "value_placeholder": "https://example.com/background.jpg",
+            "dynamic_child_prefix": "url_background_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_url_logo_overrides",
+            "label": "Seasonal Logo URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a seasonal key to a custom logo URL. Quickstart exports these as <code>url_logo_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Seasonal key (e.g. halloween)",
+            "key_validation_preset": "seasonal_key",
+            "key_input_mode": "select",
+            "value_placeholder": "https://example.com/logo.png",
+            "dynamic_child_prefix": "url_logo_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_url_square_art_overrides",
+            "label": "Seasonal Square Art URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a seasonal key to a custom square art URL. Quickstart exports these as <code>url_square_art_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Seasonal key (e.g. halloween)",
+            "key_validation_preset": "seasonal_key",
+            "key_input_mode": "select",
+            "value_placeholder": "https://example.com/square-art.png",
+            "dynamic_child_prefix": "url_square_art_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "validation_preset": "url"
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "automation_defaults"
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id",
+            "section": "automation_defaults"
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex",
+            "section": "automation_defaults"
+          },
+          {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation_defaults"
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation_defaults"
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation_defaults"
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation_defaults"
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation_defaults"
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation_defaults"
+          },
+          {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation_defaults"
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation_defaults"
+          },
+          {
+            "key": "sync_mode",
+            "label": "Sync Mode",
+            "type": "select",
+            "tooltip": "Changes the sync_mode for all collections in a Defaults File.<br><br> Default is <b>Sync</b> ",
+            "default": "sync",
+            "options": [
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ],
+            "section": "automation_defaults"
+          },
+          {
+            "key": "cache_builders",
+            "label": "Cache Builders",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Cache for all collections in a Defaults File.<br><br>Allowed values: number 0 or greater.",
+            "default": 1,
+            "input_type": "number",
+            "min": 0,
+            "step": 1,
+            "section": "automation_defaults"
+          },
+          {
+            "key": "collection_mode",
+            "label": "Collection Mode",
+            "type": "select",
+            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
+            "default": "default",
+            "options": [
+              {
+                "value": "default",
+                "label": "Library Default"
+              },
+              {
+                "value": "hide",
+                "label": "Hide Collection"
+              },
+              {
+                "value": "hide_items",
+                "label": "Hide Items in this Collection"
+              },
+              {
+                "value": "show_items",
+                "label": "Show this Collection and its Items"
+              }
+            ],
+            "section": "automation_defaults"
+          },
+          {
+            "key": "visible_home",
+            "label": "Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation_defaults"
+          },
+          {
+            "key": "visible_library",
+            "label": "Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation_defaults"
+          },
+          {
+            "key": "visible_shared",
+            "label": "Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation_defaults"
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation_defaults"
+          },
+          {
+            "key": "child_radarr_folder_overrides",
+            "label": "Seasonal Radarr Folder Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a seasonal key to a Radarr root folder override. Quickstart exports these as <code>radarr_folder_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Seasonal key (e.g. halloween)",
+            "key_validation_preset": "seasonal_key",
+            "key_input_mode": "select",
+            "value_placeholder": "C:\\Media\\Movies",
+            "dynamic_child_prefix": "radarr_folder_",
+            "dynamic_child_value_kind": "string",
+            "section": "automation_override_maps",
+            "media_types": [
+              "movie"
             ]
+          },
+          {
+            "key": "child_radarr_tag_overrides",
+            "label": "Seasonal Radarr Tag Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a seasonal key to Radarr tags. Quickstart exports these as <code>radarr_tag_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Seasonal key (e.g. halloween)",
+            "key_validation_preset": "seasonal_key",
+            "key_input_mode": "select",
+            "value_placeholder": "holiday, halloween",
+            "dynamic_child_prefix": "radarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "automation_override_maps",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "child_item_radarr_tag_overrides",
+            "label": "Seasonal Item Radarr Tag Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a seasonal key to item-level Radarr tags. Quickstart exports these as <code>item_radarr_tag_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Seasonal key (e.g. halloween)",
+            "key_validation_preset": "seasonal_key",
+            "key_input_mode": "select",
+            "value_placeholder": "seasonal, tracked",
+            "dynamic_child_prefix": "item_radarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "automation_override_maps",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "child_radarr_monitor_overrides",
+            "label": "Seasonal Radarr Monitor Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a seasonal key to a Radarr monitor override. Quickstart exports these as <code>radarr_monitor_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Seasonal key (e.g. halloween)",
+            "key_validation_preset": "seasonal_key",
+            "key_input_mode": "select",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "radarr_monitor_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "automation_override_maps",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "child_radarr_upgrade_existing_overrides",
+            "label": "Seasonal Radarr Upgrade Existing Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a seasonal key to a Radarr upgrade_existing override. Quickstart exports these as <code>radarr_upgrade_existing_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Seasonal key (e.g. halloween)",
+            "key_validation_preset": "seasonal_key",
+            "key_input_mode": "select",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "radarr_upgrade_existing_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "automation_override_maps",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "child_radarr_monitor_existing_overrides",
+            "label": "Seasonal Radarr Monitor Existing Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a seasonal key to a Radarr monitor_existing override. Quickstart exports these as <code>radarr_monitor_existing_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Seasonal key (e.g. halloween)",
+            "key_validation_preset": "seasonal_key",
+            "key_input_mode": "select",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "radarr_monitor_existing_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "automation_override_maps",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "child_radarr_search_overrides",
+            "label": "Seasonal Radarr Search Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a seasonal key to a Radarr search override. Quickstart exports these as <code>radarr_search_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Seasonal key (e.g. halloween)",
+            "key_validation_preset": "seasonal_key",
+            "key_input_mode": "select",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "radarr_search_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "automation_override_maps",
+            "media_types": [
+              "movie"
+            ]
+          },
+          {
+            "key": "use_years",
+            "label": "New Year's Day Movies",
+            "tooltip": "Movies related to New Year's Day",
+            "type": "toggle",
+            "default": true,
+            "section": "holiday_years"
+          },
+          {
+            "key": "name_years",
+            "label": "New Year's Day Movies Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the New Year's Day Movies collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "holiday_years"
+          },
+          {
+            "key": "summary_years",
+            "label": "New Year's Day Movies Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the New Year's Day Movies collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "holiday_years"
+          },
+          {
+            "key": "sync_mode_years",
+            "label": "New Year's Day Movies Sync Mode",
+            "type": "select",
+            "tooltip": "Override the sync_mode for the New Year's Day Movies collection. Leave blank to inherit the family Sync Mode value.",
+            "options": [
+              {
+                "value": "",
+                "label": "Use Family Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ],
+            "default": "",
+            "section": "holiday_years"
+          },
+          {
+            "key": "limit_years",
+            "label": "New Year's Day Movies Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the New Year's Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "holiday_years"
+          },
+          {
+            "key": "radarr_add_missing_years",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_years"
+          },
+          {
+            "key": "schedule_years",
+            "label": "Schedule - New Year's Day",
+            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
+            "type": "text_input",
+            "default": "range(12/26-01/04)",
+            "label_width": 240,
+            "section": "holiday_years"
+          },
+          {
+            "key": "visible_home_years",
+            "label": "New Year's Day Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the New Year's Day Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_years"
+          },
+          {
+            "key": "visible_library_years",
+            "label": "New Year's Day Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the New Year's Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_years"
+          },
+          {
+            "key": "visible_shared_years",
+            "label": "New Year's Day Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the New Year's Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_years"
+          },
+          {
+            "key": "hub_priority_years",
+            "label": "New Year's Day Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_years",
+              "visible_library_years",
+              "visible_shared_years"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_years"
+          },
+          {
+            "key": "use_valentine",
+            "label": "Valentine's Day Movies",
+            "tooltip": "Movies related to Valentine's Day",
+            "type": "toggle",
+            "default": true,
+            "section": "holiday_valentine"
+          },
+          {
+            "key": "name_valentine",
+            "label": "Valentine's Day Movies Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Valentine's Day Movies collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "holiday_valentine"
+          },
+          {
+            "key": "summary_valentine",
+            "label": "Valentine's Day Movies Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Valentine's Day Movies collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "holiday_valentine"
+          },
+          {
+            "key": "sync_mode_valentine",
+            "label": "Valentine's Day Movies Sync Mode",
+            "type": "select",
+            "tooltip": "Override the sync_mode for the Valentine's Day Movies collection. Leave blank to inherit the family Sync Mode value.",
+            "options": [
+              {
+                "value": "",
+                "label": "Use Family Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ],
+            "default": "",
+            "section": "holiday_valentine"
+          },
+          {
+            "key": "limit_valentine",
+            "label": "Valentine's Day Movies Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Valentine's Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "holiday_valentine"
+          },
+          {
+            "key": "radarr_add_missing_valentine",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_valentine"
+          },
+          {
+            "key": "schedule_valentine",
+            "label": "Schedule - Valentine's Day",
+            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
+            "type": "text_input",
+            "default": "range(02/01-02/29)",
+            "label_width": 240,
+            "section": "holiday_valentine"
+          },
+          {
+            "key": "visible_home_valentine",
+            "label": "Valentine's Day Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Valentine's Day Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_valentine"
+          },
+          {
+            "key": "visible_library_valentine",
+            "label": "Valentine's Day Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Valentine's Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_valentine"
+          },
+          {
+            "key": "visible_shared_valentine",
+            "label": "Valentine's Day Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Valentine's Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_valentine"
+          },
+          {
+            "key": "hub_priority_valentine",
+            "label": "Valentine's Day Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_valentine",
+              "visible_library_valentine",
+              "visible_shared_valentine"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_valentine"
+          },
+          {
+            "key": "use_patrick",
+            "label": "St. Patrick's Day Movies",
+            "tooltip": "Movies related to St. Patrick's Day",
+            "type": "toggle",
+            "default": true,
+            "section": "holiday_patrick"
+          },
+          {
+            "key": "name_patrick",
+            "label": "St. Patrick's Day Movies Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the St. Patrick's Day Movies collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "holiday_patrick"
+          },
+          {
+            "key": "summary_patrick",
+            "label": "St. Patrick's Day Movies Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the St. Patrick's Day Movies collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "holiday_patrick"
+          },
+          {
+            "key": "sync_mode_patrick",
+            "label": "St. Patrick's Day Movies Sync Mode",
+            "type": "select",
+            "tooltip": "Override the sync_mode for the St. Patrick's Day Movies collection. Leave blank to inherit the family Sync Mode value.",
+            "options": [
+              {
+                "value": "",
+                "label": "Use Family Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ],
+            "default": "",
+            "section": "holiday_patrick"
+          },
+          {
+            "key": "limit_patrick",
+            "label": "St. Patrick's Day Movies Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the St. Patrick's Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "holiday_patrick"
+          },
+          {
+            "key": "radarr_add_missing_patrick",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_patrick"
+          },
+          {
+            "key": "schedule_patrick",
+            "label": "Schedule - St. Patrick's Day",
+            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
+            "type": "text_input",
+            "default": "range(03/01-03/18)",
+            "label_width": 240,
+            "section": "holiday_patrick"
+          },
+          {
+            "key": "visible_home_patrick",
+            "label": "St. Patrick's Day Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the St. Patrick's Day Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_patrick"
+          },
+          {
+            "key": "visible_library_patrick",
+            "label": "St. Patrick's Day Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the St. Patrick's Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_patrick"
+          },
+          {
+            "key": "visible_shared_patrick",
+            "label": "St. Patrick's Day Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the St. Patrick's Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_patrick"
+          },
+          {
+            "key": "hub_priority_patrick",
+            "label": "St. Patrick's Day Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_patrick",
+              "visible_library_patrick",
+              "visible_shared_patrick"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_patrick"
+          },
+          {
+            "key": "use_easter",
+            "label": "Easter Movies",
+            "tooltip": "Movies related to Easter",
+            "type": "toggle",
+            "default": true,
+            "section": "holiday_easter"
+          },
+          {
+            "key": "name_easter",
+            "label": "Easter Movies Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Easter Movies collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "holiday_easter"
+          },
+          {
+            "key": "summary_easter",
+            "label": "Easter Movies Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Easter Movies collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "holiday_easter"
+          },
+          {
+            "key": "sync_mode_easter",
+            "label": "Easter Movies Sync Mode",
+            "type": "select",
+            "tooltip": "Override the sync_mode for the Easter Movies collection. Leave blank to inherit the family Sync Mode value.",
+            "options": [
+              {
+                "value": "",
+                "label": "Use Family Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ],
+            "default": "",
+            "section": "holiday_easter"
+          },
+          {
+            "key": "limit_easter",
+            "label": "Easter Movies Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Easter Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "holiday_easter"
+          },
+          {
+            "key": "radarr_add_missing_easter",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_easter"
+          },
+          {
+            "key": "schedule_easter",
+            "label": "Schedule - Easter",
+            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
+            "type": "text_input",
+            "default": "range(03/20-04/30)",
+            "label_width": 240,
+            "section": "holiday_easter"
+          },
+          {
+            "key": "visible_home_easter",
+            "label": "Easter Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Easter Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_easter"
+          },
+          {
+            "key": "visible_library_easter",
+            "label": "Easter Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Easter Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_easter"
+          },
+          {
+            "key": "visible_shared_easter",
+            "label": "Easter Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Easter Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_easter"
+          },
+          {
+            "key": "hub_priority_easter",
+            "label": "Easter Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_easter",
+              "visible_library_easter",
+              "visible_shared_easter"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_easter"
+          },
+          {
+            "key": "use_mother",
+            "label": "Mother's Day Movies",
+            "tooltip": "Movies related to Mother's Day",
+            "type": "toggle",
+            "default": true,
+            "section": "holiday_mother"
+          },
+          {
+            "key": "name_mother",
+            "label": "Mother's Day Movies Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Mother's Day Movies collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "holiday_mother"
+          },
+          {
+            "key": "summary_mother",
+            "label": "Mother's Day Movies Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Mother's Day Movies collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "holiday_mother"
+          },
+          {
+            "key": "sync_mode_mother",
+            "label": "Mother's Day Movies Sync Mode",
+            "type": "select",
+            "tooltip": "Override the sync_mode for the Mother's Day Movies collection. Leave blank to inherit the family Sync Mode value.",
+            "options": [
+              {
+                "value": "",
+                "label": "Use Family Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ],
+            "default": "",
+            "section": "holiday_mother"
+          },
+          {
+            "key": "limit_mother",
+            "label": "Mother's Day Movies Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Mother's Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "holiday_mother"
+          },
+          {
+            "key": "radarr_add_missing_mother",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_mother"
+          },
+          {
+            "key": "schedule_mother",
+            "label": "Schedule - Mother's Day",
+            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
+            "type": "text_input",
+            "default": "range(05/05-05/10)",
+            "label_width": 240,
+            "section": "holiday_mother"
+          },
+          {
+            "key": "visible_home_mother",
+            "label": "Mother's Day Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Mother's Day Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_mother"
+          },
+          {
+            "key": "visible_library_mother",
+            "label": "Mother's Day Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Mother's Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_mother"
+          },
+          {
+            "key": "visible_shared_mother",
+            "label": "Mother's Day Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Mother's Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_mother"
+          },
+          {
+            "key": "hub_priority_mother",
+            "label": "Mother's Day Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_mother",
+              "visible_library_mother",
+              "visible_shared_mother"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_mother"
+          },
+          {
+            "key": "use_memorial",
+            "label": "Memorial Day Movies",
+            "tooltip": "Movies related to Memorial Day",
+            "type": "toggle",
+            "default": true,
+            "section": "holiday_memorial"
+          },
+          {
+            "key": "name_memorial",
+            "label": "Memorial Day Movies Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Memorial Day Movies collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "holiday_memorial"
+          },
+          {
+            "key": "summary_memorial",
+            "label": "Memorial Day Movies Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Memorial Day Movies collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "holiday_memorial"
+          },
+          {
+            "key": "sync_mode_memorial",
+            "label": "Memorial Day Movies Sync Mode",
+            "type": "select",
+            "tooltip": "Override the sync_mode for the Memorial Day Movies collection. Leave blank to inherit the family Sync Mode value.",
+            "options": [
+              {
+                "value": "",
+                "label": "Use Family Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ],
+            "default": "",
+            "section": "holiday_memorial"
+          },
+          {
+            "key": "limit_memorial",
+            "label": "Memorial Day Movies Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Memorial Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "holiday_memorial"
+          },
+          {
+            "key": "radarr_add_missing_memorial",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_memorial"
+          },
+          {
+            "key": "schedule_memorial",
+            "label": "Schedule - Memorial Day",
+            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
+            "type": "text_input",
+            "default": "range(5/18-6/7)",
+            "label_width": 240,
+            "section": "holiday_memorial"
+          },
+          {
+            "key": "visible_home_memorial",
+            "label": "Memorial Day Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Memorial Day Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_memorial"
+          },
+          {
+            "key": "visible_library_memorial",
+            "label": "Memorial Day Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Memorial Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_memorial"
+          },
+          {
+            "key": "visible_shared_memorial",
+            "label": "Memorial Day Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Memorial Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_memorial"
+          },
+          {
+            "key": "hub_priority_memorial",
+            "label": "Memorial Day Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_memorial",
+              "visible_library_memorial",
+              "visible_shared_memorial"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_memorial"
+          },
+          {
+            "key": "use_father",
+            "label": "Father's Day Movies",
+            "tooltip": "Movies related to Father's Day",
+            "type": "toggle",
+            "default": true,
+            "section": "holiday_father"
+          },
+          {
+            "key": "name_father",
+            "label": "Father's Day Movies Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Father's Day Movies collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "holiday_father"
+          },
+          {
+            "key": "summary_father",
+            "label": "Father's Day Movies Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Father's Day Movies collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "holiday_father"
+          },
+          {
+            "key": "sync_mode_father",
+            "label": "Father's Day Movies Sync Mode",
+            "type": "select",
+            "tooltip": "Override the sync_mode for the Father's Day Movies collection. Leave blank to inherit the family Sync Mode value.",
+            "options": [
+              {
+                "value": "",
+                "label": "Use Family Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ],
+            "default": "",
+            "section": "holiday_father"
+          },
+          {
+            "key": "limit_father",
+            "label": "Father's Day Movies Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Father's Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "holiday_father"
+          },
+          {
+            "key": "radarr_add_missing_father",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_father"
+          },
+          {
+            "key": "schedule_father",
+            "label": "Schedule - Father's Day",
+            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
+            "type": "text_input",
+            "default": "range(06/15-06/20)",
+            "label_width": 240,
+            "section": "holiday_father"
+          },
+          {
+            "key": "visible_home_father",
+            "label": "Father's Day Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Father's Day Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_father"
+          },
+          {
+            "key": "visible_library_father",
+            "label": "Father's Day Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Father's Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_father"
+          },
+          {
+            "key": "visible_shared_father",
+            "label": "Father's Day Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Father's Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_father"
+          },
+          {
+            "key": "hub_priority_father",
+            "label": "Father's Day Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_father",
+              "visible_library_father",
+              "visible_shared_father"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_father"
+          },
+          {
+            "key": "use_independence",
+            "label": "Independence Day Movies",
+            "tooltip": "Movies related to Independence Day",
+            "type": "toggle",
+            "default": true,
+            "section": "holiday_independence"
+          },
+          {
+            "key": "name_independence",
+            "label": "Independence Day Movies Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Independence Day Movies collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "holiday_independence"
+          },
+          {
+            "key": "summary_independence",
+            "label": "Independence Day Movies Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Independence Day Movies collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "holiday_independence"
+          },
+          {
+            "key": "sync_mode_independence",
+            "label": "Independence Day Movies Sync Mode",
+            "type": "select",
+            "tooltip": "Override the sync_mode for the Independence Day Movies collection. Leave blank to inherit the family Sync Mode value.",
+            "options": [
+              {
+                "value": "",
+                "label": "Use Family Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ],
+            "default": "",
+            "section": "holiday_independence"
+          },
+          {
+            "key": "limit_independence",
+            "label": "Independence Day Movies Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Independence Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "holiday_independence"
+          },
+          {
+            "key": "radarr_add_missing_independence",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_independence"
+          },
+          {
+            "key": "schedule_independence",
+            "label": "Schedule - Independence Day",
+            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
+            "type": "text_input",
+            "default": "range(06/23-07/11)",
+            "label_width": 240,
+            "section": "holiday_independence"
+          },
+          {
+            "key": "visible_home_independence",
+            "label": "Independence Day Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Independence Day Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_independence"
+          },
+          {
+            "key": "visible_library_independence",
+            "label": "Independence Day Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Independence Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_independence"
+          },
+          {
+            "key": "visible_shared_independence",
+            "label": "Independence Day Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Independence Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_independence"
+          },
+          {
+            "key": "hub_priority_independence",
+            "label": "Independence Day Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_independence",
+              "visible_library_independence",
+              "visible_shared_independence"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_independence"
+          },
+          {
+            "key": "use_labor",
+            "label": "Labor Day Movies",
+            "tooltip": "Movies related to Labor Day",
+            "type": "toggle",
+            "default": true,
+            "section": "holiday_labor"
+          },
+          {
+            "key": "name_labor",
+            "label": "Labor Day Movies Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Labor Day Movies collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "holiday_labor"
+          },
+          {
+            "key": "summary_labor",
+            "label": "Labor Day Movies Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Labor Day Movies collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "holiday_labor"
+          },
+          {
+            "key": "sync_mode_labor",
+            "label": "Labor Day Movies Sync Mode",
+            "type": "select",
+            "tooltip": "Override the sync_mode for the Labor Day Movies collection. Leave blank to inherit the family Sync Mode value.",
+            "options": [
+              {
+                "value": "",
+                "label": "Use Family Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ],
+            "default": "",
+            "section": "holiday_labor"
+          },
+          {
+            "key": "limit_labor",
+            "label": "Labor Day Movies Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Labor Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "holiday_labor"
+          },
+          {
+            "key": "radarr_add_missing_labor",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_labor"
+          },
+          {
+            "key": "schedule_labor",
+            "label": "Schedule - Labor Day",
+            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
+            "type": "text_input",
+            "default": "range(09/01-09/10)",
+            "label_width": 240,
+            "section": "holiday_labor"
+          },
+          {
+            "key": "visible_home_labor",
+            "label": "Labor Day Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Labor Day Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_labor"
+          },
+          {
+            "key": "visible_library_labor",
+            "label": "Labor Day Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Labor Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_labor"
+          },
+          {
+            "key": "visible_shared_labor",
+            "label": "Labor Day Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Labor Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_labor"
+          },
+          {
+            "key": "hub_priority_labor",
+            "label": "Labor Day Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_labor",
+              "visible_library_labor",
+              "visible_shared_labor"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_labor"
+          },
+          {
+            "key": "use_halloween",
+            "label": "Halloween Movies",
+            "tooltip": "Movies related to Halloween",
+            "type": "toggle",
+            "default": true,
+            "section": "holiday_halloween"
+          },
+          {
+            "key": "name_halloween",
+            "label": "Halloween Movies Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Halloween Movies collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "holiday_halloween"
+          },
+          {
+            "key": "summary_halloween",
+            "label": "Halloween Movies Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Halloween Movies collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "holiday_halloween"
+          },
+          {
+            "key": "sync_mode_halloween",
+            "label": "Halloween Movies Sync Mode",
+            "type": "select",
+            "tooltip": "Override the sync_mode for the Halloween Movies collection. Leave blank to inherit the family Sync Mode value.",
+            "options": [
+              {
+                "value": "",
+                "label": "Use Family Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ],
+            "default": "",
+            "section": "holiday_halloween"
+          },
+          {
+            "key": "limit_halloween",
+            "label": "Halloween Movies Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Halloween Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "holiday_halloween"
+          },
+          {
+            "key": "radarr_add_missing_halloween",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_halloween"
+          },
+          {
+            "key": "schedule_halloween",
+            "label": "Schedule - Halloween",
+            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
+            "type": "text_input",
+            "default": "range(10/01-10/31)",
+            "label_width": 240,
+            "section": "holiday_halloween"
+          },
+          {
+            "key": "visible_home_halloween",
+            "label": "Halloween Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Halloween Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_halloween"
+          },
+          {
+            "key": "visible_library_halloween",
+            "label": "Halloween Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Halloween Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_halloween"
+          },
+          {
+            "key": "visible_shared_halloween",
+            "label": "Halloween Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Halloween Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_halloween"
+          },
+          {
+            "key": "hub_priority_halloween",
+            "label": "Halloween Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_halloween",
+              "visible_library_halloween",
+              "visible_shared_halloween"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_halloween"
+          },
+          {
+            "key": "use_veteran",
+            "label": "Veteran's Day Movies",
+            "tooltip": "Movies related to Veteran's Day",
+            "type": "toggle",
+            "default": true,
+            "section": "holiday_veteran"
+          },
+          {
+            "key": "name_veteran",
+            "label": "Veteran's Day Movies Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Veteran's Day Movies collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "holiday_veteran"
+          },
+          {
+            "key": "summary_veteran",
+            "label": "Veteran's Day Movies Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Veteran's Day Movies collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "holiday_veteran"
+          },
+          {
+            "key": "sync_mode_veteran",
+            "label": "Veteran's Day Movies Sync Mode",
+            "type": "select",
+            "tooltip": "Override the sync_mode for the Veteran's Day Movies collection. Leave blank to inherit the family Sync Mode value.",
+            "options": [
+              {
+                "value": "",
+                "label": "Use Family Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ],
+            "default": "",
+            "section": "holiday_veteran"
+          },
+          {
+            "key": "limit_veteran",
+            "label": "Veteran's Day Movies Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Veteran's Day Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "holiday_veteran"
+          },
+          {
+            "key": "radarr_add_missing_veteran",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_veteran"
+          },
+          {
+            "key": "schedule_veteran",
+            "label": "Schedule - Veteran's Day",
+            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
+            "type": "text_input",
+            "default": "range(11/01-11/30)",
+            "label_width": 240,
+            "section": "holiday_veteran"
+          },
+          {
+            "key": "visible_home_veteran",
+            "label": "Veteran's Day Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Veteran's Day Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_veteran"
+          },
+          {
+            "key": "visible_library_veteran",
+            "label": "Veteran's Day Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Veteran's Day Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_veteran"
+          },
+          {
+            "key": "visible_shared_veteran",
+            "label": "Veteran's Day Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Veteran's Day Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_veteran"
+          },
+          {
+            "key": "hub_priority_veteran",
+            "label": "Veteran's Day Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_veteran",
+              "visible_library_veteran",
+              "visible_shared_veteran"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_veteran"
+          },
+          {
+            "key": "use_thanksgiving",
+            "label": "Thanksgiving Movies",
+            "tooltip": "Movies related to Thanksgiving",
+            "type": "toggle",
+            "default": true,
+            "section": "holiday_thanksgiving"
+          },
+          {
+            "key": "name_thanksgiving",
+            "label": "Thanksgiving Movies Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Thanksgiving Movies collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "holiday_thanksgiving"
+          },
+          {
+            "key": "summary_thanksgiving",
+            "label": "Thanksgiving Movies Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Thanksgiving Movies collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "holiday_thanksgiving"
+          },
+          {
+            "key": "sync_mode_thanksgiving",
+            "label": "Thanksgiving Movies Sync Mode",
+            "type": "select",
+            "tooltip": "Override the sync_mode for the Thanksgiving Movies collection. Leave blank to inherit the family Sync Mode value.",
+            "options": [
+              {
+                "value": "",
+                "label": "Use Family Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ],
+            "default": "",
+            "section": "holiday_thanksgiving"
+          },
+          {
+            "key": "limit_thanksgiving",
+            "label": "Thanksgiving Movies Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Thanksgiving Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "holiday_thanksgiving"
+          },
+          {
+            "key": "radarr_add_missing_thanksgiving",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_thanksgiving"
+          },
+          {
+            "key": "schedule_thanksgiving",
+            "label": "Schedule - Thanksgiving",
+            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
+            "type": "text_input",
+            "default": "range(11/01-11/30)",
+            "label_width": 240,
+            "section": "holiday_thanksgiving"
+          },
+          {
+            "key": "visible_home_thanksgiving",
+            "label": "Thanksgiving Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Thanksgiving Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_thanksgiving"
+          },
+          {
+            "key": "visible_library_thanksgiving",
+            "label": "Thanksgiving Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Thanksgiving Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_thanksgiving"
+          },
+          {
+            "key": "visible_shared_thanksgiving",
+            "label": "Thanksgiving Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Thanksgiving Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_thanksgiving"
+          },
+          {
+            "key": "hub_priority_thanksgiving",
+            "label": "Thanksgiving Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_thanksgiving",
+              "visible_library_thanksgiving",
+              "visible_shared_thanksgiving"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_thanksgiving"
+          },
+          {
+            "key": "use_christmas",
+            "label": "Christmas Movies",
+            "tooltip": "Movies related to Christmas",
+            "type": "toggle",
+            "default": true,
+            "section": "holiday_christmas"
+          },
+          {
+            "key": "name_christmas",
+            "label": "Christmas Movies Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Christmas Movies collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "holiday_christmas"
+          },
+          {
+            "key": "summary_christmas",
+            "label": "Christmas Movies Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Christmas Movies collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "holiday_christmas"
+          },
+          {
+            "key": "sync_mode_christmas",
+            "label": "Christmas Movies Sync Mode",
+            "type": "select",
+            "tooltip": "Override the sync_mode for the Christmas Movies collection. Leave blank to inherit the family Sync Mode value.",
+            "options": [
+              {
+                "value": "",
+                "label": "Use Family Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ],
+            "default": "",
+            "section": "holiday_christmas"
+          },
+          {
+            "key": "limit_christmas",
+            "label": "Christmas Movies Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Christmas Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "holiday_christmas"
+          },
+          {
+            "key": "radarr_add_missing_christmas",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_christmas"
+          },
+          {
+            "key": "schedule_christmas",
+            "label": "Schedule - Christmas",
+            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
+            "type": "text_input",
+            "default": "range(12/01-12/31)",
+            "label_width": 240,
+            "section": "holiday_christmas"
+          },
+          {
+            "key": "visible_home_christmas",
+            "label": "Christmas Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Christmas Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_christmas"
+          },
+          {
+            "key": "visible_library_christmas",
+            "label": "Christmas Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Christmas Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_christmas"
+          },
+          {
+            "key": "visible_shared_christmas",
+            "label": "Christmas Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Christmas Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_christmas"
+          },
+          {
+            "key": "hub_priority_christmas",
+            "label": "Christmas Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_christmas",
+              "visible_library_christmas",
+              "visible_shared_christmas"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_christmas"
+          },
+          {
+            "key": "use_aapi",
+            "label": "Asian American Pacific Islander Movies",
+            "tooltip": "Movies related to Asian American Pacific Islander Month",
+            "type": "toggle",
+            "default": true,
+            "section": "holiday_aapi"
+          },
+          {
+            "key": "name_aapi",
+            "label": "Asian American Pacific Islander Movies Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Asian American Pacific Islander Movies collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "holiday_aapi"
+          },
+          {
+            "key": "summary_aapi",
+            "label": "Asian American Pacific Islander Movies Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Asian American Pacific Islander Movies collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "holiday_aapi"
+          },
+          {
+            "key": "sync_mode_aapi",
+            "label": "Asian American Pacific Islander Movies Sync Mode",
+            "type": "select",
+            "tooltip": "Override the sync_mode for the Asian American Pacific Islander Movies collection. Leave blank to inherit the family Sync Mode value.",
+            "options": [
+              {
+                "value": "",
+                "label": "Use Family Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ],
+            "default": "",
+            "section": "holiday_aapi"
+          },
+          {
+            "key": "limit_aapi",
+            "label": "Asian American Pacific Islander Movies Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Asian American Pacific Islander Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "holiday_aapi"
+          },
+          {
+            "key": "radarr_add_missing_aapi",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_aapi"
+          },
+          {
+            "key": "schedule_aapi",
+            "label": "Schedule - Asian American Pacific Islander Month",
+            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
+            "type": "text_input",
+            "default": "range(04/30-05/31)",
+            "label_width": 240,
+            "section": "holiday_aapi"
+          },
+          {
+            "key": "visible_home_aapi",
+            "label": "Asian American Pacific Islander Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Asian American Pacific Islander Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_aapi"
+          },
+          {
+            "key": "visible_library_aapi",
+            "label": "Asian American Pacific Islander Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Asian American Pacific Islander Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_aapi"
+          },
+          {
+            "key": "visible_shared_aapi",
+            "label": "Asian American Pacific Islander Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Asian American Pacific Islander Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_aapi"
+          },
+          {
+            "key": "hub_priority_aapi",
+            "label": "Asian American Pacific Islander Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_aapi",
+              "visible_library_aapi",
+              "visible_shared_aapi"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_aapi"
+          },
+          {
+            "key": "use_disabilities",
+            "label": "Disability Month Movies",
+            "tooltip": "Movies related to Disability Awareness Month",
+            "type": "toggle",
+            "default": true,
+            "section": "holiday_disabilities"
+          },
+          {
+            "key": "name_disabilities",
+            "label": "Disability Month Movies Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Disability Month Movies collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "holiday_disabilities"
+          },
+          {
+            "key": "summary_disabilities",
+            "label": "Disability Month Movies Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Disability Month Movies collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "holiday_disabilities"
+          },
+          {
+            "key": "sync_mode_disabilities",
+            "label": "Disability Month Movies Sync Mode",
+            "type": "select",
+            "tooltip": "Override the sync_mode for the Disability Month Movies collection. Leave blank to inherit the family Sync Mode value.",
+            "options": [
+              {
+                "value": "",
+                "label": "Use Family Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ],
+            "default": "",
+            "section": "holiday_disabilities"
+          },
+          {
+            "key": "limit_disabilities",
+            "label": "Disability Month Movies Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Disability Month Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "holiday_disabilities"
+          },
+          {
+            "key": "radarr_add_missing_disabilities",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_disabilities"
+          },
+          {
+            "key": "schedule_disabilities",
+            "label": "Schedule - Disability Awareness Day",
+            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
+            "type": "text_input",
+            "default": "range(12/02-12/04)",
+            "label_width": 240,
+            "section": "holiday_disabilities"
+          },
+          {
+            "key": "visible_home_disabilities",
+            "label": "Disability Month Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Disability Month Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_disabilities"
+          },
+          {
+            "key": "visible_library_disabilities",
+            "label": "Disability Month Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Disability Month Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_disabilities"
+          },
+          {
+            "key": "visible_shared_disabilities",
+            "label": "Disability Month Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Disability Month Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_disabilities"
+          },
+          {
+            "key": "hub_priority_disabilities",
+            "label": "Disability Month Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_disabilities",
+              "visible_library_disabilities",
+              "visible_shared_disabilities"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_disabilities"
+          },
+          {
+            "key": "use_black_history",
+            "label": "Black History Month Movies",
+            "tooltip": "Movies related to Black History Month",
+            "type": "toggle",
+            "default": true,
+            "section": "holiday_black_history"
+          },
+          {
+            "key": "name_black_history",
+            "label": "Black History Month Movies Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Black History Month Movies collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "holiday_black_history"
+          },
+          {
+            "key": "summary_black_history",
+            "label": "Black History Month Movies Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Black History Month Movies collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "holiday_black_history"
+          },
+          {
+            "key": "sync_mode_black_history",
+            "label": "Black History Month Movies Sync Mode",
+            "type": "select",
+            "tooltip": "Override the sync_mode for the Black History Month Movies collection. Leave blank to inherit the family Sync Mode value.",
+            "options": [
+              {
+                "value": "",
+                "label": "Use Family Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ],
+            "default": "",
+            "section": "holiday_black_history"
+          },
+          {
+            "key": "limit_black_history",
+            "label": "Black History Month Movies Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Black History Month Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "holiday_black_history"
+          },
+          {
+            "key": "radarr_add_missing_black_history",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_black_history"
+          },
+          {
+            "key": "schedule_black_history",
+            "label": "Schedule - Black History Month",
+            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
+            "type": "text_input",
+            "default": "range(02/01-03/01)",
+            "label_width": 240,
+            "section": "holiday_black_history"
+          },
+          {
+            "key": "visible_home_black_history",
+            "label": "Black History Month Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Black History Month Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_black_history"
+          },
+          {
+            "key": "visible_library_black_history",
+            "label": "Black History Month Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Black History Month Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_black_history"
+          },
+          {
+            "key": "visible_shared_black_history",
+            "label": "Black History Month Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Black History Month Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_black_history"
+          },
+          {
+            "key": "hub_priority_black_history",
+            "label": "Black History Month Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_black_history",
+              "visible_library_black_history",
+              "visible_shared_black_history"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_black_history"
+          },
+          {
+            "key": "use_lgbtq",
+            "label": "LGBTQ Month Movies",
+            "tooltip": "Movies related to LGBTQ Pride Month",
+            "type": "toggle",
+            "default": true,
+            "section": "holiday_lgbtq"
+          },
+          {
+            "key": "name_lgbtq",
+            "label": "LGBTQ Month Movies Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the LGBTQ Month Movies collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "holiday_lgbtq"
+          },
+          {
+            "key": "summary_lgbtq",
+            "label": "LGBTQ Month Movies Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the LGBTQ Month Movies collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "holiday_lgbtq"
+          },
+          {
+            "key": "sync_mode_lgbtq",
+            "label": "LGBTQ Month Movies Sync Mode",
+            "type": "select",
+            "tooltip": "Override the sync_mode for the LGBTQ Month Movies collection. Leave blank to inherit the family Sync Mode value.",
+            "options": [
+              {
+                "value": "",
+                "label": "Use Family Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ],
+            "default": "",
+            "section": "holiday_lgbtq"
+          },
+          {
+            "key": "limit_lgbtq",
+            "label": "LGBTQ Month Movies Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the LGBTQ Month Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "holiday_lgbtq"
+          },
+          {
+            "key": "radarr_add_missing_lgbtq",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_lgbtq"
+          },
+          {
+            "key": "schedule_lgbtq",
+            "label": "Schedule - LGBTQ+ Pride Month",
+            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
+            "type": "text_input",
+            "default": "range(05/31-06/30)",
+            "label_width": 240,
+            "section": "holiday_lgbtq"
+          },
+          {
+            "key": "visible_home_lgbtq",
+            "label": "LGBTQ Month Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the LGBTQ Month Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_lgbtq"
+          },
+          {
+            "key": "visible_library_lgbtq",
+            "label": "LGBTQ Month Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the LGBTQ Month Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_lgbtq"
+          },
+          {
+            "key": "visible_shared_lgbtq",
+            "label": "LGBTQ Month Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the LGBTQ Month Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_lgbtq"
+          },
+          {
+            "key": "hub_priority_lgbtq",
+            "label": "LGBTQ Month Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_lgbtq",
+              "visible_library_lgbtq",
+              "visible_shared_lgbtq"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_lgbtq"
+          },
+          {
+            "key": "use_latinx",
+            "label": "National Hispanic Heritage Movies",
+            "tooltip": "Movies related to National Hispanic Heritage Month",
+            "type": "toggle",
+            "default": true,
+            "section": "holiday_latinx"
+          },
+          {
+            "key": "name_latinx",
+            "label": "National Hispanic Heritage Movies Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the National Hispanic Heritage Movies collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "holiday_latinx"
+          },
+          {
+            "key": "summary_latinx",
+            "label": "National Hispanic Heritage Movies Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the National Hispanic Heritage Movies collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "holiday_latinx"
+          },
+          {
+            "key": "sync_mode_latinx",
+            "label": "National Hispanic Heritage Movies Sync Mode",
+            "type": "select",
+            "tooltip": "Override the sync_mode for the National Hispanic Heritage Movies collection. Leave blank to inherit the family Sync Mode value.",
+            "options": [
+              {
+                "value": "",
+                "label": "Use Family Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ],
+            "default": "",
+            "section": "holiday_latinx"
+          },
+          {
+            "key": "limit_latinx",
+            "label": "National Hispanic Heritage Movies Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the National Hispanic Heritage Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "holiday_latinx"
+          },
+          {
+            "key": "radarr_add_missing_latinx",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_latinx"
+          },
+          {
+            "key": "schedule_latinx",
+            "label": "Schedule - National Hispanic Heritage Month",
+            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
+            "type": "text_input",
+            "default": "range(09/15-10/15)",
+            "label_width": 240,
+            "section": "holiday_latinx"
+          },
+          {
+            "key": "visible_home_latinx",
+            "label": "National Hispanic Heritage Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the National Hispanic Heritage Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_latinx"
+          },
+          {
+            "key": "visible_library_latinx",
+            "label": "National Hispanic Heritage Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the National Hispanic Heritage Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_latinx"
+          },
+          {
+            "key": "visible_shared_latinx",
+            "label": "National Hispanic Heritage Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the National Hispanic Heritage Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_latinx"
+          },
+          {
+            "key": "hub_priority_latinx",
+            "label": "National Hispanic Heritage Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_latinx",
+              "visible_library_latinx",
+              "visible_shared_latinx"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_latinx"
+          },
+          {
+            "key": "use_women",
+            "label": "Women's History Month Movies",
+            "tooltip": "Movies related to Women's History Month",
+            "type": "toggle",
+            "default": true,
+            "section": "holiday_women"
+          },
+          {
+            "key": "name_women",
+            "label": "Women's History Month Movies Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Women's History Month Movies collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "holiday_women"
+          },
+          {
+            "key": "summary_women",
+            "label": "Women's History Month Movies Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Women's History Month Movies collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "holiday_women"
+          },
+          {
+            "key": "sync_mode_women",
+            "label": "Women's History Month Movies Sync Mode",
+            "type": "select",
+            "tooltip": "Override the sync_mode for the Women's History Month Movies collection. Leave blank to inherit the family Sync Mode value.",
+            "options": [
+              {
+                "value": "",
+                "label": "Use Family Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ],
+            "default": "",
+            "section": "holiday_women"
+          },
+          {
+            "key": "limit_women",
+            "label": "Women's History Month Movies Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Women's History Month Movies collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "holiday_women"
+          },
+          {
+            "key": "radarr_add_missing_women",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_women"
+          },
+          {
+            "key": "schedule_women",
+            "label": "Schedule - Women's History Month",
+            "tooltip": "Override this collection's schedule. Examples: hourly(17) or hourly(17-04), daily, weekly(sunday|tuesday), monthly(1), yearly(01/30), date(01/30/2025), range(12/01-12/31) or range(8/01-8/15|9/01-9/15), never, non_existing, all[weekly(sunday), hourly(17)].",
+            "type": "text_input",
+            "default": "range(02/28-03/31)",
+            "label_width": 240,
+            "section": "holiday_women"
+          },
+          {
+            "key": "visible_home_women",
+            "label": "Women's History Month Movies Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Women's History Month Movies collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_women"
+          },
+          {
+            "key": "visible_library_women",
+            "label": "Women's History Month Movies Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Women's History Month Movies collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_women"
+          },
+          {
+            "key": "visible_shared_women",
+            "label": "Women's History Month Movies Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Women's History Month Movies collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_women"
+          },
+          {
+            "key": "hub_priority_women",
+            "label": "Women's History Month Movies Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_women",
+              "visible_library_women",
+              "visible_shared_women"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "media_types": [
+              "movie"
+            ],
+            "section": "holiday_women"
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific seasonal collections from these collections.",
+            "placeholder": "Add seasonal key (e.g. halloween)"
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics",
+            "summary": "Core defaults that control how the Seasonal family is generated.",
+            "default_open": true
+          },
+          {
+            "id": "naming",
+            "label": "Naming",
+            "summary": "Family-level naming, emoji, and sort-title templates for generated seasonal collections."
+          },
+          {
+            "id": "scope_schedule",
+            "label": "Scope & Schedule",
+            "summary": "Controls default schedules and delete-before-rebuild behavior for generated seasonal collections."
+          },
+          {
+            "id": "builder_defaults",
+            "label": "Builder Defaults",
+            "summary": "Default builder limits, sort rules, and source lists used when a holiday does not provide its own source overrides."
+          },
+          {
+            "id": "builder_override_maps",
+            "label": "Holiday Override Maps",
+            "summary": "Per-holiday override tables for naming, builder sources, sort behavior, emoji, and delete-before-rebuild settings."
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork",
+            "summary": "Family-wide artwork plus per-holiday artwork override maps."
+          },
+          {
+            "id": "automation_defaults",
+            "label": "Automation Defaults",
+            "summary": "Default Radarr behavior and collection visibility settings for generated seasonal collections."
+          },
+          {
+            "id": "automation_override_maps",
+            "label": "Automation Override Maps",
+            "summary": "Per-holiday Radarr override tables for folder, tags, monitor, search, and upgrade behavior."
+          },
+          {
+            "id": "holiday_years",
+            "label": "New Year's Day",
+            "summary": "Core child settings and visibility overrides for New Year's Day."
+          },
+          {
+            "id": "holiday_valentine",
+            "label": "Valentine's Day",
+            "summary": "Core child settings and visibility overrides for Valentine's Day."
+          },
+          {
+            "id": "holiday_patrick",
+            "label": "St. Patrick's Day",
+            "summary": "Core child settings and visibility overrides for St. Patrick's Day."
+          },
+          {
+            "id": "holiday_easter",
+            "label": "Easter",
+            "summary": "Core child settings and visibility overrides for Easter."
+          },
+          {
+            "id": "holiday_mother",
+            "label": "Mother's Day",
+            "summary": "Core child settings and visibility overrides for Mother's Day."
+          },
+          {
+            "id": "holiday_memorial",
+            "label": "Memorial Day",
+            "summary": "Core child settings and visibility overrides for Memorial Day."
+          },
+          {
+            "id": "holiday_father",
+            "label": "Father's Day",
+            "summary": "Core child settings and visibility overrides for Father's Day."
+          },
+          {
+            "id": "holiday_independence",
+            "label": "Independence Day",
+            "summary": "Core child settings and visibility overrides for Independence Day."
+          },
+          {
+            "id": "holiday_labor",
+            "label": "Labor Day",
+            "summary": "Core child settings and visibility overrides for Labor Day."
+          },
+          {
+            "id": "holiday_halloween",
+            "label": "Halloween",
+            "summary": "Core child settings and visibility overrides for Halloween."
+          },
+          {
+            "id": "holiday_veteran",
+            "label": "Veteran's Day",
+            "summary": "Core child settings and visibility overrides for Veteran's Day."
+          },
+          {
+            "id": "holiday_thanksgiving",
+            "label": "Thanksgiving",
+            "summary": "Core child settings and visibility overrides for Thanksgiving."
+          },
+          {
+            "id": "holiday_christmas",
+            "label": "Christmas",
+            "summary": "Core child settings and visibility overrides for Christmas."
+          },
+          {
+            "id": "holiday_aapi",
+            "label": "Asian American & Pacific Islander Heritage Month",
+            "summary": "Core child settings and visibility overrides for Asian American & Pacific Islander Heritage Month."
+          },
+          {
+            "id": "holiday_disabilities",
+            "label": "Day of Persons with Disabilities",
+            "summary": "Core child settings and visibility overrides for Day of Persons with Disabilities."
+          },
+          {
+            "id": "holiday_black_history",
+            "label": "Black History Month",
+            "summary": "Core child settings and visibility overrides for Black History Month."
+          },
+          {
+            "id": "holiday_lgbtq",
+            "label": "LGBTQ+ Pride Month",
+            "summary": "Core child settings and visibility overrides for LGBTQ+ Pride Month."
+          },
+          {
+            "id": "holiday_latinx",
+            "label": "Latinx Heritage Month",
+            "summary": "Core child settings and visibility overrides for Latinx Heritage Month."
+          },
+          {
+            "id": "holiday_women",
+            "label": "Women's History Month",
+            "summary": "Core child settings and visibility overrides for Women's History Month."
           }
         ]
       },

--- a/tests/test_collection_seasonal_contract.py
+++ b/tests/test_collection_seasonal_contract.py
@@ -1,0 +1,141 @@
+import json
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+ROOT = Path(__file__).resolve().parents[1]
+QS_COLLECTIONS_PATH = ROOT / "static" / "json" / "quickstart_collections.json"
+SEASONAL_DEFAULT_PATH = ROOT / "config" / "kometa" / "defaults" / "movie" / "seasonal.yml"
+
+
+def _load_seasonal_collection():
+    data = json.loads(QS_COLLECTIONS_PATH.read_text(encoding="utf-8"))
+    for group in data:
+        for collection in group.get("collections", []):
+            if collection.get("id") == "collection_seasonal":
+                return collection
+    raise AssertionError("Missing collection_seasonal")
+
+
+def _field_map(collection):
+    return {item["key"]: item for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key")}
+
+
+def _seasonal_keys():
+    parser = YAML(typ="safe", pure=True)
+    parsed = parser.load(SEASONAL_DEFAULT_PATH.read_text(encoding="utf-8"))
+    data = parsed["dynamic_collections"]["Seasonal"]["data"]
+    return list(data.keys())
+
+
+def test_seasonal_holiday_toggles_match_repo_yaml_data():
+    collection = _load_seasonal_collection()
+    fields = _field_map(collection)
+
+    qs_keys = sorted(key.removeprefix("use_") for key in fields if key.startswith("use_") and key not in {"use_all", "use_separator"})
+
+    assert qs_keys == sorted(_seasonal_keys())
+
+
+def test_seasonal_exposes_yaml_verified_shared_fields_and_override_maps():
+    collection = _load_seasonal_collection()
+    fields = _field_map(collection)
+
+    expected_shared = {
+        "schedule": {"type": "schedule", "section": "scope_schedule"},
+        "name_mapping": {"type": "text_input", "section": "naming"},
+        "delete_collections_named": {"type": "string_list", "section": "scope_schedule"},
+        "emoji": {"type": "text_input", "section": "naming"},
+        "tmdb_collection": {"type": "string_list", "validation_preset": "numeric_id", "section": "builder_defaults"},
+        "tmdb_movie": {"type": "string_list", "validation_preset": "numeric_id", "section": "builder_defaults"},
+        "imdb_list": {"type": "string_list", "section": "builder_defaults"},
+        "imdb_search": {"type": "text_input", "section": "builder_defaults"},
+        "trakt_list": {"type": "string_list", "section": "builder_defaults"},
+        "mdblist_list": {"type": "string_list", "section": "builder_defaults"},
+        "letterboxd_list": {"type": "string_list", "section": "builder_defaults"},
+        "url_poster": {"type": "text_input", "validation_preset": "url", "section": "artwork"},
+        "url_background": {"type": "text_input", "validation_preset": "url", "section": "artwork"},
+        "url_logo": {"type": "text_input", "validation_preset": "url", "section": "artwork"},
+        "url_square_art": {"type": "text_input", "validation_preset": "url", "section": "artwork"},
+    }
+
+    for key, metadata in expected_shared.items():
+        assert key in fields
+        for meta_key, meta_value in metadata.items():
+            assert fields[key].get(meta_key) == meta_value
+
+    section_defs = collection.get("template_variable_sections") or []
+    section_ids = [section.get("id") for section in section_defs if isinstance(section, dict)]
+    assert section_ids[:8] == [
+        "basics",
+        "naming",
+        "scope_schedule",
+        "builder_defaults",
+        "builder_override_maps",
+        "artwork",
+        "automation_defaults",
+        "automation_override_maps",
+    ]
+    assert "holiday_halloween" in section_ids
+    assert "holiday_christmas" in section_ids
+    assert any(section.get("default_open") is True for section in section_defs if section.get("id") == "basics")
+
+    expected_mappings = {
+        "child_name_mapping_overrides": ("name_mapping_", "string", "builder_override_maps", None, None),
+        "child_emoji_overrides": ("emoji_", "string", "builder_override_maps", None, None),
+        "child_sort_by_overrides": ("sort_by_", "select", "builder_override_maps", None, None),
+        "child_delete_collections_named_overrides": ("delete_collections_named_", "string_list", "builder_override_maps", None, None),
+        "child_tmdb_collection_overrides": ("tmdb_collection_", "string_list", "builder_override_maps", None, None),
+        "child_tmdb_movie_overrides": ("tmdb_movie_", "string_list", "builder_override_maps", None, None),
+        "child_imdb_list_overrides": ("imdb_list_", "string_list", "builder_override_maps", None, None),
+        "child_imdb_search_overrides": ("imdb_search_", "json", "builder_override_maps", None, None),
+        "child_trakt_list_overrides": ("trakt_list_", "string_list", "builder_override_maps", None, None),
+        "child_mdblist_list_overrides": ("mdblist_list_", "string_list", "builder_override_maps", None, None),
+        "child_letterboxd_list_overrides": ("letterboxd_list_", "string_list", "builder_override_maps", None, None),
+        "child_url_poster_overrides": ("url_poster_", "string", "artwork", "url", None),
+        "child_url_background_overrides": ("url_background_", "string", "artwork", "url", None),
+        "child_url_logo_overrides": ("url_logo_", "string", "artwork", "url", None),
+        "child_url_square_art_overrides": ("url_square_art_", "string", "artwork", "url", None),
+        "child_radarr_folder_overrides": ("radarr_folder_", "string", "automation_override_maps", None, ["movie"]),
+        "child_radarr_tag_overrides": ("radarr_tag_", "string_list", "automation_override_maps", None, ["movie"]),
+        "child_item_radarr_tag_overrides": ("item_radarr_tag_", "string_list", "automation_override_maps", None, ["movie"]),
+        "child_radarr_monitor_overrides": ("radarr_monitor_", "boolean", "automation_override_maps", None, ["movie"]),
+        "child_radarr_upgrade_existing_overrides": ("radarr_upgrade_existing_", "boolean", "automation_override_maps", None, ["movie"]),
+        "child_radarr_monitor_existing_overrides": ("radarr_monitor_existing_", "boolean", "automation_override_maps", None, ["movie"]),
+        "child_radarr_search_overrides": ("radarr_search_", "boolean", "automation_override_maps", None, ["movie"]),
+    }
+
+    for key, (child_prefix, value_kind, section, value_validation_preset, media_types) in expected_mappings.items():
+        assert key in fields
+        field = fields[key]
+        assert field["type"] == "mapping_list"
+        assert field["dynamic_child_prefix"] == child_prefix
+        assert field["dynamic_child_value_kind"] == value_kind
+        assert field["key_validation_preset"] == "seasonal_key"
+        assert field["key_input_mode"] == "select"
+        assert field["section"] == section
+        if value_validation_preset is None:
+            assert "validation_preset" not in field
+        else:
+            assert field["validation_preset"] == value_validation_preset
+        if media_types is None:
+            assert "media_types" not in field
+        else:
+            assert field["media_types"] == media_types
+
+
+def test_seasonal_halloween_fields_are_grouped_in_holiday_section():
+    fields = _field_map(_load_seasonal_collection())
+
+    section_id = "holiday_halloween"
+    assert fields["use_halloween"]["section"] == section_id
+    assert fields["name_halloween"]["section"] == section_id
+    assert fields["summary_halloween"]["section"] == section_id
+    assert fields["sync_mode_halloween"]["section"] == section_id
+    assert fields["limit_halloween"]["section"] == section_id
+    assert fields["radarr_add_missing_halloween"]["section"] == section_id
+    assert fields["schedule_halloween"]["section"] == section_id
+    assert fields["visible_home_halloween"]["section"] == section_id
+    assert fields["visible_library_halloween"]["section"] == section_id
+    assert fields["visible_shared_halloween"]["section"] == section_id
+    assert fields["hub_priority_halloween"]["section"] == section_id

--- a/tests/test_importer_collection_files.py
+++ b/tests/test_importer_collection_files.py
@@ -1,3 +1,5 @@
+import json
+
 from modules import importer
 
 
@@ -362,3 +364,65 @@ def test_prepare_import_payload_collapses_streaming_dynamic_child_template_varia
     assert any("libraries.Movies.collection_files[0].template_variables.use_amc" in line for line in report.lines)
     assert any("libraries.Movies.collection_files[0].template_variables.schedule_amc" in line for line in report.lines)
     assert any("libraries.Movies.collection_files[0].template_variables.url_logo_movistar" in line for line in report.lines)
+
+
+def test_prepare_import_payload_collapses_seasonal_dynamic_child_template_variables():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Movies": {
+                    "collection_files": [
+                        {
+                            "default": "seasonal",
+                            "template_variables": {
+                                "name_mapping_halloween": "Spooky Season",
+                                "emoji_halloween": "🎃",
+                                "delete_collections_named_halloween": ["Old Halloween Movies"],
+                                "tmdb_collection_halloween": [185103, 11716],
+                                "tmdb_movie_halloween": [23437],
+                                "imdb_list_years": ["ls066838460"],
+                                "imdb_search_halloween": {"list.any": ["ls546214737"], "limit": 500},
+                                "trakt_list_halloween": ["https://trakt.tv/users/example/lists/halloween"],
+                                "mdblist_list_christmas": ["https://mdblist.com/lists/k0meta/christmas-extravaganza"],
+                                "letterboxd_list_black_history": ["https://letterboxd.com/mardarrius/list/black-is-beautiful/"],
+                                "url_logo_women": "https://example.com/women.png",
+                                "radarr_folder_halloween": r"C:\Media\Movies\Halloween",
+                                "radarr_tag_christmas": ["holiday", "christmas"],
+                                "item_radarr_tag_women": ["history"],
+                                "radarr_search_halloween": False,
+                            },
+                        }
+                    ]
+                }
+            }
+        },
+        {"Movies"},
+        set(),
+    )
+
+    libraries_payload = payload["libraries"]["libraries"]
+    assert libraries_payload["mov-library_movies-collection_seasonal"] is True
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_seasonal_child_name_mapping_overrides"]) == {"halloween": "Spooky Season"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_seasonal_child_emoji_overrides"]) == {"halloween": "🎃"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_seasonal_child_delete_collections_named_overrides"]) == {"halloween": "Old Halloween Movies"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_seasonal_child_tmdb_collection_overrides"]) == {"halloween": "185103,11716"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_seasonal_child_tmdb_movie_overrides"]) == {"halloween": "23437"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_seasonal_child_imdb_list_overrides"]) == {"years": "ls066838460"}
+    imdb_search_mapping = json.loads(libraries_payload["mov-library_movies-template_collection_seasonal_child_imdb_search_overrides"])
+    assert json.loads(imdb_search_mapping["halloween"]) == {"list.any": ["ls546214737"], "limit": 500}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_seasonal_child_trakt_list_overrides"]) == {
+        "halloween": "https://trakt.tv/users/example/lists/halloween"
+    }
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_seasonal_child_mdblist_list_overrides"]) == {
+        "christmas": "https://mdblist.com/lists/k0meta/christmas-extravaganza"
+    }
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_seasonal_child_letterboxd_list_overrides"]) == {
+        "black_history": "https://letterboxd.com/mardarrius/list/black-is-beautiful/"
+    }
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_seasonal_child_url_logo_overrides"]) == {"women": "https://example.com/women.png"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_seasonal_child_radarr_folder_overrides"]) == {"halloween": r"C:\Media\Movies\Halloween"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_seasonal_child_radarr_tag_overrides"]) == {"christmas": "holiday,christmas"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_seasonal_child_item_radarr_tag_overrides"]) == {"women": "history"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_seasonal_child_radarr_search_overrides"]) == {"halloween": "false"}
+    assert any("libraries.Movies.collection_files[0].template_variables.imdb_search_halloween" in line for line in report.lines)
+    assert any("libraries.Movies.collection_files[0].template_variables.letterboxd_list_black_history" in line for line in report.lines)

--- a/tests/test_output_collection_child_override_contract.py
+++ b/tests/test_output_collection_child_override_contract.py
@@ -53,3 +53,45 @@ def test_apply_template_var_normalizers_expands_streaming_dynamic_child_override
     assert template_vars["sonarr_search_atresplayer"] is False
     assert "child_schedule_overrides" not in template_vars
     assert "child_url_logo_overrides" not in template_vars
+
+
+def test_apply_template_var_normalizers_expands_seasonal_dynamic_child_override_maps():
+    template_vars = {
+        "child_name_mapping_overrides": '{"halloween": "Spooky Season"}',
+        "child_emoji_overrides": '{"halloween": "🎃"}',
+        "child_sort_by_overrides": '{"christmas": "title.asc"}',
+        "child_delete_collections_named_overrides": '{"halloween": ["Old Halloween Movies"]}',
+        "child_tmdb_collection_overrides": '{"halloween": ["185103", "11716"]}',
+        "child_tmdb_movie_overrides": '{"halloween": ["23437"]}',
+        "child_imdb_list_overrides": '{"years": ["ls066838460"]}',
+        "child_imdb_search_overrides": '{"halloween": {"list.any": ["ls546214737"], "limit": 500}}',
+        "child_trakt_list_overrides": '{"halloween": ["https://trakt.tv/users/example/lists/halloween"]}',
+        "child_mdblist_list_overrides": '{"christmas": ["https://mdblist.com/lists/k0meta/christmas-extravaganza"]}',
+        "child_letterboxd_list_overrides": '{"black_history": ["https://letterboxd.com/mardarrius/list/black-is-beautiful/"]}',
+        "child_url_logo_overrides": '{"women": "https://example.com/women.png"}',
+        "child_radarr_folder_overrides": '{"halloween": "C:\\\\Media\\\\Movies\\\\Halloween"}',
+        "child_radarr_tag_overrides": '{"christmas": ["holiday", "christmas"]}',
+        "child_item_radarr_tag_overrides": '{"women": ["history"]}',
+        "child_radarr_search_overrides": '{"halloween": "false"}',
+    }
+
+    output_collections._apply_template_var_normalizers(template_vars, "seasonal")
+
+    assert template_vars["name_mapping_halloween"] == "Spooky Season"
+    assert template_vars["emoji_halloween"] == "🎃"
+    assert template_vars["sort_by_christmas"] == "title.asc"
+    assert template_vars["delete_collections_named_halloween"] == ["Old Halloween Movies"]
+    assert template_vars["tmdb_collection_halloween"] == ["185103", "11716"]
+    assert template_vars["tmdb_movie_halloween"] == ["23437"]
+    assert template_vars["imdb_list_years"] == ["ls066838460"]
+    assert template_vars["imdb_search_halloween"] == {"list.any": ["ls546214737"], "limit": 500}
+    assert template_vars["trakt_list_halloween"] == ["https://trakt.tv/users/example/lists/halloween"]
+    assert template_vars["mdblist_list_christmas"] == ["https://mdblist.com/lists/k0meta/christmas-extravaganza"]
+    assert template_vars["letterboxd_list_black_history"] == ["https://letterboxd.com/mardarrius/list/black-is-beautiful/"]
+    assert template_vars["url_logo_women"] == "https://example.com/women.png"
+    assert template_vars["radarr_folder_halloween"] == r"C:\Media\Movies\Halloween"
+    assert template_vars["radarr_tag_christmas"] == ["holiday", "christmas"]
+    assert template_vars["item_radarr_tag_women"] == ["history"]
+    assert template_vars["radarr_search_halloween"] is False
+    assert "child_name_mapping_overrides" not in template_vars
+    assert "child_imdb_search_overrides" not in template_vars


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

## Summary
Adds full `seasonal` collection parity across Quickstart’s Libraries UI, importer, and exporter so missing seasonal template variables now round-trip correctly instead of being dropped.

## What Changed
- expanded `collection_seasonal` in `static/json/quickstart_collections.json` with the missing shared fields and organized them into sections
- added seasonal override-map support for child keys such as:
  - naming and emoji
  - artwork URLs
  - TMDb / IMDb / Trakt / MDBList / Letterboxd builders
  - Radarr automation fields
- added dropdown-backed seasonal key selection for the new override maps so users pick valid seasonal keys instead of free-typing them
- taught importer coercion to preserve JSON-style child values for fields like `imdb_search_*`
- taught exporter normalization to expand the new seasonal override maps back into Kometa-style `template_variables`

## Why
Quickstart already supported many explicit seasonal fields, but it was missing a broader set of valid Kometa seasonal template variables and child override mappings. That caused imports to report unsupported mappings and prevented full import/export parity. This change aligns seasonal with the same future-safe pattern already applied to universes and streaming.

## Tests
- added `tests/test_collection_seasonal_contract.py`
- added seasonal importer regression coverage in `tests/test_importer_collection_files.py`
- added seasonal exporter regression coverage in `tests/test_output_collection_child_override_contract.py`

## Verification
Ran:
```powershell
venv\Scripts\python.exe -m pytest tests\test_collection_seasonal_contract.py tests\test_output_collection_child_override_contract.py tests\test_importer_collection_files.py tests\test_collection_child_override_contract.py tests\test_collection_details_contract.py -q
```

Result: all passed.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
