### PR TITLE
added tmdb trakt simkl

### DIFF
--- a/static/json/quickstart_collections.json
+++ b/static/json/quickstart_collections.json
@@ -30842,301 +30842,35 @@
             "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
             "type": "text_input",
             "default": "020",
-            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
-          },
-          {
-            "key": "sort_prefix",
-            "label": "Sort Prefix",
-            "type": "text_input",
-            "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
-            "placeholder": "e.g. !"
-          },
-          {
-            "key": "sort_title",
-            "label": "Sort Title",
-            "type": "text_input",
-            "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom sort title format"
-          },
-          {
-            "key": "name_format",
-            "label": "Name Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_format",
-            "label": "Summary Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit",
-            "label": "Limit",
-            "type": "text_input",
-            "default": "100",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
           },
           {
             "key": "use_all",
             "label": "Use All Child Collections",
             "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "section": "children"
           },
           {
-            "key": "use_airing",
-            "label": "TMDb Airing Today",
-            "tooltip": "Collection of Shows Airing Today on TMDb.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_airing",
-            "label": "TMDb Airing Today Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the TMDb Airing Today collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_airing",
-            "label": "TMDb Airing Today Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the TMDb Airing Today collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_airing",
-            "label": "TMDb Airing Today Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the TMDb Airing Today collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_airing",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_airing",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "use_air",
-            "label": "TMDb On The Air",
-            "tooltip": "Collection of Shows currently On The Air on TMDb.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_air",
-            "label": "TMDb On The Air Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the TMDb On The Air collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_air",
-            "label": "TMDb On The Air Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the TMDb On The Air collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_air",
-            "label": "TMDb On The Air Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the TMDb On The Air collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_air",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_air",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "use_popular",
-            "label": "TMDb Popular",
-            "tooltip": "Collection of the Most Popular Movies/Shows on TMDb.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_popular",
-            "label": "TMDb Popular Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the TMDb Popular collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_popular",
-            "label": "TMDb Popular Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the TMDb Popular collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_popular",
-            "label": "TMDb Popular Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the TMDb Popular collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_popular",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_popular",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "use_top",
-            "label": "TMDb Top Rated",
-            "tooltip": "Collection of the Top Rated Movies/Shows on TMDb.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_top",
-            "label": "TMDb Top Rated Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the TMDb Top Rated collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_top",
-            "label": "TMDb Top Rated Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the TMDb Top Rated collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_top",
-            "label": "TMDb Top Rated Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the TMDb Top Rated collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_top",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_top",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "use_trending",
-            "label": "TMDb Trending",
-            "tooltip": "Collection of Trending Movies/Shows on TMDb.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_trending",
-            "label": "TMDb Trending Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the TMDb Trending collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_trending",
-            "label": "TMDb Trending Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the TMDb Trending collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_trending",
-            "label": "TMDb Trending Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the TMDb Trending collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_trending",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_trending",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
+            "key": "allowed_libraries",
+            "label": "Allowed Libraries",
+            "type": "select",
+            "section": "basics",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "movie",
+                "label": "Movie"
+              },
+              {
+                "value": "show",
+                "label": "Show"
+              }
             ]
           },
           {
@@ -31148,7 +30882,8 @@
             "options": [
               "color",
               "white"
-            ]
+            ],
+            "section": "basics"
           },
           {
             "key": "minimum_items",
@@ -31157,209 +30892,8 @@
             "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
-          },
-          {
-            "key": "ignore_ids",
-            "label": "Ignore IDs",
-            "type": "string_list",
-            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
-            "placeholder": "Add numeric ID (e.g. 603)",
-            "validation_preset": "numeric_id"
-          },
-          {
-            "key": "ignore_imdb_ids",
-            "label": "Ignore IMDb IDs",
-            "type": "string_list",
-            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
-            "placeholder": "Add IMDb ID (e.g. tt1234567)",
-            "validation_preset": "imdb_id_plex"
-          },
-          {
-            "key": "radarr_add_missing",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "radarr_search",
-            "label": "Search media when added to Radarr",
-            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_search",
-            "label": "Search media when added to Sonarr",
-            "tooltip": "Override Sonarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "radarr_monitor",
-            "label": "Monitor media when added to Radarr",
-            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "radarr_monitor_existing",
-            "label": "Set existing media from collections to monitored in Radarr",
-            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_monitor_existing",
-            "label": "Set existing media from collections to monitored in Sonarr",
-            "tooltip": "Override Sonarr monitor_existing for all collections in this Defaults File.<br><br>Marks all existing media from collections as 'monitored' in Sonarr.",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "radarr_tag",
-            "label": "Radarr Tag",
-            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
-            "type": "string_list",
-            "placeholder": "Add Radarr tag",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_tag",
-            "label": "Sonarr Tag",
-            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
-            "type": "string_list",
-            "placeholder": "Add Sonarr tag",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "item_radarr_tag",
-            "label": "Item Radarr Tag",
-            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
-            "type": "string_list",
-            "placeholder": "Add item Radarr tag",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "item_sonarr_tag",
-            "label": "Item Sonarr Tag",
-            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
-            "type": "string_list",
-            "placeholder": "Add item Sonarr tag",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "radarr_folder",
-            "label": "Radarr Root Folder",
-            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
-            "type": "text_input",
-            "placeholder": "Enter Radarr root folder path",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_folder",
-            "label": "Sonarr Root Folder",
-            "tooltip": "Override Sonarr root_folder_path for all collections in this Defaults File.",
-            "type": "text_input",
-            "placeholder": "Enter Sonarr root folder path",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "sonarr_monitor",
-            "label": "Sonarr Monitor",
-            "tooltip": "Override Sonarr monitor for all collections in this Defaults File.<br><br>Choose how Sonarr monitors episodes when adding a show.",
-            "type": "select",
-            "options": [
-              {
-                "value": "all",
-                "label": "All"
-              },
-              {
-                "value": "none",
-                "label": "None"
-              },
-              {
-                "value": "future",
-                "label": "Future"
-              },
-              {
-                "value": "missing",
-                "label": "Missing"
-              },
-              {
-                "value": "existing",
-                "label": "Existing"
-              },
-              {
-                "value": "pilot",
-                "label": "Pilot"
-              },
-              {
-                "value": "first",
-                "label": "First Season"
-              },
-              {
-                "value": "latest",
-                "label": "Latest Season"
-              }
-            ],
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "radarr_upgrade_existing",
-            "label": "Upgrade existing media in Radarr",
-            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_upgrade_existing",
-            "label": "Upgrade existing media in Sonarr",
-            "tooltip": "Override Sonarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Sonarr quality profile.",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
+            "step": 1,
+            "section": "basics"
           },
           {
             "key": "sync_mode",
@@ -31376,7 +30910,8 @@
                 "value": "sync",
                 "label": "Sync"
               }
-            ]
+            ],
+            "section": "basics"
           },
           {
             "key": "cache_builders",
@@ -31386,260 +30921,8 @@
             "default": 1,
             "input_type": "number",
             "min": 0,
-            "step": 1
-          },
-          {
-            "key": "collection_mode",
-            "label": "Collection Mode",
-            "type": "select",
-            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
-            "default": "default",
-            "options": [
-              {
-                "value": "default",
-                "label": "Library Default"
-              },
-              {
-                "value": "hide",
-                "label": "Hide Collection"
-              },
-              {
-                "value": "hide_items",
-                "label": "Hide Items in this Collection"
-              },
-              {
-                "value": "show_items",
-                "label": "Show this Collection and its Items"
-              }
-            ]
-          },
-          {
-            "key": "visible_home",
-            "label": "Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library",
-            "label": "Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared",
-            "label": "Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority",
-            "label": "Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
             "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home",
-              "visible_library",
-              "visible_shared"
-            ],
-            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_airing",
-            "label": "TMDb Airing Today Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the TMDb Airing Today collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_airing",
-            "label": "TMDb Airing Today Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the TMDb Airing Today collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_airing",
-            "label": "TMDb Airing Today Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the TMDb Airing Today collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_airing",
-            "label": "TMDb Airing Today Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_airing",
-              "visible_library_airing",
-              "visible_shared_airing"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_air",
-            "label": "TMDb On The Air Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the TMDb On The Air collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_air",
-            "label": "TMDb On The Air Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the TMDb On The Air collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_air",
-            "label": "TMDb On The Air Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the TMDb On The Air collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_air",
-            "label": "TMDb On The Air Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_air",
-              "visible_library_air",
-              "visible_shared_air"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_popular",
-            "label": "TMDb Popular Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the TMDb Popular collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_popular",
-            "label": "TMDb Popular Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the TMDb Popular collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_popular",
-            "label": "TMDb Popular Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the TMDb Popular collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_popular",
-            "label": "TMDb Popular Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_popular",
-              "visible_library_popular",
-              "visible_shared_popular"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_top",
-            "label": "TMDb Top Rated Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the TMDb Top Rated collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_top",
-            "label": "TMDb Top Rated Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the TMDb Top Rated collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_top",
-            "label": "TMDb Top Rated Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the TMDb Top Rated collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_top",
-            "label": "TMDb Top Rated Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_top",
-              "visible_library_top",
-              "visible_shared_top"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_trending",
-            "label": "TMDb Trending Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the TMDb Trending collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_trending",
-            "label": "TMDb Trending Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the TMDb Trending collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_trending",
-            "label": "TMDb Trending Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the TMDb Trending collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_trending",
-            "label": "TMDb Trending Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_trending",
-              "visible_library_trending",
-              "visible_shared_trending"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "section": "basics"
           },
           {
             "key": "collection_order",
@@ -31994,7 +31277,3125 @@
                   "episode"
                 ]
               }
+            ],
+            "section": "basics"
+          },
+          {
+            "key": "collection_mode",
+            "label": "Collection Mode",
+            "type": "select",
+            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
+            "default": "default",
+            "options": [
+              {
+                "value": "default",
+                "label": "Library Default"
+              },
+              {
+                "value": "hide",
+                "label": "Hide Collection"
+              },
+              {
+                "value": "hide_items",
+                "label": "Hide Items in this Collection"
+              },
+              {
+                "value": "show_items",
+                "label": "Show this Collection and its Items"
+              }
+            ],
+            "section": "basics"
+          },
+          {
+            "key": "schedule",
+            "label": "Schedule",
+            "type": "text",
+            "section": "basics",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "sort_prefix",
+            "label": "Sort Prefix",
+            "type": "text_input",
+            "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
+            "placeholder": "e.g. !",
+            "section": "naming"
+          },
+          {
+            "key": "sort_title",
+            "label": "Sort Title",
+            "type": "text_input",
+            "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom sort title format",
+            "section": "naming"
+          },
+          {
+            "key": "name_format",
+            "label": "Name Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection name format",
+            "section": "naming"
+          },
+          {
+            "key": "summary_format",
+            "label": "Summary Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection summary format",
+            "section": "naming"
+          },
+          {
+            "key": "name_mapping",
+            "label": "Name Mapping",
+            "type": "text",
+            "section": "naming",
+            "placeholder": "Custom collection mapping name"
+          },
+          {
+            "key": "delete_collections_named",
+            "label": "Delete Collections Named",
+            "type": "string_list",
+            "section": "naming",
+            "placeholder": "Title 1, Title 2"
+          },
+          {
+            "key": "limit",
+            "label": "Limit",
+            "type": "text_input",
+            "default": "100",
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "use_popular",
+            "label": "TMDb Popular",
+            "tooltip": "Collection of the Most Popular Movies/Shows on TMDb.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_popular",
+            "label": "TMDb Popular Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the TMDb Popular collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_popular",
+            "label": "TMDb Popular Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the TMDb Popular collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_popular",
+            "label": "TMDb Popular Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the TMDb Popular collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_popular",
+            "label": "TMDb Popular Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
             ]
+          },
+          {
+            "key": "cache_builders_popular",
+            "label": "TMDb Popular Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_popular",
+            "label": "TMDb Popular Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_popular",
+            "label": "TMDb Popular Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_top",
+            "label": "TMDb Top Rated",
+            "tooltip": "Collection of the Top Rated Movies/Shows on TMDb.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_top",
+            "label": "TMDb Top Rated Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the TMDb Top Rated collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_top",
+            "label": "TMDb Top Rated Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the TMDb Top Rated collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_top",
+            "label": "TMDb Top Rated Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the TMDb Top Rated collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_top",
+            "label": "TMDb Top Rated Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_top",
+            "label": "TMDb Top Rated Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_top",
+            "label": "TMDb Top Rated Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_top",
+            "label": "TMDb Top Rated Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_trending",
+            "label": "TMDb Trending",
+            "tooltip": "Collection of Trending Movies/Shows on TMDb.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_trending",
+            "label": "TMDb Trending Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the TMDb Trending collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_trending",
+            "label": "TMDb Trending Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the TMDb Trending collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_trending",
+            "label": "TMDb Trending Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the TMDb Trending collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_trending",
+            "label": "TMDb Trending Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_trending",
+            "label": "TMDb Trending Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_trending",
+            "label": "TMDb Trending Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_trending",
+            "label": "TMDb Trending Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_airing",
+            "label": "TMDb Airing Today",
+            "tooltip": "Collection of Shows Airing Today on TMDb.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_airing",
+            "label": "TMDb Airing Today Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the TMDb Airing Today collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_airing",
+            "label": "TMDb Airing Today Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the TMDb Airing Today collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_airing",
+            "label": "TMDb Airing Today Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the TMDb Airing Today collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_airing",
+            "label": "TMDb Airing Today Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_airing",
+            "label": "TMDb Airing Today Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_airing",
+            "label": "TMDb Airing Today Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_airing",
+            "label": "TMDb Airing Today Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_air",
+            "label": "TMDb On The Air",
+            "tooltip": "Collection of Shows currently On The Air on TMDb.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_air",
+            "label": "TMDb On The Air Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the TMDb On The Air collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_air",
+            "label": "TMDb On The Air Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the TMDb On The Air collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_air",
+            "label": "TMDb On The Air Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the TMDb On The Air collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_air",
+            "label": "TMDb On The Air Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_air",
+            "label": "TMDb On The Air Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_air",
+            "label": "TMDb On The Air Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_air",
+            "label": "TMDb On The Air Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "image",
+            "label": "Image Path",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "chart/<<style>>/<<mapping_name_encoded>>"
+          },
+          {
+            "key": "url_poster",
+            "label": "Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "file_poster",
+            "label": "Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "url_background",
+            "label": "Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "file_background",
+            "label": "Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "url_logo",
+            "label": "Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "file_logo",
+            "label": "Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "url_square_art",
+            "label": "Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "file_square_art",
+            "label": "Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_background_air",
+            "label": "TMDb On The Air Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_airing",
+            "label": "TMDb Airing Today Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_popular",
+            "label": "TMDb Popular Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_top",
+            "label": "TMDb Top Rated Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_trending",
+            "label": "TMDb Trending Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_logo_air",
+            "label": "TMDb On The Air Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_airing",
+            "label": "TMDb Airing Today Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_popular",
+            "label": "TMDb Popular Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_top",
+            "label": "TMDb Top Rated Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_trending",
+            "label": "TMDb Trending Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_poster_air",
+            "label": "TMDb On The Air Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_airing",
+            "label": "TMDb Airing Today Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_popular",
+            "label": "TMDb Popular Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_top",
+            "label": "TMDb Top Rated Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_trending",
+            "label": "TMDb Trending Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_square_art_air",
+            "label": "TMDb On The Air Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_airing",
+            "label": "TMDb Airing Today Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_popular",
+            "label": "TMDb Popular Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_top",
+            "label": "TMDb Top Rated Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_trending",
+            "label": "TMDb Trending Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_air",
+            "label": "TMDb On The Air Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_air",
+              "visible_library_air",
+              "visible_shared_air"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_airing",
+            "label": "TMDb Airing Today Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_airing",
+              "visible_library_airing",
+              "visible_shared_airing"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_popular",
+            "label": "TMDb Popular Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_popular",
+              "visible_library_popular",
+              "visible_shared_popular"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_top",
+            "label": "TMDb Top Rated Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_top",
+              "visible_library_top",
+              "visible_shared_top"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_trending",
+            "label": "TMDb Trending Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_trending",
+              "visible_library_trending",
+              "visible_shared_trending"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id",
+            "section": "basics"
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex",
+            "section": "basics"
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "item_radarr_tag_air",
+            "label": "TMDb On The Air Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_airing",
+            "label": "TMDb Airing Today Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_popular",
+            "label": "TMDb Popular Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_top",
+            "label": "TMDb Top Rated Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_trending",
+            "label": "TMDb Trending Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "item_sonarr_tag_air",
+            "label": "TMDb On The Air Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_airing",
+            "label": "TMDb Airing Today Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_popular",
+            "label": "TMDb Popular Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_top",
+            "label": "TMDb Top Rated Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_trending",
+            "label": "TMDb Trending Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_air",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_airing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_popular",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_top",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_trending",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_folder_air",
+            "label": "TMDb On The Air Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_airing",
+            "label": "TMDb Airing Today Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_popular",
+            "label": "TMDb Popular Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_top",
+            "label": "TMDb Top Rated Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_trending",
+            "label": "TMDb Trending Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_monitor_air",
+            "label": "TMDb On The Air Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_airing",
+            "label": "TMDb Airing Today Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_monitor_existing_air",
+            "label": "TMDb On The Air Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_airing",
+            "label": "TMDb Airing Today Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_popular",
+            "label": "TMDb Popular Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_top",
+            "label": "TMDb Top Rated Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_trending",
+            "label": "TMDb Trending Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_popular",
+            "label": "TMDb Popular Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_top",
+            "label": "TMDb Top Rated Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_trending",
+            "label": "TMDb Trending Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_search_air",
+            "label": "TMDb On The Air Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_airing",
+            "label": "TMDb Airing Today Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_popular",
+            "label": "TMDb Popular Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_top",
+            "label": "TMDb Top Rated Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_trending",
+            "label": "TMDb Trending Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_tag_air",
+            "label": "TMDb On The Air Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_airing",
+            "label": "TMDb Airing Today Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_popular",
+            "label": "TMDb Popular Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_top",
+            "label": "TMDb Top Rated Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_trending",
+            "label": "TMDb Trending Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_upgrade_existing_air",
+            "label": "TMDb On The Air Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_airing",
+            "label": "TMDb Airing Today Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_popular",
+            "label": "TMDb Popular Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_top",
+            "label": "TMDb Top Rated Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_trending",
+            "label": "TMDb Trending Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_add_missing",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_add_missing_air",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_add_missing_airing",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_add_missing_popular",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_add_missing_top",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_add_missing_trending",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_folder",
+            "label": "Sonarr Root Folder",
+            "tooltip": "Override Sonarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Sonarr root folder path",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_folder_air",
+            "label": "TMDb On The Air Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_airing",
+            "label": "TMDb Airing Today Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_popular",
+            "label": "TMDb Popular Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_top",
+            "label": "TMDb Top Rated Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_trending",
+            "label": "TMDb Trending Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_monitor",
+            "label": "Sonarr Monitor",
+            "tooltip": "Override Sonarr monitor for all collections in this Defaults File.<br><br>Choose how Sonarr monitors episodes when adding a show.",
+            "type": "select",
+            "options": [
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First Season"
+              },
+              {
+                "value": "latest",
+                "label": "Latest Season"
+              }
+            ],
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_monitor_air",
+            "label": "TMDb On The Air Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_airing",
+            "label": "TMDb Airing Today Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Sonarr",
+            "tooltip": "Override Sonarr monitor_existing for all collections in this Defaults File.<br><br>Marks all existing media from collections as 'monitored' in Sonarr.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_monitor_existing_air",
+            "label": "TMDb On The Air Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_airing",
+            "label": "TMDb Airing Today Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_popular",
+            "label": "TMDb Popular Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_top",
+            "label": "TMDb Top Rated Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_trending",
+            "label": "TMDb Trending Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_popular",
+            "label": "TMDb Popular Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_top",
+            "label": "TMDb Top Rated Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_trending",
+            "label": "TMDb Trending Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search",
+            "label": "Search media when added to Sonarr",
+            "tooltip": "Override Sonarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_search_air",
+            "label": "TMDb On The Air Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_airing",
+            "label": "TMDb Airing Today Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_popular",
+            "label": "TMDb Popular Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_top",
+            "label": "TMDb Top Rated Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_trending",
+            "label": "TMDb Trending Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_tag",
+            "label": "Sonarr Tag",
+            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Sonarr tag",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_tag_air",
+            "label": "TMDb On The Air Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_airing",
+            "label": "TMDb Airing Today Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_popular",
+            "label": "TMDb Popular Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_top",
+            "label": "TMDb Top Rated Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_trending",
+            "label": "TMDb Trending Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_upgrade_existing",
+            "label": "Upgrade existing media in Sonarr",
+            "tooltip": "Override Sonarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Sonarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_upgrade_existing_air",
+            "label": "TMDb On The Air Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_airing",
+            "label": "TMDb Airing Today Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_popular",
+            "label": "TMDb Popular Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_top",
+            "label": "TMDb Top Rated Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_trending",
+            "label": "TMDb Trending Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "url_background_air",
+            "label": "TMDb On The Air Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_airing",
+            "label": "TMDb Airing Today Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_popular",
+            "label": "TMDb Popular Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_top",
+            "label": "TMDb Top Rated Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_trending",
+            "label": "TMDb Trending Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_logo_air",
+            "label": "TMDb On The Air Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_airing",
+            "label": "TMDb Airing Today Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_popular",
+            "label": "TMDb Popular Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_top",
+            "label": "TMDb Top Rated Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_trending",
+            "label": "TMDb Trending Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_poster_air",
+            "label": "TMDb On The Air Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_airing",
+            "label": "TMDb Airing Today Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_popular",
+            "label": "TMDb Popular Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_top",
+            "label": "TMDb Top Rated Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_trending",
+            "label": "TMDb Trending Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_square_art_air",
+            "label": "TMDb On The Air Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_airing",
+            "label": "TMDb Airing Today Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_popular",
+            "label": "TMDb Popular Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_top",
+            "label": "TMDb Top Rated Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_trending",
+            "label": "TMDb Trending Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "visible_home",
+            "label": "Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_air",
+            "label": "TMDb On The Air Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb On The Air collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_airing",
+            "label": "TMDb Airing Today Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb Airing Today collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_popular",
+            "label": "TMDb Popular Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb Popular collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_top",
+            "label": "TMDb Top Rated Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb Top Rated collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_trending",
+            "label": "TMDb Trending Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb Trending collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library",
+            "label": "Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_air",
+            "label": "TMDb On The Air Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb On The Air collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_airing",
+            "label": "TMDb Airing Today Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb Airing Today collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_popular",
+            "label": "TMDb Popular Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb Popular collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_top",
+            "label": "TMDb Top Rated Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb Top Rated collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_trending",
+            "label": "TMDb Trending Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb Trending collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared",
+            "label": "Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_air",
+            "label": "TMDb On The Air Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb On The Air collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_airing",
+            "label": "TMDb Airing Today Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb Airing Today collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_popular",
+            "label": "TMDb Popular Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb Popular collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_top",
+            "label": "TMDb Top Rated Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb Top Rated collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_trending",
+            "label": "TMDb Trending Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the TMDb Trending collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          }
+        ],
+        "sections": [
+          {
+            "id": "basics",
+            "label": "Basics"
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "builder",
+            "label": "Builder Controls"
+          },
+          {
+            "id": "children",
+            "label": "Chart Collections"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "automation",
+            "label": "Automation"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility"
           }
         ]
       },
@@ -32016,301 +34417,35 @@
             "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
             "type": "text_input",
             "default": "020",
-            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
-          },
-          {
-            "key": "sort_prefix",
-            "label": "Sort Prefix",
-            "type": "text_input",
-            "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
-            "placeholder": "e.g. !"
-          },
-          {
-            "key": "sort_title",
-            "label": "Sort Title",
-            "type": "text_input",
-            "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom sort title format"
-          },
-          {
-            "key": "name_format",
-            "label": "Name Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_format",
-            "label": "Summary Format",
-            "type": "text_input",
-            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit",
-            "label": "Limit",
-            "type": "text_input",
-            "default": "100",
-            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
           },
           {
             "key": "use_all",
             "label": "Use All Child Collections",
             "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "section": "children"
           },
           {
-            "key": "use_collected",
-            "label": "Trakt Collected",
-            "tooltip": "Collection of the Most Collected Movies/Shows on Trakt.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_collected",
-            "label": "Trakt Collected Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Trakt Collected collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_collected",
-            "label": "Trakt Collected Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Trakt Collected collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_collected",
-            "label": "Trakt Collected Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Trakt Collected collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_collected",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_collected",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "use_popular",
-            "label": "Trakt Popular",
-            "tooltip": "Collection of the Most Popular Movies/Shows on Trakt.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_popular",
-            "label": "Trakt Popular Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Trakt Popular collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_popular",
-            "label": "Trakt Popular Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Trakt Popular collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_popular",
-            "label": "Trakt Popular Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Trakt Popular collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_popular",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_popular",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "use_recommended",
-            "label": "Trakt Recommended",
-            "tooltip": "Collection of Recommended Movies/Shows on Trakt.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_recommended",
-            "label": "Trakt Recommended Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Trakt Recommended collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_recommended",
-            "label": "Trakt Recommended Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Trakt Recommended collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_recommended",
-            "label": "Trakt Recommended Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Trakt Recommended collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_recommended",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_recommended",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "use_trending",
-            "label": "Trakt Trending",
-            "tooltip": "Collection of Trending Movies/Shows on Trakt.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_trending",
-            "label": "Trakt Trending Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Trakt Trending collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_trending",
-            "label": "Trakt Trending Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Trakt Trending collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_trending",
-            "label": "Trakt Trending Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Trakt Trending collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_trending",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_trending",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "use_watched",
-            "label": "Trakt Watched",
-            "tooltip": "Collection of the Most Watched Movies/Shows on Trakt.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_watched",
-            "label": "Trakt Watched Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Trakt Watched collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_watched",
-            "label": "Trakt Watched Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Trakt Watched collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_watched",
-            "label": "Trakt Watched Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Trakt Watched collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_watched",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_watched",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
+            "key": "allowed_libraries",
+            "label": "Allowed Libraries",
+            "type": "select",
+            "section": "basics",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "movie",
+                "label": "Movie"
+              },
+              {
+                "value": "show",
+                "label": "Show"
+              }
             ]
           },
           {
@@ -32322,7 +34457,8 @@
             "options": [
               "color",
               "white"
-            ]
+            ],
+            "section": "basics"
           },
           {
             "key": "minimum_items",
@@ -32331,209 +34467,8 @@
             "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
-          },
-          {
-            "key": "ignore_ids",
-            "label": "Ignore IDs",
-            "type": "string_list",
-            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
-            "placeholder": "Add numeric ID (e.g. 603)",
-            "validation_preset": "numeric_id"
-          },
-          {
-            "key": "ignore_imdb_ids",
-            "label": "Ignore IMDb IDs",
-            "type": "string_list",
-            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
-            "placeholder": "Add IMDb ID (e.g. tt1234567)",
-            "validation_preset": "imdb_id_plex"
-          },
-          {
-            "key": "radarr_add_missing",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "radarr_search",
-            "label": "Search media when added to Radarr",
-            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_search",
-            "label": "Search media when added to Sonarr",
-            "tooltip": "Override Sonarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "radarr_monitor",
-            "label": "Monitor media when added to Radarr",
-            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "radarr_monitor_existing",
-            "label": "Set existing media from collections to monitored in Radarr",
-            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_monitor_existing",
-            "label": "Set existing media from collections to monitored in Sonarr",
-            "tooltip": "Override Sonarr monitor_existing for all collections in this Defaults File.<br><br>Marks all existing media from collections as 'monitored' in Sonarr.",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "radarr_tag",
-            "label": "Radarr Tag",
-            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
-            "type": "string_list",
-            "placeholder": "Add Radarr tag",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_tag",
-            "label": "Sonarr Tag",
-            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
-            "type": "string_list",
-            "placeholder": "Add Sonarr tag",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "item_radarr_tag",
-            "label": "Item Radarr Tag",
-            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
-            "type": "string_list",
-            "placeholder": "Add item Radarr tag",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "item_sonarr_tag",
-            "label": "Item Sonarr Tag",
-            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
-            "type": "string_list",
-            "placeholder": "Add item Sonarr tag",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "radarr_folder",
-            "label": "Radarr Root Folder",
-            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
-            "type": "text_input",
-            "placeholder": "Enter Radarr root folder path",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_folder",
-            "label": "Sonarr Root Folder",
-            "tooltip": "Override Sonarr root_folder_path for all collections in this Defaults File.",
-            "type": "text_input",
-            "placeholder": "Enter Sonarr root folder path",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "sonarr_monitor",
-            "label": "Sonarr Monitor",
-            "tooltip": "Override Sonarr monitor for all collections in this Defaults File.<br><br>Choose how Sonarr monitors episodes when adding a show.",
-            "type": "select",
-            "options": [
-              {
-                "value": "all",
-                "label": "All"
-              },
-              {
-                "value": "none",
-                "label": "None"
-              },
-              {
-                "value": "future",
-                "label": "Future"
-              },
-              {
-                "value": "missing",
-                "label": "Missing"
-              },
-              {
-                "value": "existing",
-                "label": "Existing"
-              },
-              {
-                "value": "pilot",
-                "label": "Pilot"
-              },
-              {
-                "value": "first",
-                "label": "First Season"
-              },
-              {
-                "value": "latest",
-                "label": "Latest Season"
-              }
-            ],
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "radarr_upgrade_existing",
-            "label": "Upgrade existing media in Radarr",
-            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_upgrade_existing",
-            "label": "Upgrade existing media in Sonarr",
-            "tooltip": "Override Sonarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Sonarr quality profile.",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
+            "step": 1,
+            "section": "basics"
           },
           {
             "key": "sync_mode",
@@ -32550,7 +34485,8 @@
                 "value": "sync",
                 "label": "Sync"
               }
-            ]
+            ],
+            "section": "basics"
           },
           {
             "key": "cache_builders",
@@ -32560,260 +34496,8 @@
             "default": 1,
             "input_type": "number",
             "min": 0,
-            "step": 1
-          },
-          {
-            "key": "collection_mode",
-            "label": "Collection Mode",
-            "type": "select",
-            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
-            "default": "default",
-            "options": [
-              {
-                "value": "default",
-                "label": "Library Default"
-              },
-              {
-                "value": "hide",
-                "label": "Hide Collection"
-              },
-              {
-                "value": "hide_items",
-                "label": "Hide Items in this Collection"
-              },
-              {
-                "value": "show_items",
-                "label": "Show this Collection and its Items"
-              }
-            ]
-          },
-          {
-            "key": "visible_home",
-            "label": "Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library",
-            "label": "Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared",
-            "label": "Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority",
-            "label": "Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
             "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home",
-              "visible_library",
-              "visible_shared"
-            ],
-            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_collected",
-            "label": "Trakt Collected Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Trakt Collected collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_collected",
-            "label": "Trakt Collected Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Trakt Collected collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_collected",
-            "label": "Trakt Collected Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Trakt Collected collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_collected",
-            "label": "Trakt Collected Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_collected",
-              "visible_library_collected",
-              "visible_shared_collected"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_popular",
-            "label": "Trakt Popular Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Trakt Popular collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_popular",
-            "label": "Trakt Popular Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Trakt Popular collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_popular",
-            "label": "Trakt Popular Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Trakt Popular collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_popular",
-            "label": "Trakt Popular Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_popular",
-              "visible_library_popular",
-              "visible_shared_popular"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_recommended",
-            "label": "Trakt Recommended Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Trakt Recommended collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_recommended",
-            "label": "Trakt Recommended Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Trakt Recommended collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_recommended",
-            "label": "Trakt Recommended Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Trakt Recommended collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_recommended",
-            "label": "Trakt Recommended Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_recommended",
-              "visible_library_recommended",
-              "visible_shared_recommended"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_trending",
-            "label": "Trakt Trending Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Trakt Trending collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_trending",
-            "label": "Trakt Trending Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Trakt Trending collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_trending",
-            "label": "Trakt Trending Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Trakt Trending collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_trending",
-            "label": "Trakt Trending Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_trending",
-              "visible_library_trending",
-              "visible_shared_trending"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_watched",
-            "label": "Trakt Watched Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Trakt Watched collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_watched",
-            "label": "Trakt Watched Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Trakt Watched collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_watched",
-            "label": "Trakt Watched Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Trakt Watched collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_watched",
-            "label": "Trakt Watched Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_watched",
-              "visible_library_watched",
-              "visible_shared_watched"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "section": "basics"
           },
           {
             "key": "collection_order",
@@ -33168,291 +34852,889 @@
                   "episode"
                 ]
               }
-            ]
-          }
-        ]
-      },
-      {
-        "id": "collection_simkl",
-        "label": "Simkl Charts",
-        "url": "https://kometa.wiki/en/nightly/defaults/chart/simkl",
-        "media_types": [
-          "movie",
-          "show"
-        ],
-        "template_variables": [
+            ],
+            "section": "basics"
+          },
           {
-            "key": "collection_section",
-            "label": "Collection Section",
-            "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
-            "type": "text_input",
-            "default": "020",
-            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier."
+            "key": "collection_mode",
+            "label": "Collection Mode",
+            "type": "select",
+            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
+            "default": "default",
+            "options": [
+              {
+                "value": "default",
+                "label": "Library Default"
+              },
+              {
+                "value": "hide",
+                "label": "Hide Collection"
+              },
+              {
+                "value": "hide_items",
+                "label": "Hide Items in this Collection"
+              },
+              {
+                "value": "show_items",
+                "label": "Show this Collection and its Items"
+              }
+            ],
+            "section": "basics"
+          },
+          {
+            "key": "schedule",
+            "label": "Schedule",
+            "type": "text",
+            "section": "basics",
+            "placeholder": "weekly(sunday)"
           },
           {
             "key": "sort_prefix",
             "label": "Sort Prefix",
             "type": "text_input",
             "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
-            "placeholder": "e.g. !"
+            "placeholder": "e.g. !",
+            "section": "naming"
           },
           {
             "key": "sort_title",
             "label": "Sort Title",
             "type": "text_input",
             "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom sort title format"
+            "placeholder": "Custom sort title format",
+            "section": "naming"
           },
           {
             "key": "name_format",
             "label": "Name Format",
             "type": "text_input",
             "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection name format"
+            "placeholder": "Custom collection name format",
+            "section": "naming"
           },
           {
             "key": "summary_format",
             "label": "Summary Format",
             "type": "text_input",
             "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
-            "placeholder": "Custom collection summary format"
+            "placeholder": "Custom collection summary format",
+            "section": "naming"
+          },
+          {
+            "key": "name_mapping",
+            "label": "Name Mapping",
+            "type": "text",
+            "section": "naming",
+            "placeholder": "Custom collection mapping name"
+          },
+          {
+            "key": "delete_collections_named",
+            "label": "Delete Collections Named",
+            "type": "string_list",
+            "section": "naming",
+            "placeholder": "Title 1, Title 2"
           },
           {
             "key": "limit",
             "label": "Limit",
             "type": "text_input",
             "default": "100",
-            "tooltip": "Maximum number of items to return per Simkl list. Valid range is 1 to 500.",
+            "tooltip": "Changes the Builder Limit for all collections in this Defaults File. Valid values are numbers greater than 0.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "builder"
           },
           {
-            "key": "use_all",
-            "label": "Use All Child Collections",
-            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
+            "key": "use_collected",
+            "label": "Trakt Collected",
+            "tooltip": "Collection of the Most Collected Movies/Shows on Trakt.",
             "type": "toggle",
-            "default": true
+            "default": true,
+            "section": "children"
           },
           {
-            "key": "use_trending_today",
-            "label": "Simkl Trending Today",
-            "tooltip": "Collection of Simkl's Trending Today list.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_trending_today",
-            "label": "Simkl Trending Today Name",
+            "key": "name_collected",
+            "label": "Trakt Collected Name",
             "type": "text_input",
-            "tooltip": "Override the collection name for the Simkl Trending Today collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
+            "tooltip": "Override the collection name for the Trakt Collected collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
           },
           {
-            "key": "summary_trending_today",
-            "label": "Simkl Trending Today Summary",
+            "key": "summary_collected",
+            "label": "Trakt Collected Summary",
             "type": "text_input",
-            "tooltip": "Override the collection summary for the Simkl Trending Today collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
+            "tooltip": "Override the collection summary for the Trakt Collected collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
           },
           {
-            "key": "limit_trending_today",
-            "label": "Simkl Trending Today Limit",
+            "key": "limit_collected",
+            "label": "Trakt Collected Limit",
             "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Simkl Trending Today collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "tooltip": "Changes the Builder Limit of the Trakt Collected collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "builder"
           },
           {
-            "key": "radarr_add_missing_trending_today",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_trending_today",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "use_trending_week",
-            "label": "Simkl Trending This Week",
-            "tooltip": "Collection of Simkl's Trending This Week list.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_trending_week",
-            "label": "Simkl Trending This Week Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Simkl Trending This Week collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_trending_week",
-            "label": "Simkl Trending This Week Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Simkl Trending This Week collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_trending_week",
-            "label": "Simkl Trending This Week Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Simkl Trending This Week collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_trending_week",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_trending_week",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "use_trending_month",
-            "label": "Simkl Trending This Month",
-            "tooltip": "Collection of Simkl's Trending This Month list.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_trending_month",
-            "label": "Simkl Trending This Month Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Simkl Trending This Month collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_trending_month",
-            "label": "Simkl Trending This Month Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Simkl Trending This Month collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_trending_month",
-            "label": "Simkl Trending This Month Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Simkl Trending This Month collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_trending_month",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_trending_month",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "use_dvd",
-            "label": "Simkl DVD",
-            "tooltip": "Collection of Simkl's Recently Released on DVD list.",
-            "type": "toggle",
-            "default": true
-          },
-          {
-            "key": "name_dvd",
-            "label": "Simkl DVD Name",
-            "type": "text_input",
-            "tooltip": "Override the collection name for the Simkl DVD collection. Leave blank to inherit the family Name Format value.",
-            "placeholder": "Custom collection name format"
-          },
-          {
-            "key": "summary_dvd",
-            "label": "Simkl DVD Summary",
-            "type": "text_input",
-            "tooltip": "Override the collection summary for the Simkl DVD collection. Leave blank to inherit the family Summary Format value.",
-            "placeholder": "Custom collection summary format"
-          },
-          {
-            "key": "limit_dvd",
-            "label": "Simkl DVD Limit",
-            "type": "text_input",
-            "tooltip": "Changes the Builder Limit of the Simkl DVD collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1
-          },
-          {
-            "key": "radarr_add_missing_dvd",
-            "label": "Add missing items to Radarr",
-            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "movie"
-            ]
-          },
-          {
-            "key": "sonarr_add_missing_dvd",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
-            "tooltip_variant": "danger",
-            "type": "toggle",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "style",
-            "label": "Style",
+            "key": "sync_mode_collected",
+            "label": "Trakt Collected Sync Mode",
             "type": "select",
-            "tooltip": "Controls the visual theme of the collections created.",
-            "default": "color",
+            "section": "children",
             "options": [
-              "color",
-              "white"
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
             ]
           },
           {
-            "key": "minimum_items",
-            "label": "Minimum Items",
+            "key": "cache_builders_collected",
+            "label": "Trakt Collected Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_collected",
+            "label": "Trakt Collected Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_collected",
+            "label": "Trakt Collected Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_popular",
+            "label": "Trakt Popular",
+            "tooltip": "Collection of the Most Popular Movies/Shows on Trakt.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_popular",
+            "label": "Trakt Popular Name",
             "type": "text_input",
-            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "tooltip": "Override the collection name for the Trakt Popular collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_popular",
+            "label": "Trakt Popular Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Trakt Popular collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_popular",
+            "label": "Trakt Popular Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Trakt Popular collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
             "input_type": "number",
             "min": 1,
-            "step": 1
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_popular",
+            "label": "Trakt Popular Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_popular",
+            "label": "Trakt Popular Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_popular",
+            "label": "Trakt Popular Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_popular",
+            "label": "Trakt Popular Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_recommended",
+            "label": "Trakt Recommended",
+            "tooltip": "Collection of Recommended Movies/Shows on Trakt.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_recommended",
+            "label": "Trakt Recommended Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Trakt Recommended collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_recommended",
+            "label": "Trakt Recommended Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Trakt Recommended collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_recommended",
+            "label": "Trakt Recommended Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Trakt Recommended collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_recommended",
+            "label": "Trakt Recommended Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_recommended",
+            "label": "Trakt Recommended Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_recommended",
+            "label": "Trakt Recommended Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_recommended",
+            "label": "Trakt Recommended Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_trending",
+            "label": "Trakt Trending",
+            "tooltip": "Collection of Trending Movies/Shows on Trakt.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_trending",
+            "label": "Trakt Trending Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Trakt Trending collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_trending",
+            "label": "Trakt Trending Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Trakt Trending collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_trending",
+            "label": "Trakt Trending Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Trakt Trending collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_trending",
+            "label": "Trakt Trending Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_trending",
+            "label": "Trakt Trending Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_trending",
+            "label": "Trakt Trending Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_trending",
+            "label": "Trakt Trending Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_watched",
+            "label": "Trakt Watched",
+            "tooltip": "Collection of the Most Watched Movies/Shows on Trakt.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_watched",
+            "label": "Trakt Watched Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Trakt Watched collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_watched",
+            "label": "Trakt Watched Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Trakt Watched collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_watched",
+            "label": "Trakt Watched Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Trakt Watched collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_watched",
+            "label": "Trakt Watched Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_watched",
+            "label": "Trakt Watched Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_watched",
+            "label": "Trakt Watched Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_watched",
+            "label": "Trakt Watched Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "image",
+            "label": "Image Path",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "chart/<<style>>/<<mapping_name_encoded>>"
+          },
+          {
+            "key": "url_poster",
+            "label": "Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "file_poster",
+            "label": "Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "url_background",
+            "label": "Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "file_background",
+            "label": "Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "url_logo",
+            "label": "Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "file_logo",
+            "label": "Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "url_square_art",
+            "label": "Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "file_square_art",
+            "label": "Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_background_collected",
+            "label": "Trakt Collected Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_popular",
+            "label": "Trakt Popular Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_recommended",
+            "label": "Trakt Recommended Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_trending",
+            "label": "Trakt Trending Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_watched",
+            "label": "Trakt Watched Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_logo_collected",
+            "label": "Trakt Collected Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_popular",
+            "label": "Trakt Popular Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_recommended",
+            "label": "Trakt Recommended Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_trending",
+            "label": "Trakt Trending Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_watched",
+            "label": "Trakt Watched Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_poster_collected",
+            "label": "Trakt Collected Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_popular",
+            "label": "Trakt Popular Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_recommended",
+            "label": "Trakt Recommended Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_trending",
+            "label": "Trakt Trending Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_watched",
+            "label": "Trakt Watched Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_square_art_collected",
+            "label": "Trakt Collected Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_popular",
+            "label": "Trakt Popular Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_recommended",
+            "label": "Trakt Recommended Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_trending",
+            "label": "Trakt Trending Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_watched",
+            "label": "Trakt Watched Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_collected",
+            "label": "Trakt Collected Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_collected",
+              "visible_library_collected",
+              "visible_shared_collected"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_popular",
+            "label": "Trakt Popular Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_popular",
+              "visible_library_popular",
+              "visible_shared_popular"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_recommended",
+            "label": "Trakt Recommended Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_recommended",
+              "visible_library_recommended",
+              "visible_shared_recommended"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_trending",
+            "label": "Trakt Trending Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_trending",
+              "visible_library_trending",
+              "visible_shared_trending"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_watched",
+            "label": "Trakt Watched Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_watched",
+              "visible_library_watched",
+              "visible_shared_watched"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
           },
           {
             "key": "ignore_ids",
@@ -33460,7 +35742,8 @@
             "type": "string_list",
             "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
             "placeholder": "Add numeric ID (e.g. 603)",
-            "validation_preset": "numeric_id"
+            "validation_preset": "numeric_id",
+            "section": "basics"
           },
           {
             "key": "ignore_imdb_ids",
@@ -33468,7 +35751,130 @@
             "type": "string_list",
             "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
             "placeholder": "Add IMDb ID (e.g. tt1234567)",
-            "validation_preset": "imdb_id_plex"
+            "validation_preset": "imdb_id_plex",
+            "section": "basics"
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "item_radarr_tag_collected",
+            "label": "Trakt Collected Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_popular",
+            "label": "Trakt Popular Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_recommended",
+            "label": "Trakt Recommended Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_trending",
+            "label": "Trakt Trending Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_watched",
+            "label": "Trakt Watched Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "item_sonarr_tag_collected",
+            "label": "Trakt Collected Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_popular",
+            "label": "Trakt Popular Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_recommended",
+            "label": "Trakt Recommended Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_trending",
+            "label": "Trakt Trending Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_watched",
+            "label": "Trakt Watched Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
           },
           {
             "key": "radarr_add_missing",
@@ -33478,35 +35884,124 @@
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "automation"
           },
           {
-            "key": "sonarr_add_missing",
-            "label": "Add missing items to Sonarr",
-            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "key": "radarr_add_missing_collected",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
             "tooltip_variant": "danger",
             "type": "toggle",
             "media_types": [
-              "show"
-            ]
+              "movie"
+            ],
+            "section": "automation"
           },
           {
-            "key": "radarr_search",
-            "label": "Search media when added to Radarr",
-            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "key": "radarr_add_missing_popular",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
             "type": "toggle",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "automation"
           },
           {
-            "key": "sonarr_search",
-            "label": "Search media when added to Sonarr",
-            "tooltip": "Override Sonarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "key": "radarr_add_missing_recommended",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
             "type": "toggle",
             "media_types": [
-              "show"
-            ]
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_trending",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_watched",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_folder_collected",
+            "label": "Trakt Collected Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_popular",
+            "label": "Trakt Popular Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_recommended",
+            "label": "Trakt Recommended Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_trending",
+            "label": "Trakt Trending Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_watched",
+            "label": "Trakt Watched Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
           },
           {
             "key": "radarr_monitor",
@@ -33515,6 +36010,30 @@
             "type": "toggle",
             "media_types": [
               "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_monitor_collected",
+            "label": "Trakt Collected Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
             ]
           },
           {
@@ -33524,15 +36043,339 @@
             "type": "toggle",
             "media_types": [
               "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_monitor_existing_collected",
+            "label": "Trakt Collected Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
             ]
           },
           {
-            "key": "sonarr_monitor_existing",
-            "label": "Set existing media from collections to monitored in Sonarr",
-            "tooltip": "Override Sonarr monitor_existing for all collections in this Defaults File.<br><br>Marks all existing media from collections as 'monitored' in Sonarr.",
+            "key": "radarr_monitor_existing_popular",
+            "label": "Trakt Popular Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_recommended",
+            "label": "Trakt Recommended Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_trending",
+            "label": "Trakt Trending Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_watched",
+            "label": "Trakt Watched Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_popular",
+            "label": "Trakt Popular Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_recommended",
+            "label": "Trakt Recommended Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_trending",
+            "label": "Trakt Trending Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_watched",
+            "label": "Trakt Watched Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
             "type": "toggle",
             "media_types": [
-              "show"
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_search_collected",
+            "label": "Trakt Collected Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_popular",
+            "label": "Trakt Popular Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_recommended",
+            "label": "Trakt Recommended Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_trending",
+            "label": "Trakt Trending Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_watched",
+            "label": "Trakt Watched Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
             ]
           },
           {
@@ -33543,47 +36386,249 @@
             "placeholder": "Add Radarr tag",
             "media_types": [
               "movie"
-            ]
+            ],
+            "section": "automation"
           },
           {
-            "key": "sonarr_tag",
-            "label": "Sonarr Tag",
-            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "key": "radarr_tag_collected",
+            "label": "Trakt Collected Radarr Tags",
             "type": "string_list",
-            "placeholder": "Add Sonarr tag",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "item_radarr_tag",
-            "label": "Item Radarr Tag",
-            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
-            "type": "string_list",
-            "placeholder": "Add item Radarr tag",
+            "section": "automation",
             "media_types": [
               "movie"
-            ]
+            ],
+            "placeholder": "4k,chart"
           },
           {
-            "key": "item_sonarr_tag",
-            "label": "Item Sonarr Tag",
-            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "key": "radarr_tag_popular",
+            "label": "Trakt Popular Radarr Tags",
             "type": "string_list",
-            "placeholder": "Add item Sonarr tag",
-            "media_types": [
-              "show"
-            ]
-          },
-          {
-            "key": "radarr_folder",
-            "label": "Radarr Root Folder",
-            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
-            "type": "text_input",
-            "placeholder": "Enter Radarr root folder path",
+            "section": "automation",
             "media_types": [
               "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_recommended",
+            "label": "Trakt Recommended Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_trending",
+            "label": "Trakt Trending Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_watched",
+            "label": "Trakt Watched Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_upgrade_existing_collected",
+            "label": "Trakt Collected Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
             ]
+          },
+          {
+            "key": "radarr_upgrade_existing_popular",
+            "label": "Trakt Popular Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_recommended",
+            "label": "Trakt Recommended Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_trending",
+            "label": "Trakt Trending Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_watched",
+            "label": "Trakt Watched Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_add_missing",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_add_missing_collected",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_add_missing_popular",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_add_missing_recommended",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_add_missing_trending",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_add_missing_watched",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
           },
           {
             "key": "sonarr_folder",
@@ -33593,7 +36638,58 @@
             "placeholder": "Enter Sonarr root folder path",
             "media_types": [
               "show"
-            ]
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_folder_collected",
+            "label": "Trakt Collected Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_popular",
+            "label": "Trakt Popular Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_recommended",
+            "label": "Trakt Recommended Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_trending",
+            "label": "Trakt Trending Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_watched",
+            "label": "Trakt Watched Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
           },
           {
             "key": "sonarr_monitor",
@@ -33636,16 +36732,554 @@
             ],
             "media_types": [
               "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_monitor_collected",
+            "label": "Trakt Collected Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
             ]
           },
           {
-            "key": "radarr_upgrade_existing",
-            "label": "Upgrade existing media in Radarr",
-            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "key": "sonarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Sonarr",
+            "tooltip": "Override Sonarr monitor_existing for all collections in this Defaults File.<br><br>Marks all existing media from collections as 'monitored' in Sonarr.",
             "type": "toggle",
             "media_types": [
-              "movie"
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_monitor_existing_collected",
+            "label": "Trakt Collected Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
             ]
+          },
+          {
+            "key": "sonarr_monitor_existing_popular",
+            "label": "Trakt Popular Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_recommended",
+            "label": "Trakt Recommended Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_trending",
+            "label": "Trakt Trending Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_watched",
+            "label": "Trakt Watched Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_popular",
+            "label": "Trakt Popular Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_recommended",
+            "label": "Trakt Recommended Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_trending",
+            "label": "Trakt Trending Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_watched",
+            "label": "Trakt Watched Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search",
+            "label": "Search media when added to Sonarr",
+            "tooltip": "Override Sonarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_search_collected",
+            "label": "Trakt Collected Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_popular",
+            "label": "Trakt Popular Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_recommended",
+            "label": "Trakt Recommended Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_trending",
+            "label": "Trakt Trending Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_watched",
+            "label": "Trakt Watched Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_tag",
+            "label": "Sonarr Tag",
+            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Sonarr tag",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_tag_collected",
+            "label": "Trakt Collected Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_popular",
+            "label": "Trakt Popular Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_recommended",
+            "label": "Trakt Recommended Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_trending",
+            "label": "Trakt Trending Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_watched",
+            "label": "Trakt Watched Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
           },
           {
             "key": "sonarr_upgrade_existing",
@@ -33654,7 +37288,759 @@
             "type": "toggle",
             "media_types": [
               "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_upgrade_existing_collected",
+            "label": "Trakt Collected Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
             ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_popular",
+            "label": "Trakt Popular Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_recommended",
+            "label": "Trakt Recommended Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_trending",
+            "label": "Trakt Trending Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_watched",
+            "label": "Trakt Watched Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "url_background_collected",
+            "label": "Trakt Collected Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_popular",
+            "label": "Trakt Popular Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_recommended",
+            "label": "Trakt Recommended Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_trending",
+            "label": "Trakt Trending Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_watched",
+            "label": "Trakt Watched Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_logo_collected",
+            "label": "Trakt Collected Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_popular",
+            "label": "Trakt Popular Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_recommended",
+            "label": "Trakt Recommended Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_trending",
+            "label": "Trakt Trending Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_watched",
+            "label": "Trakt Watched Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_poster_collected",
+            "label": "Trakt Collected Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_popular",
+            "label": "Trakt Popular Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_recommended",
+            "label": "Trakt Recommended Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_trending",
+            "label": "Trakt Trending Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_watched",
+            "label": "Trakt Watched Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_square_art_collected",
+            "label": "Trakt Collected Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_popular",
+            "label": "Trakt Popular Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_recommended",
+            "label": "Trakt Recommended Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_trending",
+            "label": "Trakt Trending Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_watched",
+            "label": "Trakt Watched Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "visible_home",
+            "label": "Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_collected",
+            "label": "Trakt Collected Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Collected collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_popular",
+            "label": "Trakt Popular Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Popular collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_recommended",
+            "label": "Trakt Recommended Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Recommended collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_trending",
+            "label": "Trakt Trending Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Trending collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_watched",
+            "label": "Trakt Watched Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Watched collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library",
+            "label": "Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_collected",
+            "label": "Trakt Collected Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Collected collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_popular",
+            "label": "Trakt Popular Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Popular collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_recommended",
+            "label": "Trakt Recommended Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Recommended collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_trending",
+            "label": "Trakt Trending Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Trending collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_watched",
+            "label": "Trakt Watched Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Watched collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared",
+            "label": "Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_collected",
+            "label": "Trakt Collected Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Collected collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_popular",
+            "label": "Trakt Popular Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Popular collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_recommended",
+            "label": "Trakt Recommended Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Recommended collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_trending",
+            "label": "Trakt Trending Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Trending collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_watched",
+            "label": "Trakt Watched Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Trakt Watched collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          }
+        ],
+        "sections": [
+          {
+            "id": "basics",
+            "label": "Basics"
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "builder",
+            "label": "Builder Controls"
+          },
+          {
+            "id": "children",
+            "label": "Chart Collections"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "automation",
+            "label": "Automation"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility"
+          }
+        ]
+      },
+      {
+        "id": "collection_simkl",
+        "label": "Simkl Charts",
+        "url": "https://kometa.wiki/en/nightly/defaults/chart/simkl",
+        "media_types": [
+          "movie",
+          "show"
+        ],
+        "template_variables": [
+          {
+            "key": "collection_section",
+            "label": "Collection Section",
+            "url": "https://kometa.wiki/en/nightly/kometa/guides/order/#kometa-default-collection-sorting",
+            "type": "text_input",
+            "default": "020",
+            "tooltip": "This number determines where this collection appears in the Plex Collections page. Lower numbers/characters based on ascii are placed earlier.",
+            "section": "basics"
+          },
+          {
+            "key": "use_all",
+            "label": "Use All Child Collections",
+            "tooltip": "Set the default on/off state for all child collections in this Defaults File. Individual child toggles override this setting: if Use All is on and a specific child is off, that child stays off; if Use All is off and a specific child is on, that child stays on.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "allowed_libraries",
+            "label": "Allowed Libraries",
+            "type": "select",
+            "section": "basics",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "movie",
+                "label": "Movie"
+              },
+              {
+                "value": "show",
+                "label": "Show"
+              }
+            ]
+          },
+          {
+            "key": "style",
+            "label": "Style",
+            "type": "select",
+            "tooltip": "Controls the visual theme of the collections created.",
+            "default": "color",
+            "options": [
+              "color",
+              "white"
+            ],
+            "section": "basics"
+          },
+          {
+            "key": "minimum_items",
+            "label": "Minimum Items",
+            "type": "text_input",
+            "tooltip": "Changes the minimum_items for all collections in a Defaults File.<br><br>Allowed values: number greater than 0.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "basics"
           },
           {
             "key": "sync_mode",
@@ -33671,7 +38057,8 @@
                 "value": "sync",
                 "label": "Sync"
               }
-            ]
+            ],
+            "section": "basics"
           },
           {
             "key": "cache_builders",
@@ -33681,222 +38068,8 @@
             "default": 1,
             "input_type": "number",
             "min": 0,
-            "step": 1
-          },
-          {
-            "key": "collection_mode",
-            "label": "Collection Mode",
-            "type": "select",
-            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
-            "default": "default",
-            "options": [
-              {
-                "value": "default",
-                "label": "Library Default"
-              },
-              {
-                "value": "hide",
-                "label": "Hide Collection"
-              },
-              {
-                "value": "hide_items",
-                "label": "Hide Items in this Collection"
-              },
-              {
-                "value": "show_items",
-                "label": "Show this Collection and its Items"
-              }
-            ]
-          },
-          {
-            "key": "visible_home",
-            "label": "Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library",
-            "label": "Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared",
-            "label": "Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority",
-            "label": "Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
             "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home",
-              "visible_library",
-              "visible_shared"
-            ],
-            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_trending_today",
-            "label": "Simkl Trending Today Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Simkl Trending Today collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_trending_today",
-            "label": "Simkl Trending Today Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Simkl Trending Today collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_trending_today",
-            "label": "Simkl Trending Today Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Simkl Trending Today collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_trending_today",
-            "label": "Simkl Trending Today Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_trending_today",
-              "visible_library_trending_today",
-              "visible_shared_trending_today"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_trending_week",
-            "label": "Simkl Trending This Week Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Simkl Trending This Week collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_trending_week",
-            "label": "Simkl Trending This Week Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Simkl Trending This Week collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_trending_week",
-            "label": "Simkl Trending This Week Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Simkl Trending This Week collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_trending_week",
-            "label": "Simkl Trending This Week Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_trending_week",
-              "visible_library_trending_week",
-              "visible_shared_trending_week"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_trending_month",
-            "label": "Simkl Trending This Month Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Simkl Trending This Month collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_trending_month",
-            "label": "Simkl Trending This Month Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Simkl Trending This Month collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_trending_month",
-            "label": "Simkl Trending This Month Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Simkl Trending This Month collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_trending_month",
-            "label": "Simkl Trending This Month Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_trending_month",
-              "visible_library_trending_month",
-              "visible_shared_trending_month"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
-          },
-          {
-            "key": "visible_home_dvd",
-            "label": "Simkl DVD Visible Home",
-            "type": "toggle",
-            "tooltip": "Changes the Simkl DVD collection visible on Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_library_dvd",
-            "label": "Simkl DVD Visible Library",
-            "type": "toggle",
-            "tooltip": "Changes the Simkl DVD collection visible on Library Recommended Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "visible_shared_dvd",
-            "label": "Simkl DVD Visible Shared",
-            "type": "toggle",
-            "tooltip": "Changes the Simkl DVD collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
-            "default": false
-          },
-          {
-            "key": "hub_priority_dvd",
-            "label": "Simkl DVD Hub Priority",
-            "type": "text_input",
-            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
-            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
-            "input_type": "number",
-            "min": 1,
-            "step": 1,
-            "requires_plex_pass": true,
-            "requires_any_of_template_keys": [
-              "visible_home_dvd",
-              "visible_library_dvd",
-              "visible_shared_dvd"
-            ],
-            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority."
+            "section": "basics"
           },
           {
             "key": "collection_order",
@@ -33923,7 +38096,2623 @@
                   "episode"
                 ]
               }
+            ],
+            "section": "basics"
+          },
+          {
+            "key": "collection_mode",
+            "label": "Collection Mode",
+            "type": "select",
+            "tooltip": "Controls the collection mode of all collections in a Defaults File.<br><br> Default is <b>Library Default</b> ",
+            "default": "default",
+            "options": [
+              {
+                "value": "default",
+                "label": "Library Default"
+              },
+              {
+                "value": "hide",
+                "label": "Hide Collection"
+              },
+              {
+                "value": "hide_items",
+                "label": "Hide Items in this Collection"
+              },
+              {
+                "value": "show_items",
+                "label": "Show this Collection and its Items"
+              }
+            ],
+            "section": "basics"
+          },
+          {
+            "key": "schedule",
+            "label": "Schedule",
+            "type": "text",
+            "section": "basics",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "sort_prefix",
+            "label": "Sort Prefix",
+            "type": "text_input",
+            "tooltip": "Override the prefix prepended to generated sort titles for this Defaults File. Leave blank to inherit the Kometa default.",
+            "placeholder": "e.g. !",
+            "section": "naming"
+          },
+          {
+            "key": "sort_title",
+            "label": "Sort Title",
+            "type": "text_input",
+            "tooltip": "Override the generated Plex sort title format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom sort title format",
+            "section": "naming"
+          },
+          {
+            "key": "name_format",
+            "label": "Name Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection name format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection name format",
+            "section": "naming"
+          },
+          {
+            "key": "summary_format",
+            "label": "Summary Format",
+            "type": "text_input",
+            "tooltip": "Override the generated collection summary format for this Defaults File. Leave blank to inherit the Kometa default behavior.",
+            "placeholder": "Custom collection summary format",
+            "section": "naming"
+          },
+          {
+            "key": "name_mapping",
+            "label": "Name Mapping",
+            "type": "text",
+            "section": "naming",
+            "placeholder": "Custom collection mapping name"
+          },
+          {
+            "key": "delete_collections_named",
+            "label": "Delete Collections Named",
+            "type": "string_list",
+            "section": "naming",
+            "placeholder": "Title 1, Title 2"
+          },
+          {
+            "key": "limit",
+            "label": "Limit",
+            "type": "text_input",
+            "default": "100",
+            "tooltip": "Maximum number of items to return per Simkl list. Valid range is 1 to 500.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "period",
+            "label": "Trending Period",
+            "type": "select",
+            "section": "builder",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "today",
+                "label": "Today"
+              },
+              {
+                "value": "week",
+                "label": "Week"
+              },
+              {
+                "value": "month",
+                "label": "Month"
+              }
             ]
+          },
+          {
+            "key": "use_trending_today",
+            "label": "Simkl Trending Today",
+            "tooltip": "Collection of Simkl's Trending Today list.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_trending_today",
+            "label": "Simkl Trending Today Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Simkl Trending Today collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_trending_today",
+            "label": "Simkl Trending Today Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Simkl Trending Today collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_trending_today",
+            "label": "Simkl Trending Today Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Simkl Trending Today collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_trending_today",
+            "label": "Simkl Trending Today Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_trending_today",
+            "label": "Simkl Trending Today Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_trending_today",
+            "label": "Simkl Trending Today Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_trending_today",
+            "label": "Simkl Trending Today Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_trending_week",
+            "label": "Simkl Trending This Week",
+            "tooltip": "Collection of Simkl's Trending This Week list.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_trending_week",
+            "label": "Simkl Trending This Week Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Simkl Trending This Week collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_trending_week",
+            "label": "Simkl Trending This Week Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Simkl Trending This Week collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_trending_week",
+            "label": "Simkl Trending This Week Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Simkl Trending This Week collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_trending_week",
+            "label": "Simkl Trending This Week Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_trending_week",
+            "label": "Simkl Trending This Week Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_trending_week",
+            "label": "Simkl Trending This Week Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_trending_week",
+            "label": "Simkl Trending This Week Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_trending_month",
+            "label": "Simkl Trending This Month",
+            "tooltip": "Collection of Simkl's Trending This Month list.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_trending_month",
+            "label": "Simkl Trending This Month Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Simkl Trending This Month collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_trending_month",
+            "label": "Simkl Trending This Month Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Simkl Trending This Month collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_trending_month",
+            "label": "Simkl Trending This Month Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Simkl Trending This Month collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_trending_month",
+            "label": "Simkl Trending This Month Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_trending_month",
+            "label": "Simkl Trending This Month Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_trending_month",
+            "label": "Simkl Trending This Month Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_trending_month",
+            "label": "Simkl Trending This Month Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "use_dvd",
+            "label": "Simkl DVD",
+            "tooltip": "Collection of Simkl's Recently Released on DVD list.",
+            "type": "toggle",
+            "default": true,
+            "section": "children"
+          },
+          {
+            "key": "name_dvd",
+            "label": "Simkl DVD Name",
+            "type": "text_input",
+            "tooltip": "Override the collection name for the Simkl DVD collection. Leave blank to inherit the family Name Format value.",
+            "placeholder": "Custom collection name format",
+            "section": "children"
+          },
+          {
+            "key": "summary_dvd",
+            "label": "Simkl DVD Summary",
+            "type": "text_input",
+            "tooltip": "Override the collection summary for the Simkl DVD collection. Leave blank to inherit the family Summary Format value.",
+            "placeholder": "Custom collection summary format",
+            "section": "children"
+          },
+          {
+            "key": "limit_dvd",
+            "label": "Simkl DVD Limit",
+            "type": "text_input",
+            "tooltip": "Changes the Builder Limit of the Simkl DVD collection. Valid values are numbers greater than 0. Leave blank to inherit the family Limit value.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "section": "builder"
+          },
+          {
+            "key": "sync_mode_dvd",
+            "label": "Simkl DVD Sync Mode",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "append",
+                "label": "Append"
+              },
+              {
+                "value": "sync",
+                "label": "Sync"
+              }
+            ]
+          },
+          {
+            "key": "cache_builders_dvd",
+            "label": "Simkl DVD Cache Builders",
+            "type": "number",
+            "section": "children",
+            "placeholder": "0"
+          },
+          {
+            "key": "collection_order_dvd",
+            "label": "Simkl DVD Collection Order",
+            "type": "select",
+            "section": "children",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "custom",
+                "label": "Custom"
+              },
+              {
+                "value": "alpha",
+                "label": "Alpha"
+              },
+              {
+                "value": "release",
+                "label": "Release"
+              },
+              {
+                "value": "added",
+                "label": "Added"
+              }
+            ]
+          },
+          {
+            "key": "schedule_dvd",
+            "label": "Simkl DVD Schedule",
+            "type": "text",
+            "section": "children",
+            "placeholder": "weekly(sunday)"
+          },
+          {
+            "key": "image",
+            "label": "Image Path",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "chart/<<style>>/<<mapping_name_encoded>>"
+          },
+          {
+            "key": "url_poster",
+            "label": "Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "file_poster",
+            "label": "Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "url_background",
+            "label": "Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "file_background",
+            "label": "Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "url_logo",
+            "label": "Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "file_logo",
+            "label": "Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "url_square_art",
+            "label": "Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "file_square_art",
+            "label": "Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_background_dvd",
+            "label": "Simkl DVD Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_trending_month",
+            "label": "Simkl Trending This Month Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_trending_today",
+            "label": "Simkl Trending Today Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_background_trending_week",
+            "label": "Simkl Trending This Week Background File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/background.jpg"
+          },
+          {
+            "key": "file_logo_dvd",
+            "label": "Simkl DVD Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_trending_month",
+            "label": "Simkl Trending This Month Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_trending_today",
+            "label": "Simkl Trending Today Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_logo_trending_week",
+            "label": "Simkl Trending This Week Logo File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/logo.png"
+          },
+          {
+            "key": "file_poster_dvd",
+            "label": "Simkl DVD Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_trending_month",
+            "label": "Simkl Trending This Month Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_trending_today",
+            "label": "Simkl Trending Today Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_poster_trending_week",
+            "label": "Simkl Trending This Week Poster File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/poster.jpg"
+          },
+          {
+            "key": "file_square_art_dvd",
+            "label": "Simkl DVD Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_trending_month",
+            "label": "Simkl Trending This Month Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_trending_today",
+            "label": "Simkl Trending Today Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "file_square_art_trending_week",
+            "label": "Simkl Trending This Week Square Art File",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "/config/assets/square-art.png"
+          },
+          {
+            "key": "hub_priority",
+            "label": "Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one hub visibility toggle and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home",
+              "visible_library",
+              "visible_shared"
+            ],
+            "requirement_hint": "Enable Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_dvd",
+            "label": "Simkl DVD Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_dvd",
+              "visible_library_dvd",
+              "visible_shared_dvd"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_trending_month",
+            "label": "Simkl Trending This Month Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_trending_month",
+              "visible_library_trending_month",
+              "visible_shared_trending_month"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_trending_today",
+            "label": "Simkl Trending Today Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_trending_today",
+              "visible_library_trending_today",
+              "visible_shared_trending_today"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "hub_priority_trending_week",
+            "label": "Simkl Trending This Week Hub Priority",
+            "type": "text_input",
+            "url": "https://kometa.wiki/en/nightly/config/settings/?h=hub_priority#hub-priority",
+            "tooltip": "Sets the priority for this collection's Recommendation Hub row. Lower numbers appear first. Requires at least one of this child collection's hub visibility toggles and Plex Pass.",
+            "input_type": "number",
+            "min": 1,
+            "step": 1,
+            "requires_plex_pass": true,
+            "requires_any_of_template_keys": [
+              "visible_home_trending_week",
+              "visible_library_trending_week",
+              "visible_shared_trending_week"
+            ],
+            "requirement_hint": "Enable this child collection on Visible Home, Visible Library, or Visible Shared before setting Hub Priority.",
+            "section": "visibility"
+          },
+          {
+            "key": "ignore_ids",
+            "label": "Ignore IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of numeric IDs to ignore in this Defaults File.<br><br>Each entry must be a number like <code>603</code> or <code>1399</code>.",
+            "placeholder": "Add numeric ID (e.g. 603)",
+            "validation_preset": "numeric_id",
+            "section": "basics"
+          },
+          {
+            "key": "ignore_imdb_ids",
+            "label": "Ignore IMDb IDs",
+            "type": "string_list",
+            "tooltip": "Set a list of IMDb IDs to ignore in this Defaults File.<br><br>Each entry must look like <code>tt1234567</code>. Plex lookup is advisory and only checks the active library.",
+            "placeholder": "Add IMDb ID (e.g. tt1234567)",
+            "validation_preset": "imdb_id_plex",
+            "section": "basics"
+          },
+          {
+            "key": "item_radarr_tag",
+            "label": "Item Radarr Tag",
+            "tooltip": "Append a Radarr tag to every movie found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Radarr tag",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "item_radarr_tag_dvd",
+            "label": "Simkl DVD Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_trending_month",
+            "label": "Simkl Trending This Month Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_trending_today",
+            "label": "Simkl Trending Today Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_radarr_tag_trending_week",
+            "label": "Simkl Trending This Week Item Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag",
+            "label": "Item Sonarr Tag",
+            "tooltip": "Append a Sonarr tag to every series found by all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add item Sonarr tag",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "item_sonarr_tag_dvd",
+            "label": "Simkl DVD Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_trending_month",
+            "label": "Simkl Trending This Month Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_trending_today",
+            "label": "Simkl Trending Today Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "item_sonarr_tag_trending_week",
+            "label": "Simkl Trending This Week Item Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "collection,tracked"
+          },
+          {
+            "key": "radarr_add_missing",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Override Radarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_dvd",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_trending_month",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_trending_today",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_add_missing_trending_week",
+            "label": "Add missing items to Radarr",
+            "tooltip": "Add missing items to Radarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_folder",
+            "label": "Radarr Root Folder",
+            "tooltip": "Override Radarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Radarr root folder path",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_folder_dvd",
+            "label": "Simkl DVD Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_trending_month",
+            "label": "Simkl Trending This Month Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_trending_today",
+            "label": "Simkl Trending Today Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_folder_trending_week",
+            "label": "Simkl Trending This Week Radarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "C:\\Media\\Movies"
+          },
+          {
+            "key": "radarr_monitor",
+            "label": "Monitor media when added to Radarr",
+            "tooltip": "Override Radarr monitor for all collections in this Defaults File.<br><br>Enables monitoring of newly added media in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_monitor_dvd",
+            "label": "Simkl DVD Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Radarr",
+            "tooltip": "Override Radarr monitor_existing for all collections in this Defaults File.<br><br>Changes all existing media from collections to 'monitored' in Radarr.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_monitor_existing_dvd",
+            "label": "Simkl DVD Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_trending_month",
+            "label": "Simkl Trending This Month Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_trending_today",
+            "label": "Simkl Trending Today Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_existing_trending_week",
+            "label": "Simkl Trending This Week Radarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_trending_month",
+            "label": "Simkl Trending This Month Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_trending_today",
+            "label": "Simkl Trending Today Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_monitor_trending_week",
+            "label": "Simkl Trending This Week Radarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search",
+            "label": "Search media when added to Radarr",
+            "tooltip": "Override Radarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_search_dvd",
+            "label": "Simkl DVD Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_trending_month",
+            "label": "Simkl Trending This Month Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_trending_today",
+            "label": "Simkl Trending Today Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_search_trending_week",
+            "label": "Simkl Trending This Week Radarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_tag",
+            "label": "Radarr Tag",
+            "tooltip": "Override the Radarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Radarr tag",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_tag_dvd",
+            "label": "Simkl DVD Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_trending_month",
+            "label": "Simkl Trending This Month Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_trending_today",
+            "label": "Simkl Trending Today Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_tag_trending_week",
+            "label": "Simkl Trending This Week Radarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "radarr_upgrade_existing",
+            "label": "Upgrade existing media in Radarr",
+            "tooltip": "Override Radarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Radarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "movie"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "radarr_upgrade_existing_dvd",
+            "label": "Simkl DVD Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_trending_month",
+            "label": "Simkl Trending This Month Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_trending_today",
+            "label": "Simkl Trending Today Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "radarr_upgrade_existing_trending_week",
+            "label": "Simkl Trending This Week Radarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "movie"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_add_missing",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Override Sonarr add_missing for all collections in this Defaults File.<br><br>Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b>",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_add_missing_dvd",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_add_missing_trending_month",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_add_missing_trending_today",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_add_missing_trending_week",
+            "label": "Add missing items to Sonarr",
+            "tooltip": "Add missing items to Sonarr can generate a lot of internet traffic and disk space issues depending on the number of items missing in your library. <br> <b>Use with caution.</b> ",
+            "tooltip_variant": "danger",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_folder",
+            "label": "Sonarr Root Folder",
+            "tooltip": "Override Sonarr root_folder_path for all collections in this Defaults File.",
+            "type": "text_input",
+            "placeholder": "Enter Sonarr root folder path",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_folder_dvd",
+            "label": "Simkl DVD Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_trending_month",
+            "label": "Simkl Trending This Month Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_trending_today",
+            "label": "Simkl Trending Today Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_folder_trending_week",
+            "label": "Simkl Trending This Week Sonarr Folder",
+            "type": "text",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "C:\\Media\\Shows"
+          },
+          {
+            "key": "sonarr_monitor",
+            "label": "Sonarr Monitor",
+            "tooltip": "Override Sonarr monitor for all collections in this Defaults File.<br><br>Choose how Sonarr monitors episodes when adding a show.",
+            "type": "select",
+            "options": [
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First Season"
+              },
+              {
+                "value": "latest",
+                "label": "Latest Season"
+              }
+            ],
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_monitor_dvd",
+            "label": "Simkl DVD Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing",
+            "label": "Set existing media from collections to monitored in Sonarr",
+            "tooltip": "Override Sonarr monitor_existing for all collections in this Defaults File.<br><br>Marks all existing media from collections as 'monitored' in Sonarr.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_monitor_existing_dvd",
+            "label": "Simkl DVD Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_trending_month",
+            "label": "Simkl Trending This Month Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_trending_today",
+            "label": "Simkl Trending Today Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_existing_trending_week",
+            "label": "Simkl Trending This Week Sonarr Monitor Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_trending_month",
+            "label": "Simkl Trending This Month Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_trending_today",
+            "label": "Simkl Trending Today Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_monitor_trending_week",
+            "label": "Simkl Trending This Week Sonarr Monitor",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "all",
+                "label": "All"
+              },
+              {
+                "value": "future",
+                "label": "Future"
+              },
+              {
+                "value": "missing",
+                "label": "Missing"
+              },
+              {
+                "value": "existing",
+                "label": "Existing"
+              },
+              {
+                "value": "pilot",
+                "label": "Pilot"
+              },
+              {
+                "value": "first",
+                "label": "First"
+              },
+              {
+                "value": "latest",
+                "label": "Latest"
+              },
+              {
+                "value": "none",
+                "label": "None"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search",
+            "label": "Search media when added to Sonarr",
+            "tooltip": "Override Sonarr search for all collections in this Defaults File.<br><br>Automatically searches for media when added.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_search_dvd",
+            "label": "Simkl DVD Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_trending_month",
+            "label": "Simkl Trending This Month Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_trending_today",
+            "label": "Simkl Trending Today Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_search_trending_week",
+            "label": "Simkl Trending This Week Sonarr Search",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_tag",
+            "label": "Sonarr Tag",
+            "tooltip": "Override the Sonarr tag for all collections in this Defaults File.<br><br>Add one tag at a time.",
+            "type": "string_list",
+            "placeholder": "Add Sonarr tag",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_tag_dvd",
+            "label": "Simkl DVD Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_trending_month",
+            "label": "Simkl Trending This Month Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_trending_today",
+            "label": "Simkl Trending Today Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_tag_trending_week",
+            "label": "Simkl Trending This Week Sonarr Tags",
+            "type": "string_list",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "placeholder": "4k,chart"
+          },
+          {
+            "key": "sonarr_upgrade_existing",
+            "label": "Upgrade existing media in Sonarr",
+            "tooltip": "Override Sonarr upgrade_existing for all collections in this Defaults File.<br><br>Upgrades existing media from collections to the current Sonarr quality profile.",
+            "type": "toggle",
+            "media_types": [
+              "show"
+            ],
+            "section": "automation"
+          },
+          {
+            "key": "sonarr_upgrade_existing_dvd",
+            "label": "Simkl DVD Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_trending_month",
+            "label": "Simkl Trending This Month Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_trending_today",
+            "label": "Simkl Trending Today Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "sonarr_upgrade_existing_trending_week",
+            "label": "Simkl Trending This Week Sonarr Upgrade Existing",
+            "type": "select",
+            "section": "automation",
+            "media_types": [
+              "show"
+            ],
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "True"
+              },
+              {
+                "value": "false",
+                "label": "False"
+              }
+            ]
+          },
+          {
+            "key": "url_background_dvd",
+            "label": "Simkl DVD Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_trending_month",
+            "label": "Simkl Trending This Month Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_trending_today",
+            "label": "Simkl Trending Today Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_background_trending_week",
+            "label": "Simkl Trending This Week Background URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/background.jpg"
+          },
+          {
+            "key": "url_logo_dvd",
+            "label": "Simkl DVD Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_trending_month",
+            "label": "Simkl Trending This Month Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_trending_today",
+            "label": "Simkl Trending Today Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_logo_trending_week",
+            "label": "Simkl Trending This Week Logo URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/logo.png"
+          },
+          {
+            "key": "url_poster_dvd",
+            "label": "Simkl DVD Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_trending_month",
+            "label": "Simkl Trending This Month Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_trending_today",
+            "label": "Simkl Trending Today Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_poster_trending_week",
+            "label": "Simkl Trending This Week Poster URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/poster.jpg"
+          },
+          {
+            "key": "url_square_art_dvd",
+            "label": "Simkl DVD Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_trending_month",
+            "label": "Simkl Trending This Month Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_trending_today",
+            "label": "Simkl Trending Today Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "url_square_art_trending_week",
+            "label": "Simkl Trending This Week Square Art URL",
+            "type": "text",
+            "section": "artwork",
+            "placeholder": "https://example.com/square-art.png"
+          },
+          {
+            "key": "visible_home",
+            "label": "Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_dvd",
+            "label": "Simkl DVD Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Simkl DVD collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_trending_month",
+            "label": "Simkl Trending This Month Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Simkl Trending This Month collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_trending_today",
+            "label": "Simkl Trending Today Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Simkl Trending Today collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_home_trending_week",
+            "label": "Simkl Trending This Week Visible Home",
+            "type": "toggle",
+            "tooltip": "Changes the Simkl Trending This Week collection visible on Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library",
+            "label": "Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_dvd",
+            "label": "Simkl DVD Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Simkl DVD collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_trending_month",
+            "label": "Simkl Trending This Month Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Simkl Trending This Month collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_trending_today",
+            "label": "Simkl Trending Today Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Simkl Trending Today collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_library_trending_week",
+            "label": "Simkl Trending This Week Visible Library",
+            "type": "toggle",
+            "tooltip": "Changes the Simkl Trending This Week collection visible on Library Recommended Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared",
+            "label": "Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_dvd",
+            "label": "Simkl DVD Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Simkl DVD collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_trending_month",
+            "label": "Simkl Trending This Month Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Simkl Trending This Month collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_trending_today",
+            "label": "Simkl Trending Today Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Simkl Trending Today collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          },
+          {
+            "key": "visible_shared_trending_week",
+            "label": "Simkl Trending This Week Visible Shared",
+            "type": "toggle",
+            "tooltip": "Changes the Simkl Trending This Week collection visible on Shared Users' Home Tab (Only works with Plex Pass)",
+            "default": false,
+            "section": "visibility",
+            "options": [
+              {
+                "value": "",
+                "label": "Default"
+              },
+              {
+                "value": "true",
+                "label": "Visible"
+              },
+              {
+                "value": "false",
+                "label": "Hidden"
+              }
+            ]
+          }
+        ],
+        "sections": [
+          {
+            "id": "basics",
+            "label": "Basics"
+          },
+          {
+            "id": "naming",
+            "label": "Naming"
+          },
+          {
+            "id": "builder",
+            "label": "Builder Controls"
+          },
+          {
+            "id": "children",
+            "label": "Chart Collections"
+          },
+          {
+            "id": "artwork",
+            "label": "Artwork"
+          },
+          {
+            "id": "automation",
+            "label": "Automation"
+          },
+          {
+            "id": "visibility",
+            "label": "Visibility"
           }
         ]
       },

--- a/tests/test_collection_chart_tmdb_trakt_simkl_contract.py
+++ b/tests/test_collection_chart_tmdb_trakt_simkl_contract.py
@@ -1,0 +1,98 @@
+import json
+from pathlib import Path
+
+
+def _walk(node):
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            yield from _walk(value)
+    elif isinstance(node, list):
+        for value in node:
+            yield from _walk(value)
+
+
+def _collection(collection_id):
+    data = json.loads(Path("static/json/quickstart_collections.json").read_text(encoding="utf-8"))
+    return next(node for node in _walk(data) if node.get("id") == collection_id)
+
+
+def _field_keys(collection_id):
+    return {field["key"] for field in _collection(collection_id)["template_variables"]}
+
+
+def test_tmdb_chart_exposes_shared_child_custom_and_arr_template_variables():
+    collection = _collection("collection_tmdb")
+    keys = _field_keys("collection_tmdb")
+
+    assert [section["id"] for section in collection["sections"]] == [
+        "basics",
+        "naming",
+        "builder",
+        "children",
+        "artwork",
+        "automation",
+        "visibility",
+    ]
+    assert {
+        "image",
+        "allowed_libraries",
+        "schedule",
+        "url_logo",
+        "url_logo_popular",
+        "url_logo_top",
+        "url_logo_trending",
+        "url_logo_airing",
+        "url_logo_air",
+        "sync_mode_trending",
+        "cache_builders_airing",
+        "collection_order_air",
+        "radarr_folder_top",
+        "radarr_tag_popular",
+        "sonarr_folder_airing",
+        "sonarr_search_air",
+    }.issubset(keys)
+
+
+def test_trakt_chart_exposes_shared_child_custom_and_arr_template_variables():
+    keys = _field_keys("collection_trakt")
+
+    assert {
+        "image",
+        "allowed_libraries",
+        "schedule",
+        "url_logo",
+        "url_logo_collected",
+        "url_logo_recommended",
+        "url_logo_watched",
+        "sync_mode_recommended",
+        "cache_builders_trending",
+        "collection_order_watched",
+        "radarr_folder_collected",
+        "radarr_tag_popular",
+        "sonarr_folder_trending",
+        "sonarr_search_watched",
+    }.issubset(keys)
+
+
+def test_simkl_chart_exposes_period_shared_child_custom_and_arr_template_variables():
+    keys = _field_keys("collection_simkl")
+
+    assert {
+        "period",
+        "image",
+        "allowed_libraries",
+        "schedule",
+        "url_logo",
+        "url_logo_trending_today",
+        "url_logo_trending_week",
+        "url_logo_trending_month",
+        "url_logo_dvd",
+        "sync_mode_trending_week",
+        "cache_builders_trending_month",
+        "collection_order_dvd",
+        "radarr_folder_dvd",
+        "radarr_tag_trending_today",
+        "sonarr_folder_trending_month",
+        "sonarr_search_trending_week",
+    }.issubset(keys)

--- a/tests/test_core_backend.py
+++ b/tests/test_core_backend.py
@@ -2068,13 +2068,32 @@ def test_build_libraries_section_preserves_chart_builder_size_template_variables
                     "mov-library_movies-template_collection_trakt_limit": "75",
                     "mov-library_movies-template_collection_trakt_limit_popular": "50",
                     "mov-library_movies-template_collection_trakt_limit_recommended": "30",
+                    "mov-library_movies-template_collection_trakt_image": "chart/color/trakt",
+                    "mov-library_movies-template_collection_trakt_url_logo_collected": "https://example.com/trakt-collected.png",
+                    "mov-library_movies-template_collection_trakt_sync_mode_recommended": "append",
+                    "mov-library_movies-template_collection_trakt_cache_builders_trending": "0",
+                    "mov-library_movies-template_collection_trakt_collection_order_watched": "custom",
+                    "mov-library_movies-template_collection_trakt_radarr_folder_collected": r"C:\Media\Movies",
+                    "mov-library_movies-template_collection_trakt_sonarr_search_watched": "false",
                     "mov-library_movies-collection_tmdb": True,
                     "mov-library_movies-template_collection_tmdb_limit": "60",
                     "mov-library_movies-template_collection_tmdb_limit_airing": "20",
                     "mov-library_movies-template_collection_tmdb_limit_trending": "40",
+                    "mov-library_movies-template_collection_tmdb_allowed_libraries": "show",
+                    "mov-library_movies-template_collection_tmdb_image": "chart/color/tmdb",
+                    "mov-library_movies-template_collection_tmdb_url_logo_airing": "https://example.com/tmdb-airing.png",
+                    "mov-library_movies-template_collection_tmdb_collection_order_air": "custom",
+                    "mov-library_movies-template_collection_tmdb_radarr_folder_top": r"C:\Media\Movies",
+                    "mov-library_movies-template_collection_tmdb_sonarr_search_air": "false",
                     "mov-library_movies-collection_simkl": True,
+                    "mov-library_movies-template_collection_simkl_period": "week",
                     "mov-library_movies-template_collection_simkl_limit_trending_today": "15",
                     "mov-library_movies-template_collection_simkl_limit_dvd": "10",
+                    "mov-library_movies-template_collection_simkl_image": "chart/color/simkl",
+                    "mov-library_movies-template_collection_simkl_url_logo_trending_week": "https://example.com/simkl-week.png",
+                    "mov-library_movies-template_collection_simkl_collection_order_dvd": "custom",
+                    "mov-library_movies-template_collection_simkl_radarr_folder_dvd": r"C:\Media\Movies",
+                    "mov-library_movies-template_collection_simkl_sonarr_search_trending_week": "false",
                     "mov-library_movies-collection_anilist": True,
                     "mov-library_movies-template_collection_anilist_limit": "80",
                     "mov-library_movies-template_collection_anilist_limit_popular": "40",
@@ -2149,11 +2168,30 @@ def test_build_libraries_section_preserves_chart_builder_size_template_variables
     assert trakt_entry["template_variables"]["limit"] == "75"
     assert trakt_entry["template_variables"]["limit_popular"] == "50"
     assert trakt_entry["template_variables"]["limit_recommended"] == "30"
+    assert trakt_entry["template_variables"]["image"] == "chart/color/trakt"
+    assert trakt_entry["template_variables"]["url_logo_collected"] == "https://example.com/trakt-collected.png"
+    assert trakt_entry["template_variables"]["sync_mode_recommended"] == "append"
+    assert trakt_entry["template_variables"]["cache_builders_trending"] == "0"
+    assert trakt_entry["template_variables"]["collection_order_watched"] == "custom"
+    assert trakt_entry["template_variables"]["radarr_folder_collected"] == r"C:\Media\Movies"
+    assert trakt_entry["template_variables"]["sonarr_search_watched"] is False
     assert tmdb_entry["template_variables"]["limit"] == "60"
     assert tmdb_entry["template_variables"]["limit_airing"] == "20"
     assert tmdb_entry["template_variables"]["limit_trending"] == "40"
+    assert tmdb_entry["template_variables"]["allowed_libraries"] == "show"
+    assert tmdb_entry["template_variables"]["image"] == "chart/color/tmdb"
+    assert tmdb_entry["template_variables"]["url_logo_airing"] == "https://example.com/tmdb-airing.png"
+    assert tmdb_entry["template_variables"]["collection_order_air"] == "custom"
+    assert tmdb_entry["template_variables"]["radarr_folder_top"] == r"C:\Media\Movies"
+    assert tmdb_entry["template_variables"]["sonarr_search_air"] is False
+    assert simkl_entry["template_variables"]["period"] == "week"
     assert simkl_entry["template_variables"]["limit_trending_today"] == "15"
     assert simkl_entry["template_variables"]["limit_dvd"] == "10"
+    assert simkl_entry["template_variables"]["image"] == "chart/color/simkl"
+    assert simkl_entry["template_variables"]["url_logo_trending_week"] == "https://example.com/simkl-week.png"
+    assert simkl_entry["template_variables"]["collection_order_dvd"] == "custom"
+    assert simkl_entry["template_variables"]["radarr_folder_dvd"] == r"C:\Media\Movies"
+    assert simkl_entry["template_variables"]["sonarr_search_trending_week"] is False
     assert anilist_entry["template_variables"]["limit"] == "80"
     assert anilist_entry["template_variables"]["limit_popular"] == "40"
     assert anilist_entry["template_variables"]["limit_season"] == "25"

--- a/tests/test_importer_collection_files.py
+++ b/tests/test_importer_collection_files.py
@@ -61,6 +61,13 @@ def test_prepare_import_payload_accepts_chart_builder_size_template_variables():
                                 "limit": 75,
                                 "limit_popular": 50,
                                 "limit_recommended": 30,
+                                "image": "chart/color/trakt",
+                                "url_logo_collected": "https://example.com/trakt-collected.png",
+                                "sync_mode_recommended": "append",
+                                "cache_builders_trending": 0,
+                                "collection_order_watched": "custom",
+                                "radarr_folder_collected": r"C:\Media\Movies",
+                                "sonarr_search_watched": "false",
                             },
                         },
                         {
@@ -69,13 +76,25 @@ def test_prepare_import_payload_accepts_chart_builder_size_template_variables():
                                 "limit": 60,
                                 "limit_airing": 20,
                                 "limit_trending": 40,
+                                "allowed_libraries": "show",
+                                "image": "chart/color/tmdb",
+                                "url_logo_airing": "https://example.com/tmdb-airing.png",
+                                "collection_order_air": "custom",
+                                "radarr_folder_top": r"C:\Media\Movies",
+                                "sonarr_search_air": "false",
                             },
                         },
                         {
                             "default": "simkl",
                             "template_variables": {
+                                "period": "week",
                                 "limit_trending_today": 15,
                                 "limit_dvd": 10,
+                                "image": "chart/color/simkl",
+                                "url_logo_trending_week": "https://example.com/simkl-week.png",
+                                "collection_order_dvd": "custom",
+                                "radarr_folder_dvd": r"C:\Media\Movies",
+                                "sonarr_search_trending_week": "false",
                             },
                         },
                         {
@@ -181,11 +200,30 @@ def test_prepare_import_payload_accepts_chart_builder_size_template_variables():
     assert libraries_payload["mov-library_movies-template_collection_trakt_limit"] == 75
     assert libraries_payload["mov-library_movies-template_collection_trakt_limit_popular"] == 50
     assert libraries_payload["mov-library_movies-template_collection_trakt_limit_recommended"] == 30
+    assert libraries_payload["mov-library_movies-template_collection_trakt_image"] == "chart/color/trakt"
+    assert libraries_payload["mov-library_movies-template_collection_trakt_url_logo_collected"] == "https://example.com/trakt-collected.png"
+    assert libraries_payload["mov-library_movies-template_collection_trakt_sync_mode_recommended"] == "append"
+    assert libraries_payload["mov-library_movies-template_collection_trakt_cache_builders_trending"] == 0
+    assert libraries_payload["mov-library_movies-template_collection_trakt_collection_order_watched"] == "custom"
+    assert libraries_payload["mov-library_movies-template_collection_trakt_radarr_folder_collected"] == r"C:\Media\Movies"
+    assert libraries_payload["mov-library_movies-template_collection_trakt_sonarr_search_watched"] == "false"
     assert libraries_payload["mov-library_movies-template_collection_tmdb_limit"] == 60
     assert libraries_payload["mov-library_movies-template_collection_tmdb_limit_airing"] == 20
     assert libraries_payload["mov-library_movies-template_collection_tmdb_limit_trending"] == 40
+    assert libraries_payload["mov-library_movies-template_collection_tmdb_allowed_libraries"] == "show"
+    assert libraries_payload["mov-library_movies-template_collection_tmdb_image"] == "chart/color/tmdb"
+    assert libraries_payload["mov-library_movies-template_collection_tmdb_url_logo_airing"] == "https://example.com/tmdb-airing.png"
+    assert libraries_payload["mov-library_movies-template_collection_tmdb_collection_order_air"] == "custom"
+    assert libraries_payload["mov-library_movies-template_collection_tmdb_radarr_folder_top"] == r"C:\Media\Movies"
+    assert libraries_payload["mov-library_movies-template_collection_tmdb_sonarr_search_air"] == "false"
+    assert libraries_payload["mov-library_movies-template_collection_simkl_period"] == "week"
     assert libraries_payload["mov-library_movies-template_collection_simkl_limit_trending_today"] == 15
     assert libraries_payload["mov-library_movies-template_collection_simkl_limit_dvd"] == 10
+    assert libraries_payload["mov-library_movies-template_collection_simkl_image"] == "chart/color/simkl"
+    assert libraries_payload["mov-library_movies-template_collection_simkl_url_logo_trending_week"] == "https://example.com/simkl-week.png"
+    assert libraries_payload["mov-library_movies-template_collection_simkl_collection_order_dvd"] == "custom"
+    assert libraries_payload["mov-library_movies-template_collection_simkl_radarr_folder_dvd"] == r"C:\Media\Movies"
+    assert libraries_payload["mov-library_movies-template_collection_simkl_sonarr_search_trending_week"] == "false"
     assert libraries_payload["mov-library_movies-template_collection_anilist_limit"] == 80
     assert libraries_payload["mov-library_movies-template_collection_anilist_limit_popular"] == 40
     assert libraries_payload["mov-library_movies-template_collection_anilist_limit_season"] == 25


### PR DESCRIPTION
## What type of PR is this?

<!--
    Place an X in any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

```markdown
## Summary

Adds the next chart collection coverage pass for `tmdb`, `trakt`, and `simkl`.

- Expands Quickstart collection JSON with missing supported template variables.
- Adds shared/artwork fields, fixed child fields, custom child overrides, and ARR child overrides.
- Adds Simkl `period` support so imports using that template variable persist and export correctly.
- Organizes the new controls into the established sectioned collection UI pattern.
- Adds JSON contract coverage plus import/export assertions for the new fields.

## Testing

```powershell
venv\Scripts\python.exe -m pytest tests/test_collection_chart_tmdb_trakt_simkl_contract.py tests/test_collection_order_contract.py tests/test_collection_cache_builders_contract.py tests/test_importer_collection_files.py::test_prepare_import_payload_accepts_chart_builder_size_template_variables tests/test_core_backend.py::test_build_libraries_section_preserves_chart_builder_size_template_variables
```

Result: `11 passed`
```


## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below.
    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->

- Closes #

## Which Environment Did You Test On?

<!--
    Place an X in any/all relevant option(s), for example:
    - [X] Windows Executable
-->

- [ ] Local Install (Windows/Linux/Mac via `python quickstart.py`)
- [ ] Windows Executable
- [ ] Linux Executable
- [ ] macOS Executable
- [ ] Docker
- [ ] Other
