### PR TITLE
year and decade added

### DIFF
--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -57599,42 +57599,24 @@
             "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
             "type": "text_input",
             "default": "105",
-            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
           },
           {
-            "key": "sort_prefix",
-            "label": "Sort Prefix",
-            "type": "text_input",
-            "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
-            "placeholder": "e.g. !"
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle",
+            "default": true,
+            "section": "basics"
           },
           {
-            "key": "sort_title",
-            "label": "Sort Title",
-            "type": "text_input",
-            "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom sort title format"
-          },
-          {
-            "key": "name_format",
-            "label": "Name Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_format",
-            "label": "Summary Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "title_format",
-            "label": "Title Format",
-            "type": "text_input",
-            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom dynamic collection title format"
+            "key": "use_all",
+            "label": "Use All Child Collections",
+            "type": "toggle",
+            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting.",
+            "default": true,
+            "section": "basics"
           },
           {
             "key": "limit",
@@ -57644,14 +57626,414 @@
             "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "basics"
           },
           {
-            "key": "use_separator",
-            "label": "Use Separator",
-            "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle",
-            "default": true
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "basics"
+          },
+          {
+            "key": "sort_by",
+            "label": "Sort By",
+            "type": "select",
+            "tooltip": "Changes the Smart Filter Sort for all collections in a Defaults File.<br><br> Default is <b>Release Date (Originally Available) Descending</b> ",
+            "default": "release.desc",
+            "options": [
+              {
+                "value": "title.asc",
+                "label": "Title Ascending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "title.desc",
+                "label": "Title Descending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "season.asc",
+                "label": "Season Ascending",
+                "media_types": [
+                  "season"
+                ]
+              },
+              {
+                "value": "season.desc",
+                "label": "Season Descending",
+                "media_types": [
+                  "season"
+                ]
+              },
+              {
+                "value": "show.asc",
+                "label": "Show Ascending",
+                "media_types": [
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "show.desc",
+                "label": "Show Descending",
+                "media_types": [
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "year.asc",
+                "label": "Year Ascending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "year.desc",
+                "label": "Year Descending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "release.asc",
+                "label": "Release Date (Originally Available) Ascending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "release.desc",
+                "label": "Release Date (Originally Available) Descending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "episode_release.asc",
+                "label": "Episode Release Date Ascending",
+                "media_types": [
+                  "show",
+                  "season",
+                  "episode"
+                ]
+              },
+              {
+                "value": "episode_release.desc",
+                "label": "Episode Release Date Descending",
+                "media_types": [
+                  "show",
+                  "season",
+                  "episode"
+                ]
+              },
+              {
+                "value": "critic_rating.asc",
+                "label": "Critic Rating Ascending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "critic_rating.desc",
+                "label": "Critic Rating Descending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "audience_rating.asc",
+                "label": "Audience Rating Ascending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "audience_rating.desc",
+                "label": "Audience Rating Descending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "user_rating.asc",
+                "label": "User Rating Ascending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "season",
+                  "episode"
+                ]
+              },
+              {
+                "value": "user_rating.desc",
+                "label": "User Rating Descending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "season",
+                  "episode"
+                ]
+              },
+              {
+                "value": "content_rating.asc",
+                "label": "Content Rating Ascending",
+                "media_types": [
+                  "movie",
+                  "show"
+                ]
+              },
+              {
+                "value": "content_rating.desc",
+                "label": "Content Rating Descending",
+                "media_types": [
+                  "movie",
+                  "show"
+                ]
+              },
+              {
+                "value": "duration.asc",
+                "label": "Duration Ascending",
+                "media_types": [
+                  "movie",
+                  "episode"
+                ]
+              },
+              {
+                "value": "duration.desc",
+                "label": "Duration Descending",
+                "media_types": [
+                  "movie",
+                  "episode"
+                ]
+              },
+              {
+                "value": "progress.asc",
+                "label": "Progress Ascending",
+                "media_types": [
+                  "episode"
+                ]
+              },
+              {
+                "value": "progress.desc",
+                "label": "Progress Descending",
+                "media_types": [
+                  "episode"
+                ]
+              },
+              {
+                "value": "plays.asc",
+                "label": "Number of Plays Ascending",
+                "media_types": [
+                  "movie",
+                  "episode"
+                ]
+              },
+              {
+                "value": "plays.desc",
+                "label": "Number of Plays Descending",
+                "media_types": [
+                  "movie",
+                  "episode"
+                ]
+              },
+              {
+                "value": "unplayed.asc",
+                "label": "Unplayed Ascending",
+                "media_types": [
+                  "show"
+                ]
+              },
+              {
+                "value": "unplayed.desc",
+                "label": "Unplayed Descending",
+                "media_types": [
+                  "show"
+                ]
+              },
+              {
+                "value": "episode_added.asc",
+                "label": "Last Episode Date Added Ascending",
+                "media_types": [
+                  "show"
+                ]
+              },
+              {
+                "value": "episode_added.desc",
+                "label": "Last Episode Date Added Descending",
+                "media_types": [
+                  "show"
+                ]
+              },
+              {
+                "value": "added.asc",
+                "label": "Date Added Ascending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "season",
+                  "episode"
+                ]
+              },
+              {
+                "value": "added.desc",
+                "label": "Date Added Descending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "season",
+                  "episode"
+                ]
+              },
+              {
+                "value": "viewed.asc",
+                "label": "Date Last Viewed Ascending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "viewed.desc",
+                "label": "Date Last Viewed Descending",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "episode"
+                ]
+              },
+              {
+                "value": "resolution.asc",
+                "label": "Resolution Ascending",
+                "media_types": [
+                  "movie",
+                  "episode"
+                ]
+              },
+              {
+                "value": "resolution.desc",
+                "label": "Resolution Descending",
+                "media_types": [
+                  "movie",
+                  "episode"
+                ]
+              },
+              {
+                "value": "bitrate.asc",
+                "label": "Bitrate Ascending",
+                "media_types": [
+                  "movie",
+                  "episode"
+                ]
+              },
+              {
+                "value": "bitrate.desc",
+                "label": "Bitrate Descending",
+                "media_types": [
+                  "movie",
+                  "episode"
+                ]
+              },
+              {
+                "value": "random",
+                "label": "Random",
+                "media_types": [
+                  "movie",
+                  "show",
+                  "season",
+                  "episode"
+                ]
+              }
+            ],
+            "section": "basics"
+          },
+          {
+            "key": "search_term",
+            "label": "Search Term",
+            "type": "text_input",
+            "tooltip": "Override the smart-filter search term used by this Defaults File.",
+            "placeholder": "year",
+            "default": "year",
+            "section": "basics"
+          },
+          {
+            "key": "sort_prefix",
+            "label": "Sort Prefix",
+            "type": "text_input",
+            "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
+            "placeholder": "e.g. !",
+            "section": "naming"
+          },
+          {
+            "key": "sort_title",
+            "label": "Sort Title",
+            "type": "text_input",
+            "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom sort title format",
+            "section": "naming"
+          },
+          {
+            "key": "name_format",
+            "label": "Name Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection name format",
+            "section": "naming"
+          },
+          {
+            "key": "summary_format",
+            "label": "Summary Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection summary format",
+            "section": "naming"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format",
+            "section": "naming"
+          },
+          {
+            "key": "translation_key",
+            "label": "Translation Key",
+            "type": "text_input",
+            "tooltip": "Override the translation key used for generated collection names and summaries.",
+            "section": "naming",
+            "placeholder": "year",
+            "default": "year"
           },
           {
             "key": "data_starting",
@@ -57679,7 +58061,8 @@
                 "label": "Specific Year",
                 "kind": "year"
               }
-            ]
+            ],
+            "section": "data_range"
           },
           {
             "key": "data_ending",
@@ -57707,7 +58090,8 @@
                 "label": "Specific Year",
                 "kind": "year"
               }
-            ]
+            ],
+            "section": "data_range"
           },
           {
             "key": "data_increment",
@@ -57717,23 +58101,17 @@
             "min": 1,
             "step": 1,
             "default": "1",
-            "tooltip": "Controls the increment (i.e. every 5th year). Allowed values: number greater than 0."
+            "tooltip": "Controls the increment (i.e. every 5th year). Allowed values: number greater than 0.",
+            "section": "data_range"
           },
           {
             "key": "exclude",
             "label": "Exclude",
             "type": "string_list",
             "tooltip": "Exclude specific years from these collections.",
-            "placeholder": "Add year (e.g. 2022)"
-          },
-          {
-            "key": "minimum_items",
-            "label": "Minimum Items",
-            "type": "text_input",
-            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
+            "placeholder": "Add year key (e.g. 2024)",
+            "section": "scope",
+            "validation_preset": "year"
           },
           {
             "key": "ignore_ids",
@@ -57741,7 +58119,8 @@
             "type": "string_list",
             "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
             "placeholder": "Add numeric ID (e.g. 603)",
-            "validation_preset": "numeric_id"
+            "validation_preset": "numeric_id",
+            "section": "scope"
           },
           {
             "key": "ignore_imdb_ids",
@@ -57749,7 +58128,8 @@
             "type": "string_list",
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
-            "validation_preset": "imdb_id_plex"
+            "validation_preset": "imdb_id_plex",
+            "section": "scope"
           },
           {
             "key": "collection_mode",
@@ -57774,28 +58154,132 @@
                 "value": "show_items",
                 "label": "Show this Collection and its Items"
               }
-            ]
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "schedule",
+            "label": "Schedule Default",
+            "type": "schedule",
+            "tooltip": "Configure when collections in this Defaults File update by default.",
+            "section": "scope"
+          },
+          {
+            "key": "name_mapping",
+            "label": "Name Mapping Default",
+            "type": "text_input",
+            "tooltip": "Override the Kometa name_mapping value for generated collections in this Defaults File.",
+            "section": "scope",
+            "placeholder": "Custom name mapping"
+          },
+          {
+            "key": "delete_collections_named",
+            "label": "Delete Collections Named",
+            "type": "string_list",
+            "tooltip": "Delete old collection names when these collections run.",
+            "section": "scope",
+            "placeholder": "Add collection title to delete"
+          },
+          {
+            "key": "image",
+            "label": "Image Path Default",
+            "type": "text_input",
+            "tooltip": "Override the default Kometa image path used to build poster URLs for generated collections.",
+            "placeholder": "year/best/<<key>>",
+            "default": "year/best/<<key>>",
+            "section": "artwork"
+          },
+          {
+            "key": "url_poster",
+            "label": "Poster URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg",
+            "validation_preset": "url"
+          },
+          {
+            "key": "file_poster",
+            "label": "Poster File Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "C:\\Path\\To\\poster.jpg"
+          },
+          {
+            "key": "url_background",
+            "label": "Background URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg",
+            "validation_preset": "url"
+          },
+          {
+            "key": "file_background",
+            "label": "Background File Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "C:\\Path\\To\\background.jpg"
+          },
+          {
+            "key": "url_logo",
+            "label": "Logo URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png",
+            "validation_preset": "url"
+          },
+          {
+            "key": "file_logo",
+            "label": "Logo File Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "C:\\Path\\To\\logo.png"
+          },
+          {
+            "key": "url_square_art",
+            "label": "Square Art URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png",
+            "validation_preset": "url"
+          },
+          {
+            "key": "file_square_art",
+            "label": "Square Art File Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "C:\\Path\\To\\square-art.png"
           },
           {
             "key": "visible_home",
             "label": "Visible Home",
             "type": "toggle",
             "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "visibility"
           },
           {
             "key": "visible_library",
             "label": "Visible Library",
             "type": "toggle",
             "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "visibility"
           },
           {
             "key": "visible_shared",
             "label": "Visible Shared",
             "type": "toggle",
             "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
+            "default": false,
+            "section": "visibility"
           },
           {
             "key": "hub_priority",
@@ -57812,344 +58296,8 @@
               "visible_library",
               "visible_shared"
             ],
-            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "sort_by",
-            "label": "Sort By",
-            "type": "select",
-            "tooltip": "Changes the Smart Filter Sort for all collections in a Defaults File.<br><br> Default is <b>Release Date (Originally Available) Descending</b> ",
-            "default": "release.desc",
-            "options": [
-              {
-                "value": "title.asc",
-                "label": "Title Ascending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "title.desc",
-                "label": "Title Descending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "season.asc",
-                "label": "Season Ascending",
-                "media_types": [
-                  "season"
-                ]
-              },
-              {
-                "value": "season.desc",
-                "label": "Season Descending",
-                "media_types": [
-                  "season"
-                ]
-              },
-              {
-                "value": "show.asc",
-                "label": "Show Ascending",
-                "media_types": [
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "show.desc",
-                "label": "Show Descending",
-                "media_types": [
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "year.asc",
-                "label": "Year Ascending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "year.desc",
-                "label": "Year Descending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "release.asc",
-                "label": "Release Date (Originally Available) Ascending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "release.desc",
-                "label": "Release Date (Originally Available) Descending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "episode_release.asc",
-                "label": "Episode Release Date Ascending",
-                "media_types": [
-                  "show",
-                  "season",
-                  "episode"
-                ]
-              },
-              {
-                "value": "episode_release.desc",
-                "label": "Episode Release Date Descending",
-                "media_types": [
-                  "show",
-                  "season",
-                  "episode"
-                ]
-              },
-              {
-                "value": "critic_rating.asc",
-                "label": "Critic Rating Ascending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "critic_rating.desc",
-                "label": "Critic Rating Descending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "audience_rating.asc",
-                "label": "Audience Rating Ascending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "audience_rating.desc",
-                "label": "Audience Rating Descending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "user_rating.asc",
-                "label": "User Rating Ascending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "season",
-                  "episode"
-                ]
-              },
-              {
-                "value": "user_rating.desc",
-                "label": "User Rating Descending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "season",
-                  "episode"
-                ]
-              },
-              {
-                "value": "content_rating.asc",
-                "label": "Content Rating Ascending",
-                "media_types": [
-                  "movie",
-                  "show"
-                ]
-              },
-              {
-                "value": "content_rating.desc",
-                "label": "Content Rating Descending",
-                "media_types": [
-                  "movie",
-                  "show"
-                ]
-              },
-              {
-                "value": "duration.asc",
-                "label": "Duration Ascending",
-                "media_types": [
-                  "movie",
-                  "episode"
-                ]
-              },
-              {
-                "value": "duration.desc",
-                "label": "Duration Descending",
-                "media_types": [
-                  "movie",
-                  "episode"
-                ]
-              },
-              {
-                "value": "progress.asc",
-                "label": "Progress Ascending",
-                "media_types": [
-                  "episode"
-                ]
-              },
-              {
-                "value": "progress.desc",
-                "label": "Progress Descending",
-                "media_types": [
-                  "episode"
-                ]
-              },
-              {
-                "value": "plays.asc",
-                "label": "Number of Plays Ascending",
-                "media_types": [
-                  "movie",
-                  "episode"
-                ]
-              },
-              {
-                "value": "plays.desc",
-                "label": "Number of Plays Descending",
-                "media_types": [
-                  "movie",
-                  "episode"
-                ]
-              },
-              {
-                "value": "unplayed.asc",
-                "label": "Unplayed Ascending",
-                "media_types": [
-                  "show"
-                ]
-              },
-              {
-                "value": "unplayed.desc",
-                "label": "Unplayed Descending",
-                "media_types": [
-                  "show"
-                ]
-              },
-              {
-                "value": "episode_added.asc",
-                "label": "Last Episode Date Added Ascending",
-                "media_types": [
-                  "show"
-                ]
-              },
-              {
-                "value": "episode_added.desc",
-                "label": "Last Episode Date Added Descending",
-                "media_types": [
-                  "show"
-                ]
-              },
-              {
-                "value": "added.asc",
-                "label": "Date Added Ascending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "season",
-                  "episode"
-                ]
-              },
-              {
-                "value": "added.desc",
-                "label": "Date Added Descending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "season",
-                  "episode"
-                ]
-              },
-              {
-                "value": "viewed.asc",
-                "label": "Date Last Viewed Ascending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "viewed.desc",
-                "label": "Date Last Viewed Descending",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "episode"
-                ]
-              },
-              {
-                "value": "resolution.asc",
-                "label": "Resolution Ascending",
-                "media_types": [
-                  "movie",
-                  "episode"
-                ]
-              },
-              {
-                "value": "resolution.desc",
-                "label": "Resolution Descending",
-                "media_types": [
-                  "movie",
-                  "episode"
-                ]
-              },
-              {
-                "value": "bitrate.asc",
-                "label": "Bitrate Ascending",
-                "media_types": [
-                  "movie",
-                  "episode"
-                ]
-              },
-              {
-                "value": "bitrate.desc",
-                "label": "Bitrate Descending",
-                "media_types": [
-                  "movie",
-                  "episode"
-                ]
-              },
-              {
-                "value": "random",
-                "label": "Random",
-                "media_types": [
-                  "movie",
-                  "show",
-                  "season",
-                  "episode"
-                ]
-              }
-            ]
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
           },
           {
             "key": "item_radarr_tag",
@@ -58159,7 +58307,8 @@
             "placeholder": "Add item Radarr tag",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "visibility"
           },
           {
             "key": "item_sonarr_tag",
@@ -58169,7 +58318,334 @@
             "placeholder": "Add item Sonarr tag",
             "media_types": [
               "show"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "child_use_overrides",
+            "label": "Use Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a year child key to an override. Quickstart exports these as <code>use_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Year key (e.g. 2024)",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "use_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "year"
+          },
+          {
+            "key": "child_name_overrides",
+            "label": "Name Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a year child key to an override. Quickstart exports these as <code>name_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Year key (e.g. 2024)",
+            "value_placeholder": "Custom collection name",
+            "dynamic_child_prefix": "name_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "year"
+          },
+          {
+            "key": "child_summary_overrides",
+            "label": "Summary Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a year child key to an override. Quickstart exports these as <code>summary_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Year key (e.g. 2024)",
+            "value_placeholder": "Custom collection summary",
+            "dynamic_child_prefix": "summary_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "year"
+          },
+          {
+            "key": "child_order_overrides",
+            "label": "Sort Order Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a year child key to an override. Quickstart exports these as <code>order_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Year key (e.g. 2024)",
+            "value_placeholder": "01, 02, etc.",
+            "dynamic_child_prefix": "order_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "year"
+          },
+          {
+            "key": "child_schedule_overrides",
+            "label": "Schedule Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a year child key to an override. Quickstart exports these as <code>schedule_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Year key (e.g. 2024)",
+            "value_placeholder": "weekly(sunday)",
+            "dynamic_child_prefix": "schedule_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "year"
+          },
+          {
+            "key": "child_sort_by_overrides",
+            "label": "Sort By Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a year child key to an override. Quickstart exports these as <code>sort_by_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Year key (e.g. 2024)",
+            "value_placeholder": "title.asc, release.desc, etc.",
+            "dynamic_child_prefix": "sort_by_",
+            "dynamic_child_value_kind": "select",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "year"
+          },
+          {
+            "key": "child_limit_overrides",
+            "label": "Limit Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a year child key to an override. Quickstart exports these as <code>limit_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Year key (e.g. 2024)",
+            "value_placeholder": "10, 25, etc.",
+            "dynamic_child_prefix": "limit_",
+            "dynamic_child_value_kind": "integer",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "year"
+          },
+          {
+            "key": "child_minimum_items_overrides",
+            "label": "Minimum Items Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a year child key to an override. Quickstart exports these as <code>minimum_items_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Year key (e.g. 2024)",
+            "value_placeholder": "1, 2, etc.",
+            "dynamic_child_prefix": "minimum_items_",
+            "dynamic_child_value_kind": "integer",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "year"
+          },
+          {
+            "key": "child_url_poster_overrides",
+            "label": "Poster URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a year child key to an override. Quickstart exports these as <code>url_poster_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Year key (e.g. 2024)",
+            "value_placeholder": "https://example.com/poster.jpg",
+            "dynamic_child_prefix": "url_poster_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "year",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_file_poster_overrides",
+            "label": "Poster File Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a year child key to an override. Quickstart exports these as <code>file_poster_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Year key (e.g. 2024)",
+            "value_placeholder": "C:\\Posters\\poster.jpg",
+            "dynamic_child_prefix": "file_poster_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "year"
+          },
+          {
+            "key": "child_url_background_overrides",
+            "label": "Background URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a year child key to an override. Quickstart exports these as <code>url_background_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Year key (e.g. 2024)",
+            "value_placeholder": "https://example.com/background.jpg",
+            "dynamic_child_prefix": "url_background_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "year",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_file_background_overrides",
+            "label": "Background File Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a year child key to an override. Quickstart exports these as <code>file_background_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Year key (e.g. 2024)",
+            "value_placeholder": "C:\\Posters\\background.jpg",
+            "dynamic_child_prefix": "file_background_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "year"
+          },
+          {
+            "key": "child_url_logo_overrides",
+            "label": "Logo URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a year child key to an override. Quickstart exports these as <code>url_logo_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Year key (e.g. 2024)",
+            "value_placeholder": "https://example.com/logo.png",
+            "dynamic_child_prefix": "url_logo_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "year",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_file_logo_overrides",
+            "label": "Logo File Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a year child key to an override. Quickstart exports these as <code>file_logo_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Year key (e.g. 2024)",
+            "value_placeholder": "C:\\Posters\\logo.png",
+            "dynamic_child_prefix": "file_logo_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "year"
+          },
+          {
+            "key": "child_url_square_art_overrides",
+            "label": "Square Art URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a year child key to an override. Quickstart exports these as <code>url_square_art_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Year key (e.g. 2024)",
+            "value_placeholder": "https://example.com/square.png",
+            "dynamic_child_prefix": "url_square_art_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "year",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_file_square_art_overrides",
+            "label": "Square Art File Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a year child key to an override. Quickstart exports these as <code>file_square_art_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Year key (e.g. 2024)",
+            "value_placeholder": "C:\\Posters\\square.png",
+            "dynamic_child_prefix": "file_square_art_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "year"
+          },
+          {
+            "key": "child_visible_home_overrides",
+            "label": "Visible Home Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a year child key to an override. Quickstart exports these as <code>visible_home_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Year key (e.g. 2024)",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "visible_home_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "year"
+          },
+          {
+            "key": "child_visible_library_overrides",
+            "label": "Visible Library Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a year child key to an override. Quickstart exports these as <code>visible_library_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Year key (e.g. 2024)",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "visible_library_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "year"
+          },
+          {
+            "key": "child_visible_shared_overrides",
+            "label": "Visible Shared Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a year child key to an override. Quickstart exports these as <code>visible_shared_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Year key (e.g. 2024)",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "visible_shared_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "year"
+          },
+          {
+            "key": "child_hub_priority_overrides",
+            "label": "Hub Priority Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a year child key to an override. Quickstart exports these as <code>hub_priority_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Year key (e.g. 2024)",
+            "value_placeholder": "1, 2, etc.",
+            "dynamic_child_prefix": "hub_priority_",
+            "dynamic_child_value_kind": "string",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "year"
+          },
+          {
+            "key": "child_item_radarr_tag_overrides",
+            "label": "Item Radarr Tag Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a year child key to an override. Quickstart exports these as <code>item_radarr_tag_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Year key (e.g. 2024)",
+            "value_placeholder": "tag1, tag2",
+            "dynamic_child_prefix": "item_radarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "year",
+            "media_types": [
+              "movie"
             ]
+          },
+          {
+            "key": "child_item_sonarr_tag_overrides",
+            "label": "Item Sonarr Tag Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a year child key to an override. Quickstart exports these as <code>item_sonarr_tag_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Year key (e.g. 2024)",
+            "value_placeholder": "tag1, tag2",
+            "dynamic_child_prefix": "item_sonarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "year",
+            "media_types": [
+              "show"
+            ]
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics"
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "data_range",
+            "label": "Dynamic Range"
+          },
+          {
+            "id": "scope",
+            "label": "Scope"
+          },
+          {
+            "id": "child_override_maps",
+            "label": "Child Overrides"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility"
           }
         ]
       },
@@ -58188,42 +58664,24 @@
             "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
             "type": "text_input",
             "default": "100",
-            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
           },
           {
-            "key": "sort_prefix",
-            "label": "Sort Prefix",
-            "type": "text_input",
-            "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
-            "placeholder": "e.g. !"
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle",
+            "default": true,
+            "section": "basics"
           },
           {
-            "key": "sort_title",
-            "label": "Sort Title",
-            "type": "text_input",
-            "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom sort title format"
-          },
-          {
-            "key": "name_format",
-            "label": "Name Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_format",
-            "label": "Summary Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "title_format",
-            "label": "Title Format",
-            "type": "text_input",
-            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom dynamic collection title format"
+            "key": "use_all",
+            "label": "Use All Child Collections",
+            "type": "toggle",
+            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting.",
+            "default": true,
+            "section": "basics"
           },
           {
             "key": "limit",
@@ -58233,21 +58691,8 @@
             "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
-          },
-          {
-            "key": "use_separator",
-            "label": "Use Separator",
-            "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "exclude",
-            "label": "Exclude",
-            "type": "string_list",
-            "tooltip": "Exclude specific decades from these collections.",
-            "placeholder": "Add decade key (e.g. 2020)"
+            "step": 1,
+            "section": "basics"
           },
           {
             "key": "minimum_items",
@@ -58256,86 +58701,8 @@
             "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
-          },
-          {
-            "key": "ignore_ids",
-            "label": "Ignore IDs",
-            "type": "string_list",
-            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
-            "placeholder": "Add numeric ID (e.g. 603)",
-            "validation_preset": "numeric_id"
-          },
-          {
-            "key": "ignore_imdb_ids",
-            "label": "Ignore IMDb IDs",
-            "type": "string_list",
-            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
-            "placeholder": "Add IMDb ID (e.g. tt1234567)",
-            "validation_preset": "imdb_id_plex"
-          },
-          {
-            "key": "collection_mode",
-            "label": "Collection Mode",
-            "type": "select",
-            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
-            "default": "default",
-            "options": [
-              {
-                "value": "default",
-                "label": "Library Default"
-              },
-              {
-                "value": "hide",
-                "label": "Hide Collection"
-              },
-              {
-                "value": "hide_items",
-                "label": "Hide Items in this Collection"
-              },
-              {
-                "value": "show_items",
-                "label": "Show this Collection and its Items"
-              }
-            ]
-          },
-          {
-            "key": "visible_home",
-            "label": "Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library",
-            "label": "Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared",
-            "label": "Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority",
-            "label": "Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
             "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home",
-              "visible_library",
-              "visible_shared"
-            ],
-            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "section": "basics"
           },
           {
             "key": "sort_by",
@@ -58672,7 +59039,261 @@
                   "episode"
                 ]
               }
-            ]
+            ],
+            "section": "basics"
+          },
+          {
+            "key": "search_term",
+            "label": "Search Term",
+            "type": "text_input",
+            "tooltip": "Override the smart-filter search term used by this Defaults File.",
+            "placeholder": "decade",
+            "default": "decade",
+            "section": "basics"
+          },
+          {
+            "key": "sort_prefix",
+            "label": "Sort Prefix",
+            "type": "text_input",
+            "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
+            "placeholder": "e.g. !",
+            "section": "naming"
+          },
+          {
+            "key": "sort_title",
+            "label": "Sort Title",
+            "type": "text_input",
+            "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom sort title format",
+            "section": "naming"
+          },
+          {
+            "key": "name_format",
+            "label": "Name Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection name format",
+            "section": "naming"
+          },
+          {
+            "key": "summary_format",
+            "label": "Summary Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection summary format",
+            "section": "naming"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format",
+            "section": "naming"
+          },
+          {
+            "key": "translation_key",
+            "label": "Translation Key",
+            "type": "text_input",
+            "tooltip": "Override the translation key used for generated collection names and summaries.",
+            "section": "naming",
+            "placeholder": "decade",
+            "default": "decade"
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific decades from these collections.",
+            "placeholder": "Add decade key (e.g. 2020)",
+            "section": "scope",
+            "validation_preset": "decade"
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id",
+            "section": "scope"
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex",
+            "section": "scope"
+          },
+          {
+            "key": "collection_mode",
+            "label": "Collection Mode",
+            "type": "select",
+            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
+            "default": "default",
+            "options": [
+              {
+                "value": "default",
+                "label": "Library Default"
+              },
+              {
+                "value": "hide",
+                "label": "Hide Collection"
+              },
+              {
+                "value": "hide_items",
+                "label": "Hide Items in this Collection"
+              },
+              {
+                "value": "show_items",
+                "label": "Show this Collection and its Items"
+              }
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "schedule",
+            "label": "Schedule Default",
+            "type": "schedule",
+            "tooltip": "Configure when collections in this Defaults File update by default.",
+            "section": "scope"
+          },
+          {
+            "key": "name_mapping",
+            "label": "Name Mapping Default",
+            "type": "text_input",
+            "tooltip": "Override the Kometa name_mapping value for generated collections in this Defaults File.",
+            "section": "scope",
+            "placeholder": "Custom name mapping"
+          },
+          {
+            "key": "delete_collections_named",
+            "label": "Delete Collections Named",
+            "type": "string_list",
+            "tooltip": "Delete old collection names when these collections run.",
+            "section": "scope",
+            "placeholder": "Add collection title to delete"
+          },
+          {
+            "key": "image",
+            "label": "Image Path Default",
+            "type": "text_input",
+            "tooltip": "Override the default Kometa image path used to build poster URLs for generated collections.",
+            "placeholder": "decade/best/<<key>>",
+            "default": "decade/best/<<key>>",
+            "section": "artwork"
+          },
+          {
+            "key": "url_poster",
+            "label": "Poster URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg",
+            "validation_preset": "url"
+          },
+          {
+            "key": "file_poster",
+            "label": "Poster File Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "C:\\Path\\To\\poster.jpg"
+          },
+          {
+            "key": "url_background",
+            "label": "Background URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg",
+            "validation_preset": "url"
+          },
+          {
+            "key": "file_background",
+            "label": "Background File Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "C:\\Path\\To\\background.jpg"
+          },
+          {
+            "key": "url_logo",
+            "label": "Logo URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png",
+            "validation_preset": "url"
+          },
+          {
+            "key": "file_logo",
+            "label": "Logo File Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "C:\\Path\\To\\logo.png"
+          },
+          {
+            "key": "url_square_art",
+            "label": "Square Art URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png",
+            "validation_preset": "url"
+          },
+          {
+            "key": "file_square_art",
+            "label": "Square Art File Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "C:\\Path\\To\\square-art.png"
+          },
+          {
+            "key": "visible_home",
+            "label": "Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library",
+            "label": "Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared",
+            "label": "Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
           },
           {
             "key": "item_radarr_tag",
@@ -58682,7 +59303,345 @@
             "placeholder": "Add item Radarr tag",
             "media_types": [
               "movie"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "child_use_overrides",
+            "label": "Use Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>use_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "use_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_name_overrides",
+            "label": "Name Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>name_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "Custom collection name",
+            "dynamic_child_prefix": "name_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_summary_overrides",
+            "label": "Summary Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>summary_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "Custom collection summary",
+            "dynamic_child_prefix": "summary_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_order_overrides",
+            "label": "Sort Order Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>order_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "01, 02, etc.",
+            "dynamic_child_prefix": "order_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_schedule_overrides",
+            "label": "Schedule Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>schedule_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "weekly(sunday)",
+            "dynamic_child_prefix": "schedule_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_sort_by_overrides",
+            "label": "Sort By Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>sort_by_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "title.asc, release.desc, etc.",
+            "dynamic_child_prefix": "sort_by_",
+            "dynamic_child_value_kind": "select",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_limit_overrides",
+            "label": "Limit Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>limit_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "10, 25, etc.",
+            "dynamic_child_prefix": "limit_",
+            "dynamic_child_value_kind": "integer",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_minimum_items_overrides",
+            "label": "Minimum Items Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>minimum_items_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "1, 2, etc.",
+            "dynamic_child_prefix": "minimum_items_",
+            "dynamic_child_value_kind": "integer",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_url_poster_overrides",
+            "label": "Poster URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>url_poster_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "https://example.com/poster.jpg",
+            "dynamic_child_prefix": "url_poster_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "decade",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_file_poster_overrides",
+            "label": "Poster File Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>file_poster_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "C:\\Posters\\poster.jpg",
+            "dynamic_child_prefix": "file_poster_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_url_background_overrides",
+            "label": "Background URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>url_background_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "https://example.com/background.jpg",
+            "dynamic_child_prefix": "url_background_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "decade",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_file_background_overrides",
+            "label": "Background File Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>file_background_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "C:\\Posters\\background.jpg",
+            "dynamic_child_prefix": "file_background_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_url_logo_overrides",
+            "label": "Logo URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>url_logo_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "https://example.com/logo.png",
+            "dynamic_child_prefix": "url_logo_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "decade",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_file_logo_overrides",
+            "label": "Logo File Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>file_logo_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "C:\\Posters\\logo.png",
+            "dynamic_child_prefix": "file_logo_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_url_square_art_overrides",
+            "label": "Square Art URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>url_square_art_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "https://example.com/square.png",
+            "dynamic_child_prefix": "url_square_art_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "decade",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_file_square_art_overrides",
+            "label": "Square Art File Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>file_square_art_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "C:\\Posters\\square.png",
+            "dynamic_child_prefix": "file_square_art_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_visible_home_overrides",
+            "label": "Visible Home Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>visible_home_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "visible_home_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_visible_library_overrides",
+            "label": "Visible Library Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>visible_library_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "visible_library_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_visible_shared_overrides",
+            "label": "Visible Shared Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>visible_shared_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "visible_shared_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_hub_priority_overrides",
+            "label": "Hub Priority Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>hub_priority_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "1, 2, etc.",
+            "dynamic_child_prefix": "hub_priority_",
+            "dynamic_child_value_kind": "string",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_item_radarr_tag_overrides",
+            "label": "Item Radarr Tag Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>item_radarr_tag_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "tag1, tag2",
+            "dynamic_child_prefix": "item_radarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "decade",
+            "media_types": [
+              "movie"
             ]
+          },
+          {
+            "key": "child_item_sonarr_tag_overrides",
+            "label": "Item Sonarr Tag Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>item_sonarr_tag_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "tag1, tag2",
+            "dynamic_child_prefix": "item_sonarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "decade",
+            "media_types": [
+              "show"
+            ]
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics"
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "data_range",
+            "label": "Dynamic Range"
+          },
+          {
+            "id": "scope",
+            "label": "Scope"
+          },
+          {
+            "id": "child_override_maps",
+            "label": "Child Overrides"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility"
           }
         ]
       },
@@ -58701,42 +59660,24 @@
             "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
             "type": "text_input",
             "default": "100",
-            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
           },
           {
-            "key": "sort_prefix",
-            "label": "Sort Prefix",
-            "type": "text_input",
-            "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
-            "placeholder": "e.g. !"
+            "key": "use_separator",
+            "label": "Use Separator",
+            "tooltip": "Create a separator collection before this set of collections.",
+            "type": "toggle",
+            "default": true,
+            "section": "basics"
           },
           {
-            "key": "sort_title",
-            "label": "Sort Title",
-            "type": "text_input",
-            "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom sort title format"
-          },
-          {
-            "key": "name_format",
-            "label": "Name Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_format",
-            "label": "Summary Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "title_format",
-            "label": "Title Format",
-            "type": "text_input",
-            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom dynamic collection title format"
+            "key": "use_all",
+            "label": "Use All Child Collections",
+            "type": "toggle",
+            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting.",
+            "default": true,
+            "section": "basics"
           },
           {
             "key": "limit",
@@ -58746,21 +59687,8 @@
             "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
-          },
-          {
-            "key": "use_separator",
-            "label": "Use Separator",
-            "tooltip": "Create a separator collection before this set of collections.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "exclude",
-            "label": "Exclude",
-            "type": "string_list",
-            "tooltip": "Exclude specific decades from these collections.",
-            "placeholder": "Add decade key (e.g. 2020)"
+            "step": 1,
+            "section": "basics"
           },
           {
             "key": "minimum_items",
@@ -58769,86 +59697,8 @@
             "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
-          },
-          {
-            "key": "ignore_ids",
-            "label": "Ignore IDs",
-            "type": "string_list",
-            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
-            "placeholder": "Add numeric ID (e.g. 603)",
-            "validation_preset": "numeric_id"
-          },
-          {
-            "key": "ignore_imdb_ids",
-            "label": "Ignore IMDb IDs",
-            "type": "string_list",
-            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
-            "placeholder": "Add IMDb ID (e.g. tt1234567)",
-            "validation_preset": "imdb_id_plex"
-          },
-          {
-            "key": "collection_mode",
-            "label": "Collection Mode",
-            "type": "select",
-            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
-            "default": "default",
-            "options": [
-              {
-                "value": "default",
-                "label": "Library Default"
-              },
-              {
-                "value": "hide",
-                "label": "Hide Collection"
-              },
-              {
-                "value": "hide_items",
-                "label": "Hide Items in this Collection"
-              },
-              {
-                "value": "show_items",
-                "label": "Show this Collection and its Items"
-              }
-            ]
-          },
-          {
-            "key": "visible_home",
-            "label": "Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library",
-            "label": "Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared",
-            "label": "Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority",
-            "label": "Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
             "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home",
-              "visible_library",
-              "visible_shared"
-            ],
-            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "section": "basics"
           },
           {
             "key": "sort_by",
@@ -59185,7 +60035,272 @@
                   "episode"
                 ]
               }
-            ]
+            ],
+            "section": "basics"
+          },
+          {
+            "key": "search_term",
+            "label": "Search Term",
+            "type": "text_input",
+            "tooltip": "Override the smart-filter search term used by this Defaults File.",
+            "placeholder": "year",
+            "default": "year",
+            "section": "basics"
+          },
+          {
+            "key": "sort_prefix",
+            "label": "Sort Prefix",
+            "type": "text_input",
+            "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
+            "placeholder": "e.g. !",
+            "section": "naming"
+          },
+          {
+            "key": "sort_title",
+            "label": "Sort Title",
+            "type": "text_input",
+            "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom sort title format",
+            "section": "naming"
+          },
+          {
+            "key": "name_format",
+            "label": "Name Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection name format",
+            "section": "naming"
+          },
+          {
+            "key": "summary_format",
+            "label": "Summary Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection summary format",
+            "section": "naming"
+          },
+          {
+            "key": "title_format",
+            "label": "Title Format",
+            "type": "text_input",
+            "tooltip": "Override the generated dynamic collection title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom dynamic collection title format",
+            "section": "naming"
+          },
+          {
+            "key": "translation_key",
+            "label": "Translation Key",
+            "type": "text_input",
+            "tooltip": "Override the translation key used for generated collection names and summaries.",
+            "section": "naming",
+            "placeholder": "decade",
+            "default": "decade"
+          },
+          {
+            "key": "exclude",
+            "label": "Exclude",
+            "type": "string_list",
+            "tooltip": "Exclude specific decades from these collections.",
+            "placeholder": "Add decade key (e.g. 2020)",
+            "section": "scope",
+            "validation_preset": "decade"
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id",
+            "section": "scope"
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex",
+            "section": "scope"
+          },
+          {
+            "key": "collection_mode",
+            "label": "Collection Mode",
+            "type": "select",
+            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
+            "default": "default",
+            "options": [
+              {
+                "value": "default",
+                "label": "Library Default"
+              },
+              {
+                "value": "hide",
+                "label": "Hide Collection"
+              },
+              {
+                "value": "hide_items",
+                "label": "Hide Items in this Collection"
+              },
+              {
+                "value": "show_items",
+                "label": "Show this Collection and its Items"
+              }
+            ],
+            "section": "scope"
+          },
+          {
+            "key": "schedule",
+            "label": "Schedule Default",
+            "type": "schedule",
+            "tooltip": "Configure when collections in this Defaults File update by default.",
+            "section": "scope"
+          },
+          {
+            "key": "name_mapping",
+            "label": "Name Mapping Default",
+            "type": "text_input",
+            "tooltip": "Override the Kometa name_mapping value for generated collections in this Defaults File.",
+            "section": "scope",
+            "placeholder": "Custom name mapping"
+          },
+          {
+            "key": "delete_collections_named",
+            "label": "Delete Collections Named",
+            "type": "string_list",
+            "tooltip": "Delete old collection names when these collections run.",
+            "section": "scope",
+            "placeholder": "Add collection title to delete"
+          },
+          {
+            "key": "image",
+            "label": "Image Path Default",
+            "type": "text_input",
+            "tooltip": "Override the default Kometa image path used to build poster URLs for generated collections.",
+            "placeholder": "decade/best/<<key>>",
+            "default": "decade/best/<<key>>",
+            "section": "artwork"
+          },
+          {
+            "key": "url_poster",
+            "label": "Poster URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg",
+            "validation_preset": "url"
+          },
+          {
+            "key": "file_poster",
+            "label": "Poster File Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "C:\\Path\\To\\poster.jpg"
+          },
+          {
+            "key": "url_background",
+            "label": "Background URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg",
+            "validation_preset": "url"
+          },
+          {
+            "key": "file_background",
+            "label": "Background File Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "C:\\Path\\To\\background.jpg"
+          },
+          {
+            "key": "url_logo",
+            "label": "Logo URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png",
+            "validation_preset": "url"
+          },
+          {
+            "key": "file_logo",
+            "label": "Logo File Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "C:\\Path\\To\\logo.png"
+          },
+          {
+            "key": "url_square_art",
+            "label": "Square Art URL Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png",
+            "validation_preset": "url"
+          },
+          {
+            "key": "file_square_art",
+            "label": "Square Art File Default",
+            "type": "text_input",
+            "tooltip": "Override the default artwork source for all child collections in this Defaults File.",
+            "section": "artwork",
+            "placeholder": "C:\\Path\\To\\square-art.png"
+          },
+          {
+            "key": "visible_home",
+            "label": "Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_library",
+            "label": "Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "visible_shared",
+            "label": "Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ],
+            "section": "visibility"
           },
           {
             "key": "item_sonarr_tag",
@@ -59195,7 +60310,334 @@
             "placeholder": "Add item Sonarr tag",
             "media_types": [
               "show"
+            ],
+            "section": "visibility"
+          },
+          {
+            "key": "child_use_overrides",
+            "label": "Use Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>use_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "use_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_name_overrides",
+            "label": "Name Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>name_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "Custom collection name",
+            "dynamic_child_prefix": "name_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_summary_overrides",
+            "label": "Summary Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>summary_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "Custom collection summary",
+            "dynamic_child_prefix": "summary_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_order_overrides",
+            "label": "Sort Order Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>order_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "01, 02, etc.",
+            "dynamic_child_prefix": "order_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_schedule_overrides",
+            "label": "Schedule Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>schedule_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "weekly(sunday)",
+            "dynamic_child_prefix": "schedule_",
+            "dynamic_child_value_kind": "string",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_sort_by_overrides",
+            "label": "Sort By Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>sort_by_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "title.asc, release.desc, etc.",
+            "dynamic_child_prefix": "sort_by_",
+            "dynamic_child_value_kind": "select",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_limit_overrides",
+            "label": "Limit Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>limit_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "10, 25, etc.",
+            "dynamic_child_prefix": "limit_",
+            "dynamic_child_value_kind": "integer",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_minimum_items_overrides",
+            "label": "Minimum Items Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>minimum_items_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "1, 2, etc.",
+            "dynamic_child_prefix": "minimum_items_",
+            "dynamic_child_value_kind": "integer",
+            "section": "child_override_maps",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_url_poster_overrides",
+            "label": "Poster URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>url_poster_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "https://example.com/poster.jpg",
+            "dynamic_child_prefix": "url_poster_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "decade",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_file_poster_overrides",
+            "label": "Poster File Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>file_poster_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "C:\\Posters\\poster.jpg",
+            "dynamic_child_prefix": "file_poster_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_url_background_overrides",
+            "label": "Background URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>url_background_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "https://example.com/background.jpg",
+            "dynamic_child_prefix": "url_background_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "decade",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_file_background_overrides",
+            "label": "Background File Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>file_background_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "C:\\Posters\\background.jpg",
+            "dynamic_child_prefix": "file_background_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_url_logo_overrides",
+            "label": "Logo URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>url_logo_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "https://example.com/logo.png",
+            "dynamic_child_prefix": "url_logo_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "decade",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_file_logo_overrides",
+            "label": "Logo File Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>file_logo_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "C:\\Posters\\logo.png",
+            "dynamic_child_prefix": "file_logo_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_url_square_art_overrides",
+            "label": "Square Art URL Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>url_square_art_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "https://example.com/square.png",
+            "dynamic_child_prefix": "url_square_art_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "decade",
+            "validation_preset": "url"
+          },
+          {
+            "key": "child_file_square_art_overrides",
+            "label": "Square Art File Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>file_square_art_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "C:\\Posters\\square.png",
+            "dynamic_child_prefix": "file_square_art_",
+            "dynamic_child_value_kind": "string",
+            "section": "artwork",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_visible_home_overrides",
+            "label": "Visible Home Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>visible_home_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "visible_home_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_visible_library_overrides",
+            "label": "Visible Library Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>visible_library_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "visible_library_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_visible_shared_overrides",
+            "label": "Visible Shared Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>visible_shared_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "true or false",
+            "dynamic_child_prefix": "visible_shared_",
+            "dynamic_child_value_kind": "boolean",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_hub_priority_overrides",
+            "label": "Hub Priority Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>hub_priority_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "1, 2, etc.",
+            "dynamic_child_prefix": "hub_priority_",
+            "dynamic_child_value_kind": "string",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "decade"
+          },
+          {
+            "key": "child_item_radarr_tag_overrides",
+            "label": "Item Radarr Tag Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>item_radarr_tag_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "tag1, tag2",
+            "dynamic_child_prefix": "item_radarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "decade",
+            "media_types": [
+              "movie"
             ]
+          },
+          {
+            "key": "child_item_sonarr_tag_overrides",
+            "label": "Item Sonarr Tag Overrides",
+            "type": "mapping_list",
+            "tooltip": "Map a decade child key to an override. Quickstart exports these as <code>item_sonarr_tag_&lt;&lt;key&gt;&gt;</code> template variables.",
+            "key_placeholder": "Decade key (e.g. 2020)",
+            "value_placeholder": "tag1, tag2",
+            "dynamic_child_prefix": "item_sonarr_tag_",
+            "dynamic_child_value_kind": "string_list",
+            "section": "visibility",
+            "label_width": 320,
+            "key_validation_preset": "decade",
+            "media_types": [
+              "show"
+            ]
+          }
+        ],
+        "template_variable_sections": [
+          {
+            "id": "basics",
+            "label": "Basics"
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "data_range",
+            "label": "Dynamic Range"
+          },
+          {
+            "id": "scope",
+            "label": "Scope"
+          },
+          {
+            "id": "child_override_maps",
+            "label": "Child Overrides"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility"
           }
         ]
       }

--- a/tests/test_collection_year_decade_contract.py
+++ b/tests/test_collection_year_decade_contract.py
@@ -1,0 +1,112 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+QS_COLLECTIONS_PATH = ROOT / "static" / "json" / "quickstart_collections.json"
+
+
+def _load_collection(collection_id, media_types):
+    data = json.loads(QS_COLLECTIONS_PATH.read_text(encoding="utf-8"))
+    media_types = tuple(media_types)
+    for group in data:
+        for collection in group.get("collections", []):
+            if collection.get("id") != collection_id:
+                continue
+            if tuple(collection.get("media_types") or []) == media_types:
+                return collection
+    raise AssertionError(f"Missing {collection_id} with media types {media_types}")
+
+
+def _field_map(collection):
+    return {item["key"]: item for item in collection.get("template_variables", []) if isinstance(item, dict) and item.get("key")}
+
+
+def _assert_mapping(field, child_prefix, value_kind, section, key_validation_preset, validation_preset=None, media_types=None):
+    assert field["type"] == "mapping_list"
+    assert field["dynamic_child_prefix"] == child_prefix
+    assert field["dynamic_child_value_kind"] == value_kind
+    assert field["section"] == section
+    assert field["key_validation_preset"] == key_validation_preset
+    if validation_preset is None:
+        assert "validation_preset" not in field
+    else:
+        assert field["validation_preset"] == validation_preset
+    if media_types is None:
+        assert "media_types" not in field
+    else:
+        assert field["media_types"] == media_types
+
+
+def _assert_year_or_decade_contract(collection, key_validation_preset, expected_search_term, expected_image):
+    fields = _field_map(collection)
+
+    section_ids = [section.get("id") for section in collection.get("template_variable_sections") or [] if isinstance(section, dict)]
+    assert section_ids == ["basics", "naming", "data_range", "scope", "child_override_maps", "artwork", "visibility"]
+
+    for key in [
+        "use_all",
+        "search_term",
+        "translation_key",
+        "schedule",
+        "name_mapping",
+        "delete_collections_named",
+        "image",
+        "url_poster",
+        "file_poster",
+        "url_background",
+        "file_background",
+        "url_logo",
+        "file_logo",
+        "url_square_art",
+        "file_square_art",
+    ]:
+        assert key in fields
+
+    assert fields["search_term"]["default"] == expected_search_term
+    assert fields["image"]["default"] == expected_image
+    assert fields["exclude"]["validation_preset"] == key_validation_preset
+
+    expected_mappings = {
+        "child_use_overrides": ("use_", "boolean", "child_override_maps", None, None),
+        "child_name_overrides": ("name_", "string", "child_override_maps", None, None),
+        "child_summary_overrides": ("summary_", "string", "child_override_maps", None, None),
+        "child_order_overrides": ("order_", "string", "child_override_maps", None, None),
+        "child_schedule_overrides": ("schedule_", "string", "child_override_maps", None, None),
+        "child_sort_by_overrides": ("sort_by_", "select", "child_override_maps", None, None),
+        "child_limit_overrides": ("limit_", "integer", "child_override_maps", None, None),
+        "child_minimum_items_overrides": ("minimum_items_", "integer", "child_override_maps", None, None),
+        "child_url_poster_overrides": ("url_poster_", "string", "artwork", "url", None),
+        "child_file_poster_overrides": ("file_poster_", "string", "artwork", None, None),
+        "child_url_background_overrides": ("url_background_", "string", "artwork", "url", None),
+        "child_file_background_overrides": ("file_background_", "string", "artwork", None, None),
+        "child_url_logo_overrides": ("url_logo_", "string", "artwork", "url", None),
+        "child_file_logo_overrides": ("file_logo_", "string", "artwork", None, None),
+        "child_url_square_art_overrides": ("url_square_art_", "string", "artwork", "url", None),
+        "child_file_square_art_overrides": ("file_square_art_", "string", "artwork", None, None),
+        "child_visible_home_overrides": ("visible_home_", "boolean", "visibility", None, None),
+        "child_visible_library_overrides": ("visible_library_", "boolean", "visibility", None, None),
+        "child_visible_shared_overrides": ("visible_shared_", "boolean", "visibility", None, None),
+        "child_hub_priority_overrides": ("hub_priority_", "string", "visibility", None, None),
+        "child_item_radarr_tag_overrides": ("item_radarr_tag_", "string_list", "visibility", None, ["movie"]),
+        "child_item_sonarr_tag_overrides": ("item_sonarr_tag_", "string_list", "visibility", None, ["show"]),
+    }
+    for key, (child_prefix, value_kind, section, validation_preset, media_types) in expected_mappings.items():
+        _assert_mapping(fields[key], child_prefix, value_kind, section, key_validation_preset, validation_preset, media_types)
+
+
+def test_year_collection_exposes_shared_defaults_and_dynamic_maps():
+    collection = _load_collection("collection_year", ("movie", "show"))
+
+    _assert_year_or_decade_contract(collection, "year", "year", "year/best/<<key>>")
+
+
+def test_movie_decade_collection_exposes_shared_defaults_and_dynamic_maps():
+    collection = _load_collection("collection_decade", ("movie",))
+
+    _assert_year_or_decade_contract(collection, "decade", "decade", "decade/best/<<key>>")
+
+
+def test_show_decade_collection_uses_year_search_term_and_dynamic_maps():
+    collection = _load_collection("collection_decade", ("show",))
+
+    _assert_year_or_decade_contract(collection, "decade", "year", "decade/best/<<key>>")

--- a/tests/test_importer_collection_files.py
+++ b/tests/test_importer_collection_files.py
@@ -691,3 +691,103 @@ def test_prepare_import_payload_collapses_actor_dynamic_child_template_variables
     assert json.loads(libraries_payload["mov-library_movies-template_collection_actor_child_file_poster_overrides"]) == {"Tom Hanks": r"C:\Posters\tom-hanks.jpg"}
     assert json.loads(libraries_payload["mov-library_movies-template_collection_actor_child_visible_library_overrides"]) == {"Tom Hanks": "false"}
     assert any("libraries.Movies.collection_files[0].template_variables.tmdb_person_offset_Tom Hanks" in line for line in report.lines)
+
+
+def test_prepare_import_payload_collapses_year_dynamic_child_template_variables():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Movies": {
+                    "collection_files": [
+                        {
+                            "default": "year",
+                            "template_variables": {
+                                "search_term": "year",
+                                "image": "year/best/<<key>>",
+                                "translation_key": "year",
+                                "use_2024": False,
+                                "name_2024": "Best of This Year",
+                                "schedule_2023": "weekly(sunday)",
+                                "sort_by_2022": "title.asc",
+                                "limit_2021": 12,
+                                "minimum_items_2020": 3,
+                                "url_background_2019": "https://example.com/2019-bg.jpg",
+                                "file_logo_2018": r"C:\Logos\2018.png",
+                                "visible_home_2017": True,
+                                "item_radarr_tag_2016": ["year", "2016"],
+                            },
+                        }
+                    ]
+                }
+            }
+        },
+        {"Movies"},
+        set(),
+    )
+
+    libraries_payload = payload["libraries"]["libraries"]
+    assert libraries_payload["mov-library_movies-collection_year"] is True
+    assert libraries_payload["mov-library_movies-template_collection_year_search_term"] == "year"
+    assert libraries_payload["mov-library_movies-template_collection_year_image"] == "year/best/<<key>>"
+    assert libraries_payload["mov-library_movies-template_collection_year_translation_key"] == "year"
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_year_child_use_overrides"]) == {"2024": "false"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_year_child_name_overrides"]) == {"2024": "Best of This Year"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_year_child_schedule_overrides"]) == {"2023": "weekly(sunday)"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_year_child_sort_by_overrides"]) == {"2022": "title.asc"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_year_child_limit_overrides"]) == {"2021": "12"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_year_child_minimum_items_overrides"]) == {"2020": "3"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_year_child_url_background_overrides"]) == {"2019": "https://example.com/2019-bg.jpg"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_year_child_file_logo_overrides"]) == {"2018": r"C:\Logos\2018.png"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_year_child_visible_home_overrides"]) == {"2017": "true"}
+    assert json.loads(libraries_payload["mov-library_movies-template_collection_year_child_item_radarr_tag_overrides"]) == {"2016": "year,2016"}
+    assert any("libraries.Movies.collection_files[0].template_variables.schedule_2023" in line for line in report.lines)
+
+
+def test_prepare_import_payload_collapses_decade_dynamic_child_template_variables():
+    payload, report = importer.prepare_import_payload(
+        {
+            "libraries": {
+                "Shows": {
+                    "collection_files": [
+                        {
+                            "default": "decade",
+                            "template_variables": {
+                                "search_term": "year",
+                                "image": "decade/best/<<key>>",
+                                "translation_key": "decade",
+                                "use_2020": False,
+                                "summary_2010": "2010s favorites",
+                                "order_2000": "03",
+                                "schedule_1990": "weekly(friday)",
+                                "sort_by_1980": "critic_rating.desc",
+                                "limit_1970": 25,
+                                "url_square_art_1960": "https://example.com/1960-square.png",
+                                "file_background_1950": r"C:\Backgrounds\1950.jpg",
+                                "visible_library_1940": False,
+                                "item_sonarr_tag_1930": ["decade", "1930s"],
+                            },
+                        }
+                    ]
+                }
+            }
+        },
+        {"Shows"},
+        set(),
+    )
+
+    libraries_payload = payload["libraries"]["libraries"]
+    assert libraries_payload["mov-library_shows-collection_decade"] is True
+    assert libraries_payload["mov-library_shows-template_collection_decade_search_term"] == "year"
+    assert libraries_payload["mov-library_shows-template_collection_decade_image"] == "decade/best/<<key>>"
+    assert libraries_payload["mov-library_shows-template_collection_decade_translation_key"] == "decade"
+    assert json.loads(libraries_payload["mov-library_shows-template_collection_decade_child_use_overrides"]) == {"2020": "false"}
+    assert json.loads(libraries_payload["mov-library_shows-template_collection_decade_child_summary_overrides"]) == {"2010": "2010s favorites"}
+    assert json.loads(libraries_payload["mov-library_shows-template_collection_decade_child_order_overrides"]) == {"2000": "03"}
+    assert json.loads(libraries_payload["mov-library_shows-template_collection_decade_child_schedule_overrides"]) == {"1990": "weekly(friday)"}
+    assert json.loads(libraries_payload["mov-library_shows-template_collection_decade_child_sort_by_overrides"]) == {"1980": "critic_rating.desc"}
+    assert json.loads(libraries_payload["mov-library_shows-template_collection_decade_child_limit_overrides"]) == {"1970": "25"}
+    assert json.loads(libraries_payload["mov-library_shows-template_collection_decade_child_url_square_art_overrides"]) == {"1960": "https://example.com/1960-square.png"}
+    assert json.loads(libraries_payload["mov-library_shows-template_collection_decade_child_file_background_overrides"]) == {"1950": r"C:\Backgrounds\1950.jpg"}
+    assert json.loads(libraries_payload["mov-library_shows-template_collection_decade_child_visible_library_overrides"]) == {"1940": "false"}
+    assert json.loads(libraries_payload["mov-library_shows-template_collection_decade_child_item_sonarr_tag_overrides"]) == {"1930": "decade,1930s"}
+    assert any("libraries.Shows.collection_files[0].template_variables.schedule_1990" in line for line in report.lines)

--- a/tests/test_output_collection_child_override_contract.py
+++ b/tests/test_output_collection_child_override_contract.py
@@ -263,3 +263,59 @@ def test_apply_template_var_normalizers_expands_actor_dynamic_child_override_map
     assert template_vars["limit_Tom Hanks"] == 50
     assert template_vars["file_poster_Tom Hanks"] == r"C:\Posters\tom-hanks.jpg"
     assert template_vars["visible_library_Tom Hanks"] is False
+
+
+def test_apply_template_var_normalizers_expands_year_dynamic_child_override_maps():
+    template_vars = {
+        "child_use_overrides": '{"2024": "false"}',
+        "child_name_overrides": '{"2024": "Best of This Year"}',
+        "child_schedule_overrides": '{"2023": "weekly(sunday)"}',
+        "child_sort_by_overrides": '{"2022": "title.asc"}',
+        "child_limit_overrides": '{"2021": "12"}',
+        "child_minimum_items_overrides": '{"2020": "3"}',
+        "child_url_background_overrides": '{"2019": "https://example.com/2019-bg.jpg"}',
+        "child_file_logo_overrides": '{"2018": "C:\\\\Logos\\\\2018.png"}',
+        "child_visible_home_overrides": '{"2017": "true"}',
+        "child_item_radarr_tag_overrides": '{"2016": ["year", "2016"]}',
+    }
+
+    output_collections._apply_template_var_normalizers(template_vars, "year")
+
+    assert template_vars["use_2024"] is False
+    assert template_vars["name_2024"] == "Best of This Year"
+    assert template_vars["schedule_2023"] == "weekly(sunday)"
+    assert template_vars["sort_by_2022"] == "title.asc"
+    assert template_vars["limit_2021"] == 12
+    assert template_vars["minimum_items_2020"] == 3
+    assert template_vars["url_background_2019"] == "https://example.com/2019-bg.jpg"
+    assert template_vars["file_logo_2018"] == r"C:\Logos\2018.png"
+    assert template_vars["visible_home_2017"] is True
+    assert template_vars["item_radarr_tag_2016"] == ["year", "2016"]
+
+
+def test_apply_template_var_normalizers_expands_decade_dynamic_child_override_maps():
+    template_vars = {
+        "child_use_overrides": '{"2020": "false"}',
+        "child_summary_overrides": '{"2010": "2010s favorites"}',
+        "child_order_overrides": '{"2000": "03"}',
+        "child_schedule_overrides": '{"1990": "weekly(friday)"}',
+        "child_sort_by_overrides": '{"1980": "critic_rating.desc"}',
+        "child_limit_overrides": '{"1970": "25"}',
+        "child_url_square_art_overrides": '{"1960": "https://example.com/1960-square.png"}',
+        "child_file_background_overrides": '{"1950": "C:\\\\Backgrounds\\\\1950.jpg"}',
+        "child_visible_library_overrides": '{"1940": "false"}',
+        "child_item_sonarr_tag_overrides": '{"1930": ["decade", "1930s"]}',
+    }
+
+    output_collections._apply_template_var_normalizers(template_vars, "decade")
+
+    assert template_vars["use_2020"] is False
+    assert template_vars["summary_2010"] == "2010s favorites"
+    assert template_vars["order_2000"] == "03"
+    assert template_vars["schedule_1990"] == "weekly(friday)"
+    assert template_vars["sort_by_1980"] == "critic_rating.desc"
+    assert template_vars["limit_1970"] == 25
+    assert template_vars["url_square_art_1960"] == "https://example.com/1960-square.png"
+    assert template_vars["file_background_1950"] == r"C:\Backgrounds\1950.jpg"
+    assert template_vars["visible_library_1940"] is False
+    assert template_vars["item_sonarr_tag_1930"] == ["decade", "1930s"]


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

```markdown
## Summary

Adds full Quickstart support for the `year` and `decade` collection defaults so their template variables can round-trip through the Libraries UI, importer, and exporter.

## Changes

- Expanded `collection_year` and both movie/show `collection_decade` metadata in `quickstart_collections.json`.
- Organized fields into logical sections: basics, naming, dynamic range, scope, child overrides, artwork, and visibility.
- Added missing YAML-backed fields including `search_term`, `image`, and `translation_key`.
- Added dynamic child override maps for year/decade keys, including use/name/summary/order/schedule/sort/limit/minimum/artwork/visibility/item tags.
- Used the existing `year` and `decade` validation presets so child override keys are validated instead of free text.
- Added JSON contract tests plus importer/exporter round-trip coverage.

## Verification

- `venv\Scripts\python.exe -m pytest tests\test_collection_year_decade_contract.py tests\test_output_collection_child_override_contract.py tests\test_importer_collection_files.py -q`
- Result: `28 passed`

Also ran adjacent collection coverage:
- `venv\Scripts\python.exe -m pytest tests\test_collection_year_decade_contract.py tests\test_collection_genre_other_chart_actor_contract.py tests\test_collection_region_studio_network_contract.py tests\test_collection_streaming_contract.py tests\test_collection_seasonal_contract.py tests\test_output_collection_child_override_contract.py tests\test_importer_collection_files.py -q`
- Result: `40 passed`
```

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [x] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
